### PR TITLE
feat(settings): migrate codicon markup to wa-icon library

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -11,11 +11,7 @@ import Mark from 'mark.js';
 
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
-import {
-  badgeStyles,
-  commonViewStyles,
-  designTokens,
-} from '@shared/styles';
+import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -6,7 +6,6 @@
 // Third-party imports
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, queryAll } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Mark from 'mark.js';
 
@@ -14,7 +13,6 @@ import Mark from 'mark.js';
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import {
   badgeStyles,
-  codiconStyles,
   commonViewStyles,
   designTokens,
 } from '@shared/styles';
@@ -23,6 +21,9 @@ import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - history view styles
 import { historyViewStyles } from './styles';
@@ -36,7 +37,6 @@ type ConfigValue = string | number | boolean | string[] | null | undefined;
 export class HistoryItem extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     ...badgeStyles,
     historyViewStyles,
@@ -258,7 +258,7 @@ export class HistoryItem extends LitElement {
           Object.entries(config.toolConfig) as Array<[string, ConfigValue]>
         ).filter(([, value]) => this.hasValue(value));
         const toolSection = this.renderConfigSection(
-          html`<i class="codicon codicon-tools"></i> Config`,
+          html`<wa-icon library="texra" name="tools"></wa-icon> Config`,
           toolEntries,
         );
         if (toolSection) extraDetails.push(toolSection);
