### PR TITLE
refactor(styles): retire --spacing-* + --texra-button-secondary* tokens

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -40,12 +40,12 @@ wa-button.desktop-nav-button::part(base) {
 }
 
 wa-button.desktop-nav-button::part(base):hover {
-  background: var(--texra-toolbar-hoverBackground);
+  background: var(--wa-color-surface-raised);
 }
 
 wa-button.desktop-nav-button[aria-pressed='true']::part(base) {
   border-color: var(--texra-focusBorder);
-  background: var(--texra-button-secondaryBackground);
+  background: var(--wa-color-neutral-fill-quiet);
 }
 
 wa-button.desktop-command-button::part(base),
@@ -64,7 +64,7 @@ wa-button.desktop-command-button {
 
 wa-button.desktop-command-button::part(base):hover,
 wa-button.desktop-folder-button::part(base):hover {
-  background: var(--texra-toolbar-hoverBackground);
+  background: var(--wa-color-surface-raised);
 }
 
 .desktop-view {
@@ -127,7 +127,7 @@ wa-button.desktop-explorer-icon-button::part(base) {
 }
 
 wa-button.desktop-explorer-icon-button::part(base):hover {
-  background: var(--texra-toolbar-hoverBackground);
+  background: var(--wa-color-surface-raised);
 }
 
 wa-button.desktop-explorer-icon-button[disabled]::part(base) {
@@ -472,12 +472,12 @@ wa-button.desktop-primary-button::part(base) {
 
 wa-button.desktop-secondary-button::part(base) {
   border: 1px solid var(--texra-button-border);
-  background: var(--texra-button-secondaryBackground);
-  color: var(--texra-button-secondaryForeground);
+  background: var(--wa-color-neutral-fill-quiet);
+  color: var(--wa-color-neutral-on-quiet);
 }
 
 wa-button.desktop-secondary-button::part(base):hover {
-  background: var(--texra-button-secondaryHoverBackground);
+  background: var(--wa-color-neutral-fill-loud);
 }
 
 /* wa-dialog supplies the backdrop, modal positioning, focus trap, and panel
@@ -501,7 +501,7 @@ wa-dialog.desktop-onboarding {
   width: 38px;
   height: 38px;
   border-radius: 6px;
-  background: var(--texra-button-secondaryBackground);
+  background: var(--wa-color-neutral-fill-quiet);
   color: var(--texra-button-background);
   font-size: 20px;
 }

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -106,6 +106,10 @@
   );
   --texra-inputValidation-warningBorder: var(--desktop-color-warning);
   --texra-inputValidation-warningForeground: var(--desktop-color-warning);
+  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
+     equivalents. Keep these texra aliases until WA introduces semantic tokens
+     for tree/list rows (or until consumers move to wa-tree::part(item) styling
+     hooks); see #3690. */
   --texra-list-activeSelectionBackground: var(--desktop-color-accent);
   --texra-list-activeSelectionForeground: #ffffff;
   --texra-list-focusOutline: var(--desktop-color-accent);
@@ -202,6 +206,23 @@
   --wa-font-family-heading: var(--desktop-font-family);
   --wa-font-size-m: var(--desktop-font-size);
   --wa-font-weight-normal: var(--desktop-font-weight);
+
+  /* Web Awesome canonical space scale. Mirrors the values from
+     @awesome.me/webawesome/dist/styles/themes/default.css so consumers (and WA
+     components) can rely on --wa-space-* without importing the full default
+     theme — that import would override the color bridge below. */
+  --wa-space-scale: 1;
+  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem); /* 2px */
+  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem); /* 4px */
+  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem); /* 8px */
+  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem); /* 12px */
+  --wa-space-m: calc(var(--wa-space-scale) * 1rem); /* 16px */
+  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem); /* 24px */
+  --wa-space-xl: calc(var(--wa-space-scale) * 2rem); /* 32px */
+  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
+  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
+  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
   --wa-color-text-normal: var(--desktop-color-foreground);
   --wa-color-text-quiet: var(--desktop-color-muted);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -136,6 +136,10 @@
   --texra-inputValidation-warningForeground: var(
     --vscode-inputValidation-warningForeground
   );
+  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
+     equivalents. Keep these texra aliases until WA introduces semantic tokens
+     for tree/list rows (or until consumers move to wa-tree::part(item) styling
+     hooks); see #3690. */
   --texra-list-activeSelectionBackground: var(
     --vscode-list-activeSelectionBackground
   );
@@ -227,6 +231,23 @@
   --wa-font-family-heading: var(--texra-font-family);
   --wa-font-size-m: var(--texra-font-size);
   --wa-font-weight-normal: var(--texra-font-weight);
+
+  /* Web Awesome canonical space scale. Mirrors the values from
+     @awesome.me/webawesome/dist/styles/themes/default.css so that consumers
+     (and WA components) can rely on --wa-space-* without importing the full
+     default theme — the theme import would override our color bridge above. */
+  --wa-space-scale: 1;
+  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem); /* 2px */
+  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem); /* 4px */
+  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem); /* 8px */
+  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem); /* 12px */
+  --wa-space-m: calc(var(--wa-space-scale) * 1rem); /* 16px */
+  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem); /* 24px */
+  --wa-space-xl: calc(var(--wa-space-scale) * 2rem); /* 32px */
+  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
+  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
+  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
   --wa-color-text-normal: var(--texra-foreground);
   --wa-color-text-quiet: var(--texra-descriptionForeground);

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -167,8 +167,8 @@ export class ProgressApp extends ProgressAppBase {
       .view-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-small) var(--spacing-small) var(--spacing-tiny);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-2xs) var(--wa-space-3xs);
         border-bottom: var(--border-thin) solid var(--color-border);
         flex-shrink: 0;
       }
