### PR TITLE
docs(prd): trim CLI scope to minimum-viable v1.0 + revise logger v2

### DIFF
--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1864,7 +1864,7 @@ The goal of round 3: ship a useful CLI in three weeks, not a complete CLI in thr
 
 User direction after round 3: **MCP can wait. Make interactive and workflow agents work first.** Round 4 reverses round 3's "MCP before REPL" priority — the user wants TeXRA to be a usable, standalone CLI on its own before being a callable backend for other CLIs.
 
-This means Ink ships in v1.0 (round 3 §33.3 said no Ink). The MCP server moves from v1.0 to v1.1. The design goal is also to stay maximally coherent with the existing extension + Electron hosts: the CLI should be another thin host over the shared kernel, not a parallel product with its own semantics.
+This means Ink ships in v1.0 (round 3 §33.3 said no Ink). The MCP server moves out of the v1.x roadmap entirely (see §34.6). The design goal is also to stay maximally coherent with the existing extension + Electron hosts: the CLI should be another thin host over the shared kernel, not a parallel product with its own semantics.
 
 ### 34.1 What v1.0 ships (revised from §33.1)
 
@@ -1881,14 +1881,14 @@ Three features. Same plumbing.
 
 **2. `texra chat` interactive REPL** (~1,400–1,700 LOC; covers round 1 Phase 1 + Phase 3 minimum)
 
-- Ink-based TUI: `<App />`, `<StreamPane />`, `<ApprovalCard />`, `<PromptInput />`. Round 1 §11.3 also lists `<TodoList />` — deferred to v1.1 alongside the `/plan` slash command. Ink stays a lazy chunk per round 1 §11.3 — `texra run` headless does not load it.
+- Ink-based TUI: `<App />`, `<StreamPane />`, `<ApprovalCard />`, `<PromptInput />`. Round 1 §11.3 also lists `<TodoList />` — deferred (lands when `/plan` does; not on the v1.1 list — see §34.7). Ink stays a lazy chunk per round 1 §11.3 — `texra run` headless does not load it.
 - Tool-use agents: orchestrator (default), devise, search, generic chat. `--agent <name>` overrides.
 - Approval policy: `never | ask | yolo` only (skip `auto-edits` / `auto` for v1.0 — they need the in-project predicate from round 2 §26.3, fine to add in v1.1).
   - `ask` is the default in interactive mode; renders `<ApprovalCard />` inline for edit / bash / plan gates.
   - `never` and `yolo` work in interactive mode for users who want zero-prompt or all-prompt runs.
 - Slash commands (subset of round 1 §5.2): `/agent`, `/model`, `/yolo`, `/clear`, `/exit`. `/plan` and `/resume` deferred (no session store yet, no `<TodoList />` yet).
 - Multi-line input: Enter to submit, Shift-Enter (or Ctrl-J) for newline, Ctrl-C to cancel current run, Ctrl-D to exit.
-- No session persistence in v1.0 — `texra resume` and `--continue` ship in v1.2 alongside the JSONL session store (round 2 §27).
+- No session persistence in v1.0 — `texra resume` and `--continue` ship in v1.1 alongside the JSONL session store (round 2 §27).
 
 **3. Discovery + plumbing** (~150 LOC; unchanged from §33.1)
 

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1898,16 +1898,16 @@ Three features. Same plumbing.
 
 ### 34.2 What v1.0 explicitly does NOT ship (vs §33.2)
 
-| Item                                                           | Defer to | Why                                                                                     |
-| -------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
-| `texra mcp serve` (was v1.0 in §33.1)                          | **v1.1** | Per user direction: ship interactive + workflow first. MCP is leverage, not foundation. |
-| Approval policies `auto-edits` / `auto` (in-project predicate) | v1.1     | `never` / `ask` / `yolo` cover the simple cases; in-project predicate is round 2 §26.3. |
-| OAuth loopback + device-code                                   | v1.2     | Env vars cover ~95% of users.                                                           |
-| Keyring + file-secrets fallback                                | v1.2     | Env vars + a `--api-key` flag cover the gap.                                            |
-| `conf` + Zod layered config                                    | v1.2     | Env vars + flags are enough until users complain.                                       |
-| `texra resume` / `--continue` / session JSONL                  | v1.2     | Each `texra chat` is a fresh session in v1.0.                                           |
-| `texra-base-action` GitHub Action                              | v1.2     | Users `npm install -g @texra/cli` in a workflow step today.                             |
-| Hook system, `texra doctor`, Bun binaries                      | v1.2+    | Speculative or convenience-only.                                                        |
+| Item                                                           | Defer to   | Why                                                                                                                                                                                 |
+| -------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `texra mcp serve` (was v1.0 in §33.1)                          | **future** | Per user direction (round 4, reinforced 2026-05-09: "Don't do MCP yet"). Not part of the v1.x roadmap; revisit when there is concrete demand to wire TeXRA into another agent host. |
+| Approval policies `auto-edits` / `auto` (in-project predicate) | v1.1       | `never` / `ask` / `yolo` cover the simple cases; in-project predicate is round 2 §26.3.                                                                                             |
+| OAuth loopback + device-code                                   | v1.1       | Env vars cover ~95% of users; once auth is in, sessions/keyring follow.                                                                                                             |
+| Keyring + file-secrets fallback                                | v1.1       | Env vars + a `--api-key` flag cover the gap until OAuth lands.                                                                                                                      |
+| `conf` + Zod layered config                                    | v1.1       | Env vars + flags are enough until users complain.                                                                                                                                   |
+| `texra resume` / `--continue` / session JSONL                  | v1.1       | Each `texra chat` is a fresh session in v1.0.                                                                                                                                       |
+| `texra-base-action` GitHub Action                              | v1.2       | Users `npm install -g @texra/cli` in a workflow step today.                                                                                                                         |
+| Hook system, `texra doctor`, Bun binaries                      | v1.2+      | Speculative or convenience-only.                                                                                                                                                    |
 
 ### 34.3 On Ink — round 4 reverses round 3
 
@@ -1935,21 +1935,21 @@ Phase B largely gates Phase C — `texra chat` cannot _ship_ without working app
 - Cold start `texra --help` < 100 ms (Ink only loads when entering chat).
 - No regression in extension or desktop builds.
 
-### 34.6 v1.1 = MCP (not v1.0)
+### 34.6 MCP — out of the v1.x roadmap
 
-The §33 round 3 plan for `texra mcp serve` lands as v1.1, not v1.0. Three tools, one process per client connection, gated on `RunContext` Phase 2 (per `prd-runcontext-refactor.md`) for true concurrency. The interactive REPL and the MCP server share the same approval engine + `RunContext` plumbing; v1.1 is largely "expose what v1.0 already wires up" once the standalone CLI already makes sense on its own.
+Per user direction reinforced 2026-05-09 ("Don't do MCP yet"): `texra mcp serve` is not in v1.x. The round 2 §24 design stays in the PRD as a **future** option to revisit when there is concrete demand from a calling host (Claude Code / Codex / opencode user wiring TeXRA into their flow). Until then, the CLI is sized and shipped purely as a standalone product.
 
