### PR TITLE
docs(prd): add Electron desktop layout adaptation PRD

### DIFF
--- a/PRD/electron-shell-layout.md
+++ b/PRD/electron-shell-layout.md
@@ -1,0 +1,144 @@
+# PRD — Electron desktop layout adaptation
+
+**Status:** Draft
+**Owner:** TBD
+**Branch:** `claude/improve-electron-app-abqQx`
+**Scope:** Layout-only adaptation of the VS Code extension's UX into the Electron window, plus a small refactor to enable component sharing.
+
+## 1. Summary
+
+Replace the Electron app's tab routing and workspace-explorer sidebar with a three-pane window layout that mounts the existing extension components (`<main-app>`, `<stream-tabs>`, a new `<stream-conversation>`, `<settings-app>`) without changing their content or behavior. Refactor the Progress view's state to a module-level singleton so the rail and the conversation can be mounted independently and stay in sync.
+
+## 2. Problem
+
+The Electron app today:
+
+1. Routes between four full-window views (`Main | Progress | Settings | Logs`), forcing context switches even when the user wants the launcher and the active run visible together.
+2. Renders a workspace file-tree sidebar that duplicates `<main-app>`'s built-in file panel and requires re-tagging files every session.
+3. Cannot mount the Progress view's session rail independently — its state lives as private fields on the `ProgressApp` class instance, so the rail and conversation must always render inside the same parent.
+
+Result: the desktop feels like four small VS Code webviews stuffed into one window rather than an app native to the window it owns.
+
+## 3. Goals
+
+- G1. Single window: sessions on the left, current session/launcher in the center, settings as overlay.
+- G2. Content and behavior identical to the VS Code extension's Launcher, Progress, and Dashboard.
+- G3. Both hosts mount the **same** Lit components from `@progressView/frontend`, `@webview/frontend`, `@settingsView/frontend`. No per-host copies.
+- G4. Workspace-explorer sidebar removed.
+
+## 4. Non-goals (explicitly excluded)
+
+These were discussed and ruled out for this work. Tracked separately if pursued later.
+
+- New agent types, pre-rejection reviewers, arXiv scouts, "since-you-left" / morning rituals, daily summaries.
+- New approval surfaces (single-annotation triage, fork-from-child, edit-then-replay, side-by-side N-take).
+- New entry modes (slash dispatch, team panel, per-agent stats aggregations).
+- Multi-workspace support — deferred; the rail's structure is forward-compatible (see §12).
+- Memory auto-injection at agent session start (runtime change, not UI).
+- Math / citations / figures / numerics-table / notation-glossary rendered as native objects.
+- The right pane's diff-and-approve experience (slot reserved; built later as its own deliverable).
+- The five currently-unavailable commands (`runSetupAssistant`, `showImportOptions`, `openGettingStarted`, `cleanOutput`, `cleanBuild`).
+
+## 5. User stories
+
+- As a researcher I open the desktop app and see my recent sessions on the left and a launcher in the center, so I can pick up where I left off or start something new without switching tabs.
+- As a researcher with a running orchestrator I can see the subagent tree (parent-child lineage) in the rail while the current session's conversation, todos, background tasks, and approval gates remain in the center pane.
+- As a researcher I open Settings via the gear, the existing Dashboard appears as a window overlay, and Esc returns me to the prior view.
+- As a researcher I am no longer asked to interact with a file-tree sidebar; file staging happens inside the Launcher's existing panel.
+
+## 6. UX
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ TeXRA · workspace-name                       ⌘K   ⚙   ⊟  ⊞         │
+├──────────────┬─────────────────────────────────┬───────────────────┤
+│ ＋ New run   │                                 │                   │
+│ ⌕ Search     │                                 │                   │
+│              │                                 │                   │
+│ ● leanOrch   │                                 │                   │
+│   L lean     │   <main-app>     OR             │  (right pane —    │
+│   L leanSimp │   <stream-conversation>         │   reserved for    │
+│              │                                 │   future diff/    │
+│ ◐ crit       │   Composer pinned at the        │   approve UX,     │
+│ ✓ polish     │   bottom of <main-app>;         │   collapsed today)│
+│ ✓ enhance    │   follow-up at the bottom       │                   │
+│ … older      │   of <stream-conversation>.     │                   │
+│              │                                 │                   │
+│ Filter:      │                                 │                   │
+│  ● All       │                                 │                   │
+│  ○ Workflow  │                                 │                   │
+│  ○ Inter…    │                                 │                   │
+│              │                                 │                   │
+│ ⚙ Settings   │                                 │                   │
+└──────────────┴─────────────────────────────────┴───────────────────┘
+```
+
+**Sessions rail (left).** Chronological list of recent and active sessions, newest first. Lineage rendered with `L` indents (preserved verbatim from the extension's right rail). Status glyphs: `●` running, `◐` waiting on user, `✓` complete, `✕` failed, `◯` queued. Filter at the bottom: All / Workflow / Interactive (existing). No day-grouping headers. Settings entry at the bottom.
+
+**Center pane.** Swaps between two children based on `activeStreamId$`:
+
+- No active stream → `<main-app>` (Launcher unchanged: Interactive/Workflow toggle, instruction textarea, file panel, agent picker, model picker, voice mic, ▶).
+- Active stream → `<stream-conversation>` (todos, background tasks, conversation turns, approvals inline, usage panel, follow-up input — all unchanged from the extension's Progress view body).
+
+**Settings overlay.** `<settings-app>` mounts as a full-window overlay over the three-pane layout when the gear is clicked. Esc and the overlay's close button dismiss. Existing 8 tabs (Memory, History, Models, Agents, Multi-Agent, Tools, Git, LaTeX) unchanged.
+
+**Logs.** Reached from the menu; opens as a small drawer (matches today's separate Logs route).
+
+**Workspace name** in the title bar is a static label today. When multi-workspace lands, it becomes the trigger for collapsible workspace groups inside the same rail (no additional column).
+
+## 7. Technical architecture
+
+The Progress view's state currently lives as private signals on the `ProgressApp` class instance. To mount the rail and the conversation independently in different DOM trees while keeping them in sync, state moves to module scope. One architectural change plus mechanical extractions; no algorithmic changes.
+
+**A. Module-level reactive state.**
+New `packages/extension/src/progressView/frontend/progressState.ts` exports today's signals at module scope (`streamStates$`, `streamFilter$`, `activeStreamId$`, `childStreamsByParent$`, `tabStreams$`, `pendingApprovalIds$`, `hasAnyStreams$`, …). `messageDispatcher.ts` (already module-level) writes into it. `ProgressApp` reads from it.
+
+**B. `<stream-conversation>` element.**
+The body currently rendered by `ProgressApp.renderStreamContent()` (plus the empty-state) moves into a new Lit element that subscribes to `progressState`. Internal children unchanged: `<stream-header>`, `<context-management>`, `<todo-list>`, `<background-tasks-panel>`, `<log-list>` / `<task-group-list>`, request panels, `<usage-panel>`, `<follow-up-input>`.
+
+**C. `<progress-app>` becomes a thin shell.**
+For VS Code: renders `view-header` plus `<vscode-split-layout>` containing `<stream-conversation>` and `<stream-tabs>` — identical UX to today. For Electron: not mounted at all; the children mount directly in window panes.
+
+**D. Electron renderer shell.**
+Replaces the four-route tab router. Three panes. Center swaps between `<main-app>` and `<stream-conversation>` driven by `activeStreamId$`. Settings overlay on gear. Workspace explorer deleted.
+
+Both hosts continue importing from the same packages. No component lives in `packages/desktop/`.
+
+## 8. Phasing & PRs
+
+| PR | Phase | Touches | Visible change |
+|---|---|---|---|
+| 1 | State hoist | `progressState.ts` (new), `ProgressApp.ts`, `messageDispatcher.ts`, possibly `slices/*` | None — extension and desktop render identically |
+| 2 | Extract `<stream-conversation>` + slim `<progress-app>` | `components/StreamConversation.ts` (new), `ProgressApp.ts` | None |
+| 3 | Electron shell + workspace-explorer removal | `desktop/src/renderer/{main.ts,index.html,styles.css}`, `desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `desktopMenu.ts`, `main/index.ts` | Desktop layout flips; extension unchanged |
+
+Each PR independently shippable and revertable. Extension users see no diff until or after all three.
+
+## 9. Success criteria
+
+- VS Code extension: zero visual or behavioral diff after PRs 1 and 2. Verified via existing tests + manual smoke (start an agent, observe approvals, complete a run).
+- Electron app: opens to one window with rail + launcher visible. New run kicks off, the rail shows the session and its lineage live, the conversation appears in the center, approval gates render and resolve, follow-up input works. Settings opens via gear. No workspace-explorer sidebar exists.
+- Both hosts import `<stream-tabs>` and `<stream-conversation>` from the same source. No copy of either component in `packages/desktop/`.
+- The five currently-unavailable commands remain unavailable (separately tracked).
+
+## 10. Risks & mitigations
+
+- **PR 1 is the load-bearing refactor.** `ProgressApp.ts` is hot. Mitigation: keep the diff strictly mechanical (signal moves only, no rendering changes); merge during a quiet window; manual smoke test with a live orchestrator run including approvals; revert as a single commit if issues surface.
+- **Singleton scope** precludes mounting two independent progress views in the same page. Acceptable today; flagged here so future "compare two runs side-by-side" features know to revisit it.
+- **Settings dismissal pattern** (overlay + Esc + close button) is opinionated. Drawer or modal-card variants are reasonable alternatives if user testing prefers them; the swap is small and architecturally neutral.
+- **Workspace-explorer IPC removal** must be cleanly unwired. Mitigation: delete the IPC handlers in the same PR as the renderer change; ensure no remaining consumers in `desktopMenu.ts` or elsewhere.
+
+## 11. Open questions
+
+1. Component naming: `<stream-conversation>` vs `<active-stream-view>` vs `<progress-content>`. PRD assumes `<stream-conversation>` to match the existing `stream-` prefix family.
+2. Settings overlay dismissal: Esc + close button only, or also click-outside-to-close? PRD assumes Esc + close button.
+3. Logs: menu drawer (proposed) or fold into a Settings tab?
+4. Right pane visual treatment today: hidden completely, or visible as a thin collapsed strip with a "future" placeholder? PRD assumes hidden until a deliverable lands.
+
+## 12. Future (not in this PRD)
+
+- Multi-workspace: collapsible group headers per workspace inside the existing rail. No extra column.
+- Right pane: side-by-side diff/approve UX for tool edits and merge results.
+- The five currently-unavailable commands ported to desktop.
+- Memory auto-injection at agent session start.
+- Science-native rendering of math, citations, figures, and structured agent outputs (`review`, `numerics`, `notation`).

--- a/PRD/electron-shell-layout.md
+++ b/PRD/electron-shell-layout.md
@@ -106,11 +106,11 @@ Both hosts continue importing from the same packages. No component lives in `pac
 
 ## 8. Phasing & PRs
 
-| PR | Phase | Touches | Visible change |
-|---|---|---|---|
-| 1 | State hoist | `progressState.ts` (new), `ProgressApp.ts`, `messageDispatcher.ts`, possibly `slices/*` | None — extension and desktop render identically |
-| 2 | Extract `<stream-conversation>` + slim `<progress-app>` | `components/StreamConversation.ts` (new), `ProgressApp.ts` | None |
-| 3 | Electron shell + workspace-explorer removal | `desktop/src/renderer/{main.ts,index.html,styles.css}`, `desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `desktopMenu.ts`, `main/index.ts` | Desktop layout flips; extension unchanged |
+| PR  | Phase                                                   | Touches                                                                                                                                                             | Visible change                                  |
+| --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 1   | State hoist                                             | `progressState.ts` (new), `ProgressApp.ts`, `messageDispatcher.ts`, possibly `slices/*`                                                                             | None — extension and desktop render identically |
+| 2   | Extract `<stream-conversation>` + slim `<progress-app>` | `components/StreamConversation.ts` (new), `ProgressApp.ts`                                                                                                          | None                                            |
+| 3   | Electron shell + workspace-explorer removal             | `desktop/src/renderer/{main.ts,index.html,styles.css}`, `desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `desktopMenu.ts`, `main/index.ts` | Desktop layout flips; extension unchanged       |
 
 Each PR independently shippable and revertable. Extension users see no diff until or after all three.
 

--- a/docs/prd/electron-shell-layout.md
+++ b/docs/prd/electron-shell-layout.md
@@ -1,11 +1,10 @@
-# PRD — Electron desktop layout adaptation
+# PRD: Electron desktop layout adaptation
 
-**Status:** Draft
-**Owner:** TBD
-**Branch:** `claude/improve-electron-app-abqQx`
-**Scope:** Layout-only adaptation of the VS Code extension's UX into the Electron window, plus a small refactor to enable component sharing.
+## Status: Draft
 
 ## 1. Summary
+
+Layout-only adaptation of the VS Code extension's UX into the Electron window, plus a small refactor to enable component sharing.
 
 Replace the Electron app's tab routing and workspace-explorer sidebar with a three-pane window layout that mounts the existing extension components (`<main-app>`, `<stream-tabs>`, a new `<stream-conversation>`, `<settings-app>`) without changing their content or behavior. Refactor the Progress view's state to a module-level singleton so the rail and the conversation can be mounted independently and stay in sync.
 

--- a/docs/prd/electron-shell-layout.md
+++ b/docs/prd/electron-shell-layout.md
@@ -112,7 +112,7 @@ Both hosts continue importing from the same packages. No component lives in `pac
 | 2   | Extract `<stream-conversation>` + slim `<progress-app>` | `components/StreamConversation.ts` (new), `ProgressApp.ts`                                                                                                          | None                                            |
 | 3   | Electron shell + workspace-explorer removal             | `desktop/src/renderer/{main.ts,index.html,styles.css}`, `desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `desktopMenu.ts`, `main/index.ts` | Desktop layout flips; extension unchanged       |
 
-Each PR independently shippable and revertable. Extension users see no diff until or after all three.
+Each PR independently shippable and revertible. Extension users see no diff until or after all three.
 
 ## 9. Success criteria
 

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -179,8 +179,14 @@
   --wa-color-chart-purple: var(--desktop-color-purple);
 
   /* Diff editor. */
