### PR TITLE
feat(styles): stricter compactness — minimalist hover, smaller icons, tighter forms

### DIFF
--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -14,13 +14,17 @@ export const bannerStyles: CSSResult = css`
     margin-bottom: var(--spacing-large);
   }
 
-  /* Compact callout chrome — tighten WA default padding ~20%. */
+  /* Compact callout chrome — stricter minimalism, tight banner padding. */
+  wa-callout {
+    --padding: 4px 8px;
+  }
+
   wa-callout::part(message) {
-    padding-block: 6px;
+    padding-block: 4px;
   }
 
   wa-callout::part(icon) {
-    padding-inline-end: 8px;
+    padding-inline-end: 6px;
   }
 
   .banner-row {

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -11,8 +11,8 @@
 
 import { css } from 'lit';
 
-/** Compact wa-input / wa-select sizing — IDE-density form controls.
- * WA defaults to ~38px tall; reduce to ~26px to match VS Code chrome.
+/** Compact wa-input / wa-select sizing — stricter IDE-density form controls.
+ * WA defaults to ~38px tall; reduce to ~22px to match minimal VS Code chrome.
  * Keep selectors in sync with the canonical rules in
  * `src/shared/styles/selectStyles.ts`. */
 export const compactFormControlStyles = css`
@@ -21,13 +21,17 @@ export const compactFormControlStyles = css`
   }
 
   wa-select::part(combobox) {
-    min-height: 26px;
+    min-height: 22px;
+    min-width: 0;
     padding-block: 0;
-    padding-inline: var(--spacing-small);
+    padding-inline: 6px;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
   }
 
   wa-select::part(display-input) {
-    padding-block: 2px;
+    padding-block: 1px;
+    padding-inline: 6px;
     font-size: var(--font-size-sm);
   }
 
@@ -40,58 +44,67 @@ export const compactFormControlStyles = css`
   }
 
   wa-input::part(base) {
-    min-height: 26px;
+    min-height: 22px;
     padding-block: 0;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
   }
 
   wa-input::part(input) {
-    padding-block: 2px;
+    padding-block: 1px;
+    padding-inline: 6px;
+    font-size: var(--font-size-sm);
   }
 `;
 
 /** Compact icon action button styles — duplicated from commonViewStyles
  * so file-select components don't need to import the full common view sheet
  * just to size their toolbar icons. Keep selectors in sync with the canonical
- * rules in `src/shared/styles/commonViewStyles.ts`. */
+ * rules in `src/shared/styles/commonViewStyles.ts`.
+ *
+ * Stricter minimalism: 20×20, opacity-driven hover (no fill swap). */
 export const compactActionButtonStyles = css`
   .action-icon-button::part(base) {
-    width: 22px;
-    min-width: 22px;
-    height: 22px;
-    min-height: 22px;
+    width: 20px;
+    min-width: 0;
+    height: 20px;
+    min-height: 0;
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--texra-icon-foreground, var(--texra-foreground));
+    color: var(
+      --wa-color-text-quiet,
+      var(--texra-icon-foreground, var(--texra-foreground))
+    );
+    opacity: var(--opacity-subtle);
+    transition: opacity 120ms ease;
   }
 
   .action-icon-button::part(base):hover {
-    background: var(
-      --texra-toolbar-hoverBackground,
-      var(--texra-list-hoverBackground)
-    );
-    color: var(--texra-foreground);
+    opacity: var(--opacity-full);
+    background: transparent;
   }
 
   .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--texra-focusBorder);
