### PR TITLE
refactor(progress): StreamTabs WA-native cleanup + declarative pass

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -300,13 +300,12 @@ export class StreamTab extends LitElement {
           );
       }
 
-      .tab-container.is-active *,
-      .tab-container.is-active .tab,
-      .tab-container.is-active .tab-title,
-      .tab-container.is-active .tab-meta,
-      .tab-container.is-active .tab-description,
-      .tab-container.is-active .tab-delete,
-      .tab-container.is-active .tab-expand {
+      /*
+       * Single descendant rule covers .tab, .tab-title, .tab-meta,
+       * .tab-description, .tab-delete, .tab-expand, and any nested spans
+       * (.last-active, .model) and codicon glyphs.
+       */
+      .tab-container.is-active * {
         color: var(
           --texra-list-activeSelectionForeground,
           var(--wa-color-text-normal)
@@ -319,8 +318,8 @@ export class StreamTab extends LitElement {
        * the selection foreground.
        */
       .tab-container.is-active .tab-delete:hover,
-      .tab-container.is-active .tab-delete:focus-within,
       .tab-container.is-active .tab-delete:hover *,
+      .tab-container.is-active .tab-delete:focus-within,
       .tab-container.is-active .tab-delete:focus-within * {
         color: var(--wa-color-danger-on-quiet);
       }
@@ -448,7 +447,6 @@ export class StreamTab extends LitElement {
       <div
         class=${classMap({
           'tab-container': true,
-          'stream-tab': true,
           'is-active': this.active,
           'is-compact': this.compact,
           'has-children': hasChildren,

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -5,6 +5,8 @@
 
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/tab/tab.js';
+import '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';
 import {
   LitElement,
   html,
@@ -16,16 +18,23 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { commonViewStyles, designTokens } from '@shared/styles';
+import {
+  commonViewStyles,
+  designTokens,
+  waTabThemeTokenStyles,
+} from '@shared/styles';
 
 // Local imports - shared schemas
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
+import type { WaTabShowEvent } from '@shared/wa/tabs';
 import { AgentSelectionEvents } from '../components/profile/events';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/AgentSelectionPanel';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
+const AGENT_SUB_TAB_PANELS = ['workflow', 'toolUse'] as const satisfies readonly AgentCategory[];
 
 @customElement('agents-tab')
 export class AgentsTab extends LitElement {
@@ -47,42 +56,29 @@ export class AgentsTab extends LitElement {
         margin-bottom: var(--wa-space-xs);
       }
 
-      .agents-sub-tabs {
-        display: flex;
-        gap: 0;
-        border-bottom: var(--border-thin) solid var(--color-border);
+      /*
+       * Sub-tabs use the native wa-tab-group; we hide the body part since
+       * the tab content (agent-selection-panel) is rendered separately
+       * below, driven by the activeSubTab state.
+       */
+      wa-tab-group.agents-sub-tabs {
+        ${waTabThemeTokenStyles}
       }
 
-      .agents-sub-tab {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding: var(--wa-space-xs) var(--wa-space-s);
+      wa-tab-group.agents-sub-tabs::part(body) {
+        display: none;
+      }
+
+      wa-tab-group.agents-sub-tabs wa-tab {
         font-size: var(--font-size-sm);
-        font-family: inherit;
-        color: var(--color-text-secondary);
-        background: none;
-        border: none;
-        border-bottom: var(--border-medium) solid transparent;
-        cursor: pointer;
-        transition:
-          color var(--transition-fast),
-          border-color var(--transition-fast);
       }
 
-      .agents-sub-tab:hover {
-        color: var(--wa-color-text-normal);
+      wa-tab-group.agents-sub-tabs wa-tab::part(base) {
+        padding-block: var(--wa-space-xs);
+        padding-inline: var(--wa-space-s);
       }
 
-      .agents-sub-tab:focus-visible {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: 1px;
-        border-radius: var(--border-radius-small);
-      }
-
-      .agents-sub-tab.active {
-        color: var(--wa-color-text-normal);
-        border-bottom-color: var(--wa-color-focus);
+      wa-tab-group.agents-sub-tabs wa-tab[active]::part(base) {
         font-weight: var(--font-weight-medium);
       }
 
@@ -223,6 +219,13 @@ export class AgentsTab extends LitElement {
     this.dispatchEvent(AgentSelectionEvents.saveTeam());
   }
 
+  private handleSubTabShow = (event: WaTabShowEvent): void => {
+    const next = event.detail.name;
+    if ((AGENT_SUB_TAB_PANELS as readonly string[]).includes(next)) {
+      this.activeSubTab = next as AgentCategory;
+    }
+  };
+
   override render(): TemplateResult {
     const activeAgents =
       this.activeSubTab === 'workflow'
@@ -233,32 +236,26 @@ export class AgentsTab extends LitElement {
       <div class="agents-container tab-content-container">
         <!-- Row 1: Sub-tabs + New Agent -->
         <div class="agents-header">
-          <div class="agents-sub-tabs">
-            <button
-              class="agents-sub-tab ${this.activeSubTab === 'workflow'
-                ? 'active'
-                : ''}"
-              @click=${() => (this.activeSubTab = 'workflow')}
-            >
+          <wa-tab-group
+            class="agents-sub-tabs"
+            .active=${this.activeSubTab}
+            @wa-tab-show=${this.handleSubTabShow}
+          >
+            <wa-tab panel="workflow">
               <wa-icon library="texra" name="symbol-method"></wa-icon>
               Workflow
               <span class="agents-sub-tab-count"
                 >(${this.workflowAgents.length})</span
               >
-            </button>
-            <button
-              class="agents-sub-tab ${this.activeSubTab === 'toolUse'
-                ? 'active'
-                : ''}"
-              @click=${() => (this.activeSubTab = 'toolUse')}
-            >
+            </wa-tab>
+            <wa-tab panel="toolUse">
               <wa-icon library="texra" name="tools"></wa-icon>
               Tool Use
               <span class="agents-sub-tab-count"
                 >(${this.toolUseAgents.length})</span
               >
-            </button>
-          </div>
+            </wa-tab>
+          </wa-tab-group>
           <div class="agents-header-actions">
             <button
               class="tab-action-btn"


### PR DESCRIPTION
## Summary

Audited `StreamTabs.ts` per the WA-native migration request and **chose not to migrate it** to `wa-tab-group`. Concrete reasons:

- StreamTabs renders a **vertical multi-line stream-row list**, not a horizontal tab strip with panels. wa-tab-group's whole job is the horizontal nav-with-associated-panel pattern; forcing a vertical list of rich rows (header + description + meta line + status indicator + hover-only delete + child-stream nesting + container-query-driven density) into it would require fighting its internal flex layout, hiding most parts, and overriding most of its styling.
- Several premises in the migration brief are not present in the file: there is **no SortableJS controller**, **no drag-drop reorder**, **no middle-click-to-close**. The component is already declarative (zero `querySelector` / `setAttribute` / `classList.*` calls in the source); it routes click intents via `data-stream` / `data-action` dataset attrs through a single `@click` listener.

What I did instead:

- **StreamTabs CSS tighten**: dropped a dead `'stream-tab': true` classMap entry (no matching selector ever existed) and collapsed the redundant explicit-list active-foreground rule (`.tab-container.is-active *, .tab-container.is-active .tab, … .tab-expand`) into the descendant wildcard alone — the wildcard already covered every nested element, so the appended list was a no-op.
- **Found a real horizontal sub-tab to migrate**: `AgentsTab.agents-sub-tabs` was a hand-rolled `<button>` strip with ~40 lines of bespoke CSS (border-bottom indicator, hover/focus, active). Replaced with `<wa-tab-group>` + `<wa-tab>` driven by `wa-tab-show` and `waTabThemeTokenStyles`; body part hidden because the panel content (`agent-selection-panel`) is already rendered separately keyed off `activeSubTab`.
- Repo-wide audit: only one other tab-ish pattern, `view-tabs` in `MainApp.ts` and `ProgressApp.ts`, is already wa-tab-group. No SortableJS exists in `progressView/`.

## Test plan

- [x] `npm run typecheck` — no new errors in changed files (pre-existing electron / openrouter module-resolution errors unchanged).
- [x] `cd packages/desktop && npx vite build --mode development` — built clean in 1.68s.
- [x] `npx vitest run` — 314 pass / 4 fail; identical failure set to origin/main baseline (all 4 in `desktop/*` test files this PR doesn't touch).
- [ ] Manual: open Settings → Agents tab, confirm Workflow ↔ Tool Use sub-tab switching still works and the active indicator + count parens render correctly.
- [ ] Manual: open Progress view, confirm stream rows still highlight on hover/active, the close icon reveals on hover, and the active row keeps the brand-tinted left border + selection foreground.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor: primarily styling cleanup in `StreamTabs` and a swap from custom button tabs to `wa-tab-group` in `AgentsTab`, with minimal behavioral change limited to tab-switch event handling.
> 
> **Overview**
> **Cleans up progress StreamTabs active-state styling** by removing an unused `stream-tab` class assignment and collapsing redundant active-foreground CSS selectors into a single `.is-active *` descendant rule, while preserving the delete icon’s destructive hover/focus coloring.
> 
> **Migrates Settings → Agents sub-tabs to Web Awesome native tabs** by replacing the hand-rolled `<button>` strip with `wa-tab-group`/`wa-tab`, wiring tab changes via `wa-tab-show` into `activeSubTab`, and applying shared `waTabThemeTokenStyles` (hiding the group body since content is rendered separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2c8e226daeb8eb9f2d3319010eb2841b50f915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->