### PR TITLE
refactor(wa): token pass 4b — input/badge/testing cleanup

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -358,10 +358,10 @@ body.texra-high-contrast {
   --vscode-editorInfo-background: var(--texra-editorInfo-background);
   --vscode-editorInfo-foreground: var(--texra-editorInfo-foreground);
   --vscode-editorWarning-background: var(--texra-editorWarning-background);
-  --vscode-editorWarning-foreground: var(--texra-editorWarning-foreground);
+  --vscode-editorWarning-foreground: var(--wa-color-warning-on-quiet);
   --vscode-editorWidget-background: var(--texra-editorWidget-background);
   --vscode-editorWidget-border: var(--texra-editorWidget-border);
-  --vscode-errorForeground: var(--texra-errorForeground);
+  --vscode-errorForeground: var(--wa-color-danger-on-quiet);
   --vscode-focusBorder: var(--texra-focusBorder);
   --vscode-sideBar-background: var(--texra-sideBar-background);
   --vscode-sideBar-foreground: var(--texra-sideBar-foreground);
@@ -386,12 +386,12 @@ body.texra-high-contrast {
     --texra-button-secondaryHoverBackground
   );
   --vscode-button-separator: var(--texra-button-separator);
-  --vscode-dropdown-background: var(--texra-input-background);
+  --vscode-dropdown-background: var(--wa-form-control-background-color);
   --vscode-dropdown-border: var(--texra-dropdown-border);
-  --vscode-dropdown-foreground: var(--texra-input-foreground);
-  --vscode-input-background: var(--texra-input-background);
-  --vscode-input-border: var(--texra-input-border);
-  --vscode-input-foreground: var(--texra-input-foreground);
+  --vscode-dropdown-foreground: var(--wa-form-control-text-color);
+  --vscode-input-background: var(--wa-form-control-background-color);
+  --vscode-input-border: var(--wa-form-control-border-color);
+  --vscode-input-foreground: var(--wa-form-control-text-color);
   --vscode-input-placeholderForeground: var(
     --texra-input-placeholderForeground
   );
@@ -424,25 +424,25 @@ body.texra-high-contrast {
   --vscode-inputValidation-warningForeground: var(
     --texra-inputValidation-warningForeground
   );
-  --vscode-textArea-background: var(--texra-input-background);
-  --vscode-textArea-border: var(--texra-input-border);
-  --vscode-textArea-foreground: var(--texra-input-foreground);
+  --vscode-textArea-background: var(--wa-form-control-background-color);
+  --vscode-textArea-border: var(--wa-form-control-border-color);
+  --vscode-textArea-foreground: var(--wa-form-control-text-color);
   --vscode-textArea-placeholderForeground: var(
     --texra-input-placeholderForeground
   );
-  --vscode-checkbox-background: var(--texra-input-background);
-  --vscode-checkbox-border: var(--texra-input-border);
+  --vscode-checkbox-background: var(--wa-form-control-background-color);
+  --vscode-checkbox-border: var(--wa-form-control-border-color);
   --vscode-checkbox-foreground: var(--texra-foreground);
-  --vscode-settings-checkboxBackground: var(--texra-input-background);
-  --vscode-settings-checkboxBorder: var(--texra-input-border);
+  --vscode-settings-checkboxBackground: var(--wa-form-control-background-color);
+  --vscode-settings-checkboxBorder: var(--wa-form-control-border-color);
   --vscode-settings-checkboxForeground: var(--texra-foreground);
-  --vscode-settings-dropdownBackground: var(--texra-input-background);
+  --vscode-settings-dropdownBackground: var(--wa-form-control-background-color);
   --vscode-settings-dropdownBorder: var(--texra-dropdown-border);
-  --vscode-settings-dropdownForeground: var(--texra-input-foreground);
+  --vscode-settings-dropdownForeground: var(--wa-form-control-text-color);
   --vscode-settings-dropdownListBorder: var(--texra-dropdown-border);
-  --vscode-settings-textInputBackground: var(--texra-input-background);
-  --vscode-settings-textInputBorder: var(--texra-input-border);
-  --vscode-settings-textInputForeground: var(--texra-input-foreground);
+  --vscode-settings-textInputBackground: var(--wa-form-control-background-color);
+  --vscode-settings-textInputBorder: var(--wa-form-control-border-color);
+  --vscode-settings-textInputForeground: var(--wa-form-control-text-color);
   --vscode-list-activeSelectionBackground: var(
     --texra-list-activeSelectionBackground
   );
@@ -456,7 +456,7 @@ body.texra-high-contrast {
   --vscode-list-focusHighlightForeground: var(--texra-focusBorder);
   --vscode-list-focusOutline: var(--texra-list-focusOutline);
   --vscode-list-highlightForeground: var(--texra-focusBorder);
-  --vscode-list-hoverBackground: var(--texra-list-hoverBackground);
+  --vscode-list-hoverBackground: var(--wa-color-neutral-fill-quiet);
   --vscode-list-hoverForeground: var(--texra-list-hoverForeground);
   --vscode-list-inactiveSelectionBackground: var(
     --texra-list-inactiveSelectionBackground
@@ -474,11 +474,11 @@ body.texra-high-contrast {
   --vscode-toolbar-hoverOutline: var(--texra-toolbar-hoverOutline);
   --vscode-widget-border: var(--texra-widget-border);
   --vscode-widget-shadow: var(--texra-widget-shadow);
-  --vscode-icon-foreground: var(--texra-icon-foreground);
-  --vscode-badge-background: var(--texra-badge-background);
-  --vscode-badge-foreground: var(--texra-badge-foreground);
+  --vscode-icon-foreground: var(--wa-color-text-quiet);
+  --vscode-badge-background: var(--wa-color-neutral-fill-quiet);
+  --vscode-badge-foreground: var(--wa-color-neutral-on-quiet);
   --vscode-progressBar-background: var(--texra-progressBar-background);
-  --vscode-textBlockQuote-background: var(--texra-textBlockQuote-background);
+  --vscode-textBlockQuote-background: var(--wa-color-surface-lowered);
   --vscode-textBlockQuote-border: var(--texra-textBlockQuote-border);
   --vscode-textCodeBlock-background: var(--texra-textCodeBlock-background);
   --vscode-textLink-activeForeground: var(--texra-textLink-activeForeground);
@@ -506,8 +506,8 @@ body.texra-high-contrast {
   --vscode-terminal-ansiRed: var(--texra-terminal-ansiRed);
   --vscode-terminal-ansiWhite: var(--texra-terminal-ansiWhite);
   --vscode-terminal-ansiYellow: var(--texra-terminal-ansiYellow);
-  --vscode-testing-iconFailed: var(--texra-testing-iconFailed);
-  --vscode-testing-iconPassed: var(--texra-testing-iconPassed);
+  --vscode-testing-iconFailed: var(--wa-color-danger-fill-loud);
+  --vscode-testing-iconPassed: var(--wa-color-success-fill-loud);
   --vscode-charts-blue: var(--texra-charts-blue);
   --vscode-charts-green: var(--texra-charts-green);
   --vscode-charts-orange: var(--texra-charts-orange);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -262,9 +262,9 @@
   /* WA form-control tokens — wire to TeXRA input palette so wa-input,
      wa-textarea, wa-select, etc. inherit the host theme's editor surface
      rather than WA's default form-control colors. */
-  --wa-form-control-background-color: var(--texra-input-background);
-  --wa-form-control-text-color: var(--texra-input-foreground);
-  --wa-form-control-border-color: var(--texra-input-border);
+  --wa-form-control-background-color: var(--wa-form-control-background-color);
+  --wa-form-control-text-color: var(--wa-form-control-text-color);
+  --wa-form-control-border-color: var(--wa-form-control-border-color);
 
   --wa-color-brand-fill-loud: var(--texra-button-background);
   --wa-color-brand-on-loud: var(--texra-button-foreground);
@@ -301,12 +301,21 @@
      Aligned with desktop bridge (themeTokens.css) for cross-host parity. */
   --wa-color-danger-on-loud: #ffffff;
 
+  --wa-color-success-fill-loud: var(
+    --texra-charts-green,
+    var(--texra-inputValidation-infoBackground)
+  );
+  --wa-color-success-on-loud: #ffffff;
+  --wa-color-success-border-loud: transparent;
   --wa-color-success-fill-quiet: var(
     --texra-charts-green,
     var(--texra-inputValidation-infoBackground)
   );
   --wa-color-success-border-quiet: var(--texra-inputValidation-infoBorder);
   --wa-color-success-on-quiet: var(--texra-foreground);
+
+  --wa-color-danger-fill-loud: var(--wa-color-danger-on-quiet);
+  --wa-color-danger-border-loud: transparent;
 }
 
 body {

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -28,7 +28,7 @@ export class WorkflowHintBanner extends LitElement {
       gap: 8px;
       padding: 8px 10px;
       margin: 0 0 8px 0;
-      background: var(--texra-textBlockQuote-background);
+      background: var(--wa-color-surface-lowered);
       border-left: 3px solid var(--wa-color-text-link);
       border-radius: 3px;
       font-size: 0.9em;

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -33,7 +33,7 @@ export const groupStyles = css`
     }
 
     &.is-stopped {
-      border-left-color: var(--texra-testing-iconPassed);
+      border-left-color: var(--wa-color-success-fill-loud);
     }
   }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -61,7 +61,7 @@ export const profileViewStyles: CSSResult = css`
     font-size: 0.95em;
     padding: 0 var(--wa-space-3xs);
     border-radius: var(--border-radius-small);
-    background: var(--texra-textBlockQuote-background);
+    background: var(--wa-color-surface-lowered);
   }
 
   .not-authenticated {
@@ -117,7 +117,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .badge.visibility-badge.public {
-    background: var(--texra-testing-iconPassed);
+    background: var(--wa-color-success-fill-loud);
     color: var(--wa-color-brand-on-loud);
   }
 
@@ -316,7 +316,7 @@ export const profileViewStyles: CSSResult = css`
     flex-direction: column;
     gap: var(--wa-space-xs);
     padding: var(--wa-space-xs);
-    background: var(--texra-textBlockQuote-background);
+    background: var(--wa-color-surface-lowered);
     border-radius: var(--border-radius);
   }
 
@@ -353,7 +353,7 @@ export const profileViewStyles: CSSResult = css`
   .provider-setting-warning {
     color: var(
       --texra-inputValidation-warningForeground,
-      var(--texra-editorWarning-foreground)
+      var(--wa-color-warning-on-quiet)
     );
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
@@ -592,7 +592,7 @@ export const profileViewStyles: CSSResult = css`
 
   .deprecated-models {
     border-top: var(--border-thin) solid var(--color-border);
-    background: var(--texra-textBlockQuote-background);
+    background: var(--wa-color-surface-lowered);
   }
 
   /* Unavailable model rows (not in relay allowlist) */
@@ -614,7 +614,7 @@ export const profileViewStyles: CSSResult = css`
   .model-row-icon--warning {
     --_icon-color: var(
       --texra-list-warningForeground,
-      var(--texra-editorWarning-foreground)
+      var(--wa-color-warning-on-quiet)
     );
   }
 `;

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -117,7 +117,7 @@ export class GitTab extends LitElement {
         margin: 2px 0;
       }
       .instructions code {
-        background: var(--texra-textBlockQuote-background);
+        background: var(--wa-color-surface-lowered);
         padding: 0 var(--wa-space-2xs);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
@@ -136,7 +136,7 @@ export class GitTab extends LitElement {
         padding: var(--wa-space-3xs) 0;
       }
       .subscriptions-list code {
-        background: var(--texra-textBlockQuote-background);
+        background: var(--wa-color-surface-lowered);
         padding: var(--border-thin) var(--wa-space-xs);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -150,7 +150,7 @@ export const requestPanelStyles: CSSResult = css`
   /* Shared action button colors */
   :is(${ACTIONS}) vscode-toolbar-button[data-action='approve']::part(control),
   :is(${ACTIONS}) vscode-toolbar-button[data-action='submit']::part(control) {
-    color: var(--texra-testing-iconPassed);
+    color: var(--wa-color-success-fill-loud);
   }
 
   :is(${ACTIONS}) vscode-toolbar-button[data-action='setup']::part(control) {


### PR DESCRIPTION
Migrate 15 --texra-* tokens to Web Awesome equivalents:

Token counts: input (29), badge (8), list selection (12), errorForeground (9),
editorWarning-foreground (12), testing icons (22), icon-foreground (8),
textBlockQuote-background (13).

Bridge mappings added: success-fill-loud, danger-fill-loud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cross-host theme token mappings and updates multiple UI surfaces; regressions would be visual (contrast/readability) rather than functional.
> 
> **Overview**
> Unifies desktop and extension theming by switching several `--vscode-*`/component styles from `--texra-*` aliases to Web Awesome semantic tokens (form controls, badges, list hover, quote backgrounds, warning/error/success states).
> 
> Adds/adjusts bridge tokens in the extension (`--wa-color-success-fill-loud`, `--wa-color-danger-fill-loud`/borders) and updates affected UI components (workflow hint banner, progress log group statuses, profile badges/warnings, Git tab code blocks, request panel approve/submit actions) to consume the new WA tokens for consistent colors across hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55e0f21e1ff2fd2c847e8de1afce79de8d14480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->