### PR TITLE
feat(desktop): migrate workspace explorer tree to wa-tree

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -5,7 +5,10 @@ import './codiconStylesheet';
 import '@shared/wa';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tree/tree.js';
+import '@awesome.me/webawesome/dist/components/tree-item/tree-item.js';
 import type WaButton from '@awesome.me/webawesome/dist/components/button/button.js';
+import type WaTreeItem from '@awesome.me/webawesome/dist/components/tree-item/tree-item.js';
 import { html, nothing, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { renderEmptyState } from '@shared/wa/emptyState';
@@ -520,13 +523,27 @@ function explorerTemplate(): TemplateResult {
   }
   return html`
     ${explorerHeaderTemplate(explorerState.title)}
-    <div class="desktop-explorer-tree" role="tree">
+    <wa-tree
+      class="desktop-explorer-tree"
+      selection="single"
+      @wa-selection-change=${handleExplorerSelectionChange}
+    >
       ${treeNodesTemplate(explorerState.tree, 0)}
-    </div>
+    </wa-tree>
     <section class="desktop-explorer-selection" aria-live="polite">
       ${selectionPanelTemplate(explorerState.tree)}
     </section>
   `;
+}
+
+function handleExplorerSelectionChange(
+  event: CustomEvent<{ selection: WaTreeItem[] }>,
+): void {
+  const selected = event.detail.selection[0];
+  if (selected == null) return;
+  const filePath = selected.dataset.filePath;
+  if (filePath == null || filePath === '') return;
+  selectExplorerFile(filePath);
 }
 
 function explorerNoWorkspaceTemplate(): TemplateResult {
@@ -588,35 +605,22 @@ function treeNodeTemplate(
 ): TemplateResult {
   if (node.type === 'directory') {
     return html`
-      <details
+      <wa-tree-item
         class="desktop-explorer-directory"
-        ?open=${depth < 2}
-        style=${`--tree-depth: ${depth}`}
+        ?expanded=${depth < 2}
       >
-        <summary
-          class="desktop-explorer-row desktop-explorer-folder-row"
-          role="treeitem"
-        >
-          ${waIcon('chevron-right', { className: 'desktop-explorer-chevron' })}
-          ${waIcon('folder')}
-          <span class="desktop-explorer-name">${node.name}</span>
-        </summary>
-        <div role="group">
-          ${treeNodesTemplate(node.children ?? [], depth + 1)}
-        </div>
-      </details>
+        ${waIcon('folder')}
+        <span class="desktop-explorer-name">${node.name}</span>
+        ${treeNodesTemplate(node.children ?? [], depth + 1)}
+      </wa-tree-item>
     `;
   }
   return html`
-    <button
-      class="desktop-explorer-row desktop-explorer-file-row"
-      type="button"
-      role="treeitem"
+    <wa-tree-item
+      class="desktop-explorer-file"
       title=${node.path}
       data-file-path=${node.path}
-      data-selected=${selectedExplorerFile === node.path}
-      style=${`--tree-depth: ${depth}`}
-      @click=${() => selectExplorerFile(node.path)}
+      ?selected=${selectedExplorerFile === node.path}
       @dblclick=${() => openWorkspaceFile(node.path)}
     >
       ${waIcon('file-lines')}
@@ -632,7 +636,7 @@ function treeNodeTemplate(
           `,
         )}
       </span>
-    </button>
+    </wa-tree-item>
   `;
 }
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -605,10 +605,7 @@ function treeNodeTemplate(
 ): TemplateResult {
   if (node.type === 'directory') {
     return html`
-      <wa-tree-item
-        class="desktop-explorer-directory"
-        ?expanded=${depth < 2}
-      >
+      <wa-tree-item class="desktop-explorer-directory" ?expanded=${depth < 2}>
         ${waIcon('folder')}
         <span class="desktop-explorer-name">${node.name}</span>
         ${treeNodesTemplate(node.children ?? [], depth + 1)}

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -156,7 +156,8 @@ wa-tree.desktop-explorer-tree wa-tree-item::part(label) {
   gap: 4px;
 }
 
