### PR TITLE
feat(styles): motion polish on banners + InstructionPanel + collapsibles

### DIFF
--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,7 +1,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -18,6 +18,14 @@ export class AgentConfigBanner extends LitElement {
     visible: false,
   };
 
+  override updated(changed: PropertyValues<this>): void {
+    if (changed.has('state')) {
+      const visible = this.state.visible === true;
+      this.dataset.visible = visible ? 'true' : 'false';
+      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    }
+  }
+
   private handleAction(action: 'edit' | 'dir' | 'docs'): void {
     this.dispatchEvent(
       MainViewEvents.agentConfigAction({
@@ -27,51 +35,51 @@ export class AgentConfigBanner extends LitElement {
     );
   }
 
-  override render(): TemplateResult | typeof nothing {
-    if (!this.state.visible) return nothing;
-
+  override render(): TemplateResult {
     return html`
-      <wa-callout
-        id="agentConfigBanner"
-        variant="warning"
-        data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
-      >
-        ${waIcon('triangle-exclamation', { slot: 'icon' })}
-        <div class="banner-row">
-          <span>
-            ${this.state.agentName
-              ? `Agent file for "${this.state.agentName}" is missing.`
-              : 'Agent configuration is missing.'}
-          </span>
-          <div class="actions">
-            <wa-button
-              id="agentConfigEditButton"
-              appearance="plain"
-              size="small"
-              @click=${() => this.handleAction('edit')}
-            >
-              ${waIcon('pencil', { slot: 'start' })} Edit Agents
-            </wa-button>
-            <wa-button
-              id="agentConfigDirButton"
-              appearance="plain"
-              size="small"
-              @click=${() => this.handleAction('dir')}
-            >
-              ${waIcon('folder', { slot: 'start' })}
-              ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
-            </wa-button>
-            <wa-button
-              id="agentConfigDocButton"
-              appearance="plain"
-              size="small"
-              @click=${() => this.handleAction('docs')}
-            >
-              ${waIcon('book', { slot: 'start' })} Docs
-            </wa-button>
+      <div class="banner-frame">
+        <wa-callout
+          id="agentConfigBanner"
+          variant="warning"
+          data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
+        >
+          ${waIcon('triangle-exclamation', { slot: 'icon' })}
+          <div class="banner-row">
+            <span>
+              ${this.state.agentName
+                ? `Agent file for "${this.state.agentName}" is missing.`
+                : 'Agent configuration is missing.'}
+            </span>
+            <div class="actions">
+              <wa-button
+                id="agentConfigEditButton"
+                appearance="plain"
+                size="small"
+                @click=${() => this.handleAction('edit')}
+              >
+                ${waIcon('pencil', { slot: 'start' })} Edit Agents
+              </wa-button>
+              <wa-button
+                id="agentConfigDirButton"
+                appearance="plain"
+                size="small"
+                @click=${() => this.handleAction('dir')}
+              >
+                ${waIcon('folder', { slot: 'start' })}
+                ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
+              </wa-button>
+              <wa-button
+                id="agentConfigDocButton"
+                appearance="plain"
+                size="small"
+                @click=${() => this.handleAction('docs')}
+              >
+                ${waIcon('book', { slot: 'start' })} Docs
+              </wa-button>
+            </div>
           </div>
-        </div>
-      </wa-callout>
+        </wa-callout>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,7 +1,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -19,53 +19,61 @@ export class ApiKeyBanner extends LitElement {
     visible: false,
   };
 
+  override updated(changed: PropertyValues<this>): void {
+    if (changed.has('state')) {
+      const visible = this.state.visible === true;
+      this.dataset.visible = visible ? 'true' : 'false';
+      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    }
+  }
+
   private handleAction(action: 'set' | 'guide'): void {
     const provider = this.state.provider ?? '';
     this.dispatchEvent(MainViewEvents.apiKeyAction({ action, provider }));
   }
 
-  override render(): TemplateResult | typeof nothing {
-    if (!this.state.visible) return nothing;
-
+  override render(): TemplateResult {
     const provider = this.state.provider ?? '';
     const providerLabel = provider ? capitalize(provider) : '';
 
     return html`
-      <wa-callout id="apiKeyBanner" variant="warning">
-        ${waIcon('triangle-exclamation', { slot: 'icon' })}
-        <div class="banner-row">
-          <span>
-            ${provider
-              ? html`<strong>${providerLabel}</strong> API key missing.`
-              : 'TeXRA requires an API key to run.'}
-          </span>
-          <div class="actions">
-            <wa-button
-              id="apiKeyBannerButton"
-              appearance="plain"
-              size="small"
-              @click=${() => this.handleAction('set')}
-            >
-              ${waIcon('key', { slot: 'start' })}
-              ${provider ? 'Set Key' : 'Set API Key'}
-            </wa-button>
-            <wa-button
-              id="apiKeyGuideButton"
-              appearance="plain"
-              size="small"
-              @click=${() => this.handleAction('guide')}
-            >
-              ${waIcon('book', { slot: 'start' })}
-              ${provider ? 'Get Key' : 'API Key Guide'}
-            </wa-button>
+      <div class="banner-frame">
+        <wa-callout id="apiKeyBanner" variant="warning">
+          ${waIcon('triangle-exclamation', { slot: 'icon' })}
+          <div class="banner-row">
+            <span>
+              ${provider
+                ? html`<strong>${providerLabel}</strong> API key missing.`
+                : 'TeXRA requires an API key to run.'}
+            </span>
+            <div class="actions">
+              <wa-button
+                id="apiKeyBannerButton"
+                appearance="plain"
+                size="small"
+                @click=${() => this.handleAction('set')}
+              >
+                ${waIcon('key', { slot: 'start' })}
+                ${provider ? 'Set Key' : 'Set API Key'}
+              </wa-button>
+              <wa-button
+                id="apiKeyGuideButton"
+                appearance="plain"
+                size="small"
+                @click=${() => this.handleAction('guide')}
+              >
+                ${waIcon('book', { slot: 'start' })}
+                ${provider ? 'Get Key' : 'API Key Guide'}
+              </wa-button>
+            </div>
+            <span class="hint">
+              Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include
+              API access. You need a separate API key from the provider's
+              developer platform.
+            </span>
           </div>
-          <span class="hint">
-            Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include
-            API access. You need a separate API key from the provider's
-            developer platform.
-          </span>
-        </div>
-      </wa-callout>
+        </wa-callout>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -1,7 +1,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
@@ -38,6 +38,14 @@ export class DependencyBanner extends LitElement {
     visible: false,
   };
 
+  override updated(changed: PropertyValues<this>): void {
+    if (changed.has('state')) {
+      const visible = this.state.visible === true;
+      this.dataset.visible = visible ? 'true' : 'false';
+      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    }
+  }
+
   private handleDismiss(): void {
     this.dispatchEvent(MainViewEvents.dependencyDismiss());
   }
@@ -61,63 +69,64 @@ export class DependencyBanner extends LitElement {
     }
   }
 
-  override render(): TemplateResult | typeof nothing {
-    if (!this.state.visible) return nothing;
-
+  override render(): TemplateResult {
     const missing = this.state.missingTools ?? [];
     const tools = missing.flatMap((tool) =>
       tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
     );
 
     return html`
-      <wa-callout id="dependencyBanner" variant="warning">
-        ${waIcon('triangle-exclamation', { slot: 'icon' })}
-        <div class="banner-row">
-          <div class="missing-tools">
-            ${when(
-              tools.length === 0,
-              () => html`Missing dependencies: none`,
-              () =>
-                repeat(
-                  tools,
-                  (tool) => tool,
-                  (tool) => html`
-                    <div class="dependency-item">
-                      <span>${this.getToolLabel(tool)}</span>
-                      <wa-button
-                        class="dependency-install-button"
-                        appearance="plain"
-                        size="small"
-                        @click=${() => this.handleInstall(tool)}
-                      >
-                        ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
-                      </wa-button>
-                    </div>
-                  `,
-                ),
-            )}
+      <div class="banner-frame">
+        <wa-callout id="dependencyBanner" variant="warning">
+          ${waIcon('triangle-exclamation', { slot: 'icon' })}
+          <div class="banner-row">
+            <div class="missing-tools">
+              ${when(
+                tools.length === 0,
+                () => html`Missing dependencies: none`,
+                () =>
+                  repeat(
+                    tools,
+                    (tool) => tool,
+                    (tool) => html`
+                      <div class="dependency-item">
+                        <span>${this.getToolLabel(tool)}</span>
+                        <wa-button
+                          class="dependency-install-button"
+                          appearance="plain"
+                          size="small"
+                          @click=${() => this.handleInstall(tool)}
+                        >
+                          ${waIcon('cloud-arrow-down', { slot: 'start' })}
+                          Install
+                        </wa-button>
+                      </div>
+                    `,
+                  ),
+              )}
+            </div>
+            <div class="actions">
+              <wa-button
+                id="dependencyRecheckButton"
+                appearance="plain"
+                size="small"
+                @click=${this.handleRecheck}
+              >
+                ${waIcon('rotate-right', { slot: 'start' })} Re-check
+              </wa-button>
+              <wa-button
+                id="dependencyDismissButton"
+                appearance="plain"
+                size="small"
+                title="Dismiss (can be re-enabled in settings)"
+                @click=${this.handleDismiss}
+              >
+                ${waIcon('xmark', { slot: 'start' })} Dismiss
+              </wa-button>
+            </div>
           </div>
-          <div class="actions">
-            <wa-button
-              id="dependencyRecheckButton"
-              appearance="plain"
-              size="small"
-              @click=${this.handleRecheck}
-            >
-              ${waIcon('rotate-right', { slot: 'start' })} Re-check
-            </wa-button>
-            <wa-button
-              id="dependencyDismissButton"
-              appearance="plain"
-              size="small"
-              title="Dismiss (can be re-enabled in settings)"
-              @click=${this.handleDismiss}
-            >
-              ${waIcon('xmark', { slot: 'start' })} Dismiss
-            </wa-button>
-          </div>
-        </div>
-      </wa-callout>
+        </wa-callout>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,7 +1,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -44,62 +44,69 @@ export class GettingStartedBanner extends LitElement {
 
   @property({ type: Boolean }) visible = false;
 
+  override updated(changed: PropertyValues<this>): void {
+    if (changed.has('visible')) {
+      this.dataset.visible = this.visible ? 'true' : 'false';
+      this.setAttribute('aria-hidden', this.visible ? 'false' : 'true');
+    }
+  }
+
   private handleDismiss(): void {
     this.dispatchEvent(MainViewEvents.dismissGettingStarted());
   }
 
-  override render(): TemplateResult | typeof nothing {
-    if (!this.visible) return nothing;
-
+  override render(): TemplateResult {
     return html`
-      <wa-callout
-        id="gettingStartedBanner"
-        class="getting-started-banner"
-        variant="brand"
-      >
-        ${waIcon('lightbulb', { slot: 'icon' })}
-        <div class="getting-started-header">
-          <span>
-            <strong>Welcome to TeXRA!</strong> No LaTeX files here yet — pick
-            how you'd like to start:
-          </span>
-          <wa-button
-            appearance="plain"
-            size="small"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss getting started banner"
-            @click=${this.handleDismiss}
-          >
-            ${waIcon('xmark')}
-          </wa-button>
-        </div>
-        <ul class="getting-started-list">
-          <li>
-            <a href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}>
-              Run the setup assistant agent
-            </a>
-            -- checks tools, credentials, and LaTeX setup
-          </li>
-          <li>
-            <a href=${COMMAND_LINKS.GETTING_STARTED}>Walk me through setup</a>
-            -- takes a few minutes
-          </li>
-          <li>
-            <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}>
-              Try the sample project
-            </a>
-            -- play around risk-free
-          </li>
-          <li>
-            <a href=${COMMAND_LINKS.CLONE_OVERLEAF}>Pull from Overleaf</a>
-            -- import an existing project
-          </li>
-          <li>
-            <a href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>Grab from arXiv</a>
-            -- download a paper's source
-          </li>
-        </ul>
-      </wa-callout>
+      <div class="banner-frame">
+        <wa-callout
+          id="gettingStartedBanner"
+          class="getting-started-banner"
+          variant="brand"
+        >
+          ${waIcon('lightbulb', { slot: 'icon' })}
+          <div class="getting-started-header">
+            <span>
+              <strong>Welcome to TeXRA!</strong> No LaTeX files here yet — pick
+              how you'd like to start:
+            </span>
+            <wa-button
+              appearance="plain"
+              size="small"
+              title="Dismiss (can be re-enabled in settings)"
+              aria-label="Dismiss getting started banner"
+              @click=${this.handleDismiss}
+            >
+              ${waIcon('xmark')}
+            </wa-button>
+          </div>
+          <ul class="getting-started-list">
+            <li>
+              <a href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}>
+                Run the setup assistant agent
+              </a>
+              -- checks tools, credentials, and LaTeX setup
+            </li>
+            <li>
+              <a href=${COMMAND_LINKS.GETTING_STARTED}>Walk me through setup</a>
+              -- takes a few minutes
+            </li>
+            <li>
+              <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}>
+                Try the sample project
+              </a>
+              -- play around risk-free
+            </li>
+            <li>
+              <a href=${COMMAND_LINKS.CLONE_OVERLEAF}>Pull from Overleaf</a>
+              -- import an existing project
+            </li>
+            <li>
+              <a href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>Grab from arXiv</a>
+              -- download a paper's source
+            </li>
+          </ul>
+        </wa-callout>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -14,6 +14,7 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { keyed } from 'lit/directives/keyed.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
@@ -167,6 +168,16 @@ export class InstructionPanel extends LitElement {
         color: var(--texra-descriptionForeground);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
+        animation: session-hint-fade 150ms ease;
+      }
+
+      @keyframes session-hint-fade {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
       }
 
       .session-hint-lede {
@@ -301,12 +312,33 @@ export class InstructionPanel extends LitElement {
         max-width: var(--agent-model-listbox-max-width);
       }
 
-      .agent-select--hidden {
-        display: none;
+      /*
+       * Cross-fade between the workflow agent select and the tool-use agent
+       * select when the session toggles. Both selects stay in DOM; the
+       * inactive one collapses to zero height and removes itself from the
+       * tab/click order via visibility:hidden + tabindex/aria-hidden in the
+       * template. visibility transitions on a delay so it only flips once
+       * the opacity/height fade has finished.
+       */
+      .agent-select {
+        opacity: 0;
+        visibility: hidden;
+        max-height: 0;
+        overflow: hidden;
+        transition:
+          opacity 200ms ease,
+          max-height 200ms ease,
+          visibility 0s linear 200ms;
       }
 
       .agent-select--active {
-        display: block;
+        opacity: 1;
+        visibility: visible;
+        max-height: var(--height-large, 200px);
+        transition:
+          opacity 200ms ease,
+          max-height 200ms ease,
+          visibility 0s linear 0s;
       }
 
       /* Dropdowns in footer open upward */
@@ -317,16 +349,38 @@ export class InstructionPanel extends LitElement {
 
       .recording {
         color: var(--texra-errorForeground);
-        animation: pulse 1s infinite;
+        animation: pulse-record 1.2s ease-in-out infinite;
+        transform-origin: center;
       }
 
-      @keyframes pulse {
+      /*
+       * Reserve a fixed slot for the polish spinner so the toolbar layout
+       * doesn't jump when isPolishing toggles. Width matches the wa-spinner
+       * font-size (16px) used inside the slot.
+       */
+      .polish-spinner-slot {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        opacity: 0;
+        transition: opacity 150ms ease;
+      }
+
+      .polish-spinner-slot[aria-hidden='false'] {
+        opacity: 1;
+      }
+
+      @keyframes pulse-record {
         0%,
         100% {
           opacity: 1;
+          transform: scale(1);
         }
         50% {
           opacity: var(--opacity-disabled);
+          transform: scale(1.05);
         }
       }
     `,
@@ -357,28 +411,38 @@ export class InstructionPanel extends LitElement {
     return options.find((o) => o.value === selectedValue)?.hint ?? '';
   }
 
-  private renderSessionHint(
-    session: SessionContextValue,
-  ): TemplateResult | typeof nothing {
+  private renderSessionHint(session: SessionContextValue): unknown {
     if (!this.showSessionHint) return nothing;
 
-    const copy = SESSION_HINT_COPY[resolveSessionHintKey(session)];
-    return html`
-      <div class="session-hint" role="note" aria-label=${copy.ariaLabel}>
-        <span class="session-hint-lede">${copy.lede}</span>
-        <span class="session-hint-body">
-          ${copy.body}
-          <span class="session-hint-time">${copy.time}</span>
-        </span>
-        ${renderIconActionButton({
-          icon: 'close',
-          label: 'Dismiss this reminder',
-          title: 'Dismiss this reminder',
-          className: 'session-hint-dismiss',
-          onClick: this.handleDismissSessionHint,
-        })}
-      </div>
-    `;
+    const hintKey = resolveSessionHintKey(session);
+    const copy = SESSION_HINT_COPY[hintKey];
+    // `keyed` forces the wrapping div to be re-created when the hint key
+    // changes, which restarts the `session-hint-fade` CSS animation defined
+    // in the host stylesheet so copy swaps cross-fade instead of jump-cutting.
+    return keyed(
+      hintKey,
+      html`
+        <div
+          class="session-hint"
+          role="note"
+          data-hint-key=${hintKey}
+          aria-label=${copy.ariaLabel}
+        >
+          <span class="session-hint-lede">${copy.lede}</span>
+          <span class="session-hint-body">
+            ${copy.body}
+            <span class="session-hint-time">${copy.time}</span>
+          </span>
+          ${renderIconActionButton({
+            icon: 'close',
+            label: 'Dismiss this reminder',
+            title: 'Dismiss this reminder',
+            className: 'session-hint-dismiss',
+            onClick: this.handleDismissSessionHint,
+          })}
+        </div>
+      `,
+    );
   }
 
   private handleDismissSessionHint(): void {
@@ -542,16 +606,21 @@ export class InstructionPanel extends LitElement {
               disabled: session.isPolishing,
               action: 'polish',
             })}
-            ${session.isPolishing
-              ? html`
-                  <wa-spinner
-                    id="polishProgressContainer"
-                    style=${styleMap({
-                      fontSize: '16px',
-                    })}
-                  ></wa-spinner>
-                `
-              : nothing}
+            <span
+              class="polish-spinner-slot"
+              aria-hidden=${session.isPolishing ? 'false' : 'true'}
+            >
+              ${session.isPolishing
+                ? html`
+                    <wa-spinner
+                      id="polishProgressContainer"
+                      style=${styleMap({
+                        fontSize: '16px',
+                      })}
+                    ></wa-spinner>
+                  `
+                : nothing}
+            </span>
             ${renderIconActionButton({
               id: 'recordInstructionButton',
               icon: session.isRecording ? 'stop-circle' : 'mic',
@@ -600,8 +669,6 @@ export class InstructionPanel extends LitElement {
                     id="workflowAgent"
                     class=${classMap({
                       'agent-select': true,
-                      'agent-select--hidden':
-                        session.sessionType !== SESSION_TYPES.WORKFLOW,
                       'agent-select--active':
                         session.sessionType === SESSION_TYPES.WORKFLOW,
                     })}
@@ -631,8 +698,6 @@ export class InstructionPanel extends LitElement {
                     id="toolUseAgent"
                     class=${classMap({
                       'agent-select': true,
-                      'agent-select--hidden':
-                        session.sessionType !== SESSION_TYPES.TOOL_USE,
                       'agent-select--active':
                         session.sessionType === SESSION_TYPES.TOOL_USE,
                     })}

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -1,7 +1,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -39,6 +39,13 @@ export class LoginBanner extends LitElement {
 
   @property({ type: Boolean }) visible = false;
 
+  override updated(changed: PropertyValues<this>): void {
+    if (changed.has('visible')) {
+      this.dataset.visible = this.visible ? 'true' : 'false';
+      this.setAttribute('aria-hidden', this.visible ? 'false' : 'true');
+    }
+  }
+
   private handleSignIn(): void {
     this.dispatchEvent(MainViewEvents.signIn());
   }
@@ -47,40 +54,40 @@ export class LoginBanner extends LitElement {
     this.dispatchEvent(MainViewEvents.dismissLogin());
   }
 
-  override render(): TemplateResult | typeof nothing {
-    if (!this.visible) return nothing;
-
+  override render(): TemplateResult {
     return html`
-      <wa-callout id="loginBanner" variant="brand">
-        ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
-        <div class="banner-row">
-          <div class="banner-text">
-            <span class="banner-title">Researcher Access Program</span>
-            <span class="banner-description">${PROMO_NOTICE_SHORT}</span>
+      <div class="banner-frame">
+        <wa-callout id="loginBanner" variant="brand">
+          ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
+          <div class="banner-row">
+            <div class="banner-text">
+              <span class="banner-title">Researcher Access Program</span>
+              <span class="banner-description">${PROMO_NOTICE_SHORT}</span>
+            </div>
+            <div class="actions">
+              <wa-button
+                id="loginBannerButton"
+                appearance="filled"
+                variant="brand"
+                size="small"
+                @click=${this.handleSignIn}
+              >
+                ${waIcon('right-to-bracket', { slot: 'start' })} Sign In
+              </wa-button>
+              <wa-button
+                id="loginBannerDismissButton"
+                appearance="plain"
+                size="small"
+                title="Dismiss (can be re-enabled in settings)"
+                aria-label="Dismiss login banner"
+                @click=${this.handleDismiss}
+              >
+                ${waIcon('xmark')}
+              </wa-button>
+            </div>
           </div>
-          <div class="actions">
-            <wa-button
-              id="loginBannerButton"
-              appearance="filled"
-              variant="brand"
-              size="small"
-              @click=${this.handleSignIn}
-            >
-              ${waIcon('right-to-bracket', { slot: 'start' })} Sign In
-            </wa-button>
-            <wa-button
-              id="loginBannerDismissButton"
-              appearance="plain"
-              size="small"
-              title="Dismiss (can be re-enabled in settings)"
-              aria-label="Dismiss login banner"
-              @click=${this.handleDismiss}
-            >
-              ${waIcon('xmark')}
-            </wa-button>
-          </div>
-        </div>
-      </wa-callout>
+        </wa-callout>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -2,16 +2,58 @@
 // color, border, and padding; this stylesheet handles host display, the
 // bottom margin, and the row layout for the message + action buttons inside
 // the callout's default slot.
+//
+// Banners always render their wa-callout into the DOM and use the
+// `data-visible` attribute on the host (driven by the `visible` property /
+// equivalent state) to drive a CSS-only fade + height-collapse transition.
+// This avoids the abrupt mount/unmount jump from `if (!visible) return
+// nothing` while keeping JS out of the animation path.
 
 import { css, type CSSResult } from 'lit';
 
 export const bannerStyles: CSSResult = css`
   :host {
-    display: block;
+    /*
+     * 1fr/0fr grid trick collapses the banner's height as part of the
+     * fade-out so surrounding content slides up smoothly. The transition
+     * runs in both directions (open and dismiss) with no JS timers.
+     */
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 200ms ease;
+  }
+
+  :host([data-visible='true']) {
+    grid-template-rows: 1fr;
+  }
+
+  .banner-frame {
+    overflow: hidden;
+    min-height: 0;
   }
 
   wa-callout {
     margin-bottom: var(--spacing-large);
+    opacity: 0;
+    transform: translateY(-4px);
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease;
+    pointer-events: none;
+  }
+
+  :host([data-visible='true']) wa-callout {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  /*
+   * When the banner is hidden, drop its bottom margin so the layout fully
+   * collapses. The margin transition runs alongside the grid-row collapse.
+   */
+  :host(:not([data-visible='true'])) wa-callout {
+    margin-bottom: 0;
   }
 
   /* Compact callout chrome — tighten WA default padding ~20%. */

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -43,6 +43,12 @@ export const commonViewStyles: CSSResult = css`
     margin-top: var(--spacing-small);
   }
 
+  /*
+   * Legacy vscode-collapsible support: 'body' is the part name for that
+   * component. Long content historically clipped at --height-max; the grid
+   * trick below replaces the discrete max-height jump for wa-details
+   * ('content' part), which is the modern variant.
+   */
   .collapsible::part(body) {
     max-height: var(--height-medium);
     overflow: hidden;
@@ -51,6 +57,21 @@ export const commonViewStyles: CSSResult = css`
 
   .collapsible[open]::part(body) {
     max-height: var(--height-max);
+  }
+
+  .collapsible::part(content) {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 220ms ease;
+  }
+
+  .collapsible:not([open])::part(content) {
+    grid-template-rows: 0fr;
+  }
+
+  .collapsible::part(content) > * {
+    overflow: hidden;
+    min-height: 0;
   }
 
   /* Panel collapsible - consistent styling for collapsible panels */
@@ -68,6 +89,28 @@ export const commonViewStyles: CSSResult = css`
   .panel-collapsible::part(body),
   .panel-collapsible::part(content) {
     padding: 0 var(--spacing-small) var(--spacing-small);
+  }
+
+  /*
+   * Smooth open/close for the wa-details version of the panel using the
+   * grid 1fr/0fr trick so long content scales without a fixed max-height
+   * cap. wa-details exposes the body via the 'content' part. The direct
+   * child wrapper carries 'overflow: hidden' and 'min-height: 0' so the
+   * grid row can clamp it without truncation jumps.
+   */
+  .panel-collapsible::part(content) {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 220ms ease;
+  }
+
+  .panel-collapsible:not([open])::part(content) {
+    grid-template-rows: 0fr;
+  }
+
+  .panel-collapsible::part(content) > * {
+    overflow: hidden;
+    min-height: 0;
   }
 
   vscode-toolbar-container {


### PR DESCRIPTION
## Summary

Targeted motion polish pass across the main webview using Lit + CSS only — no JS animations.

### Surfaces touched

- **Banners** (`LoginBanner`, `GettingStartedBanner`, `ApiKeyBanner`, `AgentConfigBanner`, `DependencyBanner`): wa-callout now stays mounted; the host element toggles a \`data-visible\` attribute and animates with a grid 1fr/0fr collapse + opacity/translateY fade (180–200ms). Replaces \`if (!visible) return nothing\` pop-in/out.
- **Session hint cross-fade** (`InstructionPanel`): wrapped the hint in Lit's \`keyed()\` directive against the resolved hint key (\`workflow\` / \`toolUse\` / \`orchestrator\`) so a new node is created on session change, restarting a 150ms opacity keyframe.
- **Agent select swap** (`InstructionPanel`): replaced \`display:none\`/\`display:block\` with opacity + max-height + visibility transitions (visibility delayed 200ms when hiding, immediate when showing). Both selects stay in DOM; the inactive one collapses to height 0 cleanly.
- **wa-details panel-collapsible / collapsible** (`commonViewStyles.ts`): added the grid 1fr → 0fr pattern on \`::part(content)\` (wa-details' body part name) so long content scales without the discrete max-height jump. The legacy vscode-collapsible \`::part(body)\` rule is retained for backward compat.
- **Recording pulse** (`InstructionPanel`): added \`transform: scale(1) → scale(1.05)\` alongside the existing opacity pulse and switched easing to \`ease-in-out\` over 1.2s for more identity.
- **Polish spinner** (`InstructionPanel`): wrapped in a fixed 16×16 slot with opacity transition so toggling \`isPolishing\` no longer shifts the neighboring record/erase buttons.

### Implementation notes

- Banner host attribute is set in \`updated()\` from either \`visible\` (LoginBanner, GettingStartedBanner) or \`state.visible\` (ApiKeyBanner, AgentConfigBanner, DependencyBanner). \`aria-hidden\` mirrors the same value so screen readers respect the hidden state.
- All transitions use 150–220ms durations with \`ease\`/\`ease-in-out\` per the brief — considered, not flashy.

## Test plan

- [x] \`npm run typecheck\` — no new errors in modified files (pre-existing electron / openrouter-sdk module-resolution failures only).
- [x] \`npx vitest run\` — 309/311 passing; the 2 failures are pre-existing macOS PATH tests in \`ElectronCompositionRoot.vitest.mts\` unrelated to this change.
- [x] \`cd packages/desktop && npx vite build --mode development\` — succeeds.
- [ ] Visual sanity: open extension, toggle each banner, switch session toggle, expand/collapse a wa-details panel, start microphone recording, trigger polish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes UI rendering semantics (banners and agent selects stay mounted and are hidden via CSS/ARIA), which could cause layout or focus/assistive-tech regressions despite being style-focused.
> 
> **Overview**
> Adds CSS-driven motion/visibility behavior across the webview to avoid abrupt mount/unmount and layout jumps.
> 
> Banners now **always render** and toggle visibility via a host `data-visible` attribute + `aria-hidden`, using a new `banner-frame` wrapper and shared `bannerStyles` that animates opacity/translate and collapses height (grid 1fr/0fr) while disabling pointer events when hidden.
> 
> `InstructionPanel` gains small UX polish: session hint copy cross-fades by recreating the node with `keyed()`, workflow/tool-use agent pickers cross-fade instead of `display:none`, the recording indicator pulse is tweaked, and the polish spinner is put in a fixed-size slot to prevent toolbar shifting.
> 
> `commonViewStyles` updates collapsibles to animate `wa-details` content with the same grid collapse technique while retaining legacy `vscode-collapsible` max-height behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1885d0bd19278e83f40507f75ab042eb195285ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->