### PR TITLE
fix(wa): address bot-review findings backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ See `docs/pocketflow/` for full framework documentation.
 **Webviews and UI**
 
 - Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`packages/extension/src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
-- Use Web Awesome (`<wa-icon>` via `waIcon()` from `@shared/wa/webAwesomeIcons`) and shared utilities from `@utils/text/stringUtils` and `@utils/files/pathUtils` for consistent interactions.
+- Use Web Awesome (`<wa-icon>` via `waIcon()` from `@shared/wa/webAwesomeIcons`) and shared utilities from `@utils/text/stringUtils` and `@shared/utils/path` for consistent interactions.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js) local to reduce extension size.
 - Keep CSS modular (per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `src/common/styles/common.css`) and use Web Awesome icons (e.g., `${waIcon('chevron-down')}`) for toggle affordances.
 

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -715,18 +715,19 @@ export class ProgressApp extends ProgressAppBase {
           ${renderEmptyState({
             icon: 'robot',
             kicker: 'Progress',
-            kickerIcon: 'robot',
             title: 'No runs yet',
             body: 'Start an agent from the Launcher or Commands. New runs, streamed logs, approvals, and follow-up controls will appear here.',
             actions: [
               {
                 label: 'Open Launcher',
+                icon: 'play',
                 appearance: 'filled',
                 variant: 'brand',
                 onClick: this.onOpenLauncher,
               },
               {
                 label: 'Open Dashboard',
+                icon: 'gear',
                 appearance: 'outlined',
                 variant: 'neutral',
                 onClick: this.onOpenDashboard,

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -25,7 +25,7 @@ import './QueuedFollowUps';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
-import '@awesome.me/webawesome/dist/components/progress-ring/progress-ring.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 @customElement('follow-up-input')
@@ -208,7 +208,7 @@ export class FollowUpInput extends LitElement {
               })}
               ${when(
                 this.polishing,
-                () => html`<wa-progress-ring indeterminate></wa-progress-ring>`,
+                () => html`<wa-spinner></wa-spinner>`,
               )}
               ${renderIconActionButton({
                 id: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -206,10 +206,7 @@ export class FollowUpInput extends LitElement {
                 title: 'Polish follow-up with AI',
                 onClick: this.emitPolish,
               })}
-              ${when(
-                this.polishing,
-                () => html`<wa-spinner></wa-spinner>`,
-              )}
+              ${when(this.polishing, () => html`<wa-spinner></wa-spinner>`)}
               ${renderIconActionButton({
                 id: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
                 icon: this.recordingController.state.icon,

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -19,6 +19,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Local imports - shared styles
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -306,14 +307,19 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   };
 
   private handleSelectChange = (event: Event): void => {
-    const value = (event.target as HTMLSelectElement).value;
+    // Read from currentTarget (the wa-select host) instead of target — wa-select
+    // can retarget events from internal elements, and HTMLSelectElement is the
+    // wrong type for this Web Component anyway.
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     if (value) {
       this.selectedModel = value;
     }
   };
 
   private handleAgentSelectChange = (event: Event): void => {
-    const value = (event.target as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     if (value) {
       this.selectedAgent = value;
     }

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -14,6 +14,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -283,11 +284,15 @@ export class WorkflowToolUseFollowupSection extends LitElement {
   };
 
   private handleAgentChange = (event: Event): void => {
-    this.selectedAgent = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
+    this.selectedAgent = value;
   };
 
   private handleModelChange = (event: Event): void => {
-    this.selectedModel = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
+    this.selectedModel = value;
   };
 
   private handleQuestionInput = (event: Event): void => {

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -18,6 +18,7 @@ import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Local imports - shared constants
 import {
@@ -143,14 +144,16 @@ export class ModelSelectionList extends LitElement {
   }
 
   private handleHelperModelChange(e: Event): void {
-    const value = (e.currentTarget as HTMLSelectElement).value;
+    const select = e.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(
       ModelSelectionEvents.setHelperModel({ modelName: value }),
     );
   }
 
   private handleReasoningLevelChange(modelName: string, e: Event): void {
-    const value = (e.currentTarget as HTMLSelectElement).value;
+    const select = e.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(
       ModelSelectionEvents.setReasoningLevel({
         modelName,

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -19,6 +19,7 @@ import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -321,7 +322,10 @@ export class ToolsTab extends LitElement {
   };
 
   private emitSelect(eventName: string, key: string, e: Event): void {
-    const value = (e.target as HTMLSelectElement | null)?.value;
+    // Read from currentTarget (the wa-select host) to avoid relying on the
+    // shadow-DOM retargeted target, which is brittle for Web Components.
+    const select = e.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     if (value) {
       this.dispatchEvent(createEvent(eventName, { [key]: value }));
     }

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -10,11 +10,7 @@ import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { hostBridge, postMessage } from '@shared/hostBridge';
 import { PersistedState, createWebviewStorage } from '@shared/state';
-import {
-  designTokens,
-  commonViewStyles,
-  viewTabStyles,
-} from '@shared/styles';
+import { designTokens, commonViewStyles, viewTabStyles } from '@shared/styles';
 import {
   mainViewMessages,
   MainViewPersistedStateSchema,

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,7 +1,12 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,7 +1,12 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -310,7 +310,8 @@ export class InstructionPanel extends LitElement {
       }
 
       wa-button.execute-button:focus-visible::part(base) {
-        outline: 2px solid var(--wa-color-focus, var(--wa-color-brand-fill-loud));
+        outline: 2px solid
+          var(--wa-color-focus, var(--wa-color-brand-fill-loud));
         outline-offset: 1px;
       }
 

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -8,6 +8,7 @@
 // Side-effect imports - register WA select & option components
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
@@ -537,16 +538,16 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleAgentChange(event: Event): void {
-    const target = event.currentTarget as HTMLSelectElement & {
-      dataset: DOMStringMap;
-    };
-    const sessionType = target.dataset.sessionType as SessionType;
-    const value = target.value;
+    const select = event.currentTarget as (WaSelect & HTMLElement) | null;
+    if (!select) return;
+    const sessionType = select.dataset.sessionType as SessionType;
+    const value = typeof select.value === 'string' ? select.value : '';
     this.dispatchEvent(MainViewEvents.agentChange({ sessionType, value }));
   }
 
   private handleModelChange(event: Event): void {
-    const value = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(MainViewEvents.modelChange({ value }));
   }
 

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -8,6 +8,7 @@
 // Side-effect imports - register WA select & option components
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
@@ -108,17 +109,20 @@ export class LatexDiffsSection extends LitElement {
   }
 
   private handleBaseSelectChange(event: Event): void {
-    const value = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(MainViewEvents.baseFileChange({ value }));
   }
 
   private handleEditedSelectChange(event: Event): void {
-    const value = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(MainViewEvents.editedFileChange({ value }));
   }
 
   private handleCommitSelectChange(event: Event): void {
-    const value = (event.currentTarget as HTMLSelectElement).value;
+    const select = event.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
     this.dispatchEvent(MainViewEvents.commitChange({ value }));
   }
 

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -36,15 +36,26 @@ export const bannerStyles: CSSResult = css`
     margin-bottom: var(--spacing-large);
     opacity: 0;
     transform: translateY(-4px);