-  --wa-color-diff-inserted: light-dark(rgb(46 160 67 / 15%), rgb(46 160 67 / 30%));
-  --wa-color-diff-removed: light-dark(rgb(248 81 73 / 15%), rgb(248 81 73 / 30%));
+  --wa-color-diff-inserted: light-dark(
+    rgb(46 160 67 / 15%),
+    rgb(46 160 67 / 30%)
+  );
+  --wa-color-diff-removed: light-dark(
+    rgb(248 81 73 / 15%),
+    rgb(248 81 73 / 30%)
+  );
 
   /* Git decoration. */
   --wa-color-git-added: var(--desktop-color-success);
@@ -203,7 +209,10 @@
   /* Editor surface details. */
   --wa-color-editor-selection: var(--desktop-color-accent-subtle);
   --wa-color-editor-inactive-selection: var(--desktop-color-accent-subtle);
-  --wa-color-editor-line-highlight: light-dark(rgb(31 35 40 / 6%), rgb(255 255 255 / 4%));
+  --wa-color-editor-line-highlight: light-dark(
+    rgb(31 35 40 / 6%),
+    rgb(255 255 255 / 4%)
+  );
   --wa-color-editor-find-match: light-dark(#fff8c5, #623315);
   --wa-color-editor-find-match-highlight: light-dark(#ffe09c, #4a3219);
   --wa-color-editor-find-match-highlight-fg: var(--desktop-color-foreground);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -16,7 +16,10 @@
 .wa-light,
 .wa-dark .wa-invert {
   /* ── Web Awesome surface / text tokens ──────────────────────────────── */
-  --wa-color-text-normal: var(--vscode-editor-foreground, var(--vscode-foreground));
+  --wa-color-text-normal: var(
+    --vscode-editor-foreground,
+    var(--vscode-foreground)
+  );
   /* Some VS Code themes (notably dark) set descriptionForeground too dim to
      read against tinted surface cards. Mix at least 65% of the normal text
      color in to guarantee a readable contrast in every theme. */
@@ -33,7 +36,10 @@
   --wa-color-surface-default: var(--vscode-editor-background);
   --wa-color-surface-raised: var(--vscode-editorWidget-background);
   --wa-color-surface-lowered: var(--vscode-sideBar-background);
-  --wa-color-surface-border: var(--vscode-panel-border, var(--vscode-widget-border));
+  --wa-color-surface-border: var(
+    --vscode-panel-border,
+    var(--vscode-widget-border)
+  );
   --wa-color-surface-shadow: var(--vscode-widget-shadow);
 
   --wa-color-focus: var(--vscode-focusBorder);
@@ -54,19 +60,31 @@
 
   /* Neutral variant — outlined wa-button / wa-callout, hovers. */
   --wa-color-neutral-fill-quiet: var(--vscode-button-secondaryBackground);
-  --wa-color-neutral-border-quiet: var(--vscode-button-border, var(--vscode-widget-border));
+  --wa-color-neutral-border-quiet: var(
+    --vscode-button-border,
+    var(--vscode-widget-border)
+  );
   --wa-color-neutral-on-quiet: var(--vscode-button-secondaryForeground);
   --wa-color-neutral-fill-loud: var(--vscode-button-secondaryBackground);
-  --wa-color-neutral-border-loud: var(--vscode-button-border, var(--vscode-widget-border));
+  --wa-color-neutral-border-loud: var(
+    --vscode-button-border,
+    var(--vscode-widget-border)
+  );
   --wa-color-neutral-on-loud: var(--vscode-button-secondaryForeground);
 
   /* Warning variant. */
   --wa-color-warning-fill-loud: var(--vscode-statusBarItem-warningBackground);
   --wa-color-warning-on-loud: var(--vscode-editor-foreground);
   --wa-color-warning-border-loud: var(--vscode-inputValidation-warningBorder);
-  --wa-color-warning-fill-quiet: var(--vscode-editorWarning-background, var(--vscode-inputValidation-warningBackground));
+  --wa-color-warning-fill-quiet: var(
+    --vscode-editorWarning-background,
+    var(--vscode-inputValidation-warningBackground)
+  );
   --wa-color-warning-border-quiet: var(--vscode-inputValidation-warningBorder);
-  --wa-color-warning-on-quiet: var(--vscode-editorWarning-foreground, var(--vscode-inputValidation-warningForeground));
+  --wa-color-warning-on-quiet: var(
+    --vscode-editorWarning-foreground,
+    var(--vscode-inputValidation-warningForeground)
+  );
 
   /* Danger variant. */
   --wa-color-danger-fill-loud: var(--vscode-editorError-foreground);
@@ -74,20 +92,35 @@
   --wa-color-danger-border-loud: transparent;
   --wa-color-danger-fill-quiet: var(--vscode-inputValidation-errorBackground);
   --wa-color-danger-border-quiet: var(--vscode-inputValidation-errorBorder);
-  --wa-color-danger-on-quiet: var(--vscode-editorError-foreground, var(--vscode-errorForeground));
+  --wa-color-danger-on-quiet: var(
+    --vscode-editorError-foreground,
+    var(--vscode-errorForeground)
+  );
 
   /* Success variant. */
-  --wa-color-success-fill-loud: var(--vscode-charts-green, var(--vscode-testing-iconPassed));
+  --wa-color-success-fill-loud: var(
+    --vscode-charts-green,
+    var(--vscode-testing-iconPassed)
+  );
   --wa-color-success-on-loud: #ffffff;
   --wa-color-success-border-loud: transparent;
-  --wa-color-success-fill-quiet: var(--vscode-charts-green, var(--vscode-inputValidation-infoBackground));
+  --wa-color-success-fill-quiet: var(
+    --vscode-charts-green,
+    var(--vscode-inputValidation-infoBackground)
+  );
   --wa-color-success-border-quiet: var(--vscode-inputValidation-infoBorder);
-  --wa-color-success-on-quiet: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
+  --wa-color-success-on-quiet: var(
+    --vscode-testing-iconPassed,
+    var(--vscode-charts-green)
+  );
 
   /* Buttons — niche tokens consumers still need. */
   --wa-color-button-hover: var(--vscode-button-hoverBackground);
   --wa-color-button-border: var(--vscode-button-border, transparent);
-  --wa-color-button-separator: var(--vscode-button-separator, rgb(255 255 255 / 40%));
+  --wa-color-button-separator: var(
+    --vscode-button-separator,
+    rgb(255 255 255 / 40%)
+  );
 
   /* Lists — no native WA equivalent yet (#3690). */
   --wa-color-list-active-bg: var(--vscode-list-activeSelectionBackground);
@@ -120,7 +153,9 @@
   /* Git decoration. */
   --wa-color-git-added: var(--vscode-gitDecoration-addedResourceForeground);
   --wa-color-git-deleted: var(--vscode-gitDecoration-deletedResourceForeground);
-  --wa-color-git-modified: var(--vscode-gitDecoration-modifiedResourceForeground);
+  --wa-color-git-modified: var(
+    --vscode-gitDecoration-modifiedResourceForeground
+  );
 
   /* Debug token expressions. */
   --wa-color-debug-name: var(--vscode-debugTokenExpression-name);
@@ -137,11 +172,19 @@
 
   /* Editor surface details. */
   --wa-color-editor-selection: var(--vscode-editor-selectionBackground);
-  --wa-color-editor-inactive-selection: var(--vscode-editor-inactiveSelectionBackground);
-  --wa-color-editor-line-highlight: var(--vscode-editor-lineHighlightBackground);
+  --wa-color-editor-inactive-selection: var(
+    --vscode-editor-inactiveSelectionBackground
+  );
+  --wa-color-editor-line-highlight: var(
+    --vscode-editor-lineHighlightBackground
+  );
   --wa-color-editor-find-match: var(--vscode-editor-findMatchBackground);
-  --wa-color-editor-find-match-highlight: var(--vscode-editor-findMatchHighlightBackground);
-  --wa-color-editor-find-match-highlight-fg: var(--vscode-editor-findMatchHighlightForeground);
+  --wa-color-editor-find-match-highlight: var(
+    --vscode-editor-findMatchHighlightBackground
+  );
+  --wa-color-editor-find-match-highlight-fg: var(
+    --vscode-editor-findMatchHighlightForeground
+  );
 
   /* Tabs. */
   --wa-color-tabs-background: var(--vscode-editorGroupHeader-tabsBackground);
@@ -158,8 +201,14 @@
   --wa-color-badge-bg: var(--vscode-badge-background);
 
   /* Testing icons. */
-  --wa-color-testing-passed: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
-  --wa-color-testing-failed: var(--vscode-testing-iconFailed, var(--vscode-editorError-foreground));
+  --wa-color-testing-passed: var(
+    --vscode-testing-iconPassed,
+    var(--vscode-charts-green)
+  );
+  --wa-color-testing-failed: var(
+    --vscode-testing-iconFailed,
+    var(--vscode-editorError-foreground)
+  );
 
   /* Terminal — full palette, no WA equivalent. */
   --wa-color-terminal-background: var(--vscode-terminal-background);
@@ -178,15 +227,39 @@
   --wa-color-terminal-ansi-bright-blue: var(--vscode-terminal-ansiBrightBlue);
   --wa-color-terminal-ansi-bright-cyan: var(--vscode-terminal-ansiBrightCyan);
   --wa-color-terminal-ansi-bright-green: var(--vscode-terminal-ansiBrightGreen);
-  --wa-color-terminal-ansi-bright-magenta: var(--vscode-terminal-ansiBrightMagenta);
+  --wa-color-terminal-ansi-bright-magenta: var(
+    --vscode-terminal-ansiBrightMagenta
+  );
   --wa-color-terminal-ansi-bright-red: var(--vscode-terminal-ansiBrightRed);
   --wa-color-terminal-ansi-bright-white: var(--vscode-terminal-ansiBrightWhite);
-  --wa-color-terminal-ansi-bright-yellow: var(--vscode-terminal-ansiBrightYellow);
+  --wa-color-terminal-ansi-bright-yellow: var(
+    --vscode-terminal-ansiBrightYellow
+  );
 
   /* Typography. */
-  --wa-font-family-body: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  --wa-font-family-heading: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  --wa-font-family-mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  --wa-font-family-body: var(
+    --vscode-font-family,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif
+  );
+  --wa-font-family-heading: var(
+    --vscode-font-family,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif
+  );
+  --wa-font-family-mono: var(
+    --vscode-editor-font-family,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace
+  );
   --wa-font-size-m: var(--vscode-font-size, 13px);
   --wa-font-weight-normal: var(--vscode-font-weight, 400);
   --wa-editor-font-size: var(--vscode-editor-font-size, 13px);

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -128,11 +128,7 @@ export class StreamTab extends LitElement {
         right: var(--wa-space-3xs);
         bottom: 0;
         height: 1px;
-        background: color-mix(
-          in srgb,
-          var(--color-border) 50%,
-          transparent
-        );
+        background: color-mix(in srgb, var(--color-border) 50%, transparent);
         pointer-events: none;
       }
 
@@ -288,16 +284,9 @@ export class StreamTab extends LitElement {
           var(--wa-color-brand-fill-quiet) 85%,
           transparent
         );
-        color: var(
-          --wa-color-list-active-fg,
-          var(--wa-color-text-normal)
-        );
+        color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
         box-shadow: inset 0 0 0 1px
-          color-mix(
-            in srgb,
-            var(--wa-color-brand-fill-loud) 18%,
-            transparent
-          );
+          color-mix(in srgb, var(--wa-color-brand-fill-loud) 18%, transparent);
       }
 
       /*
@@ -306,10 +295,7 @@ export class StreamTab extends LitElement {
        * (.last-active, .model) and codicon glyphs.
        */
       .tab-container.is-active * {
-        color: var(
-          --wa-color-list-active-fg,
-          var(--wa-color-text-normal)
-        );
+        color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
       }
 
       /*

--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -22,7 +22,8 @@ export class TerminalCommandStrip extends LitElement {
         var(--wa-color-surface-default, transparent)
       );
       color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
-      border: var(--border-thin) solid var(--wa-color-surface-border, transparent);
+      border: var(--border-thin) solid
+        var(--wa-color-surface-border, transparent);
       border-radius: var(--border-radius-small);
       font-family: var(
         --wa-font-family-mono,

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -54,13 +54,18 @@ export class WorkflowHintBanner extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (this.dismissed) return nothing;
     return html`
-      <wa-callout variant="brand" role="note" aria-label="Workflow mode reminder">
+      <wa-callout
+        variant="brand"
+        role="note"
+        aria-label="Workflow mode reminder"
+      >
         ${waIcon('info', { slot: 'icon' })}
         <div class="banner-row">
           <div class="text">
             <span class="title">Workflow mode thinks across rounds.</span>
-            It reduces hallucinations and cuts fluff, so expect 10–30 minutes per
-            run. Use Stop to cancel; pick Tool-Use mode for fast, iterative edits.
+            It reduces hallucinations and cuts fluff, so expect 10–30 minutes
+            per run. Use Stop to cancel; pick Tool-Use mode for fast, iterative
+            edits.
           </div>
           ${renderIconActionButton({
             icon: 'close',

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -130,10 +130,7 @@ export const codeBlockStyles = css`
   .hljs-variable,
   .hljs-params,
   .hljs-attr {
-    color: var(
-      --wa-color-symbol-variable,
-      var(--wa-color-text-normal)
-    );
+    color: var(--wa-color-symbol-variable, var(--wa-color-text-normal));
   }
 
   .hljs-function,
@@ -150,10 +147,7 @@ export const codeBlockStyles = css`
 
   .hljs-property,
   .hljs-name {
-    color: var(
-      --wa-color-symbol-property,
-      var(--wa-color-text-normal)
-    );
+    color: var(--wa-color-symbol-property, var(--wa-color-text-normal));
   }
 
   .hljs-operator,

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -38,11 +38,7 @@ export const groupStyles = css`
     &.is-running {
       border-left-color: var(--wa-color-status-warning-bg);
       box-shadow: inset 2px 0 0
-        color-mix(
-          in srgb,
-          var(--wa-color-status-warning-bg) 35%,
-          transparent
-        );
+        color-mix(in srgb, var(--wa-color-status-warning-bg) 35%, transparent);
     }
 
     &.is-error {
@@ -56,8 +52,7 @@ export const groupStyles = css`
 
   .log-group-content {
     padding-left: var(--wa-space-2xs);
-    border-left: var(--border-thin) dashed
-      var(--wa-color-tabs-border);
+    border-left: var(--border-thin) dashed var(--wa-color-tabs-border);
   }
 
   .log-run {

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -114,10 +114,7 @@ export const toolUseStyles = css`
   }
 
   .tool-user-feedback {
-    background-color: var(
-      --wa-color-brand-fill-quiet,
-      rgba(55, 148, 255, 0.1)
-    );
+    background-color: var(--wa-color-brand-fill-quiet, rgba(55, 148, 255, 0.1));
     border-left-color: var(--wa-color-text-link, #3794ff);
   }
 
@@ -206,19 +203,13 @@ export const toolUseStyles = css`
   }
 
   .diff-inline-del {
-    background-color: var(
-      --wa-color-diff-removed,
-      rgba(255, 0, 0, 0.2)
-    );
+    background-color: var(--wa-color-diff-removed, rgba(255, 0, 0, 0.2));
     color: var(--wa-color-git-deleted, #f85149);
     text-decoration: line-through;
   }
 
   .diff-inline-add {
-    background-color: var(
-      --wa-color-diff-inserted,
-      rgba(0, 255, 0, 0.2)
-    );
+    background-color: var(--wa-color-diff-inserted, rgba(0, 255, 0, 0.2));
     color: var(--wa-color-git-added, #3fb950);
   }
 `;

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -169,11 +169,7 @@ export class SettingsApp extends SettingsAppBase {
       wa-tab-group.settings-tabs wa-tab::part(base) {
         padding-block: 6px;
         padding-inline: var(--wa-space-s);
-        color: color-mix(
-          in srgb,
-          var(--wa-color-text-normal) 65%,
-          transparent
-        );
+        color: color-mix(in srgb, var(--wa-color-text-normal) 65%, transparent);
         border-radius: var(--wa-border-radius-s, 4px)
           var(--wa-border-radius-s, 4px) 0 0;
         transition:

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -154,10 +154,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-list-item.selected {
         background: var(--wa-color-brand-fill-quiet);
-        color: var(
-          --wa-color-list-active-fg,
-          var(--wa-color-text-normal)
-        );
+        color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
         border-left-color: var(--wa-color-brand-fill-loud);
         box-shadow: inset 0 0 0 1px
           color-mix(in srgb, var(--wa-color-brand-fill-loud) 12%, transparent);

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -103,10 +103,7 @@ export class ToolCard extends LitElement {
       .tool-guide {
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-xs);
-        background: var(
-          --wa-color-surface-lowered,
-          rgba(128, 128, 128, 0.08)
-        );
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -34,7 +34,10 @@ import { AgentSelectionEvents } from '../components/profile/events';
 import '../components/profile/AgentSelectionPanel';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
-const AGENT_SUB_TAB_PANELS = ['workflow', 'toolUse'] as const satisfies readonly AgentCategory[];
+const AGENT_SUB_TAB_PANELS = [
+  'workflow',
+  'toolUse',
+] as const satisfies readonly AgentCategory[];
 
 @customElement('agents-tab')
 export class AgentsTab extends LitElement {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -282,10 +282,7 @@ export class LaTeXTab extends LitElement {
       .dependency-guide {
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-xs);
-        background: var(
-          --wa-color-surface-lowered,
-          rgba(128, 128, 128, 0.08)
-        );
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);
@@ -310,10 +307,7 @@ export class LaTeXTab extends LitElement {
         flex: 1;
         min-width: 0;
         padding: var(--wa-space-2xs) var(--wa-space-xs);
-        background: var(
-          --wa-color-surface-lowered,
-          rgba(128, 128, 128, 0.08)
-        );
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
         border-radius: var(--border-radius-small);
         font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-sm);
@@ -390,7 +384,6 @@ export class LaTeXTab extends LitElement {
       wa-tag.setting-badge {
         flex-shrink: 0;
       }
-
     `,
   ];
 
@@ -545,7 +538,8 @@ export class LaTeXTab extends LitElement {
           ? html`
               <div class="dependency-install-actions">
                 <button
-                  class="tab-action-btn ${this.copiedCommand === installCmd.command
+                  class="tab-action-btn ${this.copiedCommand ===
+                  installCmd.command
                     ? 'copy-success'
                     : ''}"
                   title=${this.copiedCommand === installCmd.command
@@ -1009,8 +1003,7 @@ export class LaTeXTab extends LitElement {
           <wa-select
             .value=${String(effective)}
             @change=${(e: Event) => {
-              const v = (e.target as WaSelect)
-                .value as LatexConfigValueFor<F>;
+              const v = (e.target as WaSelect).value as LatexConfigValueFor<F>;
               this.dispatchSetConfigValue(opts.field, v);
             }}
             style="margin-top:var(--wa-space-2xs);"

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -258,10 +258,7 @@ export class ToolsTab extends LitElement {
         padding: var(--wa-space-2xs) var(--wa-space-xs);
         margin-bottom: var(--wa-space-2xs);
         border-radius: var(--border-radius);
-        background: var(
-          --wa-color-surface-lowered,
-          rgba(128, 128, 128, 0.08)
-        );
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
       }
 
       .setting-row {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -2016,10 +2016,7 @@ export class MainApp extends MainAppBase {
             ? nothing
             : html`
                 <div class="section-separator" role="presentation"></div>
-                <wa-details
-                  class="file-selection-details"
-                  ?open=${isWorkflow}
-                >
+                <wa-details class="file-selection-details" ?open=${isWorkflow}>
                   <span slot="summary" class="file-selection-summary">
                     <wa-icon
                       library=${TEXRA_ICON_LIBRARY}
@@ -2047,8 +2044,7 @@ export class MainApp extends MainAppBase {
                           @select-multiple-files=${this
                             .handleComponentSelectMultipleFiles}
                           @remove-file=${this.handleComponentRemoveFile}
-                          @files-reordered=${this
-                            .handleComponentFilesReordered}
+                          @files-reordered=${this.handleComponentFilesReordered}
                           @checkbox-change=${this.handleComponentCheckboxChange}
                           @focus-instruction=${this
                             .handleComponentFocusInstruction}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -177,11 +177,7 @@ export class InstructionPanel extends LitElement {
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-left: 2px solid
-          color-mix(
-            in srgb,
-            var(--wa-color-brand-fill-loud) 70%,
-            transparent
-          );
+          color-mix(in srgb, var(--wa-color-brand-fill-loud) 70%, transparent);
         background: color-mix(
           in srgb,
           var(--wa-color-brand-fill-quiet) 35%,
@@ -333,11 +329,7 @@ export class InstructionPanel extends LitElement {
         filter: brightness(1.06);
         box-shadow:
           0 3px 8px
-            color-mix(
-              in srgb,
-              var(--wa-color-brand-fill-loud) 28%,
-              transparent
-            ),
+            color-mix(in srgb, var(--wa-color-brand-fill-loud) 28%, transparent),
           inset 0 1px 0 rgb(255 255 255 / 18%);
       }
 

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -68,11 +68,7 @@ export class LoginBanner extends LitElement {
         transform: translateY(-0.5px);
         box-shadow:
           0 3px 8px
-            color-mix(
-              in srgb,
-              var(--wa-color-brand-fill-loud) 28%,
-              transparent
-            ),
+            color-mix(in srgb, var(--wa-color-brand-fill-loud) 28%, transparent),
           inset 0 1px 0 rgb(255 255 255 / 18%);
       }
 

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -19,7 +19,10 @@ import { css, type CSSResult } from 'lit';
  * Centralising the writes keeps the five banner components from each carrying
  * their own copy of the visibility-derivation logic.
  */
-export function applyBannerVisibility(host: HTMLElement, visible: boolean): void {
+export function applyBannerVisibility(
+  host: HTMLElement,
+  visible: boolean,
+): void {
   host.dataset.visible = visible ? 'true' : 'false';
   host.setAttribute('aria-hidden', visible ? 'false' : 'true');
 }
@@ -145,10 +148,6 @@ export const bannerStyles: CSSResult = css`
   }
 
   .actions wa-button[appearance='plain']::part(base):hover {
-    background: color-mix(
-      in srgb,
-      currentColor 8%,
-      transparent
-    );
+    background: color-mix(in srgb, currentColor 8%, transparent);
   }
 `;

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -8,10 +8,8 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   padding: 'var(--wa-space-2xs, 4px) var(--wa-space-xs, 8px)',
   fontSize: 'var(--wa-font-size-m, 13px)',
   fontFamily: 'var(--wa-font-family-body, system-ui), system-ui',
-  color:
-    'var(--wa-color-text-normal, var(--wa-color-text-normal))',
-  background:
-    'var(--wa-color-surface-raised, var(--wa-color-surface-default))',
+  color: 'var(--wa-color-text-normal, var(--wa-color-text-normal))',
+  background: 'var(--wa-color-surface-raised, var(--wa-color-surface-default))',
   border:
     '1px solid var(--wa-color-surface-border, var(--texra-contrastBorder, transparent))',
   borderRadius: 'var(--border-radius, 3px)',

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -61,8 +61,7 @@ export const markdownStyles = css`
     padding-left: var(--wa-space-xs);
     margin-top: var(--wa-space-s);
     margin-bottom: var(--wa-space-2xs);
-    border-left: var(--border-thick) solid
-      var(--wa-color-activity-badge-bg);
+    border-left: var(--border-thick) solid var(--wa-color-activity-badge-bg);
     border-bottom: var(--border-thin) solid var(--color-border);
     padding-bottom: var(--wa-space-3xs);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
@@ -104,8 +103,7 @@ export const markdownStyles = css`
     margin: 0.5em 0;
     border-radius: var(--border-radius);
     background-color: var(--wa-color-surface-lowered);
-    border-left: var(--wa-space-3xs) solid
-      var(--wa-color-activity-badge-bg);
+    border-left: var(--wa-space-3xs) solid var(--wa-color-activity-badge-bg);
     overflow-x: auto;
   }
 
@@ -131,8 +129,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content blockquote {
-    border-left: var(--border-thick) solid
-      var(--wa-color-activity-badge-bg);
+    border-left: var(--border-thick) solid var(--wa-color-activity-badge-bg);
     margin: var(--wa-space-xs) 0;
     padding-left: var(--wa-space-l);
     color: var(--color-text-secondary);
@@ -181,8 +178,7 @@ export const markdownStyles = css`
   }
 
   .banner-content--scratchpad p:has(strong:first-child) {
-    border-left: calc(var(--wa-space-2xs) - 1px) solid
-      var(--wa-color-icon-info);
+    border-left: calc(var(--wa-space-2xs) - 1px) solid var(--wa-color-icon-info);
     padding-left: var(--wa-space-xs);
   }
 

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -27,16 +27,12 @@ export const viewTabStyles: CSSResult = css`
   wa-tab::part(base) {
     padding-block: 5px;
     padding-inline: var(--wa-space-s);
-    color: color-mix(
-      in srgb,
-      var(--wa-color-text-normal) 70%,
-      transparent
-    );
+    color: color-mix(in srgb, var(--wa-color-text-normal) 70%, transparent);
     transition:
       color 140ms ease,
       background-color 140ms ease;
-    border-radius: var(--wa-border-radius-s, 4px)
-      var(--wa-border-radius-s, 4px) 0 0;
+    border-radius: var(--wa-border-radius-s, 4px) var(--wa-border-radius-s, 4px)
+      0 0;
   }
 
   wa-tab::part(base):hover {

--- a/src/shared/wa/waColorScheme.ts
+++ b/src/shared/wa/waColorScheme.ts
@@ -38,7 +38,12 @@ function isDarkTheme(): boolean {
   }
   const kind = body.dataset.vscodeThemeKind;
   if (kind) {
-    return kind === 'vscode-dark' || kind === 'vscode-high-contrast' || kind === 'dark' || kind === 'high-contrast';
+    return (
+      kind === 'vscode-dark' ||
+      kind === 'vscode-high-contrast' ||
+      kind === 'dark' ||
+      kind === 'high-contrast'
+    );
   }
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -66,7 +66,7 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     const { ElectronSecrets } = await loadElectronSecrets();
     const warnings: string[] = [];
     const fakeStore = {
-      get: <T>(_key: string): T | undefined =>
+      get: <T,>(_key: string): T | undefined =>
         ({
           encrypted: true,
           value: Buffer.from('encrypted:value').toString('base64'),
@@ -96,7 +96,7 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     const { ElectronSecrets } = await loadElectronSecrets();
     const warnings: string[] = [];
     const fakeStore = {
-      get: <T>(_key: string): T | undefined =>
+      get: <T,>(_key: string): T | undefined =>
         ({
           encrypted: true,
           value: Buffer.from('encrypted:value').toString('base64'),


### PR DESCRIPTION
Captures the plan to replace the desktop tab routing and workspace-
explorer sidebar with a window-native three-pane layout, plus the
state-hoist refactor that lets `<stream-tabs>` and a new
`<stream-conversation>` mount independently while sharing live state
across both hosts.

https://claude.ai/code/session_015S79MvT22X8ShTRPY8MhY8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and formatting-only changes across CSS/Lit components, plus a minor TypeScript test typing tweak; no runtime logic or behavior changes are intended.
> 
> **Overview**
> Adds a draft PRD (`docs/prd/electron-shell-layout.md`) describing a planned Electron desktop UI re-layout (three-pane shell, settings overlay) and the refactors needed to share extension components/state.
> 
> Separately, applies widespread **formatting/line-wrapping cleanup** across shared/theme CSS, Lit component templates, and utility functions, and tweaks a desktop Vitest helper’s generic signature (`get: <T,>(...)`) to satisfy TypeScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1e6a4fddf4ddefca4fe88c524fcd3781076f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->