### PR TITLE
feat(ui): unify cross-host empty states, button heights, and heading scale

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -555,6 +555,9 @@ function explorerNoWorkspaceTemplate(): TemplateResult {
     icon: 'folder-open',
     title: 'No workspace',
     body: 'Open a folder before selecting files for agents.',
+    // Explorer is a subordinate sidebar; keep its title at h2 so it does not
+    // compete with the workbench's h1 main empty-state heading.
+    headingTag: 'h2',
     actions: [
       {
         label: 'Open Folder',

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -247,7 +247,7 @@ wa-tree.desktop-explorer-tree
 .desktop-explorer-empty .empty-state-title {
   margin: 12px 0 6px;
   color: var(--texra-foreground);
-  font-size: 16px;
+  font-size: var(--font-size-h2);
   font-weight: 600;
 }
 
@@ -384,7 +384,7 @@ wa-tree.desktop-explorer-tree
 .desktop-empty-workspace-panel .empty-state-title {
   margin: 20px 0 10px;
   color: var(--texra-foreground);
-  font-size: 24px;
+  font-size: var(--font-size-h1);
   font-weight: 600;
 }
 
@@ -423,7 +423,7 @@ wa-tree.desktop-explorer-tree
 .desktop-log-viewer-header h2 {
   margin: 0 0 4px;
   color: var(--texra-foreground);
-  font-size: 18px;
+  font-size: var(--font-size-h2);
   font-weight: 600;
 }
 
@@ -457,7 +457,9 @@ wa-tree.desktop-explorer-tree
 
 wa-button.desktop-primary-button::part(base),
 wa-button.desktop-secondary-button::part(base) {
-  min-height: 34px;
+  /* 30px matches the extension's --height-button so chrome buttons render
+     at the same visual scale across both hosts. */
+  min-height: 30px;
   padding: 0 14px;
   border-radius: 6px;
 }
@@ -507,7 +509,7 @@ wa-dialog.desktop-onboarding {
 .desktop-onboarding h1 {
   margin: 0;
   color: var(--texra-foreground);
-  font-size: 21px;
+  font-size: var(--font-size-h1);
   font-weight: 600;
 }
 

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -7,6 +7,13 @@
   --desktop-font-size: 13px;
   --desktop-font-weight: 400;
 
+  /* Heading scale shared with extension litStyles.ts. Use these tokens
+     instead of hardcoded heading sizes so extension and desktop hosts
+     render headings at the same visual scale. */
+  --font-size-h1: 1.5em;
+  --font-size-h2: 1.25em;
+  --font-size-h3: 1em;
+
   --desktop-color-background: light-dark(#ffffff, #1e1e1e);
   --desktop-color-foreground: light-dark(#1f2328, #d4d4d4);
   --desktop-color-muted: light-dark(#57606a, #a6a6a6);

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -43,6 +43,7 @@ import {
   registerTeXRAWebAwesomeIcons,
   TEXRA_ICON_LIBRARY,
 } from '@shared/wa/webAwesomeIcons';
+import { renderEmptyState } from '@shared/wa/emptyState';
 import { isProcessAgent } from '@shared/streams/agentKind';
 import '@shared/wa/tabs';
 import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
@@ -217,7 +218,7 @@ export class ProgressApp extends ProgressAppBase {
         background: var(--texra-editor-background, #fff);
       }
 
-      .progress-empty-kicker {
+      .progress-empty-panel .empty-state-kicker {
         display: inline-flex;
         align-items: center;
         gap: var(--spacing-small, 8px);
@@ -227,27 +228,28 @@ export class ProgressApp extends ProgressAppBase {
         font-weight: var(--font-weight-semibold, 600);
       }
 
-      .progress-empty-panel h2 {
+      .progress-empty-panel .empty-state-title {
         margin: 0 0 var(--spacing-small, 8px);
         color: var(--texra-foreground, #24292f);
-        font-size: var(--font-size-xl, 22px);
-        line-height: 1.25;
+        font-size: var(--font-size-h2, 1.25em);
+        font-weight: var(--font-weight-semibold, 600);
+        line-height: var(--line-height-heading, 1.25);
       }
 
-      .progress-empty-panel p {
+      .progress-empty-panel .empty-state-body {
         margin: 0;
         color: var(--color-text-secondary, #57606a);
         line-height: var(--line-height-normal, 1.5);
       }
 
-      .progress-empty-actions {
+      .progress-empty-panel .empty-state-actions {
         display: flex;
         flex-wrap: wrap;
         gap: var(--spacing-small, 8px);
         margin-top: var(--spacing-large, 16px);
       }
 
-      .progress-empty-actions wa-button::part(base) {
+      .progress-empty-panel .empty-state-actions wa-button::part(base) {
         min-height: var(--height-button, 30px);
       }
 
@@ -710,51 +712,27 @@ export class ProgressApp extends ProgressAppBase {
     return html`
       <section class="progress-empty-state">
         <div class="progress-empty-panel">
-          <div class="progress-empty-kicker">
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="robot"
-              variant="solid"
-            ></wa-icon>
-            Progress
-          </div>
-          <h2>No runs yet</h2>
-          <p>
-            Start an agent from the Launcher or Commands. New runs, streamed
-            logs, approvals, and follow-up controls will appear here.
-          </p>
-          <div class="progress-empty-actions">
-            <wa-button
-              appearance="filled"
-              variant="brand"
-              size="medium"
-              type="button"
-              @click=${this.onOpenLauncher}
-            >
-              <wa-icon
-                slot="start"
-                library=${TEXRA_ICON_LIBRARY}
-                name="play"
-                variant="solid"
-              ></wa-icon>
-              Open Launcher
-            </wa-button>
-            <wa-button
-              appearance="outlined"
-              variant="neutral"
-              size="medium"
-              type="button"
-              @click=${this.onOpenDashboard}
-            >
-              <wa-icon
-                slot="start"
-                library=${TEXRA_ICON_LIBRARY}
-                name="gear"
-                variant="solid"
-              ></wa-icon>
-              Open Dashboard
-            </wa-button>
-          </div>
+          ${renderEmptyState({
+            icon: 'robot',
+            kicker: 'Progress',
+            kickerIcon: 'robot',
+            title: 'No runs yet',
+            body: 'Start an agent from the Launcher or Commands. New runs, streamed logs, approvals, and follow-up controls will appear here.',
+            actions: [
+              {
+                label: 'Open Launcher',
+                appearance: 'filled',
+                variant: 'brand',
+                onClick: this.onOpenLauncher,
+              },
+              {
+                label: 'Open Dashboard',
+                appearance: 'outlined',
+                variant: 'neutral',
+                onClick: this.onOpenDashboard,
+              },
+            ],
+          })}
         </div>
       </section>
     `;

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -198,7 +198,9 @@ export class ModelSelectionList extends LitElement {
         <wa-option value=""> ${defaultLabel} </wa-option>
         ${REASONING_LEVELS.map(
           (level) => html`
-            <wa-option value=${level}> ${REASONING_LEVEL_LABELS[level]} </wa-option>
+            <wa-option value=${level}>
+              ${REASONING_LEVEL_LABELS[level]}
+            </wa-option>
           `,
         )}
       </wa-select>

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -531,9 +531,7 @@ export class MultiAgentTab extends LitElement {
               min=${NESTED_DELEGATION_DEPTH_RANGE.min}
               max=${NESTED_DELEGATION_DEPTH_RANGE.max}
               @change=${(e: Event) =>
-                this.handleNestedDelegationMaxDepthChange(
-                  e.target as WaInput,
-                )}
+                this.handleNestedDelegationMaxDepthChange(e.target as WaInput)}
             ></wa-input>
           </div>
           <p class="reliability-description">

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -376,11 +376,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="setting-row">
         <label>${label}</label>
-        <wa-select
-          class="setting-select"
-          .value=${value}
-          @change=${onChange}
-        >
+        <wa-select class="setting-select" .value=${value} @change=${onChange}>
           ${options.map(
             (opt) => html`
               <wa-option value=${opt.value}> ${opt.label} </wa-option>

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -39,6 +39,13 @@ export const designTokens: CSSResult = css`
     --font-size-xs: calc(var(--font-size) * 0.8);
     --font-size-icon: var(--font-size-lg);
     --font-size-icon-sm: var(--font-size);
+
+    /* Heading scale shared with desktop themeTokens.css. Use these tokens
+       instead of hardcoded heading sizes so extension and desktop hosts
+       render headings at the same visual scale. */
+    --font-size-h1: 1.5em;
+    --font-size-h2: 1.25em;
+    --font-size-h3: 1em;
     --line-height-tight: 1;
     --line-height-heading: 1.25;
     --line-height-normal: 1.4;

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -30,6 +30,12 @@ export interface EmptyStateOptions {
   // Defaults to 'h2'. Callers that own the surrounding semantic outline can
   // promote (h1) or demote (h3) the title without forking the helper.
   readonly headingTag?: EmptyStateHeadingTag;
+  // Optional eyebrow/kicker label rendered above the title. Used by callers
+  // that want a section badge (e.g. "Progress") without forking the helper.
+  readonly kicker?: string;
+  // Icon used inside the kicker. Defaults to the main `icon` prop so the
+  // helper stays minimal when callers want a simple eyebrow.
+  readonly kickerIcon?: TeXRAIconName;
 }
 
 const HEADING_TAGS = {
@@ -45,13 +51,24 @@ export function renderEmptyState({
   actions,
   className,
   headingTag = 'h2',
+  kicker,
+  kickerIcon,
 }: EmptyStateOptions): TemplateResult {
   const tag = HEADING_TAGS[headingTag] ?? HEADING_TAGS.h2;
   // staticHtml + literal lets the heading element stay parameterizable
   // (semantic outline) while keeping interpolated children type-checked.
   return staticHtml`
     <section class=${ifDefined(className)}>
-      ${waIcon(icon, { className: 'empty-state-icon' })}
+      ${
+        kicker
+          ? html`
+              <div class="empty-state-kicker">
+                ${waIcon(kickerIcon ?? icon, { className: 'empty-state-kicker-icon' })}
+                <span>${kicker}</span>
+              </div>
+            `
+          : waIcon(icon, { className: 'empty-state-icon' })
+      }
       <${tag} class="empty-state-title">${title}</${tag}>
       ${body ? html`<p class="empty-state-body">${body}</p>` : nothing}
       ${

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -63,7 +63,9 @@ export function renderEmptyState({
         kicker
           ? html`
               <div class="empty-state-kicker">
-                ${waIcon(kickerIcon ?? icon, { className: 'empty-state-kicker-icon' })}
+                ${waIcon(kickerIcon ?? icon, {
+                  className: 'empty-state-kicker-icon',
+                })}
                 <span>${kicker}</span>
               </div>
             `


### PR DESCRIPTION
## Summary

Frontend audit follow-up: unify a few cross-host UI inconsistencies between the VS Code extension webviews and the Electron desktop renderer so empty states, chrome buttons, and headings render at the same scale.

- Extend `renderEmptyState` (`src/shared/wa/emptyState.ts`) with optional `kicker` / `kickerIcon`. ProgressApp now consumes the shared helper instead of its own custom card; the local CSS just reuses the shared `.empty-state-*` class hooks.
- Token-ize headings: introduce `--font-size-h1/h2/h3` in both `src/shared/styles/litStyles.ts` and `packages/desktop/src/renderer/themeTokens.css` (1.5em / 1.25em / 1em scale). Desktop `styles.css` no longer hardcodes `21px` / `24px` / `18px` / `16px` for `desktop-onboarding`, `desktop-empty-workspace`, `desktop-log-viewer`, and `desktop-explorer-empty` headings.
- Unify chrome button heights to `30px` on desktop to match the extension's `--height-button: 30px` (was `34px` on `desktop-primary-button` / `desktop-secondary-button`).
- Workspace-explorer empty state now explicitly passes `headingTag: 'h2'` (was the default) so its title does not compete with the workbench's h1 main empty state when both render side-by-side.

## Test plan

- [x] `npm run typecheck` — no new errors in modified files (pre-existing OpenRouter / electron module-resolution errors are unchanged).
- [x] `npx vitest run` — 309 / 311 pass; the two failing tests are pre-existing macOS PATH-repair tests in `ElectronCompositionRoot.vitest.mts`, unrelated to this change.
- [x] `cd packages/desktop && npx vite build --mode development` — succeeds.
- [ ] Visual smoke: load extension Progress webview with no runs and confirm the empty state matches the previous "PROGRESS" kicker + h2 + two buttons layout.
- [ ] Visual smoke: launch desktop with no workspace and confirm `desktop-empty-workspace` (h1) and `desktop-explorer-empty` (h2) heading hierarchy is non-competing.
- [ ] Visual smoke: confirm desktop chrome buttons (Open Folder, Logs, Refresh) render at the 30px height matching the extension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/UI-only changes: refactors empty-state rendering and swaps hardcoded sizes for shared CSS tokens; primary risk is small layout/typography regressions across hosts.
> 
> **Overview**
> Unifies extension webview and Electron desktop *empty-state* UI by extending `renderEmptyState` with optional `kicker`/`kickerIcon` and updating the Progress view to use the shared helper (with CSS switched to `.empty-state-*` hooks).
> 
> Introduces shared heading size tokens (`--font-size-h1/h2/h3`) in both desktop `themeTokens.css` and extension `litStyles.ts`, then replaces several hardcoded heading font sizes in desktop styles to use these tokens.
> 
> Aligns desktop chrome button min-height to `30px` to match the extension, and explicitly sets the desktop explorer “No workspace” empty-state title to use `headingTag: 'h2'` for clearer semantic hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a8aa2a40e18dbd613b11bf9367971b29a9f9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->