### PR TITLE
test(jsdom): expose missing globals to fix CI kernel test failures

### DIFF
--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -23,8 +23,11 @@ const domGlobalKeys = [
   'document',
   'Document',
   'customElements',
+  'Element',
   'HTMLElement',
   'HTMLInputElement',
+  'HTMLSlotElement',
+  'HTMLDialogElement',
   'CustomEvent',
   'Event',
   'KeyboardEvent',
@@ -239,8 +242,16 @@ export function useLitComponentTestDom(
       document: dom.window.document,
       Document: dom.window.Document,
       customElements: dom.window.customElements,
+      // Web Awesome components (wa-popup, wa-option, wa-dialog) read these
+      // constructors as bare globals via instanceof checks and getAnimations
+      // calls inside microtasks. Bind the jsdom-backed implementations onto
+      // globalThis so those references resolve even after a test's beforeEach
+      // tears down the previous DOM tree.
+      Element: dom.window.Element,
       HTMLElement: dom.window.HTMLElement,
       HTMLInputElement: dom.window.HTMLInputElement,
+      HTMLSlotElement: dom.window.HTMLSlotElement,
+      HTMLDialogElement: dom.window.HTMLDialogElement,
       CustomEvent: dom.window.CustomEvent,
       Event: dom.window.Event,
       KeyboardEvent: dom.window.KeyboardEvent,


### PR DESCRIPTION
## Summary

CI on `main` has been failing across both `validate` jobs (ubuntu + macOS) since the recent Web Awesome 3.6 migration with three unhandled rejections during `vitest run`:

```
ReferenceError: HTMLSlotElement is not defined
  ❯ getText … chunk.MJFEN3CH.js:37:28
  ❯ WaOption.updateDefaultLabel … chunk.MJFEN3CH.js:165:31
  ❯ WaOption.get defaultLabel
  ❯ WaOption.get label
  ❯ WaOption.performUpdate (lit/reactive-element)

ReferenceError: Element is not defined
  ❯ WaPopup.handleAnchorChange … chunk.AXACS5N6.js:154:39   (×2)
```

All three errors originate while running `src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts`, which mounts a `wa-select` (and therefore wa-option + wa-popup). The wa-* update lifecycle dispatches microtask continuations that run *after* the synchronous test body returns, and those continuations dereference `HTMLSlotElement` / `Element` as bare globals.

## Root cause

`src/test-kernel/settings/litComponentTestUtils.ts::useLitComponentTestDom` mirrors a hand-picked list of jsdom constructors onto `globalThis` (`HTMLElement`, `HTMLInputElement`, `ShadowRoot`, `Node`, etc.). The list pre-dates the wa-* migration and never included `Element`, `HTMLSlotElement`, or `HTMLDialogElement`. In Node, these constructors are not provided as ambient globals — they only live on the jsdom `window` — so any wa-* code that reads them as bare globals crashes.

The errors only manifest when wa-popup / wa-option microtasks fire (jsdom-only behavior), which is why this slipped through local dev but appears in CI's reporter for unhandled rejections.

## Fix

Extend `domGlobalKeys` and the `replacements` map in `useLitComponentTestDom` with the missing constructors, so wa-* code finds them on `globalThis` for the suite's full lifetime:

- `Element`
- `HTMLSlotElement`
- `HTMLDialogElement`

`HTMLElement`, `Node`, and `ShadowRoot` were already wired up.

## Test plan

- [ ] CI `validate (ubuntu-latest)` Kernel tests: 0 unhandled errors, ≥318 passing
- [ ] CI `validate (macos-latest)` Kernel tests: 0 unhandled errors, ≥318 passing
- [ ] `npx vitest run src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts` exits cleanly (no `Unhandled Rejection` blocks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are confined to test-only jsdom setup, but it does widen the set of globals patched on `globalThis`, which could subtly affect other tests if they rely on missing constructors.
> 
> **Overview**
> Fixes CI kernel test failures after the Web Awesome migration by extending the jsdom test harness to mirror additional DOM constructors onto `globalThis`.
> 
> `useLitComponentTestDom` now also exposes `Element`, `HTMLSlotElement`, and `HTMLDialogElement` (with clarifying comments) so wa-* microtasks that use bare-global `instanceof` checks and related APIs no longer throw `ReferenceError`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e48679277029450985fef72809255b2185e59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->