### PR TITLE
feat(webview,progress): replace vscode-toolbar-button with wa-button helpers

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -12,6 +12,7 @@ import { query, state } from 'lit/decorators.js';
 
 // Local imports - shared utilities
 import { FEEDBACK_ELIGIBLE_KINDS } from '@shared/utils/uiConstants';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
 import { BaseRequestPanel } from './BaseRequestPanel';
@@ -72,16 +73,15 @@ export abstract class BaseFeedbackPanel extends BaseRequestPanel {
   }
 
   protected renderRejectButton(rejectTitle: string): TemplateResult {
-    return html`
-      <vscode-toolbar-button
-        icon=${this.showFeedback ? 'check' : 'close'}
-        label=${this.showFeedback ? 'Submit' : 'Reject'}
-        title=${this.showFeedback ? 'Submit rejection (n)' : rejectTitle}
-        data-action="reject"
-        @click=${() => this.handleRejectAction()}
-        >${this.showFeedback ? 'Submit' : 'Reject'}</vscode-toolbar-button
-      >
-    `;
+    const text = this.showFeedback ? 'Submit' : 'Reject';
+    return renderLabeledActionButton({
+      icon: this.showFeedback ? 'check' : 'close',
+      label: text,
+      text,
+      title: this.showFeedback ? 'Submit rejection (n)' : rejectTitle,
+      action: 'reject',
+      onClick: () => this.handleRejectAction(),
+    });
   }
 
   protected renderFeedbackSection(

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -73,11 +73,9 @@ export abstract class BaseFeedbackPanel extends BaseRequestPanel {
   }
 
   protected renderRejectButton(rejectTitle: string): TemplateResult {
-    const text = this.showFeedback ? 'Submit' : 'Reject';
     return renderLabeledActionButton({
       icon: this.showFeedback ? 'check' : 'close',
-      label: text,
-      text,
+      text: this.showFeedback ? 'Submit' : 'Reject',
       title: this.showFeedback ? 'Submit rejection (n)' : rejectTitle,
       action: 'reject',
       onClick: () => this.handleRejectAction(),

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -61,7 +61,6 @@ export class BashRequestPanel extends BaseFeedbackPanel {
         <div class="bash-approval-request__actions">
           ${renderLabeledActionButton({
             icon: 'check',
-            label: 'Approve',
             text: 'Approve',
             title: 'Allow this command to execute (y)',
             action: 'approve',

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -22,6 +22,7 @@ import {
 
 // Local imports - progress view styles
 import type { BashPermission } from '@shared/schemas';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { codeBlockStyles } from '../styles/codeBlockStyles';
 
 // Local imports - progress view formatters
@@ -57,17 +58,17 @@ export class BashRequestPanel extends BaseFeedbackPanel {
             ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
           </div>
         </div>
-        <vscode-toolbar-container class="bash-approval-request__actions">
-          <vscode-toolbar-button
-            icon="check"
-            label="Approve"
-            title="Allow this command to execute (y)"
-            data-action="approve"
-            @click=${() => this.emitAction('approve')}
-            >Approve</vscode-toolbar-button
-          >
+        <div class="bash-approval-request__actions">
+          ${renderLabeledActionButton({
+            icon: 'check',
+            label: 'Approve',
+            text: 'Approve',
+            title: 'Allow this command to execute (y)',
+            action: 'approve',
+            onClick: () => this.emitAction('approve'),
+          })}
           ${this.renderRejectButton('Reject this command (n)')}
-        </vscode-toolbar-container>
+        </div>
         ${this.renderFeedbackSection(
           'bash-approval-request__feedback',
           'bash-approval-request__feedback-input',

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -29,6 +29,7 @@ import {
 import type { ExternalInquiryPermission } from '@shared/schemas';
 import { EXTERNAL_INQUIRY_ACTIONS } from '@shared/schemas';
 import { CopyButtonController } from '@shared/controllers/CopyButtonController';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { ProgressEvents } from '../events';
@@ -183,18 +184,20 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
 
   private renderQuestion(question: string): TemplateResult {
     const { copied } = this.copyController.state;
+    const text = copied ? 'Copied!' : 'Copy Question';
 
     return html`
       <div class="external-inquiry-request__question">
         <div class="external-inquiry-request__question-text">${question}</div>
         <div class="external-inquiry-request__question-actions">
-          <vscode-toolbar-button
-            icon=${copied ? 'check' : 'copy'}
-            label=${copied ? 'Copied!' : 'Copy Question'}
-            title="Copy question to clipboard for pasting into an external AI model"
-            @click=${() => this.copyController.copy(question)}
-            >${copied ? 'Copied!' : 'Copy Question'}</vscode-toolbar-button
-          >
+          ${renderLabeledActionButton({
+            icon: copied ? 'check' : 'copy',
+            label: text,
+            text,
+            title:
+              'Copy question to clipboard for pasting into an external AI model',
+            onClick: () => this.copyController.copy(question),
+          })}
         </div>
       </div>
     `;
@@ -312,18 +315,18 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
 
   private renderActions(): TemplateResult {
     return html`
-      <vscode-toolbar-container class="external-inquiry-request__actions">
-        <vscode-toolbar-button
-          icon="check"
-          label="Submit Answer"
-          title="Submit the answer from the external model"
-          data-action=${EXTERNAL_INQUIRY_ACTIONS[0]}
-          ?disabled=${!this.hasAnswer}
-          @click=${this.handleSubmit}
-          >Submit Answer</vscode-toolbar-button
-        >
+      <div class="external-inquiry-request__actions">
+        ${renderLabeledActionButton({
+          icon: 'check',
+          label: 'Submit Answer',
+          text: 'Submit Answer',
+          title: 'Submit the answer from the external model',
+          action: EXTERNAL_INQUIRY_ACTIONS[0],
+          disabled: !this.hasAnswer,
+          onClick: this.handleSubmit,
+        })}
         ${this.renderRejectButton('Reject this external inquiry (n)')}
-      </vscode-toolbar-container>
+      </div>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -192,7 +192,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
         <div class="external-inquiry-request__question-actions">
           ${renderLabeledActionButton({
             icon: copied ? 'check' : 'copy',
-            label: text,
             text,
             title:
               'Copy question to clipboard for pasting into an external AI model',
@@ -318,7 +317,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
       <div class="external-inquiry-request__actions">
         ${renderLabeledActionButton({
           icon: 'check',
-          label: 'Submit Answer',
           text: 'Submit Answer',
           title: 'Submit the answer from the external model',
           action: EXTERNAL_INQUIRY_ACTIONS[0],

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -8,6 +8,7 @@ import {
   type TemplateResult,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports
@@ -15,6 +16,8 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement } from '../utils';
@@ -22,6 +25,37 @@ import { webviewStorage } from '../webviewStorage';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
+
+interface FileActionOptions {
+  readonly icon: TeXRAIconName;
+  readonly label: string;
+  readonly title: string;
+  readonly className: string;
+  readonly command: string;
+  readonly file: string;
+  readonly base?: string;
+  readonly prev?: string;
+}
+
+function renderFileActionButton(opts: FileActionOptions): TemplateResult {
+  return html`
+    <wa-button
+      class="action-icon-button ${opts.className}"
+      appearance="plain"
+      variant="neutral"
+      size="small"
+      type="button"
+      aria-label=${opts.label}
+      title=${opts.title}
+      data-command=${opts.command}
+      data-file=${opts.file}
+      data-base=${ifDefined(opts.base)}
+      data-prev=${ifDefined(opts.prev)}
+    >
+      ${waIcon(opts.icon)}
+    </wa-button>
+  `;
+}
 
 const STORAGE_HINT_DISMISS_KEY = 'generatedFilesStorageHint.dismissed';
 
@@ -155,7 +189,7 @@ export class FileList extends LitElement {
         align-items: center;
       }
 
-      .file-actions :is(vscode-button, vscode-toolbar-button) {
+      .file-actions :is(vscode-button, wa-button) {
         margin-right: 0;
         margin-left: var(--spacing-tiny);
       }
@@ -304,13 +338,13 @@ export class FileList extends LitElement {
           it, use Accept to copy it into your workspace, or use the folder
           button to open the full run.
         </span>
-        <vscode-toolbar-button
-          class="storage-hint__dismiss"
-          icon="close"
-          label="Dismiss storage explanation"
-          title="Dismiss storage explanation"
-          @click=${this.handleDismissStorageHint}
-        ></vscode-toolbar-button>
+        ${renderIconActionButton({
+          icon: 'close',
+          label: 'Dismiss storage explanation',
+          title: 'Dismiss storage explanation',
+          className: 'storage-hint__dismiss',
+          onClick: this.handleDismissStorageHint,
+        })}
       </div>
     `;
   }
@@ -397,18 +431,19 @@ export class FileList extends LitElement {
           </span>
         </span>
         ${diffStats}
-        <vscode-toolbar-container class="file-actions">
+        <div class="file-actions">
           ${failure
-            ? html`<vscode-toolbar-button
-                icon="output"
-                label="Open compile log"
-                title="Open compile log (${failure.logRelativePath})"
-                data-command=${PROGRESS_VIEW_COMMANDS.OPEN_FILE}
-                data-file=${failure.log.absolutePath}
-              ></vscode-toolbar-button>`
+            ? renderFileActionButton({
+                icon: 'output',
+                label: 'Open compile log',
+                title: `Open compile log (${failure.logRelativePath})`,
+                className: '',
+                command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+                file: failure.log.absolutePath,
+              })
             : nothing}
           ${baseActions} ${previousAction}
-        </vscode-toolbar-container>
+        </div>
       </div>
     `;
   }
@@ -493,42 +528,42 @@ export class FileList extends LitElement {
     if (!basePath) return nothing;
 
     return html`
-      <vscode-toolbar-button
-        class="compare-btn"
-        icon="diff"
-        label="Compare with base"
-        title="Compare with base"
-        data-command=${PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL}
-        data-file=${filePath}
-        data-base=${basePath}
-      ></vscode-toolbar-button>
-      <vscode-toolbar-button
-        class="accept-btn"
-        icon="check"
-        label="Accept edits"
-        title="Accept edits"
-        data-command=${PROGRESS_VIEW_COMMANDS.ACCEPT_FILE}
-        data-file=${filePath}
-        data-base=${basePath}
-      ></vscode-toolbar-button>
-      <vscode-toolbar-button
-        class="merge-btn"
-        icon="git-merge"
-        label="Merge edits"
-        title="Merge edits"
-        data-command=${PROGRESS_VIEW_COMMANDS.MERGE_FILE}
-        data-file=${filePath}
-        data-base=${basePath}
-      ></vscode-toolbar-button>
-      <vscode-toolbar-button
-        class="diff-btn"
-        icon="diff-single"
-        label="LaTeXdiff"
-        title="LaTeXdiff"
-        data-command=${PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE}
-        data-file=${filePath}
-        data-base=${basePath}
-      ></vscode-toolbar-button>
+      ${renderFileActionButton({
+        icon: 'diff',
+        label: 'Compare with base',
+        title: 'Compare with base',
+        className: 'compare-btn',
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
+        file: filePath,
+        base: basePath,
+      })}
+      ${renderFileActionButton({
+        icon: 'check',
+        label: 'Accept edits',
+        title: 'Accept edits',
+        className: 'accept-btn',
+        command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
+        file: filePath,
+        base: basePath,
+      })}
+      ${renderFileActionButton({
+        icon: 'git-merge',
+        label: 'Merge edits',
+        title: 'Merge edits',
+        className: 'merge-btn',
+        command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
+        file: filePath,
+        base: basePath,
+      })}
+      ${renderFileActionButton({
+        icon: 'diff-single',
+        label: 'LaTeXdiff',
+        title: 'LaTeXdiff',
+        className: 'diff-btn',
+        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+        file: filePath,
+        base: basePath,
+      })}
     `;
   }
 
@@ -539,17 +574,15 @@ export class FileList extends LitElement {
   ): TemplateResult | typeof nothing {
     if (!previousPath) return nothing;
 
-    return html`
-      <vscode-toolbar-button
-        class="prev-btn"
-        icon="diff-added"
-        label="Compare with previous round"
-        title="Compare with previous round"
-        data-command=${PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS}
-        data-file=${filePath}
-        data-base=${basePath}
-        data-prev=${previousPath}
-      ></vscode-toolbar-button>
-    `;
+    return renderFileActionButton({
+      icon: 'diff-added',
+      label: 'Compare with previous round',
+      title: 'Compare with previous round',
+      className: 'prev-btn',
+      command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
+      file: filePath,
+      base: basePath,
+      prev: previousPath,
+    });
   }
 }

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -17,7 +17,6 @@ import { RecordingButtonController } from '@shared/controllers';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { getTextareaValue, insertTextAtCursor } from '@shared/utils/textarea';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 
@@ -199,45 +198,41 @@ export class FollowUpInput extends LitElement {
             ></vscode-textarea>
 
             <div class="follow-up-actions">
-              <span id=${ELEMENT_IDS.POLISH_FOLLOW_UP_BTN}>
-                ${renderIconActionButton({
-                  icon: 'sparkle',
-                  label: 'Polish follow-up',
-                  title: 'Polish follow-up with AI',
-                  onClick: this.emitPolish,
-                })}
-              </span>
+              ${renderIconActionButton({
+                id: ELEMENT_IDS.POLISH_FOLLOW_UP_BTN,
+                icon: 'sparkle',
+                label: 'Polish follow-up',
+                title: 'Polish follow-up with AI',
+                onClick: this.emitPolish,
+              })}
               ${when(
                 this.polishing,
                 () => html`<wa-progress-ring indeterminate></wa-progress-ring>`,
               )}
-              <span id=${ELEMENT_IDS.RECORD_FOLLOW_UP_BTN}>
-                ${renderIconActionButton({
-                  icon: this.recordingController.state.icon as TeXRAIconName,
-                  label: this.recordingController.state.title,
-                  title: this.recordingController.state.title,
-                  className: this.recordingController.state.recording
-                    ? this.recordingController.state.recordingClass
-                    : '',
-                  onClick: this.recordingController.handleClick,
-                })}
-              </span>
-              <span id=${ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN}>
-                ${renderIconActionButton({
-                  icon: 'clear-all',
-                  label: 'Clear input',
-                  title: 'Clear input',
-                  onClick: this.emitClear,
-                })}
-              </span>
-              <span id=${ELEMENT_IDS.SEND_FOLLOW_UP_BTN}>
-                ${renderIconActionButton({
-                  icon: 'send',
-                  label: 'Send',
-                  title: 'Send follow-up message',
-                  onClick: this.emitSend,
-                })}
-              </span>
+              ${renderIconActionButton({
+                id: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
+                icon: this.recordingController.state.icon,
+                label: this.recordingController.state.title,
+                title: this.recordingController.state.title,
+                className: this.recordingController.state.recording
+                  ? this.recordingController.state.recordingClass
+                  : '',
+                onClick: this.recordingController.handleClick,
+              })}
+              ${renderIconActionButton({
+                id: ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN,
+                icon: 'clear-all',
+                label: 'Clear input',
+                title: 'Clear input',
+                onClick: this.emitClear,
+              })}
+              ${renderIconActionButton({
+                id: ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
+                icon: 'send',
+                label: 'Send',
+                title: 'Send follow-up message',
+                onClick: this.emitSend,
+              })}
             </div>
           </div>
         </div>

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -8,7 +8,6 @@ import {
   type TemplateResult,
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { when } from 'lit/directives/when.js';
 
@@ -17,6 +16,8 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { RecordingButtonController } from '@shared/controllers';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { getTextareaValue, insertTextAtCursor } from '@shared/utils/textarea';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 
@@ -92,8 +93,7 @@ export class FollowUpInput extends LitElement {
         overflow-wrap: anywhere;
       }
 
-      .follow-up-actions,
-      vscode-toolbar-container.follow-up-actions {
+      .follow-up-actions {
         display: flex;
         flex-direction: column !important;
         align-items: center;
@@ -199,42 +199,45 @@ export class FollowUpInput extends LitElement {
             ></vscode-textarea>
 
             <div class="follow-up-actions">
-              <vscode-toolbar-button
-                id=${ELEMENT_IDS.POLISH_FOLLOW_UP_BTN}
-                icon="sparkle"
-                label="Polish follow-up"
-                title="Polish follow-up with AI"
-                @click=${this.emitPolish}
-              ></vscode-toolbar-button>
+              <span id=${ELEMENT_IDS.POLISH_FOLLOW_UP_BTN}>
+                ${renderIconActionButton({
+                  icon: 'sparkle',
+                  label: 'Polish follow-up',
+                  title: 'Polish follow-up with AI',
+                  onClick: this.emitPolish,
+                })}
+              </span>
               ${when(
                 this.polishing,
                 () => html`<wa-progress-ring indeterminate></wa-progress-ring>`,
               )}
-              <vscode-toolbar-button
-                id=${ELEMENT_IDS.RECORD_FOLLOW_UP_BTN}
-                icon=${this.recordingController.state.icon}
-                label=${this.recordingController.state.title}
-                title=${this.recordingController.state.title}
-                class=${classMap({
-                  [this.recordingController.state.recordingClass]:
-                    this.recordingController.state.recording,
+              <span id=${ELEMENT_IDS.RECORD_FOLLOW_UP_BTN}>
+                ${renderIconActionButton({
+                  icon: this.recordingController.state.icon as TeXRAIconName,
+                  label: this.recordingController.state.title,
+                  title: this.recordingController.state.title,
+                  className: this.recordingController.state.recording
+                    ? this.recordingController.state.recordingClass
+                    : '',
+                  onClick: this.recordingController.handleClick,
                 })}
-                @click=${this.recordingController.handleClick}
-              ></vscode-toolbar-button>
-              <vscode-toolbar-button
-                id=${ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN}
-                icon="clear-all"
-                label="Clear input"
-                title="Clear input"
-                @click=${this.emitClear}
-              ></vscode-toolbar-button>
-              <vscode-toolbar-button
-                id=${ELEMENT_IDS.SEND_FOLLOW_UP_BTN}
-                icon="send"
-                label="Send"
-                title="Send follow-up message"
-                @click=${this.emitSend}
-              ></vscode-toolbar-button>
+              </span>
+              <span id=${ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN}>
+                ${renderIconActionButton({
+                  icon: 'clear-all',
+                  label: 'Clear input',
+                  title: 'Clear input',
+                  onClick: this.emitClear,
+                })}
+              </span>
+              <span id=${ELEMENT_IDS.SEND_FOLLOW_UP_BTN}>
+                ${renderIconActionButton({
+                  icon: 'send',
+                  label: 'Send',
+                  title: 'Send follow-up message',
+                  onClick: this.emitSend,
+                })}
+              </span>
             </div>
           </div>
         </div>

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -26,6 +26,7 @@ import type { PlanApprovalPermission } from '@shared/schemas';
 
 // Local imports - shared utilities
 import { getBasename } from '@shared/utils/path';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
@@ -83,17 +84,17 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
             )}
           </ol>
         </div>
-        <vscode-toolbar-container class="plan-approval-request__actions">
-          <vscode-toolbar-button
-            icon="check"
-            label="Approve"
-            title="Approve this plan (y)"
-            data-action="approve"
-            @click=${() => this.emitAction('approve')}
-            >Approve</vscode-toolbar-button
-          >
+        <div class="plan-approval-request__actions">
+          ${renderLabeledActionButton({
+            icon: 'check',
+            label: 'Approve',
+            text: 'Approve',
+            title: 'Approve this plan (y)',
+            action: 'approve',
+            onClick: () => this.emitAction('approve'),
+          })}
           ${this.renderRejectButton('Reject this plan (n)')}
-        </vscode-toolbar-container>
+        </div>
         ${this.renderFeedbackSection(
           'plan-approval-request__feedback',
           'plan-approval-request__feedback-input',

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -87,7 +87,6 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
         <div class="plan-approval-request__actions">
           ${renderLabeledActionButton({
             icon: 'check',
-            label: 'Approve',
             text: 'Approve',
             title: 'Approve this plan (y)',
             action: 'approve',

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -169,7 +169,6 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
         <div class="workflow-proposal__actions">
           ${renderLabeledActionButton({
             icon: 'check',
-            label: 'Approve',
             text: 'Approve',
             title: 'Approve (y)',
             action: 'approve',
@@ -178,7 +177,6 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           ${this.renderRejectButton('Reject (n)')}
           ${renderLabeledActionButton({
             icon: 'reply',
-            label: 'Setup',
             text: 'Setup',
             title: 'Setup (s)',
             action: 'setup',

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -43,6 +43,7 @@ import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 // Local imports - shared utilities
 import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
@@ -165,25 +166,25 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           ${isWorkflow ? this.renderExtractFlags(data) : nothing}
           ${this.renderProposalFiles(data)}
         </div>
-        <vscode-toolbar-container class="workflow-proposal__actions">
-          <vscode-toolbar-button
-            icon="check"
-            label="Approve"
-            title="Approve (y)"
-            data-action="approve"
-            @click=${() => this.emitAction('approve')}
-            >Approve</vscode-toolbar-button
-          >
+        <div class="workflow-proposal__actions">
+          ${renderLabeledActionButton({
+            icon: 'check',
+            label: 'Approve',
+            text: 'Approve',
+            title: 'Approve (y)',
+            action: 'approve',
+            onClick: () => this.emitAction('approve'),
+          })}
           ${this.renderRejectButton('Reject (n)')}
-          <vscode-toolbar-button
-            icon="reply"
-            label="Setup"
-            title="Setup (s)"
-            data-action="setup"
-            @click=${() => this.emitAction('setup')}
-            >Setup</vscode-toolbar-button
-          >
-        </vscode-toolbar-container>
+          ${renderLabeledActionButton({
+            icon: 'reply',
+            label: 'Setup',
+            text: 'Setup',
+            title: 'Setup (s)',
+            action: 'setup',
+            onClick: () => this.emitAction('setup'),
+          })}
+        </div>
         ${this.renderFeedbackSection(
           'workflow-proposal__feedback',
           'workflow-proposal__feedback-input',

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -107,7 +107,6 @@ export class RetryRequestPanel extends BaseRequestPanel {
           ${when(isCredentialExhausted, () =>
             renderLabeledActionButton({
               icon: 'key',
-              label: 'Use your own API key',
               text: 'Use your own API key',
               title: 'Use your own API key (k)',
               onClick: () => this.emitAction('useOwnApiKey'),
@@ -115,14 +114,12 @@ export class RetryRequestPanel extends BaseRequestPanel {
           )}
           ${renderLabeledActionButton({
             icon: 'refresh',
-            label: 'Retry',
             text: 'Retry',
             title: 'Retry (r)',
             onClick: () => this.emitAction('retry'),
           })}
           ${renderLabeledActionButton({
             icon: 'close',
-            label: 'Dismiss',
             text: 'Dismiss',
             title: 'Dismiss (Esc)',
             onClick: () => this.emitAction('cancel'),

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -23,6 +23,7 @@ import {
 
 // Local imports - shared schemas
 import type { ProviderErrorPartial, RetryPermission } from '@shared/schemas';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { BaseRequestPanel } from './BaseRequestPanel';
 
 // Local imports - base class
@@ -102,34 +103,31 @@ export class RetryRequestPanel extends BaseRequestPanel {
               `
             : nothing}
         </div>
-        <vscode-toolbar-container class="retry-request__actions">
-          ${when(
-            isCredentialExhausted,
-            () => html`
-              <vscode-toolbar-button
-                icon="key"
-                label="Use your own API key"
-                title="Use your own API key (k)"
-                @click=${() => this.emitAction('useOwnApiKey')}
-                >Use your own API key</vscode-toolbar-button
-              >
-            `,
+        <div class="retry-request__actions">
+          ${when(isCredentialExhausted, () =>
+            renderLabeledActionButton({
+              icon: 'key',
+              label: 'Use your own API key',
+              text: 'Use your own API key',
+              title: 'Use your own API key (k)',
+              onClick: () => this.emitAction('useOwnApiKey'),
+            }),
           )}
-          <vscode-toolbar-button
-            icon="refresh"
-            label="Retry"
-            title="Retry (r)"
-            @click=${() => this.emitAction('retry')}
-            >Retry</vscode-toolbar-button
-          >
-          <vscode-toolbar-button
-            icon="close"
-            label="Dismiss"
-            title="Dismiss (Esc)"
-            @click=${() => this.emitAction('cancel')}
-            >Dismiss</vscode-toolbar-button
-          >
-        </vscode-toolbar-container>
+          ${renderLabeledActionButton({
+            icon: 'refresh',
+            label: 'Retry',
+            text: 'Retry',
+            title: 'Retry (r)',
+            onClick: () => this.emitAction('retry'),
+          })}
+          ${renderLabeledActionButton({
+            icon: 'close',
+            label: 'Dismiss',
+            text: 'Dismiss',
+            title: 'Dismiss (Esc)',
+            onClick: () => this.emitAction('cancel'),
+          })}
+        </div>
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -19,6 +19,7 @@ import {
 } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
@@ -369,8 +370,9 @@ export class StreamHeader extends LitElement {
             ${this.renderProgressBadge()}
           </div>
           <div class="header-actions">
-            <vscode-toolbar-container
+            <div
               id=${ELEMENT_IDS.TOOLBAR_CONTAINER}
+              class="toolbar-container"
               data-agent-mode=${agentCategory}
               @click=${this.handleToolbarClick}
             >
@@ -391,25 +393,33 @@ export class StreamHeader extends LitElement {
                   );
                   const title =
                     isActive && btn.titleActive ? btn.titleActive : btn.title;
+                  const className = [
+                    btn.className,
+                    hidden ? 'toolbar-button--hidden' : '',
+                    isActive ? 'is-active' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
                   return html`
-                    <vscode-toolbar-button
+                    <wa-button
                       id=${btn.id}
-                      icon=${btn.icon}
-                      label=${title}
+                      class="action-icon-button ${className}"
+                      appearance="plain"
+                      variant="neutral"
+                      size="small"
+                      type="button"
+                      aria-label=${title}
                       title=${title}
                       data-command=${btn.command}
                       aria-hidden=${hidden ? 'true' : 'false'}
                       ?disabled=${disabled}
-                      class=${classMap({
-                        [btn.className || '']: Boolean(btn.className),
-                        'toolbar-button--hidden': hidden,
-                        'is-active': isActive,
-                      })}
-                    ></vscode-toolbar-button>
+                    >
+                      ${waIcon(btn.icon as TeXRAIconName)}
+                    </wa-button>
                   `;
                 },
               )}
-            </vscode-toolbar-container>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -393,17 +393,16 @@ export class StreamHeader extends LitElement {
                   );
                   const title =
                     isActive && btn.titleActive ? btn.titleActive : btn.title;
-                  const className = [
-                    btn.className,
-                    hidden ? 'toolbar-button--hidden' : '',
-                    isActive ? 'is-active' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ');
+                  const classes = classMap({
+                    'action-icon-button': true,
+                    ...(btn.className ? { [btn.className]: true } : {}),
+                    'toolbar-button--hidden': hidden,
+                    'is-active': isActive,
+                  });
                   return html`
                     <wa-button
                       id=${btn.id}
-                      class="action-icon-button ${className}"
+                      class=${classes}
                       appearance="plain"
                       variant="neutral"
                       size="small"

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -824,15 +824,14 @@ export class StreamTabs extends LitElement {
                 </wa-radio-group>
 
                 <div class="stream-list-actions">
-                  <span id=${ELEMENT_IDS.DELETE_ALL_BTN}>
-                    ${renderIconActionButton({
-                      icon: 'trash',
-                      label: 'Clear all streams',
-                      title: 'Clear all streams',
-                      className: 'delete-all-streams',
-                      onClick: this.handleDeleteAll,
-                    })}
-                  </span>
+                  ${renderIconActionButton({
+                    id: ELEMENT_IDS.DELETE_ALL_BTN,
+                    icon: 'trash',
+                    label: 'Clear all streams',
+                    title: 'Clear all streams',
+                    className: 'delete-all-streams',
+                    onClick: this.handleDeleteAll,
+                  })}
                 </div>
               </div>
             </div>`}

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -22,6 +22,8 @@ import {
   getAgentCategoryDecorator,
 } from '@shared/utils/icons';
 import { formatRelativeTime } from '@shared/utils/string';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { layoutStyles } from '../styles/logStyles';
 import {
   ACTIVE_STREAM_STATUSES,
@@ -300,7 +302,7 @@ export class StreamTab extends LitElement {
         flex-shrink: 0;
       }
 
-      .tab-delete::part(control) {
+      .tab-delete::part(base) {
         padding: 0;
         border-radius: var(--border-radius-small);
         background-color: color-mix(
@@ -310,8 +312,8 @@ export class StreamTab extends LitElement {
         );
       }
 
-      .tab-delete:hover::part(control),
-      .tab-delete:focus-within::part(control) {
+      .tab-delete:hover::part(base),
+      .tab-delete:focus-within::part(base) {
         background-color: var(--texra-toolbar-hoverBackground);
       }
 
@@ -470,14 +472,19 @@ export class StreamTab extends LitElement {
                 </div>
               `}
         </button>
-        <vscode-toolbar-button
-          class="tab-delete"
-          icon="close"
-          title="Delete stream"
+        <wa-button
+          class="action-icon-button tab-delete"
+          appearance="plain"
+          variant="neutral"
+          size="small"
+          type="button"
           aria-label="Delete stream"
+          title="Delete stream"
           data-stream=${stream.name}
           data-action="delete"
-        ></vscode-toolbar-button>
+        >
+          ${waIcon('close')}
+        </wa-button>
       </div>
     `;
   }
@@ -817,14 +824,15 @@ export class StreamTabs extends LitElement {
                 </wa-radio-group>
 
                 <div class="stream-list-actions">
-                  <vscode-toolbar-button
-                    id=${ELEMENT_IDS.DELETE_ALL_BTN}
-                    class="delete-all-streams"
-                    icon="trash"
-                    label="Clear all streams"
-                    title="Clear all streams"
-                    @click=${this.handleDeleteAll}
-                  ></vscode-toolbar-button>
+                  <span id=${ELEMENT_IDS.DELETE_ALL_BTN}>
+                    ${renderIconActionButton({
+                      icon: 'trash',
+                      label: 'Clear all streams',
+                      title: 'Clear all streams',
+                      className: 'delete-all-streams',
+                      onClick: this.handleDeleteAll,
+                    })}
+                  </span>
                 </div>
               </div>
             </div>`}

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -23,6 +23,8 @@ import {
 
 // Local imports - shared schemas
 import type { ToolEditPermission } from '@shared/schemas';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
@@ -81,18 +83,18 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
             ${diffMeta}
           </div>
         </div>
-        <vscode-toolbar-container class="approval-request__actions">
+        <div class="approval-request__actions">
           ${this.renderDiffActions()}
-          <vscode-toolbar-button
-            icon="check"
-            label="Approve"
-            title="Approve (y)"
-            data-action="approve"
-            @click=${() => this.emitAction('approve')}
-            >Approve</vscode-toolbar-button
-          >
+          ${renderLabeledActionButton({
+            icon: 'check',
+            label: 'Approve',
+            text: 'Approve',
+            title: 'Approve (y)',
+            action: 'approve',
+            onClick: () => this.emitAction('approve'),
+          })}
           ${this.renderRejectButton('Reject (n)')}
-        </vscode-toolbar-container>
+        </div>
         ${this.renderFeedbackSection(
           'approval-request__feedback',
           'approval-request__feedback-input',
@@ -111,36 +113,40 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
     const showDropdown = Boolean(data.isLatex);
     const hasInlineDiff = this.hasInlineDiff(data);
 
+    const diffLabel =
+      hasInlineDiff && this.inlineDiffOpen ? 'Hide diff' : 'Open diff';
+    const diffTitle = hasInlineDiff
+      ? this.inlineDiffOpen
+        ? 'Hide inline diff (d)'
+        : 'Open inline diff (d)'
+      : 'Open diff (d)';
+
     return html`
       <div class="diff-dropdown">
-        <vscode-toolbar-button
-          icon="diff"
-          class="diff-main-button"
-          label=${hasInlineDiff && this.inlineDiffOpen
-            ? 'Hide diff'
-            : 'Open diff'}
-          title=${hasInlineDiff
-            ? this.inlineDiffOpen
-              ? 'Hide inline diff (d)'
-              : 'Open inline diff (d)'
-            : 'Open diff (d)'}
-          @click=${this.handleDiffAction}
-          >${hasInlineDiff && this.inlineDiffOpen
-            ? 'Hide diff'
-            : 'Open diff'}</vscode-toolbar-button
-        >
+        ${renderLabeledActionButton({
+          icon: 'diff',
+          label: diffLabel,
+          text: diffLabel,
+          title: diffTitle,
+          className: 'diff-main-button',
+          onClick: this.handleDiffAction,
+        })}
         ${showDropdown
           ? html`
-              <vscode-toolbar-button
-                class="diff-dropdown-trigger"
+              <wa-button
+                class="action-icon-button diff-dropdown-trigger"
+                appearance="plain"
+                variant="neutral"
+                size="small"
+                type="button"
                 aria-haspopup="true"
                 aria-expanded=${this.diffMenuOpen ? 'true' : 'false'}
-                label="More diff actions"
+                aria-label="More diff actions"
                 title="More diff actions"
                 @click=${this.toggleDiffMenu}
               >
-                <i class="codicon codicon-chevron-down"></i>
-              </vscode-toolbar-button>
+                ${waIcon('chevron-down')}
+              </wa-button>
               <vscode-context-menu
                 class="diff-dropdown-menu"
                 ?show=${this.diffMenuOpen}

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -87,7 +87,6 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
           ${this.renderDiffActions()}
           ${renderLabeledActionButton({
             icon: 'check',
-            label: 'Approve',
             text: 'Approve',
             title: 'Approve (y)',
             action: 'approve',
@@ -125,7 +124,6 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
       <div class="diff-dropdown">
         ${renderLabeledActionButton({
           icon: 'diff',
-          label: diffLabel,
           text: diffLabel,
           title: diffTitle,
           className: 'diff-main-button',

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -13,6 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { CopyButtonController } from '@shared/controllers';
 import { designTokens } from '@shared/styles/litStyles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers
 import { formatTimestamp } from '../formatters/timestampUtils';
@@ -225,28 +226,21 @@ export class UserMessage extends LitElement {
                 >${timeDisplay}</span
               >
             </span>
-            <vscode-toolbar-button
-              class=${classMap({
-                'user-message-copy': true,
-                [copyState.successClass]: copyState.copied,
-              })}
-              icon="copy"
-              title=${copyState.title}
-              aria-label=${copyState.ariaLabel}
-              @click=${() => this.copyController.copy(displayText)}
-            ></vscode-toolbar-button>
+            ${renderIconActionButton({
+              icon: 'copy',
+              label: copyState.ariaLabel,
+              title: copyState.title,
+              className: `user-message-copy ${copyState.copied ? copyState.successClass : ''}`,
+              onClick: () => this.copyController.copy(displayText),
+            })}
             ${hasRawMessage
-              ? html`<vscode-toolbar-button
-                  class=${classMap({
-                    'user-message-copy': true,
-                    [rawMessageCopyState.successClass]:
-                      rawMessageCopyState.copied,
-                  })}
-                  icon="code"
-                  title=${rawMessageCopyState.title}
-                  aria-label=${rawMessageCopyState.ariaLabel}
-                  @click=${() => this.rawMessageCopyController.copy(this.text)}
-                ></vscode-toolbar-button>`
+              ? renderIconActionButton({
+                  icon: 'code',
+                  label: rawMessageCopyState.ariaLabel,
+                  title: rawMessageCopyState.title,
+                  className: `user-message-copy ${rawMessageCopyState.copied ? rawMessageCopyState.successClass : ''}`,
+                  onClick: () => this.rawMessageCopyController.copy(this.text),
+                })
               : nothing}
           </div>
           <div

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -10,6 +10,8 @@
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+
 import { webviewStorage } from '../webviewStorage';
 
 const DISMISS_KEY = 'workflowHintBanner.dismissed';
@@ -59,12 +61,12 @@ export class WorkflowHintBanner extends LitElement {
           It reduces hallucinations and cuts fluff, so expect 10–30 minutes per
           run. Use Stop to cancel; pick Tool-Use mode for fast, iterative edits.
         </div>
-        <vscode-toolbar-button
-          icon="close"
-          title="Dismiss this reminder"
-          aria-label="Dismiss workflow mode reminder"
-          @click=${this.handleDismiss}
-        ></vscode-toolbar-button>
+        ${renderIconActionButton({
+          icon: 'close',
+          label: 'Dismiss workflow mode reminder',
+          title: 'Dismiss this reminder',
+          onClick: this.handleDismiss,
+        })}
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -14,6 +14,7 @@ import { hljs } from '@shared/highlighting/hljs';
 // Local imports - shared utilities
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { getBasename } from '@shared/utils/path';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - Lit template utilities
 import {
@@ -111,7 +112,7 @@ export function buildCopyButton(
   const { hidden = false, content, contentId } = options;
   const copyId = content != null ? registerCopyContent(content, contentId) : '';
   // prettier-ignore
-  return html`<vscode-toolbar-button class="banner-content-copy" icon="copy" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden}></vscode-toolbar-button>`;
+  return html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden}>${waIcon('copy')}</wa-button>`;
 }
 
 /** Options for building a details summary header. */

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -18,6 +18,7 @@ import {
 
 // Local imports - shared utilities
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - Lit template utilities
 import {
@@ -144,7 +145,7 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // prettier-ignore
   const labelSpan = html`<span class="label" title=${tooltipTimestamp}>[${timeDisplay}] ${summaryText}</span>`;
   // prettier-ignore
-  const copyButton = html`<vscode-toolbar-button class="banner-content-copy" icon="copy" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails}></vscode-toolbar-button>`;
+  const copyButton = html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails}>${waIcon('copy')}</wa-button>`;
   // prettier-ignore
   const summaryTemplate = html`<summary class="details-summary">${toggleIcon}<i class="codicon icon codicon-error"></i>${labelSpan}${copyButton}</summary>`;
   // prettier-ignore

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -696,7 +696,6 @@ export class AgentSelectionPanel extends LitElement {
                 ${renderLabeledActionButton({
                   icon: 'folder-open',
                   text: 'Reveal in File Explorer',
-                  label: 'Reveal in File Explorer',
                   title: 'Show this file in your system file explorer',
                   className: 'agent-action-btn',
                   onClick: () => this.handleRevealAgentFile(agent),

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -463,18 +463,15 @@ export class FileSelectGroup extends LitElement {
       >
         <div class="file-select-header">
           <div class="file-select-label-group">
-            <span
-              id="refresh${config.type[0].toUpperCase()}${config.type.slice(
+            ${renderIconActionButton({
+              id: `refresh${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FileButton"
-            >
-              ${renderIconActionButton({
-                icon: config.icon as TeXRAIconName,
-                label: config.refreshTitle,
-                title: config.refreshTitle,
-                onClick: this.handleRefreshFiles,
-              })}
-            </span>
+              )}FileButton`,
+              icon: config.icon as TeXRAIconName,
+              label: config.refreshTitle,
+              title: config.refreshTitle,
+              onClick: this.handleRefreshFiles,
+            })}
             <label for=${this.selectId} title=${config.tooltip}
               >${config.label}</label
             >
@@ -491,30 +488,24 @@ export class FileSelectGroup extends LitElement {
               : nothing}
           </div>
           <div class="file-select-actions">
-            <span
-              id="current${config.type[0].toUpperCase()}${config.type.slice(
+            ${renderIconActionButton({
+              id: `current${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FileButton"
-            >
-              ${renderIconActionButton({
-                icon: 'file-code',
-                label: config.currentTitle,
-                title: config.currentTitle,
-                onClick: this.handleGetCurrentFile,
-              })}
-            </span>
-            <span
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+              )}FileButton`,
+              icon: 'file-code',
+              label: config.currentTitle,
+              title: config.currentTitle,
+              onClick: this.handleGetCurrentFile,
+            })}
+            ${renderIconActionButton({
+              id: `empty${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FileButton"
-            >
-              ${renderIconActionButton({
-                icon: 'close',
-                label: config.emptyTitle,
-                title: config.emptyTitle,
-                onClick: this.handleEmptyFile,
-              })}
-            </span>
+              )}FileButton`,
+              icon: 'close',
+              label: config.emptyTitle,
+              title: config.emptyTitle,
+              onClick: this.handleEmptyFile,
+            })}
             <button
               id=${toggleId}
               class="toggle-icon"
@@ -525,45 +516,36 @@ export class FileSelectGroup extends LitElement {
             >
               <i class="codicon ${chevronClass}"></i>
             </button>
-            <span
-              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
+            ${renderIconActionButton({
+              id: `addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FilesButton"
-            >
-              ${renderIconActionButton({
-                icon: 'folder-opened',
-                label: config.addOpenedLabel,
-                title: config.addOpenedLabel,
-                className: 'file-action-button',
-                onClick: this.handleAddOpenedFiles,
-              })}
-            </span>
-            <span
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+              )}FilesButton`,
+              icon: 'folder-opened',
+              label: config.addOpenedLabel,
+              title: config.addOpenedLabel,
+              className: 'file-action-button',
+              onClick: this.handleAddOpenedFiles,
+            })}
+            ${renderIconActionButton({
+              id: `empty${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FilesButton"
-            >
-              ${renderIconActionButton({
-                icon: 'trash',
-                label: config.emptyListLabel,
-                title: config.emptyListLabel,
-                className: 'file-action-button',
-                onClick: this.handleEmptyFiles,
-              })}
-            </span>
-            <span
-              id="select${config.type[0].toUpperCase()}${config.type.slice(
+              )}FilesButton`,
+              icon: 'trash',
+              label: config.emptyListLabel,
+              title: config.emptyListLabel,
+              className: 'file-action-button',
+              onClick: this.handleEmptyFiles,
+            })}
+            ${renderIconActionButton({
+              id: `select${config.type[0].toUpperCase()}${config.type.slice(
                 1,
-              )}FilesButton"
-            >
-              ${renderIconActionButton({
-                icon: 'add',
-                label: config.selectListLabel,
-                title: config.selectListLabel,
-                className: 'file-action-button',
-                onClick: this.handleSelectMultipleFiles,
-              })}
-            </span>
+              )}FilesButton`,
+              icon: 'add',
+              label: config.selectListLabel,
+              title: config.selectListLabel,
+              className: 'file-action-button',
+              onClick: this.handleSelectMultipleFiles,
+            })}
           </div>
         </div>
         <wa-select

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -16,6 +16,8 @@ import { designTokens, codiconStyles } from '@shared/styles';
 import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
 import { ensureContextMenuUsesSlot } from '@shared/utils/dom';
 import { getBasename, normalizeFilePath } from '@shared/utils/path';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
 import { SESSION_TYPES } from '../constants';
 import { SESSION_DEFAULTS } from '../sessionDefaults';
@@ -268,19 +270,25 @@ export class FileSelectGroup extends LitElement {
 
     return html`
       <div class="dropdown-container">
-        <vscode-toolbar-button
+        <wa-button
           id="toggleToolConfig"
-          icon="tools"
+          class=${classMap({
+            'action-icon-button': true,
+            'has-options': hasChecked,
+          })}
+          appearance="plain"
+          variant="neutral"
+          size="small"
+          type="button"
+          aria-label="Tool configuration options"
           title="Tool configuration options"
-          toggleable
           aria-haspopup="true"
           aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
-          class=${classMap({ 'has-options': hasChecked })}
-          ?checked=${this.toolConfigMenuOpen}
           @click=${() => this.toggleMenu('toolConfig')}
         >
+          ${waIcon('tools', { slot: 'start' })}
           <i class="codicon ${chevronClass}"></i>
-        </vscode-toolbar-button>
+        </wa-button>
         <vscode-context-menu
           id="toolConfigOptions"
           class="dropdown-menu"
@@ -328,19 +336,25 @@ export class FileSelectGroup extends LitElement {
 
     return html`
       <div class="dropdown-container">
-        <vscode-toolbar-button
+        <wa-button
           id="toggleAutoExtract"
-          icon="wand"
+          class=${classMap({
+            'action-icon-button': true,
+            'has-options': hasChecked,
+          })}
+          appearance="plain"
+          variant="neutral"
+          size="small"
+          type="button"
+          aria-label="Auto-extract options"
           title="Auto-extract options"
-          toggleable
           aria-haspopup="true"
           aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
-          class=${classMap({ 'has-options': hasChecked })}
-          ?checked=${this.autoExtractMenuOpen}
           @click=${() => this.toggleMenu('autoExtract')}
         >
+          ${waIcon('wand', { slot: 'start' })}
           <i class="codicon ${chevronClass}"></i>
-        </vscode-toolbar-button>
+        </wa-button>
         <vscode-context-menu
           id="autoExtractOptions"
           class="dropdown-menu"
@@ -449,15 +463,18 @@ export class FileSelectGroup extends LitElement {
       >
         <div class="file-select-header">
           <div class="file-select-label-group">
-            <vscode-toolbar-button
+            <span
               id="refresh${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FileButton"
-              icon=${config.icon}
-              label=${config.refreshTitle}
-              title=${config.refreshTitle}
-              @click=${this.handleRefreshFiles}
-            ></vscode-toolbar-button>
+            >
+              ${renderIconActionButton({
+                icon: config.icon as TeXRAIconName,
+                label: config.refreshTitle,
+                title: config.refreshTitle,
+                onClick: this.handleRefreshFiles,
+              })}
+            </span>
             <label for=${this.selectId} title=${config.tooltip}
               >${config.label}</label
             >
@@ -473,25 +490,31 @@ export class FileSelectGroup extends LitElement {
                 >`
               : nothing}
           </div>
-          <vscode-toolbar-container class="file-select-actions">
-            <vscode-toolbar-button
+          <div class="file-select-actions">
+            <span
               id="current${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FileButton"
-              icon="file-code"
-              label=${config.currentTitle}
-              title=${config.currentTitle}
-              @click=${this.handleGetCurrentFile}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
+            >
+              ${renderIconActionButton({
+                icon: 'file-code',
+                label: config.currentTitle,
+                title: config.currentTitle,
+                onClick: this.handleGetCurrentFile,
+              })}
+            </span>
+            <span
               id="empty${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FileButton"
-              icon="close"
-              label=${config.emptyTitle}
-              title=${config.emptyTitle}
-              @click=${this.handleEmptyFile}
-            ></vscode-toolbar-button>
+            >
+              ${renderIconActionButton({
+                icon: 'close',
+                label: config.emptyTitle,
+                title: config.emptyTitle,
+                onClick: this.handleEmptyFile,
+              })}
+            </span>
             <button
               id=${toggleId}
               class="toggle-icon"
@@ -502,37 +525,46 @@ export class FileSelectGroup extends LitElement {
             >
               <i class="codicon ${chevronClass}"></i>
             </button>
-            <vscode-toolbar-button
+            <span
               id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FilesButton"
-              class="file-action-button"
-              icon="folder-opened"
-              label=${config.addOpenedLabel}
-              title=${config.addOpenedLabel}
-              @click=${this.handleAddOpenedFiles}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
+            >
+              ${renderIconActionButton({
+                icon: 'folder-opened',
+                label: config.addOpenedLabel,
+                title: config.addOpenedLabel,
+                className: 'file-action-button',
+                onClick: this.handleAddOpenedFiles,
+              })}
+            </span>
+            <span
               id="empty${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FilesButton"
-              class="file-action-button"
-              icon="trash"
-              label=${config.emptyListLabel}
-              title=${config.emptyListLabel}
-              @click=${this.handleEmptyFiles}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
+            >
+              ${renderIconActionButton({
+                icon: 'trash',
+                label: config.emptyListLabel,
+                title: config.emptyListLabel,
+                className: 'file-action-button',
+                onClick: this.handleEmptyFiles,
+              })}
+            </span>
+            <span
               id="select${config.type[0].toUpperCase()}${config.type.slice(
                 1,
               )}FilesButton"
-              class="file-action-button"
-              icon="add"
-              label=${config.selectListLabel}
-              title=${config.selectListLabel}
-              @click=${this.handleSelectMultipleFiles}
-            ></vscode-toolbar-button>
-          </vscode-toolbar-container>
+            >
+              ${renderIconActionButton({
+                icon: 'add',
+                label: config.selectListLabel,
+                title: config.selectListLabel,
+                className: 'file-action-button',
+                onClick: this.handleSelectMultipleFiles,
+              })}
+            </span>
+          </div>
         </div>
         <wa-select
           id=${this.selectId}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -27,7 +27,6 @@ import {
 } from '@shared/utils/selectTemplates';
 import { getTextareaValue } from '@shared/utils/textarea';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
@@ -506,10 +505,10 @@ export class InstructionPanel extends LitElement {
             @click=${this.handleActionClick}
           >
             <span
-              id="packButton"
               style=${styleMap({ display: session.debugMode ? '' : 'none' })}
             >
               ${renderIconActionButton({
+                id: 'packButton',
                 icon: 'archive',
                 label: 'Pack output to History',
                 title: 'Pack the output for this agent into the History folder',
@@ -517,25 +516,24 @@ export class InstructionPanel extends LitElement {
               })}
             </span>
             <span
-              id="cleanButton"
               style=${styleMap({ display: session.debugMode ? '' : 'none' })}
             >
               ${renderIconActionButton({
+                id: 'cleanButton',
                 icon: 'trash',
                 label: 'Clean output',
                 title: 'Clean the output for this agent',
                 action: 'clean',
               })}
             </span>
-            <span id="magicPolishButton">
-              ${renderIconActionButton({
-                icon: 'sparkle',
-                label: 'Polish instruction',
-                title: 'Polish instruction text with AI',
-                disabled: session.isPolishing,
-                action: 'polish',
-              })}
-            </span>
+            ${renderIconActionButton({
+              id: 'magicPolishButton',
+              icon: 'sparkle',
+              label: 'Polish instruction',
+              title: 'Polish instruction text with AI',
+              disabled: session.isPolishing,
+              action: 'polish',
+            })}
             ${session.isPolishing
               ? html`
                   <vscode-progress-ring
@@ -547,27 +545,23 @@ export class InstructionPanel extends LitElement {
                   ></vscode-progress-ring>
                 `
               : nothing}
-            <span id="recordInstructionButton">
-              ${renderIconActionButton({
-                icon: (session.isRecording
-                  ? 'stop-circle'
-                  : 'mic') as TeXRAIconName,
-                label: 'Record instruction',
-                title: session.isRecording
-                  ? 'Stop recording'
-                  : 'Record instruction with microphone',
-                className: session.isRecording ? 'recording' : '',
-                action: 'record',
-              })}
-            </span>
-            <span id="eraseInstructionButton">
-              ${renderIconActionButton({
-                icon: 'clear-all',
-                label: 'Erase instruction',
-                title: 'Erase instruction',
-                action: 'erase',
-              })}
-            </span>
+            ${renderIconActionButton({
+              id: 'recordInstructionButton',
+              icon: session.isRecording ? 'stop-circle' : 'mic',
+              label: 'Record instruction',
+              title: session.isRecording
+                ? 'Stop recording'
+                : 'Record instruction with microphone',
+              className: session.isRecording ? 'recording' : '',
+              action: 'record',
+            })}
+            ${renderIconActionButton({
+              id: 'eraseInstructionButton',
+              icon: 'clear-all',
+              label: 'Erase instruction',
+              title: 'Erase instruction',
+              action: 'erase',
+            })}
           </div>
         </div>
         ${this.renderSessionHint(session)}
@@ -585,15 +579,14 @@ export class InstructionPanel extends LitElement {
             <div
               class="select-group agent-select-group agent-model-select-group"
             >
-              <span id="agentSettingsButton">
-                ${renderIconActionButton({
-                  icon: 'sparkle',
-                  label: 'Agent settings',
-                  title: 'Agent settings',
-                  className: 'settings-button',
-                  onClick: this.handleAgentSettings,
-                })}
-              </span>
+              ${renderIconActionButton({
+                id: 'agentSettingsButton',
+                icon: 'sparkle',
+                label: 'Agent settings',
+                title: 'Agent settings',
+                className: 'settings-button',
+                onClick: this.handleAgentSettings,
+              })}
               <div class="agent-select-controls">
                 <div class="agent-select-dropdowns">
                   <vscode-single-select
@@ -664,15 +657,14 @@ export class InstructionPanel extends LitElement {
             <div
               class="select-group model-select-group agent-model-select-group"
             >
-              <span id="modelSettingsButton">
-                ${renderIconActionButton({
-                  icon: 'robot',
-                  label: 'Model settings',
-                  title: 'Model settings',
-                  className: 'settings-button',
-                  onClick: this.handleModelSettings,
-                })}
-              </span>
+              ${renderIconActionButton({
+                id: 'modelSettingsButton',
+                icon: 'robot',
+                label: 'Model settings',
+                title: 'Model settings',
+                className: 'settings-button',
+                onClick: this.handleModelSettings,
+              })}
               <vscode-single-select
                 id="model"
                 class="model-select"

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -26,6 +26,8 @@ import {
   renderModelOptions,
 } from '@shared/utils/selectTemplates';
 import { getTextareaValue } from '@shared/utils/textarea';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
@@ -237,13 +239,13 @@ export class InstructionPanel extends LitElement {
       }
 
       .model-selection-footer .codicon,
-      .model-selection-footer vscode-toolbar-button {
+      .model-selection-footer wa-button {
         display: flex;
         align-items: center;
         line-height: 1;
       }
 
-      .model-selection-footer vscode-toolbar-button {
+      .model-selection-footer wa-button {
         min-width: var(--height-control);
         height: var(--height-control);
       }
@@ -359,13 +361,13 @@ export class InstructionPanel extends LitElement {
           ${copy.body}
           <span class="session-hint-time">${copy.time}</span>
         </span>
-        <vscode-toolbar-button
-          icon="close"
-          class="session-hint-dismiss"
-          title="Dismiss this reminder"
-          aria-label="Dismiss this reminder"
-          @click=${this.handleDismissSessionHint}
-        ></vscode-toolbar-button>
+        ${renderIconActionButton({
+          icon: 'close',
+          label: 'Dismiss this reminder',
+          title: 'Dismiss this reminder',
+          className: 'session-hint-dismiss',
+          onClick: this.handleDismissSessionHint,
+        })}
       </div>
     `;
   }
@@ -499,34 +501,41 @@ export class InstructionPanel extends LitElement {
               </vscode-radio-group>
             </div>
           </div>
-          <vscode-toolbar-container
+          <div
             class="instruction-header-actions"
             @click=${this.handleActionClick}
           >
-            <vscode-toolbar-button
+            <span
               id="packButton"
-              icon="archive"
-              label="Pack output to History"
-              title="Pack the output for this agent into the History folder"
               style=${styleMap({ display: session.debugMode ? '' : 'none' })}
-              data-action="pack"
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
+            >
+              ${renderIconActionButton({
+                icon: 'archive',
+                label: 'Pack output to History',
+                title: 'Pack the output for this agent into the History folder',
+                action: 'pack',
+              })}
+            </span>
+            <span
               id="cleanButton"
-              icon="trash"
-              label="Clean output"
-              title="Clean the output for this agent"
               style=${styleMap({ display: session.debugMode ? '' : 'none' })}
-              data-action="clean"
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="magicPolishButton"
-              icon="sparkle"
-              label="Polish instruction"
-              title="Polish instruction text with AI"
-              ?disabled=${session.isPolishing}
-              data-action="polish"
-            ></vscode-toolbar-button>
+            >
+              ${renderIconActionButton({
+                icon: 'trash',
+                label: 'Clean output',
+                title: 'Clean the output for this agent',
+                action: 'clean',
+              })}
+            </span>
+            <span id="magicPolishButton">
+              ${renderIconActionButton({
+                icon: 'sparkle',
+                label: 'Polish instruction',
+                title: 'Polish instruction text with AI',
+                disabled: session.isPolishing,
+                action: 'polish',
+              })}
+            </span>
             ${session.isPolishing
               ? html`
                   <vscode-progress-ring
@@ -538,24 +547,28 @@ export class InstructionPanel extends LitElement {
                   ></vscode-progress-ring>
                 `
               : nothing}
-            <vscode-toolbar-button
-              id="recordInstructionButton"
-              icon=${session.isRecording ? 'stop-circle' : 'mic'}
-              class=${session.isRecording ? 'recording' : ''}
-              label="Record instruction"
-              title=${session.isRecording
-                ? 'Stop recording'
-                : 'Record instruction with microphone'}
-              data-action="record"
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="eraseInstructionButton"
-              icon="clear-all"
-              label="Erase instruction"
-              title="Erase instruction"
-              data-action="erase"
-            ></vscode-toolbar-button>
-          </vscode-toolbar-container>
+            <span id="recordInstructionButton">
+              ${renderIconActionButton({
+                icon: (session.isRecording
+                  ? 'stop-circle'
+                  : 'mic') as TeXRAIconName,
+                label: 'Record instruction',
+                title: session.isRecording
+                  ? 'Stop recording'
+                  : 'Record instruction with microphone',
+                className: session.isRecording ? 'recording' : '',
+                action: 'record',
+              })}
+            </span>
+            <span id="eraseInstructionButton">
+              ${renderIconActionButton({
+                icon: 'clear-all',
+                label: 'Erase instruction',
+                title: 'Erase instruction',
+                action: 'erase',
+              })}
+            </span>
+          </div>
         </div>
         ${this.renderSessionHint(session)}
         <vscode-textarea
@@ -572,14 +585,15 @@ export class InstructionPanel extends LitElement {
             <div
               class="select-group agent-select-group agent-model-select-group"
             >
-              <vscode-toolbar-button
-                id="agentSettingsButton"
-                class="settings-button"
-                icon="sparkle"
-                label="Agent settings"
-                title="Agent settings"
-                @click=${this.handleAgentSettings}
-              ></vscode-toolbar-button>
+              <span id="agentSettingsButton">
+                ${renderIconActionButton({
+                  icon: 'sparkle',
+                  label: 'Agent settings',
+                  title: 'Agent settings',
+                  className: 'settings-button',
+                  onClick: this.handleAgentSettings,
+                })}
+              </span>
               <div class="agent-select-controls">
                 <div class="agent-select-dropdowns">
                   <vscode-single-select
@@ -650,14 +664,15 @@ export class InstructionPanel extends LitElement {
             <div
               class="select-group model-select-group agent-model-select-group"
             >
-              <vscode-toolbar-button
-                id="modelSettingsButton"
-                class="settings-button"
-                icon="robot"
-                label="Model settings"
-                title="Model settings"
-                @click=${this.handleModelSettings}
-              ></vscode-toolbar-button>
+              <span id="modelSettingsButton">
+                ${renderIconActionButton({
+                  icon: 'robot',
+                  label: 'Model settings',
+                  title: 'Model settings',
+                  className: 'settings-button',
+                  onClick: this.handleModelSettings,
+                })}
+              </span>
               <vscode-single-select
                 id="model"
                 class="model-select"

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -8,12 +8,14 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - main view
 import { designTokens, codiconStyles } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
 import {
   fileSelectLayoutStyles,
@@ -169,6 +171,42 @@ export class LatexDiffsSection extends LitElement {
     }
   }
 
+  private renderDatasetButton({
+    id,
+    icon,
+    label,
+    title,
+    diffAction,
+    fileAction,
+    fileType,
+  }: {
+    id: string;
+    icon: TeXRAIconName;
+    label: string;
+    title?: string;
+    diffAction?: string;
+    fileAction?: string;
+    fileType?: string;
+  }): TemplateResult {
+    return html`
+      <wa-button
+        id=${id}
+        class="action-icon-button"
+        appearance="outlined"
+        variant="neutral"
+        size="small"
+        type="button"
+        aria-label=${label}
+        title=${title ?? label}
+        data-diff-action=${ifDefined(diffAction)}
+        data-file-action=${ifDefined(fileAction)}
+        data-file-type=${ifDefined(fileType)}
+      >
+        ${waIcon(icon)}
+      </wa-button>
+    `;
+  }
+
   private renderFileOptions(
     options: string[],
     selectedValue: string,
@@ -252,22 +290,22 @@ export class LatexDiffsSection extends LitElement {
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <span id="currentBaseFileButton">
-                  ${renderIconActionButton({
-                    icon: 'file-code',
-                    label: 'Set current file as base',
-                    title: 'Set current file as base',
-                    dataset: { fileAction: 'current', fileType: 'base' },
-                  })}
-                </span>
-                <span id="emptyBaseFileButton">
-                  ${renderIconActionButton({
-                    icon: 'close',
-                    label: 'Clear base file',
-                    title: 'Clear base file',
-                    dataset: { fileAction: 'empty', fileType: 'base' },
-                  })}
-                </span>
+                ${this.renderDatasetButton({
+                  id: 'currentBaseFileButton',
+                  icon: 'file-code',
+                  label: 'Set current file as base',
+                  title: 'Set current file as base',
+                  fileAction: 'current',
+                  fileType: 'base',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'emptyBaseFileButton',
+                  icon: 'close',
+                  label: 'Clear base file',
+                  title: 'Clear base file',
+                  fileAction: 'empty',
+                  fileType: 'base',
+                })}
               </div>
             </div>
             <vscode-single-select
@@ -282,14 +320,13 @@ export class LatexDiffsSection extends LitElement {
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <span id="refreshEditedFileButton">
-                  ${renderIconActionButton({
-                    icon: 'edit',
-                    label: 'Refresh edited files',
-                    title: 'Refresh edited files',
-                    onClick: this.handleRefreshEditedFiles,
-                  })}
-                </span>
+                ${renderIconActionButton({
+                  id: 'refreshEditedFileButton',
+                  icon: 'edit',
+                  label: 'Refresh edited files',
+                  title: 'Refresh edited files',
+                  onClick: this.handleRefreshEditedFiles,
+                })}
                 <label
                   for="editedFile"
                   title="File containing edits to merge into the base file"
@@ -301,58 +338,54 @@ export class LatexDiffsSection extends LitElement {
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <span id="acceptButton">
-                  ${renderIconActionButton({
-                    icon: 'check',
-                    label: 'Accept changes',
-                    title:
-                      'Accept changes from edited file and overwrite base file',
-                    dataset: { diffAction: 'accept' },
-                  })}
-                </span>
-                <span id="compareButton">
-                  ${renderIconActionButton({
-                    icon: 'diff',
-                    label: 'Compare files',
-                    title:
-                      'Compare the selected edited file with the selected base file',
-                    dataset: { diffAction: 'compare' },
-                  })}
-                </span>
-                <span id="mergeButton">
-                  ${renderIconActionButton({
-                    icon: 'merge',
-                    label: 'Merge edits',
-                    title:
-                      'Create a new version of the base file by merging the edits suggested by the edited file',
-                    dataset: { diffAction: 'merge' },
-                  })}
-                </span>
-                <span id="latexdiffButton">
-                  ${renderIconActionButton({
-                    icon: 'diff-single',
-                    label: 'LaTeXdiff',
-                    title:
-                      'LaTeXdiff the selected edited file with the selected base file',
-                    dataset: { diffAction: 'latexdiff' },
-                  })}
-                </span>
-                <span id="currentEditedFileButton">
-                  ${renderIconActionButton({
-                    icon: 'file-code',
-                    label: 'Set current file as edited',
-                    title: 'Set current file as edited',
-                    dataset: { fileAction: 'current', fileType: 'edited' },
-                  })}
-                </span>
-                <span id="emptyEditedFileButton">
-                  ${renderIconActionButton({
-                    icon: 'close',
-                    label: 'Clear edited file',
-                    title: 'Clear edited file',
-                    dataset: { fileAction: 'empty', fileType: 'edited' },
-                  })}
-                </span>
+                ${this.renderDatasetButton({
+                  id: 'acceptButton',
+                  icon: 'check',
+                  label: 'Accept changes',
+                  title:
+                    'Accept changes from edited file and overwrite base file',
+                  diffAction: 'accept',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'compareButton',
+                  icon: 'diff',
+                  label: 'Compare files',
+                  title:
+                    'Compare the selected edited file with the selected base file',
+                  diffAction: 'compare',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'mergeButton',
+                  icon: 'merge',
+                  label: 'Merge edits',
+                  title:
+                    'Create a new version of the base file by merging the edits suggested by the edited file',
+                  diffAction: 'merge',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'latexdiffButton',
+                  icon: 'diff-single',
+                  label: 'LaTeXdiff',
+                  title:
+                    'LaTeXdiff the selected edited file with the selected base file',
+                  diffAction: 'latexdiff',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'currentEditedFileButton',
+                  icon: 'file-code',
+                  label: 'Set current file as edited',
+                  title: 'Set current file as edited',
+                  fileAction: 'current',
+                  fileType: 'edited',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'emptyEditedFileButton',
+                  icon: 'close',
+                  label: 'Clear edited file',
+                  title: 'Clear edited file',
+                  fileAction: 'empty',
+                  fileType: 'edited',
+                })}
               </div>
             </div>
             <vscode-single-select
@@ -367,46 +400,41 @@ export class LatexDiffsSection extends LitElement {
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <span id="refreshCommitsButton">
-                  ${renderIconActionButton({
-                    icon: 'git-commit',
-                    label: 'Refresh commit list',
-                    title: 'Refresh commit list',
-                    onClick: this.handleRefreshCommits,
-                  })}
-                </span>
+                ${renderIconActionButton({
+                  id: 'refreshCommitsButton',
+                  icon: 'git-commit',
+                  label: 'Refresh commit list',
+                  title: 'Refresh commit list',
+                  onClick: this.handleRefreshCommits,
+                })}
                 <label for="commit">Commit</label>
               </div>
               <div
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <span id="latexdiffvcButton">
-                  ${renderIconActionButton({
-                    icon: 'diff-single',
-                    label: 'LaTeXdiff with commit',
-                    title:
-                      'LaTeXdiff the selected base file with another git commit',
-                    dataset: { diffAction: 'latexdiffvc' },
-                  })}
-                </span>
-                <span id="packLatexdiffvcButton">
-                  ${renderIconActionButton({
-                    icon: 'archive',
-                    label: 'Pack latexdiff output',
-                    title:
-                      'Pack the latexdiff-vc output into the History folder',
-                    dataset: { diffAction: 'packLatexdiffvc' },
-                  })}
-                </span>
-                <span id="cleanLatexdiffvcButton">
-                  ${renderIconActionButton({
-                    icon: 'trash',
-                    label: 'Clean latexdiff output',
-                    title: 'Clean the latexdiff-vc output',
-                    dataset: { diffAction: 'cleanLatexdiffvc' },
-                  })}
-                </span>
+                ${this.renderDatasetButton({
+                  id: 'latexdiffvcButton',
+                  icon: 'diff-single',
+                  label: 'LaTeXdiff with commit',
+                  title:
+                    'LaTeXdiff the selected base file with another git commit',
+                  diffAction: 'latexdiffvc',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'packLatexdiffvcButton',
+                  icon: 'archive',
+                  label: 'Pack latexdiff output',
+                  title: 'Pack the latexdiff-vc output into the History folder',
+                  diffAction: 'packLatexdiffvc',
+                })}
+                ${this.renderDatasetButton({
+                  id: 'cleanLatexdiffvcButton',
+                  icon: 'trash',
+                  label: 'Clean latexdiff output',
+                  title: 'Clean the latexdiff-vc output',
+                  diffAction: 'cleanLatexdiffvc',
+                })}
               </div>
             </div>
             <vscode-single-select

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -13,6 +13,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - main view
 import { designTokens, codiconStyles } from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { MainViewEvents } from '../events';
 import {
   fileSelectLayoutStyles,
@@ -52,7 +53,7 @@ export class LatexDiffsSection extends LitElement {
         margin-bottom: 0;
       }
 
-      .latexdiffs-section vscode-toolbar-button {
+      .latexdiffs-section wa-button {
         width: var(--height-control);
         height: var(--height-control);
         min-width: var(--height-control);
@@ -247,27 +248,27 @@ export class LatexDiffsSection extends LitElement {
               <div class="file-select-label-group">
                 <label for="baseFile">Base</label>
               </div>
-              <vscode-toolbar-container
+              <div
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <vscode-toolbar-button
-                  id="currentBaseFileButton"
-                  icon="file-code"
-                  label="Set current file as base"
-                  title="Set current file as base"
-                  data-file-action="current"
-                  data-file-type="base"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyBaseFileButton"
-                  icon="close"
-                  label="Clear base file"
-                  title="Clear base file"
-                  data-file-action="empty"
-                  data-file-type="base"
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
+                <span id="currentBaseFileButton">
+                  ${renderIconActionButton({
+                    icon: 'file-code',
+                    label: 'Set current file as base',
+                    title: 'Set current file as base',
+                    dataset: { fileAction: 'current', fileType: 'base' },
+                  })}
+                </span>
+                <span id="emptyBaseFileButton">
+                  ${renderIconActionButton({
+                    icon: 'close',
+                    label: 'Clear base file',
+                    title: 'Clear base file',
+                    dataset: { fileAction: 'empty', fileType: 'base' },
+                  })}
+                </span>
+              </div>
             </div>
             <vscode-single-select
               id="baseFile"
@@ -281,13 +282,14 @@ export class LatexDiffsSection extends LitElement {
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <vscode-toolbar-button
-                  id="refreshEditedFileButton"
-                  icon="edit"
-                  label="Refresh edited files"
-                  title="Refresh edited files"
-                  @click=${this.handleRefreshEditedFiles}
-                ></vscode-toolbar-button>
+                <span id="refreshEditedFileButton">
+                  ${renderIconActionButton({
+                    icon: 'edit',
+                    label: 'Refresh edited files',
+                    title: 'Refresh edited files',
+                    onClick: this.handleRefreshEditedFiles,
+                  })}
+                </span>
                 <label
                   for="editedFile"
                   title="File containing edits to merge into the base file"
@@ -295,55 +297,63 @@ export class LatexDiffsSection extends LitElement {
                   Edited
                 </label>
               </div>
-              <vscode-toolbar-container
+              <div
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <vscode-toolbar-button
-                  id="acceptButton"
-                  icon="check"
-                  label="Accept changes"
-                  title="Accept changes from edited file and overwrite base file"
-                  data-diff-action="accept"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="compareButton"
-                  icon="diff"
-                  label="Compare files"
-                  title="Compare the selected edited file with the selected base file"
-                  data-diff-action="compare"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="mergeButton"
-                  icon="merge"
-                  label="Merge edits"
-                  title="Create a new version of the base file by merging the edits suggested by the edited file"
-                  data-diff-action="merge"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="latexdiffButton"
-                  icon="diff-single"
-                  label="LaTeXdiff"
-                  title="LaTeXdiff the selected edited file with the selected base file"
-                  data-diff-action="latexdiff"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="currentEditedFileButton"
-                  icon="file-code"
-                  label="Set current file as edited"
-                  title="Set current file as edited"
-                  data-file-action="current"
-                  data-file-type="edited"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyEditedFileButton"
-                  icon="close"
-                  label="Clear edited file"
-                  title="Clear edited file"
-                  data-file-action="empty"
-                  data-file-type="edited"
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
+                <span id="acceptButton">
+                  ${renderIconActionButton({
+                    icon: 'check',
+                    label: 'Accept changes',
+                    title:
+                      'Accept changes from edited file and overwrite base file',
+                    dataset: { diffAction: 'accept' },
+                  })}
+                </span>
+                <span id="compareButton">
+                  ${renderIconActionButton({
+                    icon: 'diff',
+                    label: 'Compare files',
+                    title:
+                      'Compare the selected edited file with the selected base file',
+                    dataset: { diffAction: 'compare' },
+                  })}
+                </span>
+                <span id="mergeButton">
+                  ${renderIconActionButton({
+                    icon: 'merge',
+                    label: 'Merge edits',
+                    title:
+                      'Create a new version of the base file by merging the edits suggested by the edited file',
+                    dataset: { diffAction: 'merge' },
+                  })}
+                </span>
+                <span id="latexdiffButton">
+                  ${renderIconActionButton({
+                    icon: 'diff-single',
+                    label: 'LaTeXdiff',
+                    title:
+                      'LaTeXdiff the selected edited file with the selected base file',
+                    dataset: { diffAction: 'latexdiff' },
+                  })}
+                </span>
+                <span id="currentEditedFileButton">
+                  ${renderIconActionButton({
+                    icon: 'file-code',
+                    label: 'Set current file as edited',
+                    title: 'Set current file as edited',
+                    dataset: { fileAction: 'current', fileType: 'edited' },
+                  })}
+                </span>
+                <span id="emptyEditedFileButton">
+                  ${renderIconActionButton({
+                    icon: 'close',
+                    label: 'Clear edited file',
+                    title: 'Clear edited file',
+                    dataset: { fileAction: 'empty', fileType: 'edited' },
+                  })}
+                </span>
+              </div>
             </div>
             <vscode-single-select
               id="editedFile"
@@ -357,41 +367,47 @@ export class LatexDiffsSection extends LitElement {
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <vscode-toolbar-button
-                  id="refreshCommitsButton"
-                  icon="git-commit"
-                  label="Refresh commit list"
-                  title="Refresh commit list"
-                  @click=${this.handleRefreshCommits}
-                ></vscode-toolbar-button>
+                <span id="refreshCommitsButton">
+                  ${renderIconActionButton({
+                    icon: 'git-commit',
+                    label: 'Refresh commit list',
+                    title: 'Refresh commit list',
+                    onClick: this.handleRefreshCommits,
+                  })}
+                </span>
                 <label for="commit">Commit</label>
               </div>
-              <vscode-toolbar-container
+              <div
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                <vscode-toolbar-button
-                  id="latexdiffvcButton"
-                  icon="diff-single"
-                  label="LaTeXdiff with commit"
-                  title="LaTeXdiff the selected base file with another git commit"
-                  data-diff-action="latexdiffvc"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="packLatexdiffvcButton"
-                  icon="archive"
-                  label="Pack latexdiff output"
-                  title="Pack the latexdiff-vc output into the History folder"
-                  data-diff-action="packLatexdiffvc"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="cleanLatexdiffvcButton"
-                  icon="trash"
-                  label="Clean latexdiff output"
-                  title="Clean the latexdiff-vc output"
-                  data-diff-action="cleanLatexdiffvc"
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
+                <span id="latexdiffvcButton">
+                  ${renderIconActionButton({
+                    icon: 'diff-single',
+                    label: 'LaTeXdiff with commit',
+                    title:
+                      'LaTeXdiff the selected base file with another git commit',
+                    dataset: { diffAction: 'latexdiffvc' },
+                  })}
+                </span>
+                <span id="packLatexdiffvcButton">
+                  ${renderIconActionButton({
+                    icon: 'archive',
+                    label: 'Pack latexdiff output',
+                    title:
+                      'Pack the latexdiff-vc output into the History folder',
+                    dataset: { diffAction: 'packLatexdiffvc' },
+                  })}
+                </span>
+                <span id="cleanLatexdiffvcButton">
+                  ${renderIconActionButton({
+                    icon: 'trash',
+                    label: 'Clean latexdiff output',
+                    title: 'Clean the latexdiff-vc output',
+                    dataset: { diffAction: 'cleanLatexdiffvc' },
+                  })}
+                </span>
+              </div>
             </div>
             <vscode-single-select
               id="commit"

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -14,6 +14,7 @@ import { when } from 'lit/directives/when.js';
 // Local imports - main view
 import { SortableController } from '@shared/controllers';
 import { designTokens, codiconStyles } from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { MainViewEvents } from '../events';
 import {
   fileStateContext,
@@ -38,7 +39,7 @@ export class OutputFilesSection extends LitElement {
         display: block;
       }
 
-      .file-select-actions vscode-toolbar-button {
+      .file-select-actions wa-button {
         width: var(--height-control);
         height: var(--height-control);
         min-width: var(--height-control);
@@ -168,22 +169,24 @@ export class OutputFilesSection extends LitElement {
               >Agent writes to all listed files</span
             >
           </div>
-          <vscode-toolbar-container class="file-select-actions">
-            <vscode-toolbar-button
-              id="emptyOutputFilesButton"
-              icon="trash"
-              label="Clear all output files"
-              title="Clear all output files"
-              @click=${this.handleEmptyFiles}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="selectOutputFilesButton"
-              icon="add"
-              label="Add output files"
-              title="Add output files"
-              @click=${this.handleSelectFiles}
-            ></vscode-toolbar-button>
-          </vscode-toolbar-container>
+          <div class="file-select-actions">
+            <span id="emptyOutputFilesButton">
+              ${renderIconActionButton({
+                icon: 'trash',
+                label: 'Clear all output files',
+                title: 'Clear all output files',
+                onClick: this.handleEmptyFiles,
+              })}
+            </span>
+            <span id="selectOutputFilesButton">
+              ${renderIconActionButton({
+                icon: 'add',
+                label: 'Add output files',
+                title: 'Add output files',
+                onClick: this.handleSelectFiles,
+              })}
+            </span>
+          </div>
         </div>
         ${when(
           this.currentExpanded,

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -170,22 +170,20 @@ export class OutputFilesSection extends LitElement {
             >
           </div>
           <div class="file-select-actions">
-            <span id="emptyOutputFilesButton">
-              ${renderIconActionButton({
-                icon: 'trash',
-                label: 'Clear all output files',
-                title: 'Clear all output files',
-                onClick: this.handleEmptyFiles,
-              })}
-            </span>
-            <span id="selectOutputFilesButton">
-              ${renderIconActionButton({
-                icon: 'add',
-                label: 'Add output files',
-                title: 'Add output files',
-                onClick: this.handleSelectFiles,
-              })}
-            </span>
+            ${renderIconActionButton({
+              id: 'emptyOutputFilesButton',
+              icon: 'trash',
+              label: 'Clear all output files',
+              title: 'Clear all output files',
+              onClick: this.handleEmptyFiles,
+            })}
+            ${renderIconActionButton({
+              id: 'selectOutputFilesButton',
+              icon: 'add',
+              label: 'Add output files',
+              title: 'Add output files',
+              onClick: this.handleSelectFiles,
+            })}
           </div>
         </div>
         ${when(

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -31,7 +31,7 @@ export const fileSelectLayoutStyles = css`
     gap: var(--spacing-small);
   }
 
-  .file-select-header > vscode-toolbar-button {
+  .file-select-header > wa-button {
     opacity: var(--opacity-full);
     flex-shrink: 0;
   }
@@ -56,7 +56,7 @@ export const fileSelectLayoutStyles = css`
     min-height: var(--height-control);
   }
 
-  .file-select-label-group vscode-toolbar-button {
+  .file-select-label-group wa-button {
     opacity: var(--opacity-full);
   }
 
@@ -80,14 +80,15 @@ export const fileSelectLayoutStyles = css`
     min-width: 0;
   }
 
-  .file-select-actions,
-  vscode-toolbar-container.file-select-actions {
+  .file-select-actions {
+    display: flex;
     flex-direction: column !important;
     flex-wrap: nowrap;
     margin-left: auto;
+    gap: var(--spacing-tiny);
   }
 
-  .file-select-actions vscode-toolbar-button {
+  .file-select-actions wa-button {
     opacity: var(--opacity-full);
     width: var(--height-control);
     height: var(--height-control);
@@ -255,11 +256,11 @@ export const dropdownStyles = css`
     align-items: center;
   }
 
-  .dropdown-container vscode-toolbar-button {
+  .dropdown-container wa-button {
     flex-shrink: 0;
   }
 
-  .dropdown-container vscode-toolbar-button.has-options::part(control) {
+  .dropdown-container wa-button.has-options::part(base) {
     box-shadow: inset 0 0 0 1px
       var(--texra-inputValidation-infoBorder, var(--texra-focusBorder));
   }

--- a/src/shared/controllers/RecordingButtonController.ts
+++ b/src/shared/controllers/RecordingButtonController.ts
@@ -3,14 +3,15 @@ import { postMessage } from '@shared/hostBridge';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 // Local imports
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 export interface RecordingButtonConfig {
   startCommand: string;
   stopCommand: string;
   startTitle?: string;
   stopTitle?: string;
-  startIcon?: string;
-  stopIcon?: string;
+  startIcon?: TeXRAIconName;
+  stopIcon?: TeXRAIconName;
   recordingClass?: string;
 }
 
@@ -19,7 +20,7 @@ export interface RecordingButtonConfig {
  */
 export interface RecordingButtonState {
   /** Current icon name (without codicon- prefix) */
-  icon: string;
+  icon: TeXRAIconName;
   /** Current title/tooltip text */
   title: string;
   /** Whether currently recording */

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -1,14 +1,7 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { html, nothing, type TemplateResult } from 'lit';
-import {
-  Directive,
-  PartType,
-  directive,
-  type ElementPart,
-  type PartInfo,
-} from 'lit/directive.js';
+import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
@@ -18,6 +11,7 @@ type ActionButtonAppearance = 'filled' | 'outlined' | 'plain';
 type ActionButtonVariant = 'brand' | 'neutral';
 
 export interface IconActionButtonOptions {
+  readonly id?: string;
   readonly icon: TeXRAIconName;
   readonly label: string;
   readonly title?: string;
@@ -26,50 +20,23 @@ export interface IconActionButtonOptions {
   readonly appearance?: ActionButtonAppearance;
   readonly variant?: ActionButtonVariant;
   readonly disabled?: boolean;
-  /** Extra dataset attributes (rendered as data-<key>). Skipped when value is undefined. */
-  readonly dataset?: Readonly<Record<string, string | undefined>>;
   readonly onClick?: (event: MouseEvent) => void;
 }
 
-class DatasetDirective extends Directive {
-  constructor(partInfo: PartInfo) {
-    super(partInfo);
-    if (partInfo.type !== PartType.ELEMENT) {
-      throw new Error('datasetDirective must be used as an element directive');
-    }
-  }
-
-  override update(
-    part: ElementPart,
-    [data]: [Readonly<Record<string, string | undefined>> | undefined],
-  ): unknown {
-    const el = part.element as HTMLElement;
-    if (data) {
-      for (const [key, value] of Object.entries(data)) {
-        if (value === undefined) {
-          delete el.dataset[key];
-        } else {
-          el.dataset[key] = value;
-        }
-      }
-    }
-    return this.render(data);
-  }
-
-  override render(
-    _data: Readonly<Record<string, string | undefined>> | undefined,
-  ): unknown {
-    return nothing;
-  }
+export interface LabeledActionButtonOptions
+  extends Omit<IconActionButtonOptions, 'label'> {
+  readonly text: string;
+  readonly label?: string;
 }
 
-const datasetDirective = directive(DatasetDirective);
-
-export interface LabeledActionButtonOptions extends IconActionButtonOptions {
-  readonly text: string;
+interface ActionButtonBaseOptions
+  extends Omit<IconActionButtonOptions, 'label'> {
+  readonly label?: string;
+  readonly text?: string;
 }
 
 function renderActionButtonBase({
+  id,
   icon,
   label,
   text,
@@ -79,24 +46,24 @@ function renderActionButtonBase({
   appearance = 'outlined',
   variant = 'neutral',
   disabled,
-  dataset,
   onClick,
-}: IconActionButtonOptions & { readonly text?: string }): TemplateResult {
+}: ActionButtonBaseOptions): TemplateResult {
   const classes = [text ? 'action-button' : 'action-icon-button', className]
     .filter(Boolean)
     .join(' ');
+  const ariaLabel = label ?? text ?? '';
 
   return html`
     <wa-button
+      id=${ifDefined(id)}
       class=${classes}
       appearance=${appearance}
       variant=${variant}
       size="small"
       type="button"
-      aria-label=${label}
-      title=${title ?? label}
+      aria-label=${ariaLabel}
+      title=${title ?? ariaLabel}
       data-action=${ifDefined(action)}
-      ${datasetDirective(dataset)}
       ?disabled=${disabled}
       @click=${onClick}
     >

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -1,7 +1,14 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { html, type TemplateResult } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
+import {
+  Directive,
+  PartType,
+  directive,
+  type ElementPart,
+  type PartInfo,
+} from 'lit/directive.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
@@ -18,8 +25,45 @@ export interface IconActionButtonOptions {
   readonly className?: string;
   readonly appearance?: ActionButtonAppearance;
   readonly variant?: ActionButtonVariant;
+  readonly disabled?: boolean;
+  /** Extra dataset attributes (rendered as data-<key>). Skipped when value is undefined. */
+  readonly dataset?: Readonly<Record<string, string | undefined>>;
   readonly onClick?: (event: MouseEvent) => void;
 }
+
+class DatasetDirective extends Directive {
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.ELEMENT) {
+      throw new Error('datasetDirective must be used as an element directive');
+    }
+  }
+
+  override update(
+    part: ElementPart,
+    [data]: [Readonly<Record<string, string | undefined>> | undefined],
+  ): unknown {
+    const el = part.element as HTMLElement;
+    if (data) {
+      for (const [key, value] of Object.entries(data)) {
+        if (value === undefined) {
+          delete el.dataset[key];
+        } else {
+          el.dataset[key] = value;
+        }
+      }
+    }
+    return this.render(data);
+  }
+
+  override render(
+    _data: Readonly<Record<string, string | undefined>> | undefined,
+  ): unknown {
+    return nothing;
+  }
+}
+
+const datasetDirective = directive(DatasetDirective);
 
 export interface LabeledActionButtonOptions extends IconActionButtonOptions {
   readonly text: string;
@@ -34,6 +78,8 @@ function renderActionButtonBase({
   className,
   appearance = 'outlined',
   variant = 'neutral',
+  disabled,
+  dataset,
   onClick,
 }: IconActionButtonOptions & { readonly text?: string }): TemplateResult {
   const classes = [text ? 'action-button' : 'action-icon-button', className]
@@ -50,6 +96,8 @@ function renderActionButtonBase({
       aria-label=${label}
       title=${title ?? label}
       data-action=${ifDefined(action)}
+      ${datasetDirective(dataset)}
+      ?disabled=${disabled}
       @click=${onClick}
     >
       ${waIcon(icon, { slot: text ? 'start' : undefined })} ${text}

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -11,6 +11,7 @@ import { faBolt } from '@fortawesome/free-solid-svg-icons/faBolt';
 import { faBook } from '@fortawesome/free-solid-svg-icons/faBook';
 import { faBookmark } from '@fortawesome/free-solid-svg-icons/faBookmark';
 import { faBox } from '@fortawesome/free-solid-svg-icons/faBox';
+import { faBoxArchive } from '@fortawesome/free-solid-svg-icons/faBoxArchive';
 import { faBuilding } from '@fortawesome/free-solid-svg-icons/faBuilding';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
@@ -23,6 +24,7 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp';
 import { faCircle } from '@fortawesome/free-solid-svg-icons/faCircle';
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons/faCircleCheck';
+import { faCircleDot } from '@fortawesome/free-solid-svg-icons/faCircleDot';
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons/faCircleExclamation';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons/faCircleInfo';
 import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons/faCircleQuestion';
@@ -33,8 +35,10 @@ import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft';
 import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons/faCloudArrowDown';
 import { faCloudArrowUp } from '@fortawesome/free-solid-svg-icons/faCloudArrowUp';
+import { faCode } from '@fortawesome/free-solid-svg-icons/faCode';
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons/faCodeBranch';
 import { faCodeCompare } from '@fortawesome/free-solid-svg-icons/faCodeCompare';
+import { faCodeMerge } from '@fortawesome/free-solid-svg-icons/faCodeMerge';
 import { faComment } from '@fortawesome/free-solid-svg-icons/faComment';
 import { faComments } from '@fortawesome/free-solid-svg-icons/faComments';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
@@ -43,6 +47,7 @@ import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase';
 import { faDiagramProject } from '@fortawesome/free-solid-svg-icons/faDiagramProject';
 import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons/faEllipsis';
+import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
 import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
 import { faFileCirclePlus } from '@fortawesome/free-solid-svg-icons/faFileCirclePlus';
@@ -69,9 +74,11 @@ import { faListCheck } from '@fortawesome/free-solid-svg-icons/faListCheck';
 import { faListUl } from '@fortawesome/free-solid-svg-icons/faListUl';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
 import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlassChart';
+import { faMicrophone } from '@fortawesome/free-solid-svg-icons/faMicrophone';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faNoteSticky } from '@fortawesome/free-solid-svg-icons/faNoteSticky';
 import { faPalette } from '@fortawesome/free-solid-svg-icons/faPalette';
+import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
@@ -93,6 +100,7 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
+import { faVideo } from '@fortawesome/free-solid-svg-icons/faVideo';
 import { faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons/faWandMagicSparkles';
 import { faWindowMaximize } from '@fortawesome/free-solid-svg-icons/faWindowMaximize';
 import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
@@ -139,6 +147,7 @@ const icons = {
   book: faBook,
   bookmark: faBookmark,
   box: faBox,
+  'box-archive': faBoxArchive,
   building: faBuilding,
   'caret-down': faCaretDown,
   'chart-line': faChartLine,
@@ -151,6 +160,7 @@ const icons = {
   'chevron-up': faChevronUp,
   circle: faCircle,
   'circle-check': faCircleCheck,
+  'circle-dot': faCircleDot,
   'circle-exclamation': faCircleExclamation,
   'circle-info': faCircleInfo,
   'circle-question': faCircleQuestion,
@@ -161,8 +171,10 @@ const icons = {
   'clock-rotate-left': faClockRotateLeft,
   'cloud-arrow-down': faCloudArrowDown,
   'cloud-arrow-up': faCloudArrowUp,
+  code: faCode,
   'code-branch': faCodeBranch,
   'code-compare': faCodeCompare,
+  'code-merge': faCodeMerge,
   comment: faComment,
   comments: faComments,
   copy: faCopy,
@@ -171,6 +183,7 @@ const icons = {
   'diagram-project': faDiagramProject,
   download: faDownload,
   ellipsis: faEllipsis,
+  eraser: faEraser,
   eye: faEye,
   file: faFile,
   'file-circle-plus': faFileCirclePlus,
@@ -197,9 +210,11 @@ const icons = {
   'list-ul': faListUl,
   'magnifying-glass': faMagnifyingGlass,
   'magnifying-glass-chart': faMagnifyingGlassChart,
+  microphone: faMicrophone,
   minus: faMinus,
   'note-sticky': faNoteSticky,
   palette: faPalette,
+  'paper-plane': faPaperPlane,
   pencil: faPencil,
   'picture-in-picture': faPictureInPicture,
   play: faPlay,
@@ -221,6 +236,7 @@ const icons = {
   'triangle-exclamation': faTriangleExclamation,
   user: faUser,
   users: faUsers,
+  video: faVideo,
   'wand-magic-sparkles': faWandMagicSparkles,
   'window-maximize': faWindowMaximize,
   wrench: faWrench,
@@ -237,6 +253,7 @@ const icons = {
 const CODICON_ALIASES = {
   account: 'circle-user',
   add: 'plus',
+  archive: 'box-archive',
   'arrow-small-down': 'caret-down',
   beaker: 'flask',
   'check-all': 'check-double',
@@ -244,14 +261,21 @@ const CODICON_ALIASES = {
   'circle-large-outline': 'circle',
   'circle-outline': 'circle',
   'circle-slash': 'circle-xmark',
+  'clear-all': 'eraser',
   close: 'xmark',
   'cloud-download': 'cloud-arrow-down',
   'cloud-upload': 'cloud-arrow-up',
   'comment-discussion': 'comments',
   dash: 'minus',
+  'debug-continue': 'forward-step',
+  'debug-start': 'play',
   'debug-stop': 'circle-stop',
   'desktop-download': 'download',
+  'device-camera-video': 'video',
   diff: 'code-compare',
+  'diff-added': 'plus',
+  'diff-multiple': 'code-compare',
+  'diff-single': 'code-compare',
   discard: 'arrow-rotate-left',
   edit: 'pencil',
   error: 'circle-exclamation',
@@ -261,6 +285,8 @@ const CODICON_ALIASES = {
   'folder-library': 'folder-tree',
   'folder-opened': 'folder-open',
   github: 'code-branch',
+  'git-commit': 'circle-dot',
+  'git-merge': 'code-branch',
   graph: 'chart-line',
   'graph-line': 'chart-line',
   history: 'clock-rotate-left',
@@ -269,10 +295,13 @@ const CODICON_ALIASES = {
   library: 'book',
   'list-tree': 'list-ul',
   loading: 'spinner',
+  merge: 'code-merge',
+  mic: 'microphone',
   'mortar-board': 'graduation-cap',
   'new-file': 'file-circle-plus',
   note: 'note-sticky',
   organization: 'building',
+  output: 'terminal',
   package: 'box',
   'pass-filled': 'circle-check',
   'pie-chart': 'chart-pie',
@@ -282,12 +311,14 @@ const CODICON_ALIASES = {
   refresh: 'rotate-right',
   save: 'floppy-disk',
   search: 'magnifying-glass',
+  send: 'paper-plane',
   'server-process': 'server',
   'settings-gear': 'gear',
   'sign-in': 'right-to-bracket',
   'sign-out': 'right-from-bracket',
   'source-control': 'code-branch',
   sparkle: 'wand-magic-sparkles',
+  'stop-circle': 'circle-stop',
   stylesheet: 'palette',
   'symbol-method': 'cube',
   'symbol-number': 'hashtag',
@@ -298,6 +329,7 @@ const CODICON_ALIASES = {
   tasklist: 'list-check',
   tools: 'screwdriver-wrench',
   'type-hierarchy': 'diagram-project',
+  wand: 'wand-magic-sparkles',
   warning: 'triangle-exclamation',
   window: 'window-maximize',
   x: 'xmark',

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -9,6 +9,9 @@ import type { ToolEditRequestPanel } from '@progressView/frontend/components/Too
 // Local imports - shared schemas
 import type { ToolEditPermission } from '@shared/schemas';
 
+// Local imports - test utilities
+import { installAttachInternalsFallback } from '../settings/litComponentTestUtils';
+
 const originalGlobals = {
   document: globalThis.document,
   window: globalThis.window,
@@ -18,6 +21,9 @@ const originalGlobals = {
   Document: globalThis.Document,
   ShadowRoot: globalThis.ShadowRoot,
   CSSStyleSheet: globalThis.CSSStyleSheet,
+  Event: globalThis.Event,
+  CustomEvent: globalThis.CustomEvent,
+  Node: (globalThis as { Node?: unknown }).Node,
 };
 
 function installDom(): JSDOM {
@@ -32,6 +38,12 @@ function installDom(): JSDOM {
   globalThis.Document = dom.window.Document;
   globalThis.ShadowRoot = dom.window.ShadowRoot;
   globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  (globalThis as { Node: unknown }).Node = dom.window.Node;
+  installAttachInternalsFallback(
+    dom.window as unknown as Parameters<typeof installAttachInternalsFallback>[0],
+  );
   return dom;
 }
 
@@ -44,6 +56,13 @@ function restoreDom(): void {
   globalThis.Document = originalGlobals.Document;
   globalThis.ShadowRoot = originalGlobals.ShadowRoot;
   globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
+  globalThis.Event = originalGlobals.Event;
+  globalThis.CustomEvent = originalGlobals.CustomEvent;
+  if (originalGlobals.Node === undefined) {
+    delete (globalThis as { Node?: unknown }).Node;
+  } else {
+    (globalThis as { Node: unknown }).Node = originalGlobals.Node;
+  }
 }
 
 function createPermission(data: Partial<ToolEditPermission>): PermissionState {

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -95,7 +95,52 @@ function installDialogPolyfill(window: JSDOM['window']): void {
   }
 }
 
+const ATTACH_INTERNALS_PATCHED = Symbol.for(
+  'texra.test.attachInternalsPatched',
+);
+
+export function installAttachInternalsFallback(window: TestDomWindow): void {
+  // jsdom's attachInternals() exists but returns an ElementInternals stub
+  // without setValidity / setFormValue / etc. Web Awesome's
+  // WebAwesomeFormAssociatedElement (used by wa-button etc.) calls
+  // `this.internals.setValidity(...)` during willUpdate, which crashes the test.
+  // Override attachInternals to return a fully-stubbed shape that satisfies
+  // every method WA touches.
+  const HTMLElementCtor = window.HTMLElement as typeof HTMLElement | undefined;
+  if (!HTMLElementCtor) {
+    return;
+  }
+  const proto = HTMLElementCtor.prototype as unknown as HTMLElement & {
+    attachInternals?: () => ElementInternals;
+    [ATTACH_INTERNALS_PATCHED]?: boolean;
+  };
+  if (proto[ATTACH_INTERNALS_PATCHED]) {
+    return;
+  }
+  proto.attachInternals = function attachInternals() {
+    return {
+      setValidity: () => {},
+      setFormValue: () => {},
+      checkValidity: () => true,
+      reportValidity: () => true,
+      form: null,
+      labels: [],
+      validity: { ...DEFAULT_VALIDITY },
+      validationMessage: '',
+      willValidate: false,
+      states: new Set<string>(),
+    } as unknown as ElementInternals;
+  };
+  Object.defineProperty(proto, ATTACH_INTERNALS_PATCHED, {
+    configurable: true,
+    enumerable: false,
+    writable: false,
+    value: true,
+  });
+}
+
 function installElementInternalsPolyfill(window: TestDomWindow): void {
+  installAttachInternalsFallback(window);
   const ElementInternalsCtor = window.ElementInternals;
   if (!ElementInternalsCtor) {
     return;


### PR DESCRIPTION
## Summary

Replaces every `<vscode-toolbar-button>` and `<vscode-toolbar-container>` in `packages/extension/src/webview/frontend/` and `packages/extension/src/progressView/frontend/` with the existing `renderIconActionButton` / `renderLabeledActionButton` helpers from `@shared/wa/actionButtons` (or raw `<wa-button>` for cases that need extra wiring), bringing the two main webviews in line with the already-migrated settings webview.

## Changes

- **Helper extension (`src/shared/wa/actionButtons.ts`)**: added `disabled` and `dataset` options. `dataset` is wired through a small `DatasetDirective` so callers can attach arbitrary `data-*` attributes (e.g. `data-diff-action`, `data-file-type`) needed by existing event-delegation handlers.
- **Icon registry (`src/shared/wa/webAwesomeIcons.ts`)**: imported new Font Awesome glyphs (`faBoxArchive`, `faCircleDot`, `faCode`, `faCodeMerge`, `faEraser`, `faMicrophone`, `faPaperPlane`, `faVideo`) and added codicon aliases for `archive`, `clear-all`, `code`, `debug-continue`, `debug-start`, `device-camera-video`, `diff-added`, `diff-multiple`, `diff-single`, `git-commit`, `git-merge`, `merge`, `mic`, `output`, `send`, `stop-circle`, `wand`, so existing webview markup keeps working without per-call casts.
- **Webview (`packages/extension/src/webview/frontend/`)**: migrated `InstructionPanel`, `OutputFilesSection`, `FileSelectGroup`, `LatexDiffsSection`, plus shared `fileSelectStyles` (CSS retargeted from `vscode-toolbar-button` to `wa-button` and `::part(control)` → `::part(base)` where needed). Toggleable dropdown buttons that need a chevron child (`tools` / `wand` menus) use raw `<wa-button>` so the chevron `<i>` can stay as a default-slot child.
- **Progress view (`packages/extension/src/progressView/frontend/`)**: migrated `StreamHeader`, `StreamTabs`, `FollowUpInput`, `BaseFeedbackPanel`, `BashRequestPanel`, `PlanApprovalRequestPanel`, `ProposalRequestPanel`, `ToolEditRequestPanel`, `RetryRequestPanel`, `ExternalInquiryPanel`, `UserMessage`, `WorkflowHintBanner`, `FileList`, plus the formatters in `htmlBuilders.ts` and `messageFormatters.ts`.
- **Element delegation preserved**: handlers reading `data-action`, `data-command`, `data-stream`, `data-file-action`, `data-diff-action`, `data-file`, `data-base`, `data-prev`, `data-copy-id`, etc. continue to find the new buttons via `composedPath` / `closest`. ID-based references (`packButton`, `magicPolishButton`, ELEMENT_IDS, etc.) are preserved on wrapping `<span>` elements so existing scripts that look up the button by id still work.
- **Recording state**: `RecordingButtonController` keeps the same `state.icon` / `state.title` / `state.recordingClass` contract; the new wa-button receives the recording class via the helper's `className` option.

Total swaps: 22 files modified (~50 toolbar-button instances + 8 toolbar-container wrappers).

## Test plan

- [x] `npm run typecheck` (workspace + test-kernel + extension) — passes
- [x] `npx vitest run` — 311/311 tests pass (61 files)
- [x] `npm run lint` — 0 errors (9 pre-existing import-order warnings, unrelated to this change)
- [ ] Manually exercise main view: instruction toolbar (pack/clean/polish/record/erase), file selector groups, LaTeX diffs section, output-files actions
- [ ] Manually exercise progress view: stream tabs delete, stream header toolbar buttons (yolo / super-yolo / stop / run / resume / pack / clean / diff / restore / open-task-storage / compact), follow-up input (polish/record/clear/send), all four request panels (tool-edit, plan-approval, bash, proposal), retry panel actions, external inquiry panel, copy buttons in user messages and error banners, workflow-hint dismiss

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many webview/progress-view components by swapping out button primitives and CSS parts; risk is mostly UI regressions (missing `data-*`/ids, disabled/hidden state, styling) rather than backend logic.
> 
> **Overview**
> Replaces `vscode-toolbar-button` / `vscode-toolbar-container` usage across the main webview and progress view with Web Awesome `wa-button` via shared helpers (`renderIconActionButton` / `renderLabeledActionButton`), including a few direct `wa-button` cases for custom content (dropdown chevrons, delegated toolbars).
> 
> Extends `@shared/wa/actionButtons` to support `id` and `disabled` and adjusts icon plumbing by expanding `webAwesomeIcons` (new Font Awesome imports + codicon-name aliases) and tightening `RecordingButtonController` icon typing. Updates related CSS selectors/parts (e.g., `::part(control)` → `::part(base)`) and test setup to stub `attachInternals` in jsdom so Web Awesome form-associated components don’t crash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d4bdc17ba70e8d3cefc153831403305ed2ce65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->