-The logger PRD's `McpProgressSink` (Phase 5, see [`prd-logger-v2.md`](./prd-logger-v2.md) §15.5) lands with v1.1 alongside `texra mcp serve`.
+The logger PRD's `McpProgressSink` (Phase 5, see [`prd-logger-v2.md`](./prd-logger-v2.md) §15.5) lands alongside MCP whenever that ships — not part of the v1.x logger work.
 
 ### 34.7 What round 4 does NOT change
 
-Round 1's architecture, platform impls, repo layout, and tech-stack picks all stand. Round 2's MCP-server design (§24) is correct — it just lands later. Round 3's logger v2 trims (§33.5, see also `prd-logger-v2.md` §15) all stay in force. Round 4 is purely a reordering of v1.0 vs v1.1 contents, not a redesign.
+Round 1's architecture, platform impls, repo layout, and tech-stack picks all stand. Round 2's MCP-server design (§24) is correct — it just is not part of v1.x. Round 3's logger v2 trims (§33.5, see also `prd-logger-v2.md` §15) all stay in force. Round 4 is a scope reordering, not a redesign.
 
-The intended shape is coherent across all three hosts:
+The intended shape stays coherent across hosts:
 
 - **Extension** stays the richest VS Code-native shell.
 - **Desktop** stays the Electron shell over the same shared kernel contracts.
-- **CLI v1.0** is the standalone shell for workflow + interactive use.
-- **MCP** is an interoperability surface layered on top in v1.1, not the thing that defines what the CLI is.
+- **CLI v1.0** is the standalone shell for workflow + interactive use — the canonical lens of round 4.
+- **MCP** is a future interoperability surface layered on top whenever it lands; it is not what defines the CLI and is not on the v1.x roadmap.
 