@@ -201,8 +201,8 @@ export class ProgressApp extends ProgressAppBase {
         flex: 1;
         min-height: 0;
         place-items: start center;
-        padding: clamp(var(--spacing-large, 16px), 7vh, 72px)
-          var(--spacing-large, 16px);
+        padding: clamp(var(--wa-space-s, 16px), 7vh, 72px)
+          var(--wa-space-s, 16px);
         overflow: auto;
         font-family:
           var(--texra-font-family, var(--vscode-font-family, system-ui)),
@@ -212,7 +212,7 @@ export class ProgressApp extends ProgressAppBase {
       .progress-empty-panel {
         box-sizing: border-box;
         width: min(720px, 100%);
-        padding: var(--spacing-xlarge, 24px);
+        padding: var(--wa-space-l, 24px);
         border: var(--border-thin, 1px) solid
           var(--color-border, var(--vscode-panel-border, #d0d7de));
         border-radius: var(--border-radius, 6px);
@@ -222,15 +222,15 @@ export class ProgressApp extends ProgressAppBase {
       .progress-empty-panel .empty-state-kicker {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small, 8px);
-        margin-bottom: var(--spacing-medium, 12px);
+        gap: var(--wa-space-2xs, 8px);
+        margin-bottom: var(--wa-space-xs, 12px);
         color: var(--color-text-secondary, #57606a);
         font-size: var(--font-size-sm, 13px);
         font-weight: var(--font-weight-semibold, 600);
       }
 
       .progress-empty-panel .empty-state-title {
-        margin: 0 0 var(--spacing-small, 8px);
+        margin: 0 0 var(--wa-space-2xs, 8px);
         color: var(--texra-foreground, #24292f);
         font-size: var(--font-size-h2, 1.25em);
         font-weight: var(--font-weight-semibold, 600);
@@ -246,8 +246,8 @@ export class ProgressApp extends ProgressAppBase {
       .progress-empty-panel .empty-state-actions {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small, 8px);
-        margin-top: var(--spacing-large, 16px);
+        gap: var(--wa-space-2xs, 8px);
+        margin-top: var(--wa-space-s, 16px);
       }
 
       .progress-empty-panel .empty-state-actions wa-button::part(base) {
@@ -305,7 +305,7 @@ export class ProgressApp extends ProgressAppBase {
       .desktop-empty-progress__body {
         display: grid;
         justify-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
         max-width: 560px;
         text-align: center;
         color: var(--wa-color-text-quiet);
@@ -317,7 +317,7 @@ export class ProgressApp extends ProgressAppBase {
       }
 
       .desktop-empty-progress h1 {
-        margin: var(--spacing-small) 0 0;
+        margin: var(--wa-space-2xs) 0 0;
         color: var(--wa-color-text-normal);
         font-size: 24px;
         font-weight: 600;
@@ -334,8 +334,8 @@ export class ProgressApp extends ProgressAppBase {
         display: flex;
         justify-content: center;
         flex-wrap: wrap;
-        gap: var(--spacing-medium);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .desktop-empty-progress wa-button::part(base) {

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -62,7 +62,7 @@ export class BackgroundTasksPanel extends LitElement {
       .task-list {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
 
       .section-content {
@@ -72,14 +72,14 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-item {
-        margin-bottom: var(--spacing-tiny);
+        margin-bottom: var(--wa-space-3xs);
       }
 
       .task-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
         font-size: var(--font-size-sm);
       }
 
@@ -135,8 +135,8 @@ export class BackgroundTasksPanel extends LitElement {
       .section-label {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-small) 0 var(--spacing-tiny);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) 0 var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
@@ -160,7 +160,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .empty-message {
-        padding: var(--spacing-small) 0;
+        padding: var(--wa-space-2xs) 0;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         font-style: italic;
@@ -168,11 +168,11 @@ export class BackgroundTasksPanel extends LitElement {
 
       /* Collapsible output per task */
       details.task-output {
-        margin-left: calc(var(--spacing-small) + var(--font-size-sm));
+        margin-left: calc(var(--wa-space-2xs) + var(--font-size-sm));
       }
 
       details.task-output > summary {
-        padding: var(--spacing-tiny) 0;
+        padding: var(--wa-space-3xs) 0;
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         cursor: pointer;
@@ -185,7 +185,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .output-container {
-        margin-top: var(--spacing-tiny);
+        margin-top: var(--wa-space-3xs);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius-small);
         overflow: hidden;

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -37,7 +37,7 @@ export class ContextManagement extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--spacing-small) 0;
+        margin: var(--wa-space-2xs) 0;
       }
 
       details {
@@ -52,7 +52,7 @@ export class ContextManagement extends LitElement {
       }
 
       .context-icon {
-        margin-right: var(--spacing-small);
+        margin-right: var(--wa-space-2xs);
       }
 
       .context-title {
@@ -62,13 +62,13 @@ export class ContextManagement extends LitElement {
       .context-content {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-large);
+        gap: var(--wa-space-s);
       }
 
       .stat-item {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         font-size: var(--font-size-sm);
       }
 
@@ -77,7 +77,7 @@ export class ContextManagement extends LitElement {
       }
 
       .summary-block {
-        margin-top: var(--spacing-small);
+        margin-top: var(--wa-space-2xs);
         display: block;
         width: 100%;
       }
@@ -85,15 +85,15 @@ export class ContextManagement extends LitElement {
       .summary-title {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-medium);
-        margin-bottom: var(--spacing-tiny);
+        margin-bottom: var(--wa-space-3xs);
       }
 
       .summary-text {
         margin: 0;
-        padding: var(--spacing-small);
+        padding: var(--wa-space-2xs);
         white-space: pre-wrap;
         word-break: break-word;
         border: var(--border-thin) solid var(--texra-widget-border);

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -105,8 +105,8 @@ export class FileList extends LitElement {
       .storage-hint {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0 var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs);
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
         line-height: 1.4;
@@ -129,8 +129,8 @@ export class FileList extends LitElement {
       .file-item {
         display: flex;
         align-items: center;
-        gap: var(--spacing-tiny);
-        padding: var(--spacing-tiny) 0;
+        gap: var(--wa-space-3xs);
+        padding: var(--wa-space-3xs) 0;
         margin-bottom: 0;
       }
 
@@ -173,19 +173,19 @@ export class FileList extends LitElement {
 
       .added {
         color: var(--texra-charts-green, green);
-        margin-left: var(--spacing-small);
+        margin-left: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
       }
 
       .removed {
         color: var(--texra-charts-red, red);
-        margin-left: var(--spacing-small);
+        margin-left: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
       }
 
       .file-actions {
         display: flex;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         flex-shrink: 0;
         flex-wrap: nowrap;
         align-items: center;
@@ -193,7 +193,7 @@ export class FileList extends LitElement {
 
       .file-actions wa-button {
         margin-right: 0;
-        margin-left: var(--spacing-tiny);
+        margin-left: var(--wa-space-3xs);
       }
 
       /* Nested round collapsibles */
@@ -206,7 +206,7 @@ export class FileList extends LitElement {
       }
 
       .round-collapsible::part(header) {
-        padding: var(--spacing-tiny) 0;
+        padding: var(--wa-space-3xs) 0;
         font-size: var(--font-size-sm);
       }
 
@@ -222,15 +222,15 @@ export class FileList extends LitElement {
       .compile-actions {
         display: flex;
         justify-content: flex-end;
-        padding: var(--spacing-small) 0;
+        padding: var(--wa-space-2xs) 0;
         border-top: var(--border-thin) solid var(--color-border);
-        margin-top: var(--spacing-tiny);
+        margin-top: var(--wa-space-3xs);
       }
 
       @media (max-width: 500px) {
         .file-item {
           flex-wrap: wrap;
-          gap: var(--spacing-small);
+          gap: var(--wa-space-2xs);
           align-items: center;
         }
 

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -40,7 +40,7 @@ export class FollowUpInput extends LitElement {
 
       :host([visible]) {
         display: block;
-        margin-top: var(--spacing-medium);
+        margin-top: var(--wa-space-xs);
         max-width: 100%;
       }
 
@@ -51,8 +51,8 @@ export class FollowUpInput extends LitElement {
       .follow-up-container {
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
-        padding: var(--spacing-small) 0;
-        gap: var(--spacing-small);
+        padding: var(--wa-space-2xs) 0;
+        gap: var(--wa-space-2xs);
         min-width: 0;
       }
 
@@ -65,7 +65,7 @@ export class FollowUpInput extends LitElement {
       .follow-up-input-row {
         display: flex;
         align-items: flex-end;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         grid-column: 1 / -1;
         min-width: 0;
       }
@@ -97,7 +97,7 @@ export class FollowUpInput extends LitElement {
         display: flex;
         flex-direction: column !important;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -36,7 +36,7 @@ export class LatexdiffResults extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--spacing-small) 0;
+        margin: var(--wa-space-2xs) 0;
       }
 
       details {

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -67,21 +67,21 @@ export class PlanView extends LitElement {
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
         color: var(--color-text-secondary);
-        margin-bottom: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
+        margin-bottom: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
       }
 
       .plan-steps {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
 
       .plan-step {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
       }
@@ -116,22 +116,22 @@ export class PlanView extends LitElement {
       .plan-step__description {
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
-        margin-top: var(--spacing-tiny);
+        margin-top: var(--wa-space-3xs);
         word-break: break-word;
       }
 
       .plan-step__files {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-tiny);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-3xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .plan-step__file {
         font-size: var(--font-size-sm);
         color: var(--texra-textLink-foreground);
         background: var(--texra-badge-background);
-        padding: var(--border-thin) var(--spacing-medium);
+        padding: var(--border-thin) var(--wa-space-xs);
         border-radius: var(--border-radius);
         font-family: var(--texra-editor-font-family, monospace), monospace;
       }

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -42,26 +42,26 @@ export class QueuedFollowUps extends LitElement {
       }
 
       .queued-collapsible::part(header) {
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         font-weight: var(--font-weight-medium);
         background-color: transparent;
       }
 
       .queued-collapsible::part(content) {
-        padding: 0 var(--spacing-small) var(--spacing-small);
+        padding: 0 var(--wa-space-2xs) var(--wa-space-2xs);
       }
 
       .queued-follow-ups-list {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
 
       .queued-follow-up-item {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
         background-color: var(--texra-editor-background);

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -30,7 +30,7 @@ export class StatisticsPanel extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--spacing-small) 0;
+        margin: var(--wa-space-2xs) 0;
       }
 
       details {
@@ -40,13 +40,13 @@ export class StatisticsPanel extends LitElement {
       .statistics-content {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-large);
+        gap: var(--wa-space-s);
       }
 
       .stat-item {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -134,11 +134,11 @@ export class StreamHeader extends LitElement {
       }
 
       .log-header {
-        padding: var(--spacing-tiny) var(--spacing-small);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
         font-size: var(--font-size-sm);
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         color: var(--color-text-secondary);
         border-bottom: var(--border-thin) solid var(--color-border);
       }
@@ -146,13 +146,13 @@ export class StreamHeader extends LitElement {
       .log-header__primary {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .header-left {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
         flex: 1;
         min-width: 0;
       }
@@ -160,7 +160,7 @@ export class StreamHeader extends LitElement {
       .stream-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         min-width: 0;
       }
 
@@ -179,9 +179,9 @@ export class StreamHeader extends LitElement {
 
       /* Status indicator overrides - base styles from statusIndicatorStyles */
       .status-indicator {
-        width: var(--spacing-medium);
-        height: var(--spacing-medium);
-        margin: 0 var(--spacing-small);
+        width: var(--wa-space-xs);
+        height: var(--wa-space-xs);
+        margin: 0 var(--wa-space-2xs);
         position: relative;
       }
 
@@ -196,8 +196,8 @@ export class StreamHeader extends LitElement {
         left: 50%;
         top: 100%;
         transform: translateX(-50%);
-        margin-top: var(--spacing-tiny);
-        padding: var(--spacing-small) var(--spacing-medium);
+        margin-top: var(--wa-space-3xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         background: var(--background-color);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius-small);
@@ -220,7 +220,7 @@ export class StreamHeader extends LitElement {
       .toolbar-container {
         display: inline-flex;
         flex-wrap: wrap;
-        gap: var(--spacing-xs, 4px);
+        gap: var(--wa-space-2xs, 4px);
         align-items: center;
       }
 
@@ -230,16 +230,16 @@ export class StreamHeader extends LitElement {
 
       /* Button type styles */
       .stop-button {
-        margin-right: var(--spacing-tiny);
+        margin-right: var(--wa-space-3xs);
         color: var(--color-error);
       }
 
       .pack-button {
-        margin-left: var(--spacing-tiny);
+        margin-left: var(--wa-space-3xs);
       }
 
       .run-button {
-        margin-left: var(--spacing-tiny);
+        margin-left: var(--wa-space-3xs);
         color: var(--color-success);
       }
 
@@ -292,7 +292,7 @@ export class StreamHeader extends LitElement {
       .parent-link {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         cursor: pointer;
@@ -323,7 +323,7 @@ export class StreamHeader extends LitElement {
       @media (max-width: 500px) {
         .log-header {
           flex-wrap: wrap;
-          gap: var(--spacing-small);
+          gap: var(--wa-space-2xs);
         }
 
         .header-left {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -108,7 +108,7 @@ export class StreamTab extends LitElement {
         align-items: center;
         position: relative;
         width: 100%;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         border-left: var(--border-thick) solid transparent;
         transition:
           border-left-color var(--transition-normal),
@@ -157,7 +157,7 @@ export class StreamTab extends LitElement {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding: var(--spacing-small);
+        padding: var(--wa-space-2xs);
         cursor: pointer;
         border: none;
         background: none;
@@ -171,7 +171,7 @@ export class StreamTab extends LitElement {
       .tab-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         width: 100%;
       }
 
@@ -203,7 +203,7 @@ export class StreamTab extends LitElement {
       .tab-meta {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
         color: var(--texra-foreground);
         opacity: var(--opacity-subtle);
@@ -213,7 +213,7 @@ export class StreamTab extends LitElement {
       .tab-meta .remote-agent,
       .tab-meta .agent-category,
       .tab-meta .multi-file {
-        margin-left: var(--spacing-small);
+        margin-left: var(--wa-space-2xs);
       }
 
       .tab-delete {
@@ -284,7 +284,7 @@ export class StreamTab extends LitElement {
       }
 
       .tab-container.is-compact .tab {
-        padding: var(--spacing-small) var(--spacing-tiny);
+        padding: var(--wa-space-2xs) var(--wa-space-3xs);
       }
 
       .tab-container.is-compact .tab-delete {
@@ -294,7 +294,7 @@ export class StreamTab extends LitElement {
       }
 
       .tab-container.is-compact .tab-header {
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
 
       .compact-subagent-hint {
@@ -315,7 +315,7 @@ export class StreamTab extends LitElement {
 
       .tab-delete:hover::part(base),
       .tab-delete:focus-within::part(base) {
-        background-color: var(--texra-toolbar-hoverBackground);
+        background-color: var(--wa-color-surface-raised);
       }
 
       .tab-delete:hover,
@@ -341,7 +341,7 @@ export class StreamTab extends LitElement {
 
       .tab-expand:hover {
         opacity: 1;
-        background-color: var(--texra-toolbar-hoverBackground);
+        background-color: var(--wa-color-surface-raised);
       }
 
       .tab-expand wa-icon {
@@ -554,13 +554,13 @@ export class StreamTabs extends LitElement {
       .stream-list-footer {
         flex-shrink: 0;
         border-top: var(--border-thin) solid var(--color-border);
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
       }
 
       .stream-list-controls {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         min-width: 0;
       }
 
@@ -568,7 +568,7 @@ export class StreamTabs extends LitElement {
         display: flex;
         justify-content: flex-start;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex: 1 1 auto;
         min-width: 0;
       }
@@ -600,9 +600,9 @@ export class StreamTabs extends LitElement {
 
       /* Recursive child stream nesting */
       .child-streams {
-        padding-left: var(--spacing-medium, 12px);
+        padding-left: var(--wa-space-xs, 12px);
         border-left: var(--border-thin) solid var(--color-border);
-        margin-left: var(--spacing-small);
+        margin-left: var(--wa-space-2xs);
       }
 
       .child-streams stream-tab {

--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -14,7 +14,7 @@ export class TerminalCommandStrip extends LitElement {
     .strip {
       display: flex;
       align-items: baseline;
-      gap: var(--spacing-small, 8px);
+      gap: var(--wa-space-2xs, 8px);
       padding: 6px 10px;
       margin: 0 0 8px 0;
       background: var(

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -123,7 +123,7 @@ export class TexraDiffView extends LitElement {
         align-items: center;
         justify-content: center;
         min-height: 240px;
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         border: var(--border-thin) solid var(--color-border);
         color: var(--color-text-muted);
         background: var(--color-background-secondary);

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -51,14 +51,14 @@ export class TodoList extends LitElement {
       .todo-list {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
 
       .todo-item {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
       }

--- a/packages/extension/src/progressView/frontend/components/ToolTimer.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolTimer.ts
@@ -23,7 +23,7 @@ export class ToolTimer extends LitElement {
     .timer {
       font-size: var(--font-size-sm, 11px);
       opacity: var(--opacity-normal, 0.85);
-      margin-left: var(--spacing-medium, 8px);
+      margin-left: var(--wa-space-xs, 8px);
       font-variant-numeric: tabular-nums;
     }
     .timer-limit {

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -45,7 +45,7 @@ export class UsagePanel extends LitElement {
       .usage-summary-footer {
         border-top: var(--border-thin) solid var(--color-border);
         background-color: var(--texra-sideBarSectionHeader-background);
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -56,7 +56,7 @@ export class UsagePanel extends LitElement {
       :is(.run-summary, .context-state) {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
         opacity: var(--opacity-normal);
@@ -71,7 +71,7 @@ export class UsagePanel extends LitElement {
       .context-gauge {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .context-gauge__track {

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -76,11 +76,11 @@ export class UserMessage extends LitElement {
       .user-message-container {
         display: flex;
         justify-content: flex-end;
-        margin: var(--spacing-small) 0;
+        margin: var(--wa-space-2xs) 0;
       }
 
       .user-message {
-        padding: var(--spacing-small);
+        padding: var(--wa-space-2xs);
         max-width: 85%;
         background-color: var(--texra-editor-selectionBackground);
         border: var(--border-thin) solid var(--texra-panel-border);
@@ -90,8 +90,8 @@ export class UserMessage extends LitElement {
       .user-message-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-tiny);
-        margin-bottom: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
+        margin-bottom: var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         color: var(--texra-descriptionForeground);
       }
@@ -99,7 +99,7 @@ export class UserMessage extends LitElement {
       .user-message-header-left {
         display: flex;
         align-items: center;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         flex: 1;
       }
 
@@ -131,7 +131,7 @@ export class UserMessage extends LitElement {
       .user-message--structured-delivery .user-message-content {
         max-height: min(45vh, 520px);
         overflow: auto;
-        padding: var(--spacing-small);
+        padding: var(--wa-space-2xs);
         background: var(
           --texra-textCodeBlock-background,
           var(--texra-editor-background)

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -39,14 +39,14 @@ export class WorkflowToolUseFollowupSection extends LitElement {
 
       .followup {
         border-top: var(--border-thin) solid var(--color-border);
-        padding: var(--spacing-small) 0;
+        padding: var(--wa-space-2xs) 0;
         color: var(--color-text-secondary);
       }
 
       .followup__header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         width: 100%;
         padding: 0;
         border: none;
@@ -64,8 +64,8 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       .followup__body {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .followup__description {
@@ -75,13 +75,13 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       .followup__controls {
         display: grid;
         grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr);
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .followup__field {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         min-width: 0;
       }
 
@@ -97,7 +97,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       .followup__actions {
         display: flex;
         justify-content: flex-end;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       @media (max-width: 600px) {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -430,7 +430,7 @@ function buildAcceptRunFilesSections(
       const isMapped = dest && source && dest !== source;
       const edit = editsByPath.get(dest);
       const diffStats = edit?.lineChanges
-        ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--spacing-small)">-${edit.lineChanges.removed}</span></span>`
+        ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--wa-space-2xs)">-${edit.lineChanges.removed}</span></span>`
         : nothing;
       // prettier-ignore
       return html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -16,7 +16,7 @@ export const codeBlockStyles = css`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     background-color: var(--texra-editorGroupHeader-tabsBackground);
     border-bottom: var(--border-thin) solid var(--color-border);
     font-size: var(--font-size-xs);
@@ -31,7 +31,7 @@ export const codeBlockStyles = css`
 
   .code-block pre {
     margin: 0;
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     background-color: var(--texra-editor-background);
     border: var(--border-thin) solid var(--texra-editorWidget-border);
     border-radius: 0;
@@ -46,7 +46,7 @@ export const codeBlockStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--spacing-small) var(--spacing-medium);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     border: none;
     background: transparent;
     color: var(--texra-descriptionForeground, #888);
@@ -84,7 +84,7 @@ export const codeBlockStyles = css`
 
   /* Syntax highlighted code blocks */
   pre.hljs {
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     overflow-x: auto;
   }
 

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -6,8 +6,8 @@ import { css } from 'lit';
  */
 export const groupStyles = css`
   .log-group-header {
-    padding: var(--spacing-small) var(--spacing-medium);
-    margin: var(--spacing-tiny) 0;
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    margin: var(--wa-space-3xs) 0;
     border-radius: var(--border-radius-small);
     cursor: pointer;
     display: flex;
@@ -38,7 +38,7 @@ export const groupStyles = css`
   }
 
   .log-group-content {
-    padding-left: var(--spacing-small);
+    padding-left: var(--wa-space-2xs);
     border-left: var(--border-thin) dashed
       var(--texra-editorGroupHeader-tabsBorder);
   }
@@ -53,7 +53,7 @@ export const groupStyles = css`
   }
 
   .group-status-icon {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .group-title {
@@ -64,11 +64,11 @@ export const groupStyles = css`
   .group-time {
     font-size: var(--font-size-sm);
     opacity: var(--opacity-subtle);
-    margin-left: var(--spacing-small);
+    margin-left: var(--wa-space-2xs);
   }
 
   :is(.group-start-time, .group-duration) {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .log-group {
@@ -84,7 +84,7 @@ export const groupStyles = css`
 
   .log-group-content
     > :is(.log-group-header, .log-group-content, .log-line, .banner-details) {
-    margin-left: var(--spacing-small);
+    margin-left: var(--wa-space-2xs);
   }
 
   .log-group-content .log-group-header {

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -10,7 +10,7 @@ export const logEntryStyles = css`
 
   .log-container {
     flex: 1 1 auto;
-    padding: var(--spacing-tiny) var(--spacing-medium);
+    padding: var(--wa-space-3xs) var(--wa-space-xs);
     min-width: 0;
     min-height: 0;
     font-family: var(--font-family);
@@ -23,7 +23,7 @@ export const logEntryStyles = css`
   .log-line {
     line-height: var(--line-height-normal);
     margin: 0;
-    padding: calc(var(--spacing-tiny) / 2) 0;
+    padding: calc(var(--wa-space-3xs) / 2) 0;
     display: block;
     white-space: pre-wrap;
     word-wrap: break-word;
@@ -35,9 +35,9 @@ export const logEntryStyles = css`
   .log-line--render-error {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: var(--spacing-small) var(--spacing-medium);
-    margin: var(--spacing-small) 0;
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    margin: var(--wa-space-2xs) 0;
     background: var(--texra-inputValidation-warningBackground);
     border: var(--border-thin) solid var(--texra-inputValidation-warningBorder);
     border-radius: var(--border-radius);
@@ -51,7 +51,7 @@ export const logEntryStyles = css`
   }
 
   .log-entry-content {
-    padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
+    padding: var(--wa-space-2xs) 0 var(--wa-space-xs) var(--wa-space-s);
     overflow: visible;
   }
 
@@ -70,7 +70,7 @@ export const logEntryStyles = css`
   .file-list-content .file-var {
     opacity: var(--opacity-normal);
     font-size: var(--font-size-sm);
-    margin-left: var(--spacing-tiny);
+    margin-left: var(--wa-space-3xs);
   }
 
   .file-list-content .file-source {
@@ -80,13 +80,13 @@ export const logEntryStyles = css`
   }
 
   .xml-link-container {
-    margin-top: var(--spacing-small);
-    padding-top: var(--spacing-small);
+    margin-top: var(--wa-space-2xs);
+    padding-top: var(--wa-space-2xs);
     border-top: var(--border-thin) solid var(--texra-widget-border);
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .xml-link-container wa-icon {
@@ -101,12 +101,12 @@ export const logEntryStyles = css`
 
   .xml-link-container .xml-fix-hint {
     flex-basis: 100%;
-    margin-top: var(--spacing-tiny);
+    margin-top: var(--wa-space-3xs);
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
     display: flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
   }
 
   .xml-link-container .xml-fix-hint wa-icon {
@@ -145,7 +145,7 @@ export const logEntryStyles = css`
   }
 
   .memory-path wa-icon {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .memory-path .file-source {
@@ -156,11 +156,11 @@ export const logEntryStyles = css`
   /* Web search result styles */
   .detail-list {
     list-style: none;
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
   }
 
   .file-list-summary {
@@ -173,12 +173,12 @@ export const logEntryStyles = css`
 
   /* File list details styling */
   .file-list-details {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
   }
 
   .banner-content-copy {
     min-width: 0;
-    padding: 0 var(--spacing-tiny);
+    padding: 0 var(--wa-space-3xs);
     opacity: 0;
     margin-left: auto;
     transition:
@@ -237,13 +237,13 @@ export const logEntryStyles = css`
   .banner-summary {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     font-size: var(--font-size);
     font-weight: var(--font-weight-semibold);
   }
 
   .banner-details {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
     content-visibility: auto;
     contain-intrinsic-size: auto 40px;
   }
@@ -259,14 +259,14 @@ export const logEntryStyles = css`
   .extract-flag {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     border-radius: var(--border-radius);
     background: var(--texra-badge-background);
     color: var(--texra-badge-foreground);
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   /* Terminal-style output: monospace font, tighter spacing, no log bullets.

--- a/packages/extension/src/progressView/frontend/styles/logStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logStyles.ts
@@ -59,7 +59,7 @@ export const layoutStyles = css`
   .log-placeholder {
     text-align: center;
     color: var(--color-text-secondary);
-    padding: var(--spacing-large) var(--spacing-medium);
+    padding: var(--wa-space-s) var(--wa-space-xs);
   }
 
   .log-placeholder a {

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -6,10 +6,10 @@ import { css } from 'lit';
  */
 export const toolUseStyles = css`
   .tool-use-section {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
     border-left: var(--border-medium) solid
       color-mix(in srgb, var(--texra-textLink-foreground) 30%, transparent);
-    padding-left: var(--spacing-medium);
+    padding-left: var(--wa-space-xs);
   }
 
   .tool-use-title {
@@ -31,11 +31,11 @@ export const toolUseStyles = css`
   .tool-use-label {
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-link);
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
   }
 
   .tool-use-subsection {
-    margin: var(--spacing-tiny) 0;
+    margin: var(--wa-space-3xs) 0;
   }
 
   .tool-use-sublabel {
@@ -46,7 +46,7 @@ export const toolUseStyles = css`
   }
 
   .tool-use-separator {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
     border: none;
     border-top: var(--border-thin) solid var(--color-border);
     opacity: var(--opacity-separator);
@@ -61,7 +61,7 @@ export const toolUseStyles = css`
 
   .banner-content--error .error-details {
     margin: 0;
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     background-color: var(
       --texra-inputValidation-errorBackground,
       rgba(255, 0, 0, 0.1)
@@ -108,7 +108,7 @@ export const toolUseStyles = css`
   }
 
   :is(.tool-user-feedback, .tool-error-content) {
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     border-radius: var(--border-radius-small);
     border-left: var(--border-thick) solid;
   }
@@ -151,7 +151,7 @@ export const toolUseStyles = css`
     font-weight: var(--font-weight-medium);
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
     transition:
       color var(--transition-fast),
       background-color var(--transition-fast);
@@ -192,7 +192,7 @@ export const toolUseStyles = css`
 
   .diff-inline-view {
     margin: 0;
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     border-radius: var(--border-radius-small);
     background-color: var(--texra-editor-background);
     white-space: pre-wrap;
@@ -202,7 +202,7 @@ export const toolUseStyles = css`
 
   :is(.diff-inline-del, .diff-inline-add) {
     border-radius: var(--border-radius);
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
   }
 
   .diff-inline-del {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -153,13 +153,13 @@ export class SettingsApp extends SettingsAppBase {
       wa-tab-panel {
         flex: 1;
         overflow: auto;
-        --padding: var(--spacing-large);
+        --padding: var(--wa-space-s);
       }
 
       .settings-unavailable {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         max-width: 640px;
         color: var(--color-text-secondary);
       }
@@ -167,7 +167,7 @@ export class SettingsApp extends SettingsAppBase {
       .settings-unavailable-title {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         color: var(--text-color);
         font-weight: var(--font-weight-medium);
       }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -43,13 +43,13 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-meta {
-        margin-top: var(--spacing-small);
+        margin-top: var(--wa-space-2xs);
       }
 
       .memory-preview {
         font-size: var(--font-size-sm);
         line-height: var(--line-height-normal);
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         border-radius: var(--border-radius);
         margin: 0;
         max-height: 200px;
@@ -58,7 +58,7 @@ export class MemoryItem extends LitElement {
 
       .memory-item.pinned {
         border-left: 3px solid var(--texra-textLink-foreground);
-        padding-left: calc(var(--spacing-medium) - 3px);
+        padding-left: calc(var(--wa-space-xs) - 3px);
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -45,7 +45,7 @@ export class MemoryList extends LitElement {
       .memory-list {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
@@ -24,10 +24,10 @@ export class MemoryToggle extends LitElement {
       }
 
       .memory-settings {
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
-        margin-bottom: var(--spacing-small);
+        margin-bottom: var(--wa-space-2xs);
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToolbar.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToolbar.ts
@@ -24,7 +24,7 @@ export class MemoryToolbar extends LitElement {
       }
 
       .view-header {
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -84,7 +84,7 @@ export class AgentSelectionPanel extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
@@ -99,7 +99,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-list-section-actions {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         text-transform: none;
         letter-spacing: normal;
         font-weight: normal;
@@ -108,8 +108,8 @@ export class AgentSelectionPanel extends LitElement {
       .agent-list-item {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-small) var(--spacing-medium);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         cursor: pointer;
         font-size: var(--font-size-sm);
         color: var(--texra-foreground);
@@ -162,7 +162,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-list-item-badges {
         display: flex;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         opacity: var(--opacity-normal);
         flex-shrink: 0;
@@ -172,7 +172,7 @@ export class AgentSelectionPanel extends LitElement {
       .agent-detail-pane {
         flex: 1;
         overflow-y: auto;
-        padding: var(--spacing-large);
+        padding: var(--wa-space-s);
         min-width: 0;
       }
 
@@ -188,8 +188,8 @@ export class AgentSelectionPanel extends LitElement {
       .agent-detail-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
+        gap: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-s);
       }
 
       .agent-detail-name {
@@ -202,14 +202,14 @@ export class AgentSelectionPanel extends LitElement {
       .agent-detail-description {
         color: var(--texra-foreground);
         line-height: var(--line-height-relaxed);
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
       }
 
       .agent-detail-meta {
         display: grid;
         grid-template-columns: auto 1fr;
-        gap: var(--spacing-small) var(--spacing-large);
-        margin-bottom: var(--spacing-large);
+        gap: var(--wa-space-2xs) var(--wa-space-s);
+        margin-bottom: var(--wa-space-s);
         font-size: var(--font-size-sm);
       }
 
@@ -226,7 +226,7 @@ export class AgentSelectionPanel extends LitElement {
       .agent-detail-tools {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       wa-tag.agent-tool-badge {
@@ -235,7 +235,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-detail-actions {
         display: flex;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
         flex-wrap: wrap;
       }
 
@@ -247,7 +247,7 @@ export class AgentSelectionPanel extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         border-top: var(--border-thin) solid var(--color-border);
@@ -284,7 +284,7 @@ export class AgentSelectionPanel extends LitElement {
         font-size: var(--font-size-xs);
         font-family: var(--texra-editor-font-family, monospace), monospace;
         color: var(--color-text-secondary);
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -306,8 +306,8 @@ export class AgentSelectionPanel extends LitElement {
       .agent-delete-confirm {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
-        padding: var(--spacing-small) var(--spacing-medium);
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         background: var(
           --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.05)
@@ -324,7 +324,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-delete-confirm-actions {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex-shrink: 0;
       }
     `,

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -29,7 +29,7 @@ export class ProviderKeyModal extends LitElement {
       }
 
       .provider-key-description {
-        margin: 0 0 var(--spacing-large);
+        margin: 0 0 var(--wa-space-s);
         color: var(--color-text-secondary);
         line-height: var(--line-height-normal);
       }
@@ -37,7 +37,7 @@ export class ProviderKeyModal extends LitElement {
       label {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         font-weight: var(--font-weight-medium);
       }
 
@@ -45,7 +45,7 @@ export class ProviderKeyModal extends LitElement {
         width: 100%;
         box-sizing: border-box;
         height: 34px;
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         color: var(--texra-input-foreground);
         background: var(--texra-input-background);
         border: var(--border-thin) solid var(--texra-input-border);
@@ -60,7 +60,7 @@ export class ProviderKeyModal extends LitElement {
 
       .provider-key-error {
         min-height: 1.4em;
-        margin: var(--spacing-small) 0 0;
+        margin: var(--wa-space-2xs) 0 0;
         color: var(--texra-errorForeground, var(--color-error));
         font-size: var(--font-size-sm);
       }
@@ -68,15 +68,15 @@ export class ProviderKeyModal extends LitElement {
       .provider-key-actions {
         display: flex;
         justify-content: flex-end;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       button {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         min-height: var(--height-button);
-        padding: var(--spacing-small) var(--spacing-large);
+        padding: var(--wa-space-2xs) var(--wa-space-s);
         border-radius: var(--border-radius);
         font: inherit;
         cursor: pointer;

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -4,11 +4,11 @@ import { css, type CSSResult } from 'lit';
 export const profileViewStyles: CSSResult = css`
   h2 {
     color: var(--texra-foreground);
-    margin-top: var(--spacing-xlarge);
-    margin-bottom: var(--spacing-medium);
+    margin-top: var(--wa-space-l);
+    margin-bottom: var(--wa-space-xs);
     font-size: var(--font-size-lg);
     border-bottom: var(--border-thin) solid var(--color-border);
-    padding-bottom: var(--spacing-small);
+    padding-bottom: var(--wa-space-2xs);
   }
 
   .profile-container {
@@ -17,20 +17,20 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .profile-info {
-    margin-bottom: var(--spacing-xlarge);
+    margin-bottom: var(--wa-space-l);
   }
 
   .profile-actions {
     display: flex;
     justify-content: flex-end;
-    margin-top: var(--spacing-medium);
+    margin-top: var(--wa-space-xs);
   }
 
   .info-row {
-    margin: var(--spacing-medium) 0;
+    margin: var(--wa-space-xs) 0;
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .label {
@@ -49,7 +49,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .profile-notice {
-    margin: var(--spacing-small) 0 var(--spacing-medium);
+    margin: var(--wa-space-2xs) 0 var(--wa-space-xs);
     color: var(--texra-descriptionForeground, var(--color-text-secondary));
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
@@ -59,23 +59,23 @@ export const profileViewStyles: CSSResult = css`
   .profile-notice code {
     font-family: var(--texra-editor-font-family, monospace), monospace;
     font-size: 0.95em;
-    padding: 0 var(--spacing-tiny);
+    padding: 0 var(--wa-space-3xs);
     border-radius: var(--border-radius-small);
     background: var(--texra-textBlockQuote-background);
   }
 
   .not-authenticated {
     text-align: center;
-    padding: var(--spacing-xlarge);
+    padding: var(--wa-space-l);
   }
 
   .not-authenticated p {
-    margin-bottom: var(--spacing-xlarge);
+    margin-bottom: var(--wa-space-l);
     color: var(--color-text-secondary);
   }
 
   .remote-agents-section {
-    margin-top: var(--spacing-xlarge);
+    margin-top: var(--wa-space-l);
   }
 
   /* ============================================
@@ -85,12 +85,12 @@ export const profileViewStyles: CSSResult = css`
   .provider-keys-table {
     width: 100%;
     border-collapse: collapse;
-    margin-top: var(--spacing-medium);
+    margin-top: var(--wa-space-xs);
   }
 
   .provider-keys-table th,
   .provider-keys-table td {
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     text-align: left;
     border-bottom: var(--border-thin) solid var(--color-border);
   }
@@ -135,27 +135,27 @@ export const profileViewStyles: CSSResult = css`
    * ============================================ */
 
   .api-access-section {
-    margin-top: var(--spacing-xlarge);
-    margin-bottom: var(--spacing-xlarge);
+    margin-top: var(--wa-space-l);
+    margin-bottom: var(--wa-space-l);
   }
 
   .api-access-description {
     color: var(--color-text-secondary);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
     line-height: var(--line-height-normal);
   }
 
   .api-access-options {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .api-access-option {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-medium);
-    padding: var(--spacing-medium);
+    gap: var(--wa-space-xs);
+    padding: var(--wa-space-xs);
     background: var(--texra-input-background);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
@@ -173,15 +173,15 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .api-access-option input[type='radio'] {
-    margin-top: var(--spacing-tiny);
+    margin-top: var(--wa-space-3xs);
     accent-color: var(--texra-focusBorder);
   }
 
   .api-access-support {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-small);
-    padding: var(--spacing-small) var(--spacing-medium);
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
@@ -206,7 +206,7 @@ export const profileViewStyles: CSSResult = css`
   .option-content {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .option-title {
@@ -225,7 +225,7 @@ export const profileViewStyles: CSSResult = css`
    * ============================================ */
 
   .provider-keys-section {
-    margin-top: var(--spacing-xlarge);
+    margin-top: var(--wa-space-l);
   }
 
   .provider-keys-section h2 {
@@ -234,7 +234,7 @@ export const profileViewStyles: CSSResult = css`
 
   .provider-keys-description {
     color: var(--color-text-secondary);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
     line-height: var(--line-height-normal);
   }
 
@@ -245,7 +245,7 @@ export const profileViewStyles: CSSResult = css`
 
   .provider-actions {
     display: flex;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     white-space: nowrap;
   }
 
@@ -253,9 +253,9 @@ export const profileViewStyles: CSSResult = css`
   .global-streaming-toggle {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
-    margin-bottom: var(--spacing-medium);
-    padding: var(--spacing-medium);
+    gap: var(--wa-space-xs);
+    margin-bottom: var(--wa-space-xs);
+    padding: var(--wa-space-xs);
     background: var(--texra-input-background);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
@@ -302,20 +302,20 @@ export const profileViewStyles: CSSResult = css`
   .provider-name-cell {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   /* Provider detail row (collapsible settings) */
   .provider-detail-row td {
-    padding: 0 var(--spacing-medium) var(--spacing-medium);
+    padding: 0 var(--wa-space-xs) var(--wa-space-xs);
     border-bottom: var(--border-thin) solid var(--color-border);
   }
 
   .provider-settings {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
-    padding: var(--spacing-medium);
+    gap: var(--wa-space-xs);
+    padding: var(--wa-space-xs);
     background: var(--texra-textBlockQuote-background);
     border-radius: var(--border-radius);
   }
@@ -323,7 +323,7 @@ export const profileViewStyles: CSSResult = css`
   .provider-setting {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .provider-setting label {
@@ -340,7 +340,7 @@ export const profileViewStyles: CSSResult = css`
   .provider-setting--block {
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .provider-setting-description {
@@ -369,7 +369,7 @@ export const profileViewStyles: CSSResult = css`
     color: var(--texra-textLink-foreground);
     cursor: pointer;
     text-decoration: none;
-    margin-left: var(--spacing-small);
+    margin-left: var(--wa-space-2xs);
   }
 
   .provider-setting-link:hover {
@@ -386,7 +386,7 @@ export const profileViewStyles: CSSResult = css`
    * ============================================ */
 
   .model-selection-section {
-    margin-top: var(--spacing-xlarge);
+    margin-top: var(--wa-space-l);
   }
 
   .model-selection-section h2 {
@@ -395,15 +395,15 @@ export const profileViewStyles: CSSResult = css`
 
   .model-selection-description {
     color: var(--color-text-secondary);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
     line-height: var(--line-height-normal);
   }
 
   .helper-model-row {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
-    margin-bottom: var(--spacing-large);
+    gap: var(--wa-space-xs);
+    margin-bottom: var(--wa-space-s);
   }
 
   .helper-model-row label {
@@ -420,14 +420,14 @@ export const profileViewStyles: CSSResult = css`
   .provider-group {
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
     overflow: hidden;
   }
 
   .provider-group-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
     width: 100%;
     background: var(--texra-editor-background);
     border: none;
@@ -446,7 +446,7 @@ export const profileViewStyles: CSSResult = css`
     align-items: center;
     flex: 1;
     min-width: 0;
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     background: none;
     border: none;
     color: inherit;
@@ -467,7 +467,7 @@ export const profileViewStyles: CSSResult = css`
     justify-content: center;
     width: 16px;
     height: 16px;
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
     transition: transform var(--transition-fast);
     color: var(--color-text-secondary);
   }
@@ -491,8 +491,8 @@ export const profileViewStyles: CSSResult = css`
   .provider-group-actions {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding-right: var(--spacing-medium);
+    gap: var(--wa-space-2xs);
+    padding-right: var(--wa-space-xs);
     white-space: nowrap;
   }
 
@@ -506,14 +506,14 @@ export const profileViewStyles: CSSResult = css`
 
   .provider-group-content {
     border-top: var(--border-thin) solid var(--color-border);
-    padding: var(--spacing-small) 0;
+    padding: var(--wa-space-2xs) 0;
   }
 
   .model-row {
     display: flex;
     align-items: center;
-    padding: var(--spacing-small) var(--spacing-medium);
-    gap: var(--spacing-medium);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    gap: var(--wa-space-xs);
   }
 
   .model-row:hover {
@@ -529,8 +529,8 @@ export const profileViewStyles: CSSResult = css`
   .short-names-toggle {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
-    margin-bottom: var(--spacing-medium);
+    gap: var(--wa-space-xs);
+    margin-bottom: var(--wa-space-xs);
     font-size: var(--font-size-sm);
   }
 
@@ -551,7 +551,7 @@ export const profileViewStyles: CSSResult = css`
 
   .model-metadata {
     display: flex;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
     color: var(--color-text-secondary);
     font-size: var(--font-size-xs);
     white-space: nowrap;
@@ -567,8 +567,8 @@ export const profileViewStyles: CSSResult = css`
   .deprecated-toggle {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: var(--spacing-small) var(--spacing-medium);
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     background: none;
     border: none;
     color: var(--color-text-secondary);
@@ -607,7 +607,7 @@ export const profileViewStyles: CSSResult = css`
    */
   .model-row-icon {
     font-size: var(--font-size-xs);
-    margin-left: var(--spacing-tiny);
+    margin-left: var(--wa-space-3xs);
     color: var(--_icon-color, var(--color-text-secondary));
   }
 

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -58,7 +58,7 @@ export class Pagination extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: var(--spacing-small) 0;
+        padding: var(--wa-space-2xs) 0;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         user-select: none;
@@ -72,7 +72,7 @@ export class Pagination extends LitElement {
       .pagination-controls {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .pagination-controls wa-button::part(base) {

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -36,8 +36,8 @@ export class ToolCard extends LitElement {
       .tool-card {
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
-        padding: var(--spacing-medium) var(--spacing-large);
-        margin-bottom: var(--spacing-medium);
+        padding: var(--wa-space-xs) var(--wa-space-s);
+        margin-bottom: var(--wa-space-xs);
         background: var(
           --texra-editor-background,
           var(--texra-sideBar-background)
@@ -54,15 +54,15 @@ export class ToolCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         flex-wrap: wrap;
-        gap: var(--spacing-medium);
-        margin-bottom: var(--spacing-small);
+        gap: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-2xs);
       }
 
       .tool-title-group {
         display: flex;
         align-items: center;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         min-width: 0;
       }
 
@@ -80,15 +80,15 @@ export class ToolCard extends LitElement {
       .tool-description {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
-        margin-bottom: var(--spacing-small);
+        margin-bottom: var(--wa-space-2xs);
         line-height: var(--line-height-normal);
       }
 
       .tool-ids {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
-        margin-bottom: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-bottom: var(--wa-space-2xs);
       }
 
       .tool-id-tag {
@@ -106,8 +106,8 @@ export class ToolCard extends LitElement {
       }
 
       .tool-guide {
-        margin-top: var(--spacing-small);
-        padding: var(--spacing-medium);
+        margin-top: var(--wa-space-2xs);
+        padding: var(--wa-space-xs);
         background: var(
           --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
@@ -122,8 +122,8 @@ export class ToolCard extends LitElement {
       .tool-guide-actions {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .tool-guide-actions wa-button::part(base) {
@@ -133,8 +133,8 @@ export class ToolCard extends LitElement {
       .tool-auth-note {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--border-thin) var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        padding: var(--border-thin) var(--wa-space-2xs);
         font-size: var(--font-size-xs);
         border-radius: var(--border-radius);
         white-space: nowrap;
@@ -168,7 +168,7 @@ export class ToolCard extends LitElement {
       }
 
       .tool-config-note {
-        margin-top: var(--spacing-small);
+        margin-top: var(--wa-space-2xs);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         font-style: italic;

--- a/packages/extension/src/settingsView/frontend/styles.ts
+++ b/packages/extension/src/settingsView/frontend/styles.ts
@@ -10,16 +10,16 @@ const settingsHeaderStyles: CSSResult = css`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--spacing-medium) var(--spacing-large);
+    padding: var(--wa-space-xs) var(--wa-space-s);
     background: var(--texra-sideBar-background);
     border-bottom: var(--border-thin) solid var(--color-border);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
   }
 
   .settings-header-user {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .settings-header-user-icon {
@@ -33,7 +33,7 @@ const settingsHeaderStyles: CSSResult = css`
   .settings-header-info {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
   }
 
   .settings-header-email {
@@ -53,7 +53,7 @@ const settingsHeaderStyles: CSSResult = css`
   .settings-header-actions {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .settings-header-auth-button {

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -44,7 +44,7 @@ export class AgentsTab extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: var(--spacing-medium);
+        margin-bottom: var(--wa-space-xs);
       }
 
       .agents-sub-tabs {
@@ -56,8 +56,8 @@ export class AgentsTab extends LitElement {
       .agents-sub-tab {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-medium) var(--spacing-large);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-xs) var(--wa-space-s);
         font-size: var(--font-size-sm);
         font-family: inherit;
         color: var(--color-text-secondary);
@@ -96,7 +96,7 @@ export class AgentsTab extends LitElement {
 
       .agents-header-actions {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .agents-create-btn {
@@ -109,9 +109,9 @@ export class AgentsTab extends LitElement {
       .agents-dir-bar {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-small) var(--spacing-medium);
-        margin-bottom: var(--spacing-medium);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        margin-bottom: var(--wa-space-xs);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         background: var(--texra-sideBar-background, rgba(128, 128, 128, 0.04));
@@ -144,7 +144,7 @@ export class AgentsTab extends LitElement {
 
       .agents-dir-actions {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex-shrink: 0;
         margin-left: auto;
       }
@@ -153,7 +153,7 @@ export class AgentsTab extends LitElement {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: var(--spacing-tiny);
+        padding: var(--wa-space-3xs);
         color: var(--color-text-secondary);
         background: none;
         border: none;

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -43,17 +43,17 @@ export class GitTab extends LitElement {
       .git-container {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .setting-block {
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
       }
 
       .setting-description {
-        margin: var(--spacing-small) 0 0 0;
+        margin: var(--wa-space-2xs) 0 0 0;
         font-size: var(--font-size-sm);
         color: var(--texra-descriptionForeground);
       }
@@ -61,8 +61,8 @@ export class GitTab extends LitElement {
       .input-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .input-row label {
@@ -82,8 +82,8 @@ export class GitTab extends LitElement {
       .token-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
         flex-wrap: wrap;
       }
 
@@ -95,7 +95,7 @@ export class GitTab extends LitElement {
       .token-actions {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex-wrap: wrap;
       }
 
@@ -105,12 +105,12 @@ export class GitTab extends LitElement {
       }
 
       .instructions {
-        margin: var(--spacing-small) 0 0 0;
+        margin: var(--wa-space-2xs) 0 0 0;
         font-size: var(--font-size-sm);
         color: var(--texra-descriptionForeground);
       }
       .instructions ol {
-        margin: var(--spacing-tiny) 0 0 0;
+        margin: var(--wa-space-3xs) 0 0 0;
         padding-left: 1.25em;
       }
       .instructions li {
@@ -118,7 +118,7 @@ export class GitTab extends LitElement {
       }
       .instructions code {
         background: var(--texra-textBlockQuote-background);
-        padding: 0 var(--spacing-small);
+        padding: 0 var(--wa-space-2xs);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
       }
@@ -126,18 +126,18 @@ export class GitTab extends LitElement {
       .subscriptions-list {
         list-style: none;
         padding: 0;
-        margin: var(--spacing-small) 0 0 0;
+        margin: var(--wa-space-2xs) 0 0 0;
       }
       .subscriptions-list li {
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
         align-items: start;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
       }
       .subscriptions-list code {
         background: var(--texra-textBlockQuote-background);
-        padding: var(--border-thin) var(--spacing-medium);
+        padding: var(--border-thin) var(--wa-space-xs);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
       }
@@ -145,7 +145,7 @@ export class GitTab extends LitElement {
         min-width: 0;
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
       .subscription-key {
         overflow-wrap: anywhere;
@@ -153,12 +153,12 @@ export class GitTab extends LitElement {
       .subscription-owners {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
       .subscription-owner-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex-wrap: wrap;
       }
       .subscription-owner-label,

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -175,28 +175,28 @@ export class LaTeXTab extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
       }
 
       .latex-title {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-medium);
         color: var(--texra-foreground);
       }
 
       .latex-description {
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
       }
 
       .dependency-card {
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-medium);
+        padding: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-xs);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         background: var(--texra-editor-background);
@@ -205,7 +205,7 @@ export class LaTeXTab extends LitElement {
       .dependency-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .dependency-icon {
@@ -234,15 +234,15 @@ export class LaTeXTab extends LitElement {
       .dependency-description {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
-        margin-top: var(--spacing-tiny);
+        margin-top: var(--wa-space-3xs);
       }
 
       .dependency-guide-toggle {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-tiny) 0;
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) 0;
+        margin-top: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
         font-family: inherit;
         color: var(--texra-textLink-foreground, #3794ff);
@@ -257,8 +257,8 @@ export class LaTeXTab extends LitElement {
       }
 
       .dependency-guide {
-        margin-top: var(--spacing-small);
-        padding: var(--spacing-medium);
+        margin-top: var(--wa-space-2xs);
+        padding: var(--wa-space-xs);
         background: var(
           --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
@@ -279,14 +279,14 @@ export class LaTeXTab extends LitElement {
 
       .dependency-install-actions {
         display: flex;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .install-command-text {
         flex: 1;
         min-width: 0;
-        padding: var(--spacing-small) var(--spacing-medium);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         background: var(
           --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
@@ -308,9 +308,9 @@ export class LaTeXTab extends LitElement {
       .prerequisite-hint {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-medium);
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-medium);
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-xs);
         border: var(--border-thin) solid
           var(--texra-editorInfo-foreground, #3794ff);
         border-radius: var(--border-radius);
@@ -331,7 +331,7 @@ export class LaTeXTab extends LitElement {
       .prerequisite-hint .hint-title {
         font-weight: var(--font-weight-medium);
         color: var(--texra-foreground);
-        margin-bottom: var(--spacing-tiny);
+        margin-bottom: var(--wa-space-3xs);
       }
 
       .prerequisite-hint .hint-description {
@@ -343,16 +343,16 @@ export class LaTeXTab extends LitElement {
       .prerequisite-hint .hint-actions {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
       }
 
       .section-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding-bottom: var(--spacing-small);
-        margin-bottom: var(--spacing-medium);
+        gap: var(--wa-space-2xs);
+        padding-bottom: var(--wa-space-2xs);
+        margin-bottom: var(--wa-space-xs);
         border-bottom: var(--border-thin) solid var(--color-border);
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-medium);
@@ -364,9 +364,9 @@ export class LaTeXTab extends LitElement {
       .setting-card {
         display: flex;
         align-items: flex-start;
-        gap: var(--spacing-medium);
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-medium);
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-xs);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         background: var(--texra-editor-background);
@@ -394,7 +394,7 @@ export class LaTeXTab extends LitElement {
       .setting-toggle {
         display: inline-flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         white-space: nowrap;
       }
 
@@ -408,7 +408,7 @@ export class LaTeXTab extends LitElement {
         font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
-        margin-bottom: var(--spacing-small);
+        margin-bottom: var(--wa-space-2xs);
       }
 
       .setting-value {
@@ -421,7 +421,7 @@ export class LaTeXTab extends LitElement {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         line-height: var(--line-height-normal);
-        margin-top: var(--spacing-small);
+        margin-top: var(--wa-space-2xs);
       }
 
       wa-tag.setting-badge {
@@ -431,8 +431,8 @@ export class LaTeXTab extends LitElement {
       .checkbox-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
         cursor: pointer;
       }
     `,
@@ -750,7 +750,7 @@ export class LaTeXTab extends LitElement {
       return html`
         <div class="tab-content-container">
           <div
-            style="text-align:center;padding:var(--spacing-large);color:var(--color-text-secondary)"
+            style="text-align:center;padding:var(--wa-space-s);color:var(--color-text-secondary)"
           >
             <wa-spinner></wa-spinner>
             Loading LaTeX settings...
@@ -781,7 +781,7 @@ export class LaTeXTab extends LitElement {
           : html`
               <div
                 class="section-header"
-                style="margin-top:var(--spacing-large)"
+                style="margin-top:var(--wa-space-s)"
               >
                 <wa-icon library="texra" name="settings-gear"></wa-icon>
                 Recommended Settings
@@ -805,7 +805,7 @@ export class LaTeXTab extends LitElement {
 
   private renderInlineCriticismSetting(): TemplateResult {
     return html`
-      <div class="section-header" style="margin-top:var(--spacing-large)">
+      <div class="section-header" style="margin-top:var(--wa-space-s)">
         <wa-icon library="texra" name="comment-discussion"></wa-icon>
         Inline Criticism
       </div>
@@ -853,7 +853,7 @@ export class LaTeXTab extends LitElement {
   private renderCompileDiffSettings(): TemplateResult {
     const cv = this.configValues;
     return html`
-      <div class="section-header" style="margin-top:var(--spacing-large)">
+      <div class="section-header" style="margin-top:var(--wa-space-s)">
         <wa-icon library="texra" name="zap"></wa-icon>
         Compile &amp; Diff
       </div>
@@ -1003,7 +1003,7 @@ export class LaTeXTab extends LitElement {
               );
               this.dispatchSetConfigValue(opts.field, clamped);
             }}
-            style="margin-top:var(--spacing-small);width:140px;"
+            style="margin-top:var(--wa-space-2xs);width:140px;"
           />
         </div>
         ${isCustom
@@ -1047,7 +1047,7 @@ export class LaTeXTab extends LitElement {
                 .value as LatexConfigValueFor<F>;
               this.dispatchSetConfigValue(opts.field, v);
             }}
-            style="margin-top:var(--spacing-small);"
+            style="margin-top:var(--wa-space-2xs);"
           >
             ${opts.options.map(
               (o) => html`

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -31,11 +31,11 @@ export class MemoryTab extends LitElement {
       .memory-view-container {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .memory-description {
-        margin: 0 0 var(--spacing-medium) 0;
+        margin: 0 0 var(--wa-space-xs) 0;
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -53,40 +53,40 @@ export class MultiAgentTab extends LitElement {
       .multi-agent-container {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .setting-block {
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
       }
 
       .setting-description {
-        margin: var(--spacing-small) 0 0 0;
+        margin: var(--wa-space-2xs) 0 0 0;
         font-size: var(--font-size-sm);
       }
 
       .multi-agent-reminder-steps {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-        gap: var(--spacing-small) var(--spacing-large);
-        margin-top: var(--spacing-tiny);
+        gap: var(--wa-space-2xs) var(--wa-space-s);
+        margin-top: var(--wa-space-3xs);
       }
 
       /* Team cards */
       .preset-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .preset-card {
         position: relative;
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-small);
-        padding: var(--spacing-medium);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-xs);
         background-color: var(--texra-editor-inactiveSelectionBackground);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
@@ -131,7 +131,7 @@ export class MultiAgentTab extends LitElement {
       .preset-card-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .preset-card-icon {
@@ -161,15 +161,15 @@ export class MultiAgentTab extends LitElement {
       .preset-card-agents {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-tiny);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-3xs);
       }
 
       .preset-card-orchestrators {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-tiny);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-3xs);
       }
 
       wa-tag.preset-agent-badge--orchestrator {
@@ -183,12 +183,12 @@ export class MultiAgentTab extends LitElement {
 
       .preset-delete-btn {
         position: absolute;
-        top: var(--spacing-small);
-        right: var(--spacing-small);
+        top: var(--wa-space-2xs);
+        right: var(--wa-space-2xs);
         display: none;
         align-items: center;
         justify-content: center;
-        padding: var(--spacing-tiny);
+        padding: var(--wa-space-3xs);
         color: var(--color-text-secondary);
         background: none;
         border: none;
@@ -215,8 +215,8 @@ export class MultiAgentTab extends LitElement {
       .reliability-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
-        padding: var(--spacing-small) 0;
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-2xs) 0;
       }
 
       .reliability-row label {
@@ -238,7 +238,7 @@ export class MultiAgentTab extends LitElement {
         color: var(--color-text-secondary);
         font-size: var(--font-size-xs);
         margin: 0;
-        padding-left: calc(140px + var(--spacing-medium));
+        padding-left: calc(140px + var(--wa-space-xs));
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -116,13 +116,13 @@ export class ToolsTab extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
       }
 
       .tools-title {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-medium);
         color: var(--texra-foreground);
@@ -131,7 +131,7 @@ export class ToolsTab extends LitElement {
       .tools-summary {
         display: flex;
         align-items: center;
-        gap: var(--spacing-large);
+        gap: var(--wa-space-s);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
       }
@@ -139,7 +139,7 @@ export class ToolsTab extends LitElement {
       .tools-health-ring {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .tools-health-ring svg {
@@ -179,7 +179,7 @@ export class ToolsTab extends LitElement {
       .tools-summary-stat {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .tools-summary-stat wa-icon {
@@ -197,15 +197,15 @@ export class ToolsTab extends LitElement {
       /* Base recheck-btn styles provided by .tab-action-btn in commonViewStyles */
 
       .category-section {
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
       }
 
       .category-header {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        padding-bottom: var(--spacing-small);
-        margin-bottom: var(--spacing-medium);
+        gap: var(--wa-space-2xs);
+        padding-bottom: var(--wa-space-2xs);
+        margin-bottom: var(--wa-space-xs);
         border-bottom: var(--border-thin) solid var(--color-border);
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-medium);
@@ -225,7 +225,7 @@ export class ToolsTab extends LitElement {
 
       .tools-empty {
         text-align: center;
-        padding: var(--spacing-large);
+        padding: var(--wa-space-s);
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
       }
@@ -233,16 +233,16 @@ export class ToolsTab extends LitElement {
       .tools-header-actions {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .setting-block {
-        margin-bottom: var(--spacing-small);
+        margin-bottom: var(--wa-space-2xs);
       }
 
       .desktop-settings {
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-medium);
+        padding: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-xs);
         background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
       }
@@ -253,7 +253,7 @@ export class ToolsTab extends LitElement {
       }
 
       .desktop-settings-description {
-        margin: var(--spacing-small) 0 0 0;
+        margin: var(--wa-space-2xs) 0 0 0;
         font-size: var(--font-size-sm);
         color: var(--texra-descriptionForeground);
       }
@@ -261,14 +261,14 @@ export class ToolsTab extends LitElement {
       .desktop-settings-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
-        margin-top: var(--spacing-small);
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
         flex-wrap: wrap;
       }
 
       .codex-inline-settings {
-        padding: var(--spacing-small) var(--spacing-medium);
-        margin-bottom: var(--spacing-small);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        margin-bottom: var(--wa-space-2xs);
         border-radius: var(--border-radius);
         background: var(
           --texra-textCodeBlock-background,
@@ -279,7 +279,7 @@ export class ToolsTab extends LitElement {
       .setting-row {
         display: flex;
         align-items: center;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
       }
 
       .setting-row label {

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -23,13 +23,13 @@ export class DependencyBanner extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .missing-tools {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -31,12 +31,12 @@ export class GettingStartedBanner extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .getting-started-list {
-        margin: var(--spacing-tiny) 0 0 0;
-        padding-left: var(--spacing-large);
+        margin: var(--wa-space-3xs) 0 0 0;
+        padding-left: var(--wa-space-s);
         line-height: var(--line-height-relaxed);
       }
     `,

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -105,7 +105,7 @@ export class InstructionPanel extends LitElement {
         --agent-model-listbox-min-width: 17rem;
         --agent-model-listbox-max-width: min(
           26rem,
-          calc(100vw - var(--spacing-xlarge))
+          calc(100vw - var(--wa-space-l))
         );
       }
 
@@ -113,10 +113,10 @@ export class InstructionPanel extends LitElement {
         display: flex;
         flex-direction: column;
         position: relative;
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         background-color: var(--background-color);
         border-radius: var(--border-radius);
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
         border: var(--border-thin) solid var(--color-border);
       }
 
@@ -124,22 +124,22 @@ export class InstructionPanel extends LitElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        gap: var(--spacing-medium);
-        margin-bottom: var(--spacing-small);
+        gap: var(--wa-space-xs);
+        margin-bottom: var(--wa-space-2xs);
         line-height: var(--line-height-relaxed);
         flex-wrap: wrap;
       }
 
       .instruction-header-leading {
         display: flex;
-        gap: var(--spacing-medium);
+        gap: var(--wa-space-xs);
         align-items: center;
         flex-wrap: wrap;
       }
 
       .instruction-header-actions {
         display: flex;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         align-items: center;
       }
 
@@ -150,7 +150,7 @@ export class InstructionPanel extends LitElement {
 
       .instruction-session-toggle wa-radio-group {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
       }
 
       .instruction-session-toggle wa-radio {
@@ -159,10 +159,10 @@ export class InstructionPanel extends LitElement {
 
       .session-hint {
         display: flex;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         align-items: flex-start;
-        margin-top: var(--spacing-small);
-        padding: var(--spacing-tiny) var(--spacing-small);
+        margin-top: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-left: 2px solid var(--wa-color-text-link);
         color: var(--wa-color-text-quiet);
         font-size: var(--font-size-sm);
@@ -197,12 +197,12 @@ export class InstructionPanel extends LitElement {
 
       .session-hint-dismiss {
         flex: 0 0 auto;
-        margin-left: var(--spacing-tiny);
+        margin-left: var(--wa-space-3xs);
       }
 
       wa-textarea#instruction {
         width: 100%;
-        margin: var(--spacing-medium) 0;
+        margin: var(--wa-space-xs) 0;
         font-family: var(--texra-editor-font-family);
         font-size: var(--font-size);
       }
@@ -216,7 +216,7 @@ export class InstructionPanel extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex-wrap: wrap;
         width: 100%;
       }
@@ -224,7 +224,7 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex: 1 1 auto;
         flex-wrap: wrap;
         min-width: 0;
@@ -234,7 +234,7 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer .agent-select-group {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex: 0 1 auto;
         min-width: 0;
       }
@@ -246,14 +246,14 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer .agent-select-group {
         max-width: calc(
           var(--agent-select-max-width) + var(--height-control) +
-            var(--spacing-small)
+            var(--wa-space-2xs)
         );
       }
 
       .model-selection-footer .model-select-group {
         max-width: calc(
           var(--model-select-max-width) + var(--height-control) +
-            var(--spacing-small)
+            var(--wa-space-2xs)
         );
       }
 
@@ -352,7 +352,7 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer .agent-select-dropdowns {
         display: flex;
         align-items: center;
-        gap: var(--spacing-small);
+        gap: var(--wa-space-2xs);
         flex: 0 1 var(--agent-select-max-width);
         width: 100%;
         min-width: 0;

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -43,10 +43,10 @@ export class LatexDiffsSection extends LitElement {
 
       .latexdiffs-section {
         margin-top: auto;
-        padding: var(--spacing-large) 0 0;
+        padding: var(--wa-space-s) 0 0;
         background-color: transparent;
         border: none;
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--wa-space-s);
       }
 
       .latexdiffs-section[data-expanded='true'] {
@@ -54,7 +54,7 @@ export class LatexDiffsSection extends LitElement {
         border: var(--border-thin) solid
           var(--texra-widget-border, var(--dropdown-border));
         border-radius: var(--border-radius);
-        padding: var(--spacing-medium);
+        padding: var(--wa-space-xs);
         overflow: visible;
       }
 

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -21,7 +21,7 @@ export class LoginBanner extends LitElement {
       .banner-text {
         display: flex;
         flex-direction: column;
-        gap: var(--spacing-tiny);
+        gap: var(--wa-space-3xs);
         min-width: 0;
       }
 

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -29,8 +29,8 @@ export const mainViewStyles: CSSResult = css`
   .view-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: 0 var(--spacing-tiny) var(--spacing-small);
+    gap: var(--wa-space-2xs);
+    padding: 0 var(--wa-space-3xs) var(--wa-space-2xs);
     flex-shrink: 0;
   }
 
@@ -54,8 +54,8 @@ export const mainViewStyles: CSSResult = css`
     border: var(--border-thin) solid
       var(--texra-widget-border, var(--dropdown-border));
     border-radius: var(--border-radius);
-    padding: var(--spacing-medium);
-    margin-bottom: var(--spacing-large);
+    padding: var(--wa-space-xs);
+    margin-bottom: var(--wa-space-s);
     overflow: visible;
   }
 

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -33,7 +33,7 @@ export const bannerStyles: CSSResult = css`
   }
 
   wa-callout {
-    margin-bottom: var(--spacing-large);
+    margin-bottom: var(--wa-space-s);
     opacity: 0;
     transform: translateY(-4px);
     transition:
@@ -74,7 +74,7 @@ export const bannerStyles: CSSResult = css`
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: var(--spacing-tiny) var(--spacing-medium);
+    gap: var(--wa-space-3xs) var(--wa-space-xs);
   }
 
   .banner-row .hint {
@@ -86,7 +86,7 @@ export const bannerStyles: CSSResult = css`
   .actions {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     flex-shrink: 0;
   }
 `;

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -36,7 +36,7 @@ export const compactFormControlStyles = css`
   }
 
   wa-select::part(expand-icon) {
-    margin-inline-start: var(--spacing-tiny);
+    margin-inline-start: var(--wa-space-3xs);
   }
 
   wa-input {
@@ -104,21 +104,21 @@ export const compactActionButtonStyles = css`
 /** Core file-select layout styles. */
 export const fileSelectLayoutStyles = css`
   .file-select {
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
   }
 
   .file-select:has(.optional-label) {
-    margin-bottom: var(--spacing-tiny);
+    margin-bottom: var(--wa-space-3xs);
   }
 
   .file-select-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
     flex-wrap: nowrap;
     line-height: var(--line-height-normal);
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     min-height: 22px;
   }
 
@@ -128,19 +128,19 @@ export const fileSelectLayoutStyles = css`
   }
 
   .file-select-header label {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .file-select label {
     display: block;
-    margin-bottom: var(--spacing-tiny);
+    margin-bottom: var(--wa-space-3xs);
     font-size: var(--font-size);
   }
 
   .file-select-label-group {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     flex-wrap: nowrap;
     flex: 1;
     min-width: 0;
@@ -158,7 +158,7 @@ export const fileSelectLayoutStyles = css`
   }
 
   .file-select-label-group label {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .file-select-hint {
@@ -176,7 +176,7 @@ export const fileSelectLayoutStyles = css`
     flex-direction: column !important;
     flex-wrap: nowrap;
     margin-left: auto;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
   }
 
   .file-select-actions wa-button {
@@ -212,7 +212,7 @@ export const toggleStyles = css`
     user-select: none;
     margin: 0;
     position: relative;
-    padding: 0 var(--spacing-tiny);
+    padding: 0 var(--wa-space-3xs);
     color: var(--text-color);
     display: flex;
     align-items: center;
@@ -239,7 +239,7 @@ export const multiFilesStyles = css`
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-top: var(--spacing-small);
+    margin-top: var(--wa-space-2xs);
     padding: 0;
   }
 
@@ -253,14 +253,14 @@ export const multiFilesStyles = css`
     border: var(--border-thin) solid
       var(--texra-widget-border, var(--dropdown-border));
     border-radius: var(--border-radius);
-    padding: var(--spacing-small);
+    padding: var(--wa-space-2xs);
     font-size: var(--font-size);
     max-height: var(--height-small);
     overflow-y: auto;
   }
 
   .file-item {
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -302,7 +302,7 @@ export const multiFilesStyles = css`
 
   .file-folder wa-icon {
     font-size: var(--font-size-xs);
-    margin-right: var(--spacing-tiny);
+    margin-right: var(--wa-space-3xs);
   }
 
   .remove-button {
@@ -332,7 +332,7 @@ export const multiFilesStyles = css`
   .file-list-placeholder {
     color: var(--color-text-secondary);
     font-style: italic;
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
   }
 `;
 
@@ -355,7 +355,7 @@ export const dropdownStyles = css`
 
   .dropdown-container .dropdown-menu {
     position: absolute;
-    top: calc(100% + var(--spacing-tiny));
+    top: calc(100% + var(--wa-space-3xs));
     left: 0;
     right: auto;
     z-index: 100;
@@ -375,14 +375,14 @@ export const dropdownStyles = css`
     display: flex;
     flex-direction: column;
     gap: 0;
-    padding: var(--spacing-tiny);
+    padding: var(--wa-space-3xs);
   }
 
   .dropdown-container .dropdown-menu wa-checkbox {
     display: flex;
     align-items: center;
     height: 20px;
-    padding: var(--spacing-tiny);
+    padding: var(--wa-space-3xs);
     font-size: var(--font-size-sm);
   }
 

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -5,7 +5,7 @@ const TOOLTIP_SHOW_DELAY_MS = 500;
 
 const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
-  padding: 'var(--spacing-small, 4px) var(--spacing-medium, 8px)',
+  padding: 'var(--wa-space-2xs, 4px) var(--wa-space-xs, 8px)',
   fontSize: 'var(--texra-font-size, 13px)',
   fontFamily: 'var(--texra-font-family, system-ui), system-ui',
   color: 'var(--texra-editorHoverWidget-foreground, var(--texra-foreground))',

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -3,7 +3,7 @@ import { css, type CSSResult } from 'lit';
 export const baseBadgeStyles: CSSResult = css`
   .badge {
     display: inline-block;
-    padding: var(--spacing-small) var(--spacing-medium);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     border-radius: var(--border-radius-medium);
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium, 500);
@@ -19,7 +19,7 @@ export const categoryBadgeStyles: CSSResult = css`
   .agent-category-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     background: var(--texra-badge-background);
     color: var(--texra-badge-foreground);
   }
@@ -73,7 +73,7 @@ export const emptyStateStyles: CSSResult = css`
     color: var(--color-text-secondary);
     font-style: italic;
     text-align: center;
-    padding: var(--spacing-xlarge);
+    padding: var(--wa-space-l);
   }
 
   .loading {
@@ -96,8 +96,8 @@ export const tintedBadgeStyles: CSSResult = css`
   .tinted-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
-    padding: 1px var(--spacing-small);
+    gap: var(--wa-space-3xs);
+    padding: 1px var(--wa-space-2xs);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
     color: var(--_tint, var(--color-text-secondary));

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -5,7 +5,7 @@ export const commonViewStyles: CSSResult = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--spacing-xlarge);
+    margin-bottom: var(--wa-space-l);
   }
 
   .view-header h1,
@@ -20,7 +20,7 @@ export const commonViewStyles: CSSResult = css`
   .list-item {
     border: var(--border-thin) solid var(--texra-panelSection-border);
     border-radius: var(--border-radius-large);
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     background-color: var(--texra-editor-background);
   }
 
@@ -36,11 +36,11 @@ export const commonViewStyles: CSSResult = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .collapsible {
-    margin-top: var(--spacing-small);
+    margin-top: var(--wa-space-2xs);
   }
 
   /*
@@ -80,7 +80,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .panel-collapsible::part(header) {
-    padding: var(--spacing-small) var(--spacing-medium);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     background-color: var(--texra-sideBarSectionHeader-background, transparent);
     color: var(--texra-sideBarTitle-foreground, var(--texra-foreground));
   }
@@ -88,7 +88,7 @@ export const commonViewStyles: CSSResult = css`
   /* "body" part is used by vscode-collapsible; "content" part by wa-details. */
   .panel-collapsible::part(body),
   .panel-collapsible::part(content) {
-    padding: 0 var(--spacing-small) var(--spacing-small);
+    padding: 0 var(--wa-space-2xs) var(--wa-space-2xs);
   }
 
   /*
@@ -116,7 +116,7 @@ export const commonViewStyles: CSSResult = css`
   vscode-toolbar-container {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     flex-wrap: nowrap;
   }
 
@@ -127,7 +127,7 @@ export const commonViewStyles: CSSResult = css`
   .action-button-group {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     flex-wrap: nowrap;
   }
 
@@ -138,7 +138,7 @@ export const commonViewStyles: CSSResult = css`
   /* Compact action button (with text) — stricter IDE-density chrome.
    * Borderless default; hover adds a subtle border (no fill swap). */
   .action-button::part(base) {
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     min-height: 22px;
     padding: 0 6px;
     border: var(--border-thin) solid transparent;
@@ -199,12 +199,12 @@ export const commonViewStyles: CSSResult = css`
   wa-checkbox::part(label),
   wa-radio::part(label) {
     font-size: var(--font-size-sm);
-    padding-inline-start: var(--spacing-small);
+    padding-inline-start: var(--wa-space-2xs);
   }
 
   wa-checkbox::part(base),
   wa-radio::part(base) {
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .clickable-link {
@@ -226,11 +226,11 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .detail-section {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
   }
 
   .detail-content {
-    padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+    padding: var(--wa-space-3xs) 0 var(--wa-space-2xs) var(--wa-space-s);
   }
 
   .detail-list {
@@ -241,14 +241,14 @@ export const commonViewStyles: CSSResult = css`
   .detail-item {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .details-summary {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: var(--spacing-tiny) 0;
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-3xs) 0;
     cursor: pointer;
     list-style: none;
     user-select: none;
@@ -287,8 +287,8 @@ export const commonViewStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-medium);
-    margin-top: calc(var(--spacing-xlarge) * 2);
+    gap: var(--wa-space-xs);
+    margin-top: calc(var(--wa-space-l) * 2);
     color: var(--color-text-secondary);
     font-style: italic;
   }
@@ -334,8 +334,8 @@ export const commonViewStyles: CSSResult = css`
   .tab-action-btn {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: var(--spacing-tiny) var(--spacing-small);
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     font-size: var(--font-size-xs);
     font-family: inherit;
     color: var(--color-text-secondary);
@@ -366,10 +366,10 @@ export const commonViewStyles: CSSResult = css`
   .settings-reminder {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
-    column-gap: var(--spacing-medium);
-    row-gap: var(--spacing-small);
-    padding: var(--spacing-medium);
-    margin-bottom: var(--spacing-large);
+    column-gap: var(--wa-space-xs);
+    row-gap: var(--wa-space-2xs);
+    padding: var(--wa-space-xs);
+    margin-bottom: var(--wa-space-s);
     border: var(--border-thin) solid var(--texra-focusBorder);
     border-radius: var(--border-radius);
     background: var(--texra-editor-background);
@@ -396,7 +396,7 @@ export const commonViewStyles: CSSResult = css`
   .settings-reminder-body {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     min-width: 0;
   }
 
@@ -404,13 +404,13 @@ export const commonViewStyles: CSSResult = css`
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .settings-reminder-list {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -419,7 +419,7 @@ export const commonViewStyles: CSSResult = css`
   .settings-reminder-list li {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .settings-reminder-step {
@@ -517,8 +517,8 @@ export const filledButtonStyles: CSSResult = css`
   .filled-button {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-small);
-    padding: var(--spacing-small) var(--spacing-medium);
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
     font-size: var(--font-size);
     font-family: inherit;
     color: var(--texra-button-foreground);
@@ -545,11 +545,11 @@ export const filledButtonStyles: CSSResult = css`
   }
 
   .filled-button--secondary {
-    color: var(--texra-button-secondaryForeground, inherit);
-    background: var(--texra-button-secondaryBackground, transparent);
+    color: var(--wa-color-neutral-on-quiet, inherit);
+    background: var(--wa-color-neutral-fill-quiet, transparent);
   }
 
   .filled-button--secondary:hover {
-    background: var(--texra-button-secondaryHoverBackground, transparent);
+    background: var(--wa-color-neutral-fill-loud, transparent);
   }
 `;

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -11,21 +11,21 @@ export const searchStyles: CSSResult = css`
   .search-container {
     display: flex;
     align-items: center;
-    margin-bottom: var(--spacing-xlarge);
-    gap: var(--spacing-medium);
+    margin-bottom: var(--wa-space-l);
+    gap: var(--wa-space-xs);
     width: 100%;
   }
 
   .search-input {
     flex: 1;
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     font-size: var(--font-size);
   }
 
   .search-controls {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     margin-left: auto;
   }
 
@@ -38,7 +38,7 @@ export const searchStyles: CSSResult = css`
 
   .action-icon-button[data-action='clear-history'] {
     color: var(--color-text-secondary);
-    margin-left: var(--spacing-small);
+    margin-left: var(--wa-space-2xs);
   }
 
   .action-icon-button[data-action='clear-history']::part(base) {
@@ -57,14 +57,14 @@ export const historyListStyles: CSSResult = css`
   .history-container {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .history-details {
     display: grid;
     grid-template-columns: 100px 1fr;
-    gap: var(--spacing-small);
-    margin-top: var(--spacing-medium);
+    gap: var(--wa-space-2xs);
+    margin-top: var(--wa-space-xs);
   }
 
   .history-label {
@@ -74,45 +74,45 @@ export const historyListStyles: CSSResult = css`
 
   .history-value {
     color: var(--texra-editor-foreground);
-    padding: var(--spacing-small) 0;
+    padding: var(--wa-space-2xs) 0;
     word-break: break-word;
   }
 
   .history-item {
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
   }
 
   .history-actions {
     display: flex;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
   }
 
   .history-timestamp {
     font-size: var(--font-size-sm);
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
   }
 
   .history-description {
     font-size: var(--font-size-sm);
     color: var(--texra-descriptionForeground);
     font-style: italic;
-    margin-top: var(--spacing-small);
+    margin-top: var(--wa-space-2xs);
     line-height: var(--line-height-normal);
   }
 
   .config-section {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     background-color: var(--texra-editor-inactiveSelectionBackground);
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     border-radius: var(--border-radius);
-    margin: var(--spacing-medium) 0;
+    margin: var(--wa-space-xs) 0;
   }
 
   .config-item {
     display: flex;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
     align-items: baseline;
   }
 
@@ -120,7 +120,7 @@ export const historyListStyles: CSSResult = css`
     font-weight: var(--font-weight-medium);
     color: var(--texra-editorInfo-foreground);
     min-width: calc(
-      var(--width-button-min) + var(--spacing-xlarge) + var(--spacing-xlarge)
+      var(--width-button-min) + var(--wa-space-l) + var(--wa-space-l)
     );
   }
 

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -51,13 +51,6 @@ export const designTokens: CSSResult = css`
     --line-height-normal: 1.4;
     --line-height-relaxed: 1.5;
 
-    /* Spacing */
-    --spacing-tiny: 2px;
-    --spacing-small: 4px;
-    --spacing-medium: 8px;
-    --spacing-large: 12px;
-    --spacing-xlarge: 20px;
-
     /* Border radius */
     --border-radius-small: 2px;
     --border-radius: 3px;

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -54,17 +54,17 @@ export const markdownStyles = css`
 
   .markdown-content h1 {
     border-bottom: var(--border-thin) solid var(--color-border);
-    padding-bottom: var(--spacing-small);
+    padding-bottom: var(--wa-space-2xs);
   }
 
   .markdown-content h2 {
-    padding-left: var(--spacing-medium);
-    margin-top: var(--spacing-large);
-    margin-bottom: var(--spacing-small);
+    padding-left: var(--wa-space-xs);
+    margin-top: var(--wa-space-s);
+    margin-bottom: var(--wa-space-2xs);
     border-left: var(--border-thick) solid
       var(--texra-activityBarBadge-background);
     border-bottom: var(--border-thin) solid var(--color-border);
-    padding-bottom: var(--spacing-tiny);
+    padding-bottom: var(--wa-space-3xs);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
     color: var(--color-text-link);
   }
@@ -93,18 +93,18 @@ export const markdownStyles = css`
 
   .markdown-content code {
     background-color: var(--texra-textCodeBlock-background);
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     border-radius: var(--border-radius);
     font-family: var(--font-family);
     font-size: var(--font-size-sm);
   }
 
   .markdown-content pre {
-    padding: var(--spacing-medium) var(--spacing-large);
+    padding: var(--wa-space-xs) var(--wa-space-s);
     margin: 0.5em 0;
     border-radius: var(--border-radius);
     background-color: var(--texra-textCodeBlock-background);
-    border-left: var(--spacing-tiny) solid
+    border-left: var(--wa-space-3xs) solid
       var(--texra-activityBarBadge-background);
     overflow-x: auto;
   }
@@ -133,8 +133,8 @@ export const markdownStyles = css`
   .markdown-content blockquote {
     border-left: var(--border-thick) solid
       var(--texra-activityBarBadge-background);
-    margin: var(--spacing-medium) 0;
-    padding-left: var(--spacing-xlarge);
+    margin: var(--wa-space-xs) 0;
+    padding-left: var(--wa-space-l);
     color: var(--color-text-secondary);
     font-style: italic;
   }
@@ -142,11 +142,11 @@ export const markdownStyles = css`
   .markdown-content table {
     border-collapse: collapse;
     width: 100%;
-    margin: var(--spacing-xlarge) 0;
+    margin: var(--wa-space-l) 0;
 
     :is(th, td) {
       border: var(--border-thin) solid var(--color-border);
-      padding: var(--spacing-small) var(--spacing-large);
+      padding: var(--wa-space-2xs) var(--wa-space-s);
     }
 
     th {
@@ -181,9 +181,9 @@ export const markdownStyles = css`
   }
 
   .banner-content--scratchpad p:has(strong:first-child) {
-    border-left: calc(var(--spacing-small) - 1px) solid
+    border-left: calc(var(--wa-space-2xs) - 1px) solid
       var(--texra-notificationsInfoIcon-foreground);
-    padding-left: var(--spacing-medium);
+    padding-left: var(--wa-space-xs);
   }
 
   .markdown-content :is(h2 + p, p + p, h1 + h1, h2 + h2, h3 + h3, h4 + h4) {

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -23,7 +23,7 @@ export const permissionCardStyles: CSSResult = css`
     background: var(--texra-editor-background);
     border: var(--border-thin) solid var(--texra-panel-border);
     border-radius: var(--border-radius-large);
-    padding: var(--spacing-xlarge);
+    padding: var(--wa-space-l);
     max-width: 600px;
     width: min(92vw, 600px);
     max-height: min(80vh, 44rem);
@@ -34,9 +34,9 @@ export const permissionCardStyles: CSSResult = css`
   .permission-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     font-weight: var(--font-weight-semibold);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--wa-space-xs);
   }
 
   .permission-body {
@@ -49,7 +49,7 @@ export const permissionCardStyles: CSSResult = css`
 
   .code-block {
     display: block;
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     background: var(--texra-textCodeBlock-background);
     border-radius: var(--border-radius);
     color: var(--texra-terminal-foreground);
@@ -62,8 +62,8 @@ export const permissionCardStyles: CSSResult = css`
   .permission-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-medium);
-    margin-top: var(--spacing-xlarge);
+    gap: var(--wa-space-xs);
+    margin-top: var(--wa-space-l);
     justify-content: flex-end;
   }
 
@@ -71,7 +71,7 @@ export const permissionCardStyles: CSSResult = css`
   .primary-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-medium);
+    gap: var(--wa-space-xs);
   }
 
   .primary-actions {
@@ -88,7 +88,7 @@ export const permissionCardStyles: CSSResult = css`
   .diff-info {
     display: inline-flex;
     align-items: baseline;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     font-size: var(--font-size-sm);
     font-family: var(--texra-editor-font-family);
   }
@@ -105,34 +105,34 @@ export const permissionCardStyles: CSSResult = css`
 
   .meta-text {
     color: var(--texra-descriptionForeground);
-    margin-left: var(--spacing-small);
+    margin-left: var(--wa-space-2xs);
   }
 
   .extract-flags {
     display: flex;
-    gap: var(--spacing-small);
+    gap: var(--wa-space-2xs);
     flex-wrap: wrap;
   }
 
   .extract-flag {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
     border-radius: var(--border-radius);
     background: var(--texra-badge-background);
     color: var(--texra-badge-foreground);
   }
 
   .file-list {
-    margin: var(--spacing-small) 0;
+    margin: var(--wa-space-2xs) 0;
   }
 
   .file-list-label {
     color: var(--texra-descriptionForeground);
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
   }
 
   .file-link {
@@ -153,21 +153,21 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .plan-steps-list {
-    margin: var(--spacing-small) 0;
-    padding-left: var(--spacing-xlarge);
+    margin: var(--wa-space-2xs) 0;
+    padding-left: var(--wa-space-l);
   }
 
   .plan-steps-list li {
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
   }
 
   .feedback-section {
-    margin-top: var(--spacing-large);
+    margin-top: var(--wa-space-s);
   }
 
   .feedback-label {
     display: block;
-    margin-bottom: var(--spacing-small);
+    margin-bottom: var(--wa-space-2xs);
     font-size: var(--font-size-sm);
     color: var(--texra-descriptionForeground);
   }
@@ -175,7 +175,7 @@ export const permissionCardStyles: CSSResult = css`
   .feedback-input {
     width: 100%;
     min-height: 60px;
-    padding: var(--spacing-medium);
+    padding: var(--wa-space-xs);
     border: var(--border-thin) solid var(--texra-input-border);
     background: var(--texra-input-background);
     color: var(--texra-input-foreground);

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -52,11 +52,11 @@ const SCROLLABLE_DETAILS = selectorGroup(
 );
 
 const sp = {
-  tiny: unsafeCSS('var(--spacing-tiny)'),
-  small: unsafeCSS('var(--spacing-small)'),
-  medium: unsafeCSS('var(--spacing-medium)'),
-  large: unsafeCSS('var(--spacing-large)'),
-  xlarge: unsafeCSS('var(--spacing-xlarge)'),
+  tiny: unsafeCSS('var(--wa-space-3xs)'),
+  small: unsafeCSS('var(--wa-space-2xs)'),
+  medium: unsafeCSS('var(--wa-space-xs)'),
+  large: unsafeCSS('var(--wa-space-s)'),
+  xlarge: unsafeCSS('var(--wa-space-l)'),
 } as const;
 
 export const requestPanelStyles: CSSResult = css`
@@ -614,7 +614,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-requests__nav-btn:hover:not(:disabled) {
-    background: var(--texra-toolbar-hoverBackground);
+    background: var(--wa-color-surface-raised);
   }
 
   .external-inquiry-requests__nav-btn:disabled {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -4,11 +4,11 @@ export const selectStyles: CSSResult = css`
   .select-group {
     display: flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--wa-space-3xs);
   }
 
   .select-group wa-icon {
-    margin-right: var(--spacing-small);
+    margin-right: var(--wa-space-2xs);
     color: var(--text-color, var(--texra-foreground));
     vertical-align: text-bottom;
   }
@@ -95,7 +95,7 @@ export const selectStyles: CSSResult = css`
   }
 
   wa-select::part(expand-icon) {
-    margin-inline-start: var(--spacing-tiny);
+    margin-inline-start: var(--wa-space-3xs);
   }
 
   wa-input {
@@ -119,6 +119,6 @@ export const selectStyles: CSSResult = css`
     color: var(--texra-errorForeground);
     opacity: var(--opacity-full);
     font-style: normal;
-    margin-left: var(--spacing-tiny);
+    margin-left: var(--wa-space-3xs);
   }
 `;

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -25,6 +25,6 @@ export const viewTabStyles: CSSResult = css`
 
   wa-tab::part(base) {
     padding-block: 4px;
-    padding-inline: var(--spacing-medium);
+    padding-inline: var(--wa-space-xs);
   }
 `;


### PR DESCRIPTION
## Summary

Pass 2 of the Web Awesome token consolidation (closes #3690).

- **`--spacing-*` retired (533 → 0):** `--wa-space-*` canonical scale is now defined in both `packages/extension/src/common/styles/common.css` and `packages/desktop/src/renderer/themeTokens.css` (mirroring `@awesome.me/webawesome/dist/styles/themes/default.css`). Every `var(--spacing-X)` call-site was migrated by closest pixel match (`tiny`→`3xs`, `small`→`2xs`, `medium`→`xs`, `large`→`s`, `xlarge`→`l`). The `--spacing-*` declarations were deleted from `src/shared/styles/litStyles.ts`. (Note: this differs slightly from the issue's proposed mapping — the canonical scale already shipped by the WA default theme is `xs=8px / s=12px / m=16px`, so I matched pixels exactly to preserve current visual sizing rather than skip a tier.)
- **`--texra-button-secondary*` consumers migrated:** all 4 in-scope consumers (`commonViewStyles.filled-button--secondary`, `desktop-secondary-button`, `desktop-nav-button[aria-pressed]`, `desktop-onboarding-icon`) now read `--wa-color-neutral-{fill,on}-{quiet,loud}` directly. The bridge mapping (`--wa-color-neutral-fill-quiet: var(--texra-button-secondaryBackground)` in `common.css` and `themeTokens.css`) stays so the wired-through palette is preserved.
- **`--texra-toolbar-hoverBackground` migrated:** 7 consumers in request panel, stream tabs, and desktop nav/command/folder/explorer buttons now use `var(--wa-color-surface-raised)` for the subtle hover.

### Deferred

- `--texra-list-hoverBackground` / `--texra-list-activeSelectionBackground`: WA does not yet expose semantic tokens for tree/list-row hover or selection. Left in place with `TODO(token-pass-3)` comments above the bridge definitions in `common.css` and `themeTokens.css`. Used by 18 consumers spanning webview, settings tabs, progress stream tabs, and desktop explorer.
- `--texra-inputValidation-*` and `--texra-charts-*`: deferred per the task brief — no WA equivalents yet.
- `--texra-button-secondaryHoverBackground`: still wired via the bridge for any future consumer; the migrated call-site uses `--wa-color-neutral-fill-loud` per the issue. (Bridge defs in `common.css`, `themeTokens.css` retained.)

### Bytes saved (litStyles.ts)

7 lines / 132 chars of `--spacing-*` declarations removed from the shared design-token block; replaced by canonical `--wa-space-*` definitions (one place each in `common.css` + `themeTokens.css`) instead of duplicated 5-token blocks across consumers.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npx vitest run` → 318/318 passing (well above 309/311 floor).
- [x] `cd packages/desktop && npx vite build --mode development` succeeds.
- [x] `grep -rn 'var(--spacing-' src packages` returns 0 (was 533).
- [x] No consumer references to `--texra-button-secondary*` outside the bridge files.
- [x] No consumer references to `--texra-toolbar-hoverBackground` outside the bridge files.
- [ ] Smoke-test extension webview hover/spacing on macOS dark theme.
- [ ] Smoke-test desktop secondary/nav-button + onboarding icon in light + dark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to CSS/token refactors; primary impact is potential minor visual regressions from updated spacing and hover/background tokens across extension and desktop UIs.
> 
> **Overview**
> **Consolidates styling tokens onto Web Awesome semantics.** Retires legacy `--spacing-*` usage by introducing the canonical `--wa-space-*` scale in both the desktop and extension token bridges, then migrating all consumers (progress view, settings view, webviews, and shared styles) to use `--wa-space-*` equivalents.
> 
> Updates secondary/hover styling to rely on WA tokens: replaces `--texra-button-secondary*` consumers with `--wa-color-neutral-{fill,on}-{quiet,loud}` and swaps remaining `--texra-toolbar-hoverBackground` usage to `--wa-color-surface-raised`. Keeps TeXRA list-row selection/hover aliases in the bridges with a `TODO(token-pass-3)` note until WA exposes dedicated semantic tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabbc7cf0e7f86b3ac1c8d1de66542f7005105bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->