### PR TITLE
fix(desktop): restore content area + slim top chrome

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -253,14 +253,14 @@ Migrate imports file-by-file, prioritizing the most-used modules first.
 
 #### 3.1 High Priority: Foundation Layer
 
-| Current                                   | Change to                                  |
-| ----------------------------------------- | ------------------------------------------ |
-| `src/utils/config/configUtils.ts`         | Use `platform().config`                    |
-| `src/utils/files/baseFS.ts`               | Use `platform().fs`                        |
-| `src/utils/files/storageFS.ts`            | Use `platform().fs` + `platform().context` |
-| `src/utils/files/workspaceFS.ts`          | Use `platform().fs` + `platform().context` |
-| `packages/extension/src/frontend/secretManager.ts`           | Use `platform().secrets`                   |
-| `src/common/state/stateManager.ts`        | Use `platform().context.getState/setState` |
+| Current                                                    | Change to                                  |
+| ---------------------------------------------------------- | ------------------------------------------ |
+| `src/utils/config/configUtils.ts`                          | Use `platform().config`                    |
+| `src/utils/files/baseFS.ts`                                | Use `platform().fs`                        |
+| `src/utils/files/storageFS.ts`                             | Use `platform().fs` + `platform().context` |
+| `src/utils/files/workspaceFS.ts`                           | Use `platform().fs` + `platform().context` |
+| `packages/extension/src/frontend/secretManager.ts`         | Use `platform().secrets`                   |
+| `src/common/state/stateManager.ts`                         | Use `platform().context.getState/setState` |
 | `packages/extension/src/frontend/ui/errorHandlingUtils.ts` | Use `platform().ui` for error dialogs      |
 
 This alone removes ~30 transitive `vscode` dependencies.

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -74,34 +74,24 @@ if (root == null) {
 
 const appRoot = root;
 
-const NAV_ROUTES: ReadonlyArray<{
-  readonly route: DesktopRoute;
-  readonly label: string;
-}> = [
-  { route: 'main', label: 'Launcher' },
-  { route: 'progress', label: 'Progress' },
-  { route: 'settings', label: 'Settings' },
-  { route: 'logs', label: 'Logs' },
-];
-
+// Utility chrome buttons used to access secondary surfaces. The four-route
+// top tab bar (Launcher / Progress / Settings / Logs) was removed in favor of
+// a single primary view (the launcher) with secondary surfaces reachable via
+// the command palette or the chrome icons below.
 render(
   html`
     <section class="desktop-shell">
-      <nav class="desktop-nav" aria-label="Desktop views">
-        ${NAV_ROUTES.map(
-          ({ route, label }) => html`
-            <wa-button
-              class="desktop-nav-button"
-              appearance="plain"
-              size="small"
-              role="button"
-              data-route-button=${route}
-              aria-pressed=${route === 'main' ? 'true' : 'false'}
-            >
-              ${label}
-            </wa-button>
-          `,
-        )}
+      <nav class="desktop-nav" aria-label="Desktop chrome">
+        <span class="desktop-brand">TeXRA</span>
+        <wa-button
+          class="desktop-back-button"
+          appearance="plain"
+          size="small"
+          data-back-to-launcher-button
+          hidden
+        >
+          ${waIcon('arrow-left', { slot: 'start' })} Back to Launcher
+        </wa-button>
         <wa-button
           class="desktop-command-button"
           appearance="outlined"
@@ -118,6 +108,28 @@ render(
           data-open-workspace-button
         >
           ${waIcon('folder-open', { slot: 'start' })} Open Folder
+        </wa-button>
+        <wa-button
+          class="desktop-icon-button"
+          appearance="plain"
+          size="small"
+          data-route-button="settings"
+          aria-pressed="false"
+          aria-label="Settings"
+          title="Settings"
+        >
+          ${waIcon('gear')}
+        </wa-button>
+        <wa-button
+          class="desktop-icon-button"
+          appearance="plain"
+          size="small"
+          data-route-button="logs"
+          aria-pressed="false"
+          aria-label="Logs"
+          title="Logs"
+        >
+          ${waIcon('file-lines')}
         </wa-button>
       </nav>
       <div class="desktop-workbench">
@@ -167,17 +179,35 @@ for (const route of DESKTOP_ROUTES) {
   routeContainers.set(route, container);
 }
 
+// The chrome only exposes Settings and Logs as utility icons (the four-route
+// top nav was removed). Other routes are reachable through the command
+// palette and the "Back to Launcher" affordance below.
+const CHROME_ROUTE_BUTTONS: ReadonlyArray<DesktopRoute> = ['settings', 'logs'];
 const routeButtons = new Map<DesktopRoute, WaButton>();
-for (const route of DESKTOP_ROUTES) {
+for (const route of CHROME_ROUTE_BUTTONS) {
   const button = appRoot.querySelector<WaButton>(
     `[data-route-button="${route}"]`,
   );
   if (button == null) {
     throw new Error(`TeXRA desktop route button was not found: ${route}`);
   }
-  button.addEventListener('click', () => setRoute(route));
+  button.addEventListener('click', () => {
+    // Toggle back to the launcher when the same chrome button is pressed
+    // again, so the icons feel like a "go to / dismiss" affordance.
+    setRoute(currentRoute === route ? 'main' : route);
+  });
   routeButtons.set(route, button);
 }
+
+const backToLauncherButton = appRoot.querySelector<WaButton>(
+  '[data-back-to-launcher-button]',
+);
+if (backToLauncherButton == null) {
+  throw new Error('TeXRA desktop back-to-launcher button was not found.');
+}
+backToLauncherButton.addEventListener('click', () => setRoute('main'));
+
+let currentRoute: DesktopRoute = 'main';
 
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 let selectedExplorerFile = '';
@@ -296,12 +326,17 @@ function setRoute(route: DesktopRoute): void {
   // runtime mutations will be reset to the template defaults — convert this
   // function to update module-level route state and trigger a shell re-render
   // before doing that.
+  currentRoute = route;
   for (const [candidate, container] of routeContainers) {
     container.hidden = candidate !== route;
   }
   for (const [candidate, button] of routeButtons) {
     button.setAttribute('aria-pressed', candidate === route ? 'true' : 'false');
   }
+  // Surface a "Back to Launcher" control whenever a non-launcher route is
+  // active so the user always has an obvious way home now that the top tab
+  // bar is gone.
+  backToLauncherButton.hidden = route === 'main';
   document.body.dataset.desktopRoute = route;
   if (route === 'logs') requestLogSnapshot();
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -11,7 +11,11 @@ body {
 }
 
 .desktop-shell {
-  min-height: 100vh;
+  /* Use an explicit viewport-locked height so percentage heights resolve all
+     the way down to the route containers. `min-height: 100vh` left percentage
+     heights ambiguous on the inner grid items, which collapsed the workbench
+     to zero height and produced the empty-content regression. */
+  height: 100vh;
   display: grid;
   grid-template-rows: var(--desktop-nav-height) minmax(0, 1fr);
   background: var(--texra-editor-background);
@@ -27,6 +31,47 @@ body {
   box-sizing: border-box;
   border-bottom: 1px solid var(--wa-color-surface-border);
   background: var(--wa-color-surface-lowered);
+}
+
+.desktop-brand {
+  margin-right: 12px;
+  color: var(--wa-color-text-normal);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+wa-button.desktop-back-button::part(base) {
+  height: 28px;
+  padding: 0 10px;
+  border-color: transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--wa-color-text-normal);
+}
+
+wa-button.desktop-back-button::part(base):hover {
+  background: var(--wa-color-surface-raised);
+}
+
+wa-button.desktop-icon-button::part(base) {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-color: transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--wa-color-text-normal);
+}
+
+wa-button.desktop-icon-button::part(base):hover {
+  background: var(--wa-color-surface-raised);
+}
+
+wa-button.desktop-icon-button[aria-pressed='true']::part(base) {
+  border-color: var(--texra-focusBorder);
+  background: var(--wa-color-neutral-fill-quiet);
 }
 
 /* Top-nav wa-button overrides — shadow DOM tinting via ::part(base). */
@@ -68,7 +113,13 @@ wa-button.desktop-folder-button::part(base):hover {
 }
 
 .desktop-view {
-  display: block;
+  /* Stack every route container in a single grid cell so all four routes
+     share the same viewport region. `[hidden]` collapses the inactive ones,
+     and the explicit grid + `100%` track means each route fills the cell
+     without relying on flaky `min-height: 100%` resolution. */
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
   box-sizing: border-box;
@@ -79,6 +130,10 @@ wa-button.desktop-folder-button::part(base):hover {
   grid-template-columns: 280px minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
+  /* Pin the workbench to the parent grid cell explicitly so children that
+     ask for `height: 100%` (the explorer + route containers) have a real,
+     percent-resolvable height to anchor against. */
+  height: 100%;
 }
 
 .desktop-explorer {
@@ -268,8 +323,16 @@ wa-tree.desktop-explorer-tree
 }
 
 .desktop-route {
-  display: block;
-  min-height: 100%;
+  /* All routes occupy the same grid cell; `[hidden]` collapses the inactive
+     ones via `display: none` below. Using `display: grid` with a single 1fr
+     row guarantees the mounted Lit app stretches to fill the available
+     height even though `:host { display: flex }` rules in the shadow DOM
+     are overridden by the host stylesheet's element-name selectors. */
+  display: grid;
+  grid-area: 1 / 1;
+  grid-template-rows: minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
 }
 
 .desktop-route[hidden] {
@@ -277,8 +340,13 @@ wa-tree.desktop-explorer-tree
 }
 
 .desktop-route > * {
-  display: block;
-  min-height: 100%;
+  /* Force mounted apps (main-app, progress-app, settings-app, log viewer)
+     to stretch the full route height. `block` here was masking the
+     `:host { display: flex }` declarations and leaving the apps unable to
+     stretch. Use a layout mode that respects child flex/grid hosts. */
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
 }
 
 .desktop-command-palette {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -779,10 +779,7 @@ export class LaTeXTab extends LitElement {
         ${this.desktopHost
           ? nothing
           : html`
-              <div
-                class="section-header"
-                style="margin-top:var(--wa-space-s)"
-              >
+              <div class="section-header" style="margin-top:var(--wa-space-s)">
                 <wa-icon library="texra" name="settings-gear"></wa-icon>
                 Recommended Settings
               </div>

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -10,11 +10,7 @@ import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { hostBridge, postMessage } from '@shared/hostBridge';
 import { PersistedState, createWebviewStorage } from '@shared/state';
-import {
-  designTokens,
-  commonViewStyles,
-  viewTabStyles,
-} from '@shared/styles';
+import { designTokens, commonViewStyles, viewTabStyles } from '@shared/styles';
 import {
   mainViewMessages,
   MainViewPersistedStateSchema,

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,7 +1,12 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,7 +1,12 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -309,7 +309,8 @@ export class InstructionPanel extends LitElement {
       }
 
       wa-button.execute-button:focus-visible::part(base) {
-        outline: 2px solid var(--wa-color-focus, var(--wa-color-brand-fill-loud));
+        outline: 2px solid
+          var(--wa-color-focus, var(--wa-color-brand-fill-loud));
         outline-offset: 1px;
       }
 

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -1,7 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { LitElement, html, css, type PropertyValues, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -165,7 +165,10 @@ export const commonViewStyles: CSSResult = css`
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--wa-color-text-quiet, var(--texra-icon-foreground, var(--texra-foreground)));
+    color: var(
+      --wa-color-text-quiet,
+      var(--texra-icon-foreground, var(--texra-foreground))
+    );
     opacity: var(--opacity-subtle);
     transition: opacity 120ms ease;
   }
@@ -176,7 +179,8 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--wa-color-focus, var(--texra-focusBorder));
+    outline: var(--border-thin) solid
+      var(--wa-color-focus, var(--texra-focusBorder));
     outline-offset: 1px;
   }
 


### PR DESCRIPTION
## Summary
- **Empty content area fix**: `.desktop-shell` used `min-height: 100vh` while inner grids relied on percentage-height chains, leaving route containers with unresolved height. Pin shell to `height: 100vh` and make `.desktop-view` an explicit grid cell so containers fill the workbench.
- **Slim top chrome**: drop the four-tab Launcher/Progress/Settings/Logs nav (redundant once launcher became the primary view). Keep brand label, command palette, open folder, plus icon-only Settings/Logs toggles + "Back to Launcher" affordance for secondary routes.

## Test plan
- [x] `npx tsc --noEmit -p packages/desktop/tsconfig.json` — clean
- [x] `cd packages/desktop && npx vite build --mode development` — clean (2.3s)
- [ ] Manual: launch desktop, confirm launcher view renders, settings/logs icons toggle, back-to-launcher works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the desktop renderer’s routing/navigation behavior and core layout CSS (grid/height), which could regress route visibility or sizing across platforms/window sizes.
> 
> **Overview**
> Fixes a desktop renderer regression where the workbench/route containers could collapse to an empty content area by pinning the shell/workbench to resolvable heights and stacking route containers in a single explicit grid cell.
> 
> Simplifies the desktop top chrome by removing the four-tab route bar and replacing it with a brand label, command/open-folder actions, icon-only Settings/Logs toggles (with launcher-toggle behavior), and a conditional “Back to Launcher” control.
> 
> Includes small doc/table formatting cleanup in `electron-migration-plan.md` and minor import/style formatting changes in extension webview components (no behavioral changes intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e798167011a7e023757196d677aa353274ba28c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->