### PR TITLE
refactor(wa): ad-hoc CSS pass 2 — settings/progress WA-native cleanup

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -14,16 +14,16 @@ export class TerminalCommandStrip extends LitElement {
     .strip {
       display: flex;
       align-items: baseline;
-      gap: var(--wa-space-2xs, 8px);
-      padding: 6px 10px;
-      margin: 0 0 8px 0;
+      gap: var(--wa-space-2xs);
+      padding: var(--wa-space-2xs) var(--wa-space-s);
+      margin: 0 0 var(--wa-space-2xs) 0;
       background: var(
         --texra-terminal-background,
         var(--texra-editor-background, transparent)
       );
       color: var(--texra-terminal-foreground, var(--wa-color-text-normal));
-      border: 1px solid var(--texra-panel-border, transparent);
-      border-radius: 3px;
+      border: var(--border-thin) solid var(--texra-panel-border, transparent);
+      border-radius: var(--border-radius-small);
       font-family: var(
         --texra-editor-font-family,
         ui-monospace,
@@ -31,7 +31,7 @@ export class TerminalCommandStrip extends LitElement {
         Consolas,
         monospace
       );
-      font-size: var(--texra-editor-font-size, 12px);
+      font-size: var(--texra-editor-font-size, var(--font-size-sm));
       max-height: min(32vh, 320px);
       overflow: auto;
       white-space: pre;
@@ -45,7 +45,7 @@ export class TerminalCommandStrip extends LitElement {
 
     .prompt {
       color: var(--texra-terminal-ansiGreen, var(--color-success, #0a0));
-      font-weight: 600;
+      font-weight: var(--font-weight-semibold);
       user-select: none;
     }
   `;

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -7,10 +7,12 @@
  * don't see it after the first run.
  */
 
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { webviewStorage } from '../webviewStorage';
 
@@ -22,25 +24,22 @@ export class WorkflowHintBanner extends LitElement {
     :host {
       display: block;
     }
-    .banner {
+    wa-callout {
+      margin: 0 0 var(--wa-space-2xs) 0;
+      --padding: var(--wa-space-2xs) var(--wa-space-xs);
+    }
+    .banner-row {
       display: flex;
       align-items: flex-start;
-      gap: 8px;
-      padding: 8px 10px;
-      margin: 0 0 8px 0;
-      background: var(--texra-textBlockQuote-background);
-      border-left: 3px solid var(--wa-color-text-link);
-      border-radius: 3px;
-      font-size: 0.9em;
-      color: var(--wa-color-text-normal);
+      gap: var(--wa-space-2xs);
     }
     .text {
       flex: 1;
-      line-height: 1.45;
+      line-height: var(--line-height-normal);
     }
     .title {
-      font-weight: 600;
-      margin-right: 4px;
+      font-weight: var(--font-weight-semibold);
+      margin-right: var(--wa-space-3xs);
     }
   `;
 
@@ -55,19 +54,22 @@ export class WorkflowHintBanner extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (this.dismissed) return nothing;
     return html`
-      <div class="banner" role="note" aria-label="Workflow mode reminder">
-        <div class="text">
-          <span class="title">Workflow mode thinks across rounds.</span>
-          It reduces hallucinations and cuts fluff, so expect 10–30 minutes per
-          run. Use Stop to cancel; pick Tool-Use mode for fast, iterative edits.
+      <wa-callout variant="brand" role="note" aria-label="Workflow mode reminder">
+        ${waIcon('info', { slot: 'icon' })}
+        <div class="banner-row">
+          <div class="text">
+            <span class="title">Workflow mode thinks across rounds.</span>
+            It reduces hallucinations and cuts fluff, so expect 10–30 minutes per
+            run. Use Stop to cancel; pick Tool-Use mode for fast, iterative edits.
+          </div>
+          ${renderIconActionButton({
+            icon: 'close',
+            label: 'Dismiss workflow mode reminder',
+            title: 'Dismiss this reminder',
+            onClick: this.handleDismiss,
+          })}
         </div>
-        ${renderIconActionButton({
-          icon: 'close',
-          label: 'Dismiss workflow mode reminder',
-          title: 'Dismiss this reminder',
-          onClick: this.handleDismiss,
-        })}
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -25,7 +25,7 @@ export class ProviderKeyModal extends LitElement {
       /* wa-dialog supplies the backdrop, modal positioning, focus trap, escape
          handling, and panel chrome; only the body content layout lives here. */
       wa-dialog.provider-key-dialog {
-        --width: min(560px, calc(100vw - 32px));
+        --width: min(560px, calc(100vw - var(--wa-space-xl, 32px)));
       }
 
       .provider-key-description {
@@ -44,7 +44,7 @@ export class ProviderKeyModal extends LitElement {
       input {
         width: 100%;
         box-sizing: border-box;
-        height: 34px;
+        height: var(--height-control);
         padding: var(--wa-space-2xs) var(--wa-space-xs);
         color: var(--wa-form-control-text-color);
         background: var(--wa-form-control-background-color);
@@ -71,13 +71,15 @@ export class ProviderKeyModal extends LitElement {
         gap: var(--wa-space-xs);
       }
 
-      button {
+      /* Action buttons share base layout; variants set color + background */
+      .provider-key-actions button {
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-2xs);
         min-height: var(--height-button);
         padding: var(--wa-space-2xs) var(--wa-space-s);
         border-radius: var(--border-radius);
+        border: var(--border-thin) solid transparent;
         font: inherit;
         cursor: pointer;
       }
@@ -85,7 +87,7 @@ export class ProviderKeyModal extends LitElement {
       .provider-key-primary {
         color: var(--wa-color-brand-on-loud);
         background: var(--wa-color-brand-fill-loud);
-        border: var(--border-thin) solid var(--wa-color-brand-fill-loud);
+        border-color: var(--wa-color-brand-fill-loud);
       }
 
       .provider-key-primary:hover {
@@ -95,7 +97,7 @@ export class ProviderKeyModal extends LitElement {
       .provider-key-secondary {
         color: var(--wa-color-text-normal);
         background: transparent;
-        border: var(--border-thin) solid var(--color-border);
+        border-color: var(--color-border);
       }
 
       .provider-key-secondary:hover {

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -189,7 +189,7 @@ export const profileViewStyles: CSSResult = css`
 
   .api-access-support-icon {
     flex-shrink: 0;
-    margin-top: 2px;
+    margin-top: var(--wa-space-3xs);
     color: var(--texra-charts-red, var(--wa-color-danger-on-quiet));
   }
 
@@ -343,11 +343,15 @@ export const profileViewStyles: CSSResult = css`
     gap: var(--wa-space-2xs);
   }
 
-  .provider-setting-description {
-    color: var(--color-text-secondary);
+  .provider-setting-description,
+  .provider-setting-warning {
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
-    padding-left: 22px;
+    padding-left: var(--wa-space-l);
+  }
+
+  .provider-setting-description {
+    color: var(--color-text-secondary);
   }
 
   .provider-setting-warning {
@@ -355,9 +359,6 @@ export const profileViewStyles: CSSResult = css`
       --texra-inputValidation-warningForeground,
       var(--texra-editorWarning-foreground)
     );
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    padding-left: 22px;
   }
 
   .provider-setting-link {

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -114,7 +114,7 @@ export class GitTab extends LitElement {
         padding-left: 1.25em;
       }
       .instructions li {
-        margin: 2px 0;
+        margin: var(--wa-space-3xs) 0;
       }
       .instructions code {
         background: var(--texra-textBlockQuote-background);

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -5,6 +5,7 @@
 
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -194,12 +195,20 @@ export class LaTeXTab extends LitElement {
         line-height: var(--line-height-relaxed);
       }
 
-      .dependency-card {
+      /* Shared card chrome for dependency + setting rows */
+      .dependency-card,
+      .setting-card {
         padding: var(--wa-space-xs);
         margin-bottom: var(--wa-space-xs);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         background: var(--wa-color-surface-default);
+      }
+
+      .setting-card {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--wa-space-xs);
       }
 
       .dependency-row {
@@ -208,16 +217,23 @@ export class LaTeXTab extends LitElement {
         gap: var(--wa-space-xs);
       }
 
-      .dependency-icon {
+      .dependency-icon,
+      .setting-status-icon {
         flex-shrink: 0;
         font-size: var(--font-size-lg);
       }
 
-      .dependency-icon.installed {
+      .setting-status-icon {
+        margin-top: var(--wa-space-3xs);
+      }
+
+      .dependency-icon.installed,
+      .setting-status-icon.is-set {
         color: var(--texra-testing-iconPassed, #73c991);
       }
 
-      .dependency-icon.missing {
+      .dependency-icon.missing,
+      .setting-status-icon.not-set {
         color: var(--texra-testing-iconFailed, #f48771);
       }
 
@@ -271,7 +287,7 @@ export class LaTeXTab extends LitElement {
       }
 
       .dependency-path {
-        margin-top: 4px;
+        margin-top: var(--wa-space-3xs);
         font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
@@ -305,86 +321,33 @@ export class LaTeXTab extends LitElement {
         border-color: var(--texra-testing-iconPassed, #73c991) !important;
       }
 
-      .prerequisite-hint {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--wa-space-xs);
-        padding: var(--wa-space-xs);
+      /* Prerequisite hint uses wa-callout; only layout for actions row + the
+         inline command text live here. */
+      wa-callout.prerequisite-hint {
         margin-bottom: var(--wa-space-xs);
-        border: var(--border-thin) solid
-          var(--texra-editorInfo-foreground, #3794ff);
-        border-radius: var(--border-radius);
-        background: var(--wa-color-surface-default);
+        --padding: var(--wa-space-xs);
       }
 
-      .prerequisite-hint .hint-icon {
-        flex-shrink: 0;
-        font-size: var(--font-size-lg);
-        color: var(--texra-editorInfo-foreground, #3794ff);
-      }
-
-      .prerequisite-hint .hint-body {
-        flex: 1;
-        min-width: 0;
-      }
-
-      .prerequisite-hint .hint-title {
+      .hint-title {
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-normal);
         margin-bottom: var(--wa-space-3xs);
       }
 
-      .prerequisite-hint .hint-description {
+      .hint-description {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         line-height: var(--line-height-normal);
       }
 
-      .prerequisite-hint .hint-actions {
+      .hint-actions {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
         margin-top: var(--wa-space-2xs);
       }
 
-      .section-header {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding-bottom: var(--wa-space-2xs);
-        margin-bottom: var(--wa-space-xs);
-        border-bottom: var(--border-thin) solid var(--color-border);
-        font-size: var(--font-size-sm);
-        font-weight: var(--font-weight-medium);
-        color: var(--color-text-secondary);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-      }
-
-      .setting-card {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--wa-space-xs);
-        padding: var(--wa-space-xs);
-        margin-bottom: var(--wa-space-xs);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius);
-        background: var(--wa-color-surface-default);
-      }
-
-      .setting-status-icon {
-        flex-shrink: 0;
-        margin-top: 2px;
-        font-size: var(--font-size-lg);
-      }
-
-      .setting-status-icon.is-set {
-        color: var(--texra-testing-iconPassed, #73c991);
-      }
-
-      .setting-status-icon.not-set {
-        color: var(--texra-testing-iconFailed, #f48771);
-      }
+      /* .section-header chrome lives in commonViewStyles. */
 
       .setting-info {
         flex: 1;
@@ -401,7 +364,7 @@ export class LaTeXTab extends LitElement {
       .setting-name {
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-normal);
-        margin-bottom: 2px;
+        margin-bottom: var(--wa-space-3xs);
       }
 
       .setting-config-key {
@@ -659,34 +622,32 @@ export class LaTeXTab extends LitElement {
     pmName: string,
   ): TemplateResult {
     return html`
-      <div class="prerequisite-hint">
-        <wa-icon library="texra" name="info" class="hint-icon"></wa-icon>
-        <div class="hint-body">
-          <div class="hint-title">${title}</div>
-          <div class="hint-description">${description}</div>
-          <div class="hint-actions">
-            <code class="install-command-text">${installCommand}</code>
-            <button
-              class="tab-action-btn"
-              title="Copy ${pmName} install command"
-              @click=${(e: Event) => this.handleCopyCommand(e, installCommand)}
-            >
-              <wa-icon library="texra" name="copy"></wa-icon>
-              Copy
-            </button>
-            <button
-              class="tab-action-btn"
-              title=${this.desktopHost
-                ? `Run ${pmName} installer`
-                : `Run ${pmName} installer in VS Code terminal`}
-              @click=${() => this.handleRunInTerminal(installCommand)}
-            >
-              <wa-icon library="texra" name="terminal"></wa-icon>
-              Run in Terminal
-            </button>
-          </div>
+      <wa-callout class="prerequisite-hint" variant="brand">
+        <wa-icon library="texra" name="info" slot="icon"></wa-icon>
+        <div class="hint-title">${title}</div>
+        <div class="hint-description">${description}</div>
+        <div class="hint-actions">
+          <code class="install-command-text">${installCommand}</code>
+          <button
+            class="tab-action-btn"
+            title="Copy ${pmName} install command"
+            @click=${(e: Event) => this.handleCopyCommand(e, installCommand)}
+          >
+            <wa-icon library="texra" name="copy"></wa-icon>
+            Copy
+          </button>
+          <button
+            class="tab-action-btn"
+            title=${this.desktopHost
+              ? `Run ${pmName} installer`
+              : `Run ${pmName} installer in VS Code terminal`}
+            @click=${() => this.handleRunInTerminal(installCommand)}
+          >
+            <wa-icon library="texra" name="terminal"></wa-icon>
+            Run in Terminal
+          </button>
         </div>
-      </div>
+      </wa-callout>
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -174,7 +174,7 @@ export class ToolsTab extends LitElement {
       .tools-health-labels {
         display: flex;
         flex-direction: column;
-        gap: 1px;
+        gap: var(--wa-space-3xs);
       }
 
       .tools-summary-stat {
@@ -201,20 +201,7 @@ export class ToolsTab extends LitElement {
         margin-bottom: var(--wa-space-s);
       }
 
-      .category-header {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding-bottom: var(--wa-space-2xs);
-        margin-bottom: var(--wa-space-xs);
-        border-bottom: var(--border-thin) solid var(--color-border);
-        font-size: var(--font-size-sm);
-        font-weight: var(--font-weight-medium);
-        color: var(--color-text-secondary);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-      }
-
+      /* .category-header chrome lives in commonViewStyles. */
       .category-header wa-icon {
         font-size: var(--font-size);
       }
@@ -249,7 +236,7 @@ export class ToolsTab extends LitElement {
       }
 
       .desktop-settings-title {
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         margin: 0;
       }
 

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -440,6 +440,24 @@ export const commonViewStyles: CSSResult = css`
     line-height: var(--line-height-tight);
   }
 
+  /* Shared section header — uppercase divider used across settings tabs.
+     LaTeXTab uses .section-header; ToolsTab uses .category-header. Both
+     resolve to identical chrome here. */
+  .section-header,
+  .category-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    padding-bottom: var(--wa-space-2xs);
+    margin-bottom: var(--wa-space-xs);
+    border-bottom: var(--border-thin) solid var(--color-border);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
   /* Utility: single-line text truncation with ellipsis */
   .truncate {
     overflow: hidden;


### PR DESCRIPTION
## Summary

Continues the ad-hoc CSS audit (pass 1: #3711) by trimming hardcoded values and consolidating duplicated chrome across the settings + progress webviews. Net **-29 lines**.

- **WorkflowHintBanner** (progressView): custom div banner with hardcoded `8px`/`3px`/`0.9em`/`600` → `wa-callout` (variant=brand) with WA tokens.
- **LaTeXTab `prerequisite-hint`**: custom Homebrew/Scoop hint banner → `wa-callout`. Removed ~25 lines of bespoke icon/title/description chrome.
- **LaTeXTab cards**: deduplicated `.dependency-card` + `.setting-card` chrome (border + padding + radius + bg now defined once), merged `is-set`/`installed` and `not-set`/`missing` icon-color rules into shared selectors.
- **TerminalCommandStrip**: replaced `1px solid`, `3px`, `6px 10px`, `8px`, `12px`, `600` with `--border-thin`, `--border-radius-small`, `--wa-space-*`, `--font-weight-semibold`.
- **ProviderKeyModal**: collapsed duplicate `.provider-key-primary` / `.provider-key-secondary` button base into one rule; `32px`/`34px`/`600` → tokens. Tests left untouched (still query `input` + `.provider-key-secondary`).
- **profile/styles.ts**: deduped `.provider-setting-description` + `.provider-setting-warning`; `22px` → `--wa-space-l`; `2px` → `--wa-space-3xs`.
- **commonViewStyles**: promoted `.section-header` + `.category-header` chrome (used by LaTeXTab + ToolsTab) to a single shared rule. Removed both local copies.
- **ToolsTab / GitTab**: `1px`/`2px` → tokens; `font-weight: 600` → `--font-weight-semibold`.

## Test plan

- [x] `npm run typecheck` — same 8 baseline errors (pre-existing openrouter / electron module-resolution issues, unrelated)
- [x] `cd packages/desktop && npx vite build --mode development` — clean (`✓ built in 1.23s`)
- [x] `npx vitest run` — same baseline `2 failed | 60 passed` (`3 failed | 315 passed`); same desktop-shell tests as `origin/main`
- [ ] Visual sanity check: WorkflowHintBanner + LaTeX prerequisite hint render with wa-callout chrome instead of custom borders

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual refactor: mostly replaces hardcoded CSS values and banner markup with Web Awesome components/tokens and shared header styles; main risk is minor layout regressions in settings/progress webviews.
> 
> **Overview**
> Improves UI consistency across settings + progress webviews by replacing hardcoded spacing/borders/font weights with Web Awesome design tokens and consolidating repeated “section header” chrome into `commonViewStyles`.
> 
> Updates hint/banner surfaces to be WA-native: `WorkflowHintBanner` and LaTeX package-manager prerequisite hints now render as `wa-callout` (with icon slot) instead of custom div chrome, and LaTeX dependency/setting cards share a single card style. Minor style token tweaks are applied in `TerminalCommandStrip`, `ProviderKeyModal`, `profile/styles`, `GitTab`, and `ToolsTab` (with Tools/LaTeX headers now relying on the shared `.category-header`/`.section-header` rule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902a3f03c174e3e73f982685b47abc86c1120fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->