### PR TITLE
refactor(wa): VS Code-square corners + retire --desktop-* tokens

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -46,7 +46,7 @@ wa-button.desktop-back-button::part(base) {
   height: 28px;
   padding: 0 10px;
   border-color: transparent;
-  border-radius: 4px;
+  border-radius: var(--wa-border-radius-m);
   background: transparent;
   color: var(--wa-color-text-normal);
 }
@@ -60,7 +60,7 @@ wa-button.desktop-icon-button::part(base) {
   height: 28px;
   padding: 0;
   border-color: transparent;
-  border-radius: 4px;
+  border-radius: var(--wa-border-radius-m);
   background: transparent;
   color: var(--wa-color-text-normal);
 }
@@ -80,7 +80,7 @@ wa-button.desktop-command-button::part(base),
 wa-button.desktop-folder-button::part(base) {
   height: 28px;
   padding: 0 var(--wa-space-s);
-  border-radius: var(--wa-border-radius-m, 4px);
+  border-radius: var(--wa-border-radius-m, 3px);
   color: var(--wa-color-text-normal);
 }
 
@@ -180,7 +180,7 @@ wa-button.desktop-explorer-icon-button::part(base) {
   height: 24px;
   padding: 0;
   border: 0;
-  border-radius: var(--wa-border-radius-m, 4px);
+  border-radius: var(--wa-border-radius-m, 3px);
   background: transparent;
   color: var(--wa-color-text-normal);
 }
@@ -205,7 +205,7 @@ wa-tree.desktop-explorer-tree wa-tree-item::part(item) {
   min-height: 24px;
   padding-inline-end: var(--wa-space-xs);
   color: var(--wa-color-text-normal);
-  border-radius: var(--wa-border-radius-s, 3px);
+  border-radius: var(--wa-border-radius-s, 2px);
   margin-inline: var(--wa-space-3xs);
   transition:
     background-color 140ms ease,
@@ -406,7 +406,7 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
 .desktop-command-palette-panel {
   width: min(560px, 100%);
   border: 1px solid var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-l, 6px);
+  border-radius: var(--wa-border-radius-l, 4px);
   background: var(--wa-color-surface-default);
   box-shadow: 0 16px 40px rgb(0 0 0 / 32%);
   overflow: hidden;
@@ -445,7 +445,7 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
   min-height: 34px;
   padding: 0 var(--wa-space-xs);
   border: 0;
-  border-radius: var(--wa-border-radius-m, 4px);
+  border-radius: var(--wa-border-radius-m, 3px);
   background: transparent;
   color: var(--wa-color-text-normal);
   font: inherit;
@@ -553,7 +553,7 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
   padding: var(--wa-space-s);
   overflow: auto;
   border: 1px solid var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-l, 6px);
+  border-radius: var(--wa-border-radius-l, 4px);
   background: var(--wa-color-surface-default);
   color: var(--wa-color-text-normal);
   font-family: var(--wa-font-family-body-monospace);
