### PR TITLE
feat(webview,settings): migrate vscode-single-select to wa-select

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -14,6 +14,8 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
 
 // Local imports - shared constants
 import {
@@ -185,23 +187,19 @@ export class ModelSelectionList extends LitElement {
       : 'Reasoning level';
 
     return html`
-      <vscode-single-select
+      <wa-select
         class="reasoning-level-select"
         .value=${currentValue}
         title=${title}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
-        <vscode-option value="" ?selected=${currentValue === ''}>
-          ${defaultLabel}
-        </vscode-option>
+        <wa-option value=""> ${defaultLabel} </wa-option>
         ${REASONING_LEVELS.map(
           (level) => html`
-            <vscode-option value=${level} ?selected=${currentValue === level}>
-              ${REASONING_LEVEL_LABELS[level]}
-            </vscode-option>
+            <wa-option value=${level}> ${REASONING_LEVEL_LABELS[level]} </wa-option>
           `,
         )}
-      </vscode-single-select>
+      </wa-select>
       ${includedAccessCap
         ? html`<wa-icon
             library="texra"
@@ -365,21 +363,15 @@ export class ModelSelectionList extends LitElement {
     return html`
       <div class="helper-model-row">
         <label>Helper model:</label>
-        <vscode-single-select
+        <wa-select
           class="helper-model-select"
           .value=${this.helperModel}
           @change=${this.handleHelperModelChange}
         >
           ${enabledModels.map(
-            (m) =>
-              html`<vscode-option
-                value=${m.name}
-                ?selected=${m.name === this.helperModel}
-              >
-                ${m.name}
-              </vscode-option>`,
+            (m) => html`<wa-option value=${m.name}> ${m.name} </wa-option>`,
           )}
-        </vscode-single-select>
+        </wa-select>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -18,6 +18,8 @@ import {
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -375,22 +377,17 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="setting-row">
         <label>${label}</label>
-        <vscode-single-select
+        <wa-select
           class="setting-select"
           .value=${value}
           @change=${onChange}
         >
           ${options.map(
             (opt) => html`
-              <vscode-option
-                value=${opt.value}
-                ?selected=${value === opt.value}
-              >
-                ${opt.label}
-              </vscode-option>
+              <wa-option value=${opt.value}> ${opt.label} </wa-option>
             `,
           )}
-        </vscode-single-select>
+        </wa-select>
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -5,6 +5,10 @@
  * action buttons, agent/model selectors, and execute button.
  */
 
+// Side-effect imports - register WA select & option components
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
@@ -262,24 +266,24 @@ export class InstructionPanel extends LitElement {
       }
 
       .agent-select-dropdowns select,
-      .agent-select-dropdowns vscode-single-select,
+      .agent-select-dropdowns wa-select,
       .agent-select {
         width: 100%;
       }
 
       .model-selection-footer .agent-model-select-group select,
-      .model-selection-footer .agent-model-select-group vscode-single-select,
-      .model-selection-footer .model-select-group vscode-single-select {
+      .model-selection-footer .agent-model-select-group wa-select,
+      .model-selection-footer .model-select-group wa-select {
         font-size: var(--font-size-sm);
       }
 
-      .model-selection-footer .agent-select-group vscode-single-select {
+      .model-selection-footer .agent-select-group wa-select {
         flex: 0 1 var(--agent-select-max-width);
         min-width: var(--agent-select-min-width);
         max-width: var(--agent-select-max-width);
       }
 
-      .model-selection-footer .model-select-group vscode-single-select {
+      .model-selection-footer .model-select-group wa-select {
         flex: 0 1 var(--model-select-max-width);
         min-width: var(--model-select-min-width);
         max-width: var(--model-select-max-width);
@@ -300,7 +304,7 @@ export class InstructionPanel extends LitElement {
       }
 
       /* Dropdowns in footer open upward */
-      vscode-single-select::part(listbox) {
+      wa-select::part(listbox) {
         bottom: 100%;
         top: auto;
       }
@@ -589,7 +593,7 @@ export class InstructionPanel extends LitElement {
               })}
               <div class="agent-select-controls">
                 <div class="agent-select-dropdowns">
-                  <vscode-single-select
+                  <wa-select
                     id="workflowAgent"
                     class=${classMap({
                       'agent-select': true,
@@ -610,7 +614,7 @@ export class InstructionPanel extends LitElement {
                     aria-hidden=${session.sessionType === SESSION_TYPES.WORKFLOW
                       ? 'false'
                       : 'true'}
-                    position="above"
+                    placement="top"
                     .value=${session.workflowAgent}
                     @focus=${this.handleAgentFocus}
                     @change=${this.handleAgentChange}
@@ -619,8 +623,8 @@ export class InstructionPanel extends LitElement {
                       session.workflowAgentOptions,
                       session.workflowAgent,
                     )}
-                  </vscode-single-select>
-                  <vscode-single-select
+                  </wa-select>
+                  <wa-select
                     id="toolUseAgent"
                     class=${classMap({
                       'agent-select': true,
@@ -641,7 +645,7 @@ export class InstructionPanel extends LitElement {
                     aria-hidden=${session.sessionType === SESSION_TYPES.TOOL_USE
                       ? 'false'
                       : 'true'}
-                    position="above"
+                    placement="top"
                     .value=${session.toolUseAgent}
                     @focus=${this.handleAgentFocus}
                     @change=${this.handleAgentChange}
@@ -650,7 +654,7 @@ export class InstructionPanel extends LitElement {
                       session.toolUseAgentOptions,
                       session.toolUseAgent,
                     )}
-                  </vscode-single-select>
+                  </wa-select>
                 </div>
               </div>
             </div>
@@ -665,10 +669,10 @@ export class InstructionPanel extends LitElement {
                 className: 'settings-button',
                 onClick: this.handleModelSettings,
               })}
-              <vscode-single-select
+              <wa-select
                 id="model"
                 class="model-select"
-                position="above"
+                placement="top"
                 aria-label="Model"
                 title=${this.getModelTooltip(
                   session.modelOptions,
@@ -679,7 +683,7 @@ export class InstructionPanel extends LitElement {
                 @change=${this.handleModelChange}
               >
                 ${renderModelOptions(session.modelOptions, session.model)}
-              </vscode-single-select>
+              </wa-select>
             </div>
           </div>
           <vscode-button

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -5,6 +5,10 @@
  * commit selector, and diff action buttons.
  */
 
+// Side-effect imports - register WA select & option components
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -209,30 +213,22 @@ export class LatexDiffsSection extends LitElement {
 
   private renderFileOptions(
     options: string[],
-    selectedValue: string,
+    _selectedValue: string,
   ): TemplateResult {
     const sortedOptions = [...options].sort((a, b) => a.localeCompare(b));
     return html`
-      <vscode-option value="" ?selected=${selectedValue === ''}
-        >None</vscode-option
-      >
+      <wa-option value="">None</wa-option>
       ${repeat(
         sortedOptions,
         (opt) => opt,
-        (opt) => html`
-          <vscode-option value=${opt} ?selected=${opt === selectedValue}>
-            ${opt}
-          </vscode-option>
-        `,
+        (opt) => html` <wa-option value=${opt}> ${opt} </wa-option> `,
       )}
     `;
   }
 
   private renderCommitOptions(): TemplateResult {
     if (!this.isGitRepo) {
-      return html`<vscode-option value="" selected
-        >Not a Git repository</vscode-option
-      >`;
+      return html`<wa-option value="">Not a Git repository</wa-option>`;
     }
     const entries = this.commitOptions.some((commit) =>
       commit.startsWith('HEAD'),
@@ -245,11 +241,7 @@ export class LatexDiffsSection extends LitElement {
         (commit) => commit,
         (commit) => {
           const [hash] = commit.split(': ');
-          return html`
-            <vscode-option value=${hash} ?selected=${hash === this.commit}>
-              ${commit}
-            </vscode-option>
-          `;
+          return html` <wa-option value=${hash}> ${commit} </wa-option> `;
         },
       )}
     `;
@@ -308,14 +300,14 @@ export class LatexDiffsSection extends LitElement {
                 })}
               </div>
             </div>
-            <vscode-single-select
+            <wa-select
               id="baseFile"
-              position="above"
+              placement="top"
               .value=${this.baseFile}
               @change=${this.handleBaseSelectChange}
             >
               ${this.renderFileOptions(this.baseFileOptions, this.baseFile)}
-            </vscode-single-select>
+            </wa-select>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -388,14 +380,14 @@ export class LatexDiffsSection extends LitElement {
                 })}
               </div>
             </div>
