### PR TITLE
feat(webview): polish the Execute button

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -269,6 +269,85 @@ export class InstructionPanel extends LitElement {
         height: var(--height-control);
       }
 
+      /*
+       * Execute is the primary action of the entire UI, so it gets a
+       * slightly larger, more distinctive treatment than the other
+       * footer wa-buttons (which are 24x24 icon-only controls).
+       */
+      wa-button.execute-button {
+        min-width: auto;
+        height: auto;
+        flex: 0 0 auto;
+      }
+
+      wa-button.execute-button::part(base) {
+        min-width: 64px;
+        min-height: 32px;
+        padding: 0 var(--wa-space-m, 0.75rem);
+        gap: var(--wa-space-2xs, 0.25rem);
+        border-radius: var(--wa-border-radius-m, 6px);
+        background: var(--wa-color-brand-fill-loud);
+        color: var(--wa-color-brand-on-loud);
+        border: 1px solid transparent;
+        box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        transition:
+          transform 120ms ease,
+          box-shadow 120ms ease,
+          background-color 120ms ease;
+      }
+
+      wa-button.execute-button::part(base):hover {
+        transform: translateY(-0.5px);
+        box-shadow: 0 2px 6px rgb(0 0 0 / 12%);
+      }
+
+      wa-button.execute-button::part(base):active {
+        transform: translateY(0.5px);
+        box-shadow: 0 0 0 transparent;
+      }
+
+      wa-button.execute-button:focus-visible::part(base) {
+        outline: 2px solid var(--wa-color-focus, var(--wa-color-brand-fill-loud));
+        outline-offset: 1px;
+      }
+
+      wa-button.execute-button wa-icon {
+        font-size: 14px;
+      }
+
+      .execute-button__label {
+        font-size: var(--font-size-sm, 0.85rem);
+        line-height: 1;
+      }
+
+      .execute-button__kbd {
+        display: inline-flex;
+        align-items: center;
+        height: 18px;
+        padding: 0 var(--wa-space-2xs, 0.25rem);
+        margin-left: var(--wa-space-2xs, 0.25rem);
+        border-radius: 4px;
+        background: rgb(255 255 255 / 18%);
+        color: inherit;
+        font-family: var(--wa-font-family-mono, ui-monospace, monospace);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.02em;
+        opacity: 0.85;
+      }
+
+      /*
+       * Hide the keyboard-shortcut chip when the toolbar is too narrow,
+       * so the button doesn't push selects off the row on tiny widgets.
+       */
+      @media (max-width: 480px) {
+        .execute-button__kbd {
+          display: none;
+        }
+      }
+
       .model-selection-footer .agent-select-controls,
       .model-selection-footer .agent-select-dropdowns {
         display: flex;
@@ -504,6 +583,18 @@ export class InstructionPanel extends LitElement {
 
   private handleExecute(): void {
     this.dispatchEvent(MainViewEvents.execute());
+  }
+
+  /**
+   * Keyboard-shortcut label shown in the Execute button. Matches the
+   * `texra.execute` keybinding declared in the extension's package.json
+   * (cmd+option+e on macOS, ctrl+alt+e elsewhere).
+   */
+  private get executeShortcutLabel(): string {
+    const isMac =
+      typeof navigator !== 'undefined' &&
+      /Mac|iPhone|iPod|iPad/.test(navigator.platform || '');
+    return isMac ? '⌘⌥E' : 'Ctrl+Alt+E';
   }
 
   private handleAgentSettings(): void {
@@ -755,12 +846,17 @@ export class InstructionPanel extends LitElement {
           </div>
           <wa-button
             id="executeButton"
-            title="Execute"
+            class="execute-button"
+            title="Execute (${this.executeShortcutLabel})"
             appearance="filled"
             variant="brand"
             @click=${this.handleExecute}
           >
             <wa-icon slot="start" library="texra" name="play"></wa-icon>
+            <span class="execute-button__label">Run</span>
+            <kbd class="execute-button__kbd" aria-hidden="true"
+              >${this.executeShortcutLabel}</kbd
+            >
           </wa-button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The Execute button is the most-clicked control in the InstructionPanel, but recent compactness migrations had reduced it to a generic icon-only `<wa-button>` that visually disappeared next to the model and agent selects. This PR gives it a distinct primary-action treatment without going garish.

### What changed (single file: `packages/extension/src/webview/frontend/components/InstructionPanel.ts`)

- **Explicit label + shortcut chip** — the button now reads `▶ Run ⌘⌥E` (or `Ctrl+Alt+E` on non-Mac), matching the existing `texra.execute` keybinding declared in `package.json`. The shortcut is now discoverable without hovering for a tooltip.
- **`.execute-button` class** with overridden `::part(base)` styling:
  - `min-width: 64px`, `min-height: 32px`, `padding: 0 var(--wa-space-m)` — sits a hair taller than the surrounding 24×24 icon controls so it reads as primary, but doesn't dominate.
  - Brand fill background, `font-weight: 600`, soft `0 1px 2px` shadow.
- **Hover / active / focus states**:
  - Hover lifts `-0.5px` with a stronger `0 2px 6px` shadow.
  - Active presses `+0.5px` with shadow collapsed.
  - 120ms ease transitions on transform / box-shadow / background.
  - `:focus-visible` outline (2px + 1px offset) using `--wa-color-focus`.
- **Responsive** — the keyboard chip hides below 480px so the toolbar still wraps cleanly on narrow side-panel widths.
- The default `.model-selection-footer wa-button { min-width / height: var(--height-control) }` rule is overridden for `.execute-button` so it isn't squeezed by the icon-button sizing the rest of the footer uses.

Pure CSS + markup — no behaviour change to `handleExecute` or the downstream event flow.

## Test plan

- [ ] Open the main webview in dev — the Execute button shows `▶ Run ⌘⌥E` (Mac) or `▶ Run Ctrl+Alt+E` (other), is taller/wider than the surrounding icon buttons.
- [ ] Hover the button → subtle lift + shadow grows.
- [ ] Press and hold → button presses down with shadow collapsing.
- [ ] Tab to it with the keyboard → focus ring appears (2px outline).
- [ ] Resize the side panel below 480px → kbd chip hides, layout wraps cleanly.
- [ ] `⌘⌥E` / `Ctrl+Alt+E` still triggers `texra.execute` (unchanged from before — same `@click` handler / no JS change).
- [ ] `npm run typecheck` shows only pre-existing errors (electron / `@openrouter/sdk` moduleResolution) — same set on origin/main without this change. No new TS errors from this PR.
- [ ] `npx vitest run` → 316/318 passed; the 2 failures are pre-existing `ElectronCompositionRoot` PATH-fixer tests unrelated to this change.
- [ ] `cd packages/desktop && npx vite build --mode development` → succeeds in ~2s.

## Notes

- Followed the proposal in the design brief almost verbatim, with minor adaptations:
  - Added the `class="execute-button"` (it was not previously set on this button).
  - The button was *not* previously using `.action-icon-button` / `.action-button`, so no class removal was needed.
  - Kept the `<wa-icon slot="start">` play icon and added the `Run` label + `<kbd>` chip in default slot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to webview UI markup/CSS and add a computed shortcut label, without altering execute behavior or data flow.
> 
> **Overview**
> Makes the InstructionPanel’s Execute control a distinct primary-action button by adding custom `.execute-button` styling (size, brand fill, hover/active/focus states) and overriding the footer’s icon-button sizing.
> 
> Updates the button content to show a `Run` label plus a responsive keyboard-shortcut chip, and adds a small getter that renders `⌘⌥E` on macOS vs `Ctrl+Alt+E` elsewhere while updating the tooltip to include the shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065ab18d7109ba4e7a7067d87352564d23857dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->