### PR TITLE
refactor(wa): native WA theming — drop --texra-* bridge, apply wa-light/wa-dark

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -372,6 +372,11 @@ function applyDesktopTheme(theme: DesktopThemeKind): void {
   );
   document.body.classList.add(`vscode-${theme}`, `texra-${theme}`);
   document.body.dataset.vscodeThemeKind = theme;
+  // Apply Web Awesome's native color-scheme class on the document root so
+  // WA's --wa-* dark-mode overrides activate (per WA theming model).
+  const root = document.documentElement;
+  root.classList.remove('wa-light', 'wa-dark');
+  root.classList.add(theme === 'light' ? 'wa-light' : 'wa-dark');
 }
 
 function getWindowTargetOrigin(): string {

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1,13 +1,13 @@
 :root {
   --desktop-nav-height: 40px;
-  font-family: var(--texra-font-family);
+  font-family: var(--wa-font-family-body);
   background: var(--wa-color-surface-default);
   color: var(--wa-color-text-normal);
 }
 
 body {
   margin: 0;
-  font-size: var(--texra-font-size);
+  font-size: var(--wa-font-size-m);
 }
 
 .desktop-shell {
@@ -556,7 +556,7 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
   border-radius: var(--wa-border-radius-l, 6px);
   background: var(--wa-color-surface-default);
   color: var(--wa-color-text-normal);
-  font-family: var(--texra-font-family-monospace);
+  font-family: var(--wa-font-family-body-monospace);
   font-size: 12px;
   line-height: 1.45;
   white-space: pre-wrap;

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -1,3 +1,21 @@
+/**
+ * Document-level theme tokens for the TeXRA desktop (Electron) renderer.
+ *
+ * Web Awesome native theming: --wa-* tokens are the single source of truth and
+ * are sourced directly from the desktop's native --desktop-color-* palette.
+ * The renderer entry (main.ts) imports the WA default theme stylesheet via
+ * @shared/wa, and applyDesktopTheme() mirrors the active theme kind onto
+ * <html class="wa-light|wa-dark"> so WA's color-scheme classes activate.
+ *
+ * --texra-* tokens remain as a thin compatibility alias layer for tokens that
+ * have no clean WA equivalent (terminal ansi, symbol icons, charts, list rows,
+ * git decoration, etc.) and a few legacy aliases consumers still reference.
+ * They no longer round-trip through --wa-*.
+ *
+ * --vscode-* tokens are re-exported at the bottom so VS Code-styled CSS reused
+ * in the desktop renderer keeps working without per-file rewrites.
+ */
+
 :root {
   color-scheme: light dark;
 
@@ -59,171 +77,21 @@
     rgb(31 35 40 / 45%),
     rgb(191 191 191 / 40%)
   );
+}
 
-  --texra-font-family: var(--desktop-font-family);
-  --texra-font-size: var(--desktop-font-size);
-  --texra-font-weight: var(--desktop-font-weight);
-  --texra-foreground: var(--desktop-color-foreground);
-  --texra-descriptionForeground: var(--desktop-color-muted);
-  --texra-editor-background: var(--desktop-color-background);
-  --texra-editor-foreground: var(--desktop-color-foreground);
-  --texra-editor-font-family: var(--desktop-font-family);
-  --texra-editor-font-size: var(--desktop-font-size);
-  --texra-sideBar-background: var(--desktop-color-sidebar);
-  --texra-sideBar-foreground: var(--desktop-color-foreground);
-  --texra-sideBarSectionHeader-background: var(--desktop-color-sidebar-header);
-  --texra-sideBarTitle-foreground: var(--desktop-color-foreground);
-  --texra-panel-border: var(--desktop-color-border);
-  --texra-panelSection-border: var(--desktop-color-border);
-  --texra-focusBorder: var(--desktop-color-accent);
-  --texra-button-background: var(--desktop-color-accent);
-  --texra-button-foreground: #ffffff;
-  --texra-button-border: transparent;
-  --texra-button-hoverBackground: var(--desktop-color-accent-hover);
-  --texra-button-secondaryBackground: var(--desktop-color-button-secondary);
-  --texra-button-secondaryForeground: var(--desktop-color-input-foreground);
-  --texra-button-secondaryHoverBackground: var(
-    --desktop-color-button-secondary-hover
-  );
-  --texra-button-separator: rgb(255 255 255 / 40%);
-  --texra-dropdown-border: var(--desktop-color-input-border);
-  --texra-input-background: var(--desktop-color-input-background);
-  --texra-input-border: var(--desktop-color-input-border);
-  --texra-input-foreground: var(--desktop-color-input-foreground);
-  --texra-input-placeholderForeground: var(--desktop-color-placeholder);
-  --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
-  --texra-inputOption-activeBorder: var(--desktop-color-accent);
-  --texra-inputOption-activeForeground: var(--desktop-color-foreground);
-  --texra-inputValidation-errorBackground: var(
-    --desktop-color-error-background
-  );
-  --texra-inputValidation-errorBorder: var(--desktop-color-error);
-  --texra-inputValidation-infoBackground: var(--desktop-color-info-background);
-  --texra-inputValidation-infoBorder: var(--desktop-color-info);
-  --texra-inputValidation-infoForeground: var(--desktop-color-info);
-  --texra-inputValidation-warningBackground: var(
-    --desktop-color-warning-background
-  );
-  --texra-inputValidation-warningBorder: var(--desktop-color-warning);
-  --texra-inputValidation-warningForeground: var(--desktop-color-warning);
-  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
-     equivalents. Keep these texra aliases until WA introduces semantic tokens
-     for tree/list rows (or until consumers move to wa-tree::part(item) styling
-     hooks); see #3690. */
-  --texra-list-activeSelectionBackground: var(--desktop-color-accent);
-  --texra-list-activeSelectionForeground: #ffffff;
-  --texra-list-focusOutline: var(--desktop-color-accent);
-  --texra-list-hoverForeground: var(--desktop-color-foreground);
-  --texra-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --texra-list-hoverBackground: var(--desktop-color-list-hover);
-  --texra-list-warningForeground: var(--desktop-color-warning);
-  --texra-menu-background: var(--desktop-color-menu-background);
-  --texra-menu-border: var(--desktop-color-menu-border);
-  --texra-menu-foreground: var(--desktop-color-input-foreground);
-  --texra-menu-selectionBackground: var(--desktop-color-accent);
-  --texra-menu-selectionForeground: #ffffff;
-  --texra-menu-separatorBackground: var(--desktop-color-menu-border);
-  --texra-toolbar-activeBackground: var(--desktop-color-toolbar-active);
-  --texra-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
-  --texra-toolbar-hoverOutline: var(--desktop-color-muted);
-  --texra-widget-border: var(--desktop-color-widget-border);
-  --texra-widget-shadow: var(--desktop-color-shadow);
-  --texra-icon-foreground: var(--desktop-color-muted);
-  --texra-badge-background: var(--desktop-color-accent);
-  --texra-badge-foreground: #ffffff;
-  --texra-textBlockQuote-background: var(--desktop-color-accent-subtle);
-  --texra-textBlockQuote-border: var(--desktop-color-accent);
-  --texra-textCodeBlock-background: var(--desktop-color-sidebar);
-  --texra-textLink-foreground: var(--desktop-color-accent);
-  --texra-textLink-activeForeground: var(--desktop-color-accent-hover);
-  --texra-textPreformat-foreground: var(--desktop-color-input-foreground);
-  --texra-errorForeground: var(--desktop-color-error);
-  --texra-editorError-foreground: var(--desktop-color-error);
-  --texra-editorWarning-foreground: var(--desktop-color-warning);
-  --texra-editorWarning-background: var(--desktop-color-warning-background);
-  --texra-editorInfo-foreground: var(--desktop-color-info);
-  --texra-editorInfo-background: var(--desktop-color-info-background);
-  --texra-editor-inactiveSelectionBackground: var(
-    --desktop-color-accent-subtle
-  );
-  --texra-editor-selectionBackground: var(--desktop-color-accent-subtle);
-  --texra-editorWidget-background: var(--desktop-color-sidebar);
-  --texra-editorWidget-border: var(--desktop-color-widget-border);
-  --texra-editorHoverWidget-background: var(--desktop-color-sidebar);
-  --texra-editorHoverWidget-border: var(--desktop-color-widget-border);
-  --texra-editorHoverWidget-foreground: var(--desktop-color-foreground);
-  --texra-progressBar-background: var(--desktop-color-accent);
-  --texra-testing-iconPassed: var(--desktop-color-success);
-  --texra-testing-iconFailed: var(--desktop-color-error);
-  --texra-charts-blue: var(--desktop-color-accent);
-  --texra-charts-green: var(--desktop-color-success);
-  --texra-charts-orange: var(--desktop-color-orange);
-  --texra-charts-red: var(--desktop-color-error);
-  --texra-charts-yellow: var(--desktop-color-yellow);
-  --texra-terminal-background: var(--desktop-color-background);
-  --texra-terminal-foreground: var(--desktop-color-input-foreground);
-  --texra-terminal-selectionBackground: var(--desktop-color-terminal-selection);
-  --texra-terminalCursor-foreground: var(--desktop-color-input-foreground);
-  --texra-terminal-ansiBlack: light-dark(#24292f, #000000);
-  --texra-terminal-ansiBlue: var(--desktop-color-accent);
-  --texra-terminal-ansiBrightBlack: light-dark(#6e7781, #666666);
-  --texra-terminal-ansiBrightBlue: light-dark(#0550ae, #3794ff);
-  --texra-terminal-ansiBrightCyan: light-dark(#1b7c83, #39cccc);
-  --texra-terminal-ansiBrightGreen: var(--desktop-color-success);
-  --texra-terminal-ansiBrightMagenta: light-dark(#8250df, #d670d6);
-  --texra-terminal-ansiBrightRed: var(--desktop-color-error);
-  --texra-terminal-ansiBrightWhite: light-dark(#ffffff, #ffffff);
-  --texra-terminal-ansiBrightYellow: var(--desktop-color-yellow);
-  --texra-terminal-ansiCyan: light-dark(#1b7c83, #4ec9b0);
-  --texra-terminal-ansiGreen: var(--desktop-color-success);
-  --texra-terminal-ansiMagenta: light-dark(#8250df, #c586c0);
-  --texra-terminal-ansiRed: var(--desktop-color-error);
-  --texra-terminal-ansiWhite: light-dark(#6e7781, #cccccc);
-  --texra-terminal-ansiYellow: var(--desktop-color-yellow);
-  --texra-terminalCursor-foreground: var(--desktop-color-input-foreground);
-  --texra-scrollbar-shadow: var(--desktop-color-shadow);
-  --texra-scrollbarSlider-background: var(--desktop-color-scrollbar);
-  --texra-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
-  --texra-scrollbarSlider-activeBackground: var(
-    --desktop-color-scrollbar-active
-  );
-  --texra-activityBarBadge-background: var(--desktop-color-accent);
-  --texra-notificationsInfoIcon-foreground: var(--desktop-color-info);
-  --texra-statusBarItem-warningBackground: var(--desktop-color-warning);
-  --texra-symbolIcon-classForeground: var(--desktop-color-orange);
-  --texra-symbolIcon-constantForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-functionForeground: var(--desktop-color-yellow);
-  --texra-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
-  --texra-symbolIcon-propertyForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
-
-  /*
-   * Web Awesome design-token bridge.
-   * WA components read --wa-*. The Electron renderer supplies its own desktop
-   * tokens (above), so this links them directly without going through --texra-*.
-   */
+/*
+ * Web Awesome design-token bridge — single source of truth.
+ * Sourced directly from the native --desktop-color-* palette above (no
+ * intermediate --texra-* layer).
+ */
+:root,
+.wa-light,
+.wa-dark .wa-invert {
   --wa-font-family-body: var(--desktop-font-family);
   --wa-font-family-heading: var(--desktop-font-family);
   --wa-font-family-mono: 'SF Mono', Monaco, monospace;
   --wa-font-size-m: var(--desktop-font-size);
   --wa-font-weight-normal: var(--desktop-font-weight);
-
-  /* Web Awesome canonical space scale. Mirrors the values from
-     @awesome.me/webawesome/dist/styles/themes/default.css so consumers (and WA
-     components) can rely on --wa-space-* without importing the full default
-     theme — that import would override the color bridge below. */
-  --wa-space-scale: 1;
-  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem); /* 2px */
-  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem); /* 4px */
-  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem); /* 8px */
-  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem); /* 12px */
-  --wa-space-m: calc(var(--wa-space-scale) * 1rem); /* 16px */
-  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem); /* 24px */
-  --wa-space-xl: calc(var(--wa-space-scale) * 2rem); /* 32px */
-  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
-  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
-  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
-  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
   --wa-color-text-normal: var(--desktop-color-foreground);
   --wa-color-text-quiet: var(--desktop-color-muted);
@@ -235,9 +103,7 @@
 
   --wa-color-focus: var(--desktop-color-accent);
 
-  /* WA form-control tokens — wire to desktop input palette so wa-input,
-     wa-textarea, wa-select, etc. inherit the renderer theme's input surface
-     rather than WA's default form-control colors. */
+  /* WA form-control tokens. */
   --wa-form-control-background-color: var(--desktop-color-input-background);
   --wa-form-control-text-color: var(--desktop-color-input-foreground);
   --wa-form-control-border-color: var(--desktop-color-input-border);
@@ -245,10 +111,6 @@
   --wa-color-brand-fill-loud: var(--desktop-color-accent);
   --wa-color-brand-on-loud: #ffffff;
   --wa-color-brand-border-loud: transparent;
-
-  /* Variant tokens for wa-callout / wa-button — wire desktop palette
-     through the WA color stack so warning/danger/success callouts blend
-     with the host theme rather than the WA defaults. */
   --wa-color-brand-fill-quiet: var(--desktop-color-info-background);
   --wa-color-brand-border-quiet: var(--desktop-color-info);
   --wa-color-brand-on-quiet: var(--desktop-color-info);
@@ -274,9 +136,6 @@
   --wa-color-success-border-quiet: var(--desktop-color-success);
   --wa-color-success-on-quiet: var(--desktop-color-success);
 
-  /* Neutral tokens for outlined wa-button / wa-callout variants. Wire to the
-     desktop muted palette so neutral surfaces blend with the renderer theme
-     rather than falling back to WA's default gray scale. */
   --wa-color-neutral-fill-quiet: var(--desktop-color-sidebar-header);
   --wa-color-neutral-border-quiet: var(--desktop-color-border);
   --wa-color-neutral-on-quiet: var(--desktop-color-foreground);
@@ -284,10 +143,162 @@
   --wa-color-neutral-border-loud: var(--desktop-color-border);
   --wa-color-neutral-on-loud: var(--desktop-color-foreground);
 
-  /* Testing status color bridge. Wire success/warning test icons to WA semantic
-     tokens so they inherit host theme status colors. */
-  --wa-color-success-on-quiet: var(--desktop-color-success);
-  --wa-color-warning-fill-quiet: var(--desktop-color-warning-background);
+  /* Web Awesome canonical space scale — kept in sync with WA default theme. */
+  --wa-space-scale: 1;
+  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem);
+  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem);
+  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem);
+  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem);
+  --wa-space-m: calc(var(--wa-space-scale) * 1rem);
+  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem);
+  --wa-space-xl: calc(var(--wa-space-scale) * 2rem);
+  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem);
+  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem);
+  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem);
+  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem);
+}
+
+/*
+ * --texra-* compatibility alias layer.
+ * Wa-aligned aliases collapse to --wa-* tokens. Niche aliases (terminal,
+ * symbol icons, charts, list rows) source --desktop-color-* directly.
+ */
+:root {
+  /* Wa-aligned aliases. */
+  --texra-foreground: var(--wa-color-text-normal);
+  --texra-descriptionForeground: var(--wa-color-text-quiet);
+  --texra-icon-foreground: var(--wa-color-text-quiet);
+  --texra-editor-background: var(--wa-color-surface-default);
+  --texra-editor-foreground: var(--wa-color-text-normal);
+  --texra-editorWidget-background: var(--wa-color-surface-raised);
+  --texra-editorWidget-border: var(--wa-color-surface-border);
+  --texra-editorHoverWidget-background: var(--wa-color-surface-raised);
+  --texra-editorHoverWidget-border: var(--wa-color-surface-border);
+  --texra-editorHoverWidget-foreground: var(--wa-color-text-normal);
+  --texra-sideBar-background: var(--wa-color-surface-lowered);
+  --texra-sideBar-foreground: var(--wa-color-text-normal);
+  --texra-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
+  --texra-sideBarTitle-foreground: var(--wa-color-text-normal);
+  --texra-panel-border: var(--wa-color-surface-border);
+  --texra-panelSection-border: var(--wa-color-surface-border);
+  --texra-widget-border: var(--desktop-color-widget-border);
+  --texra-widget-shadow: var(--desktop-color-shadow);
+  --texra-textCodeBlock-background: var(--wa-color-surface-lowered);
+  --texra-textBlockQuote-background: var(--desktop-color-accent-subtle);
+  --texra-textBlockQuote-border: var(--desktop-color-accent);
+  --texra-textLink-foreground: var(--wa-color-text-link);
+  --texra-textLink-activeForeground: var(--desktop-color-accent-hover);
+  --texra-textPreformat-foreground: var(--desktop-color-input-foreground);
+  --texra-input-background: var(--wa-form-control-background-color);
+  --texra-input-foreground: var(--wa-form-control-text-color);
+  --texra-input-border: var(--wa-form-control-border-color);
+  --texra-input-placeholderForeground: var(--desktop-color-placeholder);
+  --texra-dropdown-border: var(--wa-form-control-border-color);
+  --texra-button-background: var(--wa-color-brand-fill-loud);
+  --texra-button-foreground: var(--wa-color-brand-on-loud);
+  --texra-button-border: transparent;
+  --texra-button-hoverBackground: var(--desktop-color-accent-hover);
+  --texra-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
+  --texra-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
+  --texra-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
+  --texra-button-separator: rgb(255 255 255 / 40%);
+  --texra-errorForeground: var(--wa-color-danger-on-quiet);
+  --texra-editorError-foreground: var(--wa-color-danger-on-quiet);
+  --texra-editorWarning-foreground: var(--wa-color-warning-on-quiet);
+  --texra-editorWarning-background: var(--wa-color-warning-fill-quiet);
+  --texra-editorInfo-foreground: var(--wa-color-brand-on-quiet);
+  --texra-editorInfo-background: var(--wa-color-brand-fill-quiet);
+  --texra-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
+  --texra-editor-selectionBackground: var(--desktop-color-accent-subtle);
+  --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
+  --texra-inputOption-activeBorder: var(--desktop-color-accent);
+  --texra-inputOption-activeForeground: var(--desktop-color-foreground);
+  --texra-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
+  --texra-inputValidation-errorBorder: var(--desktop-color-error);
+  --texra-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
+  --texra-inputValidation-infoBorder: var(--desktop-color-info);
+  --texra-inputValidation-infoForeground: var(--desktop-color-info);
+  --texra-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
+  --texra-inputValidation-warningBorder: var(--desktop-color-warning);
+  --texra-inputValidation-warningForeground: var(--desktop-color-warning);
+  --texra-progressBar-background: var(--desktop-color-accent);
+  --texra-statusBarItem-warningBackground: var(--desktop-color-warning);
+  --texra-notificationsInfoIcon-foreground: var(--desktop-color-info);
+  --texra-activityBarBadge-background: var(--desktop-color-accent);
+  --texra-badge-background: var(--desktop-color-accent);
+  --texra-badge-foreground: #ffffff;
+  --texra-toolbar-activeBackground: var(--desktop-color-toolbar-active);
+  --texra-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
+  --texra-toolbar-hoverOutline: var(--desktop-color-muted);
+  --texra-focusBorder: var(--wa-color-focus);
+
+  /* List/menu/scrollbar — no WA equivalent. */
+  --texra-list-activeSelectionBackground: var(--desktop-color-accent);
+  --texra-list-activeSelectionForeground: #ffffff;
+  --texra-list-focusOutline: var(--desktop-color-accent);
+  --texra-list-hoverForeground: var(--desktop-color-foreground);
+  --texra-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
+  --texra-list-hoverBackground: var(--desktop-color-list-hover);
+  --texra-list-warningForeground: var(--desktop-color-warning);
+  --texra-menu-background: var(--desktop-color-menu-background);
+  --texra-menu-border: var(--desktop-color-menu-border);
+  --texra-menu-foreground: var(--desktop-color-input-foreground);
+  --texra-menu-selectionBackground: var(--desktop-color-accent);
+  --texra-menu-selectionForeground: #ffffff;
+  --texra-menu-separatorBackground: var(--desktop-color-menu-border);
+  --texra-scrollbar-shadow: var(--desktop-color-shadow);
+  --texra-scrollbarSlider-background: var(--desktop-color-scrollbar);
+  --texra-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
+  --texra-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
+
+  /* Charts — palette tokens with no WA equivalent. */
+  --texra-charts-blue: var(--desktop-color-accent);
+  --texra-charts-green: var(--desktop-color-success);
+  --texra-charts-orange: var(--desktop-color-orange);
+  --texra-charts-red: var(--desktop-color-error);
+  --texra-charts-yellow: var(--desktop-color-yellow);
+
+  /* Testing icons. */
+  --texra-testing-iconPassed: var(--desktop-color-success);
+  --texra-testing-iconFailed: var(--desktop-color-error);
+
+  /* Symbol icons — no WA equivalent. */
+  --texra-symbolIcon-classForeground: var(--desktop-color-orange);
+  --texra-symbolIcon-constantForeground: var(--desktop-color-accent);
+  --texra-symbolIcon-functionForeground: var(--desktop-color-yellow);
+  --texra-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
+  --texra-symbolIcon-propertyForeground: var(--desktop-color-accent);
+  --texra-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
+
+  /* Terminal — no WA equivalent. */
+  --texra-terminal-background: var(--desktop-color-background);
+  --texra-terminal-foreground: var(--desktop-color-input-foreground);
+  --texra-terminal-selectionBackground: var(--desktop-color-terminal-selection);
+  --texra-terminalCursor-foreground: var(--desktop-color-input-foreground);
+  --texra-terminal-ansiBlack: light-dark(#24292f, #000000);
+  --texra-terminal-ansiBlue: var(--desktop-color-accent);
+  --texra-terminal-ansiBrightBlack: light-dark(#6e7781, #666666);
+  --texra-terminal-ansiBrightBlue: light-dark(#0550ae, #3794ff);
+  --texra-terminal-ansiBrightCyan: light-dark(#1b7c83, #39cccc);
+  --texra-terminal-ansiBrightGreen: var(--desktop-color-success);
+  --texra-terminal-ansiBrightMagenta: light-dark(#8250df, #d670d6);
+  --texra-terminal-ansiBrightRed: var(--desktop-color-error);
+  --texra-terminal-ansiBrightWhite: light-dark(#ffffff, #ffffff);
+  --texra-terminal-ansiBrightYellow: var(--desktop-color-yellow);
+  --texra-terminal-ansiCyan: light-dark(#1b7c83, #4ec9b0);
+  --texra-terminal-ansiGreen: var(--desktop-color-success);
+  --texra-terminal-ansiMagenta: light-dark(#8250df, #c586c0);
+  --texra-terminal-ansiRed: var(--desktop-color-error);
+  --texra-terminal-ansiWhite: light-dark(#6e7781, #cccccc);
+  --texra-terminal-ansiYellow: var(--desktop-color-yellow);
+
+  /* Legacy font/typography aliases. */
+  --texra-font-family: var(--wa-font-family-body);
+  --texra-font-family-monospace: var(--wa-font-family-mono);
+  --texra-font-size: var(--wa-font-size-m);
+  --texra-font-weight: var(--wa-font-weight-normal);
+  --texra-editor-font-family: var(--desktop-font-family);
+  --texra-editor-font-size: var(--desktop-font-size);
 }
 
 body.vscode-light,
@@ -338,104 +349,76 @@ body.texra-high-contrast {
   --wa-color-brand-border-loud: CanvasText;
 }
 
-/* Compatibility exports for reused VS Code webview CSS. */
+/*
+ * VS Code variable re-exports for reused webview CSS.
+ * Sourced from --desktop-color-* / --wa-* so existing rules referencing
+ * --vscode-* still resolve in the desktop renderer.
+ */
 :root {
-  --vscode-font-family: var(--texra-font-family);
-  --vscode-font-size: var(--texra-font-size);
-  --vscode-font-weight: var(--texra-font-weight);
+  --vscode-font-family: var(--wa-font-family-body);
+  --vscode-font-size: var(--wa-font-size-m);
+  --vscode-font-weight: var(--wa-font-weight-normal);
   --vscode-foreground: var(--wa-color-text-normal);
   --vscode-descriptionForeground: var(--wa-color-text-quiet);
   --vscode-editor-background: var(--wa-color-surface-default);
   --vscode-editor-font-family: var(--wa-font-family-mono);
-  --vscode-editor-font-size: var(--texra-editor-font-size);
+  --vscode-editor-font-size: var(--desktop-font-size);
   --vscode-editor-foreground: var(--wa-color-text-normal);
-  --vscode-editor-inactiveSelectionBackground: var(
-    --texra-editor-inactiveSelectionBackground
-  );
-  --vscode-editor-selectionBackground: var(--texra-editor-selectionBackground);
-  --vscode-editorError-foreground: var(--texra-editorError-foreground);
-  --vscode-editorHoverWidget-background: var(
-    --texra-editorHoverWidget-background
-  );
-  --vscode-editorHoverWidget-border: var(--texra-editorHoverWidget-border);
-  --vscode-editorHoverWidget-foreground: var(
-    --texra-editorHoverWidget-foreground
-  );
-  --vscode-editorInfo-background: var(--texra-editorInfo-background);
-  --vscode-editorInfo-foreground: var(--texra-editorInfo-foreground);
-  --vscode-editorWarning-background: var(--texra-editorWarning-background);
+  --vscode-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
+  --vscode-editor-selectionBackground: var(--desktop-color-accent-subtle);
+  --vscode-editorError-foreground: var(--wa-color-danger-on-quiet);
+  --vscode-editorHoverWidget-background: var(--wa-color-surface-raised);
+  --vscode-editorHoverWidget-border: var(--wa-color-surface-border);
+  --vscode-editorHoverWidget-foreground: var(--wa-color-text-normal);
+  --vscode-editorInfo-background: var(--wa-color-brand-fill-quiet);
+  --vscode-editorInfo-foreground: var(--wa-color-brand-on-quiet);
+  --vscode-editorWarning-background: var(--wa-color-warning-fill-quiet);
   --vscode-editorWarning-foreground: var(--wa-color-warning-on-quiet);
-  --vscode-editorWidget-background: var(--texra-editorWidget-background);
-  --vscode-editorWidget-border: var(--texra-editorWidget-border);
+  --vscode-editorWidget-background: var(--wa-color-surface-raised);
+  --vscode-editorWidget-border: var(--wa-color-surface-border);
   --vscode-errorForeground: var(--wa-color-danger-on-quiet);
   --vscode-focusBorder: var(--wa-color-focus);
   --vscode-sideBar-background: var(--wa-color-surface-lowered);
-  --vscode-sideBar-foreground: var(--texra-sideBar-foreground);
-  --vscode-sideBarSectionHeader-background: var(
-    --texra-sideBarSectionHeader-background
-  );
-  --vscode-sideBarTitle-foreground: var(--texra-sideBarTitle-foreground);
+  --vscode-sideBar-foreground: var(--wa-color-text-normal);
+  --vscode-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
+  --vscode-sideBarTitle-foreground: var(--wa-color-text-normal);
   --vscode-panel-border: var(--wa-color-surface-border);
   --vscode-panel-background: var(--wa-color-surface-default);
   --vscode-panelTitle-activeBorder: var(--wa-color-focus);
   --vscode-panelTitle-activeForeground: var(--wa-color-text-normal);
   --vscode-panelTitle-inactiveForeground: var(--wa-color-text-quiet);
-  --vscode-panelSection-border: var(--texra-panelSection-border);
+  --vscode-panelSection-border: var(--wa-color-surface-border);
   --vscode-settings-headerBorder: var(--wa-color-surface-border);
   --vscode-button-background: var(--wa-color-brand-fill-loud);
-  --vscode-button-border: var(--texra-button-border);
+  --vscode-button-border: transparent;
   --vscode-button-foreground: var(--wa-color-brand-on-loud);
-  --vscode-button-hoverBackground: var(--texra-button-hoverBackground);
-  --vscode-button-secondaryBackground: var(--texra-button-secondaryBackground);
-  --vscode-button-secondaryForeground: var(--texra-button-secondaryForeground);
-  --vscode-button-secondaryHoverBackground: var(
-    --texra-button-secondaryHoverBackground
-  );
-  --vscode-button-separator: var(--texra-button-separator);
+  --vscode-button-hoverBackground: var(--desktop-color-accent-hover);
+  --vscode-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
+  --vscode-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
+  --vscode-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
+  --vscode-button-separator: rgb(255 255 255 / 40%);
   --vscode-dropdown-background: var(--wa-form-control-background-color);
-  --vscode-dropdown-border: var(--texra-dropdown-border);
+  --vscode-dropdown-border: var(--wa-form-control-border-color);
   --vscode-dropdown-foreground: var(--wa-form-control-text-color);
   --vscode-input-background: var(--wa-form-control-background-color);
   --vscode-input-border: var(--wa-form-control-border-color);
   --vscode-input-foreground: var(--wa-form-control-text-color);
-  --vscode-input-placeholderForeground: var(
-    --texra-input-placeholderForeground
-  );
-  --vscode-inputOption-activeBackground: var(
-    --texra-inputOption-activeBackground
-  );
-  --vscode-inputOption-activeBorder: var(--texra-inputOption-activeBorder);
-  --vscode-inputOption-activeForeground: var(
-    --texra-inputOption-activeForeground
-  );
-  --vscode-inputValidation-errorBackground: var(
-    --texra-inputValidation-errorBackground
-  );
-  --vscode-inputValidation-errorBorder: var(
-    --texra-inputValidation-errorBorder
-  );
-  --vscode-inputValidation-infoBackground: var(
-    --texra-inputValidation-infoBackground
-  );
-  --vscode-inputValidation-infoBorder: var(--texra-inputValidation-infoBorder);
-  --vscode-inputValidation-infoForeground: var(
-    --texra-inputValidation-infoForeground
-  );
-  --vscode-inputValidation-warningBackground: var(
-    --texra-inputValidation-warningBackground
-  );
-  --vscode-inputValidation-warningBorder: var(
-    --texra-inputValidation-warningBorder
-  );
-  --vscode-inputValidation-warningForeground: var(
-    --texra-inputValidation-warningForeground
-  );
+  --vscode-input-placeholderForeground: var(--desktop-color-placeholder);
+  --vscode-inputOption-activeBackground: var(--desktop-color-accent-subtle);
+  --vscode-inputOption-activeBorder: var(--desktop-color-accent);
+  --vscode-inputOption-activeForeground: var(--desktop-color-foreground);
+  --vscode-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
+  --vscode-inputValidation-errorBorder: var(--desktop-color-error);
+  --vscode-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
+  --vscode-inputValidation-infoBorder: var(--desktop-color-info);
+  --vscode-inputValidation-infoForeground: var(--desktop-color-info);
+  --vscode-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
+  --vscode-inputValidation-warningBorder: var(--desktop-color-warning);
+  --vscode-inputValidation-warningForeground: var(--desktop-color-warning);
   --vscode-textArea-background: var(--wa-form-control-background-color);
   --vscode-textArea-border: var(--wa-form-control-border-color);
   --vscode-textArea-foreground: var(--wa-form-control-text-color);
-  --vscode-textArea-placeholderForeground: var(
-    --texra-input-placeholderForeground
-  );
+  --vscode-textArea-placeholderForeground: var(--desktop-color-placeholder);
   --vscode-checkbox-background: var(--wa-form-control-background-color);
   --vscode-checkbox-border: var(--wa-form-control-border-color);
   --vscode-checkbox-foreground: var(--wa-color-text-normal);
@@ -443,113 +426,83 @@ body.texra-high-contrast {
   --vscode-settings-checkboxBorder: var(--wa-form-control-border-color);
   --vscode-settings-checkboxForeground: var(--wa-color-text-normal);
   --vscode-settings-dropdownBackground: var(--wa-form-control-background-color);
-  --vscode-settings-dropdownBorder: var(--texra-dropdown-border);
+  --vscode-settings-dropdownBorder: var(--wa-form-control-border-color);
   --vscode-settings-dropdownForeground: var(--wa-form-control-text-color);
-  --vscode-settings-dropdownListBorder: var(--texra-dropdown-border);
+  --vscode-settings-dropdownListBorder: var(--wa-form-control-border-color);
   --vscode-settings-textInputBackground: var(--wa-form-control-background-color);
   --vscode-settings-textInputBorder: var(--wa-form-control-border-color);
   --vscode-settings-textInputForeground: var(--wa-form-control-text-color);
-  --vscode-list-activeSelectionBackground: var(
-    --texra-list-activeSelectionBackground
-  );
-  --vscode-list-activeSelectionForeground: var(
-    --texra-list-activeSelectionForeground
-  );
-  --vscode-list-activeSelectionIconForeground: var(
-    --texra-list-activeSelectionForeground
-  );
-  --vscode-list-focusAndSelectionOutline: var(--texra-list-focusOutline);
+  --vscode-list-activeSelectionBackground: var(--desktop-color-accent);
+  --vscode-list-activeSelectionForeground: #ffffff;
+  --vscode-list-activeSelectionIconForeground: #ffffff;
+  --vscode-list-focusAndSelectionOutline: var(--desktop-color-accent);
   --vscode-list-focusHighlightForeground: var(--wa-color-focus);
-  --vscode-list-focusOutline: var(--texra-list-focusOutline);
+  --vscode-list-focusOutline: var(--desktop-color-accent);
   --vscode-list-highlightForeground: var(--wa-color-focus);
   --vscode-list-hoverBackground: var(--wa-color-neutral-fill-quiet);
-  --vscode-list-hoverForeground: var(--texra-list-hoverForeground);
-  --vscode-list-inactiveSelectionBackground: var(
-    --texra-list-inactiveSelectionBackground
-  );
-  --vscode-list-warningForeground: var(--texra-list-warningForeground);
-  --vscode-menu-background: var(--texra-menu-background);
-  --vscode-menu-border: var(--texra-menu-border);
-  --vscode-menu-foreground: var(--texra-menu-foreground);
-  --vscode-menu-selectionBackground: var(--texra-menu-selectionBackground);
-  --vscode-menu-selectionBorder: var(--texra-menu-selectionBackground);
-  --vscode-menu-selectionForeground: var(--texra-menu-selectionForeground);
-  --vscode-menu-separatorBackground: var(--texra-menu-separatorBackground);
-  --vscode-toolbar-activeBackground: var(--texra-toolbar-activeBackground);
-  --vscode-toolbar-hoverBackground: var(--texra-toolbar-hoverBackground);
-  --vscode-toolbar-hoverOutline: var(--texra-toolbar-hoverOutline);
-  --vscode-widget-border: var(--texra-widget-border);
-  --vscode-widget-shadow: var(--texra-widget-shadow);
+  --vscode-list-hoverForeground: var(--desktop-color-foreground);
+  --vscode-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
+  --vscode-list-warningForeground: var(--desktop-color-warning);
+  --vscode-menu-background: var(--desktop-color-menu-background);
+  --vscode-menu-border: var(--desktop-color-menu-border);
+  --vscode-menu-foreground: var(--desktop-color-input-foreground);
+  --vscode-menu-selectionBackground: var(--desktop-color-accent);
+  --vscode-menu-selectionBorder: var(--desktop-color-accent);
+  --vscode-menu-selectionForeground: #ffffff;
+  --vscode-menu-separatorBackground: var(--desktop-color-menu-border);
+  --vscode-toolbar-activeBackground: var(--desktop-color-toolbar-active);
+  --vscode-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
+  --vscode-toolbar-hoverOutline: var(--desktop-color-muted);
+  --vscode-widget-border: var(--desktop-color-widget-border);
+  --vscode-widget-shadow: var(--desktop-color-shadow);
   --vscode-icon-foreground: var(--wa-color-text-quiet);
   --vscode-badge-background: var(--wa-color-neutral-fill-quiet);
   --vscode-badge-foreground: var(--wa-color-neutral-on-quiet);
-  --vscode-progressBar-background: var(--texra-progressBar-background);
+  --vscode-progressBar-background: var(--desktop-color-accent);
   --vscode-textBlockQuote-background: var(--wa-color-surface-lowered);
-  --vscode-textBlockQuote-border: var(--texra-textBlockQuote-border);
-  --vscode-textCodeBlock-background: var(--texra-textCodeBlock-background);
-  --vscode-textLink-activeForeground: var(--texra-textLink-activeForeground);
+  --vscode-textBlockQuote-border: var(--desktop-color-accent);
+  --vscode-textCodeBlock-background: var(--desktop-color-sidebar);
+  --vscode-textLink-activeForeground: var(--desktop-color-accent-hover);
   --vscode-textLink-foreground: var(--wa-color-text-link);
-  --vscode-textPreformat-foreground: var(--texra-textPreformat-foreground);
-  --vscode-terminal-background: var(--texra-terminal-background);
-  --vscode-terminal-foreground: var(--texra-terminal-foreground);
-  --vscode-terminal-selectionBackground: var(
-    --texra-terminal-selectionBackground
-  );
-  --vscode-terminalCursor-foreground: var(--texra-terminalCursor-foreground);
+  --vscode-textPreformat-foreground: var(--desktop-color-input-foreground);
+  --vscode-terminal-background: var(--desktop-color-background);
+  --vscode-terminal-foreground: var(--desktop-color-input-foreground);
+  --vscode-terminal-selectionBackground: var(--desktop-color-terminal-selection);
+  --vscode-terminalCursor-foreground: var(--desktop-color-input-foreground);
   --vscode-terminal-ansiBlack: var(--texra-terminal-ansiBlack);
-  --vscode-terminal-ansiBlue: var(--texra-terminal-ansiBlue);
+  --vscode-terminal-ansiBlue: var(--desktop-color-accent);
   --vscode-terminal-ansiBrightBlack: var(--texra-terminal-ansiBrightBlack);
   --vscode-terminal-ansiBrightBlue: var(--texra-terminal-ansiBrightBlue);
   --vscode-terminal-ansiBrightCyan: var(--texra-terminal-ansiBrightCyan);
-  --vscode-terminal-ansiBrightGreen: var(--texra-terminal-ansiBrightGreen);
+  --vscode-terminal-ansiBrightGreen: var(--desktop-color-success);
   --vscode-terminal-ansiBrightMagenta: var(--texra-terminal-ansiBrightMagenta);
-  --vscode-terminal-ansiBrightRed: var(--texra-terminal-ansiBrightRed);
+  --vscode-terminal-ansiBrightRed: var(--desktop-color-error);
   --vscode-terminal-ansiBrightWhite: var(--texra-terminal-ansiBrightWhite);
-  --vscode-terminal-ansiBrightYellow: var(--texra-terminal-ansiBrightYellow);
+  --vscode-terminal-ansiBrightYellow: var(--desktop-color-yellow);
   --vscode-terminal-ansiCyan: var(--texra-terminal-ansiCyan);
-  --vscode-terminal-ansiGreen: var(--texra-terminal-ansiGreen);
+  --vscode-terminal-ansiGreen: var(--desktop-color-success);
   --vscode-terminal-ansiMagenta: var(--texra-terminal-ansiMagenta);
-  --vscode-terminal-ansiRed: var(--texra-terminal-ansiRed);
+  --vscode-terminal-ansiRed: var(--desktop-color-error);
   --vscode-terminal-ansiWhite: var(--texra-terminal-ansiWhite);
-  --vscode-terminal-ansiYellow: var(--texra-terminal-ansiYellow);
+  --vscode-terminal-ansiYellow: var(--desktop-color-yellow);
   --vscode-testing-iconFailed: var(--wa-color-danger-fill-loud);
   --vscode-testing-iconPassed: var(--wa-color-success-fill-loud);
-  --vscode-charts-blue: var(--texra-charts-blue);
-  --vscode-charts-green: var(--texra-charts-green);
-  --vscode-charts-orange: var(--texra-charts-orange);
-  --vscode-charts-red: var(--texra-charts-red);
-  --vscode-charts-yellow: var(--texra-charts-yellow);
-  --vscode-scrollbar-shadow: var(--texra-scrollbar-shadow);
-  --vscode-scrollbarSlider-background: var(--texra-scrollbarSlider-background);
-  --vscode-scrollbarSlider-hoverBackground: var(
-    --texra-scrollbarSlider-hoverBackground
-  );
-  --vscode-scrollbarSlider-activeBackground: var(
-    --texra-scrollbarSlider-activeBackground
-  );
-  --vscode-activityBarBadge-background: var(
-    --texra-activityBarBadge-background
-  );
-  --vscode-notificationsInfoIcon-foreground: var(
-    --texra-notificationsInfoIcon-foreground
-  );
-  --vscode-statusBarItem-warningBackground: var(
-    --texra-statusBarItem-warningBackground
-  );
-  --vscode-symbolIcon-classForeground: var(--texra-symbolIcon-classForeground);
-  --vscode-symbolIcon-constantForeground: var(
-    --texra-symbolIcon-constantForeground
-  );
-  --vscode-symbolIcon-functionForeground: var(
-    --texra-symbolIcon-functionForeground
-  );
-  --vscode-symbolIcon-keywordForeground: var(
-    --texra-symbolIcon-keywordForeground
-  );
-  --vscode-symbolIcon-propertyForeground: var(
-    --texra-symbolIcon-propertyForeground
-  );
-  --vscode-symbolIcon-variableForeground: var(
-    --texra-symbolIcon-variableForeground
-  );
+  --vscode-charts-blue: var(--desktop-color-accent);
+  --vscode-charts-green: var(--desktop-color-success);
+  --vscode-charts-orange: var(--desktop-color-orange);
+  --vscode-charts-red: var(--desktop-color-error);
+  --vscode-charts-yellow: var(--desktop-color-yellow);
+  --vscode-scrollbar-shadow: var(--desktop-color-shadow);
+  --vscode-scrollbarSlider-background: var(--desktop-color-scrollbar);
+  --vscode-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
+  --vscode-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
+  --vscode-activityBarBadge-background: var(--desktop-color-accent);
+  --vscode-notificationsInfoIcon-foreground: var(--desktop-color-info);
+  --vscode-statusBarItem-warningBackground: var(--desktop-color-warning);
+  --vscode-symbolIcon-classForeground: var(--desktop-color-orange);
+  --vscode-symbolIcon-constantForeground: var(--desktop-color-accent);
+  --vscode-symbolIcon-functionForeground: var(--desktop-color-yellow);
+  --vscode-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
+  --vscode-symbolIcon-propertyForeground: var(--desktop-color-accent);
+  --vscode-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
 }

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -1,187 +1,231 @@
 /**
- * Document-level styles for TeXRA webviews.
- * These styles target elements outside Shadow DOM (body, document root).
+ * Document-level styles for TeXRA webviews (VS Code host).
  *
- * Theme tokens map the extension host's VS Code variables to TeXRA-owned
- * variables. Electron can provide the same --texra-* contract without VS Code.
+ * Web Awesome native theming: --wa-* tokens are the single source of truth and
+ * are sourced directly from the host's --vscode-* variables. The webview entry
+ * (index.ts under @shared/wa) imports the WA default theme stylesheet, and
+ * MainApp / SettingsApp / ProgressApp mirror the VS Code theme kind onto
+ * <html class="wa-light|wa-dark"> so WA's color-scheme classes activate.
+ *
+ * --texra-* tokens remain as a thin compatibility alias layer for tokens that
+ * have no clean WA equivalent (terminal ansi, symbol icons, charts, list rows,
+ * git decoration, etc.) and a few legacy aliases consumers still reference.
+ * They no longer round-trip through --wa-*.
  */
 
+:root,
+.wa-light,
+.wa-dark .wa-invert {
+  /* ── Web Awesome surface / text tokens (light + default) ────────────── */
+  --wa-color-text-normal: var(--vscode-editor-foreground, var(--vscode-foreground));
+  --wa-color-text-quiet: var(--vscode-descriptionForeground);
+  --wa-color-text-link: var(--vscode-textLink-foreground);
+
+  --wa-color-surface-default: var(--vscode-editor-background);
+  --wa-color-surface-raised: var(--vscode-editorWidget-background);
+  --wa-color-surface-lowered: var(--vscode-sideBar-background);
+  --wa-color-surface-border: var(--vscode-panel-border, var(--vscode-widget-border));
+
+  --wa-color-focus: var(--vscode-focusBorder);
+
+  /* WA form-control tokens — wired to VS Code input palette so wa-input,
+     wa-textarea, wa-select inherit the host theme's editor surface. */
+  --wa-form-control-background-color: var(--vscode-input-background);
+  --wa-form-control-text-color: var(--vscode-input-foreground);
+  --wa-form-control-border-color: var(--vscode-input-border);
+
+  /* Brand variant — primary buttons, links, focus accents. */
+  --wa-color-brand-fill-loud: var(--vscode-button-background);
+  --wa-color-brand-on-loud: var(--vscode-button-foreground);
+  --wa-color-brand-border-loud: var(--vscode-button-border, transparent);
+  --wa-color-brand-fill-quiet: var(--vscode-inputValidation-infoBackground);
+  --wa-color-brand-border-quiet: var(--vscode-inputValidation-infoBorder);
+  --wa-color-brand-on-quiet: var(--vscode-inputValidation-infoForeground);
+
+  /* Neutral variant — outlined wa-button / wa-callout, hovers. */
+  --wa-color-neutral-fill-quiet: var(--vscode-button-secondaryBackground);
+  --wa-color-neutral-border-quiet: var(--vscode-button-border, var(--vscode-widget-border));
+  --wa-color-neutral-on-quiet: var(--vscode-button-secondaryForeground);
+  --wa-color-neutral-fill-loud: var(--vscode-button-secondaryBackground);
+  --wa-color-neutral-border-loud: var(--vscode-button-border, var(--vscode-widget-border));
+  --wa-color-neutral-on-loud: var(--vscode-button-secondaryForeground);
+
+  /* Warning variant. */
+  --wa-color-warning-fill-loud: var(--vscode-statusBarItem-warningBackground);
+  --wa-color-warning-on-loud: var(--vscode-editor-foreground);
+  --wa-color-warning-border-loud: var(--vscode-inputValidation-warningBorder);
+  --wa-color-warning-fill-quiet: var(--vscode-editorWarning-background, var(--vscode-inputValidation-warningBackground));
+  --wa-color-warning-border-quiet: var(--vscode-inputValidation-warningBorder);
+  --wa-color-warning-on-quiet: var(--vscode-editorWarning-foreground, var(--vscode-inputValidation-warningForeground));
+
+  /* Danger variant. */
+  --wa-color-danger-fill-loud: var(--vscode-editorError-foreground);
+  --wa-color-danger-on-loud: #ffffff;
+  --wa-color-danger-border-loud: transparent;
+  --wa-color-danger-fill-quiet: var(--vscode-inputValidation-errorBackground);
+  --wa-color-danger-border-quiet: var(--vscode-inputValidation-errorBorder);
+  --wa-color-danger-on-quiet: var(--vscode-editorError-foreground, var(--vscode-errorForeground));
+
+  /* Success variant. */
+  --wa-color-success-fill-loud: var(--vscode-charts-green, var(--vscode-testing-iconPassed));
+  --wa-color-success-on-loud: #ffffff;
+  --wa-color-success-border-loud: transparent;
+  --wa-color-success-fill-quiet: var(--vscode-charts-green, var(--vscode-inputValidation-infoBackground));
+  --wa-color-success-border-quiet: var(--vscode-inputValidation-infoBorder);
+  --wa-color-success-on-quiet: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
+
+  /* Typography. */
+  --wa-font-family-body: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  --wa-font-family-heading: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  --wa-font-family-mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  --wa-font-size-m: var(--vscode-font-size, 13px);
+  --wa-font-weight-normal: var(--vscode-font-weight, 400);
+
+  /* Web Awesome canonical space scale. Mirrors the values from the WA default
+     theme so consumers can rely on --wa-space-* even if the WA color-scheme
+     class hasn't been mounted yet. */
+  --wa-space-scale: 1;
+  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem); /* 2px */
+  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem); /* 4px */
+  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem); /* 8px */
+  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem); /* 12px */
+  --wa-space-m: calc(var(--wa-space-scale) * 1rem); /* 16px */
+  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem); /* 24px */
+  --wa-space-xl: calc(var(--wa-space-scale) * 2rem); /* 32px */
+  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
+  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
+  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
+}
+
+/*
+ * --texra-* compatibility alias layer.
+ *
+ * These tokens fall into two buckets:
+ *   1. Niche VS Code tokens with no clean WA equivalent (terminal ansi, symbol
+ *      icons, charts, list rows, git decoration, debug tokens, diff editor).
+ *      They remain texra-prefixed and source --vscode-* directly.
+ *   2. Legacy aliases that map cleanly to a --wa-* token. New code should
+ *      prefer the --wa-* token; these aliases exist to keep ~120 consumer
+ *      files working without a churn-heavy single-PR migration.
+ */
 :root {
-  --texra-activityBarBadge-background: var(
-    --vscode-activityBarBadge-background
-  );
-  --texra-badge-background: var(--vscode-badge-background);
-  --texra-badge-foreground: var(--vscode-badge-foreground);
-  --texra-button-background: var(--vscode-button-background);
-  --texra-button-border: var(--vscode-button-border);
-  --texra-button-foreground: var(--vscode-button-foreground);
+  /* Bucket 2 — wa-aligned aliases (prefer --wa-* in new code). */
+  --texra-foreground: var(--wa-color-text-normal);
+  --texra-descriptionForeground: var(--wa-color-text-quiet);
+  --texra-icon-foreground: var(--wa-color-text-quiet);
+  --texra-editor-background: var(--wa-color-surface-default);
+  --texra-editor-foreground: var(--wa-color-text-normal);
+  --texra-editorWidget-background: var(--wa-color-surface-raised);
+  --texra-editorWidget-border: var(--wa-color-surface-border);
+  --texra-editorHoverWidget-background: var(--wa-color-surface-raised);
+  --texra-editorHoverWidget-border: var(--wa-color-surface-border);
+  --texra-editorHoverWidget-foreground: var(--wa-color-text-normal);
+  --texra-sideBar-background: var(--wa-color-surface-lowered);
+  --texra-sideBar-foreground: var(--wa-color-text-normal);
+  --texra-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
+  --texra-sideBarTitle-foreground: var(--wa-color-text-normal);
+  --texra-panel-border: var(--wa-color-surface-border);
+  --texra-panelSection-border: var(--wa-color-surface-border);
+  --texra-widget-border: var(--wa-color-surface-border);
+  --texra-textCodeBlock-background: var(--wa-color-surface-lowered);
+  --texra-textBlockQuote-background: var(--wa-color-surface-lowered);
+  --texra-textLink-foreground: var(--wa-color-text-link);
+  --texra-textLink-activeForeground: var(--vscode-textLink-activeForeground);
+  --texra-input-background: var(--wa-form-control-background-color);
+  --texra-input-foreground: var(--wa-form-control-text-color);
+  --texra-input-border: var(--wa-form-control-border-color);
+  --texra-input-placeholderForeground: var(--vscode-input-placeholderForeground);
+  --texra-dropdown-border: var(--wa-form-control-border-color);
+  --texra-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
+  --texra-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
   --texra-button-hoverBackground: var(--vscode-button-hoverBackground);
-  --texra-button-secondaryBackground: var(--vscode-button-secondaryBackground);
-  --texra-button-secondaryForeground: var(--vscode-button-secondaryForeground);
-  --texra-button-secondaryHoverBackground: var(
-    --vscode-button-secondaryHoverBackground
-  );
-  --texra-button-separator: var(--vscode-button-separator);
+  --texra-button-border: var(--vscode-button-border, transparent);
+  --texra-button-separator: var(--vscode-button-separator, rgb(255 255 255 / 40%));
+  --texra-errorForeground: var(--wa-color-danger-on-quiet);
+  --texra-editorError-foreground: var(--wa-color-danger-on-quiet);
+  --texra-editorWarning-foreground: var(--wa-color-warning-on-quiet);
+  --texra-editorWarning-background: var(--wa-color-warning-fill-quiet);
+  --texra-editorInfo-foreground: var(--wa-color-brand-on-quiet);
+  --texra-editorInfo-background: var(--wa-color-brand-fill-quiet);
+  --texra-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
+  --texra-inputValidation-errorBorder: var(--vscode-inputValidation-errorBorder);
+  --texra-inputValidation-errorForeground: var(--wa-color-danger-on-quiet);
+  --texra-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
+  --texra-inputValidation-infoBorder: var(--wa-color-brand-border-quiet);
+  --texra-inputValidation-infoForeground: var(--wa-color-brand-on-quiet);
+  --texra-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
+  --texra-inputValidation-warningBorder: var(--wa-color-warning-border-quiet);
+  --texra-inputValidation-warningForeground: var(--wa-color-warning-on-quiet);
+  --texra-progressBar-background: var(--vscode-progressBar-background);
+  --texra-statusBarItem-warningBackground: var(--vscode-statusBarItem-warningBackground);
+  --texra-notificationsInfoIcon-foreground: var(--vscode-notificationsInfoIcon-foreground);
+  --texra-activityBarBadge-background: var(--vscode-activityBarBadge-background);
+  --texra-badge-background: var(--vscode-badge-background);
+  --texra-toolbar-activeBackground: var(--vscode-toolbar-activeBackground);
+  --texra-toolbar-hoverBackground: var(--vscode-toolbar-hoverBackground);
+  --texra-widget-shadow: var(--vscode-widget-shadow);
+  --texra-contrastBorder: var(--vscode-contrastBorder);
+  --texra-focusBorder: var(--wa-color-focus);
+
+  /* Bucket 1 — niche VS Code tokens with no clean WA equivalent. */
+  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
+     equivalents. Keep these texra aliases until WA introduces semantic tokens
+     for tree/list rows (or until consumers move to wa-tree::part(item) styling
+     hooks); see #3690. */
+  --texra-list-activeSelectionBackground: var(--vscode-list-activeSelectionBackground);
+  --texra-list-activeSelectionForeground: var(--vscode-list-activeSelectionForeground);
+  --texra-list-hoverBackground: var(--vscode-list-hoverBackground);
+  --texra-list-warningForeground: var(--vscode-list-warningForeground);
+
+  --texra-menu-background: var(--vscode-menu-background);
+  --texra-menu-border: var(--vscode-menu-border);
+  --texra-menu-foreground: var(--vscode-menu-foreground);
+
+  /* Charts — no WA equivalent. Keep as native palette tokens. */
   --texra-charts-blue: var(--vscode-charts-blue);
   --texra-charts-green: var(--vscode-charts-green);
   --texra-charts-orange: var(--vscode-charts-orange);
   --texra-charts-red: var(--vscode-charts-red);
   --texra-charts-yellow: var(--vscode-charts-yellow);
-  --texra-contrastBorder: var(--vscode-contrastBorder);
-  --texra-debugTokenExpression-name: var(--vscode-debugTokenExpression-name);
-  --texra-debugTokenExpression-number: var(
-    --vscode-debugTokenExpression-number
-  );
-  --texra-debugTokenExpression-string: var(
-    --vscode-debugTokenExpression-string
-  );
-  --texra-descriptionForeground: var(--vscode-descriptionForeground);
-  --texra-diffEditor-insertedTextBackground: var(
-    --vscode-diffEditor-insertedTextBackground
-  );
-  --texra-diffEditor-removedTextBackground: var(
-    --vscode-diffEditor-removedTextBackground
-  );
-  --texra-dropdown-border: var(--vscode-dropdown-border);
-  --texra-editor-background: var(--vscode-editor-background);
-  --texra-editor-findMatchBackground: var(--vscode-editor-findMatchBackground);
-  --texra-editor-findMatchHighlightBackground: var(
-    --vscode-editor-findMatchHighlightBackground
-  );
-  --texra-editor-findMatchHighlightForeground: var(
-    --vscode-editor-findMatchHighlightForeground
-  );
-  --texra-editor-font-family: var(
-    --vscode-editor-font-family,
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace
-  );
+
+  /* Editor surface details — fine-grained tokens with no WA equivalent. */
+  --texra-editor-font-family: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
   --texra-editor-font-size: var(--vscode-editor-font-size, 13px);
-  --texra-editor-foreground: var(--vscode-editor-foreground);
-  --texra-editor-inactiveSelectionBackground: var(
-    --vscode-editor-inactiveSelectionBackground
-  );
-  --texra-editor-lineHighlightBackground: var(
-    --vscode-editor-lineHighlightBackground
-  );
+  --texra-editor-findMatchBackground: var(--vscode-editor-findMatchBackground);
+  --texra-editor-findMatchHighlightBackground: var(--vscode-editor-findMatchHighlightBackground);
+  --texra-editor-findMatchHighlightForeground: var(--vscode-editor-findMatchHighlightForeground);
+  --texra-editor-inactiveSelectionBackground: var(--vscode-editor-inactiveSelectionBackground);
+  --texra-editor-lineHighlightBackground: var(--vscode-editor-lineHighlightBackground);
   --texra-editor-selectionBackground: var(--vscode-editor-selectionBackground);
-  --texra-editorError-foreground: var(--vscode-editorError-foreground);
-  --texra-editorGroupHeader-tabsBackground: var(
-    --vscode-editorGroupHeader-tabsBackground
-  );
-  --texra-editorGroupHeader-tabsBorder: var(
-    --vscode-editorGroupHeader-tabsBorder
-  );
-  --texra-editorHoverWidget-background: var(
-    --vscode-editorHoverWidget-background
-  );
-  --texra-editorHoverWidget-border: var(--vscode-editorHoverWidget-border);
-  --texra-editorHoverWidget-foreground: var(
-    --vscode-editorHoverWidget-foreground
-  );
-  --texra-editorInfo-background: var(--vscode-editorInfo-background);
-  --texra-editorInfo-foreground: var(--vscode-editorInfo-foreground);
-  --texra-editorWarning-background: var(--vscode-editorWarning-background);
-  --texra-editorWarning-foreground: var(--vscode-editorWarning-foreground);
-  --texra-editorWidget-background: var(--vscode-editorWidget-background);
-  --texra-editorWidget-border: var(--vscode-editorWidget-border);
-  --texra-errorForeground: var(--vscode-errorForeground);
-  --texra-focusBorder: var(--vscode-focusBorder);
-  --texra-font-family: var(
-    --vscode-font-family,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif
-  );
-  --texra-font-size: var(--vscode-font-size, 13px);
-  --texra-font-weight: var(--vscode-font-weight, 400);
-  --texra-foreground: var(--vscode-foreground);
-  --texra-gitDecoration-addedResourceForeground: var(
-    --vscode-gitDecoration-addedResourceForeground
-  );
-  --texra-gitDecoration-deletedResourceForeground: var(
-    --vscode-gitDecoration-deletedResourceForeground
-  );
-  --texra-gitDecoration-modifiedResourceForeground: var(
-    --vscode-gitDecoration-modifiedResourceForeground
-  );
-  --texra-icon-foreground: var(--vscode-icon-foreground);
-  --texra-input-background: var(--vscode-input-background);
-  --texra-input-border: var(--vscode-input-border);
-  --texra-input-foreground: var(--vscode-input-foreground);
-  --texra-input-placeholderForeground: var(
-    --vscode-input-placeholderForeground
-  );
-  --texra-inputValidation-errorBackground: var(
-    --vscode-inputValidation-errorBackground
-  );
-  --texra-inputValidation-infoBackground: var(
-    --vscode-inputValidation-infoBackground
-  );
-  --texra-inputValidation-infoBorder: var(--vscode-inputValidation-infoBorder);
-  --texra-inputValidation-infoForeground: var(
-    --vscode-inputValidation-infoForeground
-  );
-  --texra-inputValidation-warningBackground: var(
-    --vscode-inputValidation-warningBackground
-  );
-  --texra-inputValidation-warningBorder: var(
-    --vscode-inputValidation-warningBorder
-  );
-  --texra-inputValidation-warningForeground: var(
-    --vscode-inputValidation-warningForeground
-  );
-  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
-     equivalents. Keep these texra aliases until WA introduces semantic tokens
-     for tree/list rows (or until consumers move to wa-tree::part(item) styling
-     hooks); see #3690. */
-  --texra-list-activeSelectionBackground: var(
-    --vscode-list-activeSelectionBackground
-  );
-  --texra-list-activeSelectionForeground: var(
-    --vscode-list-activeSelectionForeground
-  );
-  --texra-list-hoverBackground: var(--vscode-list-hoverBackground);
-  --texra-list-warningForeground: var(--vscode-list-warningForeground);
-  --texra-menu-background: var(--vscode-menu-background);
-  --texra-menu-border: var(--vscode-menu-border);
-  --texra-menu-foreground: var(--vscode-menu-foreground);
-  --texra-notificationsInfoIcon-foreground: var(
-    --vscode-notificationsInfoIcon-foreground
-  );
-  --texra-panel-border: var(--vscode-panel-border);
-  --texra-panelSection-border: var(--vscode-panelSection-border);
-  --texra-progressBar-background: var(--vscode-progressBar-background);
-  --texra-sideBar-background: var(--vscode-sideBar-background);
-  --texra-sideBar-foreground: var(--vscode-sideBar-foreground);
-  --texra-sideBarSectionHeader-background: var(
-    --vscode-sideBarSectionHeader-background
-  );
-  --texra-sideBarTitle-foreground: var(--vscode-sideBarTitle-foreground);
-  --texra-statusBarItem-warningBackground: var(
-    --vscode-statusBarItem-warningBackground
-  );
+  --texra-editorGroupHeader-tabsBackground: var(--vscode-editorGroupHeader-tabsBackground);
+  --texra-editorGroupHeader-tabsBorder: var(--vscode-editorGroupHeader-tabsBorder);
+  --texra-textBlockQuote-border: var(--vscode-textBlockQuote-border);
+  --texra-textPreformat-foreground: var(--vscode-textPreformat-foreground);
+
+  /* Diff editor — no WA equivalent. */
+  --texra-diffEditor-insertedTextBackground: var(--vscode-diffEditor-insertedTextBackground);
+  --texra-diffEditor-removedTextBackground: var(--vscode-diffEditor-removedTextBackground);
+
+  /* Git decoration — no WA equivalent. */
+  --texra-gitDecoration-addedResourceForeground: var(--vscode-gitDecoration-addedResourceForeground);
+  --texra-gitDecoration-deletedResourceForeground: var(--vscode-gitDecoration-deletedResourceForeground);
+  --texra-gitDecoration-modifiedResourceForeground: var(--vscode-gitDecoration-modifiedResourceForeground);
+
+  /* Debug token expressions — no WA equivalent. */
+  --texra-debugTokenExpression-name: var(--vscode-debugTokenExpression-name);
+  --texra-debugTokenExpression-number: var(--vscode-debugTokenExpression-number);
+  --texra-debugTokenExpression-string: var(--vscode-debugTokenExpression-string);
+
+  /* Symbol icons — no WA equivalent. */
   --texra-symbolIcon-classForeground: var(--vscode-symbolIcon-classForeground);
-  --texra-symbolIcon-constantForeground: var(
-    --vscode-symbolIcon-constantForeground
-  );
-  --texra-symbolIcon-functionForeground: var(
-    --vscode-symbolIcon-functionForeground
-  );
-  --texra-symbolIcon-keywordForeground: var(
-    --vscode-symbolIcon-keywordForeground
-  );
-  --texra-symbolIcon-propertyForeground: var(
-    --vscode-symbolIcon-propertyForeground
-  );
-  --texra-symbolIcon-variableForeground: var(
-    --vscode-symbolIcon-variableForeground
-  );
+  --texra-symbolIcon-constantForeground: var(--vscode-symbolIcon-constantForeground);
+  --texra-symbolIcon-functionForeground: var(--vscode-symbolIcon-functionForeground);
+  --texra-symbolIcon-keywordForeground: var(--vscode-symbolIcon-keywordForeground);
+  --texra-symbolIcon-propertyForeground: var(--vscode-symbolIcon-propertyForeground);
+  --texra-symbolIcon-variableForeground: var(--vscode-symbolIcon-variableForeground);
+
+  /* Terminal — no WA equivalent. */
   --texra-terminal-ansiBlack: var(--vscode-terminal-ansiBlack);
   --texra-terminal-ansiBlue: var(--vscode-terminal-ansiBlue);
   --texra-terminal-ansiBrightBlack: var(--vscode-terminal-ansiBrightBlack);
@@ -200,139 +244,25 @@
   --texra-terminal-ansiYellow: var(--vscode-terminal-ansiYellow);
   --texra-terminal-background: var(--vscode-terminal-background);
   --texra-terminal-foreground: var(--vscode-terminal-foreground);
-  --texra-terminal-selectionBackground: var(
-    --vscode-terminal-selectionBackground
-  );
+  --texra-terminal-selectionBackground: var(--vscode-terminal-selectionBackground);
   --texra-terminalCursor-foreground: var(--vscode-terminalCursor-foreground);
-  --texra-testing-iconFailed: var(--vscode-testing-iconFailed);
-  --texra-testing-iconPassed: var(--vscode-testing-iconPassed);
-  --texra-textBlockQuote-background: var(--vscode-textBlockQuote-background);
-  --texra-textBlockQuote-border: var(--vscode-textBlockQuote-border);
-  --texra-textCodeBlock-background: var(--vscode-textCodeBlock-background);
-  --texra-textLink-activeForeground: var(--vscode-textLink-activeForeground);
-  --texra-textLink-foreground: var(--vscode-textLink-foreground);
-  --texra-textPreformat-foreground: var(--vscode-textPreformat-foreground);
-  --texra-toolbar-activeBackground: var(--vscode-toolbar-activeBackground);
-  --texra-toolbar-hoverBackground: var(--vscode-toolbar-hoverBackground);
-  --texra-widget-border: var(--vscode-widget-border);
-  --texra-widget-shadow: var(--vscode-widget-shadow);
-}
 
-/*
- * Web Awesome design-token bridge.
- *
- * WA components read --wa-*. The host (VS Code webview) supplies --vscode-*,
- * which is normalized once into --texra-* above. This block keeps Web Awesome
- * dependent on that TeXRA token contract rather than reading host tokens
- * directly.
- */
-:root {
-  --wa-font-family-body: var(--texra-font-family);
-  --wa-font-family-heading: var(--texra-font-family);
-  --wa-font-family-mono: var(--vscode-editor-font-family, var(--wa-font-family-mono));
-  --wa-font-size-m: var(--texra-font-size);
-  --wa-font-weight-normal: var(--texra-font-weight);
+  /* Testing icon colors. */
+  --texra-testing-iconFailed: var(--vscode-testing-iconFailed, var(--wa-color-danger-fill-loud));
+  --texra-testing-iconPassed: var(--vscode-testing-iconPassed, var(--wa-color-success-fill-loud));
 
-  /* Web Awesome canonical space scale. Mirrors the values from
-     @awesome.me/webawesome/dist/styles/themes/default.css so that consumers
-     (and WA components) can rely on --wa-space-* without importing the full
-     default theme — the theme import would override our color bridge above. */
-  --wa-space-scale: 1;
-  --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem); /* 2px */
-  --wa-space-2xs: calc(var(--wa-space-scale) * 0.25rem); /* 4px */
-  --wa-space-xs: calc(var(--wa-space-scale) * 0.5rem); /* 8px */
-  --wa-space-s: calc(var(--wa-space-scale) * 0.75rem); /* 12px */
-  --wa-space-m: calc(var(--wa-space-scale) * 1rem); /* 16px */
-  --wa-space-l: calc(var(--wa-space-scale) * 1.5rem); /* 24px */
-  --wa-space-xl: calc(var(--wa-space-scale) * 2rem); /* 32px */
-  --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
-  --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
-  --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
-  --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
-
-  --wa-color-text-normal: var(--wa-color-text-normal);
-  --wa-color-text-quiet: var(--wa-color-text-quiet);
-  --wa-color-text-link: var(--wa-color-text-link);
-  --wa-color-surface-default: var(--wa-color-surface-default);
-  --wa-color-surface-raised: var(--texra-editorWidget-background);
-  --wa-color-surface-lowered: var(--wa-color-surface-lowered);
-  --wa-color-surface-border: var(--wa-color-surface-border);
-
-  --wa-color-focus: var(--wa-color-focus);
-
-  /* WA form-control tokens — wire to TeXRA input palette so wa-input,
-     wa-textarea, wa-select, etc. inherit the host theme's editor surface
-     rather than WA's default form-control colors. */
-  --wa-form-control-background-color: var(--wa-form-control-background-color);
-  --wa-form-control-text-color: var(--wa-form-control-text-color);
-  --wa-form-control-border-color: var(--wa-form-control-border-color);
-
-  --wa-color-brand-fill-loud: var(--wa-color-brand-fill-loud);
-  --wa-color-brand-on-loud: var(--wa-color-brand-on-loud);
-  --wa-color-brand-border-loud: var(--texra-button-border);
-
-  /* Neutral tokens for outlined wa-button / wa-callout variants. Wire to the
-     VS Code secondary-button palette so neutral surfaces blend with the host
-     theme rather than falling back to WA's default gray scale. */
-  --wa-color-neutral-fill-quiet: var(--texra-button-secondaryBackground);
-  --wa-color-neutral-border-quiet: var(--texra-button-border);
-  --wa-color-neutral-on-quiet: var(--texra-button-secondaryForeground);
-  --wa-color-neutral-fill-loud: var(--texra-button-secondaryBackground);
-  --wa-color-neutral-border-loud: var(--texra-button-border);
-  --wa-color-neutral-on-loud: var(--texra-button-secondaryForeground);
-
-  /* Variant tokens for wa-callout / wa-button — wire VS Code validation
-     palettes through the WA color stack so brand/warning/danger/success
-     callouts blend with the host theme rather than the WA defaults. */
-  --wa-color-brand-fill-quiet: var(--texra-inputValidation-infoBackground);
-  --wa-color-brand-border-quiet: var(--texra-inputValidation-infoBorder);
-  --wa-color-brand-on-quiet: var(--texra-inputValidation-infoForeground);
-
-  --wa-color-warning-fill-loud: var(--texra-statusBarItem-warningBackground);
-  --wa-color-warning-on-loud: var(--wa-color-text-normal);
-  --wa-color-warning-border-loud: var(--texra-inputValidation-warningBorder);
-  --wa-color-warning-fill-quiet: var(--texra-inputValidation-warningBackground);
-  --wa-color-warning-border-quiet: var(--texra-inputValidation-warningBorder);
-  --wa-color-warning-on-quiet: var(--texra-inputValidation-warningForeground);
-
-  --wa-color-danger-fill-quiet: var(--texra-inputValidation-errorBackground);
-  --wa-color-danger-border-quiet: var(--texra-inputValidation-errorBorder);
-  --wa-color-danger-on-quiet: var(--texra-inputValidation-errorForeground);
-  /* Foreground on a loud danger fill (high-contrast text on red).
-     Aligned with desktop bridge (themeTokens.css) for cross-host parity. */
-  --wa-color-danger-on-loud: #ffffff;
-
-  --wa-color-success-fill-loud: var(
-    --texra-charts-green,
-    var(--texra-inputValidation-infoBackground)
-  );
-  --wa-color-success-on-loud: #ffffff;
-  --wa-color-success-border-loud: transparent;
-  --wa-color-success-fill-quiet: var(
-    --texra-charts-green,
-    var(--texra-inputValidation-infoBackground)
-  );
-  --wa-color-success-border-quiet: var(--texra-inputValidation-infoBorder);
-  --wa-color-success-on-quiet: var(--wa-color-text-normal);
-
-  --wa-color-danger-fill-loud: var(--wa-color-danger-on-quiet);
-  --wa-color-danger-border-loud: transparent;
-
-  /* Font monospace bridge for code/terminal contexts. Maps VS Code editor
-     font to WA canonical monospace token. */
-  --wa-font-family-mono: var(--vscode-editor-font-family, var(--wa-font-family-mono));
-
-  /* Testing status color bridge. Wire green text for passed tests to WA success
-     semantic token so test icons inherit host theme status colors. */
-  --wa-color-success-on-quiet: var(--wa-color-success-on-quiet);
-  --wa-color-warning-fill-quiet: var(--texra-editorWarning-background);
+  /* Legacy alias kept for monospace consumers. */
+  --texra-font-family-monospace: var(--wa-font-family-mono);
+  --texra-font-family: var(--wa-font-family-body);
+  --texra-font-size: var(--wa-font-size-m);
+  --texra-font-weight: var(--wa-font-weight-normal);
 }
 
 body {
   margin: 0;
   padding: 20px;
-  font-family: var(--texra-font-family);
-  font-size: var(--texra-font-size);
+  font-family: var(--wa-font-family-body);
+  font-size: var(--wa-font-size-m);
   color: var(--wa-color-text-normal);
   background-color: var(--wa-color-surface-default);
   box-sizing: border-box;

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -34,9 +34,9 @@ function renderWelcomeHtml(): string {
   />
   <style>
     body {
-      font-family: var(--vscode-font-family);
-      font-size: var(--vscode-font-size);
-      color: var(--vscode-foreground);
+      font-family: var(--wa-font-family-body);
+      font-size: var(--wa-font-size-m);
+      color: var(--wa-color-text-normal);
       background: transparent;
       padding: 16px;
       line-height: 1.5;

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -205,7 +205,7 @@ export class ProgressApp extends ProgressAppBase {
           var(--wa-space-s, 16px);
         overflow: auto;
         font-family:
-          var(--texra-font-family, var(--vscode-font-family, system-ui)),
+          var(--wa-font-family-body, var(--wa-font-family-body, system-ui)),
           sans-serif;
       }
 
@@ -214,7 +214,7 @@ export class ProgressApp extends ProgressAppBase {
         width: min(720px, 100%);
         padding: var(--wa-space-l, 24px);
         border: var(--border-thin, 1px) solid
-          var(--color-border, var(--vscode-panel-border, #d0d7de));
+          var(--color-border, var(--wa-color-surface-border, #d0d7de));
         border-radius: var(--border-radius, 6px);
         background: var(--wa-color-surface-default, #fff);
       }

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -98,7 +98,7 @@ export class ContextManagement extends LitElement {
         word-break: break-word;
         border: var(--border-thin) solid var(--wa-color-surface-border);
         border-radius: var(--border-radius-small);
-        background: var(--texra-editorWidget-background);
+        background: var(--wa-color-surface-raised);
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -251,7 +251,7 @@ export class StreamTab extends LitElement {
         min-width: var(--height-control);
         height: var(--height-control);
         margin: 0;
-        color: var(--texra-icon-foreground, var(--wa-color-text-normal));
+        color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
         opacity: 0;
         transition:
           opacity 120ms ease,
@@ -357,7 +357,7 @@ export class StreamTab extends LitElement {
         border-radius: var(--border-radius-small);
         background-color: color-mix(
           in srgb,
-          var(--texra-icon-foreground, var(--wa-color-text-normal)) 10%,
+          var(--wa-color-text-quiet, var(--wa-color-text-normal)) 10%,
           transparent
         );
       }
@@ -383,7 +383,7 @@ export class StreamTab extends LitElement {
         border: none;
         background: none;
         cursor: pointer;
-        color: var(--texra-icon-foreground, var(--wa-color-text-normal));
+        color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
         opacity: 0.6;
         padding: 0;
       }

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -44,7 +44,7 @@ export class UsagePanel extends LitElement {
 
       .usage-summary-footer {
         border-top: var(--border-thin) solid var(--color-border);
-        background-color: var(--texra-sideBarSectionHeader-background);
+        background-color: var(--wa-color-surface-lowered);
         padding: var(--wa-space-2xs) var(--wa-space-xs);
         display: flex;
         justify-content: space-between;

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -133,7 +133,7 @@ export class UserMessage extends LitElement {
         overflow: auto;
         padding: var(--wa-space-2xs);
         background: var(
-          --texra-textCodeBlock-background,
+          --wa-color-surface-lowered,
           var(--wa-color-surface-default)
         );
         border-radius: var(--border-radius-small);

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -309,8 +309,8 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-action-btn--danger::part(base) {
-        color: var(--texra-errorForeground, #f44);
-        border-color: var(--texra-errorForeground, #f44);
+        color: var(--wa-color-danger-on-quiet, #f44);
+        border-color: var(--wa-color-danger-on-quiet, #f44);
       }
 
       .agent-action-btn--danger:hover::part(base) {
@@ -318,7 +318,7 @@ export class AgentSelectionPanel extends LitElement {
           --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.1)
         );
-        border-color: var(--texra-errorForeground, #f44);
+        border-color: var(--wa-color-danger-on-quiet, #f44);
       }
 
       .agent-delete-confirm {
@@ -330,7 +330,7 @@ export class AgentSelectionPanel extends LitElement {
           --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.05)
         );
-        border: var(--border-thin) solid var(--texra-errorForeground, #f44);
+        border: var(--border-thin) solid var(--wa-color-danger-on-quiet, #f44);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -61,7 +61,7 @@ export class ProviderKeyModal extends LitElement {
       .provider-key-error {
         min-height: 1.4em;
         margin: var(--wa-space-2xs) 0 0;
-        color: var(--texra-errorForeground, var(--color-error));
+        color: var(--wa-color-danger-on-quiet, var(--color-error));
         font-size: var(--font-size-sm);
       }
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -109,7 +109,7 @@ export class ToolCard extends LitElement {
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-xs);
         background: var(
-          --texra-textCodeBlock-background,
+          --wa-color-surface-lowered,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius);

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -114,7 +114,7 @@ export class AgentsTab extends LitElement {
         margin-bottom: var(--wa-space-xs);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
-        background: var(--texra-sideBar-background, rgba(128, 128, 128, 0.04));
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.04));
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
       }

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -276,7 +276,7 @@ export class LaTeXTab extends LitElement {
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-xs);
         background: var(
-          --texra-textCodeBlock-background,
+          --wa-color-surface-lowered,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius);
@@ -304,7 +304,7 @@ export class LaTeXTab extends LitElement {
         min-width: 0;
         padding: var(--wa-space-2xs) var(--wa-space-xs);
         background: var(
-          --texra-textCodeBlock-background,
+          --wa-color-surface-lowered,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius-small);

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -151,7 +151,7 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__track {
         fill: none;
-        stroke: var(--texra-editorWidget-border, rgba(128, 128, 128, 0.25));
+        stroke: var(--wa-color-surface-border, rgba(128, 128, 128, 0.25));
         stroke-width: 4;
       }
 
@@ -259,7 +259,7 @@ export class ToolsTab extends LitElement {
         margin-bottom: var(--wa-space-2xs);
         border-radius: var(--border-radius);
         background: var(
-          --texra-textCodeBlock-background,
+          --wa-color-surface-lowered,
           rgba(128, 128, 128, 0.08)
         );
       }

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -53,7 +53,7 @@ export class LatexDiffsSection extends LitElement {
       .latexdiffs-section[data-expanded='true'] {
         background-color: var(--background-color);
         border: var(--border-thin) solid
-          var(--texra-widget-border, var(--dropdown-border));
+          var(--wa-color-surface-border, var(--dropdown-border));
         border-radius: var(--border-radius);
         padding: var(--wa-space-xs);
         overflow: visible;

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -187,7 +187,7 @@ export const multiFilesStyles = css`
   .multiple-files-list {
     background-color: var(--background-color);
     border: var(--border-thin) solid
-      var(--texra-widget-border, var(--dropdown-border));
+      var(--wa-color-surface-border, var(--dropdown-border));
     border-radius: var(--border-radius);
     padding: var(--wa-space-2xs);
     font-size: var(--font-size);

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -65,10 +65,24 @@ export abstract class BaseWebviewApp<TMessage = any> extends LitElement {
 
   /**
    * Handle theme updates from the extension host.
+   *
+   * Mirrors the theme kind onto `<html>` as `wa-light` / `wa-dark` so Web
+   * Awesome's color-scheme classes activate (per WA's native theming model).
+   * Also keeps the legacy `body.<theme>` class for downstream rules.
    */
   protected onThemeChange(theme: string): void {
     this.theme = theme;
     document.body.className = theme;
+    const root = document.documentElement;
+    root.classList.remove('wa-light', 'wa-dark');
+    // 'high-contrast' renders against the active OS color-scheme — pick dark
+    // unless the body class explicitly signals light HC.
+    const wantsDark =
+      theme === 'dark' ||
+      theme === 'high-contrast' ||
+      document.body.classList.contains('vscode-dark') ||
+      document.body.classList.contains('vscode-high-contrast');
+    root.classList.add(wantsDark ? 'wa-dark' : 'wa-light');
   }
 
   /**

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -6,14 +6,14 @@ const TOOLTIP_SHOW_DELAY_MS = 500;
 const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
   padding: 'var(--wa-space-2xs, 4px) var(--wa-space-xs, 8px)',
-  fontSize: 'var(--texra-font-size, 13px)',
-  fontFamily: 'var(--texra-font-family, system-ui), system-ui',
+  fontSize: 'var(--wa-font-size-m, 13px)',
+  fontFamily: 'var(--wa-font-family-body, system-ui), system-ui',
   color:
     'var(--texra-editorHoverWidget-foreground, var(--wa-color-text-normal))',
   background:
-    'var(--texra-editorHoverWidget-background, var(--wa-color-surface-default))',
+    'var(--wa-color-surface-raised, var(--wa-color-surface-default))',
   border:
-    '1px solid var(--texra-editorHoverWidget-border, var(--texra-contrastBorder, transparent))',
+    '1px solid var(--wa-color-surface-border, var(--texra-contrastBorder, transparent))',
   borderRadius: 'var(--border-radius, 3px)',
   whiteSpace: 'nowrap',
   pointerEvents: 'none',

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -35,7 +35,7 @@ export const categoryBadgeStyles: CSSResult = css`
       --texra-editorInfo-background,
       rgba(0, 127, 212, 0.15)
     );
-    color: var(--texra-editorInfo-foreground, #3794ff);
+    color: var(--wa-color-brand-on-quiet, #3794ff);
   }
 
   .category-tool-use,

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -24,7 +24,7 @@ export const compactIconActionButtonStyles: CSSResult = css`
     background: transparent;
     color: var(
       --wa-color-text-quiet,
-      var(--texra-icon-foreground, var(--wa-color-text-normal))
+      var(--wa-color-text-quiet, var(--wa-color-text-normal))
     );
     opacity: var(--opacity-subtle);
     transition: opacity 120ms ease;
@@ -68,7 +68,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .list-item {
-    border: var(--border-thin) solid var(--texra-panelSection-border);
+    border: var(--border-thin) solid var(--wa-color-surface-border);
     border-radius: var(--border-radius-large);
     padding: var(--wa-space-xs);
     background-color: var(--wa-color-surface-default);
@@ -131,7 +131,7 @@ export const commonViewStyles: CSSResult = css`
 
   .panel-collapsible::part(header) {
     padding: var(--wa-space-2xs) var(--wa-space-xs);
-    background-color: var(--texra-sideBarSectionHeader-background, transparent);
+    background-color: var(--wa-color-surface-lowered, transparent);
     color: var(--texra-sideBarTitle-foreground, var(--wa-color-text-normal));
   }
 

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -118,7 +118,7 @@ export const historyListStyles: CSSResult = css`
 
   .config-key {
     font-weight: var(--font-weight-medium);
-    color: var(--texra-editorInfo-foreground);
+    color: var(--wa-color-brand-on-quiet);
     min-width: calc(
       var(--width-button-min) + var(--wa-space-l) + var(--wa-space-l)
     );

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -15,7 +15,7 @@ export const designTokens: CSSResult = css`
 
     /* Status colors */
     --color-success: var(--wa-color-success-on-quiet, #2ea043);
-    --color-error: var(--texra-editorError-foreground, #f14c4c);
+    --color-error: var(--wa-color-danger-on-quiet, #f14c4c);
     --color-warning: var(--wa-color-warning-on-quiet, #cca700);
     --color-info: var(--texra-charts-blue, #3794ff);
     --color-added: var(--texra-charts-green, #4caf50);
@@ -25,12 +25,12 @@ export const designTokens: CSSResult = css`
     --background-color: var(--color-bg-secondary);
     --text-color: var(--texra-sideBar-foreground);
     --button-hover-background: var(--texra-button-hoverBackground);
-    --dropdown-border: var(--wa-color-surface-border);
+    --dropdown-border: var(--wa-form-control-border-color);
 
     /* Typography */
-    --font-size: var(--texra-font-size);
-    --font-family: var(--texra-font-family);
-    --font-weight: var(--texra-font-weight);
+    --font-size: var(--wa-font-size-m);
+    --font-family: var(--wa-font-family-body);
+    --font-weight: var(--wa-font-weight-normal);
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -92,7 +92,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content code {
-    background-color: var(--texra-textCodeBlock-background);
+    background-color: var(--wa-color-surface-lowered);
     padding: var(--wa-space-3xs) var(--wa-space-2xs);
     border-radius: var(--border-radius);
     font-family: var(--font-family);
@@ -103,7 +103,7 @@ export const markdownStyles = css`
     padding: var(--wa-space-xs) var(--wa-space-s);
     margin: 0.5em 0;
     border-radius: var(--border-radius);
-    background-color: var(--texra-textCodeBlock-background);
+    background-color: var(--wa-color-surface-lowered);
     border-left: var(--wa-space-3xs) solid
       var(--texra-activityBarBadge-background);
     overflow-x: auto;
@@ -177,7 +177,7 @@ export const markdownStyles = css`
 
   .markdown-content em strong,
   .markdown-content strong em {
-    color: var(--texra-editorInfo-foreground);
+    color: var(--wa-color-brand-on-quiet);
   }
 
   .banner-content--scratchpad p:has(strong:first-child) {

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -50,7 +50,7 @@ export const permissionCardStyles: CSSResult = css`
   .code-block {
     display: block;
     padding: var(--wa-space-xs);
-    background: var(--texra-textCodeBlock-background);
+    background: var(--wa-color-surface-lowered);
     border-radius: var(--border-radius);
     color: var(--texra-terminal-foreground);
     font-family: var(--wa-font-family-mono);

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -94,8 +94,8 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     border-radius: var(--border-radius);
-    border: var(--border-thin) solid var(--texra-editorHoverWidget-border);
-    background: var(--texra-editorHoverWidget-background);
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    background: var(--wa-color-surface-raised);
     padding: ${sp.medium};
     gap: ${sp.medium};
     position: relative;
@@ -352,7 +352,7 @@ export const requestPanelStyles: CSSResult = css`
   .retry-request__error-body {
     margin-top: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-xs);
@@ -628,7 +628,7 @@ export const requestPanelStyles: CSSResult = css`
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-quiet);
     padding: ${sp.small} ${sp.medium};
-    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     border-left: var(--border-thick) solid
       var(--texra-textBlockQuote-border, var(--wa-color-focus));
@@ -636,8 +636,8 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__question {
-    background: var(--texra-textCodeBlock-background, rgba(0, 0, 0, 0.05));
-    border: var(--border-thin) solid var(--texra-editorHoverWidget-border);
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.05));
+    border: var(--border-thin) solid var(--wa-color-surface-border);
     border-radius: var(--border-radius);
     padding: ${sp.medium};
     position: relative;
@@ -659,7 +659,7 @@ export const requestPanelStyles: CSSResult = css`
     justify-content: flex-end;
     margin-top: ${sp.small};
     padding-top: ${sp.small};
-    border-top: var(--border-thin) solid var(--texra-editorHoverWidget-border);
+    border-top: var(--border-thin) solid var(--wa-color-surface-border);
   }
 
   .external-inquiry-request__search-hint {
@@ -667,7 +667,7 @@ export const requestPanelStyles: CSSResult = css`
     align-items: center;
     gap: ${sp.small};
     font-size: var(--font-size-sm);
-    color: var(--texra-editorInfo-foreground, var(--wa-color-focus));
+    color: var(--wa-color-brand-on-quiet, var(--wa-color-focus));
     padding: ${sp.small} 0;
   }
 
@@ -691,7 +691,7 @@ export const requestPanelStyles: CSSResult = css`
     flex-direction: column;
     gap: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
 
@@ -734,7 +734,7 @@ export const requestPanelStyles: CSSResult = css`
     flex-direction: column;
     gap: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
 

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -84,7 +84,7 @@ export const selectStyles: CSSResult = css`
   }
 
   wa-option {
-    font-family: var(--texra-font-family);
+    font-family: var(--wa-font-family-body);
   }
 
   wa-option[disabled],

--- a/src/shared/wa/index.ts
+++ b/src/shared/wa/index.ts
@@ -14,7 +14,9 @@
 import '@awesome.me/webawesome/dist/styles/themes/default.css';
 
 import { registerTeXRAWebAwesomeIcons } from './webAwesomeIcons';
+import { applyInitialWaColorScheme } from './waColorScheme';
 
 registerTeXRAWebAwesomeIcons();
+applyInitialWaColorScheme();
 
 export { TEXRA_ICON_LIBRARY } from './webAwesomeIcons';

--- a/src/shared/wa/waColorScheme.ts
+++ b/src/shared/wa/waColorScheme.ts
@@ -1,0 +1,84 @@
+/**
+ * Apply Web Awesome's native color-scheme classes (wa-light / wa-dark) onto
+ * the document root, mirroring the host theme.
+ *
+ * Detection sources (in priority order):
+ *   1. VS Code injects <body data-vscode-theme-kind="vscode-dark|vscode-light|
+ *      vscode-high-contrast"> and adds vscode-* classes to <body>. We watch
+ *      both attribute and class changes via MutationObserver.
+ *   2. Desktop renderer (Electron) calls applyDesktopTheme() which also adds a
+ *      vscode-<kind> class to <body>; the same observer picks that up.
+ *   3. Fallback: prefers-color-scheme media query.
+ *
+ * The observer also keeps the html class in sync if the host swaps themes
+ * mid-session (e.g. user toggles VS Code light/dark).
+ */
+
+let observer: MutationObserver | null = null;
+
+function isDarkTheme(): boolean {
+  const body = document.body;
+  if (!body) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  if (
+    body.classList.contains('vscode-dark') ||
+    body.classList.contains('vscode-high-contrast') ||
+    body.classList.contains('texra-dark') ||
+    body.classList.contains('texra-high-contrast')
+  ) {
+    return true;
+  }
+  if (
+    body.classList.contains('vscode-light') ||
+    body.classList.contains('vscode-high-contrast-light') ||
+    body.classList.contains('texra-light')
+  ) {
+    return false;
+  }
+  const kind = body.dataset.vscodeThemeKind;
+  if (kind) {
+    return kind === 'vscode-dark' || kind === 'vscode-high-contrast' || kind === 'dark' || kind === 'high-contrast';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function syncWaClass(): void {
+  const root = document.documentElement;
+  const dark = isDarkTheme();
+  // Only mutate when needed to avoid layout thrash when other observers run.
+  if (dark && !root.classList.contains('wa-dark')) {
+    root.classList.remove('wa-light');
+    root.classList.add('wa-dark');
+  } else if (!dark && !root.classList.contains('wa-light')) {
+    root.classList.remove('wa-dark');
+    root.classList.add('wa-light');
+  }
+}
+
+export function applyInitialWaColorScheme(): void {
+  if (typeof document === 'undefined') return;
+  syncWaClass();
+  if (observer) return;
+  observer = new MutationObserver(syncWaClass);
+  // Body may not exist yet if this module loads before <body> parses.
+  const start = (): void => {
+    if (!document.body) {
+      requestAnimationFrame(start);
+      return;
+    }
+    syncWaClass();
+    observer?.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'data-vscode-theme-kind'],
+    });
+  };
+  start();
+  // Also react to OS-level dark-mode changes when the host hasn't set a class.
+  if (window.matchMedia) {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', syncWaClass);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Retire the legacy `--vscode-*` → `--texra-*` → `--wa-*` double-bridge in favor of Web Awesome's native theming model. `--wa-*` tokens are now the single source of truth, defined directly from `--vscode-*` (extension) or `--desktop-color-*` (desktop), scoped under `:root, .wa-light, .wa-dark .wa-invert` per WA's docs. WA's `wa-light` / `wa-dark` classes are applied to `<html>` so the framework's color-scheme token overrides activate.

## What changed

- **Bridge files simplified**: `894 → 777` lines (-117). `--wa-*` is now wired directly from VS Code / native colors. The `--texra-*` round-trip is gone.
- **Document-root WA classes**: `wa-light` / `wa-dark` applied to `<html>`.
  - **Extension**: `BaseWebviewApp.onThemeChange` mirrors VS Code theme kind. `applyInitialWaColorScheme()` (new helper, ~80 lines) runs at WA module load and uses `MutationObserver` on `body[data-vscode-theme-kind]` + `body.class` to track host theme swaps. Falls back to `prefers-color-scheme`.
  - **Desktop**: `applyDesktopTheme()` toggles `wa-light` / `wa-dark` alongside the existing `vscode-*` body classes.
- **Consumer migration**: 28 source files migrated from `--texra-*` and `--vscode-*` to `--wa-*` for tokens with clean equivalents (text, surface, link, form-control, button-secondary, danger/warning/info foregrounds, font tokens).
- **`--texra-*` kept as a thin compat layer** for niche tokens with no clean WA equivalent (~57 unique tokens still used: terminal ansi, symbol icons, charts, list rows, git decoration, debug tokens, diff editor). Wa-aligned aliases like `--texra-foreground` → `--wa-color-text-normal` retained for backward compat in remaining consumer files.

## Counts

| Metric | Before | After |
|---|---|---|
| Bridge file lines (combined) | 894 | 777 |
| Unique `--texra-*` tokens used in consumers | 122 | 57 |
| `var(--texra-*)` total references in consumers | 222 | 121 |
| `var(--vscode-*)` references in consumers | 91 | 0 |

## Decisions

- **Compat layer kept**: A full `--texra-*` removal would require migrating ~120 references across files using tokens like `--texra-terminal-ansiBlack`, `--texra-symbolIcon-classForeground`, etc. that have no WA equivalent. Per the task's allowance, kept a thin alias layer that no longer round-trips through `--wa-*`.
- **Niche tokens stay `--texra-*`**: Tree/list rows (#3690), terminal ansi colors, charts, symbol icons, git decoration, diff editor, debug tokens — sourced directly from `--vscode-*` / `--desktop-color-*` in the bridge, no `--wa-*` pass-through.
- **Charts not re-namespaced**: The task suggested `--wa-color-data-blue` for charts. Left them as `--texra-charts-*` for this PR to avoid double-renaming (chart consumers can move to a future `--wa-color-data-*` palette in a follow-up).
- **`--vscode-*` re-export block (desktop)** kept intact for the desktop renderer to satisfy reused VS Code-styled CSS that imports `--vscode-*` directly. Internally re-routed to `--wa-*` / `--desktop-color-*` instead of the old `--texra-*`.

## Files

- Bridge: `packages/extension/src/common/styles/common.css`, `packages/desktop/src/renderer/themeTokens.css`
- Theme class wiring: `src/shared/BaseWebviewApp.ts`, `src/shared/wa/index.ts`, `src/shared/wa/waColorScheme.ts` (new), `packages/desktop/src/renderer/main.ts`
- 28 consumer files migrated to `--wa-*` tokens (styles + components across webview/progressView/settingsView/desktop)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vite build` (desktop, dev mode) — clean
- [x] `npm run compile:fast` (extension webview + extension host) — clean
- [ ] Visual smoke: VS Code light + dark + high-contrast themes
- [ ] Visual smoke: Desktop light + dark
- [ ] Confirm `wa-light` / `wa-dark` classes appear on `<html>` after webview load

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the theming/token source-of-truth across both the VS Code webview and Electron desktop renderer, which can cause widespread visual regressions (especially in high-contrast and legacy `--texra-*` consumers). No auth/data-path changes.
> 
> **Overview**
> **Moves to Web Awesome native theming across hosts.** The desktop renderer and VS Code webviews now apply `wa-light`/`wa-dark` on `<html>` (desktop via `applyDesktopTheme()`, webviews via `BaseWebviewApp.onThemeChange` plus a new `applyInitialWaColorScheme()` bootstrap with a `MutationObserver` fallback).
> 
> **Makes `--wa-*` the single source of truth.** Token bridges are rewritten so `--wa-*` is derived directly from host palettes (`--desktop-color-*` on desktop, `--vscode-*` in webviews), with a slimmer `--texra-*` alias layer retained only for legacy/niche tokens (terminal, symbol icons, charts, list/menu/scrollbar, etc.).
> 
> **Updates consumers to prefer `--wa-*`.** A broad set of styles/components switch font/surface/border/status colors from `--texra-*`/`--vscode-*` to `--wa-*` (including desktop base styles, tooltip/badge/common view styles, and multiple settings/progress/webview components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a45ecb44481b16ed87130849635c6427b01e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->