-    outline-offset: -1px;
+    outline: var(--border-thin) solid
+      var(--wa-color-focus, var(--texra-focusBorder));
+    outline-offset: 1px;
   }
 
   .action-icon-button[disabled]::part(base) {
-    opacity: var(--opacity-disabled);
+    opacity: 0.35;
     background: transparent;
   }
 
   .action-icon-button wa-icon {
-    font-size: var(--font-size);
+    font-size: 13px;
   }
 `;
 
 /** Core file-select layout styles. */
 export const fileSelectLayoutStyles = css`
   .file-select {
-    margin-bottom: var(--spacing-large);
+    margin-bottom: var(--spacing-small);
   }
 
   .file-select:has(.optional-label) {
@@ -104,8 +117,9 @@ export const fileSelectLayoutStyles = css`
     align-items: center;
     margin-bottom: var(--spacing-small);
     flex-wrap: nowrap;
-    line-height: var(--line-height-relaxed);
+    line-height: var(--line-height-normal);
     gap: var(--spacing-small);
+    min-height: 22px;
   }
 
   .file-select-header > wa-button {
@@ -130,7 +144,7 @@ export const fileSelectLayoutStyles = css`
     flex-wrap: nowrap;
     flex: 1;
     min-width: 0;
-    min-height: var(--height-control);
+    min-height: 22px;
   }
 
   .file-select-label-group wa-button {
@@ -190,7 +204,7 @@ export const toggleStyles = css`
     min-width: calc(var(--width-button-min) * 2);
     display: flex;
     align-items: center;
-    height: var(--height-control);
+    height: 22px;
   }
 
   .toggle-icon {
@@ -202,7 +216,7 @@ export const toggleStyles = css`
     color: var(--text-color);
     display: flex;
     align-items: center;
-    height: var(--height-control);
+    height: 22px;
     background: none;
     border: none;
   }

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -92,56 +92,76 @@ export const commonViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
-  /* Compact action button (with text) — IDE-density chrome.
-   * Borderless by default; subtle hover surface; small font. */
+  /* Compact action button (with text) — stricter IDE-density chrome.
+   * Borderless default; hover adds a subtle border (no fill swap). */
   .action-button::part(base) {
     gap: var(--spacing-small);
-    min-height: var(--height-control);
-    padding: 0 var(--spacing-medium);
+    min-height: 22px;
+    padding: 0 6px;
     border: var(--border-thin) solid transparent;
     background: transparent;
     font-size: var(--font-size-sm);
   }
 
   .action-button::part(base):hover {
-    background: var(--texra-toolbar-hoverBackground, var(--texra-list-hoverBackground));
-    border-color: var(--texra-contrastBorder, transparent);
+    background: transparent;
+    border-color: var(--wa-color-surface-border, var(--color-border));
   }
 
   .action-button wa-icon {
     font-size: var(--font-size-sm);
   }
 
-  /* Compact icon-only action button — borderless, ~22px square.
-   * Mirrors VS Code toolbar icon density. */
+  /* Compact icon-only action button — stricter minimalism.
+   * 20×20, no hover fill, opacity-driven hover/disabled. */
   .action-icon-button::part(base) {
-    width: 22px;
-    min-width: 22px;
-    height: 22px;
-    min-height: 22px;
+    width: 20px;
+    min-width: 0;
+    height: 20px;
+    min-height: 0;
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--texra-icon-foreground, var(--texra-foreground));
+    color: var(--wa-color-text-quiet, var(--texra-icon-foreground, var(--texra-foreground)));
+    opacity: var(--opacity-subtle);
+    transition: opacity 120ms ease;
   }
 
   .action-icon-button::part(base):hover {
-    background: var(--texra-toolbar-hoverBackground, var(--texra-list-hoverBackground));
-    color: var(--texra-foreground);
+    opacity: var(--opacity-full);
+    background: transparent;
   }
 
   .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--texra-focusBorder);