@@ -314,9 +314,10 @@ export class HistoryItem extends LitElement {
           <span class="history-value">
             <span class="badge agent-category-badge ${categoryClass}">
               ${decorator.icon
-                ? html`<i
-                    class=${ifDefined(`codicon codicon-${decorator.icon}`)}
-                  ></i>`
+                ? html`<wa-icon
+                    library="texra"
+                    name=${decorator.icon}
+                  ></wa-icon>`
                 : nothing}
               ${decorator.label}
             </span>

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -20,6 +20,9 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared components & pagination utility
 import { paginate, type PageChangeDetail } from '../shared/Pagination';
 
@@ -216,7 +219,7 @@ export class HistoryList extends LitElement {
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
-        <span class="codicon codicon-history"></span>
+        <wa-icon library="texra" name="history"></wa-icon>
         <p>No history items found.</p>
         <p class="text-secondary">
           History is recorded when you run agent commands. Past results will

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -16,6 +16,9 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - memory view components (side-effect: register)
 import './MemoryItem';
 
@@ -65,7 +68,7 @@ export class MemoryList extends LitElement {
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
-        <span class="codicon codicon-database"></span>
+        <wa-icon library="texra" name="database"></wa-icon>
         <p>No saved memories yet.</p>
         <p class="text-secondary">
           Memories are created automatically when the assistant learns something

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -16,7 +16,7 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - shared schemas and events
@@ -53,7 +53,6 @@ function isBuiltIn(source: string): boolean {
 export class AgentSelectionPanel extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -7,7 +7,10 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, designTokens } from '@shared/styles';
+import { designTokens } from '@shared/styles';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
@@ -20,7 +23,7 @@ import { ProfileViewEvents } from './events';
 
 @customElement('api-access-section')
 export class ApiAccessSection extends LitElement {
-  static override styles = [designTokens, codiconStyles, profileViewStyles];
+  static override styles = [designTokens, profileViewStyles];
 
   @property({ attribute: false }) mode: 'included' | 'personal' = 'personal';
 
@@ -76,10 +79,12 @@ export class ApiAccessSection extends LitElement {
         ${this.mode === 'included'
           ? html`
               <div class="api-access-support">
-                <span
-                  class="codicon codicon-heart api-access-support-icon"
+                <wa-icon
+                  library="texra"
+                  name="heart"
+                  class="api-access-support-icon"
                   aria-hidden="true"
-                ></span>
+                ></wa-icon>
                 <span class="api-access-support-copy">
                   ${PROMO_NOTICE_LONG.supportLead}<a
                     href=${PROMO_NOTICE_LONG.supportSponsorsUrl}

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -63,11 +63,7 @@ function sortFastFirst(items: ModelSelectionItem[]): ModelSelectionItem[] {
 
 @customElement('model-selection-list')
 export class ModelSelectionList extends LitElement {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    profileViewStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, profileViewStyles];
 
   @property({ attribute: false }) models: ModelSelectionItem[] = [];
   @property({ attribute: false }) helperModel = '';

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -8,8 +8,11 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared constants
 import {
@@ -62,7 +65,6 @@ function sortFastFirst(items: ModelSelectionItem[]): ModelSelectionItem[] {
 export class ModelSelectionList extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     profileViewStyles,
   ];
@@ -204,11 +206,13 @@ export class ModelSelectionList extends LitElement {
         )}
       </vscode-single-select>
       ${includedAccessCap
-        ? html`<span
-            class="codicon codicon-warning model-row-icon model-row-icon--warning"
+        ? html`<wa-icon
+            library="texra"
+            name="warning"
+            class="model-row-icon model-row-icon--warning"
             title=${title}
             aria-hidden="true"
-          ></span>`
+          ></wa-icon>`
         : nothing}
     `;
   }
@@ -234,17 +238,21 @@ export class ModelSelectionList extends LitElement {
           <span class="model-name">${model.label}</span>
           <span class="model-shortname">(${model.name})</span>
           ${!available
-            ? html`<span
-                class="codicon codicon-key model-row-icon"
+            ? html`<wa-icon
+                library="texra"
+                name="key"
+                class="model-row-icon"
                 title="Requires ${PROVIDER_DISPLAY_NAMES[model.provider] ??
                 model.provider} API key — set via TeXRA: Set API Key command"
-              ></span>`
+              ></wa-icon>`
             : nothing}
           ${isExpensiveModel(model.provider, model.name)
-            ? html`<span
-                class="codicon codicon-warning model-row-icon model-row-icon--warning"
+            ? html`<wa-icon
+                library="texra"
+                name="warning"
+                class="model-row-icon model-row-icon--warning"
                 title=${EXPENSIVE_MODEL_HINT}
-              ></span>`
+              ></wa-icon>`
             : nothing}
         </vscode-checkbox>
         ${this.renderReasoningDropdown(model)}
@@ -305,11 +313,11 @@ export class ModelSelectionList extends LitElement {
             class="provider-group-toggle"
             @click=${() => this.toggleProvider(group.provider)}
           >
-            <span
-              class="provider-group-chevron codicon codicon-chevron-right ${isExpanded
-                ? 'expanded'
-                : ''}"
-            ></span>
+            <wa-icon
+              library="texra"
+              name="chevron-right"
+              class="provider-group-chevron ${isExpanded ? 'expanded' : ''}"
+            ></wa-icon>
             <span class="provider-group-name">${group.displayName}</span>
             <span class="provider-group-count">
               ${enabledCount}/${totalCount} enabled

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -8,11 +8,7 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import {
-  badgeStyles,
-  commonViewStyles,
-  designTokens,
-} from '@shared/styles';
+import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Side-effect imports - register WA icon component

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -10,11 +10,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 // Local imports - shared styles
 import {
   badgeStyles,
-  codiconStyles,
   commonViewStyles,
   designTokens,
 } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - profile view styles and events
 import type {
@@ -35,7 +37,6 @@ const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
 export class ProviderKeyList extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     ...badgeStyles,
     profileViewStyles,
@@ -197,7 +198,7 @@ export class ProviderKeyList extends LitElement {
               title="${isExpanded ? 'Collapse settings' : 'Expand settings'}"
               @click=${() => this.toggleExpanded(entry.provider)}
             >
-              <span class="codicon codicon-chevron-right"></span>
+              <wa-icon library="texra" name="chevron-right"></wa-icon>
             </button>
             <span class="provider-name">${entry.displayName}</span>
           </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -8,7 +8,10 @@ import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, designTokens } from '@shared/styles';
+import { designTokens } from '@shared/styles';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared events
 import { createEvent } from '@shared/utils/events';
@@ -17,7 +20,6 @@ import { createEvent } from '@shared/utils/events';
 export class ProviderKeyModal extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     css`
       :host {
         position: fixed;
@@ -279,12 +281,14 @@ export class ProviderKeyModal extends LitElement {
           <div class="provider-key-header">
             <h2 id="provider-key-title">Set ${displayName} API key</h2>
             <button
-              class="provider-key-icon codicon codicon-close"
+              class="provider-key-icon"
               type="button"
               title="Cancel"
               aria-label="Cancel"
               @click=${this.close}
-            ></button>
+            >
+              <wa-icon library="texra" name="close"></wa-icon>
+            </button>
           </div>
           <p class="provider-key-description">
             The key is stored by TeXRA on this device and is not shown again
@@ -310,7 +314,7 @@ export class ProviderKeyModal extends LitElement {
               Cancel
             </button>
             <button class="provider-key-primary" type="submit">
-              <span class="codicon codicon-key"></span>
+              <wa-icon library="texra" name="key"></wa-icon>
               Save Key
             </button>
           </div>

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -10,7 +10,7 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa';
 
 // Local imports - shared schemas
@@ -24,7 +24,6 @@ import type {
 export class ToolCard extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -267,9 +266,9 @@ export class ToolCard extends LitElement {
     ToolDashboardItem['status'],
     { icon: string; label: string }
   > = {
-    available: { icon: 'codicon-check', label: 'Ready' },
-    'not-found': { icon: 'codicon-warning', label: 'Needs setup' },
-    unknown: { icon: 'codicon-question', label: 'Not checked' },
+    available: { icon: 'check', label: 'Ready' },
+    'not-found': { icon: 'warning', label: 'Needs setup' },
+    unknown: { icon: 'question', label: 'Not checked' },
   };
 
   private renderBadge(): TemplateResult {
@@ -279,7 +278,7 @@ export class ToolCard extends LitElement {
 
     return html`
       <span class="tool-badge tool-badge--${status}">
-        <span class="codicon ${config.icon}"></span>
+        <wa-icon library="texra" name=${config.icon}></wa-icon>
         ${this.item.statusLabel ?? config.label}
       </span>
     `;
@@ -431,7 +430,7 @@ export class ToolCard extends LitElement {
     if (!this.item.authNote) return nothing;
     return html`
       <span class="tool-auth-note">
-        <span class="codicon codicon-key"></span>
+        <wa-icon library="texra" name="key"></wa-icon>
         ${this.item.authNote}
       </span>
     `;

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -15,7 +15,7 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared schemas
 import type { AgentCategory } from '@shared/schemas/agent';
@@ -24,12 +24,12 @@ import { AgentSelectionEvents } from '../components/profile/events';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/AgentSelectionPanel';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 @customElement('agents-tab')
 export class AgentsTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -118,7 +118,7 @@ export class AgentsTab extends LitElement {
         border-radius: var(--border-radius);
       }
 
-      .agents-dir-bar .codicon {
+      .agents-dir-bar wa-icon {
         font-size: var(--font-size);
         flex-shrink: 0;
       }
@@ -244,7 +244,7 @@ export class AgentsTab extends LitElement {
                 : ''}"
               @click=${() => (this.activeSubTab = 'workflow')}
             >
-              <span class="codicon codicon-symbol-method"></span>
+              <wa-icon library="texra" name="symbol-method"></wa-icon>
               Workflow
               <span class="agents-sub-tab-count"
                 >(${this.workflowAgents.length})</span
@@ -256,7 +256,7 @@ export class AgentsTab extends LitElement {
                 : ''}"
               @click=${() => (this.activeSubTab = 'toolUse')}
             >
-              <span class="codicon codicon-tools"></span>
+              <wa-icon library="texra" name="tools"></wa-icon>
               Tool Use
               <span class="agents-sub-tab-count"
                 >(${this.toolUseAgents.length})</span
@@ -269,7 +269,7 @@ export class AgentsTab extends LitElement {
               @click=${this.handleSaveTeam}
               title="Save current agent configuration as a team"
             >
-              <span class="codicon codicon-save"></span>
+              <wa-icon library="texra" name="save"></wa-icon>
               Save Team
             </button>
             ${this.desktopHost
@@ -280,7 +280,7 @@ export class AgentsTab extends LitElement {
                     @click=${this.handleCreateFromTemplate}
                     title="Create a new agent from a blank YAML template"
                   >
-                    <span class="codicon codicon-new-file"></span>
+                    <wa-icon library="texra" name="new-file"></wa-icon>
                     From Template
                   </button>
                   <button
@@ -288,7 +288,7 @@ export class AgentsTab extends LitElement {
                     @click=${this.handleCreateAgent}
                     title="Create a new agent with AI"
                   >
-                    <span class="codicon codicon-add"></span>
+                    <wa-icon library="texra" name="add"></wa-icon>
                     New Agent
                   </button>
                 `}
@@ -297,7 +297,7 @@ export class AgentsTab extends LitElement {
 
         <!-- Row 2: Custom directory info bar -->
         <div class="agents-dir-bar">
-          <span class="codicon codicon-folder"></span>
+          <wa-icon library="texra" name="folder"></wa-icon>
           <span class="agents-dir-label">Custom agents:</span>
           <span class="agents-dir-path" title=${this.customAgentDir}
             >${this.customAgentDir}</span
@@ -311,7 +311,7 @@ export class AgentsTab extends LitElement {
               @click=${this.handleOpenFolder}
               title="Open folder in file explorer"
             >
-              <span class="codicon codicon-folder-opened"></span>
+              <wa-icon library="texra" name="folder-opened"></wa-icon>
             </button>
             <button
               class="tab-action-btn"

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -9,11 +9,13 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import {
-  codiconStyles,
   commonViewStyles,
   designTokens,
   tintedBadgeStyles,
 } from '@shared/styles';
+
+// Web Awesome icon bundle (side-effect import)
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas
 import type { PRSubscriptionEntry } from '@shared/schemas/settingsViewMessages';
@@ -31,7 +33,6 @@ import {
 export class GitTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     tintedBadgeStyles,
     css`
@@ -272,7 +273,7 @@ export class GitTab extends LitElement {
                       class="tab-action-btn"
                       @click=${this.handleSetGitHubToken}
                     >
-                      <span class="codicon codicon-key"></span>
+                      <wa-icon library="texra" name="key"></wa-icon>
                       ${tokenIsSet ? 'Replace token' : 'Set token'}
                     </button>
                     ${this.githubTokenStatus === 'secret'
@@ -280,7 +281,7 @@ export class GitTab extends LitElement {
                           class="tab-action-btn token-remove-btn"
                           @click=${this.handleRemoveGitHubToken}
                         >
-                          <span class="codicon codicon-trash"></span>
+                          <wa-icon library="texra" name="trash"></wa-icon>
                           Remove
                         </button>`
                       : nothing}
@@ -288,7 +289,7 @@ export class GitTab extends LitElement {
                       class="tab-action-btn"
                       @click=${this.handleOpenGitHubTokenUrl}
                     >
-                      <span class="codicon codicon-github"></span>
+                      <wa-icon library="texra" name="github"></wa-icon>
                       Create on GitHub…
                     </button>
                   </span>
@@ -365,9 +366,10 @@ export class GitTab extends LitElement {
                                               owner.streamId,
                                             )}
                                         >
-                                          <span
-                                            class="codicon codicon-comment-discussion"
-                                          ></span>
+                                          <wa-icon
+                                            library="texra"
+                                            name="comment-discussion"
+                                          ></wa-icon>
                                           Jump to agent
                                         </button>
                                       </div>
@@ -386,7 +388,7 @@ export class GitTab extends LitElement {
                           @click=${() =>
                             this.handleUnsubscribePR(subscription.key)}
                         >
-                          <span class="codicon codicon-debug-stop"></span>
+                          <wa-icon library="texra" name="debug-stop"></wa-icon>
                           Stop
                         </button>
                       </li>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -8,7 +8,11 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
+
+// Web Awesome icon + spinner bundles (side-effect imports)
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 // Local imports - shared schemas
 import {
@@ -160,7 +164,6 @@ const RECOMMENDED_SETTINGS: SettingInfo[] = [
 export class LaTeXTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -544,11 +547,11 @@ export class LaTeXTab extends LitElement {
     return html`
       <div class="dependency-card">
         <div class="dependency-row">
-          <span
-            class="codicon dependency-icon ${installed
-              ? 'installed codicon-check'
-              : 'missing codicon-warning'}"
-          ></span>
+          <wa-icon
+            library="texra"
+            name=${installed ? 'check' : 'warning'}
+            class="dependency-icon ${installed ? 'installed' : 'missing'}"
+          ></wa-icon>
           <div class="dependency-info">
             <div class="dependency-name">${dep.name}</div>
             <div class="dependency-description">
@@ -573,7 +576,7 @@ export class LaTeXTab extends LitElement {
                       )}
                     title="${dep.actionLabel ?? 'Install'}"
                   >
-                    <span class="codicon codicon-cloud-download"></span>
+                    <wa-icon library="texra" name="cloud-download"></wa-icon>
                     ${dep.actionLabel ?? 'Install'}
                   </button>
                 `
@@ -588,7 +591,7 @@ export class LaTeXTab extends LitElement {
                   @click=${(e: Event) =>
                     this.handleCopyCommand(e, installCmd.command)}
                 >
-                  <span class="codicon codicon-copy"></span>
+                  <wa-icon library="texra" name="copy"></wa-icon>
                   Copy
                 </button>
                 <button
@@ -596,7 +599,7 @@ export class LaTeXTab extends LitElement {
                   title="Run: ${installCmd.command}"
                   @click=${() => this.handleRunInTerminal(installCmd.command)}
                 >
-                  <span class="codicon codicon-terminal"></span>
+                  <wa-icon library="texra" name="terminal"></wa-icon>
                   Run in Terminal
                 </button>
               </div>
@@ -608,11 +611,10 @@ export class LaTeXTab extends LitElement {
                 class="dependency-guide-toggle"
                 @click=${() => this.toggleGuide(dep.key)}
               >
-                <span
-                  class="codicon ${expanded
-                    ? 'codicon-chevron-down'
-                    : 'codicon-chevron-right'}"
-                ></span>
+                <wa-icon
+                  library="texra"
+                  name=${expanded ? 'chevron-down' : 'chevron-right'}
+                ></wa-icon>
                 Installation Guide
               </button>
               ${expanded
@@ -664,7 +666,7 @@ export class LaTeXTab extends LitElement {
   ): TemplateResult {
     return html`
       <div class="prerequisite-hint">
-        <span class="codicon codicon-info hint-icon"></span>
+        <wa-icon library="texra" name="info" class="hint-icon"></wa-icon>
         <div class="hint-body">
           <div class="hint-title">${title}</div>
           <div class="hint-description">${description}</div>
@@ -675,7 +677,7 @@ export class LaTeXTab extends LitElement {
               title="Copy ${pmName} install command"
               @click=${(e: Event) => this.handleCopyCommand(e, installCommand)}
             >
-              <span class="codicon codicon-copy"></span>
+              <wa-icon library="texra" name="copy"></wa-icon>
               Copy
             </button>
             <button
@@ -685,7 +687,7 @@ export class LaTeXTab extends LitElement {
                 : `Run ${pmName} installer in VS Code terminal`}
               @click=${() => this.handleRunInTerminal(installCommand)}
             >
-              <span class="codicon codicon-terminal"></span>
+              <wa-icon library="texra" name="terminal"></wa-icon>
               Run in Terminal
             </button>
           </div>
@@ -701,7 +703,7 @@ export class LaTeXTab extends LitElement {
 
     return html`
       <div class="section-header">
-        <span class="codicon codicon-package"></span>
+        <wa-icon library="texra" name="package"></wa-icon>
         Dependencies
       </div>
       ${this.renderPrerequisiteHint()}
@@ -713,11 +715,11 @@ export class LaTeXTab extends LitElement {
     const isSet = this.settings[info.key];
     return html`
       <div class="setting-card">
-        <span
-          class="codicon setting-status-icon ${isSet
-            ? 'is-set'
-            : 'not-set'} ${isSet ? 'codicon-check' : 'codicon-warning'}"
-        ></span>
+        <wa-icon
+          library="texra"
+          name=${isSet ? 'check' : 'warning'}
+          class="setting-status-icon ${isSet ? 'is-set' : 'not-set'}"
+        ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${info.name}</div>
           <div class="setting-config-key">${info.configKey}</div>
@@ -731,7 +733,7 @@ export class LaTeXTab extends LitElement {
                 @click=${() => this.handleApply(info.key, true)}
                 title="Reset this setting to default"
               >
-                <span class="codicon codicon-discard"></span>
+                <wa-icon library="texra" name="discard"></wa-icon>
                 Reset
               </button>
             `
@@ -741,7 +743,7 @@ export class LaTeXTab extends LitElement {
                 @click=${() => this.handleApply(info.key)}
                 title="Apply this setting"
               >
-                <span class="codicon codicon-check"></span>
+                <wa-icon library="texra" name="check"></wa-icon>
                 Apply
               </button>
             `}
@@ -756,7 +758,7 @@ export class LaTeXTab extends LitElement {
           <div
             style="text-align:center;padding:var(--spacing-large);color:var(--color-text-secondary)"
           >
-            <span class="codicon codicon-loading codicon-modifier-spin"></span>
+            <wa-spinner></wa-spinner>
             Loading LaTeX settings...
           </div>
         </div>
@@ -773,7 +775,7 @@ export class LaTeXTab extends LitElement {
                   @click=${() => this.handleApply()}
                   title="Apply all recommended settings"
                 >
-                  <span class="codicon codicon-check-all"></span>
+                  <wa-icon library="texra" name="check-all"></wa-icon>
                   Apply All
                 </button>
               </div>
@@ -787,7 +789,7 @@ export class LaTeXTab extends LitElement {
                 class="section-header"
                 style="margin-top:var(--spacing-large)"
               >
-                <span class="codicon codicon-settings-gear"></span>
+                <wa-icon library="texra" name="settings-gear"></wa-icon>
                 Recommended Settings
               </div>
 
@@ -810,15 +812,17 @@ export class LaTeXTab extends LitElement {
   private renderInlineCriticismSetting(): TemplateResult {
     return html`
       <div class="section-header" style="margin-top:var(--spacing-large)">
-        <span class="codicon codicon-comment-discussion"></span>
+        <wa-icon library="texra" name="comment-discussion"></wa-icon>
         Inline Criticism
       </div>
       <div class="setting-card">
-        <span
-          class="codicon setting-status-icon ${this.inlineCriticismEnabled
-            ? 'is-set codicon-check'
-            : 'not-set codicon-circle-slash'}"
-        ></span>
+        <wa-icon
+          library="texra"
+          name=${this.inlineCriticismEnabled ? 'check' : 'circle-slash'}
+          class="setting-status-icon ${this.inlineCriticismEnabled
+            ? 'is-set'
+            : 'not-set'}"
+        ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">Surface \\criticize annotations</div>
           <div class="setting-description">
@@ -856,7 +860,7 @@ export class LaTeXTab extends LitElement {
     const cv = this.configValues;
     return html`
       <div class="section-header" style="margin-top:var(--spacing-large)">
-        <span class="codicon codicon-zap"></span>
+        <wa-icon library="texra" name="zap"></wa-icon>
         Compile &amp; Diff
       </div>
       <div class="latex-description">
@@ -938,11 +942,11 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <span
-          class="codicon setting-status-icon ${effective
-            ? 'is-set codicon-check'
-            : 'not-set codicon-circle-slash'}"
-        ></span>
+        <wa-icon
+          library="texra"
+          name=${effective ? 'check' : 'circle-slash'}
+          class="setting-status-icon ${effective ? 'is-set' : 'not-set'}"
+        ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
@@ -960,7 +964,7 @@ export class LaTeXTab extends LitElement {
               @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
               title="Reset to default (${opts.defaultValue ? 'On' : 'Off'})"
             >
-              <span class="codicon codicon-discard"></span>
+              <wa-icon library="texra" name="discard"></wa-icon>
             </button>`
           : nothing}
       </div>
@@ -980,11 +984,11 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <span
-          class="codicon setting-status-icon ${isCustom
-            ? 'is-set codicon-edit'
-            : 'not-set codicon-circle-outline'}"
-        ></span>
+        <wa-icon
+          library="texra"
+          name=${isCustom ? 'edit' : 'circle-outline'}
+          class="setting-status-icon ${isCustom ? 'is-set' : 'not-set'}"
+        ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
@@ -1014,7 +1018,7 @@ export class LaTeXTab extends LitElement {
               @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
               title="Reset to default (${opts.defaultValue})"
             >
-              <span class="codicon codicon-discard"></span>
+              <wa-icon library="texra" name="discard"></wa-icon>
             </button>`
           : nothing}
       </div>
@@ -1035,11 +1039,11 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <span
-          class="codicon setting-status-icon ${isCustom
-            ? 'is-set codicon-edit'
-            : 'not-set codicon-circle-outline'}"
-        ></span>
+        <wa-icon
+          library="texra"
+          name=${isCustom ? 'edit' : 'circle-outline'}
+          class="setting-status-icon ${isCustom ? 'is-set' : 'not-set'}"
+        ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
@@ -1066,7 +1070,7 @@ export class LaTeXTab extends LitElement {
               @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
               title="Reset to default (${opts.defaultValue})"
             >
-              <span class="codicon codicon-discard"></span>
+              <wa-icon library="texra" name="discard"></wa-icon>
             </button>`
           : nothing}
       </div>

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -8,7 +8,7 @@ import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
 
 // Local imports - shared schemas
 import type { MemoryViewItem } from '@shared/schemas';
@@ -22,7 +22,6 @@ import '../components/memory/MemoryList';
 export class MemoryTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -9,7 +9,10 @@ import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
+
+// Web Awesome icon bundle (side-effect import)
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas
 import type {
@@ -27,7 +30,6 @@ export class ModelsTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconStyles,
     css`
       :host {
         display: block;
@@ -80,7 +82,11 @@ export class ModelsTab extends LitElement {
 
     return html`
       <div class="settings-reminder">
-        <span class="codicon codicon-info settings-reminder-icon"></span>
+        <wa-icon
+          library="texra"
+          name="info"
+          class="settings-reminder-icon"
+        ></wa-icon>
         <div class="settings-reminder-body">
           <div class="settings-reminder-title">API key settings</div>
           <div class="settings-reminder-description">${description}</div>
@@ -90,7 +96,7 @@ export class ModelsTab extends LitElement {
               class="tab-action-btn"
               @click=${this.handleScrollToApiConfig}
             >
-              <span class="codicon codicon-key"></span>
+              <wa-icon library="texra" name="key"></wa-icon>
               Jump to API Configuration
             </button>
           </div>

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -9,7 +9,10 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, designTokens, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
+
+// Web Awesome icon bundle (side-effect import)
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
@@ -36,7 +39,6 @@ function clampSetting(value: number, min?: number, max?: number): number {
 export class MultiAgentTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -134,7 +136,7 @@ export class MultiAgentTab extends LitElement {
         border-radius: var(--border-radius-medium);
       }
 
-      .preset-active-badge .codicon {
+      .preset-active-badge wa-icon {
         font-size: var(--font-size-xs);
       }
 
@@ -351,11 +353,15 @@ export class MultiAgentTab extends LitElement {
         title="Apply ${preset.name} team"
       >
         <div class="preset-card-header">
-          <span class="codicon ${preset.icon} preset-card-icon"></span>
+          <wa-icon
+            library="texra"
+            name=${preset.icon.replace('codicon-', '')}
+            class="preset-card-icon"
+          ></wa-icon>
           <span class="preset-card-name">${preset.name}</span>
           ${isActive
             ? html`<span class="preset-active-badge">
-                <span class="codicon codicon-check"></span> Active
+                <wa-icon library="texra" name="check"></wa-icon> Active
               </span>`
             : nothing}
         </div>
@@ -388,7 +394,7 @@ export class MultiAgentTab extends LitElement {
               @click=${(e: Event) => this.handleDeletePreset(e, preset)}
               title="Delete team"
             >
-              <span class="codicon codicon-trash"></span>
+              <wa-icon library="texra" name="trash"></wa-icon>
             </button>`
           : nothing}
       </div>
@@ -422,9 +428,11 @@ export class MultiAgentTab extends LitElement {
     return html`
       <div class="multi-agent-container tab-content-container">
         <div class="settings-reminder">
-          <span
-            class="codicon codicon-organization settings-reminder-icon"
-          ></span>
+          <wa-icon
+            library="texra"
+            name="organization"
+            class="settings-reminder-icon"
+          ></wa-icon>
           <div class="settings-reminder-body">
             <div class="settings-reminder-title">Multi-agent workflow</div>
             <div class="settings-reminder-description">

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -10,11 +10,14 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
 import {
-  codiconStyles,
   commonViewStyles,
   designTokens,
   tintedBadgeStyles,
 } from '@shared/styles';
+
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -74,14 +77,14 @@ interface CategoryMeta {
  * is a compile error.
  */
 const CATEGORY_META: Record<ToolCategory, CategoryMeta> = {
-  file: { label: 'File & Shell', icon: 'codicon-files' },
-  latex: { label: 'LaTeX', icon: 'codicon-file-code' },
-  academic: { label: 'Academic Research', icon: 'codicon-mortar-board' },
-  web: { label: 'Web', icon: 'codicon-globe' },
-  computation: { label: 'Computation', icon: 'codicon-symbol-operator' },
-  lean: { label: 'Lean 4', icon: 'codicon-beaker' },
-  workflow: { label: 'Memory & Workflow', icon: 'codicon-type-hierarchy' },
-  system: { label: 'System Dependencies', icon: 'codicon-gear' },
+  file: { label: 'File & Shell', icon: 'files' },
+  latex: { label: 'LaTeX', icon: 'file-code' },
+  academic: { label: 'Academic Research', icon: 'mortar-board' },
+  web: { label: 'Web', icon: 'globe' },
+  computation: { label: 'Computation', icon: 'symbol-operator' },
+  lean: { label: 'Lean 4', icon: 'beaker' },
+  workflow: { label: 'Memory & Workflow', icon: 'type-hierarchy' },
+  system: { label: 'System Dependencies', icon: 'gear' },
 };
 
 /** Canonical category display order. */
@@ -100,7 +103,6 @@ const CATEGORY_ORDER: ToolCategory[] = [
 export class ToolsTab extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     tintedBadgeStyles,
     css`
@@ -180,7 +182,7 @@ export class ToolsTab extends LitElement {
         gap: var(--spacing-small);
       }
 
-      .tools-summary-stat .codicon {
+      .tools-summary-stat wa-icon {
         font-size: var(--font-size-sm);
       }
 
@@ -212,7 +214,7 @@ export class ToolsTab extends LitElement {
         letter-spacing: 0.5px;
       }
 
-      .category-header .codicon {
+      .category-header wa-icon {
         font-size: var(--font-size);
       }
 
@@ -349,7 +351,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <span class="codicon codicon-shield"></span>
+          <wa-icon library="texra" name="shield"></wa-icon>
           Approval &amp; Safety
         </div>
 
@@ -424,7 +426,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <span class="codicon codicon-desktop-download"></span>
+          <wa-icon library="texra" name="desktop-download"></wa-icon>
           Desktop Diagnostics
         </div>
         <div class="desktop-settings">
@@ -453,7 +455,7 @@ export class ToolsTab extends LitElement {
               class="tab-action-btn"
               @click=${this.handleSetDesktopCrashReportingDsn}
             >
-              <span class="codicon codicon-key"></span>
+              <wa-icon library="texra" name="key"></wa-icon>
               ${this.desktopCrashReportingConfigured
                 ? 'Replace DSN'
                 : 'Set DSN'}
@@ -523,13 +525,13 @@ export class ToolsTab extends LitElement {
           </svg>
           <div class="tools-health-labels">
             <span class="tools-summary-stat tools-stat-available">
-              <span class="codicon codicon-check"></span>
+              <wa-icon library="texra" name="check"></wa-icon>
               ${available} available
             </span>
             ${missing > 0
               ? html`
                   <span class="tools-summary-stat tools-stat-missing">
-                    <span class="codicon codicon-warning"></span>
+                    <wa-icon library="texra" name="warning"></wa-icon>
                     ${missing} need setup
                   </span>
                 `
@@ -548,7 +550,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <span class="codicon ${meta.icon}"></span>
+          <wa-icon library="texra" name=${meta.icon}></wa-icon>
           ${meta.label}
           <span class="category-count">(${items.length})</span>
         </div>
@@ -576,7 +578,7 @@ export class ToolsTab extends LitElement {
       return html`
         <div class="tools-container tab-content-container">
           <div class="tools-empty">
-            <span class="codicon codicon-loading codicon-modifier-spin"></span>
+            <wa-spinner></wa-spinner>
             Loading tool information...
           </div>
         </div>
@@ -593,7 +595,7 @@ export class ToolsTab extends LitElement {
               @click=${this.handleRecheck}
               title="Re-check tool availability"
             >
-              <span class="codicon codicon-refresh"></span>
+              <wa-icon library="texra" name="refresh"></wa-icon>
               Re-check
             </button>
           </div>


### PR DESCRIPTION
## Summary

Sweep the 16 settings webview files replacing codicon spans / classes with \`<wa-icon library=\"texra\">\` from the shared registry. Continues the cross-host icon story established by #3644.

### Files migrated (13 with markup changes)
- **tabs**: MultiAgentTab, ToolsTab.
- **components/tools**: ToolCard.
- **components/profile**: ProviderKeyModal, ModelSelectionList, ProviderKeyList, ApiAccessSection, AgentSelectionPanel.
- **components/memory**: MemoryList.
- **components/history**: HistoryItem, HistoryList.

(AgentsTab, GitTab, LaTeXTab, MemoryTab, ModelsTab had no codicon literals.)

### Mechanical sweep
- Static \`<i class=\"codicon codicon-NAME\">\` / \`<span class=\"codicon codicon-NAME\">\` → \`<wa-icon library=\"texra\" name=\"NAME\">\`. The registry's CODICON_ALIASES handles non-FA names (warning, save, discard, etc.).
- Dynamic icon class strings (\`preset.icon\`, tool category meta, agent decorator icons) → \`name=\${...stripped}\` with the \`codicon-\` prefix stripped at the call site (data values still carry the legacy \`codicon-X\` strings).
- ToolsTab's \`codicon-loading codicon-modifier-spin\` pattern → \`<wa-spinner>\`.
- \`codiconStyles\` removed from \`static styles\` arrays everywhere; CSS selectors targeting \`.codicon\` inside Lit \`static styles\` blocks retargeted to \`wa-icon\` so existing \`font-size\` rules keep applying.
- Added \`@awesome.me/webawesome/dist/components/icon/icon.js\` side-effect import to files that didn't already have it.

## Test plan

- [x] \`npm run typecheck\` — clean.
- [x] \`npx vitest run\` — 309/311 (2 pre-existing timeout failures in DesktopSettingsIpc + DesktopToolEditApproval, unrelated to settings webview).
- [x] \`grep -rn 'codicon-' packages/extension/src/settingsView/frontend/\` → only the \`name=\${preset.icon.replace('codicon-', '')}\` data-strip call (the underlying data lives in \`src/shared/schemas/agentPresets.ts\`, which would be a larger schema change).
- [ ] Visual check: settings tabs render every icon (provider key chevrons, history empty-state, model badges, tool warning/check, etc.) at correct sizes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI-only refactor swapping icon markup/styling; main risk is missing/incorrect icon names or missing side-effect imports causing icons/spinners not to render in the settings webview.
> 
> **Overview**
> Migrates settings webview UI from Codicon-based markup/styling to Web Awesome `wa-icon` across history, memory, profile, agents, git, models, LaTeX, and tools surfaces.
> 
> This removes `codiconStyles` usage, updates CSS selectors that targeted `.codicon` to target `wa-icon`, adds Web Awesome side-effect imports where needed, and replaces Codicon loading spinners with `wa-spinner` in `ToolsTab`/`LaTeXTab`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea7ca1cc8fe462e7952445d4cfa1e18e92e29f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->