### PR TITLE
refactor(wa): ad-hoc CSS pass 3 — webview/progressView WA-native cleanup

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -254,25 +254,17 @@ export class AgentSelectionPanel extends LitElement {
         background: var(--wa-color-surface-default);
       }
 
-      .agent-count-link {
+      wa-button.agent-count-link::part(base) {
         font-size: var(--font-size-xs);
-        font-family: inherit;
         color: var(--wa-color-text-link);
-        background: none;
-        border: none;
-        cursor: pointer;
+        min-height: 0;
         padding: 0;
-        text-decoration: none;
+        border: none;
+        background: transparent;
       }
 
-      .agent-count-link:hover {
+      wa-button.agent-count-link::part(base):hover {
         text-decoration: underline;
-      }
-
-      .agent-count-link:focus-visible {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: 1px;
-        border-radius: var(--border-radius-small);
       }
 
       .agent-empty-message {
@@ -562,24 +554,28 @@ export class AgentSelectionPanel extends LitElement {
               <span>${SOURCE_DISPLAY_NAMES[source] ?? source}</span>
               <span class="agent-list-section-actions">
                 ${enabledInGroup < agents.length
-                  ? html`<button
+                  ? html`<wa-button
                       class="agent-count-link"
+                      appearance="plain"
+                      size="small"
                       @click=${() => this.handleSetAllEnabled(source, true)}
                       title="Show all ${SOURCE_DISPLAY_NAMES[source] ??
                       source} agents"
                     >
                       All
-                    </button>`
+                    </wa-button>`
                   : nothing}
                 ${enabledInGroup > 0
-                  ? html`<button
+                  ? html`<wa-button
                       class="agent-count-link"
+                      appearance="plain"
+                      size="small"
                       @click=${() => this.handleSetAllEnabled(source, false)}
                       title="Hide all ${SOURCE_DISPLAY_NAMES[source] ??
                       source} agents"
                     >
                       None
-                    </button>`
+                    </wa-button>`
                   : nothing}
               </span>
             </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -350,12 +350,14 @@ export class ModelSelectionList extends LitElement {
     const chevron = isOpen ? '\u25BE' : '\u25B8';
 
     return html`
-      <button
+      <wa-button
         class="deprecated-toggle"
+        appearance="plain"
+        size="small"
         @click=${() => this.toggleDeprecated(group.provider)}
       >
         ${chevron} ${group.deprecated.length} deprecated
-      </button>
+      </wa-button>
       ${isOpen
         ? html`<div class="deprecated-models">
             ${group.deprecated.map((m) => this.renderModelRow(m))}

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -155,15 +155,17 @@ export class ProviderKeyList extends LitElement {
   private renderVscodeSetting(setting: ProviderVscodeSetting): TemplateResult {
     const warningLink =
       setting.warningUrl && setting.warningUrlLabel
-        ? html` <button
+        ? html` <wa-button
             class="provider-setting-link"
+            appearance="plain"
+            size="small"
             @click=${() =>
               this.dispatchEvent(
                 ProviderKeyEvents.openUrl({ url: setting.warningUrl! }),
               )}
           >
             ${setting.warningUrlLabel}
-          </button>`
+          </wa-button>`
         : nothing;
 
     const warning = setting.warning
@@ -203,13 +205,15 @@ export class ProviderKeyList extends LitElement {
       <tr>
         <td>
           <div class="provider-name-cell">
-            <button
+            <wa-button
               class="provider-expand-btn ${isExpanded ? 'expanded' : ''}"
+              appearance="plain"
+              size="small"
               title="${isExpanded ? 'Collapse settings' : 'Expand settings'}"
               @click=${() => this.toggleExpanded(entry.provider)}
             >
               <wa-icon library="texra" name="chevron-right"></wa-icon>
-            </button>
+            </wa-button>
             <span class="provider-name">${entry.displayName}</span>
           </div>
         </td>

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -270,32 +270,13 @@ export const profileViewStyles: CSSResult = css`
     font-size: var(--font-size-sm);
   }
 
-  /* Provider row expand/collapse */
-  .provider-expand-btn {
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    background: none;
-    border: none;
+  /* Provider row expand/collapse — wa-button rotates its chevron when expanded */
+  wa-button.provider-expand-btn::part(base) {
     color: var(--color-text-secondary);
-    padding: 0;
     transition: transform var(--transition-fast);
   }
 
-  .provider-expand-btn:hover {
-    color: var(--wa-color-text-normal);
-  }
-
-  .provider-expand-btn:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: 1px;
-    border-radius: var(--border-radius-small);
-  }
-
-  .provider-expand-btn.expanded {
+  wa-button.provider-expand-btn.expanded::part(base) {
     transform: rotate(90deg);
   }
 
@@ -361,19 +342,20 @@ export const profileViewStyles: CSSResult = css`
     );
   }
 
-  .provider-setting-link {
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-link);
-    cursor: pointer;
-    text-decoration: none;
+  wa-button.provider-setting-link {
     margin-left: var(--wa-space-2xs);
   }
 
-  .provider-setting-link:hover {
+  wa-button.provider-setting-link::part(base) {
+    font-size: var(--font-size-sm);
+    color: var(--wa-color-text-link);
+    min-height: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+  }
+
+  wa-button.provider-setting-link::part(base):hover {
     text-decoration: underline;
   }
 
@@ -565,30 +547,21 @@ export const profileViewStyles: CSSResult = css`
     font-size: var(--font-size-xs);
   }
 
-  .deprecated-toggle {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-    padding: var(--wa-space-2xs) var(--wa-space-xs);
-    background: none;
-    border: none;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    font-family: inherit;
+  wa-button.deprecated-toggle {
     width: 100%;
-    text-align: left;
   }
 
-  .deprecated-toggle:hover {
+  wa-button.deprecated-toggle::part(base) {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    justify-content: flex-start;
+    border: none;
+    background: transparent;
+  }
+
+  wa-button.deprecated-toggle::part(base):hover {
     color: var(--wa-color-text-normal);
     background: var(--wa-color-neutral-fill-quiet);
-  }
-
-  .deprecated-toggle:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: 1px;
-    border-radius: var(--border-radius-small);
   }
 
   .deprecated-models {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -354,7 +354,7 @@ export class InstructionPanel extends LitElement {
       }
 
       wa-button.execute-button wa-icon {
-        font-size: 13px;
+        font-size: var(--font-size-sm);
       }
 
       .execute-button__label {
@@ -371,18 +371,18 @@ export class InstructionPanel extends LitElement {
       .execute-button__kbd {
         display: inline-flex;
         align-items: center;
-        height: 16px;
-        padding: 0 5px;
+        height: 1em;
+        padding: 0 var(--wa-space-3xs);
         margin-left: var(--wa-space-2xs);
-        border-radius: 3px;
+        border-radius: var(--border-radius-small);
         background: transparent;
         color: inherit;
         font-family: var(--wa-font-family-mono, ui-monospace, monospace);
-        font-size: 10px;
+        font-size: var(--font-size-xs);
         font-weight: 500;
         letter-spacing: 0.04em;
         opacity: 0.75;
-        box-shadow: inset 0 0 0 1px rgb(255 255 255 / 28%);
+        box-shadow: inset 0 0 0 var(--border-thin) rgb(255 255 255 / 28%);
         position: relative;
       }
 
@@ -392,7 +392,7 @@ export class InstructionPanel extends LitElement {
         left: calc(-1 * var(--wa-space-2xs));
         top: 18%;
         bottom: 18%;
-        width: 1px;
+        width: var(--border-thin);
         background: rgb(255 255 255 / 22%);
       }
 
@@ -492,14 +492,14 @@ export class InstructionPanel extends LitElement {
       /*
        * Reserve a fixed slot for the polish spinner so the toolbar layout
        * doesn't jump when isPolishing toggles. Width matches the wa-spinner
-       * font-size (16px) used inside the slot.
+       * font-size used inside the slot.
        */
       .polish-spinner-slot {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 16px;
-        height: 16px;
+        width: var(--font-size-icon, 1em);
+        height: var(--font-size-icon, 1em);
         opacity: 0;
         transition: opacity 150ms ease;
       }
@@ -762,9 +762,7 @@ export class InstructionPanel extends LitElement {
                 ? html`
                     <wa-spinner
                       id="polishProgressContainer"
-                      style=${styleMap({
-                        fontSize: '16px',
-                      })}
+                      style="font-size: var(--font-size-icon, 1em)"
                     ></wa-spinner>
                   `
                 : nothing}

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -97,7 +97,7 @@ export const tintedBadgeStyles: CSSResult = css`
     display: inline-flex;
     align-items: center;
     gap: var(--wa-space-3xs);
-    padding: 1px var(--wa-space-2xs);
+    padding: var(--border-thin) var(--wa-space-2xs);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
     color: var(--_tint, var(--color-text-secondary));


### PR DESCRIPTION
## Summary

Pass 3 of the ad-hoc CSS audit. Net **-27 lines** of bespoke CSS by swapping four hand-rolled `<button>` elements with `wa-button appearance="plain"` and tokenizing the remaining hardcoded pixel values that survived passes 1 & 2.

- **AgentSelectionPanel** — `agent-count-link` ("All" / "None" toggles per source group) is now a `wa-button`, dropping ~20 lines of link-as-button CSS (custom focus ring, hover underline, etc.).
- **ProviderKeyList** — `provider-expand-btn` (chevron toggle) and `provider-setting-link` (warning URL) are now `wa-button`s; their CSS in `profile/styles.ts` collapses to a few `::part(base)` tweaks for color and rotation.
- **ModelSelectionList** — `deprecated-toggle` follows the same pattern.
- **InstructionPanel** — execute-button kbd separator and `polish-spinner-slot` now use `--font-size-xs`, `--font-size-icon`, `--wa-space-2xs/3xs`, `--border-thin`, and `--border-radius-small` instead of `13px`/`10px`/`16px`/`5px`/`3px`/`1px` literals. The inline `style=` for the polish spinner also drops `styleMap`.
- **shared/styles/badgeStyles** — `.tinted-badge` `padding: 1px ...` -> `var(--border-thin) ...`.

## Test plan

- [x] `npm run typecheck` — 8 pre-existing baseline errors, unchanged.
- [x] `cd packages/desktop && npx vite build --mode development` — clean build.
- [x] `npx vitest run` — 4 pre-existing baseline failures, unchanged (`ElectronRendererShell`).
- [ ] Manual: open Settings -> Profile -> Models, confirm provider chevron / warning links / "All|None" toggles render and toggle correctly.
- [ ] Manual: open MainView, confirm Execute button + kbd chip and polish spinner slot still align.

Stacked on top of pass 2 (#3717) and pass 1 (#3714).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/refactor-only change: swaps a few `<button>` elements for `wa-button` and adjusts CSS tokens, with no changes to underlying data flow or events.
> 
> **Overview**
> Refactors Settings Profile UI controls to use `wa-button appearance="plain"` for agent group "All/None" toggles, deprecated-model expand toggles, provider expand chevrons, and provider warning links, removing custom button/link CSS and relying on `::part(base)` tweaks.
> 
> Tokenizes remaining hardcoded pixel values in `InstructionPanel` (execute button kbd chip + polish spinner slot sizing) and adjusts shared `.tinted-badge` padding to use `--border-thin`, reducing bespoke styling and improving theme consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bcfee90895dfb380f9370a357abe96e0e962741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->