### PR TITLE
feat(styles): restore IDE-density compactness on wa- components

### DIFF
--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -22,6 +22,8 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
 import {
+  compactActionButtonStyles,
+  compactFormControlStyles,
   fileSelectLayoutStyles,
   toggleStyles,
 } from '../styles/fileSelectStyles';
@@ -31,6 +33,8 @@ export class LatexDiffsSection extends LitElement {
   static override styles = [
     designTokens,
     codiconStyles,
+    compactActionButtonStyles,
+    compactFormControlStyles,
     fileSelectLayoutStyles,
     toggleStyles,
     css`
@@ -57,13 +61,6 @@ export class LatexDiffsSection extends LitElement {
 
       .latexdiffs-section .file-select-header {
         margin-bottom: 0;
-      }
-
-      .latexdiffs-section wa-button {
-        width: var(--height-control);
-        height: var(--height-control);
-        min-width: var(--height-control);
-        min-height: var(--height-control);
       }
 
       .latexdiffs-section[data-expanded='true'] .optional-label,
@@ -196,7 +193,7 @@ export class LatexDiffsSection extends LitElement {
       <wa-button
         id=${id}
         class="action-icon-button"
-        appearance="outlined"
+        appearance="plain"
         variant="neutral"
         size="small"
         type="button"

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -21,6 +21,7 @@ import {
   type FileStateContextValue,
 } from '../contexts/mainViewContexts';
 import {
+  compactActionButtonStyles,
   fileSelectLayoutStyles,
   toggleStyles,
   multiFilesStyles,
@@ -31,19 +32,13 @@ export class OutputFilesSection extends LitElement {
   static override styles = [
     designTokens,
     codiconStyles,
+    compactActionButtonStyles,
     fileSelectLayoutStyles,
     toggleStyles,
     multiFilesStyles,
     css`
       :host {
         display: block;
-      }
-
-      .file-select-actions wa-button {
-        width: var(--height-control);
-        height: var(--height-control);
-        min-width: var(--height-control);
-        min-height: var(--height-control);
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -14,6 +14,15 @@ export const bannerStyles: CSSResult = css`
     margin-bottom: var(--spacing-large);
   }
 
+  /* Compact callout chrome — tighten WA default padding ~20%. */
+  wa-callout::part(message) {
+    padding-block: 6px;
+  }
+
+  wa-callout::part(icon) {
+    padding-inline-end: 8px;
+  }
+
   .banner-row {
     display: flex;
     flex-wrap: wrap;

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -11,6 +11,83 @@
 
 import { css } from 'lit';
 
+/** Compact wa-input / wa-select sizing — IDE-density form controls.
+ * WA defaults to ~38px tall; reduce to ~26px to match VS Code chrome.
+ * Keep selectors in sync with the canonical rules in
+ * `src/shared/styles/selectStyles.ts`. */
+export const compactFormControlStyles = css`
+  wa-select {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(combobox) {
+    min-height: 26px;
+    padding-block: 0;
+    padding-inline: var(--spacing-small);
+  }
+
+  wa-select::part(display-input) {
+    padding-block: 2px;
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(expand-icon) {
+    margin-inline-start: var(--spacing-tiny);
+  }
+
+  wa-input {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-input::part(base) {
+    min-height: 26px;
+    padding-block: 0;
+  }
+
+  wa-input::part(input) {
+    padding-block: 2px;
+  }
+`;
+
+/** Compact icon action button styles — duplicated from commonViewStyles
+ * so file-select components don't need to import the full common view sheet
+ * just to size their toolbar icons. Keep selectors in sync with the canonical
+ * rules in `src/shared/styles/commonViewStyles.ts`. */
+export const compactActionButtonStyles = css`
+  .action-icon-button::part(base) {
+    width: 22px;
+    min-width: 22px;
+    height: 22px;
+    min-height: 22px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--texra-icon-foreground, var(--texra-foreground));
+  }
+
+  .action-icon-button::part(base):hover {
+    background: var(
+      --texra-toolbar-hoverBackground,
+      var(--texra-list-hoverBackground)
+    );
+    color: var(--texra-foreground);
+  }
+
+  .action-icon-button:focus-visible::part(base) {
+    outline: var(--border-thin) solid var(--texra-focusBorder);
+    outline-offset: -1px;
+  }
+
+  .action-icon-button[disabled]::part(base) {
+    opacity: var(--opacity-disabled);
+    background: transparent;
+  }
+
+  .action-icon-button wa-icon {
+    font-size: var(--font-size);
+  }
+`;
+
 /** Core file-select layout styles. */
 export const fileSelectLayoutStyles = css`
   .file-select {
@@ -90,10 +167,7 @@ export const fileSelectLayoutStyles = css`
 
   .file-select-actions wa-button {
     opacity: var(--opacity-full);
-    width: var(--height-control);
-    height: var(--height-control);
-    min-width: var(--height-control);
-    min-height: var(--height-control);
+    flex-shrink: 0;
   }
 
   .file-select select,
@@ -309,6 +383,8 @@ export const dropdownStyles = css`
 
 /** Combined file-select styles for components that need all of them. */
 export const fileSelectStyles = [
+  compactActionButtonStyles,
+  compactFormControlStyles,
   fileSelectLayoutStyles,
   toggleStyles,
   multiFilesStyles,

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -92,20 +92,56 @@ export const commonViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
+  /* Compact action button (with text) — IDE-density chrome.
+   * Borderless by default; subtle hover surface; small font. */
   .action-button::part(base) {
     gap: var(--spacing-small);
+    min-height: var(--height-control);
+    padding: 0 var(--spacing-medium);
+    border: var(--border-thin) solid transparent;
+    background: transparent;
+    font-size: var(--font-size-sm);
+  }
+
+  .action-button::part(base):hover {
+    background: var(--texra-toolbar-hoverBackground, var(--texra-list-hoverBackground));
+    border-color: var(--texra-contrastBorder, transparent);
   }
 
   .action-button wa-icon {
     font-size: var(--font-size-sm);
   }
 
+  /* Compact icon-only action button — borderless, ~22px square.
+   * Mirrors VS Code toolbar icon density. */
   .action-icon-button::part(base) {
-    width: var(--height-button);
-    min-width: var(--height-button);
-    height: var(--height-button);
-    min-height: var(--height-button);
+    width: 22px;
+    min-width: 22px;
+    height: 22px;
+    min-height: 22px;
     padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--texra-icon-foreground, var(--texra-foreground));
+  }
+
+  .action-icon-button::part(base):hover {
+    background: var(--texra-toolbar-hoverBackground, var(--texra-list-hoverBackground));
+    color: var(--texra-foreground);
+  }
+
+  .action-icon-button:focus-visible::part(base) {
+    outline: var(--border-thin) solid var(--texra-focusBorder);
+    outline-offset: -1px;
+  }
+
+  .action-icon-button[disabled]::part(base) {
+    opacity: var(--opacity-disabled);
+    background: transparent;
+  }
+
+  .action-icon-button wa-icon {
+    font-size: var(--font-size);
   }
 
   .clickable-link {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -72,6 +72,40 @@ export const selectStyles: CSSResult = css`
     max-height: var(--height-large, 300px);
   }
 
+  /* Compact form controls — IDE-density inputs/selects.
+   * WA defaults to ~38px tall; reduce to ~26px to match VS Code chrome. */
+  wa-select {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(combobox) {
+    min-height: 26px;
+    padding-block: 0;
+    padding-inline: var(--spacing-small);
+  }
+
+  wa-select::part(display-input) {
+    padding-block: 2px;
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(expand-icon) {
+    margin-inline-start: var(--spacing-tiny);
+  }
+
+  wa-input {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-input::part(base) {
+    min-height: 26px;
+    padding-block: 0;
+  }
+
+  wa-input::part(input) {
+    padding-block: 2px;
+  }
+
   .api-key-missing {
     color: var(--texra-errorForeground);
     opacity: var(--opacity-full);

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -47,7 +47,7 @@ function renderActionButtonBase({
   title,
   action,
   className,
-  appearance = 'outlined',
+  appearance = 'plain',
   variant = 'neutral',
   disabled,
   onClick,


### PR DESCRIPTION
## Summary

Restore the VS Code IDE-density chrome that was lost in the recent wa-* migration. Action icons, selects, inputs, and callouts looked visibly chunkier than the vscode-elements they replaced.

User-visible improvements:
- File-slot action buttons (file/X/trash/+ icons) and the bottom-right instruction-panel icon row (sparkles/mic/eraser) now render as 22x22 borderless icons with a subtle hover background, instead of 30x30 outlined boxes.
- File-slot ``<wa-select>`` "None" boxes shrink from ~38px to ~26px tall.
- Callout banners get ~20% tighter internal padding.
- File-select rows now fit in roughly the same vertical space as the pre-migration vscode-elements version.

## Key changes

- `src/shared/wa/actionButtons.ts` — helper default `appearance` flipped from `outlined` to `plain`.
- `src/shared/styles/commonViewStyles.ts` — `.action-icon-button` shrinks to 22x22 borderless with subtle hover; `.action-button` becomes borderless-by-default with font-size-sm and 24px min-height.
- `src/shared/styles/selectStyles.ts` — `wa-select::part(combobox)`, `wa-select::part(display-input)`, and `wa-input::part(base)` reduced to 26px min-height with smaller display font.
- `packages/extension/src/webview/frontend/styles/fileSelectStyles.ts` — new `compactActionButtonStyles` + `compactFormControlStyles` bundles so file-select components get the same density without depending on `commonViewStyles`. Removed conflicting `--height-control` size overrides.
- `packages/extension/src/webview/frontend/styles/bannerStyles.ts` — `wa-callout::part(message)` and `::part(icon)` padding tightened.
- `OutputFilesSection.ts`, `LatexDiffsSection.ts` — drop bespoke `wa-button { width: var(--height-control)... }` in favor of the shared compact bundles.
- `LatexDiffsSection.ts` — raw `<wa-button>` switched from `appearance="outlined"` to `appearance="plain"`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` 311/311 pass (3 pre-existing unrelated WA jsdom unhandled rejections, no test failures)
- [x] `cd packages/desktop && npx vite build --mode development` succeeds
- [ ] Visual check: file-select action buttons should be 22x22 borderless with hover; selects ~26px tall; banners visibly tighter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to shared Web Awesome styling defaults (buttons, selects/inputs, callouts) and minor component-level style wiring, with no behavioral or data-flow modifications.
> 
> **Overview**
> Restores *IDE-density* styling for Web Awesome UI controls across the extension webview by making action buttons and form controls more compact.
> 
> Defaults `wa-button` action helpers (and `LatexDiffsSection`’s inline buttons) to `appearance="plain"`, and updates shared `.action-button` / `.action-icon-button` styles to be borderless with subtle hover/focus treatment and ~22px square icon buttons.
> 
> Adds compact `wa-select`/`wa-input` sizing (≈26px height) in shared select styles and introduces reusable `compactActionButtonStyles` + `compactFormControlStyles` for file-select components, removing prior per-component size overrides; also tightens `wa-callout` banner padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b86c8174bc3d15f0a20647b77079cd98b5277d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->