### PR TITLE
feat(webview,progress): retire last vscode-elements and codicon chevrons

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/split-panel/split-panel.js';
 
 // Local imports - shared webview
 import {
@@ -255,7 +256,7 @@ export class ProgressApp extends ProgressAppBase {
         font-size: 1em;
       }
 
-      vscode-split-layout {
+      wa-split-panel {
         display: flex;
         width: 100%;
         height: 100%;
@@ -336,7 +337,7 @@ export class ProgressApp extends ProgressAppBase {
         margin-top: var(--spacing-small);
       }
 
-      .desktop-empty-progress vscode-button::part(control) {
+      .desktop-empty-progress wa-button::part(base) {
         min-height: 32px;
       }
     `,
@@ -600,7 +601,7 @@ export class ProgressApp extends ProgressAppBase {
     const compactTabs = this.narrowLayout.get() && !isEditorMode;
     const hasAnyStreams = this.hasAnyStreams$.get();
     const splitPosition =
-      this.getAttribute('data-desktop-view') === 'progress' ? '68%' : '80%';
+      this.getAttribute('data-desktop-view') === 'progress' ? 68 : 80;
 
     return html`
       <div
@@ -675,7 +676,7 @@ export class ProgressApp extends ProgressAppBase {
         ${hasAnyStreams
           ? html`
               <div class="split-container">
-                <vscode-split-layout initial-handle-position=${splitPosition}>
+                <wa-split-panel .position=${splitPosition}>
                   <div
                     slot="start"
                     class="content-area"
@@ -698,7 +699,7 @@ export class ProgressApp extends ProgressAppBase {
                     @filter-change=${this.onFilterChange}
                     @delete-all=${this.onDeleteAll}
                   ></stream-tabs>
-                </vscode-split-layout>
+                </wa-split-panel>
               </div>
             `
           : this.renderEmptyState()}

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -10,6 +10,9 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import { query, state } from 'lit/decorators.js';
 
+// Side-effect imports - register WA textarea component
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+
 // Local imports - shared utilities
 import { FEEDBACK_ELIGIBLE_KINDS } from '@shared/utils/uiConstants';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
@@ -96,12 +99,12 @@ export abstract class BaseFeedbackPanel extends BaseRequestPanel {
 
     return html`
       <div class=${containerClass}>
-        <vscode-textarea
+        <wa-textarea
           class=${inputClass}
           placeholder=${placeholder}
           rows="3"
           data-feedback-input
-        ></vscode-textarea>
+        ></wa-textarea>
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -12,6 +12,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports
@@ -190,7 +191,7 @@ export class FileList extends LitElement {
         align-items: center;
       }
 
-      .file-actions :is(vscode-button, wa-button) {
+      .file-actions wa-button {
         margin-right: 0;
         margin-left: var(--spacing-tiny);
       }
@@ -314,8 +315,10 @@ export class FileList extends LitElement {
         ${this.failureByPath.size > 0
           ? html`
               <div class="compile-actions">
-                <vscode-button
-                  appearance="primary"
+                <wa-button
+                  appearance="filled"
+                  variant="brand"
+                  size="small"
                   @click=${this.runLatexFixer}
                 >
                   <wa-icon
@@ -325,7 +328,7 @@ export class FileList extends LitElement {
                     aria-hidden="true"
                   ></wa-icon>
                   Run latexFixer
-                </vscode-button>
+                </wa-button>
               </div>
             `
           : nothing}

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -26,6 +26,7 @@ import './QueuedFollowUps';
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/progress-ring/progress-ring.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 @customElement('follow-up-input')
 export class FollowUpInput extends LitElement {
@@ -81,7 +82,7 @@ export class FollowUpInput extends LitElement {
         height: auto;
       }
 
-      #followUpInput::part(control) {
+      #followUpInput::part(textarea) {
         min-height: 106px;
         max-height: var(--height-xlarge);
         width: 100%;
@@ -187,7 +188,7 @@ export class FollowUpInput extends LitElement {
           ></queued-follow-ups>
 
           <div class="follow-up-input-row">
-            <vscode-textarea
+            <wa-textarea
               id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
               placeholder="Send follow-up message"
               rows="10"
@@ -195,7 +196,7 @@ export class FollowUpInput extends LitElement {
               .value=${live(this.value)}
               @input=${this.handleInput}
               @keydown=${this.handleKeydown}
-            ></vscode-textarea>
+            ></wa-textarea>
 
             <div class="follow-up-actions">
               ${renderIconActionButton({
@@ -254,7 +255,7 @@ export class FollowUpInput extends LitElement {
 
     if (!this.textAreaEl || !this.visible) return;
 
-    // Focus the host element directly - vscode-textarea handles focus properly
+    // Focus the host element directly - wa-textarea handles focus properly
     this.textAreaEl.focus();
     if (options.scrollIntoView) {
       this.textAreaEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -33,6 +33,7 @@ import { permissionCardStyles } from '@shared/styles/permissionCardStyles';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
@@ -332,11 +333,11 @@ export class PermissionCard extends LitElement {
     return html`
       <div class="feedback-section">
         <label class="feedback-label">Rejection feedback (optional):</label>
-        <vscode-textarea
+        <wa-textarea
           class="feedback-input"
           placeholder="Why are you rejecting?"
           rows="2"
-        ></vscode-textarea>
+        ></wa-textarea>
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -14,6 +14,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 
 // Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
+import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
@@ -38,18 +40,7 @@ import { monacoLanguageForPath } from './monacoLanguage';
 export class ToolEditRequestPanel extends BaseFeedbackPanel {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
-  @state() private diffMenuOpen = false;
   @state() private inlineDiffOpen = false;
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    document.addEventListener('click', this.handleOutsideClick, true);
-  }
-
-  override disconnectedCallback(): void {
-    document.removeEventListener('click', this.handleOutsideClick, true);
-    super.disconnectedCallback();
-  }
 
   protected override handleExtraKey(key: string): boolean {
     if (key === 'd') {
@@ -128,29 +119,30 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
         })}
         ${showDropdown
           ? html`
-              <wa-button
-                class="action-icon-button diff-dropdown-trigger"
-                appearance="plain"
-                variant="neutral"
-                size="small"
-                type="button"
-                aria-haspopup="true"
-                aria-expanded=${this.diffMenuOpen ? 'true' : 'false'}
-                aria-label="More diff actions"
-                title="More diff actions"
-                @click=${this.toggleDiffMenu}
-              >
-                ${waIcon('chevron-down')}
-              </wa-button>
-              <vscode-context-menu
+              <wa-dropdown
                 class="diff-dropdown-menu"
-                ?show=${this.diffMenuOpen}
-                .data=${[
-                  { label: 'Preview', value: 'previewProposed' },
-                  { label: 'LaTeXdiff', value: 'showLatexdiff' },
-                ]}
-                @vsc-click=${this.handleMenuClick}
-              ></vscode-context-menu>
+                placement="bottom-end"
+                @wa-select=${this.handleMenuSelect}
+              >
+                <wa-button
+                  slot="trigger"
+                  class="action-icon-button diff-dropdown-trigger"
+                  appearance="plain"
+                  variant="neutral"
+                  size="small"
+                  type="button"
+                  aria-label="More diff actions"
+                  title="More diff actions"
+                >
+                  ${waIcon('chevron-down')}
+                </wa-button>
+                <wa-dropdown-item value="previewProposed">
+                  Preview
+                </wa-dropdown-item>
+                <wa-dropdown-item value="showLatexdiff">
+                  LaTeXdiff
+                </wa-dropdown-item>
+              </wa-dropdown>
             `
           : nothing}
       </div>
@@ -215,31 +207,11 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   // Diff menu handlers
   // ===========================================================================
 
-  private handleMenuClick = (event: CustomEvent): void => {
-    const action = event.detail?.value ?? '';
+  private handleMenuSelect = (event: CustomEvent<{ item: HTMLElement }>): void => {
+    const action =
+      (event.detail?.item as HTMLElement & { value?: string })?.value ?? '';
     if (!action) return;
-    this.diffMenuOpen = false;
     this.emitAction(action);
-  };
-
-  private handleOutsideClick = (event: MouseEvent): void => {
-    if (!this.diffMenuOpen) return;
-
-    const path = event.composedPath?.() ?? [];
-    const clickedInside = path.some(
-      (node) =>
-        node instanceof Element &&
-        (node.classList.contains('diff-dropdown') ||
-          node.classList.contains('diff-dropdown-menu')),
-    );
-    if (!clickedInside) {
-      this.diffMenuOpen = false;
-    }
-  };
-
-  private toggleDiffMenu = (event: MouseEvent): void => {
-    event.stopPropagation();
-    this.diffMenuOpen = !this.diffMenuOpen;
   };
 
   private handleDiffAction = (): void => {

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -207,7 +207,9 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   // Diff menu handlers
   // ===========================================================================
 
-  private handleMenuSelect = (event: CustomEvent<{ item: HTMLElement }>): void => {
+  private handleMenuSelect = (
+    event: CustomEvent<{ item: HTMLElement }>,
+  ): void => {
     const action =
       (event.detail?.item as HTMLElement & { value?: string })?.value ?? '';
     if (!action) return;

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -9,9 +9,11 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -88,7 +90,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
         color: var(--color-text-secondary);
       }
 
-      vscode-textarea {
+      wa-textarea {
         width: 100%;
       }
 
@@ -195,17 +197,19 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                     </wa-select>
                   </label>
                 </div>
-                <vscode-textarea
+                <wa-textarea
                   aria-label="Follow-up note"
                   placeholder="Ask what the tool-use agent should do with these results."
                   rows="3"
                   resize="vertical"
                   .value=${this.initialQuestion}
                   @input=${this.handleQuestionInput}
-                ></vscode-textarea>
+                ></wa-textarea>
                 <div class="followup__actions">
-                  <vscode-button
-                    appearance="secondary"
+                  <wa-button
+                    appearance="outlined"
+                    variant="neutral"
+                    size="small"
                     ?disabled=${!ready}
                     @click=${this.setupFollowup}
                   >
@@ -216,9 +220,11 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                       aria-hidden="true"
                     ></wa-icon>
                     Setup
-                  </vscode-button>
-                  <vscode-button
-                    appearance="primary"
+                  </wa-button>
+                  <wa-button
+                    appearance="filled"
+                    variant="brand"
+                    size="small"
                     ?disabled=${!ready}
                     @click=${this.runFollowup}
                   >
@@ -229,7 +235,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                       aria-hidden="true"
                     ></wa-icon>
                     Run
-                  </vscode-button>
+                  </wa-button>
                 </div>
               </div>
             `

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -207,7 +207,9 @@ export class FileSelectGroup extends LitElement {
    * (preventDefault), translate the toggle into a checkboxChange event,
    * and react to the auto-toggle wa-dropdown applies before this fires.
    */
-  private handleMenuSelect = (event: CustomEvent<{ item: HTMLElement }>): void => {
+  private handleMenuSelect = (
+    event: CustomEvent<{ item: HTMLElement }>,
+  ): void => {
     event.preventDefault();
     const item = event.detail?.item as
       | (HTMLElement & { value?: string; checked?: boolean })
@@ -238,8 +240,7 @@ export class FileSelectGroup extends LitElement {
           aria-label="Tool configuration options"
           title="Tool configuration options"
         >
-          ${waIcon('tools', { slot: 'start' })}
-          ${waIcon('chevron-down')}
+          ${waIcon('tools', { slot: 'start' })} ${waIcon('chevron-down')}
         </wa-button>
         <wa-dropdown-item
           type="checkbox"
@@ -284,8 +285,7 @@ export class FileSelectGroup extends LitElement {
           aria-label="Auto-extract options"
           title="Auto-extract options"
         >
-          ${waIcon('wand', { slot: 'start' })}
-          ${waIcon('chevron-down')}
+          ${waIcon('wand', { slot: 'start' })} ${waIcon('chevron-down')}
         </wa-button>
         <wa-dropdown-item
           type="checkbox"
@@ -329,8 +329,7 @@ export class FileSelectGroup extends LitElement {
                 <span class="file-name-main">${display.name}</span>
                 ${display.folder
                   ? html`<span class="file-folder">
-                      ${waIcon('folder')}
-                      ${display.folder}
+                      ${waIcon('folder')} ${display.folder}
                     </span>`
                   : nothing}
               </span>
@@ -366,10 +365,7 @@ export class FileSelectGroup extends LitElement {
     const chevronName = this.currentListVisible ? 'chevron-up' : 'chevron-down';
 
     return html`
-      <div
-        class="file-select"
-        data-expanded=${String(this.currentListVisible)}
-      >
+      <div class="file-select" data-expanded=${String(this.currentListVisible)}>
         <div class="file-select-header">
           <div class="file-select-label-group">
             ${renderIconActionButton({

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -1,20 +1,19 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
+import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 import { SortableController } from '@shared/controllers';
 import { designTokens, codiconStyles } from '@shared/styles';
 import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
-import { ensureContextMenuUsesSlot } from '@shared/utils/dom';
 import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
@@ -47,20 +46,8 @@ export class FileSelectGroup extends LitElement {
   @consume({ context: fileStateContext, subscribe: true })
   private fileState?: FileStateContextValue;
 
-  /** Auto-extract menu open state */
-  @state() private autoExtractMenuOpen = false;
-
-  /** Tool config menu open state */
-  @state() private toolConfigMenuOpen = false;
-
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
-
-  @query('#toolConfigOptions')
-  private toolConfigMenu?: HTMLElement;
-
-  @query('#autoExtractOptions')
-  private autoExtractMenu?: HTMLElement;
 
   private sortableController = new SortableController(
     this,
@@ -84,10 +71,6 @@ export class FileSelectGroup extends LitElement {
       this.sortableController.reinitialize();
     }
     this.wasExpanded = isExpanded;
-
-    // Workaround for vscode-context-menu slot rendering
-    ensureContextMenuUsesSlot(this.toolConfigMenu);
-    ensureContextMenuUsesSlot(this.autoExtractMenu);
   }
 
   private get listId(): string {
@@ -96,15 +79,6 @@ export class FileSelectGroup extends LitElement {
 
   private get selectId(): string {
     return `${this.config.type}File`;
-  }
-
-  private toggleMenu(type: 'autoExtract' | 'toolConfig'): void {
-    const wasOpen =
-      type === 'autoExtract'
-        ? this.autoExtractMenuOpen
-        : this.toolConfigMenuOpen;
-    this.autoExtractMenuOpen = type === 'autoExtract' && !wasOpen;
-    this.toolConfigMenuOpen = type === 'toolConfig' && !wasOpen;
   }
 
   private handleFileChange(value: string): void {
@@ -214,38 +188,6 @@ export class FileSelectGroup extends LitElement {
     return !SESSION_DEFAULTS[sessionType].fileInputEnabled;
   }
 
-  private handleFocusOut(event: FocusEvent): void {
-    const root = this.getRootNode();
-    const activeElement =
-      root instanceof Document || root instanceof ShadowRoot
-        ? root.activeElement
-        : null;
-    const nextTarget = (event.relatedTarget ?? activeElement) as Node | null;
-
-    if (nextTarget !== null && this.isWithinComponent(nextTarget)) return;
-    this.autoExtractMenuOpen = false;
-    this.toolConfigMenuOpen = false;
-  }
-
-  private isWithinComponent(target: Node): boolean {
-    if (this.contains(target) || this.shadowRoot?.contains(target)) {
-      return true;
-    }
-
-    const MAX_SHADOW_DEPTH = 20;
-    let root = target.getRootNode();
-    let depth = 0;
-    while (root instanceof ShadowRoot && depth < MAX_SHADOW_DEPTH) {
-      if (this.contains(root.host)) {
-        return true;
-      }
-      root = root.host.getRootNode();
-      depth++;
-    }
-
-    return false;
-  }
-
   private renderFileOptions(): TemplateResult {
     const sortedOptions = [...this.currentOptions].sort((a, b) =>
       a.localeCompare(b),
@@ -260,17 +202,30 @@ export class FileSelectGroup extends LitElement {
     `;
   }
 
+  /**
+   * Handle wa-select on the checkbox-type dropdown items: keep the menu open
+   * (preventDefault), translate the toggle into a checkboxChange event,
+   * and react to the auto-toggle wa-dropdown applies before this fires.
+   */
+  private handleMenuSelect = (event: CustomEvent<{ item: HTMLElement }>): void => {
+    event.preventDefault();
+    const item = event.detail?.item as
+      | (HTMLElement & { value?: string; checked?: boolean })
+      | undefined;
+    const id = item?.value;
+    if (!id) return;
+    this.handleCheckboxChange(id, Boolean(item?.checked));
+  };
+
   private renderToolConfigMenu(): TemplateResult {
-    const hasChecked =
-      this.currentCheckboxValues.attachTeXCount ||
-      this.currentCheckboxValues.attachDiagnostics;
-    const chevronClass = this.toolConfigMenuOpen
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
+    const values = this.currentCheckboxValues;
+    const hasChecked = values.attachTeXCount || values.attachDiagnostics;
+    const disabled = this.isFileInputDisabled;
 
     return html`
-      <div class="dropdown-container">
+      <wa-dropdown placement="bottom-start" @wa-select=${this.handleMenuSelect}>
         <wa-button
+          slot="trigger"
           id="toggleToolConfig"
           class=${classMap({
             'action-icon-button': true,
@@ -282,61 +237,41 @@ export class FileSelectGroup extends LitElement {
           type="button"
           aria-label="Tool configuration options"
           title="Tool configuration options"
-          aria-haspopup="true"
-          aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
-          @click=${() => this.toggleMenu('toolConfig')}
         >
           ${waIcon('tools', { slot: 'start' })}
-          <i class="codicon ${chevronClass}"></i>
+          ${waIcon('chevron-down')}
         </wa-button>
-        <vscode-context-menu
-          id="toolConfigOptions"
-          class="dropdown-menu"
-          ?show=${this.toolConfigMenuOpen}
+        <wa-dropdown-item
+          type="checkbox"
+          value="attachTeXCount"
+          ?checked=${values.attachTeXCount}
+          ?disabled=${disabled}
         >
-          <div class="dropdown-menu-content">
-            <wa-checkbox
-              id="attachTeXCount"
-              ?checked=${this.currentCheckboxValues.attachTeXCount}
-              ?disabled=${this.isFileInputDisabled}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'attachTeXCount',
-                  (event.target as WaCheckbox).checked,
-                )}
-            >
-              Attach TeX Count
-            </wa-checkbox>
-            <wa-checkbox
-              id="attachDiagnostics"
-              ?checked=${this.currentCheckboxValues.attachDiagnostics}
-              ?disabled=${this.isFileInputDisabled}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'attachDiagnostics',
-                  (event.target as WaCheckbox).checked,
-                )}
-            >
-              Attach Diagnostics
-            </wa-checkbox>
-          </div>
-        </vscode-context-menu>
-      </div>
+          Attach TeX Count
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          type="checkbox"
+          value="attachDiagnostics"
+          ?checked=${values.attachDiagnostics}
+          ?disabled=${disabled}
+        >
+          Attach Diagnostics
+        </wa-dropdown-item>
+      </wa-dropdown>
     `;
   }
 
   private renderAutoExtractMenu(): TemplateResult {
+    const values = this.currentCheckboxValues;
     const hasChecked =
-      this.currentCheckboxValues.autoExtractFigure ||
-      this.currentCheckboxValues.autoExtractTikzFigure ||
-      this.currentCheckboxValues.autoCompileInputPdf;
-    const chevronClass = this.autoExtractMenuOpen
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
+      values.autoExtractFigure ||
+      values.autoExtractTikzFigure ||
+      values.autoCompileInputPdf;
 
     return html`
-      <div class="dropdown-container">
+      <wa-dropdown placement="bottom-start" @wa-select=${this.handleMenuSelect}>
         <wa-button
+          slot="trigger"
           id="toggleAutoExtract"
           class=${classMap({
             'action-icon-button': true,
@@ -348,55 +283,32 @@ export class FileSelectGroup extends LitElement {
           type="button"
           aria-label="Auto-extract options"
           title="Auto-extract options"
-          aria-haspopup="true"
-          aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
-          @click=${() => this.toggleMenu('autoExtract')}
         >
           ${waIcon('wand', { slot: 'start' })}
-          <i class="codicon ${chevronClass}"></i>
+          ${waIcon('chevron-down')}
         </wa-button>
-        <vscode-context-menu
-          id="autoExtractOptions"
-          class="dropdown-menu"
-          ?show=${this.autoExtractMenuOpen}
+        <wa-dropdown-item
+          type="checkbox"
+          value="autoExtractFigure"
+          ?checked=${values.autoExtractFigure}
         >
-          <div class="dropdown-menu-content">
-            <wa-checkbox
-              id="autoExtractFigure"
-              ?checked=${this.currentCheckboxValues.autoExtractFigure}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoExtractFigure',
-                  (event.target as WaCheckbox).checked,
-                )}
-            >
-              Figures
-            </wa-checkbox>
-            <wa-checkbox
-              id="autoExtractTikzFigure"
-              ?checked=${this.currentCheckboxValues.autoExtractTikzFigure}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoExtractTikzFigure',
-                  (event.target as WaCheckbox).checked,
-                )}
-            >
-              TikZ Figures
-            </wa-checkbox>
-            <wa-checkbox
-              id="autoCompileInputPdf"
-              ?checked=${this.currentCheckboxValues.autoCompileInputPdf}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoCompileInputPdf',
-                  (event.target as WaCheckbox).checked,
-                )}
-            >
-              Compile Input PDF
-            </wa-checkbox>
-          </div>
-        </vscode-context-menu>
-      </div>
+          Figures
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          type="checkbox"
+          value="autoExtractTikzFigure"
+          ?checked=${values.autoExtractTikzFigure}
+        >
+          TikZ Figures
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          type="checkbox"
+          value="autoCompileInputPdf"
+          ?checked=${values.autoCompileInputPdf}
+        >
+          Compile Input PDF
+        </wa-dropdown-item>
+      </wa-dropdown>
     `;
   }
 
@@ -417,7 +329,7 @@ export class FileSelectGroup extends LitElement {
                 <span class="file-name-main">${display.name}</span>
                 ${display.folder
                   ? html`<span class="file-folder">
-                      <i class="codicon codicon-folder" aria-hidden="true"></i>
+                      ${waIcon('folder')}
                       ${display.folder}
                     </span>`
                   : nothing}
@@ -451,15 +363,12 @@ export class FileSelectGroup extends LitElement {
   override render(): TemplateResult {
     const { config } = this;
     const toggleId = `toggle${config.type[0].toUpperCase()}${config.type.slice(1)}Files`;
-    const chevronClass = this.currentListVisible
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
+    const chevronName = this.currentListVisible ? 'chevron-up' : 'chevron-down';
 
     return html`
       <div
         class="file-select"
         data-expanded=${String(this.currentListVisible)}
-        @focusout=${this.handleFocusOut}
       >
         <div class="file-select-header">
           <div class="file-select-label-group">
@@ -514,7 +423,7 @@ export class FileSelectGroup extends LitElement {
               aria-label=${config.toggleTitle}
               @click=${this.handleToggleList}
             >
-              <i class="codicon ${chevronClass}"></i>
+              ${waIcon(chevronName)}
             </button>
             ${renderIconActionButton({
               id: `addOpened${config.type[0].toUpperCase()}${config.type.slice(

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -248,9 +248,7 @@ export class LatexDiffsSection extends LitElement {
   }
 
   override render(): TemplateResult {
-    const chevronClass = this.visible
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
+    const chevronName = this.visible ? 'chevron-up' : 'chevron-down';
 
     return html`
       <div class="latexdiffs-section" data-expanded=${String(this.visible)}>
@@ -262,10 +260,10 @@ export class LatexDiffsSection extends LitElement {
               title="LaTeXDiffs"
               @click=${this.handleToggle}
             >
-              <i class="codicon ${chevronClass}"></i>
+              ${waIcon(chevronName)}
             </span>
             <span class="optional-label"
-              ><i class="codicon codicon-source-control"></i> LaTeXDiffs</span
+              >${waIcon('source-control')} LaTeXDiffs</span
             >
           </div>
         </div>

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -15,6 +15,7 @@ import { when } from 'lit/directives/when.js';
 import { SortableController } from '@shared/controllers';
 import { designTokens, codiconStyles } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
 import {
   fileStateContext,
@@ -140,9 +141,7 @@ export class OutputFilesSection extends LitElement {
   }
 
   override render(): TemplateResult {
-    const chevronClass = this.currentExpanded
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
+    const chevronName = this.currentExpanded ? 'chevron-up' : 'chevron-down';
 
     return html`
       <div class="file-select" data-expanded=${String(this.currentExpanded)}>
@@ -156,7 +155,7 @@ export class OutputFilesSection extends LitElement {
               aria-label="Show or hide additional files for the agent's output"
               @click=${this.handleToggle}
             >
-              <i class="codicon ${chevronClass}"></i>
+              ${waIcon(chevronName)}
             </button>
             <span
               class="optional-label"

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -271,7 +271,11 @@ export const requestPanelStyles: CSSResult = css`
     display: inline-flex;
   }
 
-  .approval-request__actions .diff-dropdown wa-dropdown[open] .diff-dropdown-trigger wa-icon {
+  .approval-request__actions
+    .diff-dropdown
+    wa-dropdown[open]
+    .diff-dropdown-trigger
+    wa-icon {
     transform: rotate(180deg);
   }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -264,22 +264,14 @@ export const requestPanelStyles: CSSResult = css`
       var(--texra-button-separator, var(--texra-input-border));
   }
 
+  /* wa-dropdown handles its own popup positioning, but we still want
+     the trigger button to lay out alongside the main diff button. */
   .approval-request__actions .diff-dropdown .diff-dropdown-menu {
-    position: absolute;
-    top: calc(100% + ${sp.tiny});
-    left: 0;
-    z-index: 100;
-    min-width: 150px;
-    display: block;
+    flex: 0 0 auto;
+    display: inline-flex;
   }
 
-  .approval-request__actions .diff-dropdown .diff-dropdown-menu:not([show]) {
-    display: none;
-  }
-
-  .approval-request__actions
-    .diff-dropdown-trigger[aria-expanded='true']
-    .codicon-chevron-down {
+  .approval-request__actions .diff-dropdown wa-dropdown[open] .diff-dropdown-trigger wa-icon {
     transform: rotate(180deg);
   }
 

--- a/src/shared/utils/dom.ts
+++ b/src/shared/utils/dom.ts
@@ -21,4 +21,3 @@ export function scrollToBottom(element: HTMLElement | null): void {
 
   element.scrollTop = element.scrollHeight;
 }
-

--- a/src/shared/utils/dom.ts
+++ b/src/shared/utils/dom.ts
@@ -22,30 +22,3 @@ export function scrollToBottom(element: HTMLElement | null): void {
   element.scrollTop = element.scrollHeight;
 }
 
-/**
- * Workaround for vscode-context-menu component quirk where it auto-creates
- * an empty data array that prevents rendering of slotted children.
- * Call this in updated() lifecycle after the element is created.
- */
-export function ensureContextMenuUsesSlot(
-  menu: Element | null | undefined,
-): void {
-  const contextMenu = menu as HTMLElement & {
-    data?: unknown[];
-    _data?: unknown[];
-    requestUpdate?: () => void;
-  };
-  if (
-    contextMenu?.tagName?.toLowerCase() === 'vscode-context-menu' &&
-    Array.isArray(contextMenu.data) &&
-    contextMenu.data.length === 0
-  ) {
-    try {
-      contextMenu.data = undefined;
-      contextMenu.requestUpdate?.();
-    } catch {
-      contextMenu._data = undefined;
-      contextMenu.requestUpdate?.();
-    }
-  }
-}


### PR DESCRIPTION
## Summary

Final-mile sweep that eliminates every remaining `vscode-elements` custom element and the last `codicon` chevron markers from the webview / progress / settings frontends.

### Migrations

- **`vscode-textarea` -> `wa-textarea`** (4 files): `FollowUpInput`, `BaseFeedbackPanel`, `PermissionCard`, `WorkflowToolUseFollowupSection`. The shared `@shared/utils/textarea` helper already supports both via shadow-DOM `<textarea>` lookup. CSS `::part(control)` -> `::part(textarea)`.
- **`vscode-button` -> `wa-button`** (3 sites): `FileList` (compile-fixer button), `ProgressApp` empty state, and the `WorkflowToolUseFollowupSection` Setup/Run buttons. Primary buttons use `appearance="filled" variant="brand"`; secondary buttons use `appearance="outlined" variant="neutral"`. Style selectors retargeted accordingly (`::part(control)` -> `::part(base)`).
- **`vscode-context-menu` -> `wa-dropdown` + `wa-dropdown-item`** (2 sites, 3 menus):
  - `ToolEditRequestPanel` diff dropdown (Preview / LaTeXdiff). The wa-dropdown handles open/close internally, so the manual `diffMenuOpen` state, the document-level `handleOutsideClick` listener, and the `toggleDiffMenu` handler are gone.
  - `FileSelectGroup` tool-config and auto-extract menus. Both menus use checkbox-type `wa-dropdown-item`s; the wa-select handler calls `event.preventDefault()` to keep the menu open across toggles. The bespoke `handleFocusOut` / `isWithinComponent` shadow-DOM walking, the per-menu `*MenuOpen` state, the `toggleMenu` helper, and the `ensureContextMenuUsesSlot` DOM workaround (in `src/shared/utils/dom.ts`) are all deleted.
- **`vscode-split-layout` -> `wa-split-panel`** (`ProgressApp`). The vscode element took an `initial-handle-position="68%"` string; wa-split-panel uses a numeric `position` (0-100), so the constants are 68 / 80 instead of `'68%'` / `'80%'`.
- **`<i class="codicon codicon-chevron-*">` -> `waIcon('chevron-up'|'chevron-down')`** in `LatexDiffsSection`, `OutputFilesSection`, and `FileSelectGroup`. The matching `source-control` and `folder` codicons are migrated to the `texra` wa-icon library on the same pass.

### Tradeoffs

- `wa-dropdown` positions its menu via `wa-popup` (floating UI) rather than the absolute-positioned absolute container the old `dropdown-container` CSS implemented. The `.dropdown-container` styles in `fileSelectStyles.ts` are kept (they still apply to the `.action-icon-button` triggers and to the `dropdown-menu-content` slot was inlined into items), but the `:not([show])` and `top: calc(100% + spacing-tiny)` rules are no longer needed for the file-select menus and the diff dropdown's absolute popup CSS in `requestPanelStyles.ts` was simplified to only style the trigger / chevron rotation.
- The `.diff-dropdown-trigger[aria-expanded='true']` rotation rule was rewritten to target `wa-dropdown[open] .diff-dropdown-trigger wa-icon` so the chevron still flips when the dropdown opens.

### Verification

- `grep -rn '<vscode-' packages/extension/src/` -> empty.
- `grep -rn '<i class="codicon\|<span class="codicon' packages/extension/src/{webview,progressView,settingsView}/frontend/` -> empty.
- `npm run typecheck` clean.
- `npx vitest run` -> 311/311 passing (the 3 unhandled rejections from `WaPopup` in jsdom are pre-existing and unchanged from origin/main).
- `npm run compile:fast` clean (settingsView + webview bundles).
- `cd packages/desktop && npx vite build --mode development` -> built in ~2s.

## Test plan

- [ ] Open the Progress view, switch streams via the split panel handle, confirm the divider is draggable and the layout reflows when toggling between sidebar (80) and editor (68) placement.
- [ ] Open a tool-edit approval with `isLatex=true`, click the diff dropdown chevron, choose Preview / LaTeXdiff, confirm the menu closes after selection and the chevron rotation animates while open.
- [ ] In the launcher, open the tool-config and auto-extract dropdowns; toggle each checkbox item and confirm the dropdown stays open while toggling and that `attachTeXCount` etc. round-trip into stored checkbox state.
- [ ] Submit a follow-up via the FollowUpInput wa-textarea; confirm Enter sends, Shift+Enter inserts newline, and the polish/transcribe insert path still works.
- [ ] Trigger a permission rejection that surfaces the feedback panel and confirm the wa-textarea receives focus and submits.
- [ ] In the workflow tool-use follow-up, click Setup / Run; confirm the buttons disable when no agent/model is ready.
- [ ] Generate output files with a compile failure and verify the "Run latexFixer" wa-button renders with the brand fill.
- [ ] In the LatexDiffs section and Output Files section, click the chevron toggles and confirm they flip orientation when expanding/collapsing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces core interactive UI primitives (split layout, dropdowns, textareas, buttons) in multiple webviews, which may subtly change focus, events, and layout behavior.
> 
> **Overview**
> Removes the last remaining `vscode-elements` usage in the progress and main webviews by migrating UI primitives to Web Awesome components.
> 
> `vscode-split-layout` is replaced with `wa-split-panel` (with numeric `.position`), `vscode-context-menu` menus are replaced with `wa-dropdown`/`wa-dropdown-item` (simplifying state/outside-click handling and adding a `@wa-select` mapping for checkbox items), and `vscode-textarea`/`vscode-button` instances are converted to `wa-textarea`/`wa-button` with updated `::part(...)` styling.
> 
> Also replaces remaining codicon chevron/folder/source-control markers with `waIcon(...)` and removes the now-unneeded `ensureContextMenuUsesSlot` DOM workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0df377b5faee21f63fbdb155035cf006ef2d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->