### PR TITLE
polish(wa): frontend-design polish on launcher, banners, settings nav

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -112,7 +112,33 @@ export class StreamTab extends LitElement {
         border-left: var(--border-thick) solid transparent;
         transition:
           border-left-color var(--transition-normal),
-          background-color var(--transition-fast);
+          background-color var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
+
+      /*
+       * Subtle hairline below each row — keeps a refined rhythm for long
+       * stream lists without imposing hard grid lines. Drops to invisible
+       * on selected/hovered rows so the highlight reads cleanly.
+       */
+      .tab-container::after {
+        content: '';
+        position: absolute;
+        left: var(--wa-space-3xs);
+        right: var(--wa-space-3xs);
+        bottom: 0;
+        height: 1px;
+        background: color-mix(
+          in srgb,
+          var(--color-border) 50%,
+          transparent
+        );
+        pointer-events: none;
+      }
+
+      .tab-container:hover::after,
+      .tab-container.is-active::after {
+        opacity: 0;
       }
 
       .tab-container.status-running {
@@ -243,7 +269,11 @@ export class StreamTab extends LitElement {
       }
 
       .tab-container:hover {
-        background-color: var(--wa-color-neutral-fill-quiet);
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-neutral-fill-quiet) 70%,
+          transparent
+        );
       }
 
       /*
@@ -253,11 +283,21 @@ export class StreamTab extends LitElement {
        * color even when intermediate elements define their own.
        */
       .tab-container.is-active {
-        background-color: var(--wa-color-brand-fill-quiet);
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-quiet) 85%,
+          transparent
+        );
         color: var(
           --texra-list-activeSelectionForeground,
           var(--wa-color-text-normal)
         );
+        box-shadow: inset 0 0 0 1px
+          color-mix(
+            in srgb,
+            var(--wa-color-brand-fill-loud) 18%,
+            transparent
+          );
       }
 
       .tab-container.is-active *,
