### PR TITLE
prd: simplify pass — fix audit accuracy, stale refs, decided open que…

### DIFF
--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1297,14 +1297,14 @@ Three policies for those inner gates, selected by tool argument:
 
 ### 24.6 LOC
 
-| Item                                                                           | New      | Modified |
-| ------------------------------------------------------------------------------ | -------- | -------- |
-| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)    | ~120     | —        |
-| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`               | ~250     | —        |
+| Item                                                                                                     | New      | Modified |
+| -------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)                              | ~120     | —        |
+| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`                                         | ~250     | —        |
 | `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2; see `prd-logger-v2.md` Phase 5) | ~80      | —        |
-| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)             | —        | ~30      |
-| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                         | ~40      | —        |
-| **Subtotal**                                                                   | **~490** | **~30**  |
+| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)                                       | —        | ~30      |
+| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                                                   | ~40      | —        |
+| **Subtotal**                                                                                             | **~490** | **~30**  |
 
 ## 25. Hook system (Claude Code-style)
 
@@ -1606,7 +1606,7 @@ No other round-1 picks change.
 
 ## 29. Cross-platform shared structure → see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8
 
-The CLI is purely a *consumer* of the three-ring structure: imports Rings 1 + 2 + 3 from `packages/core/` plus its own deps (`commander`, `ink`, `@modelcontextprotocol/sdk`, `@clack/prompts`, `picocolors`, `log-update`, `ora`); contributes nothing into the rings (CLI-side platform adapters `ConfConfigProvider` and `KeyringSecrets` from §7.3 live in the CLI package, not Ring 3). Cross-host imports (CLI → extension, CLI → desktop) are forbidden by the same ESLint rule that scopes `vscode` / `electron` to the extension and desktop packages.
+The CLI is purely a _consumer_ of the three-ring structure: imports Rings 1 + 2 + 3 from `packages/core/` plus its own deps (`commander`, `ink`, `@modelcontextprotocol/sdk`, `@clack/prompts`, `picocolors`, `log-update`, `ora`); contributes nothing into the rings (CLI-side platform adapters `ConfConfigProvider` and `KeyringSecrets` from §7.3 live in the CLI package, not Ring 3). Cross-host imports (CLI → extension, CLI → desktop) are forbidden by the same ESLint rule that scopes `vscode` / `electron` to the extension and desktop packages.
 
 ## 30. Container & GitHub-runner target matrix
 
@@ -1664,26 +1664,26 @@ Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
 Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for the MCP-server surface. Phases 0, 2, 3, 4, 5 from round 1 keep their scope; Phase 1 absorbs §22 + §23 + §26 (all kernel-side, all on the critical path for tool-use agents).
 
-| Phase     | Round-1 scope                        | Round-2 additions                                                                  |
-| --------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
-| 0         | Workspace + headless workflow runner | + `RunContext` shim (`prd-runcontext-refactor.md` Phase 0) + Ring 1/2/3 reorg (`prd-runcontext-refactor.md` §8) |
+| Phase     | Round-1 scope                        | Round-2 additions                                                                                                                      |
+| --------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 0         | Workspace + headless workflow runner | + `RunContext` shim (`prd-runcontext-refactor.md` Phase 0) + Ring 1/2/3 reorg (`prd-runcontext-refactor.md` §8)                        |
 | 1         | Tool-use + approval engine           | + per-context coordinators (`prd-runcontext-refactor.md` Phase 1) + Logger v2 (`prd-logger-v2.md` Phases 0–1) + bash predicate (§26.3) |
-| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + Logger MCP sink (`prd-logger-v2.md` Phase 5) + integration test (§30.3) |
-| 2         | Config + secrets + auth              | unchanged                                                                          |
-| 3         | Interactive REPL                     | unchanged                                                                          |
-| 4         | GitHub Action                        | composite-action revision (§28)                                                    |
-| 5         | Polish, docs                         | + JSONL session migration (§27.5) + hook system v1 (§25.5)                         |
+| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + Logger MCP sink (`prd-logger-v2.md` Phase 5) + integration test (§30.3)                       |
+| 2         | Config + secrets + auth              | unchanged                                                                                                                              |
+| 3         | Interactive REPL                     | unchanged                                                                                                                              |
+| 4         | GitHub Action                        | composite-action revision (§28)                                                                                                        |
+| 5         | Polish, docs                         | + JSONL session migration (§27.5) + hook system v1 (§25.5)                                                                             |
 
 ### 31.2 Aggregate LOC
 
 After the §22/§23/§29 split into dedicated kernel PRDs, the CLI PRD's LOC accounting only counts CLI-package work. Kernel-side LOC is tracked in those PRDs.
 
-| Bucket                                                             | Round-1 net      | Round-2 additions (CLI-only after split)                                                                     | Round-2 total    |
-| ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- |
+| Bucket                                                             | Round-1 net      | Round-2 additions (CLI-only after split)                                                                                                                           | Round-2 total    |
+| ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
 | `packages/cli/`                                                    | 2,800–3,800      | +730 (round-2 CLI-package work: MCP §24, hooks adapter §25, session writer §27.6) + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.2) | **~3,880–4,880** |
-| `packages/core/` (CLI's _own_ pre-refactors only — C1–C8 from §14) | ~730             | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs) | **~950**         |
-| `texra-ai/texra-action` (separate repo)                            | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                  | **~500**         |
-| **Total v1 (this PRD's scope)**                                    | **~4,330–5,330** | **+~1,000**                                                                                                  | **~5,330–6,330** |
+| `packages/core/` (CLI's _own_ pre-refactors only — C1–C8 from §14) | ~730             | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs)                                                       | **~950**         |
+| `texra-ai/texra-action` (separate repo)                            | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                                                                        | **~500**         |
+| **Total v1 (this PRD's scope)**                                    | **~4,330–5,330** | **+~1,000**                                                                                                                                                        | **~5,330–6,330** |
 
 Kernel work that the CLI consumes but does not own (sized in the linked PRDs):
 

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -962,7 +962,7 @@ The single largest UI investment in the CLI.
 - Telemetry parity with extension (opt-in, anonymous).
 - **Exit criteria:** Public v1 release on npm + GitHub Releases. README quickstart works end-to-end for a new user.
 
-**Estimated timeline (single engineer):** 8–9.5 weeks (sum of phase ranges: 1.5 + 1.5–2 + 1–1.5 + 2 + 1 + 1). With a two-engineer team running Phase 1 + Phase 2 in parallel after Phase 0, achievable in 5.5–7 weeks.
+**Estimated timeline (single engineer):** 8–9 weeks (sum of phase ranges: 1.5 + 1.5–2 + 1–1.5 + 2 + 1 + 1). With a two-engineer team running Phase 1 + Phase 2 in parallel after Phase 0, achievable in 5.5–7 weeks.
 
 This is dramatically smaller than the Electron port's 11.5–13 week budget for the same reason the desktop budget shrunk after the §9 pre-refactorings landed: the kernel is already CLI-shaped. The CLI is a host shell over a host-neutral kernel.
 
@@ -1202,11 +1202,7 @@ The kernel work is sized in `prd-runcontext-refactor.md` §7 (~6.5 engineering w
 
 All four CLI-side sinks live in `packages/cli/src/render/sinks/`. `BootstrapLogger` is constructed in `cli/src/bin/texra.ts` immediately and threaded through config-load, secret resolution, agent-directory bootstrap, and mode selection — its buffer flushes through whichever sink the resolved mode picks.
 
-### 23.2 What the CLI inherits free
-
-The unification of progress events and log records into one `RunStreamEvent` union (per `prd-logger-v2.md` §6) means the CLI's round-1 §11.2 NDJSON renderer becomes a no-op: it forwards records and events through the same pipe, with the same Zod-validated schema. The session JSONL transcript (§27) uses the same union — a run's transcript is byte-equivalent to its NDJSON output (modulo the synthetic `session_start` / `session_end` markers).
-
-### 23.3 LOC accounting (CLI side only)
+### 23.2 LOC accounting (CLI side only)
 
 | Item                                                                             | New      |
 | -------------------------------------------------------------------------------- | -------- |
@@ -1291,9 +1287,9 @@ Three policies for those inner gates, selected by tool argument:
 - Three tools above.
 - `notifications/progress` streaming.
 - Cancellation via `notifications/cancelled`.
-- Session isolation **only** to the extent the §22.5 v1.0 migration achieves it (per-context coordinators). One concurrent run per process; concurrent calls serialize. Documented limitation.
+- Session isolation **only** to the extent `prd-runcontext-refactor.md` Phase 1 achieves it (per-context coordinators). One concurrent run per process; concurrent calls serialize. Documented limitation.
 
-**v1.1 ships (gated on §22.5 v1.1 migration):**
+**v1.1 ships (gated on `prd-runcontext-refactor.md` Phase 2 — singleton retirement):**
 
 - True concurrent sessions in one MCP-server process. The audit's singleton-retirement work removes the leak risk.
 - Optional MCP `resources` surface exposing `~/.texra/projects/<hash>/<sessionId>.jsonl` (§27) for transcript replay.
@@ -1305,7 +1301,7 @@ Three policies for those inner gates, selected by tool argument:
 | ------------------------------------------------------------------------------ | -------- | -------- |
 | `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)    | ~120     | —        |
 | `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`               | ~250     | —        |
-| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80      | —        |
+| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2; see `prd-logger-v2.md` Phase 5) | ~80      | —        |
 | `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)             | —        | ~30      |
 | `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                         | ~40      | —        |
 | **Subtotal**                                                                   | **~490** | **~30**  |
@@ -1479,7 +1475,7 @@ Match Claude Code's pattern, with TeXRA's run/stream lineage:
 
 ### 27.3 What's in the JSONL
 
-Each line is exactly one `LogRecord ∪ ProgressEventPayloads` from §23.4. The first line is a synthetic `event: "session_start"` carrying the `AgentConfigPayload`, the resolved model, the workspace root, and the approval policy. The last line is `event: "session_end"` with `AgentFlowResult`. Everything between is the round-1 §11.2 NDJSON event stream as it happened, with timestamps preserved.
+Each line is exactly one `RunStreamEvent` from `prd-logger-v2.md` §6 (the union of `LogRecord` and `ProgressEventPayloads`). The first line is a synthetic `event: "session_start"` carrying the `AgentConfigPayload`, the resolved model, the workspace root, and the approval policy. The last line is `event: "session_end"` with `AgentFlowResult`. Everything between is the round-1 §11.2 NDJSON event stream as it happened, with timestamps preserved.
 
 This gives us several wins for free:
 
