### PR TITLE
feat(progress): migrate panels to wa-details / wa-progress-ring / wa-radio

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -1,7 +1,7 @@
 /**
  * Collapsible panel for displaying background tasks (processes and subagents).
  *
- * Uses `<vscode-collapsible>` for consistent styling with other panels (Todos,
+ * Uses `<wa-details>` for consistent styling with other panels (Todos,
  * Files, etc.). Each active subagent is clickable to navigate to its stream tab.
  * Processes don't have their own tab so they are not clickable.
  */
@@ -43,6 +43,9 @@ import {
 
 // Side-effect imports - sibling components
 import './TerminalOutput';
+
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 @customElement('background-tasks-panel')
 export class BackgroundTasksPanel extends LitElement {
@@ -240,11 +243,12 @@ export class BackgroundTasksPanel extends LitElement {
     if (active + finished === 0) return nothing;
 
     return html`
-      <vscode-collapsible
+      <wa-details
         class="panel-collapsible"
-        title="Background Tasks"
+        summary="Background Tasks"
         ?open=${this.open}
-        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
+        @wa-show=${this.handleShow}
+        @wa-hide=${this.handleHide}
       >
         <div class="task-list">
           ${this.renderSection(
@@ -258,7 +262,7 @@ export class BackgroundTasksPanel extends LitElement {
             'subagent',
           )}
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 
@@ -392,8 +396,14 @@ export class BackgroundTasksPanel extends LitElement {
     `;
   }
 
-  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+  private handleShow(e: Event): void {
+    if (e.target !== e.currentTarget) return;
+    this.open = true;
+  }
+
+  private handleHide(e: Event): void {
+    if (e.target !== e.currentTarget) return;
+    this.open = false;
   }
 
   private navigateToStream(streamId: string): void {

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -20,6 +20,9 @@ import { ProgressEvents } from '../events';
 import { getComposedPathElement } from '../utils';
 import { webviewStorage } from '../webviewStorage';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 const STORAGE_HINT_DISMISS_KEY = 'generatedFilesStorageHint.dismissed';
 
 /** Parsed path components for display */
@@ -255,10 +258,10 @@ export class FileList extends LitElement {
     }
 
     return html`
-      <vscode-collapsible
+      <wa-details
         id=${ELEMENT_IDS.GENERATED_FILES_COLLAPSIBLE}
         class="panel-collapsible"
-        title="Generated Files"
+        summary="Generated Files"
         open
       >
         ${this.renderStorageHint()}
@@ -286,7 +289,7 @@ export class FileList extends LitElement {
               </div>
             `
           : nothing}
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 
@@ -327,9 +330,9 @@ export class FileList extends LitElement {
     }
 
     return html`
-      <vscode-collapsible
+      <wa-details
         class="round-collapsible panel-collapsible"
-        title=${`r${round}`}
+        summary=${`r${round}`}
         ?open=${true}
       >
         <div class="round-content">
@@ -339,7 +342,7 @@ export class FileList extends LitElement {
             (file) => this.renderFileItem(file, round),
           )}
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -23,6 +23,10 @@ import { ProgressEvents } from '../events';
 // Local imports - progress view components
 import './QueuedFollowUps';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+import '@awesome.me/webawesome/dist/components/progress-ring/progress-ring.js';
+
 @customElement('follow-up-input')
 export class FollowUpInput extends LitElement {
   static override styles = [
@@ -177,7 +181,7 @@ export class FollowUpInput extends LitElement {
 
   override render(): TemplateResult | typeof nothing {
     return html`
-      <vscode-collapsible class="panel-collapsible" title="Follow-up Input">
+      <wa-details class="panel-collapsible" summary="Follow-up Input">
         <div id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER} class="follow-up-container">
           <queued-follow-ups
             .messages=${this.queuedMessages}
@@ -204,7 +208,7 @@ export class FollowUpInput extends LitElement {
               ></vscode-toolbar-button>
               ${when(
                 this.polishing,
-                () => html`<vscode-progress-ring></vscode-progress-ring>`,
+                () => html`<wa-progress-ring indeterminate></wa-progress-ring>`,
               )}
               <vscode-toolbar-button
                 id=${ELEMENT_IDS.RECORD_FOLLOW_UP_BTN}
@@ -234,7 +238,7 @@ export class FollowUpInput extends LitElement {
             </div>
           </div>
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -161,7 +161,7 @@ export class LogList extends LitElement {
       // Force scroll to bottom when switching to a different stream tab.
       // Re-sticky so future content updates auto-scroll.
       // Must wait for child TaskGroupList to finish rendering (updateComplete)
-      // and then for a layout pass (requestAnimationFrame) so vscode-scrollable
+      // and then for a layout pass (requestAnimationFrame) so the log container
       // has an accurate scrollMax before we scroll.
       this.shouldScrollToBottom = false;
       void activeEl?.updateComplete.then(() => {

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -33,6 +33,9 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 @customElement('plan-view')
 export class PlanView extends LitElement {
   static override styles = [
@@ -190,12 +193,13 @@ export class PlanView extends LitElement {
     const total = this.plan.steps.length;
 
     return html`
-      <vscode-collapsible
+      <wa-details
         id=${ELEMENT_IDS.PLAN_VIEW_CONTAINER}
         class="plan-collapsible panel-collapsible"
-        title=${`Plan (${completed}/${total})`}
+        summary=${`Plan (${completed}/${total})`}
         ?open=${this.open}
-        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
+        @wa-show=${this.handleShow}
+        @wa-hide=${this.handleHide}
       >
         <div class="plan-summary">${this.plan.summary}</div>
         <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
@@ -205,7 +209,7 @@ export class PlanView extends LitElement {
             (step, index) => this.renderStep(step, index),
           )}
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 
@@ -250,7 +254,13 @@ export class PlanView extends LitElement {
     `;
   }
 
-  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+  private handleShow(e: Event): void {
+    if (e.target !== e.currentTarget) return;
+    this.open = true;
+  }
+
+  private handleHide(e: Event): void {
+    if (e.target !== e.currentTarget) return;
+    this.open = false;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -11,6 +11,9 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 const MAX_MESSAGE_LENGTH = 200;
 
 @customElement('queued-follow-ups')
@@ -43,7 +46,7 @@ export class QueuedFollowUps extends LitElement {
         background-color: transparent;
       }
 
-      .queued-collapsible::part(body) {
+      .queued-collapsible::part(content) {
         padding: 0 var(--spacing-small) var(--spacing-small);
       }
 
@@ -102,10 +105,10 @@ export class QueuedFollowUps extends LitElement {
   override render(): TemplateResult {
     const visible = this.messages.length > 0;
     return html`
-      <vscode-collapsible
+      <wa-details
         id=${ELEMENT_IDS.QUEUED_FOLLOW_UPS_COLLAPSIBLE}
         class="queued-collapsible"
-        title="Queued Messages"
+        summary="Queued Messages"
         ?open=${visible}
         ?hidden=${!visible}
         aria-hidden=${visible ? 'false' : 'true'}
@@ -128,7 +131,7 @@ export class QueuedFollowUps extends LitElement {
             },
           )}
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -33,6 +33,10 @@ import { getComposedPathElement, getRadioValue, setsEqual } from '../utils';
 import type { StreamState } from '../store';
 import type { StreamFilter } from '../store';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/radio/radio.js';
+import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+
 type ChildActivity = 'active' | 'finished' | 'unknown';
 
 /**
@@ -549,7 +553,8 @@ export class StreamTabs extends LitElement {
         min-width: 0;
       }
 
-      .agent-filter-group vscode-radio {
+      .agent-filter-group vscode-radio,
+      .agent-filter-group wa-radio {
         min-width: auto;
         flex: 0 0 auto;
       }
@@ -790,7 +795,7 @@ export class StreamTabs extends LitElement {
           ? nothing
           : html`<div class="stream-list-footer">
               <div class="stream-list-controls">
-                <vscode-radio-group
+                <wa-radio-group
                   id=${ELEMENT_IDS.AGENT_FILTER_CONTAINER}
                   class="agent-filter-group"
                   .value=${this.filter}
@@ -800,16 +805,16 @@ export class StreamTabs extends LitElement {
                     FILTER_BUTTONS,
                     (btn) => btn.id,
                     (btn) => html`
-                      <vscode-radio
+                      <wa-radio
                         id=${btn.id}
                         value=${btn.filter}
                         ?checked=${this.filter === btn.filter}
                       >
                         ${btn.label}
-                      </vscode-radio>
+                      </wa-radio>
                     `,
                   )}
-                </vscode-radio-group>
+                </wa-radio-group>
 
                 <div class="stream-list-actions">
                   <vscode-toolbar-button

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -189,8 +189,8 @@ export class TaskGroupList extends LitElement {
   /** True after a terminal cache rebuild, when incremental append is invalid. */
   private terminalCommittedNeedsReset = true;
 
-  /** Handle scroll events from vscode-scrollable to track user intent */
-  private handleVscScroll = (): void => {
+  /** Handle native scroll events from the log container to track user intent */
+  private handleScroll = (): void => {
     this.isSticky = this.isNearBottom(TaskGroupList.STICKY_THRESHOLD);
   };
 
@@ -770,13 +770,13 @@ export class TaskGroupList extends LitElement {
     // Show placeholder only when there are no streams in the current filter
     if (!this.hasStreams) {
       return html`
-        <vscode-scrollable
+        <div
           id=${ELEMENT_IDS.LOG_CONTENT}
           class="log-container"
-          @vsc-scrollable-scroll=${this.handleVscScroll}
+          @scroll=${this.handleScroll}
         >
           <div class="log-placeholder">${unsafeHTML(PLACEHOLDER_HTML)}</div>
-        </vscode-scrollable>
+        </div>
       `;
     }
 
@@ -789,29 +789,29 @@ export class TaskGroupList extends LitElement {
         ? ACTIVE_STREAM_STATUSES.has(this.streamStatus)
         : false;
       return html`
-        <vscode-scrollable
+        <div
           id=${ELEMENT_IDS.LOG_CONTENT}
           class="log-container"
-          @vsc-scrollable-scroll=${this.handleVscScroll}
+          @scroll=${this.handleScroll}
         >
           <div class="log-placeholder">
             ${active
               ? 'Run is starting. Progress updates will appear here.'
               : 'No log output for this stream yet.'}
           </div>
-        </vscode-scrollable>
+        </div>
       `;
     }
 
     if (this.terminal) {
       return html`
-        <vscode-scrollable
+        <div
           id=${ELEMENT_IDS.LOG_CONTENT}
           class="log-container"
-          @vsc-scrollable-scroll=${this.handleVscScroll}
+          @scroll=${this.handleScroll}
         >
           ${this.renderTerminalOutput()}
-        </vscode-scrollable>
+        </div>
       `;
     }
 
@@ -821,10 +821,10 @@ export class TaskGroupList extends LitElement {
     // the earliest timestamp. Timeline is memoized in willUpdate() — only
     // rebuilt when inputs change.
     return html`
-      <vscode-scrollable
+      <div
         id=${ELEMENT_IDS.LOG_CONTENT}
         class="log-container"
-        @vsc-scrollable-scroll=${this.handleVscScroll}
+        @scroll=${this.handleScroll}
       >
         ${repeat(
           this.cachedTimeline,
@@ -834,7 +834,7 @@ export class TaskGroupList extends LitElement {
               ? guard([item.msg], () => formatLogEntry(item.msg))
               : this.renderGroupNode(item.tree),
         )}
-      </vscode-scrollable>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -22,6 +22,9 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 import { ELEMENT_IDS } from '../constants';
 
+// Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 @customElement('todo-list')
 export class TodoList extends LitElement {
   static override styles = [
@@ -128,12 +131,13 @@ export class TodoList extends LitElement {
     const total = this.todos.length;
 
     return html`
-      <vscode-collapsible
+      <wa-details
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
         class="todo-collapsible panel-collapsible"
-        title=${`Todos (${completed}/${total})`}
+        summary=${`Todos (${completed}/${total})`}
         ?open=${this.open}
-        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
+        @wa-show=${this.handleShow}
+        @wa-hide=${this.handleHide}
       >
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
@@ -142,7 +146,7 @@ export class TodoList extends LitElement {
             (todo) => this.renderTodo(todo),
           )}
         </div>
-      </vscode-collapsible>
+      </wa-details>
     `;
   }
 
@@ -176,7 +180,14 @@ export class TodoList extends LitElement {
     `;
   }
 
-  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+  private handleShow(e: Event): void {
+    // Ignore bubbled events from nested wa-details
+    if (e.target !== e.currentTarget) return;
+    this.open = true;
+  }
+
+  private handleHide(e: Event): void {
+    if (e.target !== e.currentTarget) return;
+    this.open = false;
   }
 }

--- a/packages/extension/src/progressView/frontend/styles/logStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logStyles.ts
@@ -43,6 +43,7 @@ export const layoutStyles = css`
     contain: layout style paint;
   }
 
+  task-group-list > .log-container,
   task-group-list > vscode-scrollable,
   vscode-scrollable {
     flex: 1 1 auto;

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -1,18 +1,20 @@
 // Shared utility functions for the progress view frontend.
 
 /**
- * Type for VSCode web components that expose a value property.
- * Used for vscode-radio-group, vscode-single-select, etc.
+ * Type for radio-group-like components that expose a value property.
+ * Used for wa-radio-group / vscode-radio-group / vscode-single-select.
  */
 export type VSCodeValueElement = HTMLElement & { value?: string };
 
 /**
- * Extract value from a VSCode radio group change event.
- * Works around vscode-radio-group not updating .value synchronously on change.
- * Prefers the clicked radio element's value, falls back to group value.
+ * Extract value from a radio-group change event. Prefers the clicked
+ * radio element's value, falls back to group value. Works for both
+ * `wa-radio` (Web Awesome) and the legacy `vscode-radio` elements.
  */
 export function getRadioValue<T extends string>(event: Event): T | null {
-  const radio = getComposedPathElement(event, 'vscode-radio');
+  const radio =
+    getComposedPathElement(event, 'wa-radio') ||
+    getComposedPathElement(event, 'vscode-radio');
   const radioGroup = event.currentTarget as VSCodeValueElement | null;
   const value = radio?.getAttribute('value') || radioGroup?.value;
   return (value as T) || null;

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -64,7 +64,9 @@ export const commonViewStyles: CSSResult = css`
     color: var(--texra-sideBarTitle-foreground, var(--texra-foreground));
   }
 
-  .panel-collapsible::part(body) {
+  /* "body" part is used by vscode-collapsible; "content" part by wa-details. */
+  .panel-collapsible::part(body),
+  .panel-collapsible::part(content) {
     padding: 0 var(--spacing-small) var(--spacing-small);
   }
 


### PR DESCRIPTION
## Summary

Replace ad-hoc VS Code Elements wrappers in the progress view with native Web Awesome components, matching the migration pattern used elsewhere in the workspace.

Structural swaps:

- `vscode-collapsible` -> `wa-details` (7 occurrences across `TodoList`, `PlanView`, `QueuedFollowUps`, `FollowUpInput`, `BackgroundTasksPanel`, `FileList`)
- `vscode-scrollable` -> native `<div>` with `overflow-y: auto` (4 occurrences in `TaskGroupList`)
- `vscode-radio-group` / `vscode-radio` -> `wa-radio-group` / `wa-radio` (`StreamTabs` filter chips)
- `vscode-progress-ring` -> `wa-progress-ring` (`FollowUpInput` polish indicator)

Behavior preservation:

- The `wa-show` / `wa-hide` events drive the same `open` state that `vsc-collapsible-toggle` previously updated. Show/hide handlers guard with `e.target !== e.currentTarget` so bubbled events from nested `wa-details` don't flip the parent.
- Shared `.panel-collapsible` style now selects `::part(body), ::part(content)` so the existing padding rule applies under both vscode-collapsible and wa-details.
- `TaskGroupList` keeps the same `id` and `log-container` class on the new scrolling div; `isNearBottom()` already had a fallback path using `scrollHeight/scrollTop/clientHeight` that works on a regular div. `@scroll` listener attached directly on the scroller works without bubbling.
- `getRadioValue()` helper in `utils.ts` now prefers `wa-radio`, falls back to `vscode-radio` for any remaining consumers.

Out of scope (intentionally deferred):

- `vscode-textarea` (FollowUpInput, RetryRequestPanel, BaseFeedbackPanel, PermissionCard, WorkflowToolUseFollowupSection) — entangled with selection/template logic.
- `vscode-context-menu` (ToolEditRequestPanel) — entangled with select-templates flow.
- Webview's `InstructionPanel` progress-ring — that's outside the progressView migration target.

Coordination: shares files with the in-flight `webawesome/progressview-codicons` branch (icon migration). Conflicts will be resolved at merge.

## Test plan

- [x] `npm run typecheck` passes (root + extension package).
- [x] `npx vitest run` — 311/311 tests pass (same count as `main`).
- [x] `npm run lint` — 0 errors.
- [ ] Manual: open the progress view, expand/collapse Todos/Plan/Files/Background Tasks, verify chevron animation and persistence behave like before.
- [ ] Manual: switch streams; confirm filter radio still updates filter, log container scroll/sticky behavior preserved when running an agent.
- [ ] Manual: trigger follow-up polish; confirm `wa-progress-ring` shows during the polishing window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps core ProgressView UI primitives (collapsibles, radios, progress ring, scroll container), which can subtly change event semantics, open-state persistence, and scrolling/sticky behavior. Risk is limited to frontend UX with no backend/data-plane changes.
> 
> **Overview**
> Migrates ProgressView UI primitives from VS Code web components to Web Awesome equivalents: panels now use `wa-details` (Todos/Plan/Files/Background Tasks/Follow-up/Queued Messages), stream filtering uses `wa-radio-group`/`wa-radio`, and the follow-up polishing indicator uses `wa-progress-ring`.
> 
> Replaces `vscode-scrollable` in `TaskGroupList` with a native scrolling `div` and updates scroll listeners accordingly, while updating shared styles/utilities (`commonViewStyles` parts, `logStyles`, `getRadioValue`) to support the new components and preserve existing layout/behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b12d4b24369faacedcc70dc396cfb292710451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->