### PR TITLE
feat(webview): migrate FileSelectGroup form controls to Web Awesome

### DIFF
--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -5,6 +5,12 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+
 import { SortableController } from '@shared/controllers';
 import { designTokens, codiconStyles } from '@shared/styles';
 import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
@@ -157,8 +163,9 @@ export class FileSelectGroup extends LitElement {
   }
 
   private handleSelectChange(event: Event): void {
-    const target = event.currentTarget as HTMLSelectElement | null;
-    this.handleFileChange(target?.value ?? '');
+    const target = event.currentTarget as WaSelect | null;
+    const value = target?.value;
+    this.handleFileChange(typeof value === 'string' ? value : '');
   }
 
   private handleFocus(): void {
@@ -242,20 +249,11 @@ export class FileSelectGroup extends LitElement {
       a.localeCompare(b),
     );
     return html`
-      <vscode-option value="" ?selected=${this.currentSelectedValue === ''}
-        >None</vscode-option
-      >
+      <wa-option value="">None</wa-option>
       ${repeat(
         sortedOptions,
         (opt) => opt,
-        (opt) => html`
-          <vscode-option
-            value=${opt}
-            ?selected=${opt === this.currentSelectedValue}
-          >
-            ${opt}
-          </vscode-option>
-        `,
+        (opt) => html` <wa-option value=${opt}>${opt}</wa-option> `,
       )}
     `;
   }