-The new sequencing: **interactive + workflow** (v1.0, ~5 weeks) → **MCP server** (v1.1, ~1.5 weeks) → **auth, config, sessions** (v1.2, ~3 weeks) → polish + GitHub Action (v1.3+).
+The v1.x sequencing: **interactive + workflow** (v1.0, ~5 weeks) → **auth, config, secrets, sessions, `auto-edits`/`auto` policies** (v1.1, ~3 weeks) → polish + `texra doctor` + GitHub Action (v1.2, ~1.5 weeks) → MCP and other interop surfaces if and when there is demand (post-v1.x).

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1744,3 +1744,212 @@ Round 2 ships only `command` and `prompt` handler types in §25.5. `http` (POST 
 ---
 
 End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and _callable by every other agent that speaks MCP_ — which was the user's framing all along.
+
+---
+
+## 33. Round 3 — minimum-viable v1.0 (2026-05-08)
+
+> **Superseded by §34 (round 4)** on the Ink-vs-MCP ordering: round 4 ships the interactive REPL (Ink) in v1.0 and defers `texra mcp serve` to v1.1, reversing this round. The §33.2 deferral table below is still accurate for every row _except_ the `texra chat` Ink REPL row and the `texra mcp serve` row — those two flip in §34.2. For the canonical current v1.0 plan, read §34.
+
+User feedback after rounds 1 and 2: the scope is too large. Round 3 trims v1.0 to the two highest-leverage features and explicitly defers the rest. Rounds 1 and 2 stay as the long-range design; round 3 is what ships first.
+
+### 33.1 What v1.0 ships
+
+Two features plus minimum plumbing.
+
+**1. `texra run <workflow-agent>` headless** (~1,000 LOC; covers Phase 0 of round 1 §15)
+
+- Workflow agents only: `polish`, `correct`, `elevate`, `devise`, `criticize`, `merge`, OCR, transcribe.
+- Env-var auth only — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. (existing `lookupApiKey` resolution path; no keyring, no OAuth).
+- `--output-format text|ndjson`. In `text` mode (default): final output file path on stdout, progress on stderr. In `ndjson` mode: structured events on stdout (progress events per §11.2; log records per `prd-logger-v2.md` §5.2 — the two share transport but version independently per logger §15.1), human messages and errors on stderr.
+- Reuses all 6 existing Node platform defaults byte-for-byte (`consoleLog`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `memoryState` — exporting `createMemoryStore()` — and `EnvSecrets`). v1.0 keeps `EnvSecrets` since auth is env-vars-only; the keyring-backed replacement (round 1 §7.3) lands in v1.2.
+- No interactive features. No approval engine — workflow agents don't trigger edit/bash gates.
+- Exit codes per round 1 §5.1.
+
+**2. `texra mcp serve`** (~500 LOC; covers round 2 §24.5 v1.0)
+
+- Three MCP tools: `run_workflow`, `run_chat` (with `approvalPolicy: "never" | "yolo"` only), `list_agents`.
+- stdio JSON-RPC 2.0; one process per client connection.
+- `notifications/progress` streaming.
+- Cancellation via `notifications/cancelled`.
+- Documented v1.0 limitation: one concurrent `tools/call` per process; concurrent calls serialize. Singleton retirement (per `prd-runcontext-refactor.md` Phase 2) gates true concurrency in v1.1.
+
+This is the leverage feature. It makes every TeXRA agent callable from Claude Code, Codex, opencode, Cursor, and any future MCP host without TeXRA writing its own TUI. Users get an interactive surface for free via the calling host's UI.
+
+**3. Discovery + plumbing** (~150 LOC)
+
+- `texra agents list [--source builtin|custom|remote] [--output-format text|json]`
+- `texra models list [--provider <name>] [--output-format text|json]`
+- `texra version`, `texra --help`.
+
+**Total v1.0: ~1,650 LOC, ~3 weeks for one engineer.** Down from round 2's ~5,330–6,330 LOC v1 bundle.
+
+### 33.2 What v1.0 explicitly does NOT ship
+
+| Round 1+2 item                                              | Defer to     | Why it can wait                                                                                   |
+| ----------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------- |
+| `texra chat` Ink REPL (round 1 §5.2 / §11.3)                | v1.1+        | MCP server gives users an interactive surface via the calling host's UI. May never need our own.  |
+| Tool-use headless with `auto-edits` / `auto` / `ask` (§9.2) | v1.1         | Only `never` and `yolo` are useful headlessly; both are exposed via MCP `run_chat`.               |
+| OAuth loopback + device-code (round 1 §10)                  | v1.2         | Env vars cover ~95% of users (CI, scripts, dev containers).                                       |
+| Keyring + file-secrets fallback (§10.3)                     | v1.2         | Env vars + a `--api-key` flag cover the gap.                                                      |
+| `conf` + Zod layered config (§6.1, §8.4)                    | v1.2         | Env vars + flags are enough until users complain.                                                 |
+| `texra-base-action` GitHub Action (§12, round 2 §28)        | v1.2         | Users `npm install -g @texra/cli` in a workflow step today.                                       |
+| `texra resume` / session JSONL (round 2 §27)                | v1.2         | Workflow agents are stateless; tool-use sessions live in the MCP client's transcript (see §33.4). |
+| Hook system (round 2 §25)                                   | v2           | Speculative. Wait for concrete user requests.                                                     |
+| `texra doctor` (§8.5)                                       | nice-to-have | ~80 LOC whenever; not blocking v1.0.                                                              |
+| Self-contained Bun binaries (§13.3)                         | nice-to-have | Convenience artifact, never the canonical install path.                                           |
+| `RunContext` Phase 2 (per `prd-runcontext-refactor.md`)     | v1.1         | Required for _concurrent_ MCP sessions; not for the documented one-call-at-a-time v1.0.           |
+| Logger v2 Phase 2 (schema unification with progress)        | cut          | Over-couples slow-changing progress events to fast-changing log records (see logger PRD §15.1).   |
+| Logger v2 Phase 5 (`McpProgressSink`)                       | v1.1         | Gated on RunContext Phase 2 anyway.                                                               |
+
+### 33.3 On Ink
+
+Round 1 §6 #2 picked Ink for the interactive REPL. Ink is the right pick _when_ `texra chat` ships — Claude Code, Codex, and Gemini CLI all use it.
+
+But **Ink is only needed for the REPL.** Headless `texra run` is plain stdout / NDJSON; `texra mcp serve` is JSON-RPC framed on stdio. Neither touches Ink.
+
+- v1.0 ships _no_ REPL → no Ink dependency at all → cold start <80ms, no React in the install, smaller npm package.
+- v1.1 may ship `texra chat` → Ink as a lazy chunk per round 1 §11.3 is the correct call.
+- The MCP-server route may make `texra chat` redundant. A user wanting an interactive TeXRA experience runs `claude` (or `codex`, or `cursor`) with `texra mcp serve` configured; the calling host's TUI is already best-in-class. Building our own competes with that for no clear win.
+
+### 33.4 Sessions and resume — round 3 position
+
+Round 2 §27 specifies a JSONL session store under `~/.texra/projects/<hash>/sessions/<id>.jsonl` matching Claude Code's layout. Round 3 keeps the _layout_ but defers _implementation_ to v1.2:
+
+- v1.0's workflow agents are stateless — input file → output file. No session to resume.
+- v1.0's `texra mcp serve` runs inside an MCP client (Claude Code, Codex, …) whose own transcript is the canonical "conversation" record. The client's `--continue` / `--resume` resumes that conversation; TeXRA's contribution shows up there as `texra__run_polish` tool calls + their results.
+- Cross-tool resume (resuming a Codex session in Claude Code, or a Claude Code session in TeXRA) **does not exist** in the ecosystem as of May 2026. Each tool's JSONL contains tool-call shapes specific to that tool's runtime; transcripts are interpretable across tools but not executable. The shared on-disk _layout_ (project-hashed JSONL directories, per `cc-sessions` and similar tooling) is the right interop level.
+
+When `texra resume` lands in v1.2, matching Claude Code's directory layout buys ecosystem-tooling reuse for free; the _event schema_ stays TeXRA-specific.
+
+### 33.5 Logger v2 — round 3 consumes a trimmed subset
+
+Logger v2's direction is right, but the v1.0 CLI consumes a trimmed subset (see [`prd-logger-v2.md`](./prd-logger-v2.md) §15 for full revisions):
+
+- **Phase 2 cut** (schema unification) — share NDJSON transport, version log/progress schemas independently.
+- **Phase 5 deferred** to v1.1 (MCP sink, gated on RunContext Phase 2).
+- **Boot logger** is `swapSink()` instead of `flushTo()` — no record reordering, no overflow cap.
+- **Channel** auto-derived from `RunContext.streamId`, not pushed at every legacy call site.
+
+Net: logger v2 timeline drops from ~3.8 to ~2.7 engineering weeks for v1.0 scope (Phases 0/1/3, with `InkLogSink` rolled into Phase 1).
+
+### 33.6 Phase plan (v1.0)
+
+| Phase     | Scope                                                                                                                                       | Weeks |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| A         | Workspace package + `texra run <workflow-agent>` + headless renderer (text + NDJSON) + `agents list` + `models list` + `version` + `--help` | 1.5   |
+| B         | `texra mcp serve` v1.0 (three tools, stdio JSON-RPC, progress notifications, cancellation)                                                  | 1     |
+| C         | Polish: release scripting, `npm publish`, README quickstart                                                                                 | 0.5   |
+| **Total** | **~3 weeks single-engineer**                                                                                                                | **3** |
+
+Phases A and B are independent after the workspace skeleton lands; two engineers run them in parallel for ~2-week delivery.
+
+### 33.7 Success criteria for v1.0
+
+- `npm install -g @texra/cli && texra run polish --input paper.tex --output paper.polished.tex` succeeds end-to-end with only `ANTHROPIC_API_KEY` set. No prior TeXRA install required.
+- `texra mcp serve` is callable from Claude Code with a default `.mcp.json` config; the user can prompt Claude Code to "ask texra to polish this paragraph" and get a result.
+- `texra agents list -o json | jq` parses; the schema matches `@shared/schemas`.
+- Cold start `texra --help` < 100 ms.
+- No regression in extension or desktop builds.
+
+### 33.8 What round 3 does NOT change
+
+Round 1's architecture (§7), platform impls (§7.3), code-reuse boundary (§7.2), repo layout (§7.1), and tech-stack picks (§6 picks 1, 3, 4, 5, 8, 10) all stand. Round 2's MCP-server design (§24) ships _as-is_ — it was already the right shape. Round 3 is purely a scope trim, not a redesign.
+
+The goal of round 3: ship a useful CLI in three weeks, not a complete CLI in three months. The complete CLI is rounds 1 + 2; v1.1, v1.2, and v2 cover everything else as user demand reveals what's worth the cost.
+
+---
+
+## 34. Round 4 — interactive + workflow first, MCP defers (2026-05-08)
+
+User direction after round 3: **MCP can wait. Make interactive and workflow agents work first.** Round 4 reverses round 3's "MCP before REPL" priority — the user wants TeXRA to be a usable, standalone CLI on its own before being a callable backend for other CLIs.
+
+This means Ink ships in v1.0 (round 3 §33.3 said no Ink). The MCP server moves from v1.0 to v1.1. The design goal is also to stay maximally coherent with the existing extension + Electron hosts: the CLI should be another thin host over the shared kernel, not a parallel product with its own semantics.
+
+### 34.1 What v1.0 ships (revised from §33.1)
+
+Three features. Same plumbing.
+
+**1. `texra run <workflow-agent>` headless** (~1,000 LOC; unchanged from §33.1)
+
+- Workflow agents: `polish`, `correct`, `elevate`, `devise`, `criticize`, `merge`, OCR, transcribe.
+- Env-var auth, `--output-format text|ndjson`, exit codes per round 1 §5.1.
+- Reuses all 6 existing Node platform defaults byte-for-byte: `consoleLog`, `nodeFilesystem`, `nodeStorage`,
+  `nodeWorkspace`, `createMemoryStore()` from `memoryState`, and `EnvSecrets`.
+- Same kernel contracts as extension + desktop: `executeAgent`, `RunContext`, logger v2, approval hooks, and
+  shared Zod schemas stay the source of truth. The CLI contributes a host shell, not a forked agent runtime.
+
+**2. `texra chat` interactive REPL** (~1,400–1,700 LOC; covers round 1 Phase 1 + Phase 3 minimum)
+
+- Ink-based TUI: `<App />`, `<StreamPane />`, `<ApprovalCard />`, `<PromptInput />`. Round 1 §11.3 also lists `<TodoList />` — deferred to v1.1 alongside the `/plan` slash command. Ink stays a lazy chunk per round 1 §11.3 — `texra run` headless does not load it.
+- Tool-use agents: orchestrator (default), devise, search, generic chat. `--agent <name>` overrides.
+- Approval policy: `never | ask | yolo` only (skip `auto-edits` / `auto` for v1.0 — they need the in-project predicate from round 2 §26.3, fine to add in v1.1).
+  - `ask` is the default in interactive mode; renders `<ApprovalCard />` inline for edit / bash / plan gates.
+  - `never` and `yolo` work in interactive mode for users who want zero-prompt or all-prompt runs.
+- Slash commands (subset of round 1 §5.2): `/agent`, `/model`, `/yolo`, `/clear`, `/exit`. `/plan` and `/resume` deferred (no session store yet, no `<TodoList />` yet).
+- Multi-line input: Enter to submit, Shift-Enter (or Ctrl-J) for newline, Ctrl-C to cancel current run, Ctrl-D to exit.
+- No session persistence in v1.0 — `texra resume` and `--continue` ship in v1.2 alongside the JSONL session store (round 2 §27).
+
+**3. Discovery + plumbing** (~150 LOC; unchanged from §33.1)
+
+- `texra agents list`, `texra models list`, `texra version`, `texra --help`.
+
+**Total v1.0: ~2,550–2,850 LOC** (1,000 + 1,400–1,700 + 150)**, ~5 weeks single-engineer.** Larger than round 3's ~1,650 because the Ink REPL is the largest single UI investment in the CLI; smaller than rounds 1+2's ~5,330+ because MCP, OAuth, keyring, file config, sessions, hooks, and the GitHub Action all defer.
+
+### 34.2 What v1.0 explicitly does NOT ship (vs §33.2)
+
+| Item                                                           | Defer to | Why                                                                                     |
+| -------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `texra mcp serve` (was v1.0 in §33.1)                          | **v1.1** | Per user direction: ship interactive + workflow first. MCP is leverage, not foundation. |
+| Approval policies `auto-edits` / `auto` (in-project predicate) | v1.1     | `never` / `ask` / `yolo` cover the simple cases; in-project predicate is round 2 §26.3. |
+| OAuth loopback + device-code                                   | v1.2     | Env vars cover ~95% of users.                                                           |
+| Keyring + file-secrets fallback                                | v1.2     | Env vars + a `--api-key` flag cover the gap.                                            |
+| `conf` + Zod layered config                                    | v1.2     | Env vars + flags are enough until users complain.                                       |
+| `texra resume` / `--continue` / session JSONL                  | v1.2     | Each `texra chat` is a fresh session in v1.0.                                           |
+| `texra-base-action` GitHub Action                              | v1.2     | Users `npm install -g @texra/cli` in a workflow step today.                             |
+| Hook system, `texra doctor`, Bun binaries                      | v1.2+    | Speculative or convenience-only.                                                        |
+
+### 34.3 On Ink — round 4 reverses round 3
+
+Round 3 §33.3 said "v1.0 ships _no_ REPL → no Ink dependency." Round 4 reverses: **Ink ships in v1.0 as the lazy chunk for `texra chat`.** Pick, gating, and chunk-size budget all unchanged from round 1 (§6 #2, §11.3, §13.2). One-shot inline prompts use `@clack/prompts` per round 1 §6 #4; streaming-style approvals render through `<ApprovalCard />`.
+
+### 34.4 Phase plan (revised v1.0)
+
+| Phase     | Scope                                                                                                                                                              | Weeks |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| A         | Workspace package + `texra run <workflow-agent>` + headless renderer (text + NDJSON) + `agents list` + `models list` + `version` + `--help`                        | 1.5   |
+| B         | Approval engine (`never` / `ask` / `yolo`) + edit / bash / plan / proposal / retry / external-inquiry handlers + `--allowed-tools` / `--disallowed-tools` plumbing | 1.5   |
+| C         | `texra chat` Ink REPL: `<App />`, `<StreamPane />`, `<ApprovalCard />`, `<PromptInput />`, slash-command dispatch, Ctrl-C cancellation                             | 1.5   |
+| D         | Polish: release scripting, `npm publish`, README quickstart                                                                                                        | 0.5   |
+| **Total** | **~5 weeks single-engineer; ~3.5 weeks for two engineers (B + C overlap after A)**                                                                                 | **5** |
+
+Phase B largely gates Phase C — `texra chat` cannot _ship_ without working approval handlers — but Phase C can build the REPL skeleton (`<App />`, `<StreamPane />`, `<PromptInput />`, slash-command dispatch, Ctrl-C) against a stub approval handler in parallel with B once A's plumbing lands. Final wiring of B's edit / bash / plan / proposal / retry / external-inquiry handlers into the REPL is the join point. Phase B's handlers are CLI-side glue against existing kernel seams (`setToolEditApprovalHandler`, `bashApprovalController`, etc.), not kernel work.
+
+### 34.5 Success criteria for v1.0 (revised from §33.7)
+
+- `npm install -g @texra/cli && texra run polish --input paper.tex --output paper.polished.tex` succeeds with only `ANTHROPIC_API_KEY` set.
+- `texra chat` boots into the Ink REPL on TTY, runs an orchestrator session against `cwd`, streams tool calls + responses live, prompts inline for edit / bash approval, respects Ctrl-C cancellation.
+- `texra chat --approval-policy yolo` runs an end-to-end multi-tool flow without prompts.
+- `texra chat --approval-policy never` correctly fails when an approval is needed (exit code 4).
+- `texra agents list -o json | jq` parses; schema matches `@shared/schemas`.
+- Cold start `texra --help` < 100 ms (Ink only loads when entering chat).
+- No regression in extension or desktop builds.
+
+### 34.6 v1.1 = MCP (not v1.0)
+
+The §33 round 3 plan for `texra mcp serve` lands as v1.1, not v1.0. Three tools, one process per client connection, gated on `RunContext` Phase 2 (per `prd-runcontext-refactor.md`) for true concurrency. The interactive REPL and the MCP server share the same approval engine + `RunContext` plumbing; v1.1 is largely "expose what v1.0 already wires up" once the standalone CLI already makes sense on its own.
+
+The logger PRD's `McpProgressSink` (Phase 5, see [`prd-logger-v2.md`](./prd-logger-v2.md) §15.5) lands with v1.1 alongside `texra mcp serve`.
+
+### 34.7 What round 4 does NOT change
+
+Round 1's architecture, platform impls, repo layout, and tech-stack picks all stand. Round 2's MCP-server design (§24) is correct — it just lands later. Round 3's logger v2 trims (§33.5, see also `prd-logger-v2.md` §15) all stay in force. Round 4 is purely a reordering of v1.0 vs v1.1 contents, not a redesign.
+
+The intended shape is coherent across all three hosts:
+
+- **Extension** stays the richest VS Code-native shell.
+- **Desktop** stays the Electron shell over the same shared kernel contracts.
+- **CLI v1.0** is the standalone shell for workflow + interactive use.
+- **MCP** is an interoperability surface layered on top in v1.1, not the thing that defines what the CLI is.
+
+The new sequencing: **interactive + workflow** (v1.0, ~5 weeks) → **MCP server** (v1.1, ~1.5 weeks) → **auth, config, sessions** (v1.2, ~3 weeks) → polish + GitHub Action (v1.3+).

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -279,7 +279,7 @@ Today these go through `console.info`. After this PRD: the CLI's `bin/texra.ts` 
 - The `LogBackend` interface in `core/platform/interfaces/log.ts` is renamed to `LogSink` and moved to `core/hosts/logSink.ts` to live alongside the other host ports.
 - **Exit criteria:** `git grep "outputChannelFactory\|setOutputChannelFactory" packages/` returns zero hits. Phase aligns with `prd-runcontext-refactor.md` Phase 2 (singleton retirement); the two should land in the same release.
 
-### Phase 5 — `McpProgressSink` (gates `texra mcp serve` v1.1) (~0.3 weeks)
+### Phase 5 — `McpProgressSink` (lands when `texra mcp serve` ships, post-v1.x — see §15.5) (~0.3 weeks)
 
 - `McpProgressSink` in `packages/cli/src/mcp/sinks/`.
 - Wires into the per-`tools/call` `RunContext` in the MCP server (per `prd-cli-app.md` §24.6).
@@ -465,6 +465,8 @@ class NdjsonStdoutSink implements LogSink {
     this.queue.length = 0;
     this.head = 0;
     this.draining = false;
+    // Null before calling so a re-entrant write() inside resolve() sees
+    // a fresh idle promise on its next turn, not the one we're resolving.
     const resolve = this.resolveIdle;
     this.resolveIdle = null;
     resolve?.();
@@ -494,9 +496,9 @@ The single `idle` promise resolves only when the queue is genuinely empty — th
 | 5                     | `McpProgressSink` — lands when `texra mcp serve` ships (out of v1.x per round 4 §34.6)                                                                  | 0.3             |
 | **Total to CLI v1.0** | Phases 0 / 1 / 3 (interactive + workflow; no MCP)                                                                                                       | **~2.7**        |
 | **Total to CLI v1.1** | + Phase 4 (when `prd-runcontext-refactor.md` Phase 2 lands)                                                                                             | **~3.0**        |
-| **Total to MCP**      | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **+0.3**        |
+| **Total with MCP**    | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **~3.3**        |
 
-Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+250 net** to v1.1.
+Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
 
 ### 15.7 What round 2 does NOT change
 

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -1,10 +1,13 @@
-# PRD: Logger v2 — structured records, host sinks, schema unified with progress
+# PRD: Logger v2 — structured records, host sinks, decoupled progress schema
 
-**Status:** Draft (v1 — extracted from `prd-cli-app.md` round 2 §23; 2026-05-05)
+**Status:** Draft (v2 — round-2 revisions landed in §15; 2026-05-08)
 **Owner:** TBD
 **Date:** 2026-05-05
 **Branch:** `claude/refactor-texra-cli-tOC5U`
 **Companions:** [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md), [`prd-cli-app.md`](./prd-cli-app.md), [`prd-electron-app.md`](./prd-electron-app.md)
+
+> **Canonical status:** §15 is the current design when it differs from earlier sections. In particular, `Logger.swapSink()`
+> replaces `BootstrapLogger.flushTo()`, and logs + progress share NDJSON transport without sharing one schema.
 
 ## 1. Summary
 
@@ -13,18 +16,21 @@ Today's logger (`src/logger/logUtils.ts`) is a serviceable VS Code-shaped string
 - Emits **`LogRecord`s** (timestamp + level + message + structured fields + group stack), not pre-formatted strings.
 - Routes every record through a per-host **`LogSink`** (extension → `vscode.OutputChannel`, desktop → `electron-log`, CLI text → stderr, CLI JSON → stdout NDJSON, CLI MCP → MCP `notifications/progress`, tests → in-memory).
 - Lives on **`RunContext`** (per `prd-runcontext-refactor.md`) — one logger per run, no module globals, no second ALS scope.
-- Shares a **single Zod schema** with the round-1 CLI progress NDJSON stream — `LogRecord` is a `ProgressEvent` with `event: "log"`. Tools that parse one parse the other.
-- Provides a **`BootstrapLogger`** that buffers records emitted before `initPlatform()` returns, then flushes them through the host's chosen sink.
+- Shares the **same NDJSON transport** as the CLI progress stream while keeping `LogRecordSchema` and
+  `ProgressEventSchema` versioned independently (per §15.1).
+- Starts on an immediate stderr sink, then uses **`Logger.swapSink()`** to hand off to the resolved host sink without
+  reordering boot-time records (per §15.2).
 
 The total kernel work is ~430 LOC new + ~130 LOC modified + ~5 LOC deleted. None of it gates a v1 CLI deliverable except the structured CLI renderer (which today's logger cannot produce).
 
 ## 2. Goals
 
 - Replace `LogBackend` (`src/platform/interfaces/log.ts`) with a `LogSink` that consumes `LogRecord` objects rather than formatted strings.
-- Unify the round-1 CLI §11.2 NDJSON event stream with the log stream — one schema, one renderer pipeline, two surface modes (text vs JSON).
+- Share the round-1 CLI §11.2 NDJSON transport with the progress stream without forcing log/progress schema lockstep.
 - Move group context off its own ALS (`src/logger/logUtils.ts:10` `contextStorage`) onto a per-`Logger` stack accessible via `withGroup`/`group`.
 - Eliminate `outputChannelFactory` (line 21) and the `channels` Map (line 19) as module-level state — every host installs one `LogSink` per run via `RunContext.log`.
-- Provide a `BootstrapLogger` so log lines emitted before `initPlatform()` returns are captured and replayed (today's `console.info` boot lines are unstructured and lose group context).
+- Provide a boot-time sink handoff (`Logger.swapSink()`) so log lines emitted before `initPlatform()` returns stay
+  ordered and structured.
 - Maintain backward compatibility: `src/logger/logUtils.ts`'s public functions (`debug`, `info`, `warn`, `error`, `runWithGroupContext`, `setOutputChannelFactory`) keep working for one release, deprecated, routing to the new logger.
 
 ## 3. Non-goals
@@ -87,6 +93,8 @@ export interface Logger {
 
   /** Per-domain child — adds a static field to every emission. Cheap. */
   child(fields: LogFields): Logger;
+  /** Swap to a new sink after boot; awaits the previous sink's flush/close hooks. */
+  swapSink(next: LogSink): Promise<void>;
 }
 ```
 
@@ -104,6 +112,7 @@ export interface LogRecord {
 export interface LogSink {
   write(record: LogRecord): void;
   flush?(): Promise<void>;
+  close?(): Promise<void>;
 }
 ```
 
@@ -338,3 +347,154 @@ LogRecord (structured) + LogSink (host port) + BootstrapLogger (pre-init buffer)
 ```
 
 The logger gets honest about being structured. The CLI's two output pipelines become one. The kernel loses its second ALS scope and its last module-level state in `src/logger/`. That's the whole story.
+
+---
+
+## 15. Round 2 revisions (2026-05-08)
+
+User-feedback review after round 1 surfaces three places the design is tighter than it needs to be and one place it is too loose. The structured-record + per-host-sink + per-`RunContext` core stays — it correctly retires today's three concrete defects (§4). The four deltas:
+
+### 15.1 Cut: schema unification with progress events (was §6)
+
+**Problem.** Round 1 §6 makes `LogRecord` an `event: "log"` variant of the `RunStreamEvent` union. Every schema change in either pipeline ripples to the other. Logger fields churn often (new structured keys, new sinks, new levels); progress events are stable (driven by webview consumers and `texra-action`). Coupling slow-changing infra to fast-changing infra is the wrong direction — the _logger_ will be the one churning, and consumers of the _progress_ schema will pay for it.
+
+**Resolution.** Share the _transport_, not the _schema_. Both pipelines write NDJSON to the same stdout in `--output-format ndjson` mode, but `LogRecordSchema` and `ProgressEventSchema` are versioned independently. A new top-level `kind: "log" | "progress"` literal is added to both schemas alongside the existing per-event `event` field (which `ProgressEventSchema` already carries; for `LogRecordSchema` `event` collapses to the literal `"log"`). Consumers filter by `kind` first — cheaper than a flat discriminated union over ~20 progress event names + 1 log event, and lets a consumer that only cares about progress skip the entire `LogRecord` Zod parse.
+
+**LOC delta.** Phase 2 (was 0.5 weeks, +30/-80) is removed. The progress NDJSON renderer keeps its own schema; the log NDJSON sink keeps its own. Net: -30 LOC versus round 1's +30/-80, plus 0.5 weeks saved.
+
+### 15.2 Replace: `BootstrapLogger.flushTo` with `Logger.swapSink` (was §5.3)
+
+**Problem.** Round 1 buffers pre-`initPlatform()` records, then drains them through the host-resolved sink. Boot lines like "loaded config from …" can appear _after_ "starting agent" in the user's terminal because they were buffered until the sink resolved. Confusing for users debugging boot-time issues — exactly the case where ordering matters most.
+
+**Resolution.** Pick a default `StderrTextSink` _immediately_ at process start (no config dependency — `picocolors` auto-disables on `!isTTY`), and _swap_ to a richer sink (NDJSON, Ink, MCP) only when the mode is resolved. The swap awaits the previous sink's `flush?()` and `close?()` so no records are dropped at the boundary.
+
+```ts
+// packages/cli/src/runtime/initLogger.ts
+const initialSink = new StderrTextSink({
+  colors: process.stderr.isTTY && !process.env.NO_COLOR,
+});
+const logger = new Logger(initialSink);
+// run config load, secret resolution, agent-directory bootstrap (all log to stderr) …
+// after mode resolves:
+await logger.swapSink(resolveSink(mode)); // awaits previous flush + close
+```
+
+**Interface delta (extends §5.1 / §5.2).** `Logger` gains:
+
+```ts
+swapSink(next: LogSink): Promise<void>;
+```
+
+`LogSink` gains an optional `close?()` for sinks that hold resources (file handles, MCP transports, queued stdout writes). Sinks without resources omit it. `swapSink`'s contract: `await previous.flush?(); await previous.close?(); /* install next */`.
+
+**LOC delta.** `BootstrapLogger` class collapses to the `Logger.swapSink()` method (~30 LOC instead of ~80). The 1,000-record overflow cap from §11 becomes unnecessary — there is no buffer to overflow.
+
+### 15.3 Replace: `Logger.child({ channel })` shim pattern (was §8.1)
+
+**Problem.** Round 1's shim has every legacy `info(channel, msg)` call wrap as `bootstrapLogger.child({ channel })`. ~40 call sites; any one that forgets `.child()` loses channel attribution silently. A lint rule catches it but it is friction every time a new module logs.
+
+**Resolution.** Derive `channel` from `RunContext.streamId` + agent metadata that is already on the context. Call sites stop passing channel.
+
+```ts
+// src/logger/logUtils.ts (after migration)
+export function info(
+  channel: string,
+  message: string,
+  options: LogUtilsOptions = {},
+): void {
+  const ctx = tryUseRunContext();
+  // channel argument ignored — kept for source compatibility,
+  // deprecation warning emitted once per module
+  (ctx?.log ?? bootstrapLogger).info(
+    message,
+    options.data ? { data: options.data } : undefined,
+  );
+}
+```
+
+`channel` is no longer a logical concept; the structured `streamId` + agent name in `LogRecord.fields` is what hosts render. The extension's `VscodeOutputChannelSink` maps `streamId` → channel-per-agent (current behavior preserved); CLI sinks render `[stream-N]` prefix when more than one run is active.
+
+**LOC delta.** Shim drops from ~120 modified call sites to ~5 (just the deprecation-warning bookkeeping). Phase 3 stays at 0.5 weeks but with much less mechanical churn. Knock-on: Phase 4 (§15.6) drops from §9's 0.5w to 0.3w because the channel-derivation work that originally lived there is paid for here.
+
+### 15.4 Tighten: `LogSink.write` is sync; slow sinks queue internally (was §13 open question)
+
+**Problem.** Round 1 §13 left this open. Sync simplifies kernel call sites but means a slow sink (NDJSON serialization with deep object traversal, MCP `notifications/progress` over a slow stdio transport) blocks the agent loop.
+
+**Resolution.** Keep `write` sync at the interface — every kernel call site stays cheap. Slow sinks (`NdjsonStdoutSink`, `McpProgressSink`) maintain an internal queue + `setImmediate` flush so a million-token tool result does not stall agent execution. `flush?()` is invoked at every group pop (the closure returned by `Logger.group()` and the tail of `Logger.withGroup()`) so a sink can finalize a stanza of records together, and at process shutdown / `swapSink` (per §15.2). The example handles `process.stdout` backpressure (the `false` return + `'drain'` event per Node streams docs) and uses an index head rather than `Array.shift()` to avoid O(n²) behavior under heavy logging:
+
+```ts
+// packages/cli/src/render/sinks/NdjsonStdoutSink.ts
+class NdjsonStdoutSink implements LogSink {
+  private queue: LogRecord[] = [];
+  private head = 0;
+  private scheduled = false;
+  private waiting: Promise<void> | null = null;
+
+  write(r: LogRecord): void {
+    this.queue.push(r);
+    if (!this.scheduled) {
+      this.scheduled = true;
+      setImmediate(() => this.drain());
+    }
+  }
+
+  async flush(): Promise<void> {
+    this.drain();
+    while (this.waiting) await this.waiting;
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+  }
+
+  private drain(): void {
+    while (this.head < this.queue.length) {
+      const line = JSON.stringify(this.queue[this.head++]) + '\n';
+      const ok = process.stdout.write(line);
+      if (!ok) {
+        // backpressure: park until the kernel buffer drains
+        this.waiting = new Promise<void>((resolve) => {
+          process.stdout.once('drain', () => {
+            this.waiting = null;
+            resolve();
+            setImmediate(() => this.drain());
+          });
+        });
+        return;
+      }
+    }
+    this.queue.length = 0;
+    this.head = 0;
+    this.scheduled = false;
+  }
+}
+```
+
+`flush()` resolves only after every queued record has actually crossed the stdout boundary (waiting through any pending `drain` event); calling shutdown code can rely on it not truncating the tail.
+
+**LOC delta.** ~50 LOC added to the two slow sinks; interface gains optional `close?()` per §15.2.
+
+### 15.5 Defer: Phase 5 (`McpProgressSink`) lands when `texra mcp serve` ships
+
+**Problem.** Round 1 Phase 5 lands `McpProgressSink` for `texra mcp serve`. Per [`prd-cli-app.md`](./prd-cli-app.md) round 4 §34, `texra mcp serve` itself is deferred to CLI v1.1 (round 4 reverses round 3's "MCP first" priority — v1.0 ships interactive REPL + workflow agents instead).
+
+**Resolution.** Phase 5 stays in the plan and lands alongside `texra mcp serve` whenever that ships (currently v1.1). The CLI v1.0 logger pipeline never instantiates `McpProgressSink` — the only sinks v1.0 needs are `StderrTextSink` (headless + interactive log lines), `NdjsonStdoutSink` (for `--output-format ndjson`), `InkLogSink` (for routing log records into the `<StreamPane />` component), and `MemorySink` (tests). The unified MCP sink is a v1.1 deliverable, not a v1.0 blocker.
+
+### 15.6 Trimmed phase plan
+
+| Phase                 | Scope (revised)                                                                                                                                          | Weeks           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| 0                     | Interface (`Logger.swapSink`, `LogSink.close?()` per §15.2) + immediate stderr default + legacy `LegacyConsoleSink`                                      | 1               |
+| 1                     | Per-host sinks (extension, desktop, CLI text, CLI ndjson, CLI Ink REPL, tests)                                                                           | 1.2             |
+| ~~2~~                 | ~~Schema unification with progress~~                                                                                                                     | **cut** (§15.1) |
+| 3                     | Group ALS retirement (`runWithGroupContext` → `Logger.withGroup`); auto-derived channel from `RunContext.streamId` (per §15.3)                           | 0.5             |
+| 4                     | `outputChannelFactory` / `channels` / `mainOutputChannel` removals (channel-derivation cleanup already landed in Phase 3, so only the deletions remain)  | 0.3             |
+| 5                     | `McpProgressSink` (lands alongside `texra mcp serve` — CLI v1.1 per round 4 §34)                                                                         | 0.3             |
+| **Total to CLI v1.0** | Phases 0 / 1 / 3 (interactive + workflow; no MCP)                                                                                                        | **~2.7**        |
+| **Total to CLI v1.1** | + Phase 4 (when `prd-runcontext-refactor.md` Phase 2 lands) + Phase 5 (when `texra mcp serve` ships); the two land independently, not as a single bundle | **~3.3**        |
+
+Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+250 net** to v1.1.
+
+### 15.7 What round 2 does NOT change
+
+The round-1 _direction_ is correct and ships unchanged: structured `LogRecord`, host-port `LogSink`, one logger per `RunContext`, retirement of `outputChannelFactory` and `contextStorage` ALS, deprecation shims through `logUtils.ts` for one release. Round 2 is a tightening pass on the migration mechanics, not a redesign.

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -427,20 +427,23 @@ export function info(
 class NdjsonStdoutSink implements LogSink {
   private queue: LogRecord[] = [];
   private head = 0;
-  private scheduled = false;
-  private waiting: Promise<void> | null = null;
+  private draining = false;
+  private idle = Promise.resolve();
+  private resolveIdle: (() => void) | null = null;
 
   write(r: LogRecord): void {
     this.queue.push(r);
-    if (!this.scheduled) {
-      this.scheduled = true;
+    if (!this.draining) {
+      this.draining = true;
+      this.idle = new Promise<void>((resolve) => {
+        this.resolveIdle = resolve;
+      });
       setImmediate(() => this.drain());
     }
   }
 
   async flush(): Promise<void> {
-    this.drain();
-    while (this.waiting) await this.waiting;
+    if (this.draining) await this.idle;
   }
 
   async close(): Promise<void> {
@@ -452,46 +455,46 @@ class NdjsonStdoutSink implements LogSink {
       const line = JSON.stringify(this.queue[this.head++]) + '\n';
       const ok = process.stdout.write(line);
       if (!ok) {
-        // backpressure: park until the kernel buffer drains
-        this.waiting = new Promise<void>((resolve) => {
-          process.stdout.once('drain', () => {
-            this.waiting = null;
-            resolve();
-            setImmediate(() => this.drain());
-          });
-        });
+        // backpressure: re-enter drain after the kernel buffer empties.
+        // Stay 'draining' so flush() keeps awaiting `idle` — we only
+        // resolve it once the queue is genuinely empty (below).
+        process.stdout.once('drain', () => setImmediate(() => this.drain()));
         return;
       }
     }
     this.queue.length = 0;
     this.head = 0;
-    this.scheduled = false;
+    this.draining = false;
+    const resolve = this.resolveIdle;
+    this.resolveIdle = null;
+    resolve?.();
   }
 }
 ```
 
-`flush()` resolves only after every queued record has actually crossed the stdout boundary (waiting through any pending `drain` event); calling shutdown code can rely on it not truncating the tail.
+The single `idle` promise resolves only when the queue is genuinely empty — that is, only at the bottom of `drain()` after every record has crossed `process.stdout.write()`. Backpressure re-enters `drain()` via `'drain'` + `setImmediate` without touching `idle`, so `flush()` (which awaits `idle`) keeps waiting until the final write lands. This avoids the race in earlier drafts where a `'drain'`-event handler resolved the wait promise before the next `drain()` cycle ran.
 
 **LOC delta.** ~50 LOC added to the two slow sinks; interface gains optional `close?()` per §15.2.
 
-### 15.5 Defer: Phase 5 (`McpProgressSink`) lands when `texra mcp serve` ships
+### 15.5 Defer: Phase 5 (`McpProgressSink`) is out of the v1.x roadmap
 
-**Problem.** Round 1 Phase 5 lands `McpProgressSink` for `texra mcp serve`. Per [`prd-cli-app.md`](./prd-cli-app.md) round 4 §34, `texra mcp serve` itself is deferred to CLI v1.1 (round 4 reverses round 3's "MCP first" priority — v1.0 ships interactive REPL + workflow agents instead).
+**Problem.** Round 1 Phase 5 lands `McpProgressSink` for `texra mcp serve`. Per [`prd-cli-app.md`](./prd-cli-app.md) round 4 §34.6, `texra mcp serve` itself is **not part of the v1.x roadmap** (user direction reinforced 2026-05-09: "Don't do MCP yet").
 
-**Resolution.** Phase 5 stays in the plan and lands alongside `texra mcp serve` whenever that ships (currently v1.1). The CLI v1.0 logger pipeline never instantiates `McpProgressSink` — the only sinks v1.0 needs are `StderrTextSink` (headless + interactive log lines), `NdjsonStdoutSink` (for `--output-format ndjson`), `InkLogSink` (for routing log records into the `<StreamPane />` component), and `MemorySink` (tests). The unified MCP sink is a v1.1 deliverable, not a v1.0 blocker.
+**Resolution.** Phase 5 stays in the plan as a future deliverable that lands alongside `texra mcp serve` whenever that ships. The CLI v1.x logger pipeline never instantiates `McpProgressSink` — the only sinks v1.x needs are `StderrTextSink` (headless + interactive log lines), `NdjsonStdoutSink` (for `--output-format ndjson`), `InkLogSink` (for routing log records into the `<StreamPane />` component), and `MemorySink` (tests).
 
 ### 15.6 Trimmed phase plan
 
-| Phase                 | Scope (revised)                                                                                                                                          | Weeks           |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| 0                     | Interface (`Logger.swapSink`, `LogSink.close?()` per §15.2) + immediate stderr default + legacy `LegacyConsoleSink`                                      | 1               |
-| 1                     | Per-host sinks (extension, desktop, CLI text, CLI ndjson, CLI Ink REPL, tests)                                                                           | 1.2             |
-| ~~2~~                 | ~~Schema unification with progress~~                                                                                                                     | **cut** (§15.1) |
-| 3                     | Group ALS retirement (`runWithGroupContext` → `Logger.withGroup`); auto-derived channel from `RunContext.streamId` (per §15.3)                           | 0.5             |
-| 4                     | `outputChannelFactory` / `channels` / `mainOutputChannel` removals (channel-derivation cleanup already landed in Phase 3, so only the deletions remain)  | 0.3             |
-| 5                     | `McpProgressSink` (lands alongside `texra mcp serve` — CLI v1.1 per round 4 §34)                                                                         | 0.3             |
-| **Total to CLI v1.0** | Phases 0 / 1 / 3 (interactive + workflow; no MCP)                                                                                                        | **~2.7**        |
-| **Total to CLI v1.1** | + Phase 4 (when `prd-runcontext-refactor.md` Phase 2 lands) + Phase 5 (when `texra mcp serve` ships); the two land independently, not as a single bundle | **~3.3**        |
+| Phase                 | Scope (revised)                                                                                                                                         | Weeks           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| 0                     | Interface (`Logger.swapSink`, `LogSink.close?()` per §15.2) + immediate stderr default + legacy `LegacyConsoleSink`                                     | 1               |
+| 1                     | Per-host sinks (extension, desktop, CLI text, CLI ndjson, CLI Ink REPL, tests)                                                                          | 1.2             |
+| ~~2~~                 | ~~Schema unification with progress~~                                                                                                                    | **cut** (§15.1) |
+| 3                     | Group ALS retirement (`runWithGroupContext` → `Logger.withGroup`); auto-derived channel from `RunContext.streamId` (per §15.3)                          | 0.5             |
+| 4                     | `outputChannelFactory` / `channels` / `mainOutputChannel` removals (channel-derivation cleanup already landed in Phase 3, so only the deletions remain) | 0.3             |
+| 5                     | `McpProgressSink` — lands when `texra mcp serve` ships (out of v1.x per round 4 §34.6)                                                                  | 0.3             |
+| **Total to CLI v1.0** | Phases 0 / 1 / 3 (interactive + workflow; no MCP)                                                                                                       | **~2.7**        |
+| **Total to CLI v1.1** | + Phase 4 (when `prd-runcontext-refactor.md` Phase 2 lands)                                                                                             | **~3.0**        |
+| **Total to MCP**      | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **+0.3**        |
 
 Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+250 net** to v1.1.
 


### PR DESCRIPTION
prd-cli-app.md (round 3): pick high-value features only — `texra run` for
workflow agents (env-var auth, NDJSON output) and `texra mcp serve` (three
tools, callable from Claude Code/Codex). Defer Ink REPL, OAuth, keyring,
file config, GitHub Action, sessions, hooks. ~1,650 LOC, ~3 weeks. Ink is
only needed for the REPL; v1.0 ships without it.

prd-logger-v2.md (round 2): keep structured LogRecord + per-host LogSink +
per-RunContext logger (the right direction). Cut Phase 2 schema unification
(over-couples slow-changing progress events to fast-changing log records).
Replace BootstrapLogger.flushTo with Logger.swapSink (no record reordering
on boot). Auto-derive channel from RunContext.streamId (no per-call-site
.child()). Sync write with internal queue + setImmediate in slow sinks.
Defer McpProgressSink (Phase 5) to CLI v1.1. Timeline ~2.5w to v1.0.

https://claude.ai/code/session_01Rgh2zrPCBwAE646XP5rqb5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that change planning and design guidance (v1.0 scope and logger v2 mechanics) but do not modify runtime code.
> 
> **Overview**
> Updates the CLI PRD to **trim and reorder v1.0 scope**: round 3 defines a minimal v1.0 centered on headless `texra run` plus `texra mcp serve`, then round 4 flips priorities so **`texra chat` (Ink REPL + approvals) ships in v1.0** and **MCP is removed from the v1.x roadmap** (deferred to an unspecified future).
> 
> Revises the Logger v2 PRD to **decouple log vs progress schemas** while sharing NDJSON transport, replace boot buffering with `Logger.swapSink()` (and `LogSink.close?()`), derive “channel” from `RunContext.streamId` instead of per-call-site shims, clarify sync `write()` with internal queuing for slow sinks, and defer `McpProgressSink` to whenever MCP eventually ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a4a3cdfae4132282fdd9daff72fd005cd39a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->