@@ -568,7 +568,7 @@ wa-button.desktop-secondary-button::part(base) {
      at the same visual scale across both hosts. */
   min-height: 30px;
   padding: 0 var(--wa-space-m);
-  border-radius: var(--wa-border-radius-l, 6px);
+  border-radius: var(--wa-border-radius-l, 4px);
 }
 
 wa-button.desktop-primary-button::part(base) {
@@ -607,7 +607,7 @@ wa-dialog.desktop-onboarding {
   place-items: center;
   width: 38px;
   height: 38px;
-  border-radius: var(--wa-border-radius-l, 6px);
+  border-radius: var(--wa-border-radius-l, 4px);
   background: var(--wa-color-neutral-fill-quiet);
   color: var(--wa-color-brand-fill-loud);
   font-size: 20px;

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -1,16 +1,17 @@
 /**
  * Document-level theme tokens for the TeXRA desktop (Electron) renderer.
  *
- * Web Awesome native theming: --wa-* tokens are the single source of truth and
- * are sourced directly from the desktop's native --desktop-color-* palette.
- * The renderer entry (main.ts) imports the WA default theme stylesheet via
- * @shared/wa, and applyDesktopTheme() mirrors the active theme kind onto
+ * Web Awesome native theming: --wa-* tokens are the single source of truth.
+ * Palette values (light-dark() pairs) live directly on --wa-color-* tokens —
+ * there is no intermediate --desktop-color-* indirection. The renderer entry
+ * (main.ts) imports the WA default theme stylesheet via @shared/wa, and
+ * applyDesktopTheme() mirrors the active theme kind onto
  * <html class="wa-light|wa-dark"> so WA's color-scheme classes activate.
  *
- * --texra-* tokens remain as a thin compatibility alias layer for tokens that
- * have no clean WA equivalent (terminal ansi, symbol icons, charts, list rows,
- * git decoration, etc.) and a few legacy aliases consumers still reference.
- * They no longer round-trip through --wa-*.
+ * --texra-* tokens remain as a thin compatibility alias layer for the niche
+ * VS Code-shaped tokens (terminal ansi, symbol icons, charts, list rows,
+ * scrollbar) consumed by webviews reused inside the desktop shell. Wa-aligned
+ * --texra-* aliases collapse to --wa-* tokens.
  *
  * --vscode-* tokens are re-exported at the bottom so VS Code-styled CSS reused
  * in the desktop renderer keeps working without per-file rewrites.
@@ -19,129 +20,102 @@
 :root {
   color-scheme: light dark;
 
-  --desktop-font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', sans-serif;
-  --desktop-font-size: 13px;
-  --desktop-font-weight: 400;
-
   /* Heading scale shared with extension litStyles.ts. Use these tokens
      instead of hardcoded heading sizes so extension and desktop hosts
      render headings at the same visual scale. */
   --font-size-h1: 1.5em;
   --font-size-h2: 1.25em;
   --font-size-h3: 1em;
-
-  --desktop-color-background: light-dark(#ffffff, #1e1e1e);
-  --desktop-color-foreground: light-dark(#1f2328, #d4d4d4);
-  --desktop-color-muted: light-dark(#57606a, #a6a6a6);
-  --desktop-color-sidebar: light-dark(#f6f8fa, #181818);
-  --desktop-color-sidebar-header: light-dark(#eaeef2, #222222);
-  --desktop-color-border: light-dark(#d0d7de, #2b2b2b);
-  --desktop-color-widget-border: light-dark(#d0d7de, #454545);
-  --desktop-color-input-background: light-dark(#ffffff, #313131);
-  --desktop-color-input-border: light-dark(#d0d7de, #3c3c3c);
-  --desktop-color-input-foreground: light-dark(#1f2328, #cccccc);
-  --desktop-color-placeholder: light-dark(#6e7781, #a6a6a6);
-  --desktop-color-accent: light-dark(#0969da, #0e639c);
-  --desktop-color-accent-hover: light-dark(#0757b7, #1177bb);
-  --desktop-color-accent-subtle: light-dark(#ddf4ff, #04395e);
-  --desktop-color-button-secondary: light-dark(#f6f8fa, #313131);
-  --desktop-color-button-secondary-hover: light-dark(#eaeef2, #3c3c3c);
-  --desktop-color-toolbar-active: light-dark(#dbeafe, #37373d);
-  --desktop-color-toolbar-hover: light-dark(#eaeef2, #2a2d2e);
-  --desktop-color-list-hover: light-dark(#eef2f6, #2a2d2e);
-  --desktop-color-menu-background: light-dark(#ffffff, #252526);
-  --desktop-color-menu-border: light-dark(#d0d7de, #454545);
-  --desktop-color-shadow: light-dark(rgb(31 35 40 / 15%), rgb(0 0 0 / 36%));
-  --desktop-color-error: light-dark(#cf222e, #f48771);
-  --desktop-color-warning: light-dark(#9a6700, #cca700);
-  --desktop-color-warning-background: light-dark(#fff8c5, #332a00);
-  --desktop-color-info: light-dark(#0969da, #75beff);
-  --desktop-color-info-background: light-dark(#ddf4ff, #063b49);
-  --desktop-color-success: light-dark(#1a7f37, #73c991);
-  --desktop-color-success-background: light-dark(#d2f5dc, #1a4a25);
-  --desktop-color-error-background: light-dark(#ffebe9, #5a1d1d);
-  --desktop-color-orange: light-dark(#bc4c00, #d18616);
-  --desktop-color-yellow: light-dark(#bf8700, #cca700);
-  --desktop-color-terminal-selection: light-dark(#ddf4ff, #264f78);
-  --desktop-color-scrollbar: light-dark(
-    rgb(31 35 40 / 20%),
-    rgb(121 121 121 / 40%)
-  );
-  --desktop-color-scrollbar-hover: light-dark(
-    rgb(31 35 40 / 30%),
-    rgb(100 100 100 / 70%)
-  );
-  --desktop-color-scrollbar-active: light-dark(
-    rgb(31 35 40 / 45%),
-    rgb(191 191 191 / 40%)
-  );
 }
 
 /*
  * Web Awesome design-token bridge — single source of truth.
- * Sourced directly from the native --desktop-color-* palette above (no
- * intermediate --texra-* layer).
+ * Palette literals live here directly via light-dark(). Consumers should
+ * always reach for --wa-* tokens; the --texra-* / --vscode-* aliases below
+ * re-export these for legacy consumers.
  */
 :root,
 .wa-light,
 .wa-dark .wa-invert {
-  --wa-font-family-body: var(--desktop-font-family);
-  --wa-font-family-heading: var(--desktop-font-family);
+  --wa-font-family-body:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --wa-font-family-heading: var(--wa-font-family-body);
   --wa-font-family-mono: 'SF Mono', Monaco, monospace;
-  --wa-font-size-m: var(--desktop-font-size);
-  --wa-font-weight-normal: var(--desktop-font-weight);
+  --wa-font-size-m: 13px;
+  --wa-font-weight-normal: 400;
 
-  --wa-color-text-normal: var(--desktop-color-foreground);
-  --wa-color-text-quiet: var(--desktop-color-muted);
-  --wa-color-text-link: var(--desktop-color-accent);
-  --wa-color-surface-default: var(--desktop-color-background);
-  --wa-color-surface-raised: var(--desktop-color-sidebar);
-  --wa-color-surface-lowered: var(--desktop-color-sidebar-header);
-  --wa-color-surface-border: var(--desktop-color-border);
+  --wa-color-text-normal: light-dark(#1f2328, #d4d4d4);
+  --wa-color-text-quiet: light-dark(#57606a, #a6a6a6);
+  --wa-color-text-link: light-dark(#0969da, #0e639c);
+  --wa-color-surface-default: light-dark(#ffffff, #1e1e1e);
+  --wa-color-surface-raised: light-dark(#f6f8fa, #181818);
+  --wa-color-surface-lowered: light-dark(#eaeef2, #222222);
+  --wa-color-surface-border: light-dark(#d0d7de, #2b2b2b);
 
-  --wa-color-focus: var(--desktop-color-accent);
+  --wa-color-focus: light-dark(#0969da, #0e639c);
 
   /* WA form-control tokens. */
-  --wa-form-control-background-color: var(--desktop-color-input-background);
-  --wa-form-control-text-color: var(--desktop-color-input-foreground);
-  --wa-form-control-border-color: var(--desktop-color-input-border);
+  --wa-form-control-background-color: light-dark(#ffffff, #313131);
+  --wa-form-control-text-color: light-dark(#1f2328, #cccccc);
+  --wa-form-control-border-color: light-dark(#d0d7de, #3c3c3c);
 
-  --wa-color-brand-fill-loud: var(--desktop-color-accent);
+  /* Brand variant — primary buttons, links, focus accents. */
+  --wa-color-brand-fill-loud: light-dark(#0969da, #0e639c);
   --wa-color-brand-on-loud: #ffffff;
   --wa-color-brand-border-loud: transparent;
-  --wa-color-brand-fill-quiet: var(--desktop-color-info-background);
-  --wa-color-brand-border-quiet: var(--desktop-color-info);
-  --wa-color-brand-on-quiet: var(--desktop-color-info);
+  --wa-color-brand-fill-quiet: light-dark(#ddf4ff, #063b49);
+  --wa-color-brand-border-quiet: light-dark(#0969da, #75beff);
+  --wa-color-brand-on-quiet: light-dark(#0969da, #75beff);
 
-  --wa-color-warning-fill-loud: var(--desktop-color-warning);
+  /* Warning variant. */
+  --wa-color-warning-fill-loud: light-dark(#9a6700, #cca700);
   --wa-color-warning-on-loud: #ffffff;
   --wa-color-warning-border-loud: transparent;
-  --wa-color-warning-fill-quiet: var(--desktop-color-warning-background);
-  --wa-color-warning-border-quiet: var(--desktop-color-warning);
-  --wa-color-warning-on-quiet: var(--desktop-color-warning);
+  --wa-color-warning-fill-quiet: light-dark(#fff8c5, #332a00);
+  --wa-color-warning-border-quiet: light-dark(#9a6700, #cca700);
+  --wa-color-warning-on-quiet: light-dark(#9a6700, #cca700);
 
-  --wa-color-danger-fill-loud: var(--desktop-color-error);
+  /* Danger variant. */
+  --wa-color-danger-fill-loud: light-dark(#cf222e, #f48771);
   --wa-color-danger-on-loud: #ffffff;
   --wa-color-danger-border-loud: transparent;
-  --wa-color-danger-fill-quiet: var(--desktop-color-error-background);
-  --wa-color-danger-border-quiet: var(--desktop-color-error);
-  --wa-color-danger-on-quiet: var(--desktop-color-error);
+  --wa-color-danger-fill-quiet: light-dark(#ffebe9, #5a1d1d);
+  --wa-color-danger-border-quiet: light-dark(#cf222e, #f48771);
+  --wa-color-danger-on-quiet: light-dark(#cf222e, #f48771);
 
-  --wa-color-success-fill-loud: var(--desktop-color-success);
+  /* Success variant. */
+  --wa-color-success-fill-loud: light-dark(#1a7f37, #73c991);
   --wa-color-success-on-loud: #ffffff;
   --wa-color-success-border-loud: transparent;
-  --wa-color-success-fill-quiet: var(--desktop-color-success-background);
-  --wa-color-success-border-quiet: var(--desktop-color-success);
-  --wa-color-success-on-quiet: var(--desktop-color-success);
+  --wa-color-success-fill-quiet: light-dark(#d2f5dc, #1a4a25);
+  --wa-color-success-border-quiet: light-dark(#1a7f37, #73c991);
+  --wa-color-success-on-quiet: light-dark(#1a7f37, #73c991);
 
-  --wa-color-neutral-fill-quiet: var(--desktop-color-sidebar-header);
-  --wa-color-neutral-border-quiet: var(--desktop-color-border);
-  --wa-color-neutral-on-quiet: var(--desktop-color-foreground);
-  --wa-color-neutral-fill-loud: var(--desktop-color-sidebar-header);
-  --wa-color-neutral-border-loud: var(--desktop-color-border);
-  --wa-color-neutral-on-loud: var(--desktop-color-foreground);
+  /* Neutral variant. */
+  --wa-color-neutral-fill-quiet: light-dark(#eaeef2, #222222);
+  --wa-color-neutral-border-quiet: light-dark(#d0d7de, #2b2b2b);
+  --wa-color-neutral-on-quiet: light-dark(#1f2328, #d4d4d4);
+  --wa-color-neutral-fill-loud: light-dark(#eaeef2, #222222);
+  --wa-color-neutral-border-loud: light-dark(#d0d7de, #2b2b2b);
+  --wa-color-neutral-on-loud: light-dark(#1f2328, #d4d4d4);
+
+  /* Data palette — chart/identity colors with no semantic WA equivalent. */
+  --wa-color-data-orange: light-dark(#bc4c00, #d18616);
+  --wa-color-data-yellow: light-dark(#bf8700, #cca700);
+
+  /* Border-radius — VS Code-square overrides. WA default theme ships
+     s≈3px / m≈6px / l≈12px which feels too rounded against VS Code's
+     near-flat form-control aesthetic. Pin to the in-house --border-radius
+     scale (litStyles.ts) so wa-button, wa-input, wa-callout, wa-dialog,
+     wa-card all read as native VS Code controls. */
+  --wa-border-radius-s: 2px;
+  --wa-border-radius-m: 3px;
+  --wa-border-radius-l: 4px;
+  --wa-border-radius-xl: 6px;
+  --wa-border-radius-pill: 9999px;
+  --wa-border-radius-circle: 50%;
+  --wa-border-radius-square: 0px;
 
   /* Web Awesome canonical space scale — kept in sync with WA default theme. */
   --wa-space-scale: 1;
@@ -161,7 +135,8 @@
 /*
  * --texra-* compatibility alias layer.
  * Wa-aligned aliases collapse to --wa-* tokens. Niche aliases (terminal,
- * symbol icons, charts, list rows) source --desktop-color-* directly.
+ * symbol icons, charts, list rows, scrollbar) hold light-dark() literals
+ * directly since WA has no semantic equivalent.
  */
 :root {
   /* Wa-aligned aliases. */
@@ -181,26 +156,26 @@
   --texra-sideBarTitle-foreground: var(--wa-color-text-normal);
   --texra-panel-border: var(--wa-color-surface-border);
   --texra-panelSection-border: var(--wa-color-surface-border);
-  --texra-widget-border: var(--desktop-color-widget-border);
-  --texra-widget-shadow: var(--desktop-color-shadow);
+  --texra-widget-border: light-dark(#d0d7de, #454545);
+  --texra-widget-shadow: light-dark(rgb(31 35 40 / 15%), rgb(0 0 0 / 36%));
   --texra-textCodeBlock-background: var(--wa-color-surface-lowered);
-  --texra-textBlockQuote-background: var(--desktop-color-accent-subtle);
-  --texra-textBlockQuote-border: var(--desktop-color-accent);
+  --texra-textBlockQuote-background: light-dark(#ddf4ff, #04395e);
+  --texra-textBlockQuote-border: var(--wa-color-brand-fill-loud);
   --texra-textLink-foreground: var(--wa-color-text-link);
-  --texra-textLink-activeForeground: var(--desktop-color-accent-hover);
-  --texra-textPreformat-foreground: var(--desktop-color-input-foreground);
+  --texra-textLink-activeForeground: light-dark(#0757b7, #1177bb);
+  --texra-textPreformat-foreground: var(--wa-form-control-text-color);
   --texra-input-background: var(--wa-form-control-background-color);
   --texra-input-foreground: var(--wa-form-control-text-color);
   --texra-input-border: var(--wa-form-control-border-color);
-  --texra-input-placeholderForeground: var(--desktop-color-placeholder);
+  --texra-input-placeholderForeground: light-dark(#6e7781, #a6a6a6);
   --texra-dropdown-border: var(--wa-form-control-border-color);
   --texra-button-background: var(--wa-color-brand-fill-loud);
   --texra-button-foreground: var(--wa-color-brand-on-loud);
   --texra-button-border: transparent;
-  --texra-button-hoverBackground: var(--desktop-color-accent-hover);
+  --texra-button-hoverBackground: light-dark(#0757b7, #1177bb);
   --texra-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
   --texra-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
-  --texra-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
+  --texra-button-secondaryHoverBackground: light-dark(#eaeef2, #3c3c3c);
   --texra-button-separator: rgb(255 255 255 / 40%);
   --texra-errorForeground: var(--wa-color-danger-on-quiet);
   --texra-editorError-foreground: var(--wa-color-danger-on-quiet);
@@ -208,97 +183,106 @@
   --texra-editorWarning-background: var(--wa-color-warning-fill-quiet);
   --texra-editorInfo-foreground: var(--wa-color-brand-on-quiet);
   --texra-editorInfo-background: var(--wa-color-brand-fill-quiet);
-  --texra-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --texra-editor-selectionBackground: var(--desktop-color-accent-subtle);
-  --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
-  --texra-inputOption-activeBorder: var(--desktop-color-accent);
-  --texra-inputOption-activeForeground: var(--desktop-color-foreground);
+  --texra-editor-inactiveSelectionBackground: light-dark(#ddf4ff, #04395e);
+  --texra-editor-selectionBackground: light-dark(#ddf4ff, #04395e);
+  --texra-inputOption-activeBackground: light-dark(#ddf4ff, #04395e);
+  --texra-inputOption-activeBorder: var(--wa-color-brand-fill-loud);
+  --texra-inputOption-activeForeground: var(--wa-color-text-normal);
   --texra-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
-  --texra-inputValidation-errorBorder: var(--desktop-color-error);
+  --texra-inputValidation-errorBorder: var(--wa-color-danger-fill-loud);
   --texra-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
-  --texra-inputValidation-infoBorder: var(--desktop-color-info);
-  --texra-inputValidation-infoForeground: var(--desktop-color-info);
+  --texra-inputValidation-infoBorder: var(--wa-color-brand-on-quiet);
+  --texra-inputValidation-infoForeground: var(--wa-color-brand-on-quiet);
   --texra-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
-  --texra-inputValidation-warningBorder: var(--desktop-color-warning);
-  --texra-inputValidation-warningForeground: var(--desktop-color-warning);
-  --texra-progressBar-background: var(--desktop-color-accent);
-  --texra-statusBarItem-warningBackground: var(--desktop-color-warning);
-  --texra-notificationsInfoIcon-foreground: var(--desktop-color-info);
-  --texra-activityBarBadge-background: var(--desktop-color-accent);
-  --texra-badge-background: var(--desktop-color-accent);
+  --texra-inputValidation-warningBorder: var(--wa-color-warning-on-quiet);
+  --texra-inputValidation-warningForeground: var(--wa-color-warning-on-quiet);
+  --texra-progressBar-background: var(--wa-color-brand-fill-loud);
+  --texra-statusBarItem-warningBackground: var(--wa-color-warning-fill-loud);
+  --texra-notificationsInfoIcon-foreground: var(--wa-color-brand-on-quiet);
+  --texra-activityBarBadge-background: var(--wa-color-brand-fill-loud);
+  --texra-badge-background: var(--wa-color-brand-fill-loud);
   --texra-badge-foreground: #ffffff;
-  --texra-toolbar-activeBackground: var(--desktop-color-toolbar-active);
-  --texra-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
-  --texra-toolbar-hoverOutline: var(--desktop-color-muted);
+  --texra-toolbar-activeBackground: light-dark(#dbeafe, #37373d);
+  --texra-toolbar-hoverBackground: light-dark(#eaeef2, #2a2d2e);
+  --texra-toolbar-hoverOutline: var(--wa-color-text-quiet);
   --texra-focusBorder: var(--wa-color-focus);
 
   /* List/menu/scrollbar — no WA equivalent. */
-  --texra-list-activeSelectionBackground: var(--desktop-color-accent);
+  --texra-list-activeSelectionBackground: var(--wa-color-brand-fill-loud);
   --texra-list-activeSelectionForeground: #ffffff;
-  --texra-list-focusOutline: var(--desktop-color-accent);
-  --texra-list-hoverForeground: var(--desktop-color-foreground);
-  --texra-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --texra-list-hoverBackground: var(--desktop-color-list-hover);
-  --texra-list-warningForeground: var(--desktop-color-warning);
-  --texra-menu-background: var(--desktop-color-menu-background);
-  --texra-menu-border: var(--desktop-color-menu-border);
-  --texra-menu-foreground: var(--desktop-color-input-foreground);
-  --texra-menu-selectionBackground: var(--desktop-color-accent);
+  --texra-list-focusOutline: var(--wa-color-brand-fill-loud);
+  --texra-list-hoverForeground: var(--wa-color-text-normal);
+  --texra-list-inactiveSelectionBackground: light-dark(#ddf4ff, #04395e);
+  --texra-list-hoverBackground: light-dark(#eef2f6, #2a2d2e);
+  --texra-list-warningForeground: var(--wa-color-warning-fill-loud);
+  --texra-menu-background: light-dark(#ffffff, #252526);
+  --texra-menu-border: light-dark(#d0d7de, #454545);
+  --texra-menu-foreground: var(--wa-form-control-text-color);
+  --texra-menu-selectionBackground: var(--wa-color-brand-fill-loud);
   --texra-menu-selectionForeground: #ffffff;
-  --texra-menu-separatorBackground: var(--desktop-color-menu-border);
-  --texra-scrollbar-shadow: var(--desktop-color-shadow);
-  --texra-scrollbarSlider-background: var(--desktop-color-scrollbar);
-  --texra-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
-  --texra-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
+  --texra-menu-separatorBackground: light-dark(#d0d7de, #454545);
+  --texra-scrollbar-shadow: light-dark(rgb(31 35 40 / 15%), rgb(0 0 0 / 36%));
+  --texra-scrollbarSlider-background: light-dark(
+    rgb(31 35 40 / 20%),
+    rgb(121 121 121 / 40%)
+  );
+  --texra-scrollbarSlider-hoverBackground: light-dark(
+    rgb(31 35 40 / 30%),
+    rgb(100 100 100 / 70%)
+  );
+  --texra-scrollbarSlider-activeBackground: light-dark(
+    rgb(31 35 40 / 45%),
+    rgb(191 191 191 / 40%)
+  );
 
-  /* Charts — palette tokens with no WA equivalent. */
-  --texra-charts-blue: var(--desktop-color-accent);
-  --texra-charts-green: var(--desktop-color-success);
-  --texra-charts-orange: var(--desktop-color-orange);
-  --texra-charts-red: var(--desktop-color-error);
-  --texra-charts-yellow: var(--desktop-color-yellow);
+  /* Charts — palette tokens with no WA semantic equivalent. */
+  --texra-charts-blue: var(--wa-color-brand-fill-loud);
+  --texra-charts-green: var(--wa-color-success-fill-loud);
+  --texra-charts-orange: var(--wa-color-data-orange);
+  --texra-charts-red: var(--wa-color-danger-fill-loud);
+  --texra-charts-yellow: var(--wa-color-data-yellow);
 
   /* Testing icons. */
-  --texra-testing-iconPassed: var(--desktop-color-success);
-  --texra-testing-iconFailed: var(--desktop-color-error);
+  --texra-testing-iconPassed: var(--wa-color-success-fill-loud);
+  --texra-testing-iconFailed: var(--wa-color-danger-fill-loud);
 
   /* Symbol icons — no WA equivalent. */
-  --texra-symbolIcon-classForeground: var(--desktop-color-orange);
-  --texra-symbolIcon-constantForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-functionForeground: var(--desktop-color-yellow);
+  --texra-symbolIcon-classForeground: var(--wa-color-data-orange);
+  --texra-symbolIcon-constantForeground: var(--wa-color-brand-fill-loud);
+  --texra-symbolIcon-functionForeground: var(--wa-color-data-yellow);
   --texra-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
-  --texra-symbolIcon-propertyForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
+  --texra-symbolIcon-propertyForeground: var(--wa-color-brand-fill-loud);
+  --texra-symbolIcon-variableForeground: var(--wa-form-control-text-color);
 
   /* Terminal — no WA equivalent. */
-  --texra-terminal-background: var(--desktop-color-background);
-  --texra-terminal-foreground: var(--desktop-color-input-foreground);
-  --texra-terminal-selectionBackground: var(--desktop-color-terminal-selection);
-  --texra-terminalCursor-foreground: var(--desktop-color-input-foreground);
+  --texra-terminal-background: var(--wa-color-surface-default);
+  --texra-terminal-foreground: var(--wa-form-control-text-color);
+  --texra-terminal-selectionBackground: light-dark(#ddf4ff, #264f78);
+  --texra-terminalCursor-foreground: var(--wa-form-control-text-color);
   --texra-terminal-ansiBlack: light-dark(#24292f, #000000);
-  --texra-terminal-ansiBlue: var(--desktop-color-accent);
+  --texra-terminal-ansiBlue: var(--wa-color-brand-fill-loud);
   --texra-terminal-ansiBrightBlack: light-dark(#6e7781, #666666);
   --texra-terminal-ansiBrightBlue: light-dark(#0550ae, #3794ff);
   --texra-terminal-ansiBrightCyan: light-dark(#1b7c83, #39cccc);
-  --texra-terminal-ansiBrightGreen: var(--desktop-color-success);
+  --texra-terminal-ansiBrightGreen: var(--wa-color-success-fill-loud);
   --texra-terminal-ansiBrightMagenta: light-dark(#8250df, #d670d6);
-  --texra-terminal-ansiBrightRed: var(--desktop-color-error);
+  --texra-terminal-ansiBrightRed: var(--wa-color-danger-fill-loud);
   --texra-terminal-ansiBrightWhite: light-dark(#ffffff, #ffffff);
-  --texra-terminal-ansiBrightYellow: var(--desktop-color-yellow);
+  --texra-terminal-ansiBrightYellow: var(--wa-color-data-yellow);
   --texra-terminal-ansiCyan: light-dark(#1b7c83, #4ec9b0);
-  --texra-terminal-ansiGreen: var(--desktop-color-success);
+  --texra-terminal-ansiGreen: var(--wa-color-success-fill-loud);
   --texra-terminal-ansiMagenta: light-dark(#8250df, #c586c0);
-  --texra-terminal-ansiRed: var(--desktop-color-error);
+  --texra-terminal-ansiRed: var(--wa-color-danger-fill-loud);
   --texra-terminal-ansiWhite: light-dark(#6e7781, #cccccc);
-  --texra-terminal-ansiYellow: var(--desktop-color-yellow);
+  --texra-terminal-ansiYellow: var(--wa-color-data-yellow);
 
   /* Legacy font/typography aliases. */
   --texra-font-family: var(--wa-font-family-body);
   --texra-font-family-monospace: var(--wa-font-family-mono);
   --texra-font-size: var(--wa-font-size-m);
   --texra-font-weight: var(--wa-font-weight-normal);
-  --texra-editor-font-family: var(--desktop-font-family);
-  --texra-editor-font-size: var(--desktop-font-size);
+  --texra-editor-font-family: var(--wa-font-family-body);
+  --texra-editor-font-size: var(--wa-font-size-m);
 }
 
 body.vscode-light,
@@ -315,44 +299,52 @@ body.vscode-high-contrast,
 body.vscode-high-contrast-light,
 body.texra-high-contrast {
   color-scheme: light dark;
-  --desktop-color-background: Canvas;
-  --desktop-color-foreground: CanvasText;
-  --desktop-color-muted: GrayText;
-  --desktop-color-sidebar: Canvas;
-  --desktop-color-sidebar-header: Canvas;
-  --desktop-color-border: CanvasText;
-  --desktop-color-widget-border: CanvasText;
-  --desktop-color-input-background: Field;
-  --desktop-color-input-border: CanvasText;
-  --desktop-color-input-foreground: FieldText;
-  --desktop-color-placeholder: GrayText;
-  --desktop-color-accent: Highlight;
-  --desktop-color-accent-hover: Highlight;
-  --desktop-color-accent-subtle: Canvas;
-  --desktop-color-button-secondary: ButtonFace;
-  --desktop-color-button-secondary-hover: ButtonFace;
-  --desktop-color-toolbar-active: Highlight;
-  --desktop-color-toolbar-hover: ButtonFace;
-  --desktop-color-list-hover: ButtonFace;
-  --desktop-color-menu-background: Canvas;
-  --desktop-color-menu-border: CanvasText;
-  --desktop-color-error: Mark;
-  --desktop-color-warning: Mark;
-  --desktop-color-info: Highlight;
-  --desktop-color-success: Highlight;
+
+  /* Override --wa-* tokens directly to system high-contrast palette. */
+  --wa-color-text-normal: CanvasText;
+  --wa-color-text-quiet: GrayText;
+  --wa-color-text-link: LinkText;
+  --wa-color-surface-default: Canvas;
+  --wa-color-surface-raised: Canvas;
+  --wa-color-surface-lowered: Canvas;
+  --wa-color-surface-border: CanvasText;
+  --wa-color-focus: Highlight;
+  --wa-form-control-background-color: Field;
+  --wa-form-control-text-color: FieldText;
+  --wa-form-control-border-color: CanvasText;
+  --wa-color-brand-fill-loud: Highlight;
+  --wa-color-brand-on-loud: HighlightText;
+  --wa-color-brand-border-loud: CanvasText;
+  --wa-color-warning-fill-loud: Mark;
+  --wa-color-danger-fill-loud: Mark;
+  --wa-color-success-fill-loud: Highlight;
+
+  /* High-contrast-only --texra-* overrides. */
+  --texra-widget-border: CanvasText;
   --texra-button-foreground: HighlightText;
+  --texra-button-secondaryHoverBackground: ButtonFace;
+  --texra-toolbar-activeBackground: Highlight;
+  --texra-toolbar-hoverBackground: ButtonFace;
   --texra-list-activeSelectionForeground: HighlightText;
+  --texra-list-hoverBackground: ButtonFace;
+  --texra-menu-background: Canvas;
+  --texra-menu-border: CanvasText;
   --texra-menu-selectionForeground: HighlightText;
   --texra-badge-foreground: HighlightText;
   --texra-contrastBorder: CanvasText;
-  --wa-color-brand-on-loud: HighlightText;
-  --wa-color-brand-border-loud: CanvasText;
+  --texra-input-placeholderForeground: GrayText;
+  --texra-editor-selectionBackground: Canvas;
+  --texra-editor-inactiveSelectionBackground: Canvas;
+  --texra-textBlockQuote-background: Canvas;
+  --texra-inputOption-activeBackground: Canvas;
+  --texra-list-inactiveSelectionBackground: Canvas;
+  --texra-terminal-selectionBackground: Highlight;
 }
 
 /*
  * VS Code variable re-exports for reused webview CSS.
- * Sourced from --desktop-color-* / --wa-* so existing rules referencing
- * --vscode-* still resolve in the desktop renderer.
+ * Sourced from --wa-* tokens so existing rules referencing --vscode-*
+ * still resolve in the desktop renderer.
  */
 :root {
   --vscode-font-family: var(--wa-font-family-body);
@@ -362,10 +354,10 @@ body.texra-high-contrast {
   --vscode-descriptionForeground: var(--wa-color-text-quiet);
   --vscode-editor-background: var(--wa-color-surface-default);
   --vscode-editor-font-family: var(--wa-font-family-mono);
-  --vscode-editor-font-size: var(--desktop-font-size);
+  --vscode-editor-font-size: var(--wa-font-size-m);
   --vscode-editor-foreground: var(--wa-color-text-normal);
-  --vscode-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --vscode-editor-selectionBackground: var(--desktop-color-accent-subtle);
+  --vscode-editor-inactiveSelectionBackground: var(--texra-editor-inactiveSelectionBackground);
+  --vscode-editor-selectionBackground: var(--texra-editor-selectionBackground);
   --vscode-editorError-foreground: var(--wa-color-danger-on-quiet);
   --vscode-editorHoverWidget-background: var(--wa-color-surface-raised);
   --vscode-editorHoverWidget-border: var(--wa-color-surface-border);
@@ -392,10 +384,10 @@ body.texra-high-contrast {
   --vscode-button-background: var(--wa-color-brand-fill-loud);
   --vscode-button-border: transparent;
   --vscode-button-foreground: var(--wa-color-brand-on-loud);
-  --vscode-button-hoverBackground: var(--desktop-color-accent-hover);
+  --vscode-button-hoverBackground: var(--texra-button-hoverBackground);
   --vscode-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
   --vscode-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
-  --vscode-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
+  --vscode-button-secondaryHoverBackground: var(--texra-button-secondaryHoverBackground);
   --vscode-button-separator: rgb(255 255 255 / 40%);
   --vscode-dropdown-background: var(--wa-form-control-background-color);
   --vscode-dropdown-border: var(--wa-form-control-border-color);
@@ -403,22 +395,22 @@ body.texra-high-contrast {
   --vscode-input-background: var(--wa-form-control-background-color);
   --vscode-input-border: var(--wa-form-control-border-color);
   --vscode-input-foreground: var(--wa-form-control-text-color);
-  --vscode-input-placeholderForeground: var(--desktop-color-placeholder);
-  --vscode-inputOption-activeBackground: var(--desktop-color-accent-subtle);
-  --vscode-inputOption-activeBorder: var(--desktop-color-accent);
-  --vscode-inputOption-activeForeground: var(--desktop-color-foreground);
+  --vscode-input-placeholderForeground: var(--texra-input-placeholderForeground);
+  --vscode-inputOption-activeBackground: var(--texra-inputOption-activeBackground);
+  --vscode-inputOption-activeBorder: var(--wa-color-brand-fill-loud);
+  --vscode-inputOption-activeForeground: var(--wa-color-text-normal);
   --vscode-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
-  --vscode-inputValidation-errorBorder: var(--desktop-color-error);
+  --vscode-inputValidation-errorBorder: var(--wa-color-danger-fill-loud);
   --vscode-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
-  --vscode-inputValidation-infoBorder: var(--desktop-color-info);
-  --vscode-inputValidation-infoForeground: var(--desktop-color-info);
+  --vscode-inputValidation-infoBorder: var(--wa-color-brand-on-quiet);
+  --vscode-inputValidation-infoForeground: var(--wa-color-brand-on-quiet);
   --vscode-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
-  --vscode-inputValidation-warningBorder: var(--desktop-color-warning);
-  --vscode-inputValidation-warningForeground: var(--desktop-color-warning);
+  --vscode-inputValidation-warningBorder: var(--wa-color-warning-on-quiet);
+  --vscode-inputValidation-warningForeground: var(--wa-color-warning-on-quiet);
   --vscode-textArea-background: var(--wa-form-control-background-color);
   --vscode-textArea-border: var(--wa-form-control-border-color);
   --vscode-textArea-foreground: var(--wa-form-control-text-color);
-  --vscode-textArea-placeholderForeground: var(--desktop-color-placeholder);
+  --vscode-textArea-placeholderForeground: var(--texra-input-placeholderForeground);
   --vscode-checkbox-background: var(--wa-form-control-background-color);
   --vscode-checkbox-border: var(--wa-form-control-border-color);
   --vscode-checkbox-foreground: var(--wa-color-text-normal);
@@ -432,79 +424,79 @@ body.texra-high-contrast {
   --vscode-settings-textInputBackground: var(--wa-form-control-background-color);
   --vscode-settings-textInputBorder: var(--wa-form-control-border-color);
   --vscode-settings-textInputForeground: var(--wa-form-control-text-color);
-  --vscode-list-activeSelectionBackground: var(--desktop-color-accent);
+  --vscode-list-activeSelectionBackground: var(--wa-color-brand-fill-loud);
   --vscode-list-activeSelectionForeground: #ffffff;
   --vscode-list-activeSelectionIconForeground: #ffffff;
-  --vscode-list-focusAndSelectionOutline: var(--desktop-color-accent);
+  --vscode-list-focusAndSelectionOutline: var(--wa-color-brand-fill-loud);
   --vscode-list-focusHighlightForeground: var(--wa-color-focus);
-  --vscode-list-focusOutline: var(--desktop-color-accent);
+  --vscode-list-focusOutline: var(--wa-color-brand-fill-loud);
   --vscode-list-highlightForeground: var(--wa-color-focus);
   --vscode-list-hoverBackground: var(--wa-color-neutral-fill-quiet);
-  --vscode-list-hoverForeground: var(--desktop-color-foreground);
-  --vscode-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --vscode-list-warningForeground: var(--desktop-color-warning);
-  --vscode-menu-background: var(--desktop-color-menu-background);
-  --vscode-menu-border: var(--desktop-color-menu-border);
-  --vscode-menu-foreground: var(--desktop-color-input-foreground);
-  --vscode-menu-selectionBackground: var(--desktop-color-accent);
-  --vscode-menu-selectionBorder: var(--desktop-color-accent);
+  --vscode-list-hoverForeground: var(--wa-color-text-normal);
+  --vscode-list-inactiveSelectionBackground: var(--texra-list-inactiveSelectionBackground);
+  --vscode-list-warningForeground: var(--wa-color-warning-fill-loud);
+  --vscode-menu-background: var(--texra-menu-background);
+  --vscode-menu-border: var(--texra-menu-border);
+  --vscode-menu-foreground: var(--wa-form-control-text-color);
+  --vscode-menu-selectionBackground: var(--wa-color-brand-fill-loud);
+  --vscode-menu-selectionBorder: var(--wa-color-brand-fill-loud);
   --vscode-menu-selectionForeground: #ffffff;
-  --vscode-menu-separatorBackground: var(--desktop-color-menu-border);
-  --vscode-toolbar-activeBackground: var(--desktop-color-toolbar-active);
-  --vscode-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
-  --vscode-toolbar-hoverOutline: var(--desktop-color-muted);
-  --vscode-widget-border: var(--desktop-color-widget-border);
-  --vscode-widget-shadow: var(--desktop-color-shadow);
+  --vscode-menu-separatorBackground: var(--texra-menu-separatorBackground);
+  --vscode-toolbar-activeBackground: var(--texra-toolbar-activeBackground);
+  --vscode-toolbar-hoverBackground: var(--texra-toolbar-hoverBackground);
+  --vscode-toolbar-hoverOutline: var(--wa-color-text-quiet);
+  --vscode-widget-border: var(--texra-widget-border);
+  --vscode-widget-shadow: var(--texra-widget-shadow);
   --vscode-icon-foreground: var(--wa-color-text-quiet);
   --vscode-badge-background: var(--wa-color-neutral-fill-quiet);
   --vscode-badge-foreground: var(--wa-color-neutral-on-quiet);
-  --vscode-progressBar-background: var(--desktop-color-accent);
+  --vscode-progressBar-background: var(--wa-color-brand-fill-loud);
   --vscode-textBlockQuote-background: var(--wa-color-surface-lowered);
-  --vscode-textBlockQuote-border: var(--desktop-color-accent);
-  --vscode-textCodeBlock-background: var(--desktop-color-sidebar);
-  --vscode-textLink-activeForeground: var(--desktop-color-accent-hover);
+  --vscode-textBlockQuote-border: var(--wa-color-brand-fill-loud);
+  --vscode-textCodeBlock-background: var(--wa-color-surface-raised);
+  --vscode-textLink-activeForeground: var(--texra-textLink-activeForeground);
   --vscode-textLink-foreground: var(--wa-color-text-link);
-  --vscode-textPreformat-foreground: var(--desktop-color-input-foreground);
-  --vscode-terminal-background: var(--desktop-color-background);
-  --vscode-terminal-foreground: var(--desktop-color-input-foreground);
-  --vscode-terminal-selectionBackground: var(--desktop-color-terminal-selection);
-  --vscode-terminalCursor-foreground: var(--desktop-color-input-foreground);
+  --vscode-textPreformat-foreground: var(--wa-form-control-text-color);
+  --vscode-terminal-background: var(--texra-terminal-background);
+  --vscode-terminal-foreground: var(--texra-terminal-foreground);
+  --vscode-terminal-selectionBackground: var(--texra-terminal-selectionBackground);
+  --vscode-terminalCursor-foreground: var(--texra-terminalCursor-foreground);
   --vscode-terminal-ansiBlack: var(--texra-terminal-ansiBlack);
-  --vscode-terminal-ansiBlue: var(--desktop-color-accent);
+  --vscode-terminal-ansiBlue: var(--wa-color-brand-fill-loud);
   --vscode-terminal-ansiBrightBlack: var(--texra-terminal-ansiBrightBlack);
   --vscode-terminal-ansiBrightBlue: var(--texra-terminal-ansiBrightBlue);
   --vscode-terminal-ansiBrightCyan: var(--texra-terminal-ansiBrightCyan);
-  --vscode-terminal-ansiBrightGreen: var(--desktop-color-success);
+  --vscode-terminal-ansiBrightGreen: var(--wa-color-success-fill-loud);
   --vscode-terminal-ansiBrightMagenta: var(--texra-terminal-ansiBrightMagenta);
-  --vscode-terminal-ansiBrightRed: var(--desktop-color-error);
+  --vscode-terminal-ansiBrightRed: var(--wa-color-danger-fill-loud);
   --vscode-terminal-ansiBrightWhite: var(--texra-terminal-ansiBrightWhite);
-  --vscode-terminal-ansiBrightYellow: var(--desktop-color-yellow);
+  --vscode-terminal-ansiBrightYellow: var(--wa-color-data-yellow);
   --vscode-terminal-ansiCyan: var(--texra-terminal-ansiCyan);
-  --vscode-terminal-ansiGreen: var(--desktop-color-success);
+  --vscode-terminal-ansiGreen: var(--wa-color-success-fill-loud);
   --vscode-terminal-ansiMagenta: var(--texra-terminal-ansiMagenta);
-  --vscode-terminal-ansiRed: var(--desktop-color-error);
+  --vscode-terminal-ansiRed: var(--wa-color-danger-fill-loud);
   --vscode-terminal-ansiWhite: var(--texra-terminal-ansiWhite);
-  --vscode-terminal-ansiYellow: var(--desktop-color-yellow);
+  --vscode-terminal-ansiYellow: var(--wa-color-data-yellow);
   --vscode-testing-iconFailed: var(--wa-color-danger-fill-loud);
   --vscode-testing-iconPassed: var(--wa-color-success-fill-loud);
-  --vscode-charts-blue: var(--desktop-color-accent);
-  --vscode-charts-green: var(--desktop-color-success);
-  --vscode-charts-orange: var(--desktop-color-orange);
-  --vscode-charts-red: var(--desktop-color-error);
-  --vscode-charts-yellow: var(--desktop-color-yellow);
-  --vscode-scrollbar-shadow: var(--desktop-color-shadow);
-  --vscode-scrollbarSlider-background: var(--desktop-color-scrollbar);
-  --vscode-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
-  --vscode-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
-  --vscode-activityBarBadge-background: var(--desktop-color-accent);
-  --vscode-notificationsInfoIcon-foreground: var(--desktop-color-info);
-  --vscode-statusBarItem-warningBackground: var(--desktop-color-warning);
-  --vscode-symbolIcon-classForeground: var(--desktop-color-orange);
-  --vscode-symbolIcon-constantForeground: var(--desktop-color-accent);
-  --vscode-symbolIcon-functionForeground: var(--desktop-color-yellow);
+  --vscode-charts-blue: var(--wa-color-brand-fill-loud);
+  --vscode-charts-green: var(--wa-color-success-fill-loud);
+  --vscode-charts-orange: var(--wa-color-data-orange);
+  --vscode-charts-red: var(--wa-color-danger-fill-loud);
+  --vscode-charts-yellow: var(--wa-color-data-yellow);
+  --vscode-scrollbar-shadow: var(--texra-scrollbar-shadow);
+  --vscode-scrollbarSlider-background: var(--texra-scrollbarSlider-background);
+  --vscode-scrollbarSlider-hoverBackground: var(--texra-scrollbarSlider-hoverBackground);
+  --vscode-scrollbarSlider-activeBackground: var(--texra-scrollbarSlider-activeBackground);
+  --vscode-activityBarBadge-background: var(--wa-color-brand-fill-loud);
+  --vscode-notificationsInfoIcon-foreground: var(--wa-color-brand-on-quiet);
+  --vscode-statusBarItem-warningBackground: var(--wa-color-warning-fill-loud);
+  --vscode-symbolIcon-classForeground: var(--wa-color-data-orange);
+  --vscode-symbolIcon-constantForeground: var(--wa-color-brand-fill-loud);
+  --vscode-symbolIcon-functionForeground: var(--wa-color-data-yellow);
   --vscode-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
-  --vscode-symbolIcon-propertyForeground: var(--desktop-color-accent);
-  --vscode-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
+  --vscode-symbolIcon-propertyForeground: var(--wa-color-brand-fill-loud);
+  --vscode-symbolIcon-variableForeground: var(--wa-form-control-text-color);
 }
 
 /* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -81,6 +81,19 @@
   --wa-font-size-m: var(--vscode-font-size, 13px);
   --wa-font-weight-normal: var(--vscode-font-weight, 400);
 
+  /* Border-radius — VS Code-square overrides. WA default theme ships
+     s≈3px / m≈6px / l≈12px which feels too rounded against VS Code's
+     near-flat form-control aesthetic. Pin to the in-house --border-radius
+     scale (litStyles.ts) so wa-button, wa-input, wa-callout, wa-dialog,
+     wa-card all read as native VS Code controls. */
+  --wa-border-radius-s: 2px;
+  --wa-border-radius-m: 3px;
+  --wa-border-radius-l: 4px;
+  --wa-border-radius-xl: 6px;
+  --wa-border-radius-pill: 9999px;
+  --wa-border-radius-circle: 50%;
+  --wa-border-radius-square: 0px;
+
   /* Web Awesome canonical space scale. Mirrors the values from the WA default
      theme so consumers can rely on --wa-space-* even if the WA color-scheme
      class hasn't been mounted yet. */

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
@@ -26,7 +26,7 @@ function createThemeDocument(extraCss = ''): Document {
 }
 
 describe('desktop theme tokens', () => {
-  it('exports textarea and text input colors through the VS Code token bridge', () => {
+  it('exports textarea and text input colors through the WA form-control bridge', () => {
     const document = createThemeDocument(`
       textarea,
       input[type='text'] {
@@ -41,23 +41,23 @@ describe('desktop theme tokens', () => {
 
     expect(
       rootStyle.getPropertyValue('--vscode-textArea-background').trim(),
-    ).toBe('var(--texra-input-background)');
+    ).toBe('var(--wa-form-control-background-color)');
     expect(rootStyle.getPropertyValue('--vscode-textArea-border').trim()).toBe(
-      'var(--texra-input-border)',
+      'var(--wa-form-control-border-color)',
     );
     expect(
       rootStyle.getPropertyValue('--vscode-textArea-foreground').trim(),
-    ).toBe('var(--texra-input-foreground)');
+    ).toBe('var(--wa-form-control-text-color)');
     expect(
       rootStyle
         .getPropertyValue('--vscode-settings-textInputBackground')
         .trim(),
-    ).toBe('var(--texra-input-background)');
+    ).toBe('var(--wa-form-control-background-color)');
     expect(rootStyle.getPropertyValue('--texra-input-background').trim()).toBe(
-      'var(--desktop-color-input-background)',
+      'var(--wa-form-control-background-color)',
     );
     expect(
-      rootStyle.getPropertyValue('--desktop-color-input-background').trim(),
+      rootStyle.getPropertyValue('--wa-form-control-background-color').trim(),
     ).toMatch(/^light-dark\(#ffffff,\s*#313131\)$/);
   });
 
@@ -71,5 +71,38 @@ describe('desktop theme tokens', () => {
     expect(darkBlock).toContain('color-scheme: dark;');
     expect(darkBlock).not.toContain('--texra-input-background');
     expect(darkBlock).not.toContain('--vscode-textArea-background');
+  });
+
+  it('overrides --wa-border-radius-* tokens to VS Code-square values', () => {
+    const document = createThemeDocument();
+    const rootStyle = document.defaultView!.getComputedStyle(
+      document.documentElement,
+    );
+
+    expect(rootStyle.getPropertyValue('--wa-border-radius-s').trim()).toBe(
+      '2px',
+    );
+    expect(rootStyle.getPropertyValue('--wa-border-radius-m').trim()).toBe(
+      '3px',
+    );
+    expect(rootStyle.getPropertyValue('--wa-border-radius-l').trim()).toBe(
+      '4px',
+    );
+    expect(rootStyle.getPropertyValue('--wa-border-radius-pill').trim()).toBe(
+      '9999px',
+    );
+    expect(rootStyle.getPropertyValue('--wa-border-radius-circle').trim()).toBe(
+      '50%',
+    );
+  });
+
+  it('does not retain --desktop-color-* / --desktop-font-* indirection (palette lives on --wa-* directly)', () => {
+    // Strip CSS comments so wording in doc-comments cannot accidentally satisfy
+    // the assertion. We only care about real declarations and var() refs.
+    const css = readThemeTokens().replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(css).not.toMatch(/--desktop-color-[a-zA-Z-]+\s*:/);
+    expect(css).not.toMatch(/--desktop-font-[a-zA-Z-]+\s*:/);
+    expect(css).not.toMatch(/var\(--desktop-color-[a-zA-Z-]+\)/);
+    expect(css).not.toMatch(/var\(--desktop-font-[a-zA-Z-]+\)/);
   });
 });


### PR DESCRIPTION
## Summary

Two coupled refactors against the WA bridge files (`packages/extension/src/common/styles/common.css` and `packages/desktop/src/renderer/themeTokens.css`).

### Refactor 1 — VS Code-square corners

WA's default theme ships border-radius `s≈3px / m≈6px / l≈12px` which feels too rounded against VS Code's near-flat form-control aesthetic. Both bridge files now override `--wa-border-radius-*` to the in-house VS Code-square scale already used by `litStyles.ts`:

| Token | WA default | New override |
| --- | --- | --- |
| `--wa-border-radius-s` | 0.1875rem (~3px) | **2px** |
| `--wa-border-radius-m` | 0.375rem (~6px) | **3px** |
| `--wa-border-radius-l` | 0.75rem (~12px) | **4px** |
| `--wa-border-radius-xl` | (n/a) | **6px** (added) |
| `--wa-border-radius-pill` | 9999px | 9999px (kept) |
| `--wa-border-radius-circle` | 50% | 50% (kept) |
| `--wa-border-radius-square` | 0px | 0px (added explicitly) |

Hardcoded `border-radius: 4px` on the desktop nav back/icon buttons migrated to `var(--wa-border-radius-m)`. Stale fallback values inside `var(--wa-border-radius-X, Ypx)` updated to match the new overrides so the inert fallback no longer misleads readers.

### Refactor 2 — Retire `--desktop-*` tokens

The desktop `themeTokens.css` ran palette literals through a `--desktop-color-*` / `--desktop-font-*` indirection layer that had no purpose beyond historical naming — every \`--wa-*\` token already aliased a \`--desktop-*\` token, and \`--desktop-*\` was the only place \`light-dark()\` lived. Move all literals directly onto the canonical \`--wa-*\` tokens.

Migration counts (per the user's mapping):

| Old `--desktop-*` token | New canonical |
| --- | --- |
| `--desktop-color-foreground/muted/background/sidebar/sidebar-header/border` | `--wa-color-text-normal/text-quiet/surface-default/surface-raised/surface-lowered/surface-border` |
| `--desktop-color-input-background/input-border/input-foreground` | `--wa-form-control-background-color/border-color/text-color` |
| `--desktop-color-accent/accent-hover/accent-subtle` | `--wa-color-brand-fill-loud` (+ inlined hover/subtle literals where needed) |
| `--desktop-color-error/warning/success/info` (+ -background variants) | `--wa-color-{danger,warning,success,brand}-{fill-loud,fill-quiet}` |
| `--desktop-color-menu-*/list-*/toolbar-*/scrollbar-*` | `--texra-menu-*/list-*/toolbar-*/scrollbar-*` (inlined literals; no WA equivalent) |
| `--desktop-color-orange/yellow` | `--wa-color-data-orange/yellow` (renamed into WA namespace) |
| `--desktop-color-shadow/widget-border/placeholder/terminal-selection` | inlined `light-dark()` literals on the consuming `--texra-*` aliases |
| `--desktop-font-family/size/weight` | `--wa-font-family-body/size-m/weight-normal` |

The `--texra-*` and `--vscode-*` re-export layers remain (extension webviews reused inside the desktop shell still consume them) but now reference `--wa-*` tokens. The high-contrast override block now patches `--wa-*` directly instead of `--desktop-*`.

`DesktopThemeTokens.vitest.mts` updated:
- bridge-shape assertion follows the new path (`--vscode-textArea-* → --wa-form-control-* → light-dark literal`),
- new test asserts the VS Code-square border-radius overrides,
- new test guards that `--desktop-color-*` / `--desktop-font-*` indirection cannot creep back (regex matches actual declarations and `var()` refs, ignoring doc-comments).

### Bridge file size diff

- `themeTokens.css` 509 lines (was 509 — content reorganized, palette inlined onto `--wa-*` so no net delta)
- `common.css` 291 lines (was 270 — +21 lines for the radius override block; same comment otherwise)

### Verified counts

- `var(--desktop-color-*)` consumers: **0** (was ~38 unique refs across `themeTokens.css` + `styles.css`).
- `var(--desktop-font-*)` consumers: **0** (was 3 in the bridge file).
- `var(--desktop-*)` consumers across `packages/` + `src/`: **4** — all `var(--desktop-nav-height)` (a renderer-local layout token in `styles.css`, not a theme token).
- `var(--wa-border-radius-*)` consumers across `packages/` + `src/`: 17 m / 13 s / 12 l / 12 scale.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `cd packages/desktop && npx vite build --mode development` — clean.
- [x] `npm run compile:fast` (extension webviews) — clean.
- [x] `npx vitest run src/test-kernel/desktop/DesktopThemeTokens.vitest.mts` — 4/4 pass.
- [ ] Smoke-test extension VS Code build (launcher / settings / progress) and confirm wa-button, wa-input, wa-callout, wa-dialog corners read as VS Code-square.
- [ ] Smoke-test desktop Electron build and confirm theme palette unchanged (light + dark) plus same square corners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it reshapes core theme-token plumbing for both the desktop renderer and VS Code webviews; any mismatch in token aliases can cause widespread visual regressions across controls and legacy CSS bridges.
> 
> **Overview**
> Unifies theming around **direct `--wa-*` tokens** by removing the `--desktop-color-*` / `--desktop-font-*` indirection in the desktop renderer and moving all palette `light-dark()` literals onto the canonical WA tokens; the high-contrast block now overrides `--wa-*` directly.
> 
> Introduces **VS Code-square corner overrides** by pinning `--wa-border-radius-*` (s/m/l/xl, plus pill/circle/square) in both desktop `themeTokens.css` and extension `common.css`, and updates desktop UI styles to consume these tokens (replacing hardcoded radii and adjusting fallback values).
> 
> Updates tests (`DesktopThemeTokens.vitest.mts`) to validate the new `--vscode-* → --wa-form-control-*` bridge, assert the border-radius overrides, and guard against reintroducing any `--desktop-*` token usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061f1c6a03c8db8a2544b484d85776500833e946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->