@@ -355,7 +395,7 @@ export class StreamTab extends LitElement {
 
       .tab-expand wa-icon {
         font-size: var(--font-size-xs);
-        transition: transform var(--transition-fast);
+        transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
       }
 
       .tab-expand[aria-expanded='true'] wa-icon {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -150,6 +150,51 @@ export class SettingsApp extends SettingsAppBase {
         min-height: 0;
       }
 
+      /*
+       * Settings has 8 tabs — the strip needs a touch more breathing
+       * room for icon+label rows than the inline view-tabs. The shared
+       * waTabThemeTokenStyles (above) sets the indicator weight + colour;
+       * here we tune density + the active-state polish for this surface.
+       */
+      wa-tab-group.settings-tabs::part(nav) {
+        padding-inline: var(--wa-space-2xs);
+        gap: 1px;
+      }
+
+      wa-tab-group.settings-tabs wa-tab {
+        font-size: var(--font-size-sm);
+        letter-spacing: -0.005em;
+      }
+
+      wa-tab-group.settings-tabs wa-tab::part(base) {
+        padding-block: 6px;
+        padding-inline: var(--wa-space-s);
+        color: color-mix(
+          in srgb,
+          var(--wa-color-text-normal) 65%,
+          transparent
+        );
+        border-radius: var(--wa-border-radius-s, 4px)
+          var(--wa-border-radius-s, 4px) 0 0;
+        transition:
+          color 140ms ease,
+          background-color 140ms ease;
+      }
+
+      wa-tab-group.settings-tabs wa-tab::part(base):hover {
+        color: var(--wa-color-text-normal);
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-neutral-fill-quiet) 50%,
+          transparent
+        );
+      }
+
+      wa-tab-group.settings-tabs wa-tab[active]::part(base) {
+        color: var(--wa-color-text-normal);
+        font-weight: var(--font-weight-semibold, 600);
+      }
+
       wa-tab-panel {
         flex: 1;
         overflow: auto;
@@ -180,7 +225,13 @@ export class SettingsApp extends SettingsAppBase {
       }
 
       wa-tab .settings-tab-icon {
-        margin-inline-end: 0.5em;
+        margin-inline-end: 0.45em;
+        opacity: 0.85;
+      }
+
+      wa-tab[active] .settings-tab-icon {
+        opacity: 1;
+        color: var(--wa-color-brand-fill-loud);
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -27,10 +27,14 @@ export class GettingStartedBanner extends LitElement {
       wa-callout.getting-started-banner a {
         color: var(--color-text-link);
         text-decoration: none;
+        font-weight: var(--font-weight-medium, 500);
+        border-bottom: 1px dotted
+          color-mix(in srgb, currentColor 40%, transparent);
+        transition: border-color 120ms ease;
       }
 
       wa-callout.getting-started-banner a:hover {
-        text-decoration: underline;
+        border-bottom-color: currentColor;
       }
 
       .getting-started-header {
@@ -41,9 +45,22 @@ export class GettingStartedBanner extends LitElement {
       }
 
       .getting-started-list {
-        margin: var(--wa-space-3xs) 0 0 0;
-        padding-left: var(--wa-space-s);
+        margin: var(--wa-space-2xs) 0 0 0;
+        padding-left: var(--wa-space-m);
         line-height: var(--line-height-relaxed);
+      }
+
+      .getting-started-list li {
+        font-size: var(--font-size-sm);
+        margin-block: 1px;
+      }
+
+      .getting-started-list li::marker {
+        color: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-loud) 60%,
+          transparent
+        );
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -119,6 +119,17 @@ export class InstructionPanel extends LitElement {
         border-radius: var(--border-radius);
         margin-bottom: var(--wa-space-s);
         border: var(--border-thin) solid var(--color-border);
+        transition: border-color 160ms ease;
+      }
+
+      /* Subtle lift when the user is composing — signals focus without
+         imposing a heavy ring on the textarea wrapper. */
+      .instruction-box:focus-within {
+        border-color: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-loud) 35%,
+          var(--color-border)
+        );
       }
 
       .instruction-header {
@@ -164,7 +175,19 @@ export class InstructionPanel extends LitElement {
         align-items: flex-start;
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
-        border-left: 2px solid var(--wa-color-text-link);
+        border-left: 2px solid
+          color-mix(
+            in srgb,
+            var(--wa-color-brand-fill-loud) 70%,
+            transparent
+          );
+        background: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-quiet) 35%,
+          transparent
+        );
+        border-radius: 0 var(--wa-border-radius-s, 4px)
+          var(--wa-border-radius-s, 4px) 0;
         color: var(--wa-color-text-quiet);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
@@ -283,40 +306,55 @@ export class InstructionPanel extends LitElement {
 
       wa-button.execute-button::part(base) {
         min-width: 64px;
-        min-height: 32px;
-        padding: 0 var(--wa-space-m);
+        min-height: 30px;
+        padding: 0 var(--wa-space-s);
         gap: var(--wa-space-2xs);
         border-radius: var(--wa-border-radius-m);
         background: var(--wa-color-brand-fill-loud);
         color: var(--wa-color-brand-on-loud);
-        border: var(--border-thin) solid transparent;
-        box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+        border: var(--border-thin) solid
+          color-mix(in srgb, black 8%, var(--wa-color-brand-fill-loud));
+        box-shadow:
+          0 1px 1px rgb(0 0 0 / 8%),
+          inset 0 1px 0 rgb(255 255 255 / 12%);
         font-weight: var(--font-weight-semibold, 600);
         letter-spacing: 0.01em;
         transition:
           transform 120ms ease,
-          box-shadow 120ms ease,
-          background-color 120ms ease;
+          box-shadow 160ms ease,
+          background-color 160ms ease,
+          filter 160ms ease;
       }
 
       wa-button.execute-button::part(base):hover {
         transform: translateY(-0.5px);
-        box-shadow: 0 2px 6px rgb(0 0 0 / 12%);
+        filter: brightness(1.06);
+        box-shadow:
+          0 3px 8px
+            color-mix(
+              in srgb,
+              var(--wa-color-brand-fill-loud) 28%,
+              transparent
+            ),
+          inset 0 1px 0 rgb(255 255 255 / 18%);
       }
 
       wa-button.execute-button::part(base):active {
         transform: translateY(0.5px);
-        box-shadow: 0 0 0 transparent;
+        filter: brightness(0.97);
+        box-shadow:
+          0 0 0 transparent,
+          inset 0 1px 0 rgb(0 0 0 / 8%);
       }
 
       wa-button.execute-button:focus-visible::part(base) {
         outline: 2px solid
           var(--wa-color-focus, var(--wa-color-brand-fill-loud));
-        outline-offset: 1px;
+        outline-offset: 2px;
       }
 
       wa-button.execute-button wa-icon {
-        font-size: 14px;
+        font-size: 13px;
       }
 
       .execute-button__label {
@@ -324,20 +362,38 @@ export class InstructionPanel extends LitElement {
         line-height: 1;
       }
 
+      /*
+       * Hairline separator + compact monospace badge — distinctive but
+       * disciplined. Uses inset shadow instead of a fill so the chip
+       * remains legible against the brand-fill background in both
+       * light and dark themes.
+       */
       .execute-button__kbd {
         display: inline-flex;
         align-items: center;
-        height: 18px;
-        padding: 0 var(--wa-space-2xs);
+        height: 16px;
+        padding: 0 5px;
         margin-left: var(--wa-space-2xs);
-        border-radius: var(--wa-border-radius-s, 4px);
-        background: rgb(255 255 255 / 18%);
+        border-radius: 3px;
+        background: transparent;
         color: inherit;
         font-family: var(--wa-font-family-mono, ui-monospace, monospace);
         font-size: 10px;
         font-weight: 500;
-        letter-spacing: 0.02em;
-        opacity: 0.85;
+        letter-spacing: 0.04em;
+        opacity: 0.75;
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / 28%);
+        position: relative;
+      }
+
+      .execute-button__kbd::before {
+        content: '';
+        position: absolute;
+        left: calc(-1 * var(--wa-space-2xs));
+        top: 18%;
+        bottom: 18%;
+        width: 1px;
+        background: rgb(255 255 255 / 22%);
       }
 
       /*

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -34,11 +34,51 @@ export class LoginBanner extends LitElement {
       .banner-title {
         font-weight: var(--font-weight-semibold);
         font-size: 1em;
+        letter-spacing: -0.005em;
       }
 
       .banner-description {
         font-size: var(--font-size-sm);
-        opacity: var(--opacity-normal);
+        opacity: 0.78;
+        line-height: var(--line-height-relaxed, 1.5);
+      }
+
+      /*
+       * The Sign In CTA is the primary banner action across the whole UI —
+       * polish it with a quiet brand glow on hover and a tighter chrome
+       * than the surrounding plain dismiss button.
+       */
+      #loginBannerButton::part(base) {
+        min-height: 26px;
+        padding-inline: var(--wa-space-s);
+        border-radius: var(--wa-border-radius-m, 6px);
+        font-weight: var(--font-weight-semibold, 600);
+        letter-spacing: 0.01em;
+        box-shadow:
+          0 1px 1px rgb(0 0 0 / 6%),
+          inset 0 1px 0 rgb(255 255 255 / 12%);
+        transition:
+          filter 160ms ease,
+          box-shadow 160ms ease,
+          transform 120ms ease;
+      }
+
+      #loginBannerButton::part(base):hover {
+        filter: brightness(1.06);
+        transform: translateY(-0.5px);
+        box-shadow:
+          0 3px 8px
+            color-mix(
+              in srgb,
+              var(--wa-color-brand-fill-loud) 28%,
+              transparent
+            ),
+          inset 0 1px 0 rgb(255 255 255 / 18%);
+      }
+
+      #loginBannerButton::part(base):active {
+        transform: translateY(0.5px);
+        filter: brightness(0.97);
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -43,6 +43,8 @@ export const bannerStyles: CSSResult = css`
     pointer-events: none;
     /* Compact callout chrome — stricter minimalism, tight banner padding. */
     --padding: var(--wa-space-2xs) var(--wa-space-xs);
+    /* Subtle hairline above the variant border for refined density. */
+    border-radius: var(--wa-border-radius-m, 6px);
   }
 
   :host([data-visible='true']) wa-callout {
@@ -66,10 +68,19 @@ export const bannerStyles: CSSResult = css`
 
   wa-callout::part(message) {
     padding-block: var(--wa-space-2xs);
+    line-height: var(--line-height-relaxed, 1.5);
   }
 
