### PR TITLE
feat(webview): migrate ad-hoc badges to wa-tag

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -21,11 +21,11 @@ import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { STREAM_STATUS, type ActiveChildInfo } from '@shared/schemas';
 import {
   designTokens,
   commonViewStyles,
-  tintedBadgeStyles,
 } from '@shared/styles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
@@ -53,7 +53,6 @@ export class BackgroundTasksPanel extends LitElement {
     designTokens,
     commonViewStyles,
     codiconIconClasses,
-    tintedBadgeStyles,
     css`
       :host {
         display: block;
@@ -134,15 +133,6 @@ export class BackgroundTasksPanel extends LitElement {
         flex-shrink: 0;
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
-      }
-
-      /* Variant tints for shared .tinted-badge */
-      .tinted-badge--running {
-        --_tint: var(--color-warning);
-      }
-
-      .tinted-badge--waiting {
-        --_tint: var(--color-text-secondary);
       }
 
       .section-label {
@@ -363,13 +353,10 @@ export class BackgroundTasksPanel extends LitElement {
           ${child.elapsed
             ? html`<span class="task-elapsed">(${child.elapsed})</span>`
             : nothing}
-          <span
-            class=${classMap({
-              'tinted-badge': true,
-              'tinted-badge--running': !waiting,
-              'tinted-badge--waiting': waiting,
-            })}
-            >${waiting ? 'waiting' : 'running'}</span
+          <wa-tag
+            variant=${waiting ? 'neutral' : 'warning'}
+            size="small"
+            >${waiting ? 'waiting' : 'running'}</wa-tag
           >
         </div>
         ${entry?.stdout

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -10,7 +11,6 @@ import {
   designTokens,
   animationStyles,
   commonViewStyles,
-  tintedBadgeStyles,
 } from '@shared/styles';
 import {
   STREAM_STATUS,
@@ -122,7 +122,6 @@ export class StreamHeader extends LitElement {
     commonViewStyles,
     codiconIconClasses,
     statusIndicatorStyles,
-    tintedBadgeStyles,
     css`
       :host {
         display: block;
@@ -306,7 +305,9 @@ export class StreamHeader extends LitElement {
         font-size: var(--font-size-xs);
       }
 
-      /* Uses shared .tinted-badge base; no --_tint override = inherits text-secondary default */
+      wa-tag.progress-badge .codicon {
+        font-size: var(--font-size-xs);
+      }
 
       @media (max-width: 500px) {
         .log-header {
@@ -429,8 +430,10 @@ export class StreamHeader extends LitElement {
   private renderProgressBadge(): TemplateResult | typeof nothing {
     const p = this.progress;
     if (!p || p.conversationTurns <= 0) return nothing;
-    return html`<span
-      class="tinted-badge"
+    return html`<wa-tag
+      class="progress-badge"
+      variant="neutral"
+      size="small"
       title="Conversation turns: ${p.conversationTurns}, Tool calls: ${p.toolCallCount}"
     >
       <i class="codicon codicon-pulse"></i>
@@ -438,7 +441,7 @@ export class StreamHeader extends LitElement {
       turns${p.toolCallCount > 0
         ? html`, ${p.toolCallCount} tool calls`
         : nothing}
-    </span>`;
+    </wa-tag>`;
   }
 
   private renderParentLink(): TemplateResult | typeof nothing {

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, queryAll } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -221,7 +222,9 @@ export class HistoryItem extends LitElement {
     const config = this.item.agentConfig;
     const timestamp = new Date(this.item.timestamp).toLocaleString();
     const isToolUse = config.agentCategory === AGENT_CATEGORY.TOOL_USE;
-    const categoryClass = isToolUse ? 'category-tool-use' : 'category-workflow';
+    const categoryVariant: 'warning' | 'brand' = isToolUse
+      ? 'warning'
+      : 'brand';
     const decorator = getAgentCategoryDecorator(config.agentCategory);
     const instructionText = config.instruction?.trim()
       ? config.instruction
@@ -308,7 +311,11 @@ export class HistoryItem extends LitElement {
         <div class="history-details basic-details">
           <span class="history-label">Category:</span>
           <span class="history-value">
-            <span class="badge agent-category-badge ${categoryClass}">
+            <wa-tag
+              class="agent-category-badge"
+              variant=${categoryVariant}
+              size="small"
+            >
               ${decorator.icon
                 ? html`<wa-icon
                     library="texra"
@@ -316,7 +323,7 @@ export class HistoryItem extends LitElement {
                   ></wa-icon>`
                 : nothing}
               ${decorator.label}
-            </span>
+            </wa-tag>
           </span>
           <span class="history-label">Agent:</span>
           <span class="history-value">${config.agent ?? 'Unknown'}</span>

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -5,6 +5,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import {
   LitElement,
   html,
@@ -228,15 +229,8 @@ export class AgentSelectionPanel extends LitElement {
         gap: var(--spacing-small);
       }
 
-      .agent-tool-badge {
-        display: inline-block;
-        padding: var(--border-thin) var(--spacing-small);
-        font-size: var(--font-size-xs);
+      wa-tag.agent-tool-badge {
         font-family: var(--texra-editor-font-family);
-        background: var(--texra-textBlockQuote-background);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius);
-        color: var(--color-text-secondary);
       }
 
       .agent-detail-actions {
@@ -286,15 +280,6 @@ export class AgentSelectionPanel extends LitElement {
         font-style: italic;
       }
 
-      .agent-source-badge {
-        display: inline-block;
-        padding: var(--border-thin) var(--spacing-small);
-        font-size: var(--font-size-xs);
-        font-weight: var(--font-weight-medium);
-        border-radius: var(--border-radius);
-        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
-        color: var(--texra-badge-foreground);
-      }
 
       .agent-detail-path {
         font-size: var(--font-size-xs);
@@ -627,16 +612,16 @@ export class AgentSelectionPanel extends LitElement {
         <div class="agent-detail-header">
           <span class="agent-detail-name">${agent.name}</span>
           ${builtIn
-            ? html`<span class="agent-source-badge">Built-in</span>`
+            ? html`<wa-tag variant="neutral" size="small">Built-in</wa-tag>`
             : nothing}
           ${isCustom
-            ? html`<span class="agent-source-badge" title="Custom agent"
-                >★ Custom</span
+            ? html`<wa-tag variant="neutral" size="small" title="Custom agent"
+                >★ Custom</wa-tag
               >`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span class="agent-source-badge" title="Remote agent"
-                >☁ Remote</span
+            ? html`<wa-tag variant="neutral" size="small" title="Remote agent"
+                >☁ Remote</wa-tag
               >`
             : nothing}
         </div>
@@ -664,7 +649,13 @@ export class AgentSelectionPanel extends LitElement {
                 <div class="agent-detail-meta-value">
                   <div class="agent-detail-tools">
                     ${agent.tools.map(
-                      (t) => html`<span class="agent-tool-badge">${t}</span>`,
+                      (t) =>
+                        html`<wa-tag
+                          class="agent-tool-badge"
+                          variant="neutral"
+                          size="small"
+                          >${t}</wa-tag
+                        >`,
                     )}
                   </div>
                 </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -273,11 +274,15 @@ export class ModelSelectionList extends LitElement {
         : keyStatus?.status === 'env'
           ? 'Env key'
           : 'No key';
+    const keyStatusVariant: 'success' | 'neutral' =
+      keyStatus?.status === 'set' ? 'success' : 'neutral';
     const providerKeyActions = keyStatus
       ? html`
-          <span
-            class="provider-group-key-status key-status-badge ${keyStatus.status}"
-            >${keyStatusLabel}</span
+          <wa-tag
+            class="provider-group-key-status"
+            variant=${keyStatusVariant}
+            size="small"
+            >${keyStatusLabel}</wa-tag
           >
           ${renderLabeledActionButton({
             icon: 'key',

--- a/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
@@ -3,6 +3,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -48,6 +49,14 @@ export class ProfileInfo extends LitElement {
     });
   }
 
+  private tierVariant(): 'brand' | 'neutral' | 'warning' {
+    const t = this.tier.toLowerCase();
+    if (t === 'ultra') return 'brand';
+    if (t === 'max') return 'neutral';
+    // 'free' or unknown — emphasize upgrade path with a warning tint.
+    return 'warning';
+  }
+
   override render(): TemplateResult {
     const expiration = this.formatExpiration();
     return html`
@@ -62,9 +71,13 @@ export class ProfileInfo extends LitElement {
         </div>
         <div class="info-row">
           <span class="label">Tier:</span>
-          <span class="badge tier-badge ${this.tier.toLowerCase()}">
+          <wa-tag
+            class="tier-badge"
+            variant=${this.tierVariant()}
+            size="small"
+          >
             ${this.tier}
-          </span>
+          </wa-tag>
         </div>
         <div class="profile-notice">
           ${PROMO_NOTICE_LONG.promoLead}<code>${PROMO_NOTICE_LONG.promoCode}</code>${PROMO_NOTICE_LONG.promoTail}

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -27,6 +28,15 @@ const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
   set: 'Set',
   env: 'Env',
   'not-set': 'Not Set',
+};
+
+const STATUS_VARIANTS: Record<
+  ProviderKeyStatus['status'],
+  'brand' | 'neutral' | 'success' | 'warning' | 'danger'
+> = {
+  set: 'success',
+  env: 'neutral',
+  'not-set': 'neutral',
 };
 
 @customElement('provider-key-list')
@@ -200,8 +210,11 @@ export class ProviderKeyList extends LitElement {
           </div>
         </td>
         <td>
-          <span class="key-status-badge ${entry.status}"
-            >${STATUS_LABELS[entry.status]}</span
+          <wa-tag
+            class="key-status-badge"
+            variant=${STATUS_VARIANTS[entry.status]}
+            size="small"
+            >${STATUS_LABELS[entry.status]}</wa-tag
           >
         </td>
         <td>${this.renderActions(entry)}</td>

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -43,7 +43,7 @@ export const profileViewStyles: CSSResult = css`
     color: var(--texra-foreground);
   }
 
-  .tier-badge {
+  wa-tag.tier-badge {
     text-transform: uppercase;
     font-weight: var(--font-weight-semibold);
   }
@@ -62,21 +62,6 @@ export const profileViewStyles: CSSResult = css`
     padding: 0 var(--spacing-tiny);
     border-radius: var(--border-radius-small);
     background: var(--texra-textBlockQuote-background);
-  }
-
-  .tier-badge.free {
-    background: var(--texra-inputValidation-warningBackground);
-    color: var(--texra-inputValidation-warningForeground);
-  }
-
-  .tier-badge.max {
-    background: var(--texra-badge-background);
-    color: var(--texra-badge-foreground);
-  }
-
-  .tier-badge.ultra {
-    background: var(--texra-textLink-activeForeground);
-    color: var(--texra-button-foreground);
   }
 
   .not-authenticated {
@@ -256,31 +241,6 @@ export const profileViewStyles: CSSResult = css`
   .provider-name {
     font-weight: var(--font-weight-medium);
     white-space: nowrap;
-  }
-
-  .key-status-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-small);
-    font-size: var(--font-size-sm);
-    padding: var(--spacing-tiny) var(--spacing-small);
-    border-radius: var(--border-radius);
-  }
-
-  .key-status-badge.set {
-    background: var(--texra-testing-iconPassed);
-    color: var(--texra-button-foreground);
-  }
-
-  .key-status-badge.env {
-    background: var(--texra-badge-background);
-    color: var(--texra-badge-foreground);
-  }
-
-  .key-status-badge.not-set {
-    background: var(--texra-input-background);
-    color: var(--color-text-secondary);
-    border: var(--border-thin) solid var(--color-border);
   }
 
   .provider-actions {

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -6,6 +6,7 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -70,38 +71,8 @@ export class ToolCard extends LitElement {
         white-space: nowrap;
       }
 
-      .tool-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--border-thin) var(--spacing-small);
-        font-size: var(--font-size-xs);
-        border-radius: var(--border-radius);
+      wa-tag.tool-badge {
         white-space: nowrap;
-        font-weight: var(--font-weight-medium);
-      }
-
-      .tool-badge--available {
-        color: var(--texra-testing-iconPassed, #73c991);
-        background: color-mix(
-          in srgb,
-          var(--texra-testing-iconPassed, #73c991) 12%,
-          transparent
-        );
-      }
-
-      .tool-badge--not-found {
-        color: var(--texra-testing-iconFailed, #f48771);
-        background: color-mix(
-          in srgb,
-          var(--texra-testing-iconFailed, #f48771) 12%,
-          transparent
-        );
-      }
-
-      .tool-badge--unknown {
-        color: var(--texra-badge-foreground);
-        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
       }
 
       .tool-description {
@@ -264,11 +235,23 @@ export class ToolCard extends LitElement {
 
   private static readonly STATUS_CONFIG: Record<
     ToolDashboardItem['status'],
-    { icon: string; label: string }
+    {
+      icon: string;
+      label: string;
+      variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
+    }
   > = {
-    available: { icon: 'check', label: 'Ready' },
-    'not-found': { icon: 'warning', label: 'Needs setup' },
-    unknown: { icon: 'question', label: 'Not checked' },
+    available: { icon: 'check', label: 'Ready', variant: 'success' },
+    'not-found': {
+      icon: 'warning',
+      label: 'Needs setup',
+      variant: 'danger',
+    },
+    unknown: {
+      icon: 'question',
+      label: 'Not checked',
+      variant: 'neutral',
+    },
   };
 
   private renderBadge(): TemplateResult {
@@ -277,10 +260,10 @@ export class ToolCard extends LitElement {
       ToolCard.STATUS_CONFIG[status] ?? ToolCard.STATUS_CONFIG.unknown;
 
     return html`
-      <span class="tool-badge tool-badge--${status}">
+      <wa-tag class="tool-badge" variant=${config.variant} size="small">
         <wa-icon library="texra" name=${config.icon}></wa-icon>
         ${this.item.statusLabel ?? config.label}
-      </span>
+      </wa-tag>
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import {
   LitElement,
   html,
@@ -137,13 +138,8 @@ export class AgentsTab extends LitElement {
         min-width: 0;
       }
 
-      .agents-dir-default-badge {
+      wa-tag.agents-dir-default-badge {
         flex-shrink: 0;
-        padding: 0 var(--spacing-small);
-        font-size: var(--font-size-xs);
-        color: var(--texra-badge-foreground);
-        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
-        border-radius: var(--border-radius);
       }
 
       .agents-dir-actions {
@@ -303,7 +299,12 @@ export class AgentsTab extends LitElement {
             >${this.customAgentDir}</span
           >
           ${this.customAgentDirIsDefault
-            ? html`<span class="agents-dir-default-badge">default</span>`
+            ? html`<wa-tag
+                class="agents-dir-default-badge"
+                variant="neutral"
+                size="small"
+                >default</wa-tag
+              >`
             : nothing}
           <div class="agents-dir-actions">
             <button

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -11,7 +12,6 @@ import { customElement, property } from 'lit/decorators.js';
 import {
   commonViewStyles,
   designTokens,
-  tintedBadgeStyles,
 } from '@shared/styles';
 
 // Web Awesome icon bundle (side-effect import)
@@ -34,7 +34,6 @@ export class GitTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    tintedBadgeStyles,
     css`
       :host {
         display: block;
@@ -102,19 +101,6 @@ export class GitTab extends LitElement {
       .token-remove-btn:hover {
         color: var(--texra-errorForeground);
         border-color: var(--texra-errorForeground);
-      }
-
-      .tinted-badge--ok {
-        --_tint: var(
-          --texra-testing-iconPassed,
-          var(--texra-terminal-ansiGreen)
-        );
-      }
-      .tinted-badge--warn {
-        --_tint: var(--texra-editorWarning-foreground, #cca700);
-      }
-      .tinted-badge--info {
-        --_tint: var(--texra-badge-background);
       }
 
       .instructions {
@@ -244,12 +230,12 @@ export class GitTab extends LitElement {
 
   private renderTokenStatusBadge(): TemplateResult {
     if (this.githubTokenStatus === 'secret') {
-      return html`<span class="tinted-badge tinted-badge--ok">Set</span>`;
+      return html`<wa-tag variant="success" size="small">Set</wa-tag>`;
     }
     if (this.githubTokenStatus === 'env') {
-      return html`<span class="tinted-badge tinted-badge--info">Env</span>`;
+      return html`<wa-tag variant="neutral" size="small">Env</wa-tag>`;
     }
-    return html`<span class="tinted-badge tinted-badge--warn">Not set</span>`;
+    return html`<wa-tag variant="warning" size="small">Not set</wa-tag>`;
   }
 
   override render(): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -423,22 +424,8 @@ export class LaTeXTab extends LitElement {
         margin-top: var(--spacing-small);
       }
 
-      .setting-badge {
+      wa-tag.setting-badge {
         flex-shrink: 0;
-        font-size: var(--font-size-xs);
-        padding: var(--spacing-tiny) var(--border-radius-large);
-        border-radius: var(--border-radius-small);
-        font-weight: var(--font-weight-medium);
-      }
-
-      .setting-badge.is-set {
-        background: var(--texra-testing-iconPassed, #73c991);
-        color: var(--texra-editor-background);
-      }
-
-      .setting-badge.not-set {
-        background: var(--texra-badge-background);
-        color: var(--texra-badge-foreground);
       }
 
       .checkbox-row {
@@ -562,7 +549,12 @@ export class LaTeXTab extends LitElement {
             )}
           </div>
           ${installed
-            ? html`<span class="setting-badge is-set">Installed</span>`
+            ? html`<wa-tag
+                class="setting-badge"
+                variant="success"
+                size="small"
+                >Installed</wa-tag
+              >`
             : dep.actionEvent
               ? html`
                   <button
@@ -580,7 +572,12 @@ export class LaTeXTab extends LitElement {
                     ${dep.actionLabel ?? 'Install'}
                   </button>
                 `
-              : html`<span class="setting-badge not-set">Not found</span>`}
+              : html`<wa-tag
+                  class="setting-badge"
+                  variant="neutral"
+                  size="small"
+                  >Not found</wa-tag
+                >`}
         </div>
         ${!installed && installCmd
           ? html`

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -5,6 +5,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -115,28 +116,11 @@ export class MultiAgentTab extends LitElement {
 
       .preset-card.active .preset-card-name,
       .preset-card.active .preset-card-description,
-      .preset-card.active .preset-card-icon,
-      .preset-card.active .preset-active-badge {
+      .preset-card.active .preset-card-icon {
         color: inherit;
       }
 
-      .preset-active-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-tiny);
-        padding: var(--border-thin) var(--border-radius-large);
-        font-size: var(--font-size-xs);
-        font-weight: var(--font-weight-medium);
-        color: var(--texra-focusBorder);
-        background: color-mix(
-          in srgb,
-          var(--texra-focusBorder) 15%,
-          transparent
-        );
-        border-radius: var(--border-radius-medium);
-      }
-
-      .preset-active-badge wa-icon {
+      wa-tag.preset-active-badge wa-icon {
         font-size: var(--font-size-xs);
       }
 
@@ -184,22 +168,7 @@ export class MultiAgentTab extends LitElement {
         margin-top: var(--spacing-tiny);
       }
 
-      .preset-agent-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-tiny);
-        padding: var(--border-thin) var(--border-radius-large);
-        font-size: var(--font-size-xs);
-        color: var(--texra-badge-foreground);
-        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
-        border-radius: var(--border-radius);
-      }
-
-      .preset-agent-badge--orchestrator {
-        color: var(--texra-button-foreground);
-        background: var(--texra-button-background);
-        border: var(--border-thin) solid
-          var(--texra-button-background, var(--texra-focusBorder));
+      wa-tag.preset-agent-badge--orchestrator {
         font-weight: var(--font-weight-semibold);
       }
 
@@ -360,9 +329,13 @@ export class MultiAgentTab extends LitElement {
           ></wa-icon>
           <span class="preset-card-name">${preset.name}</span>
           ${isActive
-            ? html`<span class="preset-active-badge">
+            ? html`<wa-tag
+                class="preset-active-badge"
+                variant="brand"
+                size="small"
+              >
                 <wa-icon library="texra" name="check"></wa-icon> Active
-              </span>`
+              </wa-tag>`
             : nothing}
         </div>
         <p class="preset-card-description">${preset.description}</p>
@@ -370,22 +343,30 @@ export class MultiAgentTab extends LitElement {
           ? html`<div class="preset-card-orchestrators">
               ${orchestratorAgents.map(
                 (name) => html`
-                  <span
+                  <wa-tag
                     class="preset-agent-badge preset-agent-badge--orchestrator"
+                    variant="brand"
+                    size="small"
                     title="${name} is the orchestrator for this team"
                   >
                     <span class="preset-orchestrator-icon" aria-hidden="true"
                       >🎯</span
                     >
                     ${name}
-                  </span>
+                  </wa-tag>
                 `,
               )}
             </div>`
           : nothing}
         <div class="preset-card-agents">
           ${teammateAgents.map(
-            (name) => html`<span class="preset-agent-badge">${name}</span>`,
+            (name) =>
+              html`<wa-tag
+                class="preset-agent-badge"
+                variant="neutral"
+                size="small"
+                >${name}</wa-tag
+              >`,
           )}
         </div>
         ${deletable

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -12,7 +13,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import {
   commonViewStyles,
   designTokens,
-  tintedBadgeStyles,
 } from '@shared/styles';
 
 // Side-effect imports - register WA icon and spinner components
@@ -104,7 +104,6 @@ export class ToolsTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    tintedBadgeStyles,
     css`
       :host {
         display: block;
@@ -442,15 +441,16 @@ export class ToolsTab extends LitElement {
             >
               Enable native crash reporting
             </vscode-checkbox>
-            <span
-              class=${this.desktopCrashReportingConfigured
-                ? 'tinted-badge tinted-badge--ok'
-                : 'tinted-badge tinted-badge--warn'}
+            <wa-tag
+              variant=${this.desktopCrashReportingConfigured
+                ? 'success'
+                : 'warning'}
+              size="small"
             >
               ${this.desktopCrashReportingConfigured
                 ? 'DSN set'
                 : 'DSN missing'}
-            </span>
+            </wa-tag>
             <button
               class="tab-action-btn"
               @click=${this.handleSetDesktopCrashReportingDsn}


### PR DESCRIPTION
## Summary

Replaces hand-rolled badge / pill / chip markup in the settings, history, and progress webviews with native `<wa-tag>` components and drops the now-redundant CSS.

### Files migrated (badge -> wa-tag mapping)

Settings view:
- `tabs/LaTeXTab.ts` — `setting-badge is-set` -> `wa-tag variant=success`; `setting-badge not-set` -> `wa-tag variant=neutral`
- `tabs/AgentsTab.ts` — `agents-dir-default-badge` -> `wa-tag variant=neutral`
- `tabs/GitTab.ts` — `tinted-badge--ok|warn|info` -> `wa-tag variant=success|warning|neutral`
- `tabs/ToolsTab.ts` — DSN status `tinted-badge` -> `wa-tag variant=success|warning`
- `tabs/MultiAgentTab.ts` — `preset-active-badge`, `preset-agent-badge`, `preset-agent-badge--orchestrator` -> `wa-tag variant=brand|neutral`
- `components/tools/ToolCard.ts` — status badge -> `wa-tag variant=success|danger|neutral` driven by tool status
- `components/profile/ProfileInfo.ts` — `tier-badge` -> `wa-tag variant=brand|neutral|warning` based on tier (ultra/max/free)
- `components/profile/ProviderKeyList.ts` — `key-status-badge` -> `wa-tag variant=success|neutral`
- `components/profile/ModelSelectionList.ts` — provider key status -> `wa-tag variant=success|neutral`
- `components/profile/AgentSelectionPanel.ts` — `agent-source-badge` and `agent-tool-badge` -> `wa-tag variant=neutral`
- `components/history/HistoryItem.ts` — `agent-category-badge` -> `wa-tag variant=brand|warning` (workflow vs tool-use)

Progress view:
- `components/StreamHeader.ts` — progress `tinted-badge` -> `wa-tag variant=neutral`
- `components/BackgroundTasksPanel.ts` — running/waiting `tinted-badge--running|waiting` -> `wa-tag variant=warning|neutral`

### Left in place (heavily customized)

- `workflow-proposal__category-badge` and `external-inquiry-request__mode-badge` in the progress view request panels: these share an uppercase, header-aligned style baked into `requestPanelStyles` and act as section accents for the panel layout, so swapping in `wa-tag` would distort the panel visuals.
- `agent-list-item-badges` in `AgentSelectionPanel` is a container `<span>`, not an actual badge.

### Cleanup

- Each touched component now imports `@awesome.me/webawesome/dist/components/tag/tag.js`.
- Dropped per-component badge CSS that wa-tag now provides (background / border-radius / padding / borders); kept layout-specific declarations (margins, font-family for tool-name tags, custom hooks via class names).
- Removed unused `tintedBadgeStyles` imports / references in the migrated components.

## Test plan

- [x] `npm run typecheck` reports no new errors (only pre-existing OpenRouter / Electron failures unchanged from `main`).
- [x] `npx vitest run` keeps the same pass count as baseline (309 pass / 2 unrelated desktop-test failures).
- [ ] Visual smoke-test in extension dev host (Settings > LaTeX, Tools, Agents, Multi-Agent, History; Progress view: stream header, background tasks).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps badge markup/styling for a shared Web Awesome component; main risk is minor visual regressions if `wa-tag` variants/styles differ from the removed CSS.
> 
> **Overview**
> Migrates settings/history/progress webviews from custom badge/pill markup (and `tintedBadgeStyles`-driven CSS) to the native Web Awesome `wa-tag` component, adding the side-effect `tag.js` import where needed.
> 
> Updates badge state mapping to `wa-tag` `variant`/`size` props (e.g., running/waiting, tool status, provider key status, tier), and deletes the now-redundant per-component CSS for those badges while keeping only layout-specific styling hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5932c8a9f35c9e0d45decde7d69c44bee509a1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->