### PR TITLE
fix(webview): restore launcher action row layout + density

### DIFF
--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -369,7 +369,11 @@ export class FileSelectGroup extends LitElement {
     const chevronName = this.currentListVisible ? 'chevron-up' : 'chevron-down';
 
     return html`
-      <div class="file-select" data-expanded=${String(this.currentListVisible)}>
+      <div
+        class="file-select"
+        data-expanded=${String(this.currentListVisible)}
+        data-has-current=${String(Boolean(this.currentSelectedValue))}
+      >
         <div class="file-select-header">
           <div class="file-select-label-group">
             ${renderIconActionButton({

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -96,7 +96,8 @@ export const fileSelectLayoutStyles = css`
 
   .file-select-actions {
     display: flex;
-    flex-direction: column !important;
+    flex-direction: row;
+    align-items: center;
     flex-wrap: nowrap;
     margin-left: auto;
     gap: var(--wa-space-3xs);
@@ -110,6 +111,15 @@ export const fileSelectLayoutStyles = css`
   .file-select select,
   .file-select wa-select {
     width: 100%;
+  }
+
+  /* Hide the inline wa-select when there's no current selection AND the list
+     isn't expanded — saves a wasted row showing "None". The select still
+     surfaces as soon as the user expands, picks a current file, or starts
+     filtering. */
+  .file-select:not([data-expanded='true']):not([data-has-current='true'])
+    wa-select {
+    display: none;
   }
 
   .file-select:not([data-expanded='true']) .file-action-button {


### PR DESCRIPTION
## Summary
Two density regressions in the launcher's file-select slots from earlier WA passes:

1. **Action icons stacked vertically.** \`.file-select-actions\` had \`flex-direction: column !important\` (leftover from the pre-WA dropdown era). Each slot's action row collapsed into a tall sidebar of icons instead of a single horizontal row.
2. **Empty wa-select wasted a row per slot.** Each slot kept a full-width \`wa-select\` mounted with a "None" placeholder even when nothing was selected. Hide it unless there's a current selection or the list is expanded — wire \`data-has-current\` for the condition.

Restores the VS Code-native compact look while keeping all WA components.

## Test plan
- [x] \`npx tsc --noEmit\` (no new errors)
- [ ] Manual: Launcher slots (Input/Reference/Auxiliary/Media) collapse to one row when empty; action icons render horizontally; expanding shows the wa-select

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only adjustments in the webview: tweaks layout CSS and conditionally hides a select control, with no changes to persistence or backend logic.
> 
> **Overview**
> Restores the launcher `file-select` compact layout by switching `.file-select-actions` back to a horizontal row (removing the vertical/`!important` stacking regression).
> 
> Adds `data-has-current` to `FileSelectGroup` and uses it in `fileSelectStyles` to hide the inline `wa-select` when the list is collapsed and no current file is selected, avoiding an empty “None” row until the user expands or selects a file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22852118e93891a8431e1c2695df5606828b2caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->