-    outline-offset: -1px;
+    outline: var(--border-thin) solid var(--wa-color-focus, var(--texra-focusBorder));
+    outline-offset: 1px;
   }
 
   .action-icon-button[disabled]::part(base) {
-    opacity: var(--opacity-disabled);
+    opacity: 0.35;
     background: transparent;
   }
 
   .action-icon-button wa-icon {
-    font-size: var(--font-size);
+    font-size: 13px;
+  }
+
+  /* Stricter compactness for wa-checkbox / wa-radio — smaller label,
+   * tighter gap between control and label. */
+  wa-checkbox,
+  wa-radio {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-checkbox::part(label),
+  wa-radio::part(label) {
+    font-size: var(--font-size-sm);
+    padding-inline-start: var(--spacing-small);
+  }
+
+  wa-checkbox::part(base),
+  wa-radio::part(base) {
+    gap: var(--spacing-small);
   }
 
   .clickable-link {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -72,20 +72,25 @@ export const selectStyles: CSSResult = css`
     max-height: var(--height-large, 300px);
   }
 
-  /* Compact form controls — IDE-density inputs/selects.
-   * WA defaults to ~38px tall; reduce to ~26px to match VS Code chrome. */
+  /* Compact form controls — stricter IDE-density inputs/selects.
+   * WA defaults to ~38px tall; reduce to ~22px for minimal VS Code chrome.
+   * Border uses subtle surface-border, not heavier panel border. */
   wa-select {
     font-size: var(--font-size-sm);
   }
 
   wa-select::part(combobox) {
-    min-height: 26px;
+    min-height: 22px;
+    min-width: 0;
     padding-block: 0;
-    padding-inline: var(--spacing-small);
+    padding-inline: 6px;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
   }
 
   wa-select::part(display-input) {
-    padding-block: 2px;
+    padding-block: 1px;
+    padding-inline: 6px;
     font-size: var(--font-size-sm);
   }
 
@@ -98,12 +103,16 @@ export const selectStyles: CSSResult = css`
   }
 
   wa-input::part(base) {
-    min-height: 26px;
+    min-height: 22px;
     padding-block: 0;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
   }
 
   wa-input::part(input) {
-    padding-block: 2px;
+    padding-block: 1px;
+    padding-inline: 6px;
+    font-size: var(--font-size-sm);
   }
 
   .api-key-missing {

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -4,6 +4,7 @@ export const waTabThemeTokenStyles: CSSResult = css`
   --track-width: var(--border-thin);
   --track-color: var(--color-border);
   --indicator-color: var(--texra-focusBorder);
+  --indicator-width: 1.5px;
 `;
 
 export const viewTabStyles: CSSResult = css`
@@ -15,5 +16,15 @@ export const viewTabStyles: CSSResult = css`
 
   .view-header wa-tab-group.view-tabs::part(body) {
     display: none;
+  }
+
+  /* Stricter compactness — small font, tight vertical padding. */
+  wa-tab {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-tab::part(base) {
+    padding-block: 4px;
+    padding-inline: var(--spacing-medium);
   }
 `;


### PR DESCRIPTION
## Summary

Follow-up to #3678. The previous pass landed on 22-26px controls with
considered IDE chrome, but still felt like "breathing-room" UI rather
than the stricter vscode-elements minimalism. This PR tightens the
density further — opacity-driven hover (no fill swaps), smaller icon
buttons, single 22px baseline across form controls, and reduced
banner/tab/checkbox padding.

### px deltas

| Surface | Before (#3678) | After |
| --- | --- | --- |
| `.action-icon-button` | 22×22, hover background fill | **20×20**, opacity 0.7 → 1 (no fill) |
| `.action-icon-button` icon | inherited (`--font-size`) | 13px |
| `.action-icon-button[disabled]` | `--opacity-disabled` (0.5) | **0.35** |
| `.action-icon-button` focus | outline-offset −1px | outline-offset +1px |
| `.action-button` | min-height 24, padding 0 8 | **22**, padding 0 6 |
| `.action-button` hover | background fill | subtle 1px border (no fill) |
| `wa-input::part(base)` | min-height 26 | **22**, subtle `--wa-color-surface-border` |
| `wa-input::part(input)` | padding-block 2 | padding-block 1, padding-inline 6 |
| `wa-select::part(combobox)` | min-height 26 | **22**, min-width 0, padding-inline 6 |
| `wa-select::part(display-input)` | padding-block 2 | padding-block 1, padding-inline 6 |
| `wa-callout::part(message)` | padding-block 6 | **4** |
| `wa-callout::part(icon)` | padding-inline-end 8 | **6** |
| `wa-callout` outer | (default) | `--padding: 4px 8px` |
| `wa-checkbox` / `wa-radio` label | inherited | `--font-size-sm`, gap `--spacing-small` |
| `wa-tab` | inherited | `--font-size-sm`, padding-block 4 |
| `wa-tab-group` indicator | (default) | 1.5px |
| File-select row gap | `--spacing-large` (12) | `--spacing-small` (4) |
| `.file-select-label-group`, `.optional-label`, `.toggle-icon` | 24 (`--height-control`) | 22 |

### Files touched

- `src/shared/styles/commonViewStyles.ts` — `.action-icon-button`,
  `.action-button`, new `wa-checkbox`/`wa-radio` rules.
- `src/shared/styles/selectStyles.ts` — canonical wa-input/wa-select
  compactness.
- `src/shared/styles/viewTabStyles.ts` — wa-tab + indicator width.
- `packages/extension/src/webview/frontend/styles/fileSelectStyles.ts`
  — duplicated icon-button + form-control rules, row layout heights.
- `packages/extension/src/webview/frontend/styles/bannerStyles.ts`
  — wa-callout padding.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 311 passing, 61 files (matches baseline; the
      three pre-existing WaPopup unhandled rejections in
      `ModelSelectionProviderKeys.vitest.ts` are unrelated)
- [x] `cd packages/desktop && npx vite build --mode development` —
      built in 1.32s
- [ ] Visual check in extension host: no hover fill flashes on icon
      buttons (opacity only); inputs / selects share a single 22px
      baseline; banner top/bottom padding noticeably reduced; file
      rows ~52-60px each
- [ ] Visual check in desktop shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes that adjust shared styling tokens and component chrome; main risk is minor layout regressions (clipping/spacing) across webviews due to smaller control heights and padding.
> 
> **Overview**
> Tightens the extension/shared UI styling toward a stricter “minimal VS Code” density: form controls (`wa-input`/`wa-select`) move to a 22px baseline with reduced padding and subtle surface-border styling.
> 
> Updates action buttons to a more minimalist interaction model (20×20 icon buttons, opacity-driven hover/disabled, focus outline offset tweaks; text action buttons switch hover fill to a subtle border). Also reduces banner (`wa-callout`) padding, compacts file-select row spacing/heights, and makes tabs/checkboxes/radios smaller (smaller tab font/padding, thicker tab indicator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f984fbe57c4fec4ad5b9f2506ebb8bf90fe973c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->