@@ -1610,19 +1606,7 @@ No other round-1 picks change.
 
 ## 29. Cross-platform shared structure → see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8
 
-§29 has been promoted into [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8 (three-ring kernel structure). The CLI-specific implications stay here:
-
-### 29.1 What the CLI is allowed to import
-
-Per the rule — "the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is" — the CLI's `packages/cli/src/` can import Rings 1 + 2 + 3 from `packages/core/`, plus `commander`, `ink`, `@modelcontextprotocol/sdk`, `@clack/prompts`, `picocolors`, `log-update`, `ora`. Cross-host imports (CLI → extension, CLI → desktop) are forbidden by the same ESLint rule.
-
-### 29.2 What the CLI ships in each ring
-
-- **No Ring 1 contributions** — the CLI is a host shell, not a logic library.
-- **No Ring 2 contributions** — runtime orchestration lives in core.
-- **No Ring 3 contributions** — the CLI uses the existing Node defaults (`consoleLog`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `memoryState`) plus the two CLI-side platform adapters from §7.3 (`ConfConfigProvider`, `KeyringSecrets`). The latter are CLI-package code, not Ring 3 code.
-
-The CLI is purely a _consumer_ of the three-ring structure. The benefits accrue at the kernel boundary: a future Tauri or daemon host imports the rings and ships only their own host package.
+The CLI is purely a *consumer* of the three-ring structure: imports Rings 1 + 2 + 3 from `packages/core/` plus its own deps (`commander`, `ink`, `@modelcontextprotocol/sdk`, `@clack/prompts`, `picocolors`, `log-update`, `ora`); contributes nothing into the rings (CLI-side platform adapters `ConfConfigProvider` and `KeyringSecrets` from §7.3 live in the CLI package, not Ring 3). Cross-host imports (CLI → extension, CLI → desktop) are forbidden by the same ESLint rule that scopes `vscode` / `electron` to the extension and desktop packages.
 
 ## 30. Container & GitHub-runner target matrix
 
@@ -1682,9 +1666,9 @@ Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for th
 
 | Phase     | Round-1 scope                        | Round-2 additions                                                                  |
 | --------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
-| 0         | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29)                         |
-| 1         | Tool-use + approval engine           | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
-| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3)                  |
+| 0         | Workspace + headless workflow runner | + `RunContext` shim (`prd-runcontext-refactor.md` Phase 0) + Ring 1/2/3 reorg (`prd-runcontext-refactor.md` §8) |
+| 1         | Tool-use + approval engine           | + per-context coordinators (`prd-runcontext-refactor.md` Phase 1) + Logger v2 (`prd-logger-v2.md` Phases 0–1) + bash predicate (§26.3) |
+| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + Logger MCP sink (`prd-logger-v2.md` Phase 5) + integration test (§30.3) |
 | 2         | Config + secrets + auth              | unchanged                                                                          |
 | 3         | Interactive REPL                     | unchanged                                                                          |
 | 4         | GitHub Action                        | composite-action revision (§28)                                                    |
@@ -1696,7 +1680,7 @@ After the §22/§23/§29 split into dedicated kernel PRDs, the CLI PRD's LOC acc
 
 | Bucket                                                             | Round-1 net      | Round-2 additions (CLI-only after split)                                                                     | Round-2 total    |
 | ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- |