-            <vscode-single-select
+            <wa-select
               id="editedFile"
-              position="above"
+              placement="top"
               .value=${this.editedFile}
               @change=${this.handleEditedSelectChange}
             >
               ${this.renderFileOptions(this.editedFileOptions, this.editedFile)}
-            </vscode-single-select>
+            </wa-select>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -437,15 +429,15 @@ export class LatexDiffsSection extends LitElement {
                 })}
               </div>
             </div>
-            <vscode-single-select
+            <wa-select
               id="commit"
-              position="above"
+              placement="top"
               .value=${this.commit}
               ?disabled=${!this.isGitRepo}
               @change=${this.handleCommitSelectChange}
             >
               ${this.renderCommitOptions()}
-            </vscode-single-select>
+            </wa-select>
           </div>
         </div>
       </div>

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -13,7 +13,7 @@ export const selectStyles: CSSResult = css`
     vertical-align: text-bottom;
   }
 
-  .select-group vscode-single-select {
+  .select-group wa-select {
     flex: 1;
     min-width: 6rem;
     max-width: 10rem;
@@ -32,20 +32,20 @@ export const selectStyles: CSSResult = css`
     max-width: 10rem;
   }
 
-  vscode-option {
+  wa-option {
     font-family: var(--texra-font-family);
   }
 
-  vscode-option.disabled-option,
-  vscode-option.disabled-model,
-  vscode-option.disabled-agent,
-  vscode-option[data-requires-key='true'] {
+  wa-option.disabled-option,
+  wa-option.disabled-model,
+  wa-option.disabled-agent,
+  wa-option[data-requires-key='true'] {
     color: var(--color-text-secondary, var(--texra-descriptionForeground));
     opacity: var(--opacity-subtle, 0.7);
     font-style: italic;
   }
 
-  vscode-option[data-tool-use='true'] {
+  wa-option[data-tool-use='true'] {
     font-style: italic;
   }
 
@@ -68,7 +68,7 @@ export const selectStyles: CSSResult = css`
     color: var(--button-hover-background, var(--texra-button-hoverBackground));
   }
 
-  vscode-single-select::part(listbox) {
+  wa-select::part(listbox) {
     max-height: var(--height-large, 300px);
   }
 

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -2,6 +2,8 @@
  * Lit-native template helpers for rendering select options.
  */
 
+import '@awesome.me/webawesome/dist/components/option/option.js';
+
 import { html, nothing, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -24,18 +26,14 @@ function buildAgentTooltip(opt: AgentOptionData): string {
   return hints.join('\n');
 }
 
-function renderAgentOption(
-  opt: AgentOptionData,
-  selectedValue: string,
-): TemplateResult {
+function renderAgentOption(opt: AgentOptionData): TemplateResult {
   const { properties } = AGENT_DECORATORS;
   const tooltip = buildAgentTooltip(opt);
 
   const isOrch = opt.isOrchestrator;
   return html`
-    <vscode-option
+    <wa-option
       value=${opt.value}
-      ?selected=${opt.value === selectedValue}
       title=${tooltip || nothing}
       data-label=${opt.label}
       data-tool-use=${opt.isToolUse ? 'true' : nothing}
@@ -49,27 +47,24 @@ function renderAgentOption(
       ${opt.isRemote
         ? html`<span class="agent-icon"> ${properties.remote.unicode}</span>`
         : nothing}
-    </vscode-option>
+    </wa-option>
   `;
 }
 
 export function renderAgentOptions(
   options: AgentOptionData[],
-  selectedValue: string,
+  _selectedValue: string,
 ): TemplateResult {
   return html`
     ${repeat(
       options,
       (opt) => opt.value,
-      (opt) => renderAgentOption(opt, selectedValue),
+      (opt) => renderAgentOption(opt),
     )}
   `;
 }
 
-function renderModelOption(
-  opt: ModelOptionData,
-  selectedValue: string,
-): TemplateResult {
+function renderModelOption(opt: ModelOptionData): TemplateResult {
   const decorator = getModelProviderDecorator(opt.provider ?? '');
   const display = decorator.unicode
     ? `${decorator.unicode} ${opt.label}`
@@ -82,9 +77,8 @@ function renderModelOption(
   const tooltip = hints.join(' | ');
 
   return html`
-    <vscode-option
+    <wa-option
       value=${opt.value}
-      ?selected=${opt.value === selectedValue}
       ?disabled=${opt.disabled}
       title=${tooltip || nothing}
       data-provider=${opt.provider || nothing}
@@ -96,19 +90,19 @@ function renderModelOption(
       ${opt.requiresKey
         ? html`<span class="api-key-missing"> ✗</span>`
         : nothing}
-    </vscode-option>
+    </wa-option>
   `;
 }
 
 export function renderModelOptions(
   options: ModelOptionData[],
-  selectedValue: string,
+  _selectedValue: string,
 ): TemplateResult {
   return html`
     ${repeat(
       options,
       (opt) => opt.value,
-      (opt) => renderModelOption(opt, selectedValue),
+      (opt) => renderModelOption(opt),
     )}
   `;
 }


### PR DESCRIPTION
## Summary

Replaces \`vscode-single-select\` / \`vscode-option\` in the shared
\`selectTemplates\` helpers and their extension consumers with native
\`wa-select\` / \`wa-option\`.

- Selection is now driven by the parent's bound \`.value\` — the per-option
  \`?selected\` attribute is dropped (wa-select reads \`.value\` directly).
- \`position="above"\` is replaced by \`placement="top"\` on \`wa-select\`.
- CSS shadow-DOM selectors retargeted from \`vscode-single-select::part(listbox)\`
  to \`wa-select::part(listbox)\`. Element selectors retargeted from
  \`vscode-single-select\`/\`vscode-option\` to \`wa-select\`/\`wa-option\`.
- Side-effect imports for \`@awesome.me/webawesome/dist/components/select/select.js\`
  and \`.../option/option.js\` added to consumer files (and \`option/option.js\`
  to \`selectTemplates.ts\` so wa-option registers when the helper module loads).

## Files changed

- \`src/shared/utils/selectTemplates.ts\` — \`renderAgentOption\` + \`renderModelOption\`
- \`src/shared/styles/selectStyles.ts\` — shared listbox + option CSS
- \`packages/extension/src/webview/frontend/components/InstructionPanel.ts\` — workflowAgent / toolUseAgent / model selects
- \`packages/extension/src/webview/frontend/components/LatexDiffsSection.ts\` — base / edited / commit selects
- \`packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts\` — Codex inline setting selects
- \`packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts\` — reasoning level + helper-model selects

## Deferred

The two \`progressView\` consumers (\`ProposalRequestPanel\`,
\`WorkflowToolUseFollowupSection\`) are deferred to a follow-up PR to avoid
conflict with the in-flight progressView codicons PR (#3663). Both PRs touch
the same progressView files; they will be migrated once that PR merges.

The shared \`selectStyles.ts\` is also imported by those deferred consumers — they
will lose the listbox shadow-DOM styling on their remaining
\`vscode-single-select\` elements until the follow-up PR migrates them. This is a
transient state.

## Test plan

- [x] \`npm run typecheck\` — only pre-existing baseline errors (electron + openrouter module resolution); no new errors introduced
- [x] \`npx vitest run\` — 309/311 passing (the 2 failures are pre-existing macOS PATH-fixer tests in \`ElectronCompositionRoot.vitest.mts\`)
- [x] \`cd packages/desktop && npx vite build --mode development\` — builds cleanly
- [ ] Manual: workflowAgent / toolUseAgent / model dropdowns in InstructionPanel render and select correctly; dropdowns open upward (placement="top")
- [ ] Manual: LaTeXDiffs base / edited / commit dropdowns render and select correctly
- [ ] Manual: Tools tab Codex sandbox / reasoning / approval selects work
- [ ] Manual: Models tab reasoning-level + helper-model dropdowns work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps select components and related styling; main risk is subtle behavior/styling regressions in dropdown selection/placement across webviews/settings.
> 
> **Overview**
> Migrates the extension webview and settings UIs from `vscode-single-select`/`vscode-option` to Web Awesome `wa-select`/`wa-option`, including adding the needed side-effect component registrations.
> 
> Selection rendering is simplified to rely on the parent `.value` (dropping per-option `?selected`), `position="above"` is replaced with `placement="top"`, and shared select CSS is retargeted to `wa-*` elements/parts. Shared `selectTemplates` now emits `wa-option` for agent/model option lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6924306815679297fe4497e843a58895882915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->