+    /* Defer 'visibility: hidden' until the fade-out completes so hidden
+       banners are removed from the keyboard tab order while still allowing
+       the close transition to animate. Without this, focusable descendants
+       (e.g. wa-button) remain reachable via Tab when opacity is 0. */
+    visibility: hidden;
     transition:
       opacity 180ms ease,
-      transform 180ms ease;
+      transform 180ms ease,
+      visibility 0s linear 180ms;
     pointer-events: none;
   }
 
   :host([data-visible='true']) wa-callout {
     opacity: 1;
     transform: translateY(0);
+    visibility: visible;
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      visibility 0s linear 0s;
     pointer-events: auto;
   }
 

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -348,7 +348,8 @@ export const dropdownStyles = css`
     flex-shrink: 0;
   }
 
-  .dropdown-container wa-button.has-options::part(base) {
+  .dropdown-container wa-button.has-options::part(base),
+  wa-button.has-options::part(base) {
     box-shadow: inset 0 0 0 1px
       var(--texra-inputValidation-infoBorder, var(--texra-focusBorder));
   }

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -159,6 +159,9 @@ function verifyDistEntrypoints(entries, failures) {
     'extension/dist/progressView/bundle.js',
     'extension/dist/settingsView/bundle.js',
     'extension/dist/webview/bundle.js',
+    // Shared commons bundle is referenced from every webview HTML template via
+    // BaseViewContentProvider. Missing this file would silently break webviews.
+    'extension/dist/shared/commons.js',
   ]) {
     assertEntryExists(entries, entryPath, failures);
   }

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -165,7 +165,10 @@ export const commonViewStyles: CSSResult = css`
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--wa-color-text-quiet, var(--texra-icon-foreground, var(--texra-foreground)));
+    color: var(
+      --wa-color-text-quiet,
+      var(--texra-icon-foreground, var(--texra-foreground))
+    );
     opacity: var(--opacity-subtle);
     transition: opacity 120ms ease;
   }