@@ -289,30 +287,30 @@ export class FileSelectGroup extends LitElement {
           ?show=${this.toolConfigMenuOpen}
         >
           <div class="dropdown-menu-content">
-            <vscode-checkbox
+            <wa-checkbox
               id="attachTeXCount"
               ?checked=${this.currentCheckboxValues.attachTeXCount}
               ?disabled=${this.isFileInputDisabled}
               @change=${(event: Event) =>
                 this.handleCheckboxChange(
                   'attachTeXCount',
-                  (event.target as HTMLInputElement).checked,
+                  (event.target as WaCheckbox).checked,
                 )}
             >
               Attach TeX Count
-            </vscode-checkbox>
-            <vscode-checkbox
+            </wa-checkbox>
+            <wa-checkbox
               id="attachDiagnostics"
               ?checked=${this.currentCheckboxValues.attachDiagnostics}
               ?disabled=${this.isFileInputDisabled}
               @change=${(event: Event) =>
                 this.handleCheckboxChange(
                   'attachDiagnostics',
-                  (event.target as HTMLInputElement).checked,
+                  (event.target as WaCheckbox).checked,
                 )}
             >
               Attach Diagnostics
-            </vscode-checkbox>
+            </wa-checkbox>
           </div>
         </vscode-context-menu>
       </div>
@@ -349,39 +347,39 @@ export class FileSelectGroup extends LitElement {
           ?show=${this.autoExtractMenuOpen}
         >
           <div class="dropdown-menu-content">
-            <vscode-checkbox
+            <wa-checkbox
               id="autoExtractFigure"
               ?checked=${this.currentCheckboxValues.autoExtractFigure}
               @change=${(event: Event) =>
                 this.handleCheckboxChange(
                   'autoExtractFigure',
-                  (event.target as HTMLInputElement).checked,
+                  (event.target as WaCheckbox).checked,
                 )}
             >
               Figures
-            </vscode-checkbox>
-            <vscode-checkbox
+            </wa-checkbox>
+            <wa-checkbox
               id="autoExtractTikzFigure"
               ?checked=${this.currentCheckboxValues.autoExtractTikzFigure}
               @change=${(event: Event) =>
                 this.handleCheckboxChange(
                   'autoExtractTikzFigure',
-                  (event.target as HTMLInputElement).checked,
+                  (event.target as WaCheckbox).checked,
                 )}
             >
               TikZ Figures
-            </vscode-checkbox>
-            <vscode-checkbox
+            </wa-checkbox>
+            <wa-checkbox
               id="autoCompileInputPdf"
               ?checked=${this.currentCheckboxValues.autoCompileInputPdf}
               @change=${(event: Event) =>
                 this.handleCheckboxChange(
                   'autoCompileInputPdf',
-                  (event.target as HTMLInputElement).checked,
+                  (event.target as WaCheckbox).checked,
                 )}
             >
               Compile Input PDF
-            </vscode-checkbox>
+            </wa-checkbox>
           </div>
         </vscode-context-menu>
       </div>
@@ -536,14 +534,14 @@ export class FileSelectGroup extends LitElement {
             ></vscode-toolbar-button>
           </vscode-toolbar-container>
         </div>
-        <vscode-single-select
+        <wa-select
           id=${this.selectId}
           .value=${this.currentSelectedValue}
           @focus=${this.handleFocus}
           @change=${this.handleSelectChange}
         >
           ${this.renderFileOptions()}
-        </vscode-single-select>
+        </wa-select>
         ${when(
           this.currentListVisible,
           () => html`

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -60,7 +60,7 @@ export const fileSelectLayoutStyles = css`
     opacity: var(--opacity-full);
   }
 
-  .file-select-label-group vscode-textfield {
+  .file-select-label-group wa-input {
     flex: 1;
     min-width: 0;
     margin: 0;
@@ -96,7 +96,7 @@ export const fileSelectLayoutStyles = css`
   }
 
   .file-select select,
-  .file-select vscode-single-select {
+  .file-select wa-select {
     width: 100%;
   }
 
@@ -289,7 +289,7 @@ export const dropdownStyles = css`
     padding: var(--spacing-tiny);
   }
 
-  .dropdown-container .dropdown-menu vscode-checkbox {
+  .dropdown-container .dropdown-menu wa-checkbox {
     display: flex;
     align-items: center;
     height: 20px;
@@ -297,11 +297,11 @@ export const dropdownStyles = css`
     font-size: var(--font-size-sm);
   }
 
-  .dropdown-container .dropdown-menu vscode-checkbox {
+  .dropdown-container .dropdown-menu wa-checkbox {
     transition: background-color var(--transition-fast);
   }
 
-  .dropdown-container .dropdown-menu vscode-checkbox:hover {
+  .dropdown-container .dropdown-menu wa-checkbox:hover {
     background: var(--texra-list-hoverBackground);
   }
 `;


### PR DESCRIPTION
## Summary
- Migrate `FileSelectGroup`'s `<vscode-checkbox>` (5 instances) to `<wa-checkbox>` and `<vscode-single-select>` (with `<vscode-option>` children) to `<wa-select>` / `<wa-option>`. The component does not use `selectTemplates`, so the select migration is in-scope.
- Retarget shared `fileSelectStyles` selectors from `vscode-checkbox`, `vscode-textfield`, `vscode-single-select` to their Web Awesome counterparts (`wa-checkbox`, `wa-input`, `wa-select`).
- Add side-effect imports for the WA components and switch checkbox `event.target` casts from `HTMLInputElement` to the `WaCheckbox` type; select handler now uses `WaSelect`.

## Behavior swaps
- `wa-checkbox` emits `change` (same as native) and exposes `.checked` -> handlers preserved 1:1.
- `wa-select` emits `change` and exposes `.value` (string in single-select) -> handler narrows non-string to `''` for safety.
- `wa-option` replaces `vscode-option`; the `?selected` attribute is no longer needed because `wa-select` reflects selection from its bound `.value`.
- `<vscode-textfield>` is not actually rendered by `FileSelectGroup`, but the leftover style selector is updated to `wa-input` for the shared rule that other consumers may use later.

## Test plan
- [x] `npm run typecheck` (passes)
- [x] `npx vitest run` (311/311)
- [ ] Manual smoke: open input/reference/auxiliary/media file selectors, toggle Tool Config and Auto-Extract menus, confirm checkbox state persists and the file dropdown still posts `fileChange` events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps underlying web components; main risk is subtle behavior/styling differences in `wa-select`/`wa-checkbox` change events and value/checked bindings.
> 
> **Overview**
> Migrates `FileSelectGroup` form controls from VS Code web components to Web Awesome: `vscode-single-select`/`vscode-option` become `wa-select`/`wa-option`, and dropdown menu `vscode-checkbox` entries become `wa-checkbox`.
> 
> Updates event handling and typings to use `WaSelect`/`WaCheckbox` (`.value` narrowing and `.checked` reads), and retargets shared `fileSelectStyles` selectors from `vscode-*` controls to `wa-*` counterparts (including `wa-input`, `wa-select`, and `wa-checkbox`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e830436065dbf893a1726aa091c8616111d023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->