### PR TITLE
fix(webview): restore launcher visual hierarchy — tabs, toggle, callout, textarea, toolbar prominent

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1,10 +1,11 @@
-import { html, type TemplateResult } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import { provide } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
@@ -1967,38 +1968,6 @@ export class MainApp extends MainAppBase {
         </div>
 
         <div class="main-content">
-          <div class=${fileSelectionClasses}>
-            ${repeat(
-              FILE_SELECT_CONFIGS,
-              (config) => config.type,
-              (config) => html`
-                <file-select-group
-                  .config=${config}
-                  @file-change=${this.handleComponentFileChange}
-                  @refresh-files=${this.handleComponentRefreshFiles}
-                  @get-current-file=${this.handleComponentGetCurrentFile}
-                  @empty-file=${this.handleComponentEmptyFile}
-                  @toggle-list=${this.handleComponentToggleList}
-                  @add-opened-files=${this.handleComponentAddOpenedFiles}
-                  @empty-files=${this.handleComponentEmptyFiles}
-                  @select-multiple-files=${this
-                    .handleComponentSelectMultipleFiles}
-                  @remove-file=${this.handleComponentRemoveFile}
-                  @files-reordered=${this.handleComponentFilesReordered}
-                  @checkbox-change=${this.handleComponentCheckboxChange}
-                  @focus-instruction=${this.handleComponentFocusInstruction}
-                ></file-select-group>
-              `,
-            )}
-            <output-files-section
-              @toggle-list=${this.handleComponentToggleList}
-              @empty-files=${this.handleComponentEmptyFiles}
-              @select-multiple-files=${this.handleComponentSelectMultipleFiles}
-              @remove-file=${this.handleComponentRemoveFile}
-              @files-reordered=${this.handleComponentFilesReordered}
-            ></output-files-section>
-          </div>
-
           <instruction-panel
             .showSessionHint=${!this.sessionHintDismissed.get()}
             @session-type-change=${this.handleComponentSessionTypeChange}
@@ -2041,6 +2010,58 @@ export class MainApp extends MainAppBase {
             @dismiss-getting-started=${this
               .handleComponentDismissGettingStarted}
           ></banner-group>
+
+          ${isToolUse
+            ? nothing
+            : html`
+                <div class="section-separator" role="presentation"></div>
+                <wa-details class="file-selection-details">
+                  <span slot="summary" class="file-selection-summary">
+                    <wa-icon
+                      library=${TEXRA_ICON_LIBRARY}
+                      name="folder-tree"
+                      variant="solid"
+                    ></wa-icon>
+                    Files
+                  </span>
+                  <div class=${fileSelectionClasses}>
+                    ${repeat(
+                      FILE_SELECT_CONFIGS,
+                      (config) => config.type,
+                      (config) => html`
+                        <file-select-group
+                          .config=${config}
+                          @file-change=${this.handleComponentFileChange}
+                          @refresh-files=${this.handleComponentRefreshFiles}
+                          @get-current-file=${this
+                            .handleComponentGetCurrentFile}
+                          @empty-file=${this.handleComponentEmptyFile}
+                          @toggle-list=${this.handleComponentToggleList}
+                          @add-opened-files=${this
+                            .handleComponentAddOpenedFiles}
+                          @empty-files=${this.handleComponentEmptyFiles}
+                          @select-multiple-files=${this
+                            .handleComponentSelectMultipleFiles}
+                          @remove-file=${this.handleComponentRemoveFile}
+                          @files-reordered=${this
+                            .handleComponentFilesReordered}
+                          @checkbox-change=${this.handleComponentCheckboxChange}
+                          @focus-instruction=${this
+                            .handleComponentFocusInstruction}
+                        ></file-select-group>
+                      `,
+                    )}
+                    <output-files-section
+                      @toggle-list=${this.handleComponentToggleList}
+                      @empty-files=${this.handleComponentEmptyFiles}
+                      @select-multiple-files=${this
+                        .handleComponentSelectMultipleFiles}
+                      @remove-file=${this.handleComponentRemoveFile}
+                      @files-reordered=${this.handleComponentFilesReordered}
+                    ></output-files-section>
+                  </div>
+                </wa-details>
+              `}
         </div>
 
         <latexdiffs-section

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -49,13 +49,66 @@ export const mainViewStyles: CSSResult = css`
     min-height: 0;
   }
 
-  .file-selection-group {
-    background-color: var(--background-color);
-    border: var(--border-thin) solid
-      var(--texra-widget-border, var(--dropdown-border));
-    border-radius: var(--border-radius);
-    padding: var(--wa-space-xs);
+  /*
+   * Hairline separator between sections of the launcher. Kept subtle
+   * (single-pixel surface-border line) so the primary instruction flow
+   * stays the dominant visual element, with secondary regions like the
+   * file-select group quietly demarcated below.
+   */
+  .section-separator {
+    border-top: var(--border-thin) solid
+      var(--wa-color-surface-border, var(--color-border));
+    margin: 0 0 var(--wa-space-2xs);
+  }
+
+  /*
+   * Files section sits BELOW the instruction-panel (textarea + toolbar).
+   * Wrapped in a wa-details so the four file slots (Input/Reference/
+   * Auxiliary/Media) plus Multiple Outputs collapse to a single slim
+   * summary row by default — keeping the primary "what do you want to
+   * do?" textarea front-and-center and unblocked.
+   */
+  wa-details.file-selection-details {
     margin-bottom: var(--wa-space-s);
+    background: transparent;
+  }
+
+  wa-details.file-selection-details::part(base) {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+  }
+
+  wa-details.file-selection-details::part(header) {
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
+    min-height: 22px;
+    font-size: var(--font-size-sm);
+    color: var(--wa-color-text-quiet);
+  }
+
+  wa-details.file-selection-details[open]::part(header) {
+    color: var(--wa-color-text-normal);
+  }
+
+  wa-details.file-selection-details::part(content) {
+    padding: var(--wa-space-2xs) 0 0;
+  }
+
+  wa-details.file-selection-details .file-selection-summary {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+  }
+
+  wa-details.file-selection-details .file-selection-summary wa-icon {
+    color: var(--wa-color-text-quiet);
+  }
+
+  .file-selection-group {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
     overflow: visible;
   }
 


### PR DESCRIPTION
## Summary

- Reorder the launcher webview right panel so the primary instruction flow (mode toggle, brand-tinted hint callout, monospace textarea, bottom toolbar with Run button + kbd chip) sits directly under the tab strip — the previously preferred visual hierarchy.
- Demote the four file-select slots (Input/Reference/Auxiliary/Media) and the Multiple Outputs slot into a single collapsed `wa-details` "Files" summary placed BELOW the textarea/toolbar and banners, so they no longer dominate the top of the panel.
- Replace the heavy bordered panel around the file group with a subtle hairline `--wa-color-surface-border` separator between the primary flow and the files region; the `wa-details` affordance now demarcates the secondary section.
- Hide the entire files region in tool-use (Interactive) mode via `{nothing}` on the wrapper, mirroring the prior `--disabled` behavior without leaving an empty wa-details summary.
- All existing functionality preserved: the per-slot file-select-group component, OutputFilesSection, and every action button still mount and dispatch their original events; the wa-details only adds a wrapper.
- All visuals use existing WA components (`wa-details`, `wa-icon`, `wa-tab-group`, `wa-callout` via InstructionPanel) and existing tokens (`--wa-space-*`, `--wa-color-surface-border`, `--wa-color-text-quiet`).
- No new files, no new abstractions, no new color schemes.

## Test plan

- [ ] `npm run typecheck` baseline unchanged (still 8 pre-existing errors in `packages/desktop/src/main/platform/paths.ts` + `src/agent/modelHandlers/*` unrelated to this PR).
- [ ] `cd packages/desktop && npx vite build --mode development` — clean.
- [ ] `npm run compile:fast` — clean.
- [ ] Open the right-panel launcher webview in dev: confirm tab strip → mode toggle row → hint callout → textarea → bottom toolbar with brand-filled Run button is the visual order.
- [ ] Confirm the "Files" wa-details collapsible appears BELOW the toolbar and banners and is collapsed by default in workflow mode.
- [ ] Toggle to Interactive (tool-use) — confirm the entire Files section disappears.
- [ ] Expand the Files wa-details — confirm all four slots and the Multiple Outputs slot still mount with their existing actions.
- [ ] Confirm LaTeXDiffs section still sits at the very bottom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that rearrange and restyle the launcher’s file-selection region; no business logic or message handling behavior is modified.
> 
> **Overview**
> Restores the launcher panel’s visual hierarchy by moving the file-selection UI below the instruction flow and banners, and wrapping it in a collapsible `wa-details` “Files” section (hidden entirely in tool-use mode).
> 
> Replaces the previous heavy bordered file-selection container with a subtle hairline separator and new `wa-details` styling, while keeping existing `file-select-group`/`output-files-section` event wiring intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71457e2b8b1a76a0adb29ec7b58e5fd5a02cfcb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->