@@ -176,7 +179,8 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--wa-color-focus, var(--texra-focusBorder));
+    outline: var(--border-thin) solid
+      var(--wa-color-focus, var(--texra-focusBorder));
     outline-offset: 1px;
   }
 

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -36,9 +36,7 @@ export const selectStyles: CSSResult = css`
     font-family: var(--texra-font-family);
   }
 
-  wa-option.disabled-option,
-  wa-option.disabled-model,
-  wa-option.disabled-agent,
+  wa-option[disabled],
   wa-option[data-requires-key='true'] {
     color: var(--color-text-secondary, var(--texra-descriptionForeground));
     opacity: var(--opacity-subtle, 0.7);

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -17,6 +17,10 @@ export interface EmptyStateAction {
   // Forwarded onto the underlying <wa-button>. Lets callers re-apply host-
   // specific button classes (e.g. desktop-primary-button) for theming hooks.
   readonly className?: string;
+  // Optional leading icon, rendered with slot="start" inside the button.
+  // Lets callers preserve action-icon affordances (e.g. play/gear) without
+  // forking the helper or dropping back to inline templates.
+  readonly icon?: TeXRAIconName;
 }
 
 export type EmptyStateHeadingTag = 'h1' | 'h2' | 'h3';
@@ -85,6 +89,9 @@ export function renderEmptyState({
                       variant=${action.variant ?? 'neutral'}
                       @click=${action.onClick}
                     >
+                      ${action.icon
+                        ? waIcon(action.icon, { slot: 'start' })
+                        : nothing}
                       ${action.label}
                     </wa-button>
                   `,


### PR DESCRIPTION
## Summary

