### PR TITLE
chore: code-simplifier sweep on recent WA migration work

### DIFF
--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -12,7 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { AgentConfigBannerState } from '@shared/schemas';
-import { bannerStyles } from '../styles/bannerStyles';
+import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('agent-config-banner')
@@ -25,9 +25,7 @@ export class AgentConfigBanner extends LitElement {
 
   override updated(changed: PropertyValues<this>): void {
     if (changed.has('state')) {
-      const visible = this.state.visible === true;
-      this.dataset.visible = visible ? 'true' : 'false';
-      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      applyBannerVisibility(this, this.state.visible === true);
     }
   }
 

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -13,7 +13,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { ApiKeyBannerState } from '@shared/schemas';
 import { capitalize } from '@shared/utils/string';
-import { bannerStyles } from '../styles/bannerStyles';
+import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('api-key-banner')
@@ -26,9 +26,7 @@ export class ApiKeyBanner extends LitElement {
 
   override updated(changed: PropertyValues<this>): void {
     if (changed.has('state')) {
-      const visible = this.state.visible === true;
-      this.dataset.visible = visible ? 'true' : 'false';
-      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      applyBannerVisibility(this, this.state.visible === true);
     }
   }
 

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -15,7 +15,7 @@ import { when } from 'lit/directives/when.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { DependencyBannerState } from '@shared/schemas';
-import { bannerStyles } from '../styles/bannerStyles';
+import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('dependency-banner')
@@ -46,9 +46,7 @@ export class DependencyBanner extends LitElement {
 
   override updated(changed: PropertyValues<this>): void {
     if (changed.has('state')) {
-      const visible = this.state.visible === true;
-      this.dataset.visible = visible ? 'true' : 'false';
-      this.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      applyBannerVisibility(this, this.state.visible === true);
     }
   }
 

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -14,7 +14,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { COMMAND_LINKS } from '@shared/utils/uiConstants';
 
-import { bannerStyles } from '../styles/bannerStyles';
+import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('getting-started-banner')
@@ -69,8 +69,7 @@ export class GettingStartedBanner extends LitElement {
 
   override updated(changed: PropertyValues<this>): void {
     if (changed.has('visible')) {
-      this.dataset.visible = this.visible ? 'true' : 'false';
-      this.setAttribute('aria-hidden', this.visible ? 'false' : 'true');
+      applyBannerVisibility(this, this.visible);
     }
   }
 

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -14,7 +14,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { PROMO_NOTICE_SHORT } from '@shared/copy/promoNotice';
 
-import { bannerStyles } from '../styles/bannerStyles';
+import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('login-banner')
@@ -87,8 +87,7 @@ export class LoginBanner extends LitElement {
 
   override updated(changed: PropertyValues<this>): void {
     if (changed.has('visible')) {
-      this.dataset.visible = this.visible ? 'true' : 'false';
-      this.setAttribute('aria-hidden', this.visible ? 'false' : 'true');
+      applyBannerVisibility(this, this.visible);
     }
   }
 

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -11,6 +11,19 @@
 
 import { css, type CSSResult } from 'lit';
 
+/**
+ * Drive the CSS-only fade + height-collapse transition on a banner host.
+ *
+ * The shared `bannerStyles` selectors key off `[data-visible='true']` and the
+ * accompanying `aria-hidden` attribute provides the matching a11y signal.
+ * Centralising the writes keeps the five banner components from each carrying
+ * their own copy of the visibility-derivation logic.
+ */
+export function applyBannerVisibility(host: HTMLElement, visible: boolean): void {
+  host.dataset.visible = visible ? 'true' : 'false';
+  host.setAttribute('aria-hidden', visible ? 'false' : 'true');
+}
+
 export const bannerStyles: CSSResult = css`
   :host {
     /*

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -10,96 +10,19 @@
  */
 
 import { css } from 'lit';
+import {
+  compactFormControlStyles,
+  compactIconActionButtonStyles,
+} from '@shared/styles';
 
-/** Compact wa-input / wa-select sizing — stricter IDE-density form controls.
- * WA defaults to ~38px tall; reduce to ~22px to match minimal VS Code chrome.
- * Keep selectors in sync with the canonical rules in
- * `src/shared/styles/selectStyles.ts`. */
-export const compactFormControlStyles = css`
-  wa-select {
-    font-size: var(--font-size-sm);
-  }
-
-  wa-select::part(combobox) {
-    min-height: 22px;
-    min-width: 0;
-    padding-block: 0;
-    padding-inline: 6px;
-    border: var(--border-thin) solid
-      var(--wa-color-surface-border, var(--color-border));
-  }
-
-  wa-select::part(display-input) {
-    padding-block: 1px;
-    padding-inline: 6px;
-    font-size: var(--font-size-sm);
-  }
-
-  wa-select::part(expand-icon) {
-    margin-inline-start: var(--wa-space-3xs);
-  }
-
-  wa-input {
-    font-size: var(--font-size-sm);
-  }
-
-  wa-input::part(base) {
-    min-height: 22px;
-    padding-block: 0;
-    border: var(--border-thin) solid
-      var(--wa-color-surface-border, var(--color-border));
-  }
-
-  wa-input::part(input) {
-    padding-block: 1px;
-    padding-inline: 6px;
-    font-size: var(--font-size-sm);
-  }
-`;
-
-/** Compact icon action button styles — duplicated from commonViewStyles
- * so file-select components don't need to import the full common view sheet
- * just to size their toolbar icons. Keep selectors in sync with the canonical
- * rules in `src/shared/styles/commonViewStyles.ts`.
- *
- * Stricter minimalism: 20×20, opacity-driven hover (no fill swap). */
-export const compactActionButtonStyles = css`
-  .action-icon-button::part(base) {
-    width: 20px;
-    min-width: 0;
-    height: 20px;
-    min-height: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(
-      --wa-color-text-quiet,
-      var(--texra-icon-foreground, var(--wa-color-text-normal))
-    );
-    opacity: var(--opacity-subtle);
-    transition: opacity 120ms ease;
-  }
-
-  .action-icon-button::part(base):hover {
-    opacity: var(--opacity-full);
-    background: transparent;
-  }
-
-  .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid
-      var(--wa-color-focus, var(--wa-color-focus));
-    outline-offset: 1px;
-  }
-
-  .action-icon-button[disabled]::part(base) {
-    opacity: 0.35;
-    background: transparent;
-  }
-
-  .action-icon-button wa-icon {
-    font-size: 13px;
-  }
-`;
+/**
+ * Re-exported under the legacy names so existing imports keep working. The
+ * canonical definitions live in `@shared/styles/selectStyles` and
+ * `@shared/styles/commonViewStyles`; importing from here keeps file-select
+ * components from having to pull the full common view / select sheets.
+ */
+export const compactActionButtonStyles = compactIconActionButtonStyles;
+export { compactFormControlStyles };
 
 /** Core file-select layout styles. */
 export const fileSelectLayoutStyles = css`

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -1,5 +1,55 @@
 import { css, type CSSResult } from 'lit';
 
+/**
+ * Compact icon-only action button — stricter minimalism.
+ * 20×20, no hover fill, opacity-driven hover/disabled.
+ *
+ * Exported as a focused subset so file-select/main-view components can pull
+ * just the icon-button rules without inheriting the full common view sheet.
+ * `commonViewStyles` below interpolates this block to keep a single source
+ * of truth for the selectors.
+ */
+export const compactIconActionButtonStyles: CSSResult = css`
+  .action-icon-button {
+    flex-shrink: 0;
+  }
+
+  .action-icon-button::part(base) {
+    width: 20px;
+    min-width: 0;
+    height: 20px;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(
+      --wa-color-text-quiet,
+      var(--texra-icon-foreground, var(--wa-color-text-normal))
+    );
+    opacity: var(--opacity-subtle);
+    transition: opacity 120ms ease;
+  }
+
+  .action-icon-button::part(base):hover {
+    opacity: var(--opacity-full);
+    background: transparent;
+  }
+
+  .action-icon-button:focus-visible::part(base) {
+    outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: 1px;
+  }
+
+  .action-icon-button[disabled]::part(base) {
+    opacity: 0.35;
+    background: transparent;
+  }
+
+  .action-icon-button wa-icon {
+    font-size: 13px;
+  }
+`;
+
 export const commonViewStyles: CSSResult = css`
   .view-header {
     display: flex;
@@ -131,10 +181,6 @@ export const commonViewStyles: CSSResult = css`
     flex-wrap: nowrap;
   }
 
-  .action-icon-button {
-    flex-shrink: 0;
-  }
-
   /* Compact action button (with text) — stricter IDE-density chrome.
    * Borderless default; hover adds a subtle border (no fill swap). */
   .action-button::part(base) {
@@ -155,42 +201,7 @@ export const commonViewStyles: CSSResult = css`
     font-size: var(--font-size-sm);
   }
 
-  /* Compact icon-only action button — stricter minimalism.
-   * 20×20, no hover fill, opacity-driven hover/disabled. */
-  .action-icon-button::part(base) {
-    width: 20px;
-    min-width: 0;
-    height: 20px;
-    min-height: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(
-      --wa-color-text-quiet,
-      var(--texra-icon-foreground, var(--wa-color-text-normal))
-    );
-    opacity: var(--opacity-subtle);
-    transition: opacity 120ms ease;
-  }
-
-  .action-icon-button::part(base):hover {
-    opacity: var(--opacity-full);
-    background: transparent;
-  }
-
-  .action-icon-button:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: 1px;
-  }
-
-  .action-icon-button[disabled]::part(base) {
-    opacity: 0.35;
-    background: transparent;
-  }
-
-  .action-icon-button wa-icon {
-    font-size: 13px;
-  }
+  ${compactIconActionButtonStyles}
 
   /* Stricter compactness for wa-checkbox / wa-radio — smaller label,
    * tighter gap between control and label. */

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -1,13 +1,14 @@
 // Core styles
 export {
   commonViewStyles,
+  compactIconActionButtonStyles,
   filledButtonStyles,
   focusRingStyles,
 } from './commonViewStyles';
 export { designTokens, animationStyles } from './litStyles';
 
 // Component styles
-export { selectStyles } from './selectStyles';
+export { selectStyles, compactFormControlStyles } from './selectStyles';
 export { statusIndicatorStyles } from './statusIndicatorStyles';
 export { permissionCardStyles } from './permissionCardStyles';
 export { requestPanelStyles } from './requestPanelStyles';

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -1,5 +1,56 @@
 import { css, type CSSResult } from 'lit';
 
+/**
+ * Compact wa-input / wa-select sizing — stricter IDE-density form controls.
+ * WA defaults to ~38px tall; reduce to ~22px to match minimal VS Code chrome.
+ *
+ * Exported as a focused subset so file-select / main-view components can pull
+ * just the form-control rules without inheriting the full select sheet.
+ * `selectStyles` below interpolates this block to keep a single source of
+ * truth for the selectors.
+ */
+export const compactFormControlStyles: CSSResult = css`
+  wa-select {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(combobox) {
+    min-height: 22px;
+    min-width: 0;
+    padding-block: 0;
+    padding-inline: 6px;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
+  }
+
+  wa-select::part(display-input) {
+    padding-block: 1px;
+    padding-inline: 6px;
+    font-size: var(--font-size-sm);
+  }
+
+  wa-select::part(expand-icon) {
+    margin-inline-start: var(--wa-space-3xs);
+  }
+
+  wa-input {
+    font-size: var(--font-size-sm);
+  }
+
+  wa-input::part(base) {
+    min-height: 22px;
+    padding-block: 0;
+    border: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
+  }
+
+  wa-input::part(input) {
+    padding-block: 1px;
+    padding-inline: 6px;
+    font-size: var(--font-size-sm);
+  }
+`;
+
 export const selectStyles: CSSResult = css`
   .select-group {
     display: flex;
@@ -71,47 +122,8 @@ export const selectStyles: CSSResult = css`
   }
 
   /* Compact form controls — stricter IDE-density inputs/selects.
-   * WA defaults to ~38px tall; reduce to ~22px for minimal VS Code chrome.
    * Border uses subtle surface-border, not heavier panel border. */
-  wa-select {
-    font-size: var(--font-size-sm);
-  }
-
-  wa-select::part(combobox) {
-    min-height: 22px;
-    min-width: 0;
-    padding-block: 0;
-    padding-inline: 6px;
-    border: var(--border-thin) solid
-      var(--wa-color-surface-border, var(--color-border));
-  }
-
-  wa-select::part(display-input) {
-    padding-block: 1px;
-    padding-inline: 6px;
-    font-size: var(--font-size-sm);
-  }
-
-  wa-select::part(expand-icon) {
-    margin-inline-start: var(--wa-space-3xs);
-  }
-
-  wa-input {
-    font-size: var(--font-size-sm);
-  }
-
-  wa-input::part(base) {
-    min-height: 22px;
-    padding-block: 0;
-    border: var(--border-thin) solid
-      var(--wa-color-surface-border, var(--color-border));
-  }
-
-  wa-input::part(input) {
-    padding-block: 1px;
-    padding-inline: 6px;
-    font-size: var(--font-size-sm);
-  }
+  ${compactFormControlStyles}
 
   .api-key-missing {
     color: var(--wa-color-danger-on-quiet);


### PR DESCRIPTION
## Summary

Simplification pass over the WA-native + token-migration files merged in the last ~12 PRs. Behaviour-preserving — same selectors, same property values, same hosts.

- Extract `compactIconActionButtonStyles` from `commonViewStyles` and `compactFormControlStyles` from `selectStyles` as named exports, then have the parent sheets interpolate them. Collapses the two explicitly-duplicated CSSResult blocks in `fileSelectStyles.ts` (each carrying a "keep selectors in sync" warning) into thin re-exports of the canonical shared blocks.
- Drop a stray `var(--wa-color-focus, var(--wa-color-focus))` self-fallback that fell out of the duplication.
- Add `applyBannerVisibility(host, visible)` helper in `bannerStyles` and use it from all five inline banners (`ApiKey`, `AgentConfig`, `Dependency`, `GettingStarted`, `Login`) so the `data-visible` / `aria-hidden` writes live in one place.
- Net `-48` lines across 10 files.

## Test plan

- [x] `npm run typecheck` — same 8 baseline errors before/after (all pre-existing electron / @openrouter/sdk module-resolution issues).
- [x] `cd packages/desktop && npx vite build --mode development` — clean (`built in 1.38s`).
- [x] `npx vitest run` — 4 failures matching baseline (3 file failures, 314 passing); no new regressions.
- [ ] Smoke-check that `OutputFilesSection`, `LatexDiffsSection`, `FileSelectGroup` still render compact icons + form controls identically.
- [ ] Smoke-check banner enter/exit transitions still fade + collapse height (`data-visible` toggle).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes a few repeated DOM attribute writes and CSS blocks; main risk is minor UI/UX regressions if a selector/export is missed or changes subtly affect styling.
> 
> **Overview**
> Simplifies recent WebAwesome migration code by **deduplicating banner visibility logic and compact style snippets**.
> 
> All five inline banner components now call a shared `applyBannerVisibility()` helper (in `bannerStyles.ts`) to set `data-visible` and `aria-hidden`, instead of each duplicating those attribute writes.
> 
> Shared compact CSS blocks for icon-only action buttons and compact inputs/selects are extracted as named exports (`compactIconActionButtonStyles`, `compactFormControlStyles`), re-used via interpolation in `commonViewStyles`/`selectStyles`, and `fileSelectStyles.ts` is reduced to thin re-exports of those canonical rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0951fdf13a11f3f6530a6a9b5c802c8123b1b888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->