### PR TITLE
refactor(webview): consolidate banner styles into shared bannerStyles

### DIFF
--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -7,16 +7,12 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { AgentConfigBannerState } from '@shared/schemas';
-import { warningBannerStyles } from '../styles/warningBannerStyles';
+import { bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('agent-config-banner')
 export class AgentConfigBanner extends LitElement {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    warningBannerStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, bannerStyles];
 
   @property({ attribute: false }) state: AgentConfigBannerState = {
     visible: false,
@@ -37,7 +33,6 @@ export class AgentConfigBanner extends LitElement {
     return html`
       <wa-callout
         id="agentConfigBanner"
-        class="warning-banner"
         variant="warning"
         data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
       >

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -8,16 +8,12 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { ApiKeyBannerState } from '@shared/schemas';
 import { capitalize } from '@shared/utils/string';
-import { warningBannerStyles } from '../styles/warningBannerStyles';
+import { bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('api-key-banner')
 export class ApiKeyBanner extends LitElement {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    warningBannerStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, bannerStyles];
 
   @property({ attribute: false }) state: ApiKeyBannerState = {
     visible: false,
@@ -35,7 +31,7 @@ export class ApiKeyBanner extends LitElement {
     const providerLabel = provider ? capitalize(provider) : '';
 
     return html`
-      <wa-callout id="apiKeyBanner" class="warning-banner" variant="warning">
+      <wa-callout id="apiKeyBanner" variant="warning">
         ${waIcon('triangle-exclamation', { slot: 'icon' })}
         <div class="banner-row">
           <span>

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -9,7 +9,7 @@ import { when } from 'lit/directives/when.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { DependencyBannerState } from '@shared/schemas';
-import { warningBannerStyles } from '../styles/warningBannerStyles';
+import { bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('dependency-banner')
@@ -17,7 +17,7 @@ export class DependencyBanner extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    warningBannerStyles,
+    bannerStyles,
     css`
       .dependency-item {
         display: flex;
@@ -70,11 +70,7 @@ export class DependencyBanner extends LitElement {
     );
 
     return html`
-      <wa-callout
-        id="dependencyBanner"
-        class="warning-banner"
-        variant="warning"
-      >
+      <wa-callout id="dependencyBanner" variant="warning">
         ${waIcon('triangle-exclamation', { slot: 'icon' })}
         <div class="banner-row">
           <span class="missing-tools">

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -8,6 +8,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { COMMAND_LINKS } from '@shared/utils/uiConstants';
 
+import { bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('getting-started-banner')
@@ -15,15 +16,8 @@ export class GettingStartedBanner extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    bannerStyles,
     css`
-      :host {
-        display: block;
-      }
-
-      wa-callout.getting-started-banner {
-        margin-bottom: var(--spacing-large);
-      }
-
       wa-callout.getting-started-banner a {
         color: var(--color-text-link);
         text-decoration: none;

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -8,6 +8,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { PROMO_NOTICE_SHORT } from '@shared/copy/promoNotice';
 
+import { bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('login-banner')
@@ -15,22 +16,8 @@ export class LoginBanner extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    bannerStyles,
     css`
-      :host {
-        display: block;
-      }
-
-      wa-callout.login-banner {
-        margin-bottom: var(--spacing-large);
-      }
-
-      .banner-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--spacing-medium);
-      }
-
       .banner-text {
         display: flex;
         flex-direction: column;
@@ -46,13 +33,6 @@ export class LoginBanner extends LitElement {
       .banner-description {
         font-size: var(--font-size-sm);
         opacity: var(--opacity-normal);
-      }
-
-      .actions {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-small);
-        flex-shrink: 0;
       }
     `,
   ];
@@ -71,7 +51,7 @@ export class LoginBanner extends LitElement {
     if (!this.visible) return nothing;
 
     return html`
-      <wa-callout id="loginBanner" class="login-banner" variant="brand">
+      <wa-callout id="loginBanner" variant="brand">
         ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
         <div class="banner-row">
           <div class="banner-text">

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -1,15 +1,16 @@
-// Shared layout for inline banners. wa-callout owns the variant color,
-// border, and padding; this stylesheet just lays out the message + actions
-// inside the callout's default slot.
+// Shared layout for inline wa-callout banners. wa-callout owns the variant
+// color, border, and padding; this stylesheet handles host display, the
+// bottom margin, and the row layout for the message + action buttons inside
+// the callout's default slot.
 
 import { css, type CSSResult } from 'lit';
 
-export const warningBannerStyles: CSSResult = css`
+export const bannerStyles: CSSResult = css`
   :host {
     display: block;
   }
 
-  wa-callout.warning-banner {
+  wa-callout {
     margin-bottom: var(--spacing-large);
   }
 
@@ -31,5 +32,6 @@ export const warningBannerStyles: CSSResult = css`
     display: flex;
     align-items: center;
     gap: var(--spacing-small);
+    flex-shrink: 0;
   }
 `;


### PR DESCRIPTION
## Summary
- Renames `warningBannerStyles.ts` to `bannerStyles.ts` and broadens it so all five wa-callout banners share `:host { display: block }`, `wa-callout { margin-bottom }`, `.banner-row`, `.banner-row .hint`, and `.actions`.
- Drops the duplicated inline copies of those rules from `LoginBanner` and `GettingStartedBanner` (which had been carrying the same blocks individually since the wa-callout migration in #3648). Banner-specific styling stays inline: `.banner-text` / `.banner-title` / `.banner-description` on `LoginBanner`; `<a>` link colors plus `.getting-started-header` / `.getting-started-list` on `GettingStartedBanner`.
- Strips `class="warning-banner"` (ApiKeyBanner, AgentConfigBanner, DependencyBanner) and `class="login-banner"` (LoginBanner) since those classes only scoped the now-shared `margin-bottom`. The `getting-started-banner` class is retained because the `<a>` link rules still key off it.

Net: 6 files changed, 20 insertions, 57 deletions.

## Test plan
- [x] `grep -rn 'warningBannerStyles\|warning-banner' packages/extension/src/webview/frontend/` -> empty
- [x] `npm run typecheck` -> only pre-existing errors in desktop / openrouter SDK (same as `main`); webview is clean
- [x] `npx vitest run` -> webview-relevant tests all pass; only flaky desktop tests differ (same on `main`)
- [ ] Sanity-check banner rendering in the extension webview (API key warning, agent-config warning, dependency warning, login brand banner, getting-started brand banner)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to webview CSS/markup: consolidates shared banner layout styles and removes now-unneeded banner-specific classes, with minimal chance of visual regressions.
> 
> **Overview**
> Consolidates shared layout styling for webview `wa-callout` banners into a renamed/broadened `bannerStyles` stylesheet (formerly `warningBannerStyles`), including host display, callout spacing, and common `.banner-row`/`.actions` rules.
> 
> Updates all banner components to import `bannerStyles`, removes duplicated inline style blocks from `LoginBanner` and `GettingStartedBanner`, and drops now-unnecessary `class` scoping on several `wa-callout` usages (keeping `getting-started-banner` where link styling still relies on it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d1fce4f4888bbce8209d1628a686229451c682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->