### PR TITLE
fix(wa): VS Code-compact dropdown items

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -506,3 +506,12 @@ body.texra-high-contrast {
   --vscode-symbolIcon-propertyForeground: var(--desktop-color-accent);
   --vscode-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
 }
+
+/* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes
+   each option ~32px tall; VS Code menus run ~22-24px. */
+wa-option::part(base),
+wa-dropdown-item::part(base) {
+  padding: var(--wa-space-3xs) var(--wa-space-xs);
+  min-height: 0;
+  line-height: var(--wa-line-height-condensed);
+}

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -267,3 +267,12 @@ body {
   background-color: var(--wa-color-surface-default);
   box-sizing: border-box;
 }
+
+/* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes
+   each option ~32px tall; VS Code menus run ~22-24px. */
+wa-option::part(base),
+wa-dropdown-item::part(base) {
+  padding: var(--wa-space-3xs) var(--wa-space-xs);
+  min-height: 0;
+  line-height: var(--wa-line-height-condensed);
+}


### PR DESCRIPTION
## Summary
WA defaults to ~0.5em block padding on \`wa-option\` and \`wa-dropdown-item\`, making each menu line ~32px tall. VS Code menus run ~22-24px. Override \`::part(base)\` padding + \`min-height: 0\` + \`line-height: condensed\` in both bridge files (\`packages/extension/src/common/styles/common.css\` and \`packages/desktop/src/renderer/themeTokens.css\`).

## Test plan
- [ ] Open any \`wa-select\` (e.g. agent picker, mode picker) and verify menu rows are ~22-24px tall
- [ ] Open any \`wa-dropdown\` (e.g. file-select tool config menu) — same density

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that reduces padding/line-height for `wa-option`/`wa-dropdown-item` across both desktop and extension; main risk is unintended visual/layout impact in dropdown menus.
> 
> **Overview**
> Makes Web Awesome dropdown/select menus match VS Code’s denser menu height by overriding `wa-option::part(base)` and `wa-dropdown-item::part(base)` styling.
> 
> Applies the same compact padding, `min-height: 0`, and condensed line-height overrides in both the desktop theme bridge (`themeTokens.css`) and the extension webview bridge (`common.css`) so the two hosts render consistent dropdown row density.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228f851e7b99f259cfcde714f5e0203242e53d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->