Sweeps unaddressed Cursor Bugbot / Copilot findings from the recent Web Awesome migration PRs (#3658–#3698). Audited 60+ inline review comments across 16 PRs; most were already addressed in main (e.g. icon aliases, badge selectors, chevron rotation, MCP spinner sentinel) or stylistic suggestions deferred. The findings below were genuine bugs, regressions, or accessibility holes.

## Findings addressed

| File | Line | Issue | Source PR |
| --- | --- | --- | --- |
| `packages/extension/src/progressView/frontend/components/FollowUpInput.ts` | 211 | `wa-progress-ring indeterminate` is not a real attribute — renders a static empty ring. Switched to `wa-spinner`. | #3660 |
| `src/shared/styles/selectStyles.ts` | 39–46 | Stale `wa-option.disabled-option/-model/-agent` selectors no longer match (options now disabled via `disabled` attribute). Use `wa-option[disabled]`. | #3669 |
| `packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts` | 308–320 | `HTMLSelectElement` cast on `wa-select` `@change` handler — type-safety regression. Use `WaSelect` and read from `currentTarget`. | #3674 |
| `packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts` | 285–291 | Same `WaSelect` typing fix. | #3669 |
| `packages/extension/src/webview/frontend/components/LatexDiffsSection.ts` | 110–123 | Same `WaSelect` typing fix (3 handlers). | #3669 |
| `packages/extension/src/webview/frontend/components/InstructionPanel.ts` | 539–551 | Same `WaSelect` typing fix (agent + model). | #3669 |
| `packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts` | 145–159 | Same `WaSelect` typing fix. | #3669 |
| `packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts` | 323–328 | `emitSelect` read from `target`; switched to `currentTarget` typed as `WaSelect`. | #3669 |
| `src/shared/wa/emptyState.ts` | 12–20, 80–94 | `EmptyStateAction` had no `icon` field; play/gear icons on Progress empty-state buttons were dropped during migration. Added optional `icon` and rendered with `slot="start"`. | #3680 |
| `packages/extension/src/progressView/frontend/ProgressApp.ts` | 715–735 | Pass `icon: 'play'`/`icon: 'gear'` on actions; drop redundant `kickerIcon: 'robot'` (defaults to `icon`). | #3680 |
| `packages/extension/src/webview/frontend/styles/bannerStyles.ts` | 35–58 | Hidden banners only set `opacity: 0` + `pointer-events: none`; keyboard users could still Tab into invisible `wa-button`s. Added `visibility: hidden` with `transition-delay` so it kicks in after the fade-out animation. | #3682 |
| `packages/extension/src/webview/frontend/styles/fileSelectStyles.ts` | 351–355 | `.dropdown-container wa-button.has-options::part(base)` highlight no longer matches after the wrapper was dropped. Added a top-level `wa-button.has-options` selector. | #3679 |
| `scripts/verify-vsix-contents.mjs` | 156–169 | VSIX verification didn't require `dist/shared/commons.js`, even though every webview HTML references it via `BaseViewContentProvider`. Added to the required-entrypoints list. | #3685 |
| `AGENTS.md` | 307 | Bullet referenced nonexistent `@utils/files/pathUtils`. Updated to real `@shared/utils/path`. | #3685 |

## Deferred / skipped

- Stylistic refactors (token-based transitions, merging duplicate selectors, replacing string literals with `SESSION_TYPES`/`TEXRA_ICON_LIBRARY` constants) — better suited to a `/simplify` follow-up.
- Token-mapping disagreements on desktop (`--wa-color-surface-lowered`, `--wa-color-neutral-fill-quiet`) — these are deliberate design choices in PR #3681's bridge, not regressions.
- `::part(content) > *` invalid-CSS finding — left in place; the rule is dormant but harmless and the collapse behavior is delivered by `display: grid; grid-template-rows: 0fr` on the part itself.
- Banner host-attribute timing (`updated()` vs `willUpdate()`) — a 1-frame paint flash that affects only first paint when banners start visible (uncommon path).
- Findings already addressed in main (git-merge alias, cloud icon, toolbar-container flex, chevron rotation, badge selectors, recording token, session-hint border, split-panel display, MCP sentinel, file-folder selectors, dropdown-container) verified by re-reading the current source.

Closes #3684.

## Test plan

- [x] `npm run typecheck` — pre-existing electron / @openrouter/sdk errors only; no new errors from this change.
- [x] `npx vitest run` — 316/318 passing (only the pre-existing `ElectronCompositionRoot` `fix-path` failures remain).
- [x] `cd packages/desktop && npx vite build --mode development` — builds cleanly.
- [ ] Visual smoke: open the Progress empty state and confirm the play/gear icons render on the action buttons.
- [ ] Visual smoke: open a follow-up polish action and confirm the spinner animates while polishing.
- [ ] Tab through a hidden banner and confirm focus skips its buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX and tooling fixes focused on Web Awesome component correctness and accessibility; behavior changes are localized to event handling and presentation but touch several webviews.
> 
> **Overview**
> Fixes several regressions from the Web Awesome migration across the Progress, Main, and Settings webviews.
> 
> Webview selects now read values from the `wa-select` host (`event.currentTarget` typed as `WaSelect`) instead of incorrectly casting `event.target` to `HTMLSelectElement`, avoiding broken/undefined selections under shadow-DOM event retargeting. The Progress follow-up “polish” indicator switches from a non-functional `wa-progress-ring` usage to `wa-spinner`, and the Progress empty-state actions regain leading play/gear icons via a new optional `icon` field in `renderEmptyState`.
> 
> Improves UI polish/accessibility by ensuring hidden banners are actually non-focusable (`visibility` transition), updating `wa-option` disabled styling to match the `[disabled]` attribute, fixing a dropped button highlight selector, and tightening VSIX verification to require `dist/shared/commons.js` (used by all webviews). Documentation is updated to reference the correct shared path utility import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dec91923053800aa082599f16dd936d12c1bc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->