### PR TITLE
fix(ui): icon spacing, tab layout, split-panel visual regressions

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -259,7 +259,6 @@ export class ProgressApp extends ProgressAppBase {
       }
 
       wa-split-panel {
-        display: flex;
         width: 100%;
         height: 100%;
       }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -180,7 +180,7 @@ export class SettingsApp extends SettingsAppBase {
       }
 
       wa-tab .settings-tab-icon {
-        margin-inline-end: var(--spacing-xsmall);
+        margin-inline-end: 0.5em;
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -239,7 +239,7 @@ export class FileSelectGroup extends LitElement {
           aria-label="Tool configuration options"
           title="Tool configuration options"
         >
-          ${waIcon('tools', { slot: 'start' })} ${waIcon('chevron-down')}
+          ${waIcon('tools')}
         </wa-button>
         <wa-dropdown-item
           type="checkbox"
@@ -284,7 +284,7 @@ export class FileSelectGroup extends LitElement {
           aria-label="Auto-extract options"
           title="Auto-extract options"
         >
-          ${waIcon('wand', { slot: 'start' })} ${waIcon('chevron-down')}
+          ${waIcon('wand')}
         </wa-button>
         <wa-dropdown-item
           type="checkbox"


### PR DESCRIPTION
## Summary

Three focused fixes for visual regressions reported after the recent `wa-*` (Web Awesome) migration.

### 1. FileSelectGroup — icon overlapping the section label

`packages/extension/src/webview/frontend/components/FileSelectGroup.ts`

The Launcher's per-section dropdown triggers (Input, Reference, Auxiliary, Media)
each rendered TWO icons inside a single `.action-icon-button`:

```html
${waIcon('tools', { slot: 'start' })} ${waIcon('chevron-down')}
```

But the shared button is locked to 20x20 (`width: 20px; height: 20px; padding: 0`)
and each `wa-icon` is `font-size: 13px`, so 13 + 13 = 26px of content overflowed
the 20px box. With `flex: gap = 4px` between flex items, the trailing chevron
visually collided with the adjacent `<label>` text — exactly the "tools icon
glued to the 't' of Input" / "wand glued to Media" the user reported.

The chevron was a vscode-elements-era affordance; `wa-dropdown` already
displays a popover on click, so the secondary glyph is redundant. Removed it
from both `renderToolConfigMenu` and `renderAutoExtractMenu`.

### 2. SettingsApp — tab icons detached from labels

`packages/extension/src/settingsView/frontend/SettingsApp.ts`

The override `wa-tab .settings-tab-icon { margin-inline-end: var(--spacing-xsmall); }`
referenced an **undefined token** — `--spacing-xsmall` is not declared anywhere
(only `--spacing-tiny | small | medium | large | xlarge` exist in `litStyles.ts`).
With no fallback, the property resolved to its initial value (0), which then
won the cascade against `wa-tab`'s built-in
`::slotted(wa-icon:first-child) { margin-inline-end: 0.5em }` rule, leaving
icons with **zero margin** — making them appear glued to or detached from
their tab labels depending on rendering quirks.

Replaced with the literal `0.5em` to match the framework's intended
spacing without depending on a missing variable.

### 3. ProgressApp — split panel broken after migration

`packages/extension/src/progressView/frontend/ProgressApp.ts`

Old vscode-split-layout was a flex-based component, so the previous
`wa-split-panel { display: flex; ... }` block was carried over from the
migration. But `wa-split-panel` is implemented with **CSS grid** internally
— its `render()` writes `style.gridTemplateColumns = "<primary> var(--divider-width) auto"`
on the host element. Overriding `display: flex` from outside silently nuked
the grid template, so the start/end panels and the draggable divider could
not size themselves correctly. Removed the `display` override; the host's
intrinsic `display: grid` now applies and the divider drag works again.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 318/318 passing (3 pre-existing unhandled rejections in `ModelSelectionProviderKeys.vitest.ts`, unrelated)
- [x] `cd packages/desktop && npx vite build --mode development` succeeds (built in 2.20s)
- [ ] Manual smoke: Launcher Input/Reference/Auxiliary/Media headers — icons no longer overlap labels
- [ ] Manual smoke: Settings tabs (Memory/History/Models/Agents/...) — icon spacing looks correct
- [ ] Manual smoke: Progress view — split panel sizes correctly, divider draggable, content fills panels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only CSS/template tweaks; changes are localized to icon rendering and `wa-split-panel` styling with minimal behavioral impact.
> 
> **Overview**
> Fixes a few *Web Awesome migration* visual regressions across the extension UI.
> 
> In `FileSelectGroup`, removes the extra chevron icon from dropdown trigger buttons so the icon button no longer overflows/overlaps adjacent labels. In `SettingsApp`, hard-codes tab icon spacing to `0.5em` instead of an undefined CSS token to restore consistent icon/label separation. In `ProgressApp`, stops forcing `wa-split-panel` to `display: flex`, allowing its native grid layout to size panels/divider correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ae0f9ac21969f5910a0e2e61c36942355a6c43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->