### PR TITLE
polish(wa): frontend-design round 2 — progress view + agent picker + outputs

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -151,6 +151,11 @@ wa-button.desktop-command-button {
   min-height: 34px;
   padding: 0 var(--wa-space-xs) 0 var(--wa-space-s);
   border-bottom: 1px solid var(--wa-color-surface-border);
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--wa-color-surface-default) 60%, transparent),
+    transparent
+  );
   box-sizing: border-box;
 }
 
@@ -162,6 +167,7 @@ wa-button.desktop-command-button {
   color: var(--wa-color-text-normal);
   font-size: 11px;
   font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
@@ -199,6 +205,12 @@ wa-tree.desktop-explorer-tree wa-tree-item::part(item) {
   min-height: 24px;
   padding-inline-end: var(--wa-space-xs);
   color: var(--wa-color-text-normal);
+  border-radius: var(--wa-border-radius-s, 3px);
+  margin-inline: var(--wa-space-3xs);
+  transition:
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    color 140ms ease;
 }
 
 wa-tree.desktop-explorer-tree wa-tree-item::part(label) {
@@ -212,6 +224,8 @@ wa-tree.desktop-explorer-tree wa-tree-item::part(label) {
 wa-tree.desktop-explorer-tree
   wa-tree-item:not([aria-disabled='true']):hover::part(item) {
   background: var(--wa-color-neutral-fill-quiet);
+  box-shadow: inset 1px 0 0
+    color-mix(in srgb, var(--wa-color-text-normal) 8%, transparent);
 }
 
 wa-tree.desktop-explorer-tree
@@ -219,6 +233,24 @@ wa-tree.desktop-explorer-tree
   background: var(--wa-color-brand-fill-quiet);
   color: var(--wa-color-brand-on-quiet);
   border-inline-start-color: var(--wa-color-brand-on-quiet);
+  box-shadow: inset 2px 0 0 var(--wa-color-brand-fill-loud);
+}
+
+wa-tree.desktop-explorer-tree wa-tree-item:focus-visible::part(item) {
+  outline: var(--wa-focus-ring, 2px solid var(--wa-color-focus));
+  outline-offset: -1px;
+}
+
+/*
+ * Folder icons render with brand tint, file icons with quiet tint, so the
+ * tree's hierarchical structure reads at a glance without adding new colour.
+ */
+wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-directory wa-icon {
+  color: color-mix(in srgb, var(--wa-color-brand-fill-loud) 70%, transparent);
+}
+
+wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
+  color: var(--wa-color-text-quiet);
 }
 
 .desktop-explorer-name {
@@ -241,6 +273,8 @@ wa-tree.desktop-explorer-tree
   height: 6px;
   border-radius: 50%;
   background: var(--wa-color-text-quiet);
+  box-shadow: 0 0 0 1px
+    color-mix(in srgb, var(--wa-color-surface-default) 70%, transparent);
 }
 
 .desktop-explorer-category-dot[data-category='input'] {
@@ -270,12 +304,19 @@ wa-tree.desktop-explorer-tree
 
 .desktop-explorer-selection {
   border-top: 1px solid var(--wa-color-surface-border);
+  background: color-mix(
+    in srgb,
+    var(--wa-color-surface-default) 50%,
+    transparent
+  );
 }
 
 .desktop-explorer-selected-path {
   min-width: 0;
   overflow: hidden;
   color: var(--wa-color-text-normal);
+  font-family: var(--wa-font-family-code, monospace), monospace;
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -65,25 +65,39 @@ export class PlanView extends LitElement {
 
       .plan-summary {
         font-size: var(--font-size);
-        line-height: var(--line-height-normal);
+        line-height: var(--line-height-relaxed);
         color: var(--color-text-secondary);
-        margin-bottom: var(--wa-space-2xs);
-        padding: var(--wa-space-3xs) 0;
+        margin-bottom: var(--wa-space-xs);
+        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs);
+        border-bottom: var(--border-thin) dashed
+          color-mix(in srgb, var(--color-border) 60%, transparent);
       }
 
       .plan-steps {
         display: flex;
         flex-direction: column;
-        gap: var(--wa-space-3xs);
+        gap: 0;
       }
 
       .plan-step {
         display: flex;
         align-items: flex-start;
         gap: var(--wa-space-2xs);
-        padding: var(--wa-space-3xs) 0;
+        padding: var(--wa-space-2xs) var(--wa-space-2xs) var(--wa-space-2xs)
+          var(--wa-space-3xs);
+        margin-inline: calc(-1 * var(--wa-space-3xs));
+        border-radius: var(--border-radius-small);
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
+        transition: background-color 140ms ease;
+      }
+
+      .plan-step:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-neutral-fill-quiet) 50%,
+          transparent
+        );
       }
 
       .plan-step__number {
@@ -143,6 +157,20 @@ export class PlanView extends LitElement {
 
       .plan-step--pending .plan-step__icon {
         color: var(--color-text-secondary);
+      }
+
+      .plan-step--in-progress {
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-quiet) 65%,
+          transparent
+        );
+        box-shadow: inset 2px 0 0
+          color-mix(in srgb, var(--wa-color-brand-fill-loud) 50%, transparent);
+      }
+
+      .plan-step--in-progress:hover {
+        background-color: var(--wa-color-brand-fill-quiet);
       }
 
       .plan-step--in-progress .plan-step__icon {

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -40,13 +40,30 @@ export class StatisticsPanel extends LitElement {
       .statistics-content {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--wa-space-s);
+        gap: var(--wa-space-2xs) var(--wa-space-s);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        margin-top: var(--wa-space-2xs);
+        background: color-mix(
+          in srgb,
+          var(--wa-color-neutral-fill-quiet) 50%,
+          transparent
+        );
+        border-radius: var(--border-radius-small);
+        border: var(--border-thin) solid
+          color-mix(in srgb, var(--color-border) 70%, transparent);
       }
 
       .stat-item {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         gap: var(--wa-space-2xs);
+        font-variant-numeric: tabular-nums;
+        color: var(--wa-color-text-normal);
+      }
+
+      .stat-item wa-icon {
+        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-sm);
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -134,13 +134,18 @@ export class StreamHeader extends LitElement {
       }
 
       .log-header {
-        padding: var(--wa-space-3xs) var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         font-size: var(--font-size-sm);
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-2xs);
         color: var(--color-text-secondary);
         border-bottom: var(--border-thin) solid var(--color-border);
+        background: linear-gradient(
+          to bottom,
+          color-mix(in srgb, var(--wa-color-surface-default) 80%, transparent),
+          transparent
+        );
       }
 
       .log-header__primary {
@@ -170,6 +175,9 @@ export class StreamHeader extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: var(--wa-color-text-normal);
+        font-weight: var(--font-weight-medium);
+        letter-spacing: -0.005em;
       }
 
       .header-actions {
@@ -293,17 +301,23 @@ export class StreamHeader extends LitElement {
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-3xs);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         cursor: pointer;
         white-space: nowrap;
         opacity: var(--opacity-subtle);
-        transition: opacity var(--transition-fast);
+        border-radius: var(--border-radius-small);
+        transition:
+          opacity 140ms ease,
+          background-color 140ms ease,
+          color 140ms ease;
       }
 
       .parent-link:hover {
         opacity: var(--opacity-full);
         color: var(--color-text-link);
+        background-color: var(--wa-color-neutral-fill-quiet);
       }
 
       .parent-link:focus-visible {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -15,17 +15,34 @@ export const groupStyles = css`
     background-color: transparent;
     border-left: var(--border-medium) solid var(--color-border);
     transition:
-      border-left-color var(--transition-normal),
-      background-color var(--transition-fast);
+      border-left-color 180ms ease,
+      background-color 140ms ease,
+      box-shadow 140ms ease;
   }
 
+  /*
+   * Subtle inset highlight on hover gives each group row a tactile "lift"
+   * without pulling focus from running-state colour cues.
+   */
   .log-group-header:hover {
-    background-color: var(--wa-color-neutral-fill-quiet);
+    background-color: color-mix(
+      in srgb,
+      var(--wa-color-neutral-fill-quiet) 70%,
+      transparent
+    );
+    box-shadow: inset 1px 0 0
+      color-mix(in srgb, var(--wa-color-text-normal) 8%, transparent);
   }
 
   .log-group-header {
     &.is-running {
       border-left-color: var(--texra-statusBarItem-warningBackground);
+      box-shadow: inset 2px 0 0
+        color-mix(
+          in srgb,
+          var(--texra-statusBarItem-warningBackground) 35%,
+          transparent
+        );
     }
 
     &.is-error {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -67,6 +67,7 @@ export class AgentSelectionPanel extends LitElement {
         min-height: 300px;
         max-height: 500px;
         overflow: hidden;
+        background: var(--wa-color-surface-default);
       }
 
       /* --- Left: Agent list --- */
@@ -89,8 +90,12 @@ export class AgentSelectionPanel extends LitElement {
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
         text-transform: uppercase;
-        letter-spacing: 0.05em;
-        background: var(--wa-color-surface-default);
+        letter-spacing: 0.06em;
+        background: color-mix(
+          in srgb,
+          var(--wa-color-surface-default) 92%,
+          var(--wa-color-text-normal) 4%
+        );
         border-bottom: var(--border-thin) solid var(--color-border);
         position: sticky;
         top: 0;
@@ -114,8 +119,27 @@ export class AgentSelectionPanel extends LitElement {
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);
         border-left: var(--border-medium) solid transparent;
-        transition: background var(--transition-fast);
+        transition:
+          background-color 140ms ease,
+          border-left-color 140ms ease,
+          box-shadow 140ms ease;
         outline: none;
+      }
+
+      /*
+       * Source-tinted left rail — uses existing WA semantic colours so each
+       * group gets a quiet identity cue without introducing a new palette.
+       * Built-in = brand, custom = success, remote = neutral. The hairline
+       * shows on hover/selected so the resting state stays calm.
+       */
+      .agent-list-item[data-source='custom']:hover,
+      .agent-list-item[data-source='custom'].selected {
+        border-left-color: var(--wa-color-success-fill-loud);
+      }
+
+      .agent-list-item[data-source='remote']:hover,
+      .agent-list-item[data-source='remote'].selected {
+        border-left-color: var(--wa-color-text-quiet);
       }
 
       .agent-list-item:hover {
@@ -133,7 +157,9 @@ export class AgentSelectionPanel extends LitElement {
           --texra-list-activeSelectionForeground,
           var(--wa-color-text-normal)
         );
-        border-left-color: var(--wa-color-focus);
+        border-left-color: var(--wa-color-brand-fill-loud);
+        box-shadow: inset 0 0 0 1px
+          color-mix(in srgb, var(--wa-color-brand-fill-loud) 12%, transparent);
       }
 
       .agent-list-item.selected .agent-list-item-name,
@@ -501,9 +527,18 @@ export class AgentSelectionPanel extends LitElement {
     const key = agentKey(agent);
     const isSelected = this.selectedKey === key;
 
+    const sourceTone = isBuiltIn(agent.source)
+      ? 'builtin'
+      : agent.source === AGENT_SOURCE.CUSTOM
+        ? 'custom'
+        : agent.source === AGENT_SOURCE.REMOTE
+          ? 'remote'
+          : 'builtin';
+
     return html`
       <div
         class="agent-list-item ${isSelected ? 'selected' : ''}"
+        data-source=${sourceTone}
         role="option"
         aria-selected=${isSelected}
         tabindex=${isSelected ? '0' : '-1'}

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -40,6 +40,60 @@ export class OutputFilesSection extends LitElement {
       :host {
         display: block;
       }
+
+      /*
+       * OutputFilesSection feed treatment — tighter row chrome, soft inset
+       * highlight on hover, brand-tinted remove affordance. Sits on top of
+       * the shared multiFilesStyles so other consumers (latexdiffs) keep
+       * their leaner row chrome.
+       */
+      .multiple-files-list {
+        background: color-mix(
+          in srgb,
+          var(--wa-color-neutral-fill-quiet) 25%,
+          transparent
+        );
+        padding: var(--wa-space-3xs);
+      }
+
+      .file-item {
+        padding: 5px var(--wa-space-2xs);
+        border-radius: var(--border-radius-small);
+        transition:
+          background-color 140ms ease,
+          box-shadow 140ms ease;
+      }
+
+      .file-item:hover {
+        background-color: var(--wa-color-neutral-fill-quiet);
+        box-shadow: inset 1px 0 0
+          color-mix(in srgb, var(--wa-color-brand-fill-loud) 40%, transparent);
+      }
+
+      .file-item .file-name {
+        font-size: var(--font-size-sm);
+        color: var(--wa-color-text-normal);
+      }
+
+      .file-item .remove-button {
+        opacity: 0;
+        transition: opacity 140ms ease;
+      }
+
+      .file-item:hover .remove-button,
+      .file-item:focus-within .remove-button {
+        opacity: 1;
+      }
+
+      .file-item .remove-button:hover::part(base) {
+        color: var(--wa-color-danger-fill-loud);
+      }
+
+      .file-list-placeholder {
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-relaxed);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+      }
     `,
   ];
 


### PR DESCRIPTION
## Summary

Round 2 of WA polish, extending the rhythm established in round 1 (#3714) to the secondary surfaces where users spend most of their active runtime.

- **Progress board chrome** — group rows gain inset hover highlight, running groups get a brand-tinted left-rail glow, plan steps get hairline hover and an in-progress card treatment.
- **Statistics row** — metrics now sit in a soft surface tile with tabular-nums for stable alignment.
- **Stream header** — top-edge gradient, medium-weight stream name with tighter tracking, padded parent-link hover.
- **Output files feed** — quiet tray background, per-row brand inset on hover, remove icon hidden until row is hovered/focused (danger tint).
- **Agent picker** — source-tinted left rail (built-in=brand, custom=success, remote=neutral), brand-fill ring on selected row, slightly warmed sticky group headers.
- **Desktop workspace explorer** — refined wa-tree rows (rounded inset margin, brand-fill rail on selection, focus ring), folder icons brand-tinted vs file icons quiet, monospace selection path.

All polish via WA tokens and `::part()` — no new tokens, no palette changes, no replaced WA components.

## Test plan
- [ ] `npm run typecheck` shows the same 8 pre-existing baseline errors (unchanged)
- [ ] `cd packages/desktop && npx vite build --mode development` builds clean
- [ ] Visual check in light + dark theme: progress view group rows, plan steps, output files list, agent selection panel, desktop workspace explorer
- [ ] Keyboard navigation in agent picker (Arrow/Home/End) still focuses + scrolls correctly
- [ ] Reduced-motion preference: animations remain subtle (140-180ms eases only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are almost entirely CSS/styling tweaks; only minor runtime change is adding a `data-source` attribute for agent list items to drive new visuals.
> 
> **Overview**
> Applies a second round of UI polish across the extension’s progress view and settings, plus the desktop explorer and output files list, using WA tokens and subtle transitions/gradients.
> 
> Progress view gets refreshed chrome (header gradient/typography, hover/active treatments for group rows and plan steps, and a tiled statistics panel with tabular numerics). The agent picker adds source-aware left-rail styling via a new `data-source` attribute and updates selected/hover states. Output files list rows gain a tray background, hover inset highlight, and a remove button that only appears on hover/focus; desktop workspace explorer tree rows get rounded/indented hover/selected/focus styling, icon tinting for folders vs files, and a monospace selected path display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85655e72b0acd9d842e21a3cbb0742b6bf420bc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->