### PR TITLE
feat(progress): migrate progressView selects to wa-select

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -17,6 +17,8 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
 
 // Local imports - shared styles
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -136,14 +138,13 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                       name="sparkle"
                       aria-hidden="true"
                     ></wa-icon>
-                    <vscode-single-select
+                    <wa-select
                       class="proposal-agent-dropdown"
-                      position="below"
                       .value=${currentAgent}
                       @change=${this.handleAgentSelectChange}
                     >
                       ${renderAgentOptions(agentOptions, currentAgent)}
-                    </vscode-single-select>
+                    </wa-select>
                   </div>
                 `
               : html`<span class="workflow-proposal__agent"
@@ -157,14 +158,13 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                       name="robot"
                       aria-hidden="true"
                     ></wa-icon>
-                    <vscode-single-select
+                    <wa-select
                       class="proposal-model-dropdown"
-                      position="below"
                       .value=${currentModel}
                       @change=${this.handleSelectChange}
                     >
                       ${renderModelOptions(modelOptions, currentModel)}
-                    </vscode-single-select>
+                    </wa-select>
                   </div>
                 `
               : html`<span class="workflow-proposal__model"

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -10,6 +10,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
 
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -170,27 +172,27 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                 <div class="followup__controls">
                   <label class="followup__field">
                     <span class="followup__label">Agent</span>
-                    <vscode-single-select
-                      position="above"
+                    <wa-select
+                      placement="top"
                       aria-label="Follow-up tool-use agent"
                       .value=${this.selectedAgent}
                       ?disabled=${agents.length === 0}
                       @change=${this.handleAgentChange}
                     >
                       ${renderAgentOptions(agents, this.selectedAgent)}
-                    </vscode-single-select>
+                    </wa-select>
                   </label>
                   <label class="followup__field">
                     <span class="followup__label">Model</span>
-                    <vscode-single-select
-                      position="above"
+                    <wa-select
+                      placement="top"
                       aria-label="Follow-up model"
                       .value=${this.selectedModel}
                       ?disabled=${models.length === 0}
                       @change=${this.handleModelChange}
                     >
                       ${renderModelOptions(models, this.selectedModel)}
-                    </vscode-single-select>
+                    </wa-select>
                   </label>
                 </div>
                 <vscode-textarea


### PR DESCRIPTION
Follow-up to #3669; closes the style gap on the deferred progressView consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI component swap: replaces `vscode-single-select` with `wa-select` in two progressView components, with minimal behavioral change aside from select positioning/placement attributes.
> 
> **Overview**
> Updates progressView dropdowns to use WebAwesome `wa-select` (and registers `wa-option`) instead of `vscode-single-select` in the proposal request panel and workflow tool-use follow-up section.
> 
> Adjusts select props from `position` to `placement` where applicable while keeping existing value binding and change handlers intact to close styling gaps in deferred progressView consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a90dd67dc51ff1abb5508a84d489aa33d82cb99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->