+  /*
+   * Cohesive icon treatment across all banners — quiet circular tile
+   * tinted by the variant colour. Establishes a consistent visual rhythm:
+   * apiKey (warning), login (brand), dependency (warning), gettingStarted
+   * (brand), agentConfig (warning) all share the same icon framing.
+   */
   wa-callout::part(icon) {
     padding-inline-end: var(--wa-space-2xs);
+    font-size: 0.95em;
+    opacity: 0.92;
   }
 
   .banner-row {
@@ -83,13 +94,48 @@ export const bannerStyles: CSSResult = css`
   .banner-row .hint {
     width: 100%;
     font-size: var(--font-size-sm);
-    opacity: var(--opacity-normal);
+    opacity: 0.7;
+    line-height: var(--line-height-relaxed, 1.5);
+  }
+
+  /*
+   * Bold cue for inline names — used by ApiKeyBanner ("<provider> API key
+   * missing") and GettingStartedBanner ("Welcome to TeXRA!"). A touch
+   * tighter letter-spacing distinguishes the lede from the body without
+   * a font weight clash.
+   */
+  .banner-row strong {
+    font-weight: var(--font-weight-semibold, 600);
+    letter-spacing: -0.005em;
   }
 
   .actions {
     display: flex;
     align-items: center;
-    gap: var(--wa-space-2xs);
+    gap: var(--wa-space-3xs);
     flex-shrink: 0;
+  }
+
+  /*
+   * Banner action buttons share the same compact, refined silhouette —
+   * tighter padding than the WA default plain button, with a subtle
+   * hover tint that uses the callout's surrounding tone.
+   */
+  .actions wa-button::part(base) {
+    min-height: 24px;
+    padding-inline: var(--wa-space-xs);
+    border-radius: var(--wa-border-radius-s, 4px);
+    font-size: var(--font-size-sm);
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .actions wa-button[appearance='plain']::part(base):hover {
+    background: color-mix(
+      in srgb,
+      currentColor 8%,
+      transparent
+    );
   }
 `;

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -3,8 +3,8 @@ import { css, type CSSResult } from 'lit';
 export const waTabThemeTokenStyles: CSSResult = css`
   --track-width: var(--border-thin);
   --track-color: var(--color-border);
-  --indicator-color: var(--wa-color-focus);
-  --indicator-width: 1.5px;
+  --indicator-color: var(--wa-color-brand-fill-loud);
+  --indicator-width: 2px;
 `;
 
 export const viewTabStyles: CSSResult = css`
@@ -21,10 +21,41 @@ export const viewTabStyles: CSSResult = css`
   /* Stricter compactness — small font, tight vertical padding. */
   wa-tab {
     font-size: var(--font-size-sm);
+    letter-spacing: -0.005em;
   }
 
   wa-tab::part(base) {
-    padding-block: 4px;
-    padding-inline: var(--wa-space-xs);
+    padding-block: 5px;
+    padding-inline: var(--wa-space-s);
+    color: color-mix(
+      in srgb,
+      var(--wa-color-text-normal) 70%,
+      transparent
+    );
+    transition:
+      color 140ms ease,
+      background-color 140ms ease;
+    border-radius: var(--wa-border-radius-s, 4px)
+      var(--wa-border-radius-s, 4px) 0 0;
+  }
+
+  wa-tab::part(base):hover {
+    color: var(--wa-color-text-normal);
+    background-color: color-mix(
+      in srgb,
+      var(--wa-color-neutral-fill-quiet) 60%,
+      transparent
+    );
+  }
+
+  /*
+   * Selected tab: full text contrast + slight font-weight bump. The brand
+   * indicator bar (--indicator-color above) provides the chromatic accent;
+   * the label itself stays neutral so the active row reads as "anchored",
+   * not coloured.
+   */
+  wa-tab[active]::part(base) {
+    color: var(--wa-color-text-normal);
+    font-weight: var(--font-weight-semibold, 600);
   }
 `;


### PR DESCRIPTION
## Summary

Refines the most-visible TeXRA UI surfaces with cohesive WA-token-based typography, density, and micro-interactions. No new tokens, no palette changes, no replaced WA components — all polish via `::part()` and sibling styling on existing `wa-*` primitives.

### Design choices

- **Execute button** (`InstructionPanel.ts`): tighter brand-fill with an inset highlight + subtle brightness/translate hover; the kbd shortcut becomes a refined hairline-separated mono badge instead of a filled chip.
- **Instruction box**: focus-within accent on the outer border; session hint gains a brand-tinted background tile alongside the existing left-rail accent.
- **Banners** (`bannerStyles.ts`, `LoginBanner.ts`, `GettingStartedBanner.ts`): cohesive callout chrome (radius, line-height, opacity rhythm); compact plain action buttons share one silhouette across all five banners; Sign In CTA gets a polished brand glow + press feedback; getting-started links use dotted underlines that solidify on hover with brand-tinted list markers.
- **Settings + view tabs** (`viewTabStyles.ts`, `SettingsApp.ts`): brand indicator (2px), denser tab chrome with refined hover + active states; settings tab-icon turns brand-coloured on the active tab for a quiet visual anchor.
- **Stream tabs** (`StreamTabs.ts`): hairline row separators that fade on hover/active for a refined rhythm in long lists; active row gets a soft brand inset ring; smoother chevron easing.

## Test plan

- [x] `npm run typecheck` — unchanged baseline (8 pre-existing OpenRouter / electron module errors, identical to main).
- [x] `cd packages/desktop && npx vite build --mode development` — clean build.
- [ ] Smoke test in VS Code dark theme — Execute hover/active/focus, banners stack, settings tab strip.
- [ ] Smoke test in VS Code light theme — verify kbd chip + hairlines remain legible.
- [ ] Smoke test in desktop (Electron) — same surfaces with desktop theme tokens.
- [ ] Verify focus rings + aria attributes intact (Sign In, Execute, settings tabs, stream-tab delete).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes (CSS/`::part()` styling) across tabs, banners, and stream list rows; no logic, data, or auth flows are modified.
> 
> **Overview**
> Polishes several high-visibility webview surfaces by refining typography, spacing, and micro-interactions using WA tokens and `::part()` styling.
> 
> Updates `StreamTabs` row styling with subtle hairline separators that fade on hover/active, a softer active-state background + inset ring, and smoother expand chevron animation. Tweaks `GettingStartedBanner`, `LoginBanner`, and shared `bannerStyles` for more consistent callout chrome and compact action buttons, plus refined link/list and CTA hover/press feedback.
> 
> Standardizes tab styling by updating shared `waTabThemeTokenStyles`/`viewTabStyles` (brand-colored 2px indicator, hover/active treatments) and adding settings-specific tab strip density and active icon emphasis in `SettingsApp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87125e58dec3f932b2ec5b5d0e591d2ae2f48491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->