### PR TITLE
fix(wa,styles): batch follow-up issues from recent migrations

### DIFF
--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -269,7 +269,9 @@
   --wa-color-danger-fill-quiet: var(--texra-inputValidation-errorBackground);
   --wa-color-danger-border-quiet: var(--texra-inputValidation-errorBorder);
   --wa-color-danger-on-quiet: var(--texra-inputValidation-errorForeground);
-  --wa-color-danger-on-loud: var(--texra-errorForeground);
+  /* Foreground on a loud danger fill (high-contrast text on red).
+     Aligned with desktop bridge (themeTokens.css) for cross-host parity. */
+  --wa-color-danger-on-loud: #ffffff;
 
   --wa-color-success-fill-quiet: var(
     --texra-charts-green,

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -215,6 +215,15 @@ export class StreamHeader extends LitElement {
 
       /* Note: .is-ready and other status states from statusIndicatorStyles */
 
+      /* Replaces flex layout previously provided by vscode-toolbar-container.
+         Without this, toolbar buttons would stack vertically in block flow. */
+      .toolbar-container {
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: var(--spacing-xs, 4px);
+        align-items: center;
+      }
+
       .toolbar-button--hidden {
         display: none;
       }

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -590,7 +590,7 @@ export class StreamTabs extends LitElement {
         color: var(--color-text-secondary);
       }
 
-      .delete-all-streams::part(control) {
+      .delete-all-streams::part(base) {
         border-radius: var(--border-radius-medium);
       }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -535,17 +535,16 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
   const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
 
   if (typeof mcpOutput?.status === 'string') {
-    const statusIsInProgress = mcpOutput.status === 'in_progress';
     let statusIconName: string;
     if (mcpOutput.status === 'failed') {
       statusIconName = 'error';
-    } else if (statusIsInProgress) {
-      statusIconName = '';
+    } else if (mcpOutput.status === 'in_progress') {
+      statusIconName = SPINNER_ICON_NAME;
     } else {
       statusIconName = 'check';
     }
     // prettier-ignore
-    const statusIconTemplate = statusIsInProgress
+    const statusIconTemplate = statusIconName === SPINNER_ICON_NAME
       ? html`<wa-spinner></wa-spinner>`
       : html`<wa-icon library="texra" name=${statusIconName} aria-hidden="true"></wa-icon>`;
     // prettier-ignore

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -163,7 +163,7 @@ export class InstructionPanel extends LitElement {
         align-items: flex-start;
         margin-top: var(--spacing-small);
         padding: var(--spacing-tiny) var(--spacing-small);
-        border-left: 2px solid var(--wa-color-brand-fill-loud);
+        border-left: 2px solid var(--wa-color-text-link);
         color: var(--wa-color-text-quiet);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
@@ -257,7 +257,7 @@ export class InstructionPanel extends LitElement {
         );
       }
 
-      .model-selection-footer .codicon,
+      .model-selection-footer wa-icon,
       .model-selection-footer wa-button {
         display: flex;
         align-items: center;
@@ -347,7 +347,7 @@ export class InstructionPanel extends LitElement {
       }
 
       .recording {
-        color: var(--wa-color-danger-on-loud);
+        color: var(--wa-color-danger-on-quiet);
         animation: pulse-record 1.2s ease-in-out infinite;
         transform-origin: center;
       }

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -300,7 +300,7 @@ export const multiFilesStyles = css`
     font-size: var(--font-size-xs);
   }
 
-  .file-folder .codicon {
+  .file-folder wa-icon {
     font-size: var(--font-size-xs);
     margin-right: var(--spacing-tiny);
   }

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -24,8 +24,8 @@ export const categoryBadgeStyles: CSSResult = css`
     color: var(--texra-badge-foreground);
   }
 
-  .category-badge .codicon,
-  .agent-category-badge .codicon {
+  .category-badge wa-icon,
+  .agent-category-badge wa-icon {
     font-size: var(--font-size-sm);
   }
 
@@ -110,7 +110,7 @@ export const tintedBadgeStyles: CSSResult = css`
     white-space: nowrap;
   }
 
-  .tinted-badge .codicon {
+  .tinted-badge wa-icon {
     font-size: var(--font-size-xs);
   }
 `;

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -293,7 +293,7 @@ export const commonViewStyles: CSSResult = css`
     font-style: italic;
   }
 
-  .empty-state .codicon {
+  .empty-state wa-icon {
     font-size: calc(var(--font-size) * 2.5);
     opacity: var(--opacity-disabled);
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -204,7 +204,7 @@ export const requestPanelStyles: CSSResult = css`
    * Approval requests (tool edits)
    * ================================================================ */
 
-  .approval-requests__header .codicon {
+  .approval-requests__header wa-icon {
     color: var(--texra-editor-foreground);
   }
 
@@ -283,7 +283,7 @@ export const requestPanelStyles: CSSResult = css`
    * Bash approval requests
    * ================================================================ */
 
-  .bash-approval-requests__header .codicon {
+  .bash-approval-requests__header wa-icon {
     color: var(--texra-terminal-ansiYellow);
   }
 
@@ -305,7 +305,7 @@ export const requestPanelStyles: CSSResult = css`
    * Retry requests
    * ================================================================ */
 
-  .retry-requests__header .codicon {
+  .retry-requests__header wa-icon {
     color: var(--color-warning);
   }
 
@@ -370,7 +370,7 @@ export const requestPanelStyles: CSSResult = css`
    * Workflow proposals
    * ================================================================ */
 
-  .workflow-proposals__header .codicon {
+  .workflow-proposals__header wa-icon {
     color: var(--texra-textLink-foreground);
   }
 
@@ -419,8 +419,8 @@ export const requestPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  .workflow-proposal__agent-select .codicon,
-  .workflow-proposal__model-select .codicon {
+  .workflow-proposal__agent-select wa-icon,
+  .workflow-proposal__model-select wa-icon {
     color: var(--texra-descriptionForeground);
     flex-shrink: 0;
   }
@@ -525,7 +525,7 @@ export const requestPanelStyles: CSSResult = css`
    * Plan approval requests
    * ================================================================ */
 
-  .plan-approval-requests__header .codicon {
+  .plan-approval-requests__header wa-icon {
     color: var(--texra-textLink-foreground);
   }
 
@@ -579,7 +579,7 @@ export const requestPanelStyles: CSSResult = css`
    * External inquiry requests
    * ================================================================ */
 
-  .external-inquiry-requests__header .codicon {
+  .external-inquiry-requests__header wa-icon {
     color: var(--texra-focusBorder);
   }
 

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -7,7 +7,7 @@ export const selectStyles: CSSResult = css`
     gap: var(--spacing-tiny);
   }
 
-  .select-group .codicon {
+  .select-group wa-icon {
     margin-right: var(--spacing-small);
     color: var(--text-color, var(--texra-foreground));
     vertical-align: text-bottom;
@@ -64,7 +64,7 @@ export const selectStyles: CSSResult = css`
     border-radius: var(--border-radius-small);
   }
 
-  .codicon.clickable:hover {
+  wa-icon.clickable:hover {
     color: var(--button-hover-background, var(--texra-button-hoverBackground));
   }
 

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -33,6 +33,7 @@ import { faCircleUser } from '@fortawesome/free-solid-svg-icons/faCircleUser';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons/faCircleXmark';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft';
+import { faCloud } from '@fortawesome/free-solid-svg-icons/faCloud';
 import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons/faCloudArrowDown';
 import { faCloudArrowUp } from '@fortawesome/free-solid-svg-icons/faCloudArrowUp';
 import { faCode } from '@fortawesome/free-solid-svg-icons/faCode';
@@ -169,6 +170,7 @@ const icons = {
   'circle-xmark': faCircleXmark,
   clock: faClock,
   'clock-rotate-left': faClockRotateLeft,
+  cloud: faCloud,
   'cloud-arrow-down': faCloudArrowDown,
   'cloud-arrow-up': faCloudArrowUp,
   code: faCode,
@@ -286,7 +288,7 @@ const CODICON_ALIASES = {
   'folder-opened': 'folder-open',
   github: 'code-branch',
   'git-commit': 'circle-dot',
-  'git-merge': 'code-branch',
+  'git-merge': 'code-merge',
   graph: 'chart-line',
   'graph-line': 'chart-line',
   history: 'clock-rotate-left',


### PR DESCRIPTION
## Summary

Batches eight small follow-up fixes from the recent Web Awesome migration PRs (#3658, #3663, #3681). All changes are mechanical / low-risk — token swaps, alias fixes, CSS retargeting, and one icon-registry addition.

## Issues addressed

- **#3687** — `.session-hint` `border-left` switched from `--wa-color-brand-fill-loud` to `--wa-color-text-link` to preserve the original `--vscode-textLink-foreground` color (`InstructionPanel.ts`).
- **#3688** — Reconciled `--wa-color-danger-on-loud` between extension and desktop bridges. Extension `common.css` now maps it to `#ffffff` (high-contrast on red, matching desktop semantics). `.recording` retargeted to `--wa-color-danger-on-quiet` (the right slot for plain error text on a normal surface).
- **#3665** — `git-merge` codicon alias now resolves to `code-merge` (`faCodeMerge`) instead of `code-branch` (`faCodeBranch`) in `webAwesomeIcons.ts`.
- **#3666** — `.delete-all-streams::part(control)` → `::part(base)` (Web Awesome button shadow part) in `StreamTabs.ts`.
- **#3667** — Added explicit `display: inline-flex` rule for `.toolbar-container` in `StreamHeader.ts` to replace the layout previously provided by `vscode-toolbar-container`.
- **#3671** — Added `faCloud` import + canonical `cloud` entry to the WA icon registry so remote agent stream decorators render correctly.
- **#3672** — Swept stale `.codicon` CSS selectors and retargeted at `wa-icon` in `requestPanelStyles.ts`, `badgeStyles.ts`, `commonViewStyles.ts`, `selectStyles.ts`, `fileSelectStyles.ts`, and `InstructionPanel.ts`.
- **#3673** — MCP status spinner in `toolFormatters.ts` now uses the `SPINNER_ICON_NAME` sentinel pattern consistent with the rest of the formatter module.

## Test plan

- [x] `npm run typecheck` — no new errors introduced (pre-existing OpenRouter SDK / Electron module-resolution errors are unchanged from `main`).
- [x] `npx vitest run` — 316/318 passing (the 2 failing `ElectronCompositionRoot` tests fail identically on `main`; unrelated to this PR).
- [x] `cd packages/desktop && npx vite build --mode development` — builds successfully.

## Out of scope (deferred)

- #3686, #3670, #3664 — meta tracking issues; will be closed once their child issues land here.
- #3690, #3689 — token consolidation; deferred to a larger separate PR.
- #3684 — review backlog; broader scope.
- #3677 — already addressed in #3674.

Closes #3687, #3688, #3665, #3666, #3667, #3671, #3672, #3673.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical CSS/token and icon-registry adjustments after the Web Awesome migration; low risk but could cause minor UI regressions in webview styling or icon rendering.
> 
> **Overview**
> **Fixes Web Awesome migration follow-ups** across extension webviews by retargeting styling and icon usage to WA semantics.
> 
> Aligns danger color tokens (`--wa-color-danger-on-loud` set to `#fff`, `.recording` uses `--wa-color-danger-on-quiet`), restores expected link-accent styling for the instruction session hint, and replaces legacy `.codicon` selectors with `wa-icon` selectors in shared style sheets.
> 
> Addresses WA component API differences by switching `wa-button` part styling from `::part(control)` to `::part(base)` and reintroducing an explicit flex layout for the stream toolbar container.
> 
> Improves icon correctness/coverage by adding the `cloud` icon to the WA registry, fixing the `git-merge` alias to map to `code-merge`, and ensuring MCP `in_progress` status renders via the standard `SPINNER_ICON_NAME` spinner sentinel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997d11a8a4befb5736c19d5752be8b018c46ea23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->