### PR TITLE
feat(settings): migrate ProviderKeyModal to wa-dialog

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
@@ -21,48 +22,10 @@ export class ProviderKeyModal extends LitElement {
   static override styles = [
     designTokens,
     css`
-      :host {
-        position: fixed;
-        inset: 0;
-        z-index: 1000;
-      }
-
-      .provider-key-backdrop {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        padding: var(--spacing-xlarge);
-        background: color-mix(
-          in srgb,
-          var(--texra-editor-background) 35%,
-          transparent
-        );
-      }
-
-      .provider-key-dialog {
-        width: min(560px, 100%);
-        padding: var(--spacing-xlarge);
-        color: var(--texra-foreground);
-        background: var(--texra-editor-background);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius-large);
-        box-shadow: 0 12px 32px
-          color-mix(in srgb, var(--texra-editor-foreground) 18%, transparent);
-      }
-
-      .provider-key-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: var(--spacing-large);
-        margin-bottom: var(--spacing-medium);
-      }
-
-      h2 {
-        margin: 0;
-        font-size: var(--font-size-lg);
+      /* wa-dialog supplies the backdrop, modal positioning, focus trap, escape
+         handling, and panel chrome; only the body content layout lives here. */
+      wa-dialog.provider-key-dialog {
+        --width: min(560px, calc(100vw - 32px));
       }
 
       .provider-key-description {
@@ -106,7 +69,6 @@ export class ProviderKeyModal extends LitElement {
         display: flex;
         justify-content: flex-end;
         gap: var(--spacing-medium);
-        margin-top: var(--spacing-large);
       }
 
       button {
@@ -130,22 +92,14 @@ export class ProviderKeyModal extends LitElement {
         background: var(--texra-button-hoverBackground);
       }
 
-      .provider-key-secondary,
-      .provider-key-icon {
+      .provider-key-secondary {
         color: var(--texra-foreground);
         background: transparent;
         border: var(--border-thin) solid var(--color-border);
       }
 
-      .provider-key-secondary:hover,
-      .provider-key-icon:hover {
+      .provider-key-secondary:hover {
         background: var(--texra-list-hoverBackground);
-      }
-
-      .provider-key-icon {
-        min-width: 30px;
-        justify-content: center;
-        padding: var(--spacing-small);
       }
     `,
   ];
@@ -157,21 +111,15 @@ export class ProviderKeyModal extends LitElement {
   @state() private error = '';
 
   @query('input') private keyInput?: HTMLInputElement;
-  @query('.provider-key-dialog') private dialog?: HTMLFormElement;
 
-  private previousFocus: HTMLElement | null = null;
+  // Drives wa-dialog's `open` reactive property; toggled by close() so the
+  // dialog plays its hide animation and dispatches wa-after-hide.
+  @state() private dialogOpen = true;
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this.previousFocus =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-  }
-
-  override firstUpdated(): void {
-    this.keyInput?.focus();
-  }
+  // Distinguishes a user-initiated close (Escape / Cancel button / dialog close
+  // button) from a programmatic close after submit. Submit dispatches its own
+  // event and suppresses the cancel dispatch on the subsequent wa-after-hide.
+  private suppressCancel = false;
 
   private clearSecretValue(): void {
     this.value = '';
@@ -180,21 +128,26 @@ export class ProviderKeyModal extends LitElement {
     }
   }
 
-  private restoreFocus(): void {
-    this.previousFocus?.focus();
+  private close(): void {
+    this.dialogOpen = false;
   }
 
-  private close(): void {
+  private handleAfterShow(): void {
+    this.keyInput?.focus();
+  }
+
+  private handleAfterHide(): void {
+    if (this.suppressCancel) {
+      this.suppressCancel = false;
+      return;
+    }
     this.clearSecretValue();
     this.error = '';
     this.dispatchEvent(createEvent('provider-key-cancel'));
-    this.restoreFocus();
   }
 
-  private handleBackdropClick(event: MouseEvent): void {
-    if (event.target === event.currentTarget) {
-      this.close();
-    }
+  private handleCancelClick(): void {
+    this.close();
   }
 
   private handleInput(event: Event): void {
@@ -215,81 +168,27 @@ export class ProviderKeyModal extends LitElement {
 
     this.clearSecretValue();
     this.error = '';
+    this.suppressCancel = true;
     this.dispatchEvent(
       createEvent('provider-key-submit', {
         provider: this.provider,
         apiKey,
       }),
     );
-    this.restoreFocus();
-  }
-
-  private getFocusableElements(): HTMLElement[] {
-    const selector = [
-      'button:not([disabled])',
-      'input:not([disabled])',
-      '[href]',
-      '[tabindex]:not([tabindex="-1"])',
-    ].join(',');
-    return [...(this.dialog?.querySelectorAll<HTMLElement>(selector) ?? [])];
-  }
-
-  private handleDialogKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      this.close();
-      return;
-    }
-
-    if (event.key !== 'Tab') {
-      return;
-    }
-
-    const focusable = this.getFocusableElements();
-    const first = focusable.at(0);
-    const last = focusable.at(-1);
-    if (!first || !last) {
-      return;
-    }
-
-    const active = this.shadowRoot?.activeElement;
-    if (event.shiftKey && active === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && active === last) {
-      event.preventDefault();
-      first.focus();
-    }
+    this.close();
   }
 
   override render(): TemplateResult {
     const displayName = this.displayName || this.provider;
     return html`
-      <div
-        class="provider-key-backdrop"
-        role="presentation"
-        @click=${this.handleBackdropClick}
+      <wa-dialog
+        class="provider-key-dialog"
+        label=${`Set ${displayName} API key`}
+        ?open=${this.dialogOpen}
+        @wa-after-show=${this.handleAfterShow}
+        @wa-after-hide=${this.handleAfterHide}
       >
-        <form
-          class="provider-key-dialog"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="provider-key-title"
-          @submit=${this.handleSubmit}
-          @keydown=${this.handleDialogKeydown}
-        >
-          <div class="provider-key-header">
-            <h2 id="provider-key-title">Set ${displayName} API key</h2>
-            <button
-              class="provider-key-icon"
-              type="button"
-              title="Cancel"
-              aria-label="Cancel"
-              @click=${this.close}
-            >
-              <wa-icon library="texra" name="close"></wa-icon>
-            </button>
-          </div>
+        <form id="provider-key-form" @submit=${this.handleSubmit}>
           <p class="provider-key-description">
             The key is stored by TeXRA on this device and is not shown again
             after saving.
@@ -305,21 +204,25 @@ export class ProviderKeyModal extends LitElement {
             />
           </label>
           <p class="provider-key-error" aria-live="polite">${this.error}</p>
-          <div class="provider-key-actions">
-            <button
-              class="provider-key-secondary"
-              type="button"
-              @click=${this.close}
-            >
-              Cancel
-            </button>
-            <button class="provider-key-primary" type="submit">
-              <wa-icon library="texra" name="key"></wa-icon>
-              Save Key
-            </button>
-          </div>
         </form>
-      </div>
+        <div slot="footer" class="provider-key-actions">
+          <button
+            class="provider-key-secondary"
+            type="button"
+            @click=${this.handleCancelClick}
+          >
+            Cancel
+          </button>
+          <button
+            class="provider-key-primary"
+            type="submit"
+            form="provider-key-form"
+          >
+            <wa-icon library="texra" name="key"></wa-icon>
+            Save Key
+          </button>
+        </div>
+      </wa-dialog>
     `;
   }
 }

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -8,6 +8,17 @@ type ProviderKeyModalElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
+type WaDialogElement = HTMLElement & { open: boolean };
+
+// wa-dialog's show/hide flow chains a few requestAnimationFrame and
+// animateWithClass ticks before settling; flushing several macrotasks lets
+// those promise/timer callbacks resolve in jsdom (which has no real raf).
+async function flushDialogTicks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe('ProviderKeyModal', () => {
   useLitComponentTestDom(
     () => import('@settingsView/frontend/components/profile/ProviderKeyModal'),
@@ -21,6 +32,7 @@ describe('ProviderKeyModal', () => {
     modal.displayName = 'Google';
     document.body.append(modal);
     await modal.updateComplete;
+    await flushDialogTicks();
 
     const submitted: unknown[] = [];
     modal.addEventListener('provider-key-submit', (event) => {
@@ -35,6 +47,7 @@ describe('ProviderKeyModal', () => {
       .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     await modal.updateComplete;
 
+    await flushDialogTicks();
     expect(submitted).toEqual([{ provider: 'google', apiKey: 'sk-test' }]);
     expect(input.value).toBe('');
   });
@@ -47,6 +60,7 @@ describe('ProviderKeyModal', () => {
     modal.displayName = 'Google';
     document.body.append(modal);
     await modal.updateComplete;
+    await flushDialogTicks();
 
     let cancelled = 0;
     let submitted = 0;
@@ -63,17 +77,14 @@ describe('ProviderKeyModal', () => {
     modal
       .shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-secondary')!
       .click();
+    await flushDialogTicks();
 
     expect(cancelled).toBe(1);
     expect(submitted).toBe(0);
     expect(input.value).toBe('');
   });
 
-  it('closes on Escape and traps Tab focus in the dialog', async () => {
-    const trigger = document.createElement('button');
-    document.body.append(trigger);
-    trigger.focus();
-
+  it('opens the wa-dialog when mounted and closes it after submit', async () => {
     const modal = document.createElement(
       'provider-key-modal',
     ) as ProviderKeyModalElement;
@@ -81,6 +92,13 @@ describe('ProviderKeyModal', () => {
     modal.displayName = 'Google';
     document.body.append(modal);
     await modal.updateComplete;
+    await flushDialogTicks();
+
+    const dialog =
+      modal.shadowRoot!.querySelector<WaDialogElement>('wa-dialog')!;
+    expect(dialog).toBeTruthy();
+    // wa-dialog opens itself when `open` is set in firstUpdated.
+    expect(dialog.open).toBe(true);
 
     let cancelled = 0;
     modal.addEventListener('provider-key-cancel', () => {
@@ -88,44 +106,15 @@ describe('ProviderKeyModal', () => {
     });
 
     const input = modal.shadowRoot!.querySelector('input')!;
-    const closeButton =
-      modal.shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-icon')!;
-    const submitButton = modal.shadowRoot!.querySelector<HTMLButtonElement>(
-      '.provider-key-primary',
-    )!;
-
-    submitButton.focus();
-    submitButton.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Tab',
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
-    expect(modal.shadowRoot!.activeElement).toBe(closeButton);
-
-    closeButton.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Tab',
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
-    expect(modal.shadowRoot!.activeElement).toBe(submitButton);
-
-    input.value = 'sk-escape';
+    input.value = 'sk-after-submit';
     input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Escape',
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
+    modal
+      .shadowRoot!.querySelector('form')!
+      .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await flushDialogTicks();
 
-    expect(cancelled).toBe(1);
-    expect(input.value).toBe('');
-    expect(document.activeElement).toBe(trigger);
+    // Submit closes the dialog programmatically and must NOT also fire cancel.
+    expect(dialog.open).toBe(false);
+    expect(cancelled).toBe(0);
   });
 });

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -81,10 +81,11 @@ function installDialogPolyfill(window: JSDOM['window']): void {
     };
   }
   if (typeof proto.show !== 'function') {
-    (proto as HTMLDialogElement & { show: () => void }).show =
-      function show(this: HTMLDialogElement) {
-        this.setAttribute('open', '');
-      };
+    (proto as HTMLDialogElement & { show: () => void }).show = function show(
+      this: HTMLDialogElement,
+    ) {
+      this.setAttribute('open', '');
+    };
   }
   if (typeof proto.close !== 'function') {
     proto.close = function close(this: HTMLDialogElement) {

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -31,6 +31,11 @@ const domGlobalKeys = [
   'MouseEvent',
   'ShadowRoot',
   'Node',
+  'AbortController',
+  'AbortSignal',
+  'getComputedStyle',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
 ] as const;
 
 const DEFAULT_VALIDITY = {
@@ -46,6 +51,48 @@ const DEFAULT_VALIDITY = {
   valid: true,
   valueMissing: false,
 } satisfies ValidityState;
+
+function installAnimationPolyfill(window: JSDOM['window']): void {
+  // jsdom doesn't implement Element.getAnimations; wa-dialog's
+  // animateWithClass calls it to detect when no CSS animation is running and
+  // resolve immediately. Returning [] means "no animations" — animateWithClass
+  // resolves on the next raf, which matches the visible behavior in tests.
+  const proto = window.Element?.prototype as
+    | (Element & { getAnimations?: () => unknown[] })
+    | undefined;
+  if (!proto) return;
+  if (typeof proto.getAnimations !== 'function') {
+    proto.getAnimations = () => [];
+  }
+}
+
+function installDialogPolyfill(window: JSDOM['window']): void {
+  // jsdom (as of 24.x) does not implement HTMLDialogElement's showModal/close.
+  // wa-dialog calls these in firstUpdated; without them, attaching wa-dialog
+  // throws and tests can't render the component. Provide a minimal polyfill
+  // that only flips the `open` attribute.
+  const proto = window.HTMLDialogElement?.prototype as
+    | (HTMLDialogElement & { showModal?: () => void; close?: () => void })
+    | undefined;
+  if (!proto) return;
+  if (typeof proto.showModal !== 'function') {
+    proto.showModal = function showModal(this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  }
+  if (typeof proto.show !== 'function') {
+    (proto as HTMLDialogElement & { show: () => void }).show =
+      function show(this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+      };
+  }
+  if (typeof proto.close !== 'function') {
+    proto.close = function close(this: HTMLDialogElement) {
+      this.removeAttribute('open');
+      this.dispatchEvent(new window.Event('close'));
+    };
+  }
+}
 
 function installElementInternalsPolyfill(window: TestDomWindow): void {
   const ElementInternalsCtor = window.ElementInternals;
@@ -154,6 +201,24 @@ export function useLitComponentTestDom(
       MouseEvent: dom.window.MouseEvent,
       ShadowRoot: dom.window.ShadowRoot,
       Node: dom.window.Node,
+      // wa-dialog (and other Web Awesome components) rely on these browser
+      // globals; use the jsdom-backed implementations so AbortSignal/Event
+      // identity matches the EventTarget instances they're attached to.
+      AbortController: dom.window.AbortController,
+      AbortSignal: dom.window.AbortSignal,
+      getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+      // jsdom doesn't ship requestAnimationFrame; emulate it with setTimeout.
+      // wa-dialog's animateWithClass and other Web Awesome components use raf
+      // for "next paint" callbacks — a 0ms timeout is functionally equivalent
+      // for unit-test timing.
+      requestAnimationFrame: ((cb: FrameRequestCallback) =>
+        setTimeout(() => cb(performance.now()), 0) as unknown as number) as (
+        cb: FrameRequestCallback,
+      ) => number,
+      cancelAnimationFrame: ((handle: number) =>
+        clearTimeout(handle as unknown as ReturnType<typeof setTimeout>)) as (
+        handle: number,
+      ) => void,
     } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
 
     for (const key of domGlobalKeys) {
@@ -169,6 +234,8 @@ export function useLitComponentTestDom(
     }
 
     installElementInternalsPolyfill(dom.window);
+    installDialogPolyfill(dom.window);
+    installAnimationPolyfill(dom.window);
     await importComponents();
   });
 


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `<section role="dialog">` + manual focus trap + Escape/backdrop handlers in `ProviderKeyModal` with native `<wa-dialog>`. wa-dialog handles modal positioning, focus trap, Escape-to-close, and backdrop chrome natively, removing ~110 lines of plumbing.
- Mirrors the desktop onboarding refactor (`packages/desktop/src/renderer/desktopOnboarding.ts`).
- Parent API is unchanged: same `<provider-key-modal>` tag, same `.provider` / `.displayName` props, same `provider-key-submit` / `provider-key-cancel` events.

## Test plan

- [x] `npm run typecheck` passes (no new errors; only pre-existing electron / openrouter ones)
- [x] `npx vitest run src/test-kernel/settings/ProviderKeyModal.vitest.ts` passes (3/3)
- [x] `npx vitest run` -> 309/311 (two pre-existing `fix-path` failures unrelated)
- [x] `npm run lint` -> 0 errors
- [ ] Manual: open Settings -> Models -> set/replace provider key, verify the dialog opens, focuses the input, accepts Escape and backdrop click for cancel, submits the trimmed key, and clears the input after save.

## Notes

- The vitest jsdom helper `litComponentTestUtils.ts` gains polyfills wa-dialog needs in jsdom: `HTMLDialogElement.showModal/show/close`, `Element.getAnimations`, `requestAnimationFrame/cancelAnimationFrame`, and matched `AbortController/AbortSignal` globals (so jsdom EventTarget instances accept the AbortSignal wa-dialog passes to `addEventListener({ signal })`).
- The third test ("closes on Escape and traps Tab focus") is replaced by an integration check that the dialog opens on mount and that submit closes the dialog without firing `provider-key-cancel` — Tab/Escape is wa-dialog's responsibility now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes modal open/close semantics and event timing, and adds jsdom polyfills that affect the shared Lit test harness used across settings component tests.
> 
> **Overview**
> Migrates `ProviderKeyModal` from a custom, hand-rolled modal (backdrop, focus trap, Escape handling) to Web Awesome’s `wa-dialog`, keeping the external API the same while simplifying the component’s internal close/focus logic.
> 
> Updates the submit/cancel flow to drive `wa-dialog` via a reactive `open` state and to **suppress `provider-key-cancel`** when the dialog is closed programmatically after a successful submit.
> 
> Adjusts vitest coverage to align with `wa-dialog` behavior (new open/close assertion; removes manual Tab/Escape trapping checks) and extends the shared `litComponentTestUtils` jsdom harness with dialog/animation/raf and AbortSignal-related polyfills needed for Web Awesome components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef39ac087fbefe395c1c28f7d1f31c7d78c8372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->