-| `packages/cli/`                                                    | 2,800–3,800      | +730 + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.3)                        | **~3,880–4,880** |
+| `packages/cli/`                                                    | 2,800–3,800      | +730 (round-2 CLI-package work: MCP §24, hooks adapter §25, session writer §27.6) + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.2) | **~3,880–4,880** |
 | `packages/core/` (CLI's _own_ pre-refactors only — C1–C8 from §14) | ~730             | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs) | **~950**         |
 | `texra-ai/texra-action` (separate repo)                            | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                  | **~500**         |
 | **Total v1 (this PRD's scope)**                                    | **~4,330–5,330** | **+~1,000**                                                                                                  | **~5,330–6,330** |

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -41,7 +41,7 @@ The total kernel work is ~430 LOC new + ~130 LOC modified + ~5 LOC deleted. None
 
 ### 4.1 Module-level state collides under concurrency
 
-`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The general concurrency case for retiring this kind of binding is in `prd-runcontext-refactor.md` §4.5 (and `setOutputChannelFactory` is one of the 19 setter pairs in that PRD's §4.2 table). Logger-specific consequence: the `setOutputChannelFactory(null)` reset in test teardown calls `dispose?.()` on every cached channel and disposes channels for *other* concurrent runs — visible today only as occasional vitest flakes; visible always in an MCP-server or re-entrant-SDK process.
+`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The general concurrency case for retiring this kind of binding is in `prd-runcontext-refactor.md` §4.5 (and `setOutputChannelFactory` is one of the 19 setter pairs in that PRD's §4.2 table). Logger-specific consequence: the `setOutputChannelFactory(null)` reset in test teardown calls `dispose?.()` on every cached channel and disposes channels for _other_ concurrent runs — visible today only as occasional vitest flakes; visible always in an MCP-server or re-entrant-SDK process.
 
 ### 4.2 Two ALS scopes that shadow each other
 

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -8,7 +8,7 @@
 
 ## 1. Summary
 
-Today's logger (`src/logger/logUtils.ts`) is a serviceable VS Code-shaped string sink. It is also wrong for the CLI in three concrete ways and wrong for the future MCP-server / re-entrant SDK / `texra serve` daemon in five. This PRD specifies a host-neutral structured logger that:
+Today's logger (`src/logger/logUtils.ts`) is a serviceable VS Code-shaped string sink. It is also wrong for the CLI in three concrete ways (enumerated in §4) — module-level state that collides under concurrency, a second ALS scope that shadows the runtime host's scope, and a per-line config lookup that's silently ignored during boot — plus one duplication issue with the round-1 CLI NDJSON pipeline. This PRD specifies a host-neutral structured logger that:
 
 - Emits **`LogRecord`s** (timestamp + level + message + structured fields + group stack), not pre-formatted strings.
 - Routes every record through a per-host **`LogSink`** (extension → `vscode.OutputChannel`, desktop → `electron-log`, CLI text → stderr, CLI JSON → stdout NDJSON, CLI MCP → MCP `notifications/progress`, tests → in-memory).
@@ -41,11 +41,7 @@ The total kernel work is ~430 LOC new + ~130 LOC modified + ~5 LOC deleted. None
 
 ### 4.1 Module-level state collides under concurrency
 
-`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The audit (per `prd-runcontext-refactor.md` §4) finds exactly one setter in production code (`packages/extension/src/extension.ts`), but:
-
-- Tests have to `setOutputChannelFactory(null)` in `afterEach`, which calls `dispose?.()` on every cached channel. With concurrent vitest runs in the same process this disposes channels for _other_ tests' runs.
-- An MCP-server mode that hosts concurrent runs cannot share these channels — two `tools/call`s want two distinct sinks.
-- A re-entrant SDK has the same problem.
+`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The general concurrency case for retiring this kind of binding is in `prd-runcontext-refactor.md` §4.5 (and `setOutputChannelFactory` is one of the 19 setter pairs in that PRD's §4.2 table). Logger-specific consequence: the `setOutputChannelFactory(null)` reset in test teardown calls `dispose?.()` on every cached channel and disposes channels for *other* concurrent runs — visible today only as occasional vitest flakes; visible always in an MCP-server or re-entrant-SDK process.
 
 ### 4.2 Two ALS scopes that shadow each other
 
@@ -320,15 +316,18 @@ Net code: **~+310 LOC** (the new structured pipeline is bigger than the string-b
 - An MCP client receives `notifications/progress` for every log emitted inside a `tools/call` (Phase 5 integration test).
 - Boot-time log lines from `texra` show up _with_ their structured fields in the final rendered output, not before init drops them.
 
-## 13. Open questions
+## 13. Decisions
 
-- **Should `LogSink.write` be sync or async?** Today's logger is sync. Async would let sinks batch (e.g., NDJSON write coalescing), but every kernel emit site assumes sync. Lean: keep sync; sinks that need async use a queue + `flush?()`.
+- **`LogSink.write` is sync; sinks that need async batching wrap their own queue and flush via `flush?()`.** Every kernel emit site assumes sync.
+- **The extension's per-agent OutputChannel pattern is preserved** — implemented as a `VscodeOutputChannelSink` configuration option, not a kernel-level concept. Other hosts opt out.
+
+## 14. Open questions
+
 - **Should `BootstrapLogger` be exposed as a public API for SDK consumers?** Some users may want to capture pre-init logs from `runAgent()`. Lean: yes; export from `@texra/cli/sdk` once the SDK lands.
 - **Schema versioning policy: per-record `schemaVersion` field, or repo-version pinning?** Per-record is robust to in-flight upgrades but bloats every line by ~20 bytes. Lean: repo-version pinning; consumers verify `@texra/shared/schemas` major matches.
-- **Should the extension's per-agent output channel pattern survive?** It's a UX choice (filtering to one agent's logs) that doesn't translate to other hosts. Lean: keep it as a `VscodeOutputChannelSink` configuration option, not a kernel concept.
 - **Do we need a `trace` level below `debug`?** Today's vocabulary stops at `debug`. OTel uses `trace`. Lean: not yet — add when a consumer asks.
 
-## 14. Tech stack one-liner
+## 15. Tech stack one-liner
 
 ```
 LogRecord (structured) + LogSink (host port) + BootstrapLogger (pre-init buffer)

--- a/prds/prd-runcontext-refactor.md
+++ b/prds/prd-runcontext-refactor.md
@@ -8,13 +8,13 @@
 
 ## 1. Summary
 
-The TeXRA agent runtime today reaches host services through two ALS scopes plus ~20 module-level `let X | undefined` setter pairs and three exported singleton coordinators. That ambient-state model is fine for the VS Code extension (one process, one user, one runtime host) but leaks under three workloads the next 12 months will bring:
+The TeXRA agent runtime today reaches host services through two ALS scopes plus 19 module-level `let X | undefined` setter pairs and three exported singleton coordinators. That ambient-state model is fine for the VS Code extension (one process, one user, one runtime host) but leaks under three workloads the next 12 months will bring:
 
 - The **CLI's `texra mcp serve`** mode, which must host N concurrent sessions per process (one per MCP `tools/call`).
 - A **re-entrant SDK** — multiple `Promise.all([runAgent(...), runAgent(...)])` calls from a single Node process.
 - An eventual **`texra serve` daemon** or **embedded library** that runs many users' workloads in one process.
 
-This PRD specifies the refactor: a single explicit `RunContext` value carrying every per-run service (progress sink, logger, abort signal, approval policy, coordinators, capabilities), threaded through the kernel call graph; one ALS scope at the outermost entry point as a migration ergonomics shim; and a phased deletion of the ~20 singleton bindings the audit names. It also specifies the three-ring layering of `packages/core/` that this work makes legible.
+This PRD specifies the refactor: a single explicit `RunContext` value carrying every per-run service (progress sink, logger, abort signal, approval policy, coordinators, capabilities), threaded through the kernel call graph; one ALS scope at the outermost entry point as a migration ergonomics shim; and a phased deletion of the 19 singleton bindings the audit names. It also specifies the three-ring layering of `packages/core/` that this work makes legible.
 
 The kernel migration is independently valuable to all three hosts (extension, desktop, CLI) and does not gate any v1 CLI deliverable except `texra mcp serve` v1.1 (true session concurrency).
 
@@ -45,7 +45,7 @@ A May 2026 audit of `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/event
 | `runtimeHostScope` | `src/agent/runtime/AgentRuntimeHost.ts:12` | Current `AgentRuntimeHost` (≡ `ProgressSink`)       | `runWithAgentRuntimeHost(host, fn)` (line 27) | `getAgentRuntimeHost()` (line 23) — falls back to `defaultAgentRuntimeHost` (line 11), then `getDefaultProgressSink()` |
 | `contextStorage`   | `src/logger/logUtils.ts:10`                | `Map<channel-key, group-id stack>` for log grouping | `runWithGroupContext()` (line 130)            | `getActiveGroupStack()` (line 63), `runWithGroupContext` (line 136)                                                    |
 
-### 4.2 Module-level setter/getter pairs (~12 in audit, plus the 8 the controllers list)
+### 4.2 Module-level setter/getter pairs (19)
 
 | Concern                         | Setter                            | File:line                                       |
 | ------------------------------- | --------------------------------- | ----------------------------------------------- |
@@ -53,14 +53,23 @@ A May 2026 audit of `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/event
 | Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`      |
 | Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`     |
 | Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113` |
-| Latex-preview handler           | `setLatexBuildDisplay`            | `src/tools/approval/latexPreview.ts:21`         |
+| Latex build-display handler     | `setOpenBuildDisplay`             | `src/tools/approval/latexPreview.ts:22,24`      |
 | GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`             |
 | Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`              |
+| Linter provider                 | `setLinterProvider`               | `src/tools/DiagnosticsTool.ts:10,12`            |
+| Lean VS Code services           | `setLeanVscodeServices`           | `src/tools/lean/leanVscodeServices.ts:45,47`    |
+| Setup platform                  | `setSetupPlatform`                | `src/tools/setup/platform.ts:108,111`           |
+| Tool-unavailable notification   | `setToolNotificationHandler`      | `src/tools/toolUnavailableNotification.ts:21,28` |
+| Worktree support flag           | `setWorktreeSupportEnabled`       | `src/tools/worktreeConfig.ts:12,14`             |
 | Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`               |
 | Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                     |
 | Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                        |
 | Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                        |
 | Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                    |
+| Default stream-log store        | `setDefaultStreamLogStore`        | `src/logger/StreamLogStore.ts:668,675`          |
+| Agent directories               | `setAgentDirectories`             | `src/agent/index/agentDirectoriesRegistry.ts:8,11` |
+
+Counted via `git grep "^export function set[A-Z]" packages/core/src/{agent,tools,auth,logger,eventBus}/` against the v1 audit cutoff. The list is exhaustive within those zones; categories outside (e.g. `src/extension/`) are intentionally excluded.
 
 ### 4.3 Exported singleton coordinators (3)
 
@@ -98,8 +107,6 @@ export interface RunContext {
   readonly runId: RunId;
   /** Stream tab id within the run (one per agent activation). */
   readonly streamId: StreamTabId;
-  /** Lineage from the user-initiated root, useful for log prefixes. */
-  readonly streamLineage: readonly StreamTabId[];
 
   /** Where progress events go. Replaces `getAgentRuntimeHost()`. */
   readonly progress: ProgressSink;
@@ -118,13 +125,11 @@ export interface RunContext {
   /** Runtime-resolved capabilities. Replaces setExtensionChecker, setGitHubTokenProvider, … */
   readonly capabilities: RunCapabilities;
 
-  /** Coordinators bound to this run's progress sink. Replaces exported singletons. */
+  /** Coordinators bound to this run's progress sink. Replaces the three exported singletons in §4.3. */
   readonly coordinators: {
     plan: PlanApprovalCoordinator;
     proposal: AgentProposalCoordinator;
     retry: RetryRequestCoordinator;
-    edit: ToolEditApprovalController;
-    bash: BashApprovalController;
   };
 
   /** Spawn a child context for a delegate_agent / delegate_workflow subagent. */
@@ -146,7 +151,7 @@ export interface ChildContextOptions {
 }
 ```
 
-`buildAgentLaunchContext()` in `executeAgent.ts:166` already constructs almost all of this; the refactor is to (a) lift it to the kernel boundary so it's the only entry point that matters, (b) rename it `buildRunContext()`, and (c) pass the result explicitly into every coordinator method that today reads from a singleton.
+`buildAgentLaunchContext()` in `executeAgent.ts:583` already constructs almost all of this; the refactor is to (a) lift it to the kernel boundary so it's the only entry point that matters, (b) rename it `buildRunContext()`, and (c) pass the result explicitly into every coordinator method that today reads from a singleton.
 
 ## 6. Migration shim — one ALS, gradual cutover
 
@@ -237,7 +242,7 @@ Each phase is independently mergeable and ships a concrete kernel improvement.
 | 3         | 4 capability setters                                                  | `tools/{approval,github,externalToolDefs}/*`                                   | +60 / -110      | 1                 |
 | 4         | 4 auth singletons + extension-id setter                               | `auth/*`                                                                       | +80 / -130      | 1                 |
 | 5         | (sweep)                                                               | `executionRegistry.ts` + lint rule cleanups                                    | +20 / -30       | 0.5               |
-| **Total** | **~14 ambient bindings + 3 coordinators**                             |                                                                                | **+460 / -470** | **~6.5**          |
+| **Total** | **19 ambient bindings + 3 coordinators**                             |                                                                                | **+460 / -470** | **~6.5**          |
 
 Net code change: **~-10 LOC** (the refactor pays for itself in deleted boilerplate). The CLI consumes Phase 1 deliverables for v1.0 and Phase 2 for v1.1; the extension and desktop benefit from every phase but don't gate on them.
 
@@ -324,20 +329,23 @@ A flat-config rule that the host of each package can import only the rings it ca
 - The three-ring ESLint rule has zero exceptions in `packages/core/src/agent/`, `core/tools/`, `core/auth/` after Phase 5.
 - A new "synthetic host" package (~80 LOC scaffold, used in tests and as a reference) imports Rings 1+2+3 and runs `executeAgent('polish', …)` end-to-end.
 
-## 11. Open questions
+## 11. Decisions
 
-- **Should `RunContext.workspaceRoot` be a string or a `WorkspaceProvider`?** Today's `WorkspaceProvider` is platform-level (one per process); `workspaceRoot` is per-run. The CLI's `--cwd` flag needs to override per-run; the extension's multi-root workspace also wants per-run. Lean: keep it a string, derive from `WorkspaceProvider` at context-build time, override-aware.
+- **`RunContext.workspaceRoot` is a `string`** — derived from `WorkspaceProvider` at context-build time, overridable per-run by the CLI's `--cwd` flag and by per-root invocations from the extension's multi-root workspace.
+- **Singleton retirement lands before the kernel package split** — fewer reader sites that depend on module-load order across packages.
+- **`ctx.signal` is the canonical run-cancel; modelHandler `signal` params take precedence when explicitly passed.** Today every modelHandler accepts an explicit `signal` parameter from `ExecuteAgentOptions`; the two compose, not collide.
+
+## 12. Open questions
+
 - **Should `RunCapabilities` be open or closed?** Open (free-form `{ [k]: unknown }` plus typed accessors) is more future-proof; closed is type-safer. Lean: closed for v1, open for v2 if external plugins ever ship.
 - **Is `child()` enough for delegate semantics, or do we need a dedicated `delegationContext` field?** Today's delegate flow recursively calls `executeAgent` with new options; the recursion is handled at the call site, not in the context. Lean: keep `child()` only; don't add a delegation field until a concrete reader needs it.
-- **Should the singleton retirement land before or after the kernel package split (`packages/core/`)?** Lean: before. Singleton retirement makes the package split safer (fewer reader sites that depend on module-load order across packages).
-- **Should `ctx.signal` chain into modelHandler-level abort signals automatically?** Today every modelHandler accepts an explicit `signal` parameter from `ExecuteAgentOptions`. Lean: keep both — `ctx.signal` is the canonical run-cancel; modelHandler params take precedence when explicitly passed.
 
-## 12. Tech stack one-liner
+## 13. Tech stack one-liner
 
 ```
 Single AsyncLocalStorage + RunContext threaded explicitly through the kernel call graph
 - packages/core/src/runtime/runContext.ts as the only allowed scope
-- Phased deletion of ~14 module-level setter pairs and 3 singleton coordinators
+- Phased deletion of 19 module-level setter pairs and 3 singleton coordinators
 - Three concentric rings under packages/core/ (pure logic / runtime / platform defaults)
 - ESLint rule no-ambient-runtime-state guards the agnostic zones
 - Independently mergeable phases; CLI v1.0 consumes Phase 1, v1.1 consumes Phase 2

--- a/prds/prd-runcontext-refactor.md
+++ b/prds/prd-runcontext-refactor.md
@@ -47,26 +47,26 @@ A May 2026 audit of `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/event
 
 ### 4.2 Module-level setter/getter pairs (19)
 
-| Concern                         | Setter                            | File:line                                       |
-| ------------------------------- | --------------------------------- | ----------------------------------------------- |
-| Default progress sink           | `setDefaultProgressSink`          | `src/agent/runtime/ProgressSink.ts:14`          |
-| Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`      |
-| Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`     |
-| Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113` |
-| Latex build-display handler     | `setOpenBuildDisplay`             | `src/tools/approval/latexPreview.ts:22,24`      |
-| GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`             |
-| Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`              |
-| Linter provider                 | `setLinterProvider`               | `src/tools/DiagnosticsTool.ts:10,12`            |
-| Lean VS Code services           | `setLeanVscodeServices`           | `src/tools/lean/leanVscodeServices.ts:45,47`    |
-| Setup platform                  | `setSetupPlatform`                | `src/tools/setup/platform.ts:108,111`           |
-| Tool-unavailable notification   | `setToolNotificationHandler`      | `src/tools/toolUnavailableNotification.ts:21,28` |
-| Worktree support flag           | `setWorktreeSupportEnabled`       | `src/tools/worktreeConfig.ts:12,14`             |
-| Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`               |
-| Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                     |
-| Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                        |
-| Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                        |
-| Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                    |
-| Default stream-log store        | `setDefaultStreamLogStore`        | `src/logger/StreamLogStore.ts:668,675`          |
+| Concern                         | Setter                            | File:line                                          |
+| ------------------------------- | --------------------------------- | -------------------------------------------------- |
+| Default progress sink           | `setDefaultProgressSink`          | `src/agent/runtime/ProgressSink.ts:14`             |
+| Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`         |
+| Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`        |
+| Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113`    |
+| Latex build-display handler     | `setOpenBuildDisplay`             | `src/tools/approval/latexPreview.ts:22,24`         |
+| GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`                |
+| Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`                 |
+| Linter provider                 | `setLinterProvider`               | `src/tools/DiagnosticsTool.ts:10,12`               |
+| Lean VS Code services           | `setLeanVscodeServices`           | `src/tools/lean/leanVscodeServices.ts:45,47`       |
+| Setup platform                  | `setSetupPlatform`                | `src/tools/setup/platform.ts:108,111`              |
+| Tool-unavailable notification   | `setToolNotificationHandler`      | `src/tools/toolUnavailableNotification.ts:21,28`   |
+| Worktree support flag           | `setWorktreeSupportEnabled`       | `src/tools/worktreeConfig.ts:12,14`                |
+| Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`                  |
+| Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                        |
+| Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                           |
+| Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                           |
+| Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                       |
+| Default stream-log store        | `setDefaultStreamLogStore`        | `src/logger/StreamLogStore.ts:668,675`             |
 | Agent directories               | `setAgentDirectories`             | `src/agent/index/agentDirectoriesRegistry.ts:8,11` |
 
 Counted via `git grep "^export function set[A-Z]" packages/core/src/{agent,tools,auth,logger,eventBus}/` against the v1 audit cutoff. The list is exhaustive within those zones; categories outside (e.g. `src/extension/`) are intentionally excluded.
@@ -242,7 +242,7 @@ Each phase is independently mergeable and ships a concrete kernel improvement.
 | 3         | 4 capability setters                                                  | `tools/{approval,github,externalToolDefs}/*`                                   | +60 / -110      | 1                 |
 | 4         | 4 auth singletons + extension-id setter                               | `auth/*`                                                                       | +80 / -130      | 1                 |
 | 5         | (sweep)                                                               | `executionRegistry.ts` + lint rule cleanups                                    | +20 / -30       | 0.5               |
-| **Total** | **19 ambient bindings + 3 coordinators**                             |                                                                                | **+460 / -470** | **~6.5**          |
+| **Total** | **19 ambient bindings + 3 coordinators**                              |                                                                                | **+460 / -470** | **~6.5**          |
 
 Net code change: **~-10 LOC** (the refactor pays for itself in deleted boilerplate). The CLI consumes Phase 1 deliverables for v1.0 and Phase 2 for v1.1; the extension and desktop benefit from every phase but don't gate on them.
 


### PR DESCRIPTION
…stions

Aggregated findings from a /simplify pass with three parallel review agents (content reuse, quality, factual reconsideration vs latest main):

prd-runcontext-refactor.md
- §4.2: Correct setLatexBuildDisplay (line 21) → setOpenBuildDisplay (lines 22, 24). Add 7 missing setter pairs the audit missed: setLinterProvider, setLeanVscodeServices, setSetupPlatform, setToolNotificationHandler, setWorktreeSupportEnabled, setDefaultStreamLogStore, setAgentDirectories. Reconcile binding count: 12 → 19 across §1, §4.2, §7, §13.
- §4.2: Add a counting-method footnote ("git grep ^export function set[A-Z] across packages/core/src/{agent,tools,auth,logger,eventBus}").
- §5: Drop unjustified RunContext fields (streamLineage, coordinators. edit, coordinators.bash) — only plan/proposal/retry coordinators are in §4.3's retired-singleton list. Fix buildAgentLaunchContext line 166 → 583.
- §11 → §11+§12: Promote 3 already-decided open questions (workspaceRoot type, retirement-vs-package-split order, ctx.signal chaining) to a Decisions section; keep 2 genuinely-open questions.

prd-logger-v2.md
- §1: Drop unsupported "wrong in three concrete ways and in five" claim — §4 enumerates exactly three defects plus one duplication.
- §4.1: Tighten module-state motivation to reference RunContext PRD §4.5 rather than re-deriving the concurrency case.
- §13 → §13+§14: Promote 2 decided open questions (sync write, per-agent OutputChannel preservation) to Decisions; keep 3 open.

prd-cli-app.md
- §15: Phase-week sum 1.5 + 1.5–2 + 1–1.5 + 2 + 1 + 1 = 8–9 weeks (was incorrectly 8–9.5).
- §24.5, §31.1: Stale §22.5/§22.6 refs (split into kernel PRDs) → "prd-runcontext-refactor.md Phase 1/Phase 2".
- §27.3: Stale §23.4 ref → "prd-logger-v2.md §6".
- §23: Delete §23.2 narrative (byte-equivalent NDJSON claim duplicated Logger §6 + §27); §23.3 renumbered to §23.2.
- §29: Compress to one paragraph (CLI is purely a ring consumer).
- §31.2: Label the "+730" round-2 CLI-package work explicitly (MCP §24 + hooks adapter §25 + session writer §27.6) so the row doesn't read as a copy-paste of round-1 §19.1's core number.

Skipped (not worth churn): compressing §22.1/§23.1 stubs further (they add CLI-specific value); restructuring §31.1's phase mapping (small contradictions but not factually wrong); ApprovalPolicy constant cross-link (cosmetic).

Net: +45 / -54 lines across the three PRDs. No semantic content removed; fixes are factual corrections + duplication cleanup.

https://claude.ai/code/session_017pa2sVWiofqS6iP75MxsmT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to PRD markdown (no runtime code changes); main risk is only that updated counts/links could still be inconsistent and mislead planning.
> 
> **Overview**
> Updates the CLI, `RunContext`, and Logger v2 PRDs to **correct audit accuracy and remove stale/duplicated spec text**.
> 
> `prd-runcontext-refactor.md` fixes the ambient-binding inventory (12→19), corrects a misnamed setter (`setOpenBuildDisplay`), drops unjustified `RunContext` fields, and promotes several previously “open questions” into a **Decisions** section.
> 
> `prd-logger-v2.md` tightens the problem statement to match the enumerated defects, references the RunContext PRD for the concurrency rationale, and similarly converts decided items into **Decisions**.
> 
> `prd-cli-app.md` refreshes references to the extracted kernel PRDs/phases, clarifies the unified `RunStreamEvent` transcript wording, compresses the ring-structure section, removes duplicated narrative, and fixes minor planning/accounting text (timeline and LOC tables).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d2f2413d6d4f47ed51983457f42fe24ffbb49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->