### PR TITLE
feat(settings): migrate form controls to wa-checkbox / wa-input / wa-details

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -21,6 +21,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - history view styles
 import { historyViewStyles } from './styles';
@@ -106,13 +107,24 @@ export class HistoryItem extends LitElement {
     }
   }
 
-  private handleToggle(event: CustomEvent<{ open?: boolean }>): void {
+  private handleShow(event: Event): void {
     if (!this.item) return;
-    const open = event.detail?.open ?? this.open;
+    if (event.target !== event.currentTarget) return;
     this.dispatchEvent(
       HistoryViewEvents.toggleItem({
         historyId: this.item.id,
-        open,
+        open: true,
+      }),
+    );
+  }
+
+  private handleHide(event: Event): void {
+    if (!this.item) return;
+    if (event.target !== event.currentTarget) return;
+    this.dispatchEvent(
+      HistoryViewEvents.toggleItem({
+        historyId: this.item.id,
+        open: false,
       }),
     );
   }
@@ -372,15 +384,16 @@ export class HistoryItem extends LitElement {
         </div>
         ${extraDetails.length
           ? html`
-              <vscode-collapsible
+              <wa-details
                 class="collapsible"
-                heading="More details"
+                summary="More details"
                 ?open=${this.open}
-                @vsc-collapsible-toggle=${this.handleToggle}
+                @wa-show=${this.handleShow}
+                @wa-hide=${this.handleHide}
                 data-id=${this.item.id}
               >
                 <div class="history-details extra-details">${extraDetails}</div>
-              </vscode-collapsible>
+              </wa-details>
             `
           : nothing}
       </div>

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -6,6 +6,8 @@
 // Third-party imports
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -34,7 +36,7 @@ export class SearchBar extends LitElement {
   }
 
   private handleInput(event: Event): void {
-    const target = event.currentTarget as HTMLInputElement | null;
+    const target = event.currentTarget as WaInput | null;
     const term = target?.value?.trim() ?? '';
     if (this.searchTimeoutId) {
       clearTimeout(this.searchTimeoutId);
@@ -69,14 +71,14 @@ export class SearchBar extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="search-container">
-        <vscode-textfield
+        <wa-input
           class="search-input"
           type="search"
           placeholder="Search history items..."
           .value=${this.searchTerm}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
-        ></vscode-textfield>
+        ></wa-input>
         <div class="search-controls action-button-group">
           ${renderIconActionButton({
             icon: 'chevron-up',

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -6,6 +6,7 @@
 import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -109,10 +110,9 @@ export class MemoryItem extends LitElement {
     }
   }
 
-  private handleContentsToggle(event: CustomEvent<{ open?: boolean }>): void {
-    if (event.detail?.open) {
-      this.contentsOpened = true;
-    }
+  private handleContentsShow(event: Event): void {
+    if (event.target !== event.currentTarget) return;
+    this.contentsOpened = true;
   }
 
   private renderMeta(item: MemoryViewItem): string {
@@ -166,10 +166,10 @@ export class MemoryItem extends LitElement {
         <div class="text-secondary memory-meta">
           ${this.renderMeta(this.item)}
         </div>
-        <vscode-collapsible
+        <wa-details
           class="collapsible"
-          heading="Contents"
-          @vsc-collapsible-toggle=${this.handleContentsToggle}
+          summary="Contents"
+          @wa-show=${this.handleContentsShow}
         >
           ${this.contentsOpened
             ? html`<div class="memory-preview">
@@ -180,7 +180,7 @@ export class MemoryItem extends LitElement {
                   : html`<em class="text-secondary">This note is empty.</em>`}
               </div>`
             : nothing}
-        </vscode-collapsible>
+        </wa-details>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
@@ -5,6 +5,8 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -34,7 +36,7 @@ export class MemoryToggle extends LitElement {
   @property({ attribute: false }) disabled = false;
 
   private handleChange(event: Event): void {
-    const target = event.currentTarget as HTMLInputElement | null;
+    const target = event.currentTarget as WaCheckbox | null;
     this.dispatchEvent(
       MemoryViewEvents.toggleEnabled({ enabled: Boolean(target?.checked) }),
     );
@@ -43,13 +45,13 @@ export class MemoryToggle extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="memory-settings">
-        <vscode-checkbox
+        <wa-checkbox
           ?checked=${this.enabled}
           ?disabled=${this.disabled}
           @change=${this.handleChange}
         >
           Enable memory for chat agents
-        </vscode-checkbox>
+        </wa-checkbox>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -16,6 +16,8 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 // Local imports - shared constants
 import {
@@ -218,10 +220,10 @@ export class ModelSelectionList extends LitElement {
 
     return html`
       <div class="model-row${unavailableClass}">
-        <vscode-checkbox
+        <wa-checkbox
           ?checked=${model.enabled}
           @change=${(e: Event) => {
-            const checked = (e.target as HTMLInputElement).checked;
+            const checked = (e.target as WaCheckbox).checked;
             this.dispatchEvent(
               ModelSelectionEvents.setModelEnabled({
                 modelName: model.name,
@@ -249,7 +251,7 @@ export class ModelSelectionList extends LitElement {
                 title=${EXPENSIVE_MODEL_HINT}
               ></wa-icon>`
             : nothing}
-        </vscode-checkbox>
+        </wa-checkbox>
         ${this.renderReasoningDropdown(model)}
         <span class="model-metadata">
           ${model.contextWindow
@@ -384,17 +386,17 @@ export class ModelSelectionList extends LitElement {
         <h2>Model Selection</h2>
         ${this.renderHelperModelDropdown()}
         <div class="short-names-toggle">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.preferShortModelNames}
             @change=${(e: Event) => {
-              const enabled = (e.target as HTMLInputElement).checked;
+              const enabled = (e.target as WaCheckbox).checked;
               this.dispatchEvent(
                 ModelSelectionEvents.setPreferShortModelNames({ enabled }),
               );
             }}
           >
             Use short model names
-          </vscode-checkbox>
+          </wa-checkbox>
           <span class="short-names-description">
             Send unpinned names (e.g. gpt-5.5 instead of gpt-5.5-2026-04-15)
           </span>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -14,6 +14,10 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - profile view styles and events
 import type {
@@ -97,10 +101,10 @@ export class ProviderKeyList extends LitElement {
   private renderDetailRow(entry: ProviderKeyStatus): TemplateResult {
     const streamingToggle = html`
       <div class="provider-setting">
-        <vscode-checkbox
+        <wa-checkbox
           ?checked=${entry.streaming}
           @change=${(e: Event) => {
-            const checked = (e.target as HTMLInputElement).checked;
+            const checked = (e.target as WaCheckbox).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setStreaming({
                 provider: entry.provider,
@@ -110,7 +114,7 @@ export class ProviderKeyList extends LitElement {
           }}
         >
           Streaming
-        </vscode-checkbox>
+        </wa-checkbox>
       </div>
     `;
 
@@ -118,12 +122,12 @@ export class ProviderKeyList extends LitElement {
       ? html`
           <div class="provider-setting">
             <label>Custom endpoint</label>
-            <vscode-textfield
+            <wa-input
               class="endpoint-input"
               .value=${entry.customEndpoint}
               placeholder="Leave blank for default"
               @change=${(e: Event) => {
-                const value = (e.target as HTMLInputElement).value.trim();
+                const value = (e.target as WaInput).value?.trim() ?? '';
                 this.dispatchEvent(
                   ProviderKeyEvents.setEndpoint({
                     provider: entry.provider,
@@ -131,7 +135,7 @@ export class ProviderKeyList extends LitElement {
                   }),
                 );
               }}
-            ></vscode-textfield>
+            ></wa-input>
           </div>
         `
       : nothing;
@@ -170,10 +174,10 @@ export class ProviderKeyList extends LitElement {
 
     return html`
       <div class="provider-setting provider-setting--block">
-        <vscode-checkbox
+        <wa-checkbox
           ?checked=${setting.value}
           @change=${(e: Event) => {
-            const checked = (e.target as HTMLInputElement).checked;
+            const checked = (e.target as WaCheckbox).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setVscodeSetting({
                 key: setting.key,
@@ -183,7 +187,7 @@ export class ProviderKeyList extends LitElement {
           }}
         >
           ${setting.label}
-        </vscode-checkbox>
+        </wa-checkbox>
         <span class="provider-setting-description">${setting.description}</span>
         ${warning}
       </div>
@@ -230,17 +234,17 @@ export class ProviderKeyList extends LitElement {
   private renderGlobalStreamingToggle(): TemplateResult {
     return html`
       <div class="global-streaming-toggle">
-        <vscode-checkbox
+        <wa-checkbox
           ?checked=${this.globalStreamingDefault}
           @change=${(e: Event) => {
-            const checked = (e.target as HTMLInputElement).checked;
+            const checked = (e.target as WaCheckbox).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setGlobalStreaming({ enabled: checked }),
             );
           }}
         >
           Enable streaming
-        </vscode-checkbox>
+        </wa-checkbox>
         <span class="global-streaming-description"
           >Global default for all providers</span
         >

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -261,7 +261,7 @@ export const profileViewStyles: CSSResult = css`
     border-radius: var(--border-radius);
   }
 
-  .global-streaming-toggle vscode-checkbox {
+  .global-streaming-toggle wa-checkbox {
     font-weight: var(--font-weight-medium);
   }
 
@@ -332,7 +332,7 @@ export const profileViewStyles: CSSResult = css`
     min-width: 120px;
   }
 
-  .provider-setting vscode-checkbox {
+  .provider-setting wa-checkbox {
     font-size: var(--font-size-sm);
     min-width: 120px;
   }
@@ -520,7 +520,7 @@ export const profileViewStyles: CSSResult = css`
     background: var(--texra-list-hoverBackground);
   }
 
-  .model-row vscode-checkbox {
+  .model-row wa-checkbox {
     flex: 1;
     min-width: 0;
     font-size: var(--font-size-sm);

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -5,8 +5,10 @@
 
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -224,7 +226,7 @@ export class ToolCard extends LitElement {
   }
 
   private handleToggle(e: Event): void {
-    const target = e.currentTarget as HTMLInputElement | null;
+    const target = e.currentTarget as WaCheckbox | null;
     this.dispatchEvent(
       createEvent('tool-toggle', {
         toolId: this.item.id,
@@ -395,7 +397,7 @@ export class ToolCard extends LitElement {
   private renderToggle(): TemplateResult | typeof nothing {
     if (!this.item.toggleable) return nothing;
     return html`
-      <vscode-checkbox
+      <wa-checkbox
         class="tool-toggle"
         title="${this.item.enabled !== false ? 'Disable' : 'Enable'} ${this.item
           .name} for agent runs"
@@ -405,7 +407,7 @@ export class ToolCard extends LitElement {
         @change=${this.handleToggle}
       >
         Use in runs
-      </vscode-checkbox>
+      </wa-checkbox>
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -13,6 +13,10 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared schemas
 import type { PRSubscriptionEntry } from '@shared/schemas/settingsViewMessages';
@@ -66,7 +70,7 @@ export class GitTab extends LitElement {
         font-size: var(--font-size-sm);
       }
 
-      .input-row vscode-textfield {
+      .input-row wa-input {
         flex: 1;
       }
 
@@ -179,7 +183,7 @@ export class GitTab extends LitElement {
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
   private handleMarkCommitsToggle(event: Event): void {
-    const target = event.target as HTMLInputElement | null;
+    const target = event.target as WaCheckbox | null;
     this.dispatchEvent(
       createEvent('git-mark-commits-toggle', {
         enabled: Boolean(target?.checked),
@@ -188,7 +192,7 @@ export class GitTab extends LitElement {
   }
 
   private handleAuthorNameChange(event: Event): void {
-    const target = event.target as HTMLInputElement | null;
+    const target = event.target as WaInput | null;
     const name = target?.value?.trim();
     if (name) {
       this.dispatchEvent(createEvent('git-author-name-change', { name }));
@@ -196,7 +200,7 @@ export class GitTab extends LitElement {
   }
 
   private handleAuthorEmailChange(event: Event): void {
-    const target = event.target as HTMLInputElement | null;
+    const target = event.target as WaInput | null;
     const email = target?.value?.trim();
     if (email) {
       this.dispatchEvent(createEvent('git-author-email-change', { email }));
@@ -383,13 +387,13 @@ export class GitTab extends LitElement {
           : nothing}
 
         <div class="setting-block">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.markCommits}
             ?disabled=${this.toggleDisabled}
             @change=${this.handleMarkCommitsToggle}
           >
             Mark commits with TeXRA author info
-          </vscode-checkbox>
+          </wa-checkbox>
           <p class="setting-description">
             When enabled, commits made by TeXRA agents are attributed to a
             custom author identity instead of your personal git config.
@@ -401,19 +405,19 @@ export class GitTab extends LitElement {
               <div class="setting-block">
                 <div class="input-row">
                   <label>Name</label>
-                  <vscode-textfield
+                  <wa-input
                     .value=${this.authorName}
                     placeholder=${DEFAULT_GIT_AUTHOR_NAME}
                     @change=${this.handleAuthorNameChange}
-                  ></vscode-textfield>
+                  ></wa-input>
                 </div>
                 <div class="input-row">
                   <label>Email</label>
-                  <vscode-textfield
+                  <wa-input
                     .value=${this.authorEmail}
                     placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
                     @change=${this.handleAuthorEmailChange}
-                  ></vscode-textfield>
+                  ></wa-input>
                 </div>
                 <p class="setting-description">
                   These values are set as GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -14,6 +14,10 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
@@ -250,13 +254,13 @@ export class MultiAgentTab extends LitElement {
   @state() private activePresetId: string | null = null;
 
   private emitToggle(eventName: string, event: Event): void {
-    const target = event.target as HTMLInputElement | null;
+    const target = event.target as WaCheckbox | null;
     this.dispatchEvent(
       createEvent(eventName, { enabled: Boolean(target?.checked) }),
     );
   }
 
-  private handleNestedDelegationMaxDepthChange(input: HTMLInputElement): void {
+  private handleNestedDelegationMaxDepthChange(input: WaInput): void {
     const parsed = Number(input.value);
     if (Number.isNaN(parsed)) {
       input.value = String(this.nestedDelegationMaxDepth);
@@ -285,7 +289,7 @@ export class MultiAgentTab extends LitElement {
 
   private handleReliabilityChange(
     setting: NumberVscodeSetting,
-    input: HTMLInputElement,
+    input: WaInput,
   ): void {
     const parsed = Number(input.value);
     if (Number.isNaN(parsed)) {
@@ -388,15 +392,15 @@ export class MultiAgentTab extends LitElement {
     return html`
       <div class="reliability-row">
         <label>${setting.label}</label>
-        <vscode-textfield
+        <wa-input
           class="reliability-input"
           type="number"
           .value=${String(setting.value)}
           min=${setting.min ?? nothing}
           max=${setting.max ?? nothing}
           @change=${(e: Event) =>
-            this.handleReliabilityChange(setting, e.target as HTMLInputElement)}
-        ></vscode-textfield>
+            this.handleReliabilityChange(setting, e.target as WaInput)}
+        ></wa-input>
         ${setting.unit
           ? html`<span class="reliability-unit">${setting.unit}</span>`
           : nothing}
@@ -474,13 +478,13 @@ export class MultiAgentTab extends LitElement {
         </p>
 
         <div class="setting-block">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.allowOrchestratorKill}
             @change=${(e: Event) =>
               this.emitToggle('allow-orchestrator-kill-toggle', e)}
           >
             Let orchestrator stop agents early
-          </vscode-checkbox>
+          </wa-checkbox>
           <p class="text-secondary setting-description">
             The orchestrator can cancel agents that are stuck or no longer
             needed. Turn this off if you want every agent to finish no matter
@@ -489,13 +493,13 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.detachSubagentsOnStop}
             @change=${(e: Event) =>
               this.emitToggle('detach-subagents-on-stop-toggle', e)}
           >
             Keep agents running if I stop the orchestrator
-          </vscode-checkbox>
+          </wa-checkbox>
           <p class="text-secondary setting-description">
             Normally everything stops when you stop the orchestrator. Turn this
             on to let agents that are mid-task finish on their own.
@@ -503,13 +507,13 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.worktreeSupport}
             @change=${(e: Event) =>
               this.emitToggle('worktree-support-toggle', e)}
           >
             Allow agents to work in git worktrees
-          </vscode-checkbox>
+          </wa-checkbox>
           <p class="text-secondary setting-description">
             When enabled, delegated agents can operate in git worktrees outside
             the main workspace. All tool calls within the subagent automatically
@@ -520,7 +524,7 @@ export class MultiAgentTab extends LitElement {
         <div class="setting-block">
           <div class="reliability-row">
             <label>Max delegation depth</label>
-            <vscode-textfield
+            <wa-input
               class="reliability-input"
               type="number"
               .value=${String(this.nestedDelegationMaxDepth)}
@@ -528,9 +532,9 @@ export class MultiAgentTab extends LitElement {
               max=${NESTED_DELEGATION_DEPTH_RANGE.max}
               @change=${(e: Event) =>
                 this.handleNestedDelegationMaxDepthChange(
-                  e.target as HTMLInputElement,
+                  e.target as WaInput,
                 )}
-            ></vscode-textfield>
+            ></wa-input>
           </div>
           <p class="reliability-description">
             Depth 1 (default): only the top-level orchestrator may delegate;

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -17,6 +17,8 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -308,7 +310,7 @@ export class ToolsTab extends LitElement {
   }
 
   private emitToggle(eventName: string, e: Event): void {
-    const target = e.target as HTMLInputElement | null;
+    const target = e.target as WaCheckbox | null;
     this.dispatchEvent(
       createEvent(eventName, { enabled: Boolean(target?.checked) }),
     );
@@ -354,12 +356,12 @@ export class ToolsTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <vscode-checkbox
+          <wa-checkbox
             ?checked=${this.bashApprovalEnabled}
             @change=${this.handleBashApprovalToggle}
           >
             Require approval for shell commands &amp; Codex sessions
-          </vscode-checkbox>
+          </wa-checkbox>
         </div>
       </div>
     `;
@@ -429,12 +431,12 @@ export class ToolsTab extends LitElement {
             are scrubbed before upload and performance tracing stays disabled.
           </p>
           <div class="desktop-settings-row">
-            <vscode-checkbox
+            <wa-checkbox
               ?checked=${this.desktopCrashReportingEnabled}
               @change=${this.handleDesktopCrashReportingToggle}
             >
               Enable native crash reporting
-            </vscode-checkbox>
+            </wa-checkbox>
             <wa-tag
               variant=${this.desktopCrashReportingConfigured
                 ? 'success'


### PR DESCRIPTION
## Summary

- Replace `vscode-checkbox` with `wa-checkbox` across 7 files (~13 instances): MemoryToggle, ToolCard, ToolsTab, GitTab, MultiAgentTab, ProviderKeyList, ModelSelectionList.
- Replace `vscode-textfield` with `wa-input` across 4 files (~6 instances): SearchBar, ProviderKeyList, MultiAgentTab, GitTab. Number / search / password types map cleanly to `wa-input`.
- Replace `vscode-collapsible` with `wa-details` in MemoryItem and HistoryItem; rewire `vsc-collapsible-toggle` handlers to `wa-show` / `wa-hide` (with `event.target !== event.currentTarget` guards).
- Update CSS selectors in `profile/styles.ts` (3 rules) and `tabs/GitTab.ts` (1 rule) from `vscode-checkbox` / `vscode-textfield` to `wa-checkbox` / `wa-input`.
- Type-narrow change-event targets to the imported `WaCheckbox` / `WaInput` classes; handle `wa-input.value` being `string | null` where needed.

## Test plan

- [x] `npm run typecheck` — no new errors (8 errors all pre-existing: openrouter SDK module resolution, electron types, etc.).
- [x] `npx vitest run` — 309/311 passing (the 2 failures are pre-existing on origin/main, related to wa-select needing DOM in vitest).
- [x] `cd packages/desktop && npx vite build --mode development` — succeeds.
- [ ] Manually verify checkbox toggles (memory, tools, multi-agent, git, provider keys, model selection) update settings correctly.
- [ ] Manually verify text inputs (git author name/email, search bar, provider custom endpoints, reliability inputs) commit on change.
- [ ] Manually verify collapsibles (memory item Contents, history item More details) open/close and remember state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps core settings UI controls to new Web Awesome components and event contracts, which could subtly break change/toggle behavior or collapsible state handling across multiple tabs. No backend/data model changes, but it touches several user-facing settings flows.
> 
> **Overview**
> Migrates settings-view form controls from VS Code web components to Web Awesome equivalents: `vscode-checkbox`→`wa-checkbox`, `vscode-textfield`→`wa-input`, and `vscode-collapsible`→`wa-details` across history, memory, profile, git, multi-agent, and tools UI.
> 
> Rewires event handling and typing to match the new components (e.g., `wa-show`/`wa-hide` instead of `vsc-collapsible-toggle`, plus `WaCheckbox`/`WaInput` target narrowing and `wa-input.value` null-safety), and updates a few CSS selectors to target the new tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316224bff0466f81a81e431039d5574512a46690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->