-wa-tree.desktop-explorer-tree wa-tree-item:not([aria-disabled='true']):hover::part(item) {
+wa-tree.desktop-explorer-tree
+  wa-tree-item:not([aria-disabled='true']):hover::part(item) {
   background: var(--texra-list-hoverBackground);
 }
 

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -135,60 +135,36 @@ wa-button.desktop-explorer-icon-button[disabled]::part(base) {
   cursor: default;
 }
 
-.desktop-explorer-tree {
+wa-tree.desktop-explorer-tree {
   min-width: 0;
   overflow: auto;
   padding: 4px 0;
+  --indent-size: 14px;
 }
 
-.desktop-explorer-directory {
+wa-tree.desktop-explorer-tree wa-tree-item::part(item) {
+  min-height: 24px;
+  padding-inline-end: 8px;
+  color: var(--texra-foreground);
+}
+
+wa-tree.desktop-explorer-tree wa-tree-item::part(label) {
+  flex: 1 1 auto;
   min-width: 0;
-}
-
-.desktop-explorer-directory > summary {
-  list-style: none;
-}
-
-.desktop-explorer-directory > summary::-webkit-details-marker {
-  display: none;
-}
-
-.desktop-explorer-directory[open] > summary .desktop-explorer-chevron {
-  transform: rotate(90deg);
-}
-
-.desktop-explorer-row {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
   gap: 4px;
-  width: 100%;
-  min-height: 24px;
-  padding: 0 8px 0 calc(8px + var(--tree-depth, 0) * 14px);
-  border: 0;
-  border-radius: 0;
-  box-sizing: border-box;
-  background: transparent;
-  color: var(--texra-foreground);
-  font: inherit;
-  text-align: left;
 }
 
-.desktop-explorer-folder-row {
-  cursor: pointer;
-}
-
-.desktop-explorer-file-row {
-  cursor: default;
-}
-
-.desktop-explorer-row:hover {
+wa-tree.desktop-explorer-tree wa-tree-item:not([aria-disabled='true']):hover::part(item) {
   background: var(--texra-list-hoverBackground);
 }
 
-.desktop-explorer-file-row[data-selected='true'] {
+wa-tree.desktop-explorer-tree
+  wa-tree-item:state(selected):not([aria-disabled='true'])::part(item) {
   background: var(--texra-list-activeSelectionBackground);
   color: var(--texra-list-activeSelectionForeground);
+  border-inline-start-color: var(--texra-list-activeSelectionForeground);
 }
 
 .desktop-explorer-name {


### PR DESCRIPTION
## Summary
- Replace the desktop renderer's hand-rolled `<details>` / `<summary>` / `<button>` workspace tree with native `<wa-tree selection="single">` + `<wa-tree-item>`. Selection now flows through `wa-selection-change`, and wa-tree provides built-in keyboard nav (arrows, Home/End, type-ahead, Enter to select), focus management, and `role="tree"` ARIA semantics.
- Drop the manual `--tree-depth` indentation variable and chevron-rotation CSS; wa-tree-item handles depth indentation and expand-icon rotation natively. Folder/file icons and the per-file category dot strip are preserved as label content.
- CSS cleanup: removed `.desktop-explorer-row`, `.desktop-explorer-folder-row`, `.desktop-explorer-file-row`, `.desktop-explorer-directory`, and the `summary` reset rules (~32 lines). Added `wa-tree-item::part(item)` overrides for hover and `:state(selected)` to keep the existing TeXRA list color tokens.

## Behavior changes
- Selection: single-click on a file row selects it via wa-tree's selection model; double-click still opens the file. Folder rows expand/collapse via the built-in chevron (also keyboard-driven).
- Keyboard: arrow keys, Home/End, type-ahead, and Enter now work out of the box (previously only Tab traversal between buttons worked).
- ARIA: `role="tree"` / `role="treeitem"` are now provided by the components rather than hand-authored.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx vitest run src/test-kernel/desktop/ElectronRendererShell.vitest.mts` — 7/7 pass; existing assertions (`id="desktop-explorer"`, `REQUEST_TREE`, `OPEN_FILE`, `SELECT_FILE`, `Use as ${typedCategory}`) still match
- [x] `npx vitest run src/test-kernel/desktop/` — all desktop suites pass when run individually (two suites flake under heavy parallel load with 5s timeouts, unrelated to this change)
- [x] `cd packages/desktop && npx vite build --mode development` — builds successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI-behavior change in a core navigation surface: selection/expansion and event handling now depend on `wa-tree`’s selection model and DOM structure, which could affect click/keyboard interactions and styling consistency.
> 
> **Overview**
> Replaces the desktop workspace explorer’s custom `<details>/<summary>/<button>` tree with WebAwesome `wa-tree`/`wa-tree-item`, wiring file selection through `wa-selection-change` and keeping double-click-to-open behavior.
> 
> Cleans up and retargets explorer CSS to style `wa-tree-item` parts (hover/selected states, indentation) while removing the prior depth/chevron and row-specific rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0a7948b966710ea48d50409b71d9cf08846e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->