### PR TITLE
fix(wa): address review findings from PRs #3644-#3656

### DIFF
--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -98,18 +98,21 @@ export function createFirstRunWalkthrough({
       </ol>
       <div slot="footer" class="desktop-onboarding-actions">
         <wa-button
+          class="desktop-secondary-button"
           appearance="outlined"
           @click=${() => navigateAndClose('settings')}
         >
           Open Settings
         </wa-button>
         <wa-button
+          class="desktop-secondary-button"
           appearance="outlined"
           @click=${() => navigateAndClose('main')}
         >
           Go to Launcher
         </wa-button>
         <wa-button
+          class="desktop-primary-button"
           appearance="filled"
           variant="brand"
           data-onboarding-dismiss

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -369,17 +369,20 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
       icon: 'folder-open',
       title,
       body,
+      headingTag: 'h1',
       actions: [
         {
           label: 'Open Folder',
           appearance: 'filled',
           variant: 'brand',
+          className: 'desktop-primary-button',
           onClick: () =>
             postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
         },
         {
           label: 'Logs',
           appearance: 'outlined',
+          className: 'desktop-secondary-button',
           onClick: () => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
         },
       ],
@@ -557,6 +560,7 @@ function explorerNoWorkspaceTemplate(): TemplateResult {
         label: 'Open Folder',
         appearance: 'filled',
         variant: 'brand',
+        className: 'desktop-primary-button',
         onClick: () =>
           postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
       },

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -169,6 +169,7 @@ wa-tree.desktop-explorer-tree
 }
 
 .desktop-explorer-name {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -178,6 +179,8 @@ wa-tree.desktop-explorer-tree
 .desktop-explorer-category-strip {
   display: flex;
   gap: 3px;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .desktop-explorer-category-dot {
@@ -578,7 +581,7 @@ wa-dialog.desktop-onboarding {
     justify-content: stretch;
   }
 
-  .desktop-onboarding-actions button {
+  .desktop-onboarding-actions wa-button {
     flex: 1 1 150px;
   }
 }

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -87,7 +87,9 @@
   --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
   --texra-inputOption-activeBorder: var(--desktop-color-accent);
   --texra-inputOption-activeForeground: var(--desktop-color-foreground);
-  --texra-inputValidation-errorBackground: var(--desktop-color-error-background);
+  --texra-inputValidation-errorBackground: var(
+    --desktop-color-error-background
+  );
   --texra-inputValidation-errorBorder: var(--desktop-color-error);
   --texra-inputValidation-infoBackground: var(--desktop-color-info-background);
   --texra-inputValidation-infoBorder: var(--desktop-color-info);

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -35,6 +35,8 @@
   --desktop-color-info: light-dark(#0969da, #75beff);
   --desktop-color-info-background: light-dark(#ddf4ff, #063b49);
   --desktop-color-success: light-dark(#1a7f37, #73c991);
+  --desktop-color-success-background: light-dark(#d2f5dc, #1a4a25);
+  --desktop-color-error-background: light-dark(#ffebe9, #5a1d1d);
   --desktop-color-orange: light-dark(#bc4c00, #d18616);
   --desktop-color-yellow: light-dark(#bf8700, #cca700);
   --desktop-color-terminal-selection: light-dark(#ddf4ff, #264f78);
@@ -85,7 +87,7 @@
   --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
   --texra-inputOption-activeBorder: var(--desktop-color-accent);
   --texra-inputOption-activeForeground: var(--desktop-color-foreground);
-  --texra-inputValidation-errorBackground: light-dark(#ffebe9, #5a1d1d);
+  --texra-inputValidation-errorBackground: var(--desktop-color-error-background);
   --texra-inputValidation-errorBorder: var(--desktop-color-error);
   --texra-inputValidation-infoBackground: var(--desktop-color-info-background);
   --texra-inputValidation-infoBorder: var(--desktop-color-info);
@@ -223,16 +225,26 @@
   --wa-color-danger-fill-loud: var(--desktop-color-error);
   --wa-color-danger-on-loud: #ffffff;
   --wa-color-danger-border-loud: transparent;
-  --wa-color-danger-fill-quiet: var(--desktop-color-error);
+  --wa-color-danger-fill-quiet: var(--desktop-color-error-background);
   --wa-color-danger-border-quiet: var(--desktop-color-error);
-  --wa-color-danger-on-quiet: #ffffff;
+  --wa-color-danger-on-quiet: var(--desktop-color-error);
 
   --wa-color-success-fill-loud: var(--desktop-color-success);
   --wa-color-success-on-loud: #ffffff;
   --wa-color-success-border-loud: transparent;
-  --wa-color-success-fill-quiet: var(--desktop-color-success);
+  --wa-color-success-fill-quiet: var(--desktop-color-success-background);
   --wa-color-success-border-quiet: var(--desktop-color-success);
-  --wa-color-success-on-quiet: #ffffff;
+  --wa-color-success-on-quiet: var(--desktop-color-success);
+
+  /* Neutral tokens for outlined wa-button / wa-callout variants. Wire to the
+     desktop muted palette so neutral surfaces blend with the renderer theme
+     rather than falling back to WA's default gray scale. */
+  --wa-color-neutral-fill-quiet: var(--desktop-color-sidebar-header);
+  --wa-color-neutral-border-quiet: var(--desktop-color-border);
+  --wa-color-neutral-on-quiet: var(--desktop-color-foreground);
+  --wa-color-neutral-fill-loud: var(--desktop-color-sidebar-header);
+  --wa-color-neutral-border-loud: var(--desktop-color-border);
+  --wa-color-neutral-on-loud: var(--desktop-color-foreground);
 }
 
 body.vscode-light,

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -242,6 +242,16 @@
   --wa-color-brand-on-loud: var(--texra-button-foreground);
   --wa-color-brand-border-loud: var(--texra-button-border);
 
+  /* Neutral tokens for outlined wa-button / wa-callout variants. Wire to the
+     VS Code secondary-button palette so neutral surfaces blend with the host
+     theme rather than falling back to WA's default gray scale. */
+  --wa-color-neutral-fill-quiet: var(--texra-button-secondaryBackground);
+  --wa-color-neutral-border-quiet: var(--texra-button-border);
+  --wa-color-neutral-on-quiet: var(--texra-button-secondaryForeground);
+  --wa-color-neutral-fill-loud: var(--texra-button-secondaryBackground);
+  --wa-color-neutral-border-loud: var(--texra-button-border);
+  --wa-color-neutral-on-loud: var(--texra-button-secondaryForeground);
+
   /* Variant tokens for wa-callout / wa-button — wire VS Code validation
      palettes through the WA color stack so brand/warning/danger/success
      callouts blend with the host theme rather than the WA defaults. */

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -73,7 +73,7 @@ export class DependencyBanner extends LitElement {
       <wa-callout id="dependencyBanner" variant="warning">
         ${waIcon('triangle-exclamation', { slot: 'icon' })}
         <div class="banner-row">
-          <span class="missing-tools">
+          <div class="missing-tools">
             ${when(
               tools.length === 0,
               () => html`Missing dependencies: none`,
@@ -96,7 +96,7 @@ export class DependencyBanner extends LitElement {
                   `,
                 ),
             )}
-          </span>
+          </div>
           <div class="actions">
             <wa-button
               id="dependencyRecheckButton"

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -5,6 +5,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { html, nothing, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { html as staticHtml, literal } from 'lit/static-html.js';
 
 import { waIcon, type TeXRAIconName } from './webAwesomeIcons';
 
@@ -13,7 +14,12 @@ export interface EmptyStateAction {
   readonly onClick: () => void;
   readonly appearance?: 'filled' | 'outlined';
   readonly variant?: 'brand' | 'neutral';
+  // Forwarded onto the underlying <wa-button>. Lets callers re-apply host-
+  // specific button classes (e.g. desktop-primary-button) for theming hooks.
+  readonly className?: string;
 }
+
+export type EmptyStateHeadingTag = 'h1' | 'h2' | 'h3';
 
 export interface EmptyStateOptions {
   readonly icon: TeXRAIconName;
@@ -21,7 +27,16 @@ export interface EmptyStateOptions {
   readonly body?: string;
   readonly actions?: readonly EmptyStateAction[];
   readonly className?: string;
+  // Defaults to 'h2'. Callers that own the surrounding semantic outline can
+  // promote (h1) or demote (h3) the title without forking the helper.
+  readonly headingTag?: EmptyStateHeadingTag;
 }
+
+const HEADING_TAGS = {
+  h1: literal`h1`,
+  h2: literal`h2`,
+  h3: literal`h3`,
+} as const satisfies Record<EmptyStateHeadingTag, ReturnType<typeof literal>>;
 
 export function renderEmptyState({
   icon,
@@ -29,11 +44,15 @@ export function renderEmptyState({
   body,
   actions,
   className,
+  headingTag = 'h2',
 }: EmptyStateOptions): TemplateResult {
-  return html`
+  const tag = HEADING_TAGS[headingTag] ?? HEADING_TAGS.h2;
+  // staticHtml + literal lets the heading element stay parameterizable
+  // (semantic outline) while keeping interpolated children type-checked.
+  return staticHtml`
     <section class=${ifDefined(className)}>
       ${waIcon(icon, { className: 'empty-state-icon' })}
-      <h2 class="empty-state-title">${title}</h2>
+      <${tag} class="empty-state-title">${title}</${tag}>
       ${body ? html`<p class="empty-state-body">${body}</p>` : nothing}
       ${actions && actions.length > 0
         ? html`
@@ -41,6 +60,7 @@ export function renderEmptyState({
               ${actions.map(
                 (action) => html`
                   <wa-button
+                    class=${ifDefined(action.className)}
                     appearance=${action.appearance ?? 'outlined'}
                     variant=${action.variant ?? 'neutral'}
                     @click=${action.onClick}

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -54,24 +54,26 @@ export function renderEmptyState({
       ${waIcon(icon, { className: 'empty-state-icon' })}
       <${tag} class="empty-state-title">${title}</${tag}>
       ${body ? html`<p class="empty-state-body">${body}</p>` : nothing}
-      ${actions && actions.length > 0
-        ? html`
-            <div class="empty-state-actions">
-              ${actions.map(
-                (action) => html`
-                  <wa-button
-                    class=${ifDefined(action.className)}
-                    appearance=${action.appearance ?? 'outlined'}
-                    variant=${action.variant ?? 'neutral'}
-                    @click=${action.onClick}
-                  >
-                    ${action.label}
-                  </wa-button>
-                `,
-              )}
-            </div>
-          `
-        : nothing}
+      ${
+        actions && actions.length > 0
+          ? html`
+              <div class="empty-state-actions">
+                ${actions.map(
+                  (action) => html`
+                    <wa-button
+                      class=${ifDefined(action.className)}
+                      appearance=${action.appearance ?? 'outlined'}
+                      variant=${action.variant ?? 'neutral'}
+                      @click=${action.onClick}
+                    >
+                      ${action.label}
+                    </wa-button>
+                  `,
+                )}
+              </div>
+            `
+          : nothing
+      }
     </section>
   `;
 }

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -230,7 +230,11 @@ const icons = {
 // Codicon-name aliases. Lets existing markup keep using familiar codicon names
 // (e.g. <wa-icon name="warning">) while resolving to the closest Font Awesome
 // glyph in the registry above. Prefer canonical names for new code.
-const CODICON_ALIASES: Readonly<Record<string, string>> = {
+//
+// `as const satisfies …` keeps alias keys as a literal union (so
+// `keyof typeof CODICON_ALIASES` narrows TeXRAIconName) and compile-checks
+// every alias value against the registered icon names.
+const CODICON_ALIASES = {
   account: 'circle-user',
   add: 'plus',
   'arrow-small-down': 'caret-down',
@@ -298,7 +302,7 @@ const CODICON_ALIASES: Readonly<Record<string, string>> = {
   window: 'window-maximize',
   x: 'xmark',
   zap: 'bolt',
-} as const;
+} as const satisfies Readonly<Record<string, keyof typeof icons>>;
 
 let isRegistered = false;
 
@@ -307,7 +311,8 @@ function dataUri(svg: string): string {
 }
 
 function resolveIcon(name: string): FontAwesomeIconDefinition | undefined {
-  const canonical = CODICON_ALIASES[name] ?? name;
+  const aliased = (CODICON_ALIASES as Readonly<Record<string, keyof typeof icons>>)[name];
+  const canonical = aliased ?? name;
   return icons[canonical as keyof typeof icons];
 }
 

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -311,7 +311,9 @@ function dataUri(svg: string): string {
 }
 
 function resolveIcon(name: string): FontAwesomeIconDefinition | undefined {
-  const aliased = (CODICON_ALIASES as Readonly<Record<string, keyof typeof icons>>)[name];
+  const aliased = (
+    CODICON_ALIASES as Readonly<Record<string, keyof typeof icons>>
+  )[name];
   const canonical = aliased ?? name;
   return icons[canonical as keyof typeof icons];
 }


### PR DESCRIPTION
Closes #3657.

Single follow-up PR clearing the bot-review queue from the Web Awesome migration PR chain (#3644–#3656). All findings tracked in the issue are addressed.

## Summary

### Theming / token bridge
- **Extension `common.css`**: wired `--wa-color-neutral-{fill,border,on}-{quiet,loud}` to the VS Code secondary-button palette so outlined wa-buttons stop falling back to WA's default gray.
- **Desktop `themeTokens.css`**:
  - Added `--desktop-color-error-background` / `--desktop-color-success-background` and pointed `--texra-inputValidation-errorBackground` at the new error background.
  - Wired `--wa-color-danger-fill-quiet` / `--wa-color-success-fill-quiet` to those soft surfaces (mirroring how `warning-quiet` is wired) so quiet/loud levels are visually distinct.
  - Added matching `--wa-color-neutral-*` tokens against the desktop muted palette.

### Type safety / API
- `src/shared/wa/webAwesomeIcons.ts`: typed `CODICON_ALIASES` with `as const satisfies Readonly<Record<string, keyof typeof icons>>` so `TeXRAIconName` keeps its literal union and alias values are compile-checked against the registered icons. Updated `resolveIcon()` to widen safely for runtime lookups.
- `src/shared/wa/emptyState.ts`:
  - Added `EmptyStateAction.className` (forwarded onto `<wa-button>`).
  - Added `EmptyStateOptions.headingTag` (`'h1' | 'h2' | 'h3'`, default `'h2'`); the title is rendered via `lit/static-html` so callers can preserve their semantic outline.

### Restored host theming hooks
- `packages/desktop/src/renderer/main.ts`: empty-workspace placeholder now passes `headingTag: 'h1'`, and both placeholders + the explorer empty state pass `desktop-primary-button` / `desktop-secondary-button` `className`s through to the `<wa-button>` elements.
- `packages/desktop/src/renderer/desktopOnboarding.ts`: re-applied `desktop-primary-button` / `desktop-secondary-button` classes on the dialog footer buttons so the existing `::part(base)` rules in `styles.css` activate again.

### Markup / layout
- `DependencyBanner.ts`: replaced `<span class="missing-tools">` with `<div>` so the contained `<div class="dependency-item">` children are valid HTML (block-in-inline was being rewritten by the browser).
- `styles.css`:
  - Mobile media query (`max-width: 560px`) now targets `wa-button` instead of native `button`.
  - `.desktop-explorer-name` gains `flex: 1 1 auto` and `.desktop-explorer-category-strip` gains `margin-left: auto; flex-shrink: 0` so the wa-tree-item label correctly distributes space between filename and category dots.

## Test plan
- [x] `npm run typecheck` (workspace-recursive) — clean
- [x] `npx vitest run` — 311/311 pass
- [x] `cd packages/desktop && npx vite build --mode development` — succeeds
- [ ] Smoke: launch desktop, verify onboarding dialog and empty-workspace placeholder render with desktop-styled buttons; quiet danger/success callouts now read as soft surfaces; explorer tree row layout unchanged.
- [ ] Smoke: open dependency banner with a missing tool; confirm no DOM rewriting warnings, layout intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to UI theming/token wiring, small markup/layout tweaks, and TypeScript type-safety improvements with no business logic or data handling changes.
> 
> **Overview**
> Restores consistent Web Awesome theming across Desktop and the VS Code extension by adding neutral token mappings and refining danger/success *quiet* surfaces so outlined buttons/callouts no longer fall back to default WA grays.
> 
> Improves shared WA helpers: `renderEmptyState` now supports a configurable `headingTag` and forwards per-action `className` onto underlying `wa-button`s, while `webAwesomeIcons` tightens `CODICON_ALIASES` typing to compile-check alias targets.
> 
> Polishes UI/layout correctness: Desktop re-applies `desktop-primary-button`/`desktop-secondary-button` classes (on onboarding and empty states), updates explorer row flex behavior for filename vs category dots, fixes mobile CSS to target `wa-button`, and makes `DependencyBanner` HTML valid by swapping an inline `span` wrapper to a `div`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e4e4c724c9c906862d96710c92d94135cee9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->