### PR TITLE
feat(webview): migrate InstructionPanel form controls to Web Awesome

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -11,6 +11,12 @@ import { consume } from '@lit/context';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+import '@awesome.me/webawesome/dist/components/radio/radio.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas and types
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
@@ -138,12 +144,12 @@ export class InstructionPanel extends LitElement {
         align-items: center;
       }
 
-      .instruction-session-toggle vscode-radio-group {
+      .instruction-session-toggle wa-radio-group {
         display: flex;
         gap: var(--spacing-small);
       }
 
-      .instruction-session-toggle vscode-radio {
+      .instruction-session-toggle wa-radio {
         font-size: var(--font-size-sm);
       }
 
@@ -180,14 +186,14 @@ export class InstructionPanel extends LitElement {
         margin-left: var(--spacing-tiny);
       }
 
-      vscode-textarea#instruction {
+      wa-textarea#instruction {
         width: 100%;
         margin: var(--spacing-medium) 0;
         font-family: var(--texra-editor-font-family);
         font-size: var(--font-size);
       }
 
-      vscode-textarea#instruction::part(control) {
+      wa-textarea#instruction::part(textarea) {
         max-height: var(--height-xlarge);
         transition: height var(--transition-fast);
       }
@@ -474,30 +480,28 @@ export class InstructionPanel extends LitElement {
                 id="sessionType"
                 .value=${session.sessionType}
               />
-              <vscode-radio-group
+              <wa-radio-group
                 id="sessionTypeToggle"
                 aria-label="Choose the session type"
                 orientation="horizontal"
                 .value=${session.sessionType}
                 @change=${this.handleSessionTypeChange}
               >
-                <vscode-radio
+                <wa-radio
                   value="toolUse"
                   data-session-type="toolUse"
-                  ?checked=${session.sessionType === SESSION_TYPES.TOOL_USE}
                   title=${getSessionTitle(SESSION_TYPES.TOOL_USE)}
                 >
                   Interactive
-                </vscode-radio>
-                <vscode-radio
+                </wa-radio>
+                <wa-radio
                   value="workflow"
                   data-session-type="workflow"
-                  ?checked=${session.sessionType === SESSION_TYPES.WORKFLOW}
                   title=${getSessionTitle(SESSION_TYPES.WORKFLOW)}
                 >
                   Workflow
-                </vscode-radio>
-              </vscode-radio-group>
+                </wa-radio>
+              </wa-radio-group>
             </div>
           </div>
           <div
@@ -536,13 +540,12 @@ export class InstructionPanel extends LitElement {
             })}
             ${session.isPolishing
               ? html`
-                  <vscode-progress-ring
+                  <wa-spinner
                     id="polishProgressContainer"
                     style=${styleMap({
-                      width: '16px',
-                      height: '16px',
+                      fontSize: '16px',
                     })}
-                  ></vscode-progress-ring>
+                  ></wa-spinner>
                 `
               : nothing}
             ${renderIconActionButton({
@@ -565,7 +568,7 @@ export class InstructionPanel extends LitElement {
           </div>
         </div>
         ${this.renderSessionHint(session)}
-        <vscode-textarea
+        <wa-textarea
           id="instruction"
           rows="10"
           resize="none"
@@ -573,7 +576,7 @@ export class InstructionPanel extends LitElement {
           .value=${session.instruction}
           @input=${this.handleInput}
           @paste=${this.handleInstructionPaste}
-        ></vscode-textarea>
+        ></wa-textarea>
         <div class="instruction-controls">
           <div class="model-selection-footer">
             <div
@@ -682,13 +685,15 @@ export class InstructionPanel extends LitElement {
               </vscode-single-select>
             </div>
           </div>
-          <vscode-button
+          <wa-button
             id="executeButton"
-            icon="play"
             title="Execute"
-            appearance="primary"
+            appearance="filled"
+            variant="brand"
             @click=${this.handleExecute}
-          ></vscode-button>
+          >
+            <wa-icon slot="start" library="texra" name="play"></wa-icon>
+          </wa-button>
         </div>
       </div>
     `;

--- a/src/shared/utils/textarea.ts
+++ b/src/shared/utils/textarea.ts
@@ -11,12 +11,14 @@ interface VscodeTextarea extends HTMLElement {
 }
 
 /**
- * Resolve a vscode-textarea element to its underlying HTMLTextAreaElement.
- * This is an internal helper for insertTextAtCursor - selection operations
- * (.selectionStart, .selectionEnd) are NOT proxied by vscode-textarea.
+ * Resolve a vscode-textarea or wa-textarea element to its underlying
+ * HTMLTextAreaElement. This is an internal helper for insertTextAtCursor —
+ * selection operations (.selectionStart, .selectionEnd) are NOT proxied by
+ * either host element.
  *
- * For .value access, use the host element directly - vscode-textarea proxies .value.
- * For .focus(), use the host element directly - it works on the vscode-textarea host.
+ * For .value access, use the host element directly — both vscode-textarea
+ * and wa-textarea expose .value as a property on the host.
+ * For .focus(), use the host element directly.
  */
 function resolveTextareaTarget(target: TextareaTarget): TextareaResolution {
   if (!target) {
@@ -30,6 +32,14 @@ function resolveTextareaTarget(target: TextareaTarget): TextareaResolution {
   const host = target as VscodeTextarea;
   if (host.wrappedElement instanceof HTMLTextAreaElement) {
     return { host: target, textarea: host.wrappedElement };
+  }
+
+  // wa-textarea (and similar shadow-DOM-based hosts) keep the underlying
+  // <textarea> inside their shadow root rather than exposing wrappedElement.
+  const shadowTextarea =
+    host.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea') ?? null;
+  if (shadowTextarea) {
+    return { host: target, textarea: shadowTextarea };
   }
 
   return { host: null, textarea: null };


### PR DESCRIPTION
## Summary

Migrate the non-select form controls in `InstructionPanel.ts` from `vscode-elements` to Web Awesome. The agent/model selects are intentionally untouched here and are being migrated in a parallel branch (`webawesome/selectTemplates-wa-select`).

### Component swaps

- `<vscode-radio-group>` / `<vscode-radio>` (session toggle) -> `<wa-radio-group>` / `<wa-radio>`. Dropped the per-radio `?checked=` attribute since `wa-radio-group` drives selection from its bound `.value`.
- `<vscode-textarea id="instruction" rows="10" resize="none">` -> `<wa-textarea id="instruction" rows="10" resize="none">`. Same `value` / `placeholder` semantics; `paste` event still bubbles via `composedPath` from the inner shadow `<textarea>`.
- `<vscode-progress-ring>` (indeterminate polish indicator) -> `<wa-spinner>`. Sized via `font-size: 16px` (wa-spinner scales with `font-size`).
- `<vscode-button id="executeButton" appearance="primary" icon="play">` -> `<wa-button appearance="filled" variant="brand">` with `<wa-icon slot="start" library="texra" name="play">`.

### CSS retargets (same file's `static styles`)

- `.instruction-session-toggle vscode-radio-group` -> `... wa-radio-group`
- `.instruction-session-toggle vscode-radio` -> `... wa-radio`
- `vscode-textarea#instruction` -> `wa-textarea#instruction`
- `vscode-textarea#instruction::part(control)` -> `wa-textarea#instruction::part(textarea)` (wa-textarea exposes the inner input as the `textarea` part, not `control`)

### Paste handler shim

`insertTextAtCursor` in `src/shared/utils/textarea.ts` previously relied on `vscode-textarea`'s `wrappedElement` to access the inner `HTMLTextAreaElement` for selection-aware insertion. wa-textarea instead nests its `<textarea>` inside the shadow root. Extended `resolveTextareaTarget` to fall back to `host.shadowRoot?.querySelector('textarea')` when `wrappedElement` is missing — keeps the existing vscode-textarea path working while supporting wa-textarea (and any other shadow-DOM-based textarea host). `getTextareaValue` already worked unchanged because both hosts expose `.value` as a property.

### Side-effect imports added

```ts
import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
import '@awesome.me/webawesome/dist/components/radio/radio.js';
import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
import '@awesome.me/webawesome/dist/components/button/button.js';
import '@awesome.me/webawesome/dist/components/icon/icon.js';
```

### Out of scope

- `<vscode-single-select>` / `<vscode-option>` instances (workflowAgent, toolUseAgent, model) — handled by `webawesome/selectTemplates-wa-select`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` -> 310/311 (1 pre-existing fix-path failure in `DesktopToolEditApproval.vitest.mts`, unrelated to this change)
- [x] `cd packages/desktop && npx vite build --mode development` succeeds
- [ ] Manual smoke: toggle Interactive/Workflow radios, type/paste into instruction textarea, polish (spinner appears), execute button click

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: swaps core input controls (session toggle, instruction textarea, execute button, spinner) and tweaks textarea insertion plumbing to traverse shadow DOM, which could affect input/paste/selection behavior in the webview.
> 
> **Overview**
> Migrates `InstructionPanel` non-select form controls from `vscode-*` elements to Web Awesome (`wa-radio-group`/`wa-radio`, `wa-textarea`, `wa-spinner`, `wa-button` + `wa-icon`), including updated side-effect component imports and CSS part/selectors.
> 
> Updates `resolveTextareaTarget` in `src/shared/utils/textarea.ts` to support shadow-DOM-based textareas by falling back to `host.shadowRoot.querySelector('textarea')`, keeping selection-aware insertion working for `wa-textarea` while preserving the existing `wrappedElement` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fef86b9caa11b173190c7aa27764e7c2edeff11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->