### PR TITLE
feat(progress): migrate codicon markup to wa-icon library

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -9,6 +9,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { z } from 'zod';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 // Local imports - shared webview
 import {
@@ -37,7 +38,7 @@ import {
   select,
   combine,
 } from '@shared/signals';
-import { codiconStyles, designTokens, viewTabStyles } from '@shared/styles';
+import { designTokens, viewTabStyles } from '@shared/styles';
 import {
   registerTeXRAWebAwesomeIcons,
   TEXRA_ICON_LIBRARY,
@@ -142,7 +143,6 @@ const ProgressAppBase = SignalWatcher(
 export class ProgressApp extends ProgressAppBase {
   // Static 'styles' override lost through mixin type erasure; still works at runtime.
   static styles = [
-    codiconStyles,
     designTokens,
     viewTabStyles,
     css`

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -20,6 +20,9 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { STREAM_STATUS, type ActiveChildInfo } from '@shared/schemas';
@@ -27,8 +30,6 @@ import {
   designTokens,
   commonViewStyles,
 } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { ProgressEvents } from '../events';
 
 // Local imports - contexts
@@ -52,7 +53,6 @@ export class BackgroundTasksPanel extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -158,7 +158,7 @@ export class BackgroundTasksPanel extends LitElement {
         color: var(--texra-foreground);
       }
 
-      .section-label .codicon {
+      .section-label wa-icon {
         font-size: var(--font-size-xs);
       }
 
@@ -265,15 +265,19 @@ export class BackgroundTasksPanel extends LitElement {
     const hasFinished = finishedCount > 0;
     if (!hasActive && !hasFinished) return nothing;
 
-    const icon =
-      kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
+    const icon = kind === 'process' ? 'terminal' : 'server-process';
     const label = kind === 'process' ? 'Processes' : 'Subagents';
 
     return html`
       <details>
         <summary class="section-label">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon ${icon}"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
+          <wa-icon library="texra" name=${icon} aria-hidden="true"></wa-icon>
           <span
             >${label}${hasActive
               ? html` &middot; ${active.length} active`
@@ -315,15 +319,16 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <div class="task-item">
         <div class="task-header">
-          <i
+          <wa-icon
+            library="texra"
+            name=${icon}
+            aria-hidden="true"
             class=${classMap({
-              codicon: true,
-              [icon]: true,
               'task-icon': true,
               'task-icon--process': !isAgentTool(child),
               'task-icon--subagent': isAgentTool(child),
             })}
-          ></i>
+          ></wa-icon>
           <span
             class=${classMap({
               'task-name': true,
@@ -373,7 +378,12 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <details class="task-output" open>
         <summary>
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
           ${label}
         </summary>
         <div class="output-container">
@@ -407,13 +417,13 @@ function isAgentTool(child: ActiveChildInfo): boolean {
   );
 }
 
-/** Pick the appropriate codicon for a background task item. */
+/** Pick the appropriate wa-icon name for a background task item. */
 function getTaskIcon(child: ActiveChildInfo): string {
-  if (child.toolName === 'bash') return 'codicon-terminal';
-  if (isAgentTool(child)) return 'codicon-robot';
+  if (child.toolName === 'bash') return 'terminal';
+  if (isAgentTool(child)) return 'robot';
   // Subagents (delegation, workflow) default to server-process;
   // processes without a toolName fall back to terminal.
-  return child.childStreamId ? 'codicon-server-process' : 'codicon-terminal';
+  return child.childStreamId ? 'server-process' : 'terminal';
 }
 
 /** Check if a child is in a waiting/idle state rather than actively processing. */

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -26,10 +26,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { STREAM_STATUS, type ActiveChildInfo } from '@shared/schemas';
-import {
-  designTokens,
-  commonViewStyles,
-} from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
 import { ProgressEvents } from '../events';
 
 // Local imports - contexts
@@ -358,9 +355,7 @@ export class BackgroundTasksPanel extends LitElement {
           ${child.elapsed
             ? html`<span class="task-elapsed">(${child.elapsed})</span>`
             : nothing}
-          <wa-tag
-            variant=${waiting ? 'neutral' : 'warning'}
-            size="small"
+          <wa-tag variant=${waiting ? 'neutral' : 'warning'} size="small"
             >${waiting ? 'waiting' : 'running'}</wa-tag
           >
         </div>

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -12,9 +12,11 @@ import { html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -38,7 +40,6 @@ export class BashRequestPanel extends BaseFeedbackPanel {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     codeBlockStyles,
     requestPanelStyles,
   ];

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -10,12 +10,11 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
-
-// Local imports - shared utilities
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 
 // Local imports - local components (re-use StatItem type)
 import type { StatItem } from './StatisticsPanel';
@@ -35,7 +34,6 @@ export class ContextManagement extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -74,7 +72,7 @@ export class ContextManagement extends LitElement {
         font-size: var(--font-size-sm);
       }
 
-      .stat-item .codicon {
+      .stat-item wa-icon {
         opacity: var(--opacity-subtle);
       }
 
@@ -110,7 +108,7 @@ export class ContextManagement extends LitElement {
 
   /** Action configuration (icon, label, color) */
   @property({ attribute: false }) config: ActionConfig = {
-    icon: 'codicon-history',
+    icon: 'history',
     label: 'Context Management',
     color: 'var(--texra-foreground)',
   };
@@ -129,8 +127,18 @@ export class ContextManagement extends LitElement {
     return html`
       <details style="--accent-color: ${this.config.color}">
         <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon ${this.config.icon} context-icon"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
+          <wa-icon
+            library="texra"
+            name=${this.config.icon}
+            class="context-icon"
+            aria-hidden="true"
+          ></wa-icon>
           <span class="context-title">${this.config.label}</span>
         </summary>
         <div class="context-content" data-log-id=${this.logId}>
@@ -139,7 +147,11 @@ export class ContextManagement extends LitElement {
             (item) => item.label,
             (item) => html`
               <span class="stat-item" title=${item.label}>
-                <i class="codicon ${item.icon}"></i>
+                <wa-icon
+                  library="texra"
+                  name=${item.icon}
+                  aria-hidden="true"
+                ></wa-icon>
                 ${item.value}
               </span>
             `,
@@ -148,7 +160,11 @@ export class ContextManagement extends LitElement {
             ? html`
                 <div class="summary-block">
                   <div class="summary-title">
-                    <i class="codicon codicon-note"></i>
+                    <wa-icon
+                      library="texra"
+                      name="note"
+                      aria-hidden="true"
+                    ></wa-icon>
                     Compaction summary
                   </div>
                   <pre class="summary-text">${this.summary}</pre>

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -20,8 +20,9 @@ import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -64,12 +65,7 @@ export function clearInquiryDraft(requestId: string): void {
 
 @customElement('external-inquiry-panel')
 export class ExternalInquiryPanel extends BaseFeedbackPanel {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    codiconIconClasses,
-    requestPanelStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @state() private answerText = '';
   @state() private sessionLinksText = '';
@@ -205,7 +201,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   private renderSearchHint(): TemplateResult {
     return html`
       <div class="external-inquiry-request__search-hint">
-        <i class="codicon codicon-lightbulb"></i>
+        <wa-icon library="texra" name="lightbulb" aria-hidden="true"></wa-icon>
         Consider enabling <strong>Search</strong> mode in the external tool for
         this question
       </div>
@@ -216,14 +212,22 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     return html`
       <div class="external-inquiry-request__attach-files">
         <div class="external-inquiry-request__attach-label">
-          <i class="codicon codicon-cloud-upload"></i>
+          <wa-icon
+            library="texra"
+            name="cloud-upload"
+            aria-hidden="true"
+          ></wa-icon>
           Files to upload to the external model:
         </div>
         <div class="external-inquiry-request__file-list">
           ${files.map(
             (file) => html`
               <div class="external-inquiry-request__file-item">
-                <i class="codicon codicon-file"></i>
+                <wa-icon
+                  library="texra"
+                  name="file"
+                  aria-hidden="true"
+                ></wa-icon>
                 <span>${file}</span>
               </div>
             `,

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -11,11 +11,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { ELEMENT_IDS } from '../constants';
@@ -81,7 +83,6 @@ function parsePath(path: string): ParsedPath {
 export class FileList extends LitElement {
   static override styles = [
     designTokens,
-    codiconIconClasses,
     commonViewStyles,
     css`
       :host {
@@ -110,7 +111,7 @@ export class FileList extends LitElement {
         line-height: 1.4;
       }
 
-      .storage-hint .codicon {
+      .storage-hint wa-icon {
         flex-shrink: 0;
       }
 
@@ -317,7 +318,12 @@ export class FileList extends LitElement {
                   appearance="primary"
                   @click=${this.runLatexFixer}
                 >
-                  <span slot="start" class="codicon codicon-tools"></span>
+                  <wa-icon
+                    slot="start"
+                    library="texra"
+                    name="tools"
+                    aria-hidden="true"
+                  ></wa-icon>
                   Run latexFixer
                 </vscode-button>
               </div>
@@ -332,7 +338,11 @@ export class FileList extends LitElement {
 
     return html`
       <div class="storage-hint" role="note">
-        <i class="codicon codicon-folder-opened" aria-hidden="true"></i>
+        <wa-icon
+          library="texra"
+          name="folder-opened"
+          aria-hidden="true"
+        ></wa-icon>
         <span class="storage-hint__text">
           Files stay in task-run storage until accepted. Click a file to preview
           it, use Accept to copy it into your workspace, or use the folder
@@ -413,11 +423,13 @@ export class FileList extends LitElement {
     return html`
       <div class="file-item">
         ${failure
-          ? html`<i
-              class="codicon codicon-warning compile-warning"
+          ? html`<wa-icon
+              library="texra"
+              name="warning"
+              class="compile-warning"
               title="Compile check failed"
               aria-label="Compile check failed"
-            ></i>`
+            ></wa-icon>`
           : nothing}
         <span class="file-name">
           <span

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -10,23 +10,22 @@ import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import type { DiffResultDisplay, DiffStatus } from '@shared/schemas';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
-
-// Local imports - shared utilities
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 
 // Local imports - progress view events
 import { ProgressEvents } from '../events';
 
 // Local imports - schemas
 
-/** Status icon class lookup for latexdiff entries. */
+/** Status wa-icon name lookup for latexdiff entries. */
 const LATEXDIFF_STATUS_ICONS: Record<DiffStatus, string> = {
-  success: 'codicon-check',
-  error: 'codicon-error',
+  success: 'check',
+  error: 'error',
 };
 
 @customElement('latexdiff-results')
@@ -34,7 +33,6 @@ export class LatexdiffResults extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -121,7 +119,7 @@ export class LatexdiffResults extends LitElement {
         data-run-id=${ifDefined(runId)}
         title=${ifDefined(message)}
       >
-        <i class="codicon ${icon}"></i>
+        <wa-icon library="texra" name=${icon} aria-hidden="true"></wa-icon>
         ${this.renderFileLink(baseFile, baseLabel)}
         <span class="arrow">→</span>
         ${this.renderFileLink(revisedFile, revisedLabel)}
@@ -143,8 +141,13 @@ export class LatexdiffResults extends LitElement {
     return html`
       <details open>
         <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-diff"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
+          <wa-icon library="texra" name="diff" aria-hidden="true"></wa-icon>
           <span>${summaryText}</span>
         </summary>
         <ul

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -21,11 +21,15 @@ import { z } from 'zod';
 // Local imports - side-effect: register component
 import './TaskGroupList';
 
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
 import { PersistedState } from '@shared/state';
-import { codiconStyles, designTokens } from '@shared/styles';
+import { designTokens } from '@shared/styles';
 import { postMessage } from '@shared/hostBridge';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { copyWithFeedback } from '@shared/utils/clipboard';
@@ -70,7 +74,7 @@ interface CachedStream {
 
 @customElement('log-list')
 export class LogList extends LitElement {
-  static override styles = [designTokens, codiconStyles, ...logStyles];
+  static override styles = [designTokens, ...logStyles];
 
   // Log context - only updates when logs/groups change (not on metadata-only changes)
   @consume({ context: streamLogContext, subscribe: true })

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -28,9 +28,11 @@ import {
   PERMISSION_KIND,
 } from '@shared/utils/uiConstants';
 import { designTokens } from '@shared/styles/litStyles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { filledButtonStyles } from '@shared/styles/commonViewStyles';
 import { permissionCardStyles } from '@shared/styles/permissionCardStyles';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
@@ -70,14 +72,14 @@ type ActionConfig = {
 // Configuration
 // =============================================================================
 
-/** Icon for each permission type header */
+/** wa-icon name for each permission type header */
 const PERMISSION_ICONS: Record<PermissionState['kind'], string> = {
-  [PERMISSION_KIND.TOOL_EDIT]: 'codicon-diff',
-  [PERMISSION_KIND.BASH]: 'codicon-terminal',
-  [PERMISSION_KIND.RETRY]: 'codicon-refresh',
-  [PERMISSION_KIND.PROPOSAL]: 'codicon-rocket',
-  [PERMISSION_KIND.PLAN_APPROVAL]: 'codicon-tasklist',
-  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'codicon-globe',
+  [PERMISSION_KIND.TOOL_EDIT]: 'diff',
+  [PERMISSION_KIND.BASH]: 'terminal',
+  [PERMISSION_KIND.RETRY]: 'refresh',
+  [PERMISSION_KIND.PROPOSAL]: 'rocket',
+  [PERMISSION_KIND.PLAN_APPROVAL]: 'tasklist',
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'globe',
 };
 
 /** Title for each permission type */
@@ -93,74 +95,39 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
 /** Primary actions (approve/reject) for each permission type */
 const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
   [PERMISSION_KIND.TOOL_EDIT]: [
-    {
-      action: 'approve',
-      label: 'Approve',
-      icon: 'codicon-check',
-      variant: 'approve',
-    },
-    { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
+    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
   [PERMISSION_KIND.BASH]: [
-    {
-      action: 'approve',
-      label: 'Approve',
-      icon: 'codicon-check',
-      variant: 'approve',
-    },
-    { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
+    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
   [PERMISSION_KIND.RETRY]: [
-    {
-      action: 'retry',
-      label: 'Retry',
-      icon: 'codicon-refresh',
-      variant: 'approve',
-    },
-    { action: 'cancel', label: 'Cancel', icon: 'codicon-x', variant: 'reject' },
+    { action: 'retry', label: 'Retry', icon: 'refresh', variant: 'approve' },
+    { action: 'cancel', label: 'Cancel', icon: 'x', variant: 'reject' },
   ],
   [PERMISSION_KIND.PROPOSAL]: [
-    {
-      action: 'approve',
-      label: 'Approve',
-      icon: 'codicon-check',
-      variant: 'approve',
-    },
-    { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
+    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
   [PERMISSION_KIND.PLAN_APPROVAL]: [
-    {
-      action: 'approve',
-      label: 'Approve',
-      icon: 'codicon-check',
-      variant: 'approve',
-    },
-    { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
+    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
   // External inquiry uses its own panel with answer textarea; only reject here as fallback.
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: [
-    {
-      action: 'reject',
-      label: 'Reject',
-      icon: 'codicon-x',
-      variant: 'reject',
-    },
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
 };
 
 /** Secondary actions for each permission type */
 const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
   [PERMISSION_KIND.TOOL_EDIT]: [
-    {
-      action: 'openDiff',
-      label: 'Diff',
-      icon: 'codicon-diff',
-      variant: 'secondary',
-    },
+    { action: 'openDiff', label: 'Diff', icon: 'diff', variant: 'secondary' },
     {
       action: 'previewProposed',
       label: 'Preview',
-      icon: 'codicon-eye',
+      icon: 'eye',
       variant: 'secondary',
     },
     {
@@ -173,12 +140,7 @@ const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
   [PERMISSION_KIND.BASH]: [],
   [PERMISSION_KIND.RETRY]: [],
   [PERMISSION_KIND.PROPOSAL]: [
-    {
-      action: 'setup',
-      label: 'Setup',
-      icon: 'codicon-reply',
-      variant: 'secondary',
-    },
+    { action: 'setup', label: 'Setup', icon: 'reply', variant: 'secondary' },
   ],
   [PERMISSION_KIND.PLAN_APPROVAL]: [],
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: [],
@@ -192,7 +154,6 @@ const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
 export class PermissionCard extends LitElement {
   static override styles = [
     designTokens,
-    codiconIconClasses,
     filledButtonStyles,
     permissionCardStyles,
   ];
@@ -213,7 +174,11 @@ export class PermissionCard extends LitElement {
     return html`
       <div class="permission-card" data-type=${this.permission.kind}>
         <div class="permission-header">
-          <i class="codicon ${PERMISSION_ICONS[this.permission.kind]}"></i>
+          <wa-icon
+            library="texra"
+            name=${PERMISSION_ICONS[this.permission.kind]}
+            aria-hidden="true"
+          ></wa-icon>
           <span>${this.getTitle()}</span>
         </div>
         <div class="permission-body">${this.renderBody()}</div>
@@ -326,7 +291,12 @@ export class PermissionCard extends LitElement {
         (flag) => flag,
         (flag) =>
           html`<span class="extract-flag"
-            ><i class="codicon codicon-file-media"></i> ${flag}</span
+            ><wa-icon
+              library="texra"
+              name="file-media"
+              aria-hidden="true"
+            ></wa-icon>
+            ${flag}</span
           >`,
       )}
     </p>`;
@@ -461,7 +431,13 @@ export class PermissionCard extends LitElement {
         data-action=${action}
         @click=${this.handleActionClick}
       >
-        ${icon ? html`<i class="codicon ${icon}"></i>` : nothing}
+        ${icon
+          ? html`<wa-icon
+              library="texra"
+              name=${icon}
+              aria-hidden="true"
+            ></wa-icon>`
+          : nothing}
         ${displayLabel}
       </button>
     `;

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -15,7 +15,6 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -33,12 +32,7 @@ import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
 @customElement('plan-approval-request-panel')
 export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    codiconIconClasses,
-    requestPanelStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   override render(): TemplateResult {
     const data = this.permission.data as PlanApprovalPermission;

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -16,6 +16,10 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+
 // Local imports - shared styles
 import {
   designTokens,
@@ -28,7 +32,6 @@ import {
   type Plan,
   type PlanStep,
 } from '@shared/schemas';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
@@ -41,7 +44,6 @@ export class PlanView extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     animationStyles,
     css`
       :host {
@@ -228,14 +230,14 @@ export class PlanView extends LitElement {
         })}
       >
         <span class="plan-step__number">${index + 1}.</span>
-        <i
-          class=${classMap({
-            codicon: true,
-            [`codicon-${icon}`]: true,
-            'plan-step__icon': true,
-            spin: isInProgress,
-          })}
-        ></i>
+        ${isInProgress
+          ? html`<wa-spinner class="plan-step__icon"></wa-spinner>`
+          : html`<wa-icon
+              library="texra"
+              name=${icon}
+              class="plan-step__icon"
+              aria-hidden="true"
+            ></wa-icon>`}
         <div class="plan-step__body">
           <div class="plan-step__title">${step.title}</div>
           <div class="plan-step__description">${step.description}</div>

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -15,10 +15,12 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -60,7 +62,6 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     requestPanelStyles,
     selectStyles,
   ];
@@ -130,7 +131,11 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
             ${hasAgentOptions
               ? html`
                   <div class="workflow-proposal__agent-select">
-                    <i class="codicon codicon-sparkle"></i>
+                    <wa-icon
+                      library="texra"
+                      name="sparkle"
+                      aria-hidden="true"
+                    ></wa-icon>
                     <vscode-single-select
                       class="proposal-agent-dropdown"
                       position="below"
@@ -147,7 +152,11 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
             ${hasModelOptions
               ? html`
                   <div class="workflow-proposal__model-select">
-                    <i class="codicon codicon-robot"></i>
+                    <wa-icon
+                      library="texra"
+                      name="robot"
+                      aria-hidden="true"
+                    ></wa-icon>
                     <vscode-single-select
                       class="proposal-model-dropdown"
                       position="below"
@@ -243,7 +252,12 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
         (flag) =>
           html`<span
             class="workflow-proposal__category-badge workflow-proposal__category-badge--workflow workflow-proposal__extract-flag"
-            ><i class="codicon codicon-file-media"></i> ${flag}</span
+            ><wa-icon
+              library="texra"
+              name="file-media"
+              aria-hidden="true"
+            ></wa-icon>
+            ${flag}</span
           >`,
       )}
     </div>`;

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -4,9 +4,11 @@ import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
@@ -21,7 +23,6 @@ export class QueuedFollowUps extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -124,7 +125,12 @@ export class QueuedFollowUps extends LitElement {
               const { display, full } = this.truncateMessage(message);
               return html`
                 <div class="queued-follow-up-item" title=${ifDefined(full)}>
-                  <i class="codicon codicon-comment queued-follow-up-icon"></i>
+                  <wa-icon
+                    library="texra"
+                    name="comment"
+                    class="queued-follow-up-icon"
+                    aria-hidden="true"
+                  ></wa-icon>
                   <span class="queued-follow-up-text">${display}</span>
                 </div>
               `;

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -19,9 +19,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -111,12 +113,7 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
 
 @customElement('request-panels')
 export class RequestPanels extends LitElement {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    codiconIconClasses,
-    requestPanelStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @property({ attribute: false }) permissions: PermissionState[] = [];
 
@@ -177,7 +174,11 @@ export class RequestPanels extends LitElement {
   ): TemplateResult {
     return html`
       <div class="${config.cssClass}__header">
-        <i class="codicon codicon-${config.icon}"></i>
+        <wa-icon
+          library="texra"
+          name=${config.icon}
+          aria-hidden="true"
+        ></wa-icon>
         <span>${config.title}</span>
         ${extra}
       </div>
@@ -232,7 +233,11 @@ export class RequestPanels extends LitElement {
           ?disabled=${this._eiIndex === 0}
           @click=${this._eiPrev}
         >
-          <i class="codicon codicon-chevron-left"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-left"
+            aria-hidden="true"
+          ></wa-icon>
         </button>
         <span class="external-inquiry-requests__counter">
           ${this._eiIndex + 1} / ${perms.length}
@@ -243,7 +248,11 @@ export class RequestPanels extends LitElement {
           ?disabled=${this._eiIndex === perms.length - 1}
           @click=${this._eiNext}
         >
-          <i class="codicon codicon-chevron-right"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            aria-hidden="true"
+          ></wa-icon>
         </button>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -13,9 +13,11 @@ import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -30,12 +32,7 @@ import { BaseRequestPanel } from './BaseRequestPanel';
 
 @customElement('retry-request-panel')
 export class RetryRequestPanel extends BaseRequestPanel {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    codiconIconClasses,
-    requestPanelStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   override handleKeyboardShortcut(key: string): boolean {
     const data = this.permission.data as RetryPermission;
@@ -95,7 +92,12 @@ export class RetryRequestPanel extends BaseRequestPanel {
             ? html`
                 <details class="retry-request__error-details">
                   <summary class="retry-request__error-summary">
-                    <i class="codicon codicon-chevron-right toggle-icon"></i>
+                    <wa-icon
+                      library="texra"
+                      name="chevron-right"
+                      class="toggle-icon"
+                      aria-hidden="true"
+                    ></wa-icon>
                     Error details
                   </summary>
                   <div class="retry-request__error-body">${detailsText}</div>

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -9,12 +9,11 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
-
-// Local imports - shared utilities
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 
 /** Stat item to display */
 export interface StatItem {
@@ -28,7 +27,6 @@ export class StatisticsPanel extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -67,8 +65,18 @@ export class StatisticsPanel extends LitElement {
     return html`
       <details>
         <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-graph"></i>
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
+          <wa-icon
+            library="texra"
+            name="graph"
+            class="icon"
+            aria-hidden="true"
+          ></wa-icon>
           <span>Statistics</span>
         </summary>
         <div class="statistics-content" data-log-id=${this.logId}>
@@ -77,7 +85,11 @@ export class StatisticsPanel extends LitElement {
             (item) => item.label,
             (item) => html`
               <span class="stat-item" title=${item.label}>
-                <i class="codicon ${item.icon}"></i>
+                <wa-icon
+                  library="texra"
+                  name=${item.icon}
+                  aria-hidden="true"
+                ></wa-icon>
                 ${item.value}
               </span>
             `,

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -17,9 +17,11 @@ import {
   type ConversationProgress,
   type StreamTabInfo,
 } from '@shared/schemas';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
@@ -121,7 +123,6 @@ export class StreamHeader extends LitElement {
     designTokens,
     animationStyles,
     commonViewStyles,
-    codiconIconClasses,
     statusIndicatorStyles,
     css`
       :host {
@@ -302,11 +303,11 @@ export class StreamHeader extends LitElement {
         border-radius: var(--border-radius-small);
       }
 
-      .parent-link .codicon {
+      .parent-link wa-icon {
         font-size: var(--font-size-xs);
       }
 
-      wa-tag.progress-badge .codicon {
+      wa-tag.progress-badge wa-icon {
         font-size: var(--font-size-xs);
       }
 
@@ -445,7 +446,7 @@ export class StreamHeader extends LitElement {
       size="small"
       title="Conversation turns: ${p.conversationTurns}, Tool calls: ${p.toolCallCount}"
     >
-      <i class="codicon codicon-pulse"></i>
+      <wa-icon library="texra" name="pulse" aria-hidden="true"></wa-icon>
       ${p.conversationTurns}
       turns${p.toolCallCount > 0
         ? html`, ${p.toolCallCount} tool calls`
@@ -469,7 +470,7 @@ export class StreamHeader extends LitElement {
         title="Go to parent: ${displayName}"
         @click=${this.navigateToParent}
       >
-        <i class="codicon codicon-arrow-left"></i>
+        <wa-icon library="texra" name="arrow-left" aria-hidden="true"></wa-icon>
         ${displayName}
       </span>
     `;

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -16,11 +16,13 @@ import {
   animationStyles,
   commonViewStyles,
 } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import {
   AGENT_DECORATORS,
   getAgentCategoryDecorator,
 } from '@shared/utils/icons';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -95,7 +97,6 @@ export class StreamTab extends LitElement {
   static override styles = [
     designTokens,
     animationStyles,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -343,12 +344,12 @@ export class StreamTab extends LitElement {
         background-color: var(--texra-toolbar-hoverBackground);
       }
 
-      .tab-expand .codicon {
+      .tab-expand wa-icon {
         font-size: var(--font-size-xs);
         transition: transform var(--transition-fast);
       }
 
-      .tab-expand[aria-expanded='true'] .codicon {
+      .tab-expand[aria-expanded='true'] wa-icon {
         transform: rotate(90deg);
       }
     `,
@@ -416,7 +417,11 @@ export class StreamTab extends LitElement {
                 : childStreamLabel}
               aria-expanded=${this.expanded ? 'true' : 'false'}
             >
-              <i class="codicon codicon-chevron-right"></i>
+              <wa-icon
+                library="texra"
+                name="chevron-right"
+                aria-hidden="true"
+              ></wa-icon>
             </button>`
           : nothing}
         <button
@@ -431,12 +436,14 @@ export class StreamTab extends LitElement {
               stream.name}</span
             >
             ${this.childCount > 0 && this.compact
-              ? html`<i
-                  class="codicon codicon-chevron-right compact-subagent-hint"
+              ? html`<wa-icon
+                  library="texra"
+                  name="chevron-right"
+                  class="compact-subagent-hint"
                   role="img"
                   aria-label=${childStreamLabel}
                   title=${childStreamLabel}
-                ></i>`
+                ></wa-icon>`
               : nothing}
           </div>
           ${this.compact
@@ -456,17 +463,23 @@ export class StreamTab extends LitElement {
                   <span class="model"
                     >${stream.modelLabel ?? stream.model ?? ''}</span
                   >
-                  <i
-                    class=${`codicon codicon-${agentDecorator.icon} agent-category`}
+                  <wa-icon
+                    library="texra"
+                    name=${agentDecorator.icon}
+                    class="agent-category"
+                    aria-hidden="true"
                     title=${`Category: ${agentDecorator.label}`}
-                  ></i>
+                  ></wa-icon>
                   ${when(
                     stream.isRemote,
                     () => html`
-                      <i
-                        class=${`codicon codicon-${AGENT_DECORATORS.properties.remote.icon} remote-agent`}
+                      <wa-icon
+                        library="texra"
+                        name=${AGENT_DECORATORS.properties.remote.icon}
+                        class="remote-agent"
+                        aria-hidden="true"
                         title=${AGENT_DECORATORS.properties.remote.hint}
-                      ></i>
+                      ></wa-icon>
                     `,
                   )}
                 </div>

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -19,7 +19,11 @@ import stripAnsi from 'strip-ansi';
 import { STREAM_STATUS } from '@shared/schemas';
 
 // Local imports - shared utilities
-import { designTokens, codiconStyles } from '@shared/styles';
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+
+import { designTokens } from '@shared/styles';
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
@@ -103,11 +107,11 @@ function processTerminalText(text: string): string {
     .join('\n');
 }
 
-/** Maps group status to codicon class (with optional animation) */
-function getStatusIcon(status: string): string {
+/** Maps group status to a wa-icon name; null indicates an animated spinner. */
+function getStatusIcon(status: string): string | null {
   switch (status) {
     case STREAM_STATUS.RUNNING:
-      return 'sync spin';
+      return null;
     case STREAM_STATUS.ERROR:
       return 'error';
     case STREAM_STATUS.STOPPED:
@@ -119,7 +123,7 @@ function getStatusIcon(status: string): string {
 
 @customElement('task-group-list')
 export class TaskGroupList extends LitElement {
-  static override styles = [designTokens, codiconStyles, ...logStyles];
+  static override styles = [designTokens, ...logStyles];
 
   /** All task groups to render */
   @property({ attribute: false }) groups: TaskGroup[] = [];
@@ -639,14 +643,22 @@ export class TaskGroupList extends LitElement {
       ? formatDuration(group.endTime - group.startTime)
       : '';
 
+    const statusIcon = getStatusIcon(group.status);
     return html`
       <span class="group-status-icon">
-        <i class="codicon codicon-${getStatusIcon(group.status)}"></i>
+        ${statusIcon
+          ? html`<wa-icon
+              library="texra"
+              name=${statusIcon}
+              aria-hidden="true"
+            ></wa-icon>`
+          : html`<wa-spinner></wa-spinner>`}
       </span>
       <span class="group-title">${group.name}</span>
       <span class="group-time">
         <span class="group-start-time" data-start=${String(group.startTime)}>
-          <i class="codicon codicon-clock"></i> ${formattedStartTime}
+          <wa-icon library="texra" name="clock" aria-hidden="true"></wa-icon>
+          ${formattedStartTime}
         </span>
         ${durationText
           ? html`<span class="group-duration">${durationText}</span>`

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -11,6 +11,10 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+
 // Local imports - shared styles
 import {
   designTokens,
@@ -18,7 +22,6 @@ import {
   commonViewStyles,
 } from '@shared/styles';
 import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 import { ELEMENT_IDS } from '../constants';
 
@@ -30,7 +33,6 @@ export class TodoList extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     animationStyles,
     css`
       :host {
@@ -167,14 +169,14 @@ export class TodoList extends LitElement {
           'todo-item--completed': status === TODO_STATUS.COMPLETED,
         })}
       >
-        <i
-          class=${classMap({
-            codicon: true,
-            [`codicon-${icon}`]: true,
-            'todo-item__icon': true,
-            spin: isInProgress,
-          })}
-        ></i>
+        ${isInProgress
+          ? html`<wa-spinner class="todo-item__icon"></wa-spinner>`
+          : html`<wa-icon
+              library="texra"
+              name=${icon}
+              class="todo-item__icon"
+              aria-hidden="true"
+            ></wa-icon>`}
         <span class="todo-item__content">${content}</span>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -13,9 +13,11 @@ import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import {
-  codiconIconClasses,
   commonViewStyles,
   designTokens,
   requestPanelStyles,
@@ -34,12 +36,7 @@ import { monacoLanguageForPath } from './monacoLanguage';
 
 @customElement('tool-edit-request-panel')
 export class ToolEditRequestPanel extends BaseFeedbackPanel {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    codiconIconClasses,
-    requestPanelStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @state() private diffMenuOpen = false;
   @state() private inlineDiffOpen = false;

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -4,10 +4,12 @@ import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 import type { TokenUsageStats } from '@shared/schemas';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view
 import { formatTokens } from '../formatters/timestampUtils';
@@ -31,7 +33,6 @@ function fillColor(percent: number): string {
 export class UsagePanel extends LitElement {
   static override styles = [
     designTokens,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -61,7 +62,7 @@ export class UsagePanel extends LitElement {
         opacity: var(--opacity-normal);
       }
 
-      :is(.run-summary, .context-state) .codicon {
+      :is(.run-summary, .context-state) wa-icon {
         font-size: var(--font-size-icon-sm);
         opacity: var(--opacity-subtle);
       }
@@ -171,43 +172,59 @@ export class UsagePanel extends LitElement {
     const cacheWrite = this.usage.cacheCreationInputTokens ?? 0;
 
     return html`
-      <i class="codicon codicon-pie-chart"></i>
+      <wa-icon library="texra" name="pie-chart" aria-hidden="true"></wa-icon>
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
-        <i class="codicon codicon-arrow-up" title="Input tokens"></i
+        <wa-icon
+          library="texra"
+          name="arrow-up"
+          title="Input tokens"
+          aria-hidden="true"
+        ></wa-icon
         >${formatTokens(inputTokens)}
         ${when(
           cacheRead > 0,
           () =>
             html` ·
-              <i
-                class="codicon codicon-cloud-download"
+              <wa-icon
+                library="texra"
+                name="cloud-download"
                 title="Cache read tokens (discounted)"
-              ></i>
+                aria-hidden="true"
+              ></wa-icon>
               ${formatTokens(cacheRead)}`,
         )}
         ${when(
           cacheMiss > 0,
           () =>
             html` ·
-              <i
-                class="codicon codicon-cloud-upload"
+              <wa-icon
+                library="texra"
+                name="cloud-upload"
                 title="Cache miss tokens (full price)"
-              ></i>
+                aria-hidden="true"
+              ></wa-icon>
               ${formatTokens(cacheMiss)}`,
         )}
         ${when(
           cacheWrite > 0,
           () =>
             html` ·
-              <i
-                class="codicon codicon-database"
+              <wa-icon
+                library="texra"
+                name="database"
                 title="Cache creation tokens (1.25x cost)"
-              ></i>
+                aria-hidden="true"
+              ></wa-icon>
               ${formatTokens(cacheWrite)}`,
         )}
         ·
-        <i class="codicon codicon-arrow-down" title="Output tokens"></i
+        <wa-icon
+          library="texra"
+          name="arrow-down"
+          title="Output tokens"
+          aria-hidden="true"
+        ></wa-icon
         >${formatTokens(outputTokens)} · $${cost.toFixed(3)}
       </span>
     `;
@@ -221,7 +238,7 @@ export class UsagePanel extends LitElement {
 
     return html`
       <span class="context-gauge" title="${clamped.toFixed(0)}% context used">
-        <i class="codicon codicon-window"></i>
+        <wa-icon library="texra" name="window" aria-hidden="true"></wa-icon>
         <span class="context-gauge__track">
           <span
             class="context-gauge__fill"

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -9,10 +9,12 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 // Local imports - shared styles
 import { CopyButtonController } from '@shared/controllers';
 import { designTokens } from '@shared/styles/litStyles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers
@@ -66,7 +68,6 @@ function decodeXmlEntitiesForDisplay(text: string): string {
 export class UserMessage extends LitElement {
   static override styles = [
     designTokens,
-    codiconIconClasses,
     css`
       :host {
         display: block;
@@ -221,7 +222,12 @@ export class UserMessage extends LitElement {
         >
           <div class="user-message-header">
             <span class="user-message-header-left">
-              <i class="codicon codicon-comment user-message-icon"></i>
+              <wa-icon
+                library="texra"
+                name="comment"
+                class="user-message-icon"
+                aria-hidden="true"
+              ></wa-icon>
               <span class="user-message-timestamp" title=${tooltipTimestamp}
                 >${timeDisplay}</span
               >

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -8,9 +8,11 @@ import {
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
 import {
   renderAgentOptions,
@@ -25,7 +27,6 @@ export class WorkflowToolUseFollowupSection extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    codiconIconClasses,
     selectStyles,
     css`
       :host {
@@ -145,12 +146,17 @@ export class WorkflowToolUseFollowupSection extends LitElement {
           aria-expanded=${this.expanded ? 'true' : 'false'}
           @click=${this.toggleExpanded}
         >
-          <i
-            class=${`codicon codicon-chevron-${this.expanded ? 'down' : 'right'}`}
+          <wa-icon
+            library="texra"
+            name=${this.expanded ? 'chevron-down' : 'chevron-right'}
             aria-hidden="true"
-          ></i>
+          ></wa-icon>
           <span class="followup__title">Tool-use follow-up</span>
-          <i class="codicon codicon-comment-discussion" aria-hidden="true"></i>
+          <wa-icon
+            library="texra"
+            name="comment-discussion"
+            aria-hidden="true"
+          ></wa-icon>
         </button>
 
         ${this.expanded
@@ -201,7 +207,12 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                     ?disabled=${!ready}
                     @click=${this.setupFollowup}
                   >
-                    <span slot="start" class="codicon codicon-reply"></span>
+                    <wa-icon
+                      slot="start"
+                      library="texra"
+                      name="reply"
+                      aria-hidden="true"
+                    ></wa-icon>
                     Setup
                   </vscode-button>
                   <vscode-button
@@ -209,7 +220,12 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                     ?disabled=${!ready}
                     @click=${this.runFollowup}
                   >
-                    <span slot="start" class="codicon codicon-play"></span>
+                    <wa-icon
+                      slot="start"
+                      library="texra"
+                      name="play"
+                      aria-hidden="true"
+                    ></wa-icon>
                     Run
                   </vscode-button>
                 </div>

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -137,76 +137,77 @@ export const TOOL_LABEL_MAP: Record<string, string> = {
 
 /**
  * Tool icon mapping for different tool types.
- * Maps tool names to VS Code codicon classes.
+ * Maps tool names to wa-icon names (codicon-style aliases supported via the
+ * shared TeXRA icon library).
  */
 export const TOOL_ICON_MAP: Record<string, string> = {
   // File operations
-  read_file: 'codicon-file',
-  write_file: 'codicon-new-file',
-  edit_file: 'codicon-edit',
-  str_replace_editor: 'codicon-edit',
-  apply_path: 'codicon-diff',
+  read_file: 'file',
+  write_file: 'new-file',
+  edit_file: 'edit',
+  str_replace_editor: 'edit',
+  apply_path: 'diff',
 
   // Search/find
-  glob: 'codicon-search',
-  grep: 'codicon-search',
-  ls: 'codicon-folder-opened',
+  glob: 'search',
+  grep: 'search',
+  ls: 'folder-opened',
 
   // Shell
-  bash: 'codicon-terminal',
-  wolfram: 'codicon-symbol-operator',
+  bash: 'terminal',
+  wolfram: 'symbol-operator',
 
   // Web/research
-  web_fetch: 'codicon-globe',
-  web_search: 'codicon-globe',
-  arxiv_search: 'codicon-book',
-  arxiv_metadata: 'codicon-book',
-  download_arxiv_source: 'codicon-cloud-download',
-  crossref_search: 'codicon-references',
-  crossref_doi: 'codicon-references',
+  web_fetch: 'globe',
+  web_search: 'globe',
+  arxiv_search: 'book',
+  arxiv_metadata: 'book',
+  download_arxiv_source: 'cloud-download',
+  crossref_search: 'references',
+  crossref_doi: 'references',
 
   // LaTeX
-  texcount: 'codicon-symbol-numeric',
-  extract_figures: 'codicon-file-media',
-  extract_tikz_figures: 'codicon-file-media',
-  extract_bib_entries: 'codicon-library',
+  texcount: 'symbol-numeric',
+  extract_figures: 'file-media',
+  extract_tikz_figures: 'file-media',
+  extract_bib_entries: 'library',
 
   // Diagnostics
-  diagnostics: 'codicon-checklist',
+  diagnostics: 'checklist',
 
   // Task management
-  todo_write: 'codicon-tasklist',
+  todo_write: 'tasklist',
 
   // Memory
-  memory: 'codicon-database',
+  memory: 'database',
 
   // Zotero
-  zotero_add: 'codicon-library',
-  zotero_search: 'codicon-library',
-  zotero_export: 'codicon-library',
+  zotero_add: 'library',
+  zotero_search: 'library',
+  zotero_export: 'library',
 
   // Lean 4
-  lean_diagnostics: 'codicon-warning',
-  lean_file: 'codicon-file-code',
-  lean_project: 'codicon-folder-library',
-  lean_inspect: 'codicon-inspect',
-  lean_loogle: 'codicon-search',
+  lean_diagnostics: 'warning',
+  lean_file: 'file-code',
+  lean_project: 'folder-library',
+  lean_inspect: 'inspect',
+  lean_loogle: 'search',
 
   // Workflow/delegation (includes legacy names for historical log entries)
-  delegate_workflow: 'codicon-list-tree',
-  delegate_agent: 'codicon-account',
-  propose_workflow: 'codicon-list-tree',
-  propose_agent: 'codicon-account',
+  delegate_workflow: 'list-tree',
+  delegate_agent: 'account',
+  propose_workflow: 'list-tree',
+  propose_agent: 'account',
 
   // Execution history
-  executions: 'codicon-history',
-  runs: 'codicon-history',
-  accept_run_files: 'codicon-check',
+  executions: 'history',
+  runs: 'history',
+  accept_run_files: 'check',
 
   // External agents
-  codex: 'codicon-robot',
-  codex_patch: 'codicon-diff',
-  codex_thread: 'codicon-comment-discussion',
-  codex_todo: 'codicon-checklist',
-  codex_turn: 'codicon-check-all',
+  codex: 'robot',
+  codex_patch: 'diff',
+  codex_thread: 'comment-discussion',
+  codex_todo: 'checklist',
+  codex_turn: 'check-all',
 };

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -12,7 +12,6 @@ import type { FileListEntry } from '@shared/schemas';
 import { hljs } from '@shared/highlighting/hljs';
 
 // Local imports - shared utilities
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { getBasename } from '@shared/utils/path';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -102,7 +101,7 @@ export function wrapInPre(text: string, className = ''): TemplateResult {
 }
 
 // Note: Toggle icons now use CSS-only rotation via details[open] selector.
-// Always render with CHEVRON_RIGHT_CLASS and CSS will rotate when open.
+// Always render the chevron-right icon and CSS will rotate when open.
 
 /** Build a copy button for banner content. */
 export function buildCopyButton(
@@ -115,12 +114,18 @@ export function buildCopyButton(
   return html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden}>${waIcon('copy')}</wa-button>`;
 }
 
+/**
+ * Sentinel value for {@link DetailsSummaryOptions.iconName} that renders an
+ * inline `<wa-spinner>` instead of a `<wa-icon>`. Used for in-progress states.
+ */
+export const SPINNER_ICON_NAME = '__spinner__';
+
 /** Options for building a details summary header. */
 export interface DetailsSummaryOptions {
-  iconClass: string;
+  /** wa-icon name (codicon-style aliases supported), or {@link SPINNER_ICON_NAME}. */
+  iconName: string;
   label: string;
   labelClass?: string;
-  includeIconClass?: boolean;
   timestamp?: { display: string; tooltip: string };
   copyButton?: {
     title: string;
@@ -137,17 +142,17 @@ export function buildDetailsSummary(
   options: DetailsSummaryOptions,
 ): TemplateResult {
   const {
-    iconClass,
+    iconName,
     label,
     labelClass = 'label',
-    includeIconClass = true,
     timestamp,
     copyButton,
     extraContent,
   } = options;
-  const iconClasses = includeIconClass
-    ? `codicon icon ${iconClass}`
-    : `codicon ${iconClass}`;
+  // prettier-ignore
+  const iconTemplate = iconName === SPINNER_ICON_NAME
+    ? html`<wa-spinner class="icon"></wa-spinner>`
+    : html`<wa-icon library="texra" name=${iconName} class="icon" aria-hidden="true"></wa-icon>`;
   // prettier-ignore
   const timestampTemplate = timestamp
     ? html` <span class="timestamp" title=${timestamp.tooltip}>${timestamp.display}</span>`
@@ -158,7 +163,7 @@ export function buildDetailsSummary(
   const extraTemplate = extraContent ?? nothing;
   // Toggle icon uses CSS rotation via details[open] selector - always start with chevron-right
   // prettier-ignore
-  return html`<summary class="details-summary"><i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i> <i class=${iconClasses}></i> <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</summary>`;
+  return html`<summary class="details-summary"><wa-icon library="texra" name="chevron-right" class="toggle-icon" aria-hidden="true"></wa-icon> ${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</summary>`;
 }
 
 /** Build rendered templates for file list. */
@@ -170,7 +175,7 @@ export function buildFileListRender(files: FileListEntry[]): {
 
   // prettier-ignore
   const items = html`${files.map((file) => {
-    const icon = file.ok ? 'codicon-check' : 'codicon-warning';
+    const iconName = file.ok ? 'check' : 'warning';
     const filePath = file.path;
     const fileName = getBasename(filePath);
 
@@ -179,7 +184,7 @@ export function buildFileListRender(files: FileListEntry[]): {
     const sourceText = file.sourceDisplay ?? source;
 
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}><i class=${`codicon ${icon}`}></i> <span class="file-link clickable-link" data-file=${filePath}>${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name=${iconName} aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath}>${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
   })}`;
 
   const loadedFiles = files.filter((file) => file.ok).length;
@@ -190,10 +195,10 @@ export function buildFileListRender(files: FileListEntry[]): {
   return { items, summary };
 }
 
-/** Get appropriate icon class for a tool. */
-export function getToolIconClass(toolName: string, isError = false): string {
-  if (isError) return 'codicon-error';
-  return TOOL_ICON_MAP[toolName] ?? 'codicon-wrench';
+/** Get appropriate wa-icon name for a tool. */
+export function getToolIconName(toolName: string, isError = false): string {
+  if (isError) return 'error';
+  return TOOL_ICON_MAP[toolName] ?? 'wrench';
 }
 
 // ============================================================================
@@ -259,7 +264,7 @@ export function buildCodeBlock(
   // prettier-ignore
   const languageBadge = showLanguage ? html`<span class="code-block-language">${getLanguageLabel(language)}</span>` : nothing;
   // prettier-ignore
-  const copyButton = showCopy ? html`<button class="code-block-copy" title="Copy to clipboard" data-copy-id=${registerCopyContent(text)} data-copy-type="code-block"><i class="codicon codicon-copy"></i></button>` : nothing;
+  const copyButton = showCopy ? html`<button class="code-block-copy" title="Copy to clipboard" data-copy-id=${registerCopyContent(text)} data-copy-type="code-block"><wa-icon library="texra" name="copy" aria-hidden="true"></wa-icon></button>` : nothing;
   // prettier-ignore
   const codeTemplate = html`<pre class=${classMap(preClasses)}><code>${isHighlighted ? unsafeHTML(highlighted) : text}</code></pre>`;
   // prettier-ignore
@@ -285,7 +290,7 @@ export function buildFileLinkWithLines(
   const displayText = fileName + lineInfo;
 
   // prettier-ignore
-  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)}><i class="codicon codicon-file"></i> ${displayText}</span>`;
+  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)}><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> ${displayText}</span>`;
 }
 
 // ============================================================================
@@ -297,7 +302,7 @@ export function buildMemoryPathDisplay(memoryPath: string): TemplateResult {
   if (!memoryPath) return html``;
   const fileName = getBasename(memoryPath) || memoryPath;
   // prettier-ignore
-  return html`<span class="memory-path"><i class="codicon codicon-database"></i> ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
+  return html`<span class="memory-path"><wa-icon library="texra" name="database" aria-hidden="true"></wa-icon> ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
 }
 
 // ============================================================================
@@ -308,7 +313,7 @@ export function buildMemoryPathDisplay(memoryPath: string): TemplateResult {
 export function buildExecutionsPathDisplay(execPath: string): TemplateResult {
   if (!execPath) return html``;
   // prettier-ignore
-  return html`<span class="memory-path"><i class="codicon codicon-history"></i> ${execPath}</span>`;
+  return html`<span class="memory-path"><wa-icon library="texra" name="history" aria-hidden="true"></wa-icon> ${execPath}</span>`;
 }
 
 // ============================================================================

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -28,20 +28,20 @@ import { buildDetailsSummary } from '../htmlBuilders';
 const BANNER_CONFIG: Record<
   string,
   {
-    iconClass: string;
+    iconName: string;
     labelText: string;
     copyTitle: string;
     contentClass: string;
   }
 > = {
   thinking: {
-    iconClass: 'codicon-lightbulb',
+    iconName: 'lightbulb',
     labelText: 'Thinking',
     copyTitle: 'Copy thinking',
     contentClass: 'banner-content--thinking',
   },
   scratchpad: {
-    iconClass: 'codicon-pencil',
+    iconName: 'pencil',
     labelText: 'Scratchpad',
     copyTitle: 'Copy scratchpad',
     contentClass: 'banner-content--scratchpad',
@@ -66,7 +66,7 @@ export function formatBannerContentTemplate(
 
   // prettier-ignore
   return html`<details class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
-    iconClass: config.iconClass,
+    iconName: config.iconName,
     label: config.labelText,
     copyButton: {
       title: config.copyTitle,
@@ -102,7 +102,7 @@ export function formatModelResponseTemplate(
 
   // prettier-ignore
   return html`<details class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
-    iconClass: 'codicon-sparkle',
+    iconName: 'sparkle',
     label: 'Assistant',
     timestamp: verbose
       ? { display: `[${timeDisplay}]`, tooltip: tooltipTimestamp }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -24,10 +24,14 @@ import {
 } from '../litTemplates';
 
 // Local imports - formatter helpers
-import { buildToolUseSection, wrapInPre } from '../htmlBuilders';
+import {
+  buildToolUseSection,
+  wrapInPre,
+  SPINNER_ICON_NAME,
+} from '../htmlBuilders';
 
 type RenderableSection = TemplateResult | typeof nothing | undefined | null;
-type BadgeData = { iconClass: string; label: string };
+type BadgeData = { iconName: string; label: string };
 type CodexToolRenderer = (input: unknown) => TemplateResult | typeof nothing;
 
 /** Lenient schema for parsing codex tool input in the renderer. */
@@ -41,9 +45,13 @@ type CodexInputDisplay = z.infer<typeof CodexInputDisplaySchema>;
 type CodexFileChangeToolInput = z.infer<typeof CodexFileChangeToolInputSchema>;
 type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
 
-function renderBadge({ iconClass, label }: BadgeData): TemplateResult {
+function renderBadge({ iconName, label }: BadgeData): TemplateResult {
   // prettier-ignore
-  return html`<span class="extract-flag"><i class="codicon ${iconClass}"></i> ${label}</span>`;
+  const iconTemplate = iconName === SPINNER_ICON_NAME
+    ? html`<wa-spinner></wa-spinner>`
+    : html`<wa-icon library="texra" name=${iconName} aria-hidden="true"></wa-icon>`;
+  // prettier-ignore
+  return html`<span class="extract-flag">${iconTemplate} ${label}</span>`;
 }
 
 function renderBadgeSection(
@@ -58,7 +66,7 @@ function renderBadgeSection(
     label,
     html`${repeat(
       badges,
-      (badge) => `${badge.iconClass}:${badge.label}`,
+      (badge) => `${badge.iconName}:${badge.label}`,
       renderBadge,
     )}`,
   );
@@ -95,10 +103,10 @@ function renderCodexPromptSection(input: CodexInputDisplay): RenderableSection {
 function renderCodexModeSection(input: CodexInputDisplay): RenderableSection {
   const badges = [
     ...(input.sandbox_mode
-      ? [{ iconClass: 'codicon-shield', label: input.sandbox_mode }]
+      ? [{ iconName: 'shield', label: input.sandbox_mode }]
       : []),
     ...(input.thread_id
-      ? [{ iconClass: 'codicon-comment-discussion', label: 'follow-up' }]
+      ? [{ iconName: 'comment-discussion', label: 'follow-up' }]
       : []),
   ];
 
@@ -121,8 +129,7 @@ function renderCodexFileStatusSection(patchStatus: string): RenderableSection {
   return patchStatus
     ? renderBadgeSection('Status:', [
         {
-          iconClass:
-            patchStatus === 'failed' ? 'codicon-error' : 'codicon-check',
+          iconName: patchStatus === 'failed' ? 'error' : 'check',
           label: patchStatus,
         },
       ])
@@ -134,7 +141,7 @@ function renderCodexFileChangeItem(
 ): TemplateResult {
   return html`
     <li class="detail-item">
-      <i class="codicon codicon-file"></i>
+      <wa-icon library="texra" name="file" aria-hidden="true"></wa-icon>
       <span class="file-link clickable-link" data-file=${change.path}
         >${change.path}</span
       >
@@ -200,7 +207,7 @@ function renderCodexTodoProgressSection(
   return totalCount > 0
     ? renderBadgeSection('Progress:', [
         {
-          iconClass: 'codicon-checklist',
+          iconName: 'checklist',
           label: `${completedCount}/${totalCount} completed`,
         },
       ])
@@ -213,11 +220,11 @@ function renderCodexTodoItem(item: {
 }): TemplateResult {
   return html`
     <li class="detail-item">
-      <i
-        class="codicon ${item.completed
-          ? 'codicon-pass-filled'
-          : 'codicon-circle-large-outline'}"
-      ></i>
+      <wa-icon
+        library="texra"
+        name=${item.completed ? 'pass-filled' : 'circle-large-outline'}
+        aria-hidden="true"
+      ></wa-icon>
       <span>${item.text}</span>
     </li>
   `;
@@ -262,16 +269,16 @@ function renderCodexTodoContent(
 
 function getCodexTurnStateIcon(state: string): string {
   return state === 'failed'
-    ? 'codicon-error'
+    ? 'error'
     : state === 'running'
-      ? 'codicon-sync spin'
-      : 'codicon-check';
+      ? SPINNER_ICON_NAME
+      : 'check';
 }
 
 function renderCodexTurnStateSection(state: string): RenderableSection {
   return state
     ? renderBadgeSection('State:', [
-        { iconClass: getCodexTurnStateIcon(state), label: state },
+        { iconName: getCodexTurnStateIcon(state), label: state },
       ])
     : nothing;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -45,27 +45,27 @@ const ACTION_CONFIG: Record<
   { icon: string; label: string; color: string }
 > = {
   compaction: {
-    icon: 'codicon-fold',
+    icon: 'fold',
     label: 'Compacted',
     color: 'var(--texra-charts-blue)',
   },
   clear_tool_uses: {
-    icon: 'codicon-trash',
+    icon: 'trash',
     label: 'Cleared Tool Uses',
     color: 'var(--texra-charts-green)',
   },
   clear_thinking: {
-    icon: 'codicon-lightbulb',
+    icon: 'lightbulb',
     label: 'Cleared Thinking',
     color: 'var(--texra-charts-green)',
   },
   truncation: {
-    icon: 'codicon-ellipsis',
+    icon: 'ellipsis',
     label: 'Truncated',
     color: 'var(--texra-charts-orange)',
   },
   max_tokens_reduced: {
-    icon: 'codicon-arrow-small-down',
+    icon: 'arrow-small-down',
     label: 'Max Tokens Reduced',
     color: 'var(--texra-charts-yellow)',
   },
@@ -80,7 +80,7 @@ function buildContextManagementItems(data: ContextManagementData): {
   const { action } = data;
 
   const config: ActionConfig = ACTION_CONFIG[action] || {
-    icon: 'codicon-history',
+    icon: 'history',
     label: action || 'Context Management',
     color: 'var(--texra-foreground)',
   };
@@ -94,7 +94,7 @@ function buildContextManagementItems(data: ContextManagementData): {
     data.reducedMaxTokens !== undefined
   ) {
     items.push({
-      icon: 'codicon-arrow-down',
+      icon: 'arrow-down',
       label: 'Max tokens reduced',
       value: `${formatTokens(data.originalMaxTokens)} → ${formatTokens(data.reducedMaxTokens)}`,
     });
@@ -105,7 +105,7 @@ function buildContextManagementItems(data: ContextManagementData): {
     const tokensFreed = data.tokensBefore - data.tokensAfter;
     if (tokensFreed > 0) {
       items.push({
-        icon: 'codicon-dash',
+        icon: 'dash',
         label: 'Tokens freed',
         value: formatTokens(tokensFreed),
       });
@@ -118,20 +118,20 @@ function buildContextManagementItems(data: ContextManagementData): {
       ? `${data.utilizationBefore.toFixed(1)}% → ${data.utilizationAfter.toFixed(1)}%`
       : `${data.utilizationBefore.toFixed(1)}%`;
   items.push({
-    icon: 'codicon-pie-chart',
+    icon: 'pie-chart',
     label: 'Context utilization',
     value: utilizationDisplay,
   });
 
   items.push({
-    icon: 'codicon-window',
+    icon: 'window',
     label: 'Context window',
     value: formatTokens(data.contextWindow),
   });
 
   if (data.details) {
     items.push({
-      icon: 'codicon-info',
+      icon: 'info',
       label: 'Details',
       value: data.details,
     });

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -42,20 +42,18 @@ export function formatFileListTemplate(
   if (!parseResult.success) {
     // prettier-ignore
     return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
-      iconClass: 'codicon-file',
+      iconName: 'file',
       label: 'Files (raw)',
       labelClass: 'summary-text',
-      includeIconClass: false,
     })}<ul class="file-list-content" data-log-id=${ifDefined(id)}><pre>${text ?? ''}</pre></ul></details>`;
   }
 
   const renderData = buildFileListRender(parseResult.data);
   // prettier-ignore
   return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
-    iconClass: 'codicon-file',
+    iconName: 'file',
     label: renderData?.summary ?? 'Files',
     labelClass: 'summary-text',
-    includeIconClass: false,
   })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${renderData?.items ?? ''}</ul></details>`;
 }
 
@@ -63,7 +61,7 @@ export function formatFileListTemplate(
 function renderXmlLink(xmlFile: string, documentTag: string | null) {
   const xmlFileName = getBasename(xmlFile);
   // prettier-ignore
-  return html`<div class="xml-link-container"><i class="codicon codicon-file-code"></i> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile}>${xmlFileName}</span>${documentTag ? html` <span class="document-tag">(Expected &lt;${documentTag}&gt; block)</span>` : ''}</div>`;
+  return html`<div class="xml-link-container"><wa-icon library="texra" name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile}>${xmlFileName}</span>${documentTag ? html` <span class="document-tag">(Expected &lt;${documentTag}&gt; block)</span>` : ''}</div>`;
 }
 
 /** Format missing outputs entry as TemplateResult. */
@@ -90,14 +88,13 @@ export function formatMissingOutputsTemplate(
   const listItems = missing.map((f) => {
     const filePath = String(f);
     const basename = getBasename(filePath);
-    return html`<li class="detail-item" title=${filePath}><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file=${filePath}>${basename}</span></li>`;
+    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name="warning" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath}>${basename}</span></li>`;
   });
   // prettier-ignore
   return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
-    iconClass: 'codicon-warning',
+    iconName: 'warning',
     label: `Missing outputs (${missing.length})`,
     labelClass: 'summary-text',
-    includeIconClass: false,
   })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile, documentTag) : ''}</details>`;
 }
 
@@ -133,31 +130,16 @@ type StatFieldConfig = readonly [
 
 // Statistics field configuration
 const STAT_FIELDS: readonly StatFieldConfig[] = [
-  ['inputTokens', 'codicon-arrow-up', 'Input tokens', formatTokens],
-  ['outputTokens', 'codicon-arrow-down', 'Output tokens', formatTokens],
-  ['cacheReadInputTokens', 'codicon-history', 'Cache hits', formatTokens],
-  [
-    'cacheMissInputTokens',
-    'codicon-cloud-upload',
-    'Cache misses',
-    formatTokens,
-  ],
-  ['cacheCreationInputTokens', 'codicon-save', 'Cache writes', formatTokens],
-  [
-    'percentageCached',
-    'codicon-graph-line',
-    'Cached %',
-    (v) => `${v.toFixed(2)}%`,
-  ],
-  [
-    'reasoningTokens',
-    'codicon-comment-discussion',
-    'Reasoning tokens',
-    formatTokens,
-  ],
-  ['toolUseTokens', 'codicon-tools', 'Tool tokens', formatTokens],
-  ['elapsedTime', 'codicon-clock', 'Elapsed time', (v) => `${v}s`],
-  ['cost', 'codicon-rocket', 'Cost', (v) => `$${v.toFixed(3)}`],
+  ['inputTokens', 'arrow-up', 'Input tokens', formatTokens],
+  ['outputTokens', 'arrow-down', 'Output tokens', formatTokens],
+  ['cacheReadInputTokens', 'history', 'Cache hits', formatTokens],
+  ['cacheMissInputTokens', 'cloud-upload', 'Cache misses', formatTokens],
+  ['cacheCreationInputTokens', 'save', 'Cache writes', formatTokens],
+  ['percentageCached', 'graph-line', 'Cached %', (v) => `${v.toFixed(2)}%`],
+  ['reasoningTokens', 'comment-discussion', 'Reasoning tokens', formatTokens],
+  ['toolUseTokens', 'tools', 'Tool tokens', formatTokens],
+  ['elapsedTime', 'clock', 'Elapsed time', (v) => `${v}s`],
+  ['cost', 'rocket', 'Cost', (v) => `$${v.toFixed(3)}`],
 ];
 
 /** Format statistics entry as TemplateResult. */

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -19,7 +19,6 @@ import {
 // Local imports - shared utilities
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
-
 // Local imports - Lit template utilities
 import {
   html,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -17,8 +17,8 @@ import {
 } from '@shared/schemas';
 
 // Local imports - shared utilities
-import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+
 
 // Local imports - Lit template utilities
 import {
@@ -141,13 +141,13 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // prettier-ignore
   const contentTemplate = html`<div class="banner-content log-entry-content banner-content--error">${detailTemplate}</div>`;
   // prettier-ignore
-  const toggleIcon = html`<i class="${CHEVRON_RIGHT_CLASS} toggle-icon" style=${styleMap({ visibility: hasDetails ? '' : 'hidden' })}></i>`;
+  const toggleIcon = html`<wa-icon library="texra" name="chevron-right" class="toggle-icon" aria-hidden="true" style=${styleMap({ visibility: hasDetails ? '' : 'hidden' })}></wa-icon>`;
   // prettier-ignore
   const labelSpan = html`<span class="label" title=${tooltipTimestamp}>[${timeDisplay}] ${summaryText}</span>`;
   // prettier-ignore
   const copyButton = html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails}>${waIcon('copy')}</wa-button>`;
   // prettier-ignore
-  const summaryTemplate = html`<summary class="details-summary">${toggleIcon}<i class="codicon icon codicon-error"></i>${labelSpan}${copyButton}</summary>`;
+  const summaryTemplate = html`<summary class="details-summary">${toggleIcon}<wa-icon library="texra" name="error" class="icon" aria-hidden="true"></wa-icon>${labelSpan}${copyButton}</summary>`;
   // prettier-ignore
   return html`<details class=${classMap({
     'banner-details': true,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -47,13 +47,14 @@ import {
 import {
   buildToolUseSection,
   wrapInPre,
-  getToolIconClass,
+  getToolIconName,
   buildFileLinkWithLines,
   buildEditDiffSection,
   buildMemoryPathDisplay,
   buildExecutionsPathDisplay,
   buildCodeBlock,
   buildDetailsSummary,
+  SPINNER_ICON_NAME,
 } from '../htmlBuilders';
 import { normalizeToolUseData } from '../logDataParsers';
 import { registerProposalInput } from '../proposalInputStore';
@@ -161,10 +162,10 @@ const STATUS_SUFFIXES: Record<string, string> = {
   failed: ' (failed)',
 };
 
-// Web search status-based icon classes
+// Web search status-based wa-icon names; SPINNER_ICON_NAME triggers a spinner.
 const STATUS_ICONS: Record<string, string> = {
-  failed: 'codicon codicon-error',
-  in_progress: 'codicon codicon-sync spin',
+  failed: 'error',
+  in_progress: SPINNER_ICON_NAME,
 };
 
 /** Build the banner content wrapper shared by tool-use and web-search entries. */
@@ -432,7 +433,7 @@ function buildAcceptRunFilesSections(
         ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--spacing-small)">-${edit.lineChanges.removed}</span></span>`
         : nothing;
       // prettier-ignore
-      return html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
+      return html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
     })}`;
     // prettier-ignore
     sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
@@ -478,13 +479,13 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
     extractFlags.push('Extract TikZ');
   if (extractFlags.length > 0) {
     // prettier-ignore
-    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><i class="codicon codicon-file-media"></i> ${f}</span>`)}`));
+    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><wa-icon library="texra" name="file-media" aria-hidden="true"></wa-icon> ${f}</span>`)}`));
   }
 
   const fileGroups = getProposalFileGroups(delegateInput);
   if (fileGroups.length > 0) {
     // prettier-ignore
-    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
+    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
     // prettier-ignore
     sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
   }
@@ -534,16 +535,21 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
   const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
 
   if (typeof mcpOutput?.status === 'string') {
-    let statusIcon: string;
+    const statusIsInProgress = mcpOutput.status === 'in_progress';
+    let statusIconName: string;
     if (mcpOutput.status === 'failed') {
-      statusIcon = 'codicon-error';
-    } else if (mcpOutput.status === 'in_progress') {
-      statusIcon = 'codicon-sync spin';
+      statusIconName = 'error';
+    } else if (statusIsInProgress) {
+      statusIconName = '';
     } else {
-      statusIcon = 'codicon-check';
+      statusIconName = 'check';
     }
     // prettier-ignore
-    sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${statusIcon}"></i> ${mcpOutput.status}</span>`));
+    const statusIconTemplate = statusIsInProgress
+      ? html`<wa-spinner></wa-spinner>`
+      : html`<wa-icon library="texra" name=${statusIconName} aria-hidden="true"></wa-icon>`;
+    // prettier-ignore
+    sections.push(buildToolUseSection('Status:', html`<span class="extract-flag">${statusIconTemplate} ${mcpOutput.status}</span>`));
     renderedMcpOutput = true;
   }
 
@@ -690,13 +696,13 @@ export function formatToolUseTemplate(
   // Determine display state
   const isInProgress = status === 'in_progress';
   const showAsError = normalizedToolLog.isError && !isUserFeedback;
-  let iconClass: string;
+  let iconName: string;
   if (isUserFeedback) {
-    iconClass = 'codicon-comment';
+    iconName = 'comment';
   } else if (isInProgress) {
-    iconClass = 'codicon-sync spin';
+    iconName = SPINNER_ICON_NAME;
   } else {
-    iconClass = getToolIconClass(toolName, showAsError);
+    iconName = getToolIconName(toolName, showAsError);
   }
 
   const titleBase = toolName.startsWith('mcp:')
@@ -803,7 +809,7 @@ export function formatToolUseTemplate(
       : null;
 
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration"><i class="codicon codicon-reply"></i> Setup</span>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration"><wa-icon library="texra" name="reply" aria-hidden="true"></wa-icon> Setup</span>` : nothing}`;
 
   // prettier-ignore
   return html`<details class=${classMap({
@@ -813,10 +819,9 @@ export function formatToolUseTemplate(
     'tool-use-user-feedback': isUserFeedback,
     'tool-use-in-progress': isInProgress,
   })} ?open=${shouldOpen}>${buildDetailsSummary({
-    iconClass,
+    iconName,
     label: titleText,
     labelClass: 'tool-use-title',
-    includeIconClass: false,
     extraContent,
   })}${bannerContentTemplate}</details>`;
 }
@@ -836,7 +841,7 @@ export function formatWebSearchTemplate(
 
   const providerLabel = PROVIDER_LABELS[providerKey] ?? 'Web';
   const statusSuffix = STATUS_SUFFIXES[statusKey] ?? '';
-  const iconClass = STATUS_ICONS[statusKey] ?? 'codicon codicon-globe';
+  const iconName = STATUS_ICONS[statusKey] ?? 'globe';
 
   let titleText = `${providerLabel} Search`;
   if (query) titleText += `: "${query}"`;
@@ -848,7 +853,7 @@ export function formatWebSearchTemplate(
   if (resultCount > 0) {
     // prettier-ignore
     const resultItems = (results ?? []).map(
-      (r) => html`<li class="detail-item"><i class="codicon codicon-link"></i> <a href=${r.url ?? ''} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
+      (r) => html`<li class="detail-item"><wa-icon library="texra" name="link" aria-hidden="true"></wa-icon> <a href=${r.url ?? ''} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
     );
     // prettier-ignore
     const resultsTemplate = html`<span class="file-list-summary">Results (${resultCount})</span><ul class="detail-list">${resultItems}</ul>`;
@@ -876,10 +881,9 @@ export function formatWebSearchTemplate(
     'tool-use-details': true,
     'tool-use-error': statusKey === 'failed',
   })} ?open=${shouldOpen}>${buildDetailsSummary({
-    iconClass,
+    iconName,
     label: titleText,
     labelClass: 'tool-use-title',
-    includeIconClass: false,
   })}${bannerContentTemplate}</details>`;
 }
 
@@ -907,9 +911,7 @@ export function formatWebFetchTemplate(
   const statusKey = typeof status === 'string' ? status : '';
   const isFailed = statusKey === 'failed';
 
-  const iconClass = isFailed
-    ? 'codicon codicon-error'
-    : 'codicon codicon-cloud-download';
+  const iconName = isFailed ? 'error' : 'cloud-download';
 
   let titleText = 'Web Fetch';
   if (url) {
@@ -952,9 +954,8 @@ export function formatWebFetchTemplate(
     'tool-use-details': true,
     'tool-use-error': isFailed,
   })} ?open=${shouldOpen}>${buildDetailsSummary({
-    iconClass,
+    iconName,
     label: titleText,
     labelClass: 'tool-use-title',
-    includeIconClass: false,
   })}${bannerContentTemplate}</details>`;
 }

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -89,7 +89,7 @@ export const logEntryStyles = css`
     gap: var(--spacing-small);
   }
 
-  .xml-link-container .codicon {
+  .xml-link-container wa-icon {
     opacity: var(--opacity-subtle);
   }
 
@@ -109,7 +109,7 @@ export const logEntryStyles = css`
     gap: var(--spacing-tiny);
   }
 
-  .xml-link-container .xml-fix-hint .codicon {
+  .xml-link-container .xml-fix-hint wa-icon {
     opacity: var(--opacity-full);
     color: var(--color-text-link);
   }
@@ -144,7 +144,7 @@ export const logEntryStyles = css`
     color: var(--color-text-secondary);
   }
 
-  .memory-path .codicon {
+  .memory-path wa-icon {
     margin-right: var(--spacing-small);
   }
 

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -54,7 +54,7 @@ export const toolUseStyles = css`
 
   :is(.tool-use-error, .banner-details--error)
     > .details-summary
-    :is(.tool-use-title, .label, .codicon),
+    :is(.tool-use-title, .label, wa-icon),
   .banner-content--error {
     color: var(--color-error);
   }
@@ -89,17 +89,13 @@ export const toolUseStyles = css`
     color: var(--texra-editorWarning-foreground, #ff8c00);
   }
 
-  .tool-use-user-feedback > .details-summary :is(.tool-use-title, .codicon) {
+  .tool-use-user-feedback > .details-summary :is(.tool-use-title, wa-icon) {
     color: var(--texra-textLink-foreground, #3794ff);
   }
 
-  .tool-use-in-progress > .details-summary :is(.tool-use-title, .codicon) {
+  .tool-use-in-progress > .details-summary :is(.tool-use-title, wa-icon),
+  .tool-use-in-progress > .details-summary wa-spinner {
     color: var(--texra-charts-yellow, #cca700);
-  }
-
-  /* Uses @keyframes spin from animationStyles (included via logStyles) */
-  .tool-use-in-progress > .details-summary .codicon.spin {
-    animation: spin 1s linear infinite;
   }
 
   .tool-use-in-progress > .details-summary tool-timer {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -280,7 +280,6 @@ export class AgentSelectionPanel extends LitElement {
         font-style: italic;
       }
 
-
       .agent-detail-path {
         font-size: var(--font-size-xs);
         font-family: var(--texra-editor-font-family, monospace), monospace;

--- a/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
@@ -71,11 +71,7 @@ export class ProfileInfo extends LitElement {
         </div>
         <div class="info-row">
           <span class="label">Tier:</span>
-          <wa-tag
-            class="tier-badge"
-            variant=${this.tierVariant()}
-            size="small"
-          >
+          <wa-tag class="tier-badge" variant=${this.tierVariant()} size="small">
             ${this.tier}
           </wa-tag>
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -9,10 +9,7 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import {
-  commonViewStyles,
-  designTokens,
-} from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -549,10 +549,7 @@ export class LaTeXTab extends LitElement {
             )}
           </div>
           ${installed
-            ? html`<wa-tag
-                class="setting-badge"
-                variant="success"
-                size="small"
+            ? html`<wa-tag class="setting-badge" variant="success" size="small"
                 >Installed</wa-tag
               >`
             : dep.actionEvent

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -10,10 +10,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
-import {
-  commonViewStyles,
-  designTokens,
-} from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';

--- a/src/shared/schemas/todoDisplay.ts
+++ b/src/shared/schemas/todoDisplay.ts
@@ -1,6 +1,6 @@
 import { TODO_STATUS, type TodoStatus } from './todo';
 
-/** Codicon icon names for each todo/plan step status (used in webview components). */
+/** wa-icon names for each todo/plan step status (used in webview components). */
 export const STATUS_ICONS: Record<TodoStatus, string> = {
   [TODO_STATUS.PENDING]: 'circle-outline',
   [TODO_STATUS.IN_PROGRESS]: 'loading',

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -23,14 +23,18 @@ export interface IconActionButtonOptions {
   readonly onClick?: (event: MouseEvent) => void;
 }
 
-export interface LabeledActionButtonOptions
-  extends Omit<IconActionButtonOptions, 'label'> {
+export interface LabeledActionButtonOptions extends Omit<
+  IconActionButtonOptions,
+  'label'
+> {
   readonly text: string;
   readonly label?: string;
 }
 
-interface ActionButtonBaseOptions
-  extends Omit<IconActionButtonOptions, 'label'> {
+interface ActionButtonBaseOptions extends Omit<
+  IconActionButtonOptions,
+  'label'
+> {
   readonly label?: string;
   readonly text?: string;
 }

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -42,7 +42,9 @@ function installDom(): JSDOM {
   globalThis.CustomEvent = dom.window.CustomEvent;
   (globalThis as { Node: unknown }).Node = dom.window.Node;
   installAttachInternalsFallback(
-    dom.window as unknown as Parameters<typeof installAttachInternalsFallback>[0],
+    dom.window as unknown as Parameters<
+      typeof installAttachInternalsFallback
+    >[0],
   );
   return dom;
 }


### PR DESCRIPTION
## Summary

- Sweep across the progressView webview (formatters, components, shared styles) replacing inline codicon spans/classes with `<wa-icon library="texra">` from the shared registry. The codicon-style aliases (`warning`, `pass-filled`, `circle-outline`, `fold`, etc.) defined in `src/shared/wa/webAwesomeIcons.ts` handle names that don't match canonical Font Awesome names.
- Refactored `buildDetailsSummary` to take an `iconName` (canonical / alias string) and added a `SPINNER_ICON_NAME` sentinel, so in-progress headers (tool calls, MCP status, codex turn state) render `<wa-spinner>` instead of the old `codicon-modifier-spin` animation.
- Renamed `getToolIconClass` to `getToolIconName`; `TOOL_ICON_MAP` now stores bare wa-icon names (no `codicon-` prefix). Specialized formatters (codex badges, web search/fetch, latexdiff results, plan/todo status) updated alongside.
- TodoList and PlanView swap the codicon-loading spin pattern for an inline `<wa-spinner>`; TaskGroupList does the same for the running-status group header.
- Static styles arrays drop `codiconStyles` / `codiconIconClasses`; CSS selectors targeting `.codicon` inside Lit static blocks switch to `wa-icon` (and `wa-spinner` where applicable) so existing font-size / opacity rules keep applying.
- Added `@awesome.me/webawesome/dist/components/icon/icon.js` (and `/spinner/spinner.js` where used) side-effect imports to files that didn't already have them.

35 files modified — the 24 panel/list components plus `ProgressApp`, `LogList`, `TaskGroupList`, the 7 formatter modules, two style modules, and the shared todo-status icon map. `CHEVRON_RIGHT_CLASS` and `getToolIconClass` imports are no longer used inside `progressView/`.

## Test plan

- [ ] `npm run typecheck` clean (only pre-existing unrelated OpenRouter SDK errors remain).
- [ ] `npx vitest run` — pass count unchanged (pre-existing 2 failures in desktop fix-path test).
- [ ] Manual: open the Progress view in VS Code and verify: tool-use banners show the right icon (running tools show a spinner, completed tools show the tool icon, errors show the error icon), thinking/scratchpad/assistant banners show the lightbulb/pencil/sparkle icon, statistics panel renders, file list / missing outputs / latexdiff results render with their icons, todo list shows the spinner for in-progress items, queued follow-ups / external inquiry / permission cards / proposal panels render their icons.
- [ ] Manual: confirm the chevron rotation on `<details>` toggles still works for tool-use, statistics, latexdiff, retry, context-management, file-list, and background-tasks summaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI/icon rendering refactor across the progress webview; main risk is missing/incorrect icon names or spinner rendering causing visual regressions in many panels.
> 
> **Overview**
> **Migrates progress-view icon rendering from VS Code codicon CSS classes to Web Awesome components.** Across progressView panels, lists, and log formatters, inline `<i class="codicon ...">` markup and `codicon*` style dependencies are replaced with `<wa-icon library="texra" name="...">`.
> 
> **Standardizes “in progress” visuals on `<wa-spinner>`.** `buildDetailsSummary` now takes `iconName` (with `SPINNER_ICON_NAME` sentinel) and tool/log formatters and UI components (e.g., tool-use banners, todo/plan/task group status) switch from codicon spin classes to spinners; CSS selectors are updated from `.codicon` to `wa-icon`/`wa-spinner`, and required WA icon/spinner side-effect imports are added where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844b75028e56a5265478485b58f7c4a5115c01df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->