### PR TITLE
refactor(settings): post-3675 simplify pass

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -107,25 +107,12 @@ export class HistoryItem extends LitElement {
     }
   }
 
-  private handleShow(event: Event): void {
+  private dispatchToggle(event: Event, open: boolean): void {
     if (!this.item) return;
+    // Ignore wa-show/wa-hide bubbling up from any nested wa-details.
     if (event.target !== event.currentTarget) return;
     this.dispatchEvent(
-      HistoryViewEvents.toggleItem({
-        historyId: this.item.id,
-        open: true,
-      }),
-    );
-  }
-
-  private handleHide(event: Event): void {
-    if (!this.item) return;
-    if (event.target !== event.currentTarget) return;
-    this.dispatchEvent(
-      HistoryViewEvents.toggleItem({
-        historyId: this.item.id,
-        open: false,
-      }),
+      HistoryViewEvents.toggleItem({ historyId: this.item.id, open }),
     );
   }
 
@@ -388,8 +375,8 @@ export class HistoryItem extends LitElement {
                 class="collapsible"
                 summary="More details"
                 ?open=${this.open}
-                @wa-show=${this.handleShow}
-                @wa-hide=${this.handleHide}
+                @wa-show=${(e: Event) => this.dispatchToggle(e, true)}
+                @wa-hide=${(e: Event) => this.dispatchToggle(e, false)}
                 data-id=${this.item.id}
               >
                 <div class="history-details extra-details">${extraDetails}</div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -198,7 +198,9 @@ export class ModelSelectionList extends LitElement {
         <wa-option value=""> ${defaultLabel} </wa-option>
         ${REASONING_LEVELS.map(
           (level) => html`
-            <wa-option value=${level}> ${REASONING_LEVEL_LABELS[level]} </wa-option>
+            <wa-option value=${level}>
+              ${REASONING_LEVEL_LABELS[level]}
+            </wa-option>
           `,
         )}
       </wa-select>

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -531,9 +531,7 @@ export class MultiAgentTab extends LitElement {
               min=${NESTED_DELEGATION_DEPTH_RANGE.min}
               max=${NESTED_DELEGATION_DEPTH_RANGE.max}
               @change=${(e: Event) =>
-                this.handleNestedDelegationMaxDepthChange(
-                  e.target as WaInput,
-                )}
+                this.handleNestedDelegationMaxDepthChange(e.target as WaInput)}
             ></wa-input>
           </div>
           <p class="reliability-description">

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -376,11 +376,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="setting-row">
         <label>${label}</label>
-        <wa-select
-          class="setting-select"
-          .value=${value}
-          @change=${onChange}
-        >
+        <wa-select class="setting-select" .value=${value} @change=${onChange}>
           ${options.map(
             (opt) => html`
               <wa-option value=${opt.value}> ${opt.label} </wa-option>


### PR DESCRIPTION
## Summary
- Consolidate `HistoryItem`'s near-duplicate `handleShow`/`handleHide` handlers (introduced when migrating from `vscode-collapsible` to `wa-details` in #3675) into a single `dispatchToggle(event, open)` helper.
- The `currentTarget` guard against nested `wa-details` bubbling is now stated once, with a comment explaining its intent.
- Net -13 lines, no behavior change.

I evaluated the rest of the PR-3675 surface for shared-helper opportunities (e.g. a `getCheckboxValue(e)` / `getInputValue(e)` helper to absorb the repeated `as WaCheckbox | null` / `as WaInput | null` casts across 8 files) and decided against it: the call-site savings are 1 line each, and a helper would add an indirection layer the codebase otherwise avoids. The per-file casts are explicit and direct, which matches CLAUDE.md's "explicit over compact" guidance.

## Test plan
- [x] `npm run typecheck` passes.
- [x] `npx vitest run` — 311/311 pass (the 3 unhandled WA-SSR rejections are pre-existing and unrelated).
- [ ] Smoke-test the History tab in the settings view: expanding/collapsing the "More details" section still toggles correctly and the parent wrapper does not react to nested toggles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor and formatting-only template changes in settings UI components; behavior should remain the same aside from reduced duplicated event-handling code.
> 
> **Overview**
> **Simplifies History item expand/collapse wiring** by replacing separate `handleShow`/`handleHide` handlers with a single `dispatchToggle(event, open)` helper (including a clarified guard to ignore bubbled `wa-details` events).
> 
> Also applies minor template cleanups in a few settings components (`ModelSelectionList`, `MultiAgentTab`, `ToolsTab`) that only adjust markup formatting/line breaks without intended behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9840b52c764c86fefea1a0d22a9f47b2af600593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->