### PR TITLE
refactor(wa): more declarative + native WA patterns across progress/settings

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -19,8 +19,9 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA icon and button components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
 
 // Local imports - shared styles
 import {
@@ -227,8 +228,9 @@ export class RequestPanels extends LitElement {
     const current = perms[this._eiIndex];
     const nav = html`
       <div class="external-inquiry-requests__nav">
-        <button
-          class="external-inquiry-requests__nav-btn"
+        <wa-button
+          appearance="plain"
+          size="small"
           title="Previous inquiry"
           ?disabled=${this._eiIndex === 0}
           @click=${this._eiPrev}
@@ -238,12 +240,13 @@ export class RequestPanels extends LitElement {
             name="chevron-left"
             aria-hidden="true"
           ></wa-icon>
-        </button>
+        </wa-button>
         <span class="external-inquiry-requests__counter">
           ${this._eiIndex + 1} / ${perms.length}
         </span>
-        <button
-          class="external-inquiry-requests__nav-btn"
+        <wa-button
+          appearance="plain"
+          size="small"
           title="Next inquiry"
           ?disabled=${this._eiIndex === perms.length - 1}
           @click=${this._eiNext}
@@ -253,7 +256,7 @@ export class RequestPanels extends LitElement {
             name="chevron-right"
             aria-hidden="true"
           ></wa-icon>
-        </button>
+        </wa-button>
       </div>
     `;
 

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -6,6 +6,7 @@
 
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import {
   LitElement,
   html,
@@ -153,10 +154,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-list-item.selected {
         background: var(--wa-color-brand-fill-quiet);
-        color: var(
-          --texra-list-activeSelectionForeground,
-          var(--wa-color-text-normal)
-        );
+        color: var(--wa-color-text-normal);
         border-left-color: var(--wa-color-brand-fill-loud);
         box-shadow: inset 0 0 0 1px
           color-mix(in srgb, var(--wa-color-brand-fill-loud) 12%, transparent);
@@ -172,8 +170,6 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-list-item-checkbox {
-        accent-color: var(--wa-color-focus);
-        cursor: pointer;
         flex-shrink: 0;
       }
 
@@ -309,16 +305,13 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-action-btn--danger::part(base) {
-        color: var(--wa-color-danger-on-quiet, #f44);
-        border-color: var(--wa-color-danger-on-quiet, #f44);
+        color: var(--wa-color-danger-on-quiet);
+        border-color: var(--wa-color-danger-on-quiet);
       }
 
       .agent-action-btn--danger:hover::part(base) {
-        background: var(
-          --texra-inputValidation-errorBackground,
-          rgba(255, 0, 0, 0.1)
-        );
-        border-color: var(--wa-color-danger-on-quiet, #f44);
+        background: var(--wa-color-danger-fill-quiet);
+        border-color: var(--wa-color-danger-on-quiet);
       }
 
       .agent-delete-confirm {
@@ -326,11 +319,8 @@ export class AgentSelectionPanel extends LitElement {
         align-items: center;
         gap: var(--wa-space-xs);
         padding: var(--wa-space-2xs) var(--wa-space-xs);
-        background: var(
-          --texra-inputValidation-errorBackground,
-          rgba(255, 0, 0, 0.05)
-        );
-        border: var(--border-thin) solid var(--wa-color-danger-on-quiet, #f44);
+        background: var(--wa-color-danger-fill-quiet);
+        border: var(--border-thin) solid var(--wa-color-danger-on-quiet);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);
@@ -543,10 +533,9 @@ export class AgentSelectionPanel extends LitElement {
         }}
         title=${agent.description ?? agent.name}
       >
-        <input
-          type="checkbox"
+        <wa-checkbox
           class="agent-list-item-checkbox"
-          .checked=${agent.enabled}
+          ?checked=${agent.enabled}
           @click=${(e: Event) => {
             e.stopPropagation();
             this.handleToggleEnabled(agent);
@@ -554,7 +543,7 @@ export class AgentSelectionPanel extends LitElement {
           title=${agent.enabled
             ? 'Hide from agent selector'
             : 'Show in agent selector'}
-        />
+        ></wa-checkbox>
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${agent.source === AGENT_SOURCE.REMOTE

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -6,6 +6,13 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -229,12 +236,12 @@ export class LaTeXTab extends LitElement {
 
       .dependency-icon.installed,
       .setting-status-icon.is-set {
-        color: var(--texra-testing-iconPassed, #73c991);
+        color: var(--wa-color-success-fill-loud);
       }
 
       .dependency-icon.missing,
       .setting-status-icon.not-set {
-        color: var(--texra-testing-iconFailed, #f48771);
+        color: var(--wa-color-danger-fill-loud);
       }
 
       .dependency-info {
@@ -316,9 +323,9 @@ export class LaTeXTab extends LitElement {
         white-space: nowrap;
       }
 
-      .copy-success {
-        color: var(--texra-testing-iconPassed, #73c991) !important;
-        border-color: var(--texra-testing-iconPassed, #73c991) !important;
+      .tab-action-btn.copy-success {
+        color: var(--wa-color-success-fill-loud);
+        border-color: var(--wa-color-success-fill-loud);
       }
 
       /* Prerequisite hint uses wa-callout; only layout for actions row + the
@@ -354,13 +361,6 @@ export class LaTeXTab extends LitElement {
         min-width: 0;
       }
 
-      .setting-toggle {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        white-space: nowrap;
-      }
-
       .setting-name {
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-normal);
@@ -391,13 +391,6 @@ export class LaTeXTab extends LitElement {
         flex-shrink: 0;
       }
 
-      .checkbox-row {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        margin-top: var(--wa-space-2xs);
-        cursor: pointer;
-      }
     `,
   ];
 
@@ -414,6 +407,17 @@ export class LaTeXTab extends LitElement {
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
   @state() private expandedGuides = new Set<string>();
+  /** Command string most recently copied; clears after a brief flash. */
+  @state() private copiedCommand: string | null = null;
+  private copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  override disconnectedCallback(): void {
+    if (this.copyResetTimer) {
+      clearTimeout(this.copyResetTimer);
+      this.copyResetTimer = null;
+    }
+    super.disconnectedCallback();
+  }
 
   private toggleGuide(key: string): void {
     const next = new Set(this.expandedGuides);
@@ -429,7 +433,7 @@ export class LaTeXTab extends LitElement {
   private handleInlineCriticismToggle(event: Event): void {
     this.dispatchEvent(
       createEvent('inline-criticism-toggle', {
-        enabled: (event.target as HTMLInputElement).checked,
+        enabled: Boolean((event.target as WaSwitch | null)?.checked),
       }),
     );
   }
@@ -459,17 +463,15 @@ export class LaTeXTab extends LitElement {
     );
   }
 
-  private async handleCopyCommand(e: Event, command: string): Promise<void> {
-    const button = (e.currentTarget ?? e.target) as HTMLElement;
+  private async handleCopyCommand(command: string): Promise<void> {
     const ok = await copyTextToClipboard(command);
-    if (ok) {
-      button.classList.add('copy-success');
-      button.setAttribute('title', 'Copied!');
-      setTimeout(() => {
-        button.classList.remove('copy-success');
-        button.setAttribute('title', 'Copy command');
-      }, 2000);
-    }
+    if (!ok) return;
+    this.copiedCommand = command;
+    if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
+    this.copyResetTimer = setTimeout(() => {
+      this.copiedCommand = null;
+      this.copyResetTimer = null;
+    }, 2000);
   }
 
   private handleRunInTerminal(command: string): void {
@@ -543,10 +545,13 @@ export class LaTeXTab extends LitElement {
           ? html`
               <div class="dependency-install-actions">
                 <button
-                  class="tab-action-btn"
-                  title="Copy: ${installCmd.command}"
-                  @click=${(e: Event) =>
-                    this.handleCopyCommand(e, installCmd.command)}
+                  class="tab-action-btn ${this.copiedCommand === installCmd.command
+                    ? 'copy-success'
+                    : ''}"
+                  title=${this.copiedCommand === installCmd.command
+                    ? 'Copied!'
+                    : `Copy: ${installCmd.command}`}
+                  @click=${() => this.handleCopyCommand(installCmd.command)}
                 >
                   <wa-icon library="texra" name="copy"></wa-icon>
                   Copy
@@ -629,9 +634,13 @@ export class LaTeXTab extends LitElement {
         <div class="hint-actions">
           <code class="install-command-text">${installCommand}</code>
           <button
-            class="tab-action-btn"
-            title="Copy ${pmName} install command"
-            @click=${(e: Event) => this.handleCopyCommand(e, installCommand)}
+            class="tab-action-btn ${this.copiedCommand === installCommand
+              ? 'copy-success'
+              : ''}"
+            title=${this.copiedCommand === installCommand
+              ? 'Copied!'
+              : `Copy ${pmName} install command`}
+            @click=${() => this.handleCopyCommand(installCommand)}
           >
             <wa-icon library="texra" name="copy"></wa-icon>
             Copy
@@ -782,14 +791,12 @@ export class LaTeXTab extends LitElement {
             agent-revised LaTeX files and show them as editor diagnostics.
           </div>
         </div>
-        <label class="setting-toggle">
-          <input
-            type="checkbox"
-            .checked=${this.inlineCriticismEnabled}
-            @change=${this.handleInlineCriticismToggle}
-          />
-          <span>${this.inlineCriticismEnabled ? 'On' : 'Off'}</span>
-        </label>
+        <wa-switch
+          ?checked=${this.inlineCriticismEnabled}
+          @change=${this.handleInlineCriticismToggle}
+        >
+          ${this.inlineCriticismEnabled ? 'On' : 'Off'}
+        </wa-switch>
       </div>
     `;
   }
@@ -944,13 +951,13 @@ export class LaTeXTab extends LitElement {
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
-          <input
+          <wa-input
             type="number"
             min=${opts.min}
-            max=${opts.max ?? ''}
+            max=${opts.max ?? nothing}
             .value=${String(effective)}
             @change=${(e: Event) => {
-              const raw = (e.target as HTMLInputElement).valueAsNumber;
+              const raw = Number((e.target as WaInput).value);
               if (Number.isNaN(raw)) return;
               // Coerce to integer first — paste / spinner can produce decimals
               // that the backend `.int()` schema would silently reject.
@@ -962,7 +969,7 @@ export class LaTeXTab extends LitElement {
               this.dispatchSetConfigValue(opts.field, clamped);
             }}
             style="margin-top:var(--wa-space-2xs);width:140px;"
-          />
+          ></wa-input>
         </div>
         ${isCustom
           ? html`<button
@@ -999,9 +1006,10 @@ export class LaTeXTab extends LitElement {
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
-          <select
+          <wa-select
+            .value=${String(effective)}
             @change=${(e: Event) => {
-              const v = (e.target as HTMLSelectElement)
+              const v = (e.target as WaSelect)
                 .value as LatexConfigValueFor<F>;
               this.dispatchSetConfigValue(opts.field, v);
             }}
@@ -1009,12 +1017,10 @@ export class LaTeXTab extends LitElement {
           >
             ${opts.options.map(
               (o) => html`
-                <option value=${o.value} ?selected=${o.value === effective}>
-                  ${o.label}
-                </option>
+                <wa-option value=${String(o.value)}>${o.label}</wa-option>
               `,
             )}
-          </select>
+          </wa-select>
         </div>
         ${isCustom
           ? html`<button

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -596,29 +596,6 @@ export const requestPanelStyles: CSSResult = css`
     text-align: center;
   }
 
-  .external-inquiry-requests__nav-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    padding: 0;
-    border: none;
-    border-radius: var(--border-radius-small);
-    background: transparent;
-    color: var(--wa-color-text-normal);
-    cursor: pointer;
-  }
-
-  .external-inquiry-requests__nav-btn:hover:not(:disabled) {
-    background: var(--wa-color-surface-raised);
-  }
-
-  .external-inquiry-requests__nav-btn:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
   .external-inquiry-request__mode-badge {
     background: var(--wa-color-neutral-fill-quiet);
     color: var(--wa-color-neutral-on-quiet);


### PR DESCRIPTION
## Summary

Six focused conversions across the audited webview files. Trades hand-rolled imperative DOM mutation, native form controls, and stale `--texra-*` token bridges for declarative state, native WA components, and direct `--wa-*` tokens.

- **LaTeXTab — declarative copy feedback.** Imperative `button.classList.add('copy-success') + setAttribute('title') + setTimeout(...)` collapsed into a `@state copiedCommand` flag bound reactively to the class and title. Removes the side-effecting handler altogether.
- **LaTeXTab — native `<input>`/`<select>`/`<input type=checkbox>` -> `<wa-input>`, `<wa-select>` + `<wa-option>`, `<wa-switch>`.** Brings the LaTeX tab in line with how MultiAgentTab/InstructionPanel/etc. already render form controls. Drops `.setting-toggle` and unused `.checkbox-row` rules.
- **LaTeXTab — drop `--texra-testing-iconPassed/Failed`** (with hex fallbacks `#73c991` / `#f48771`) in favor of `--wa-color-success-fill-loud` / `--wa-color-danger-fill-loud`. Continues the recent `--texra-*` bridge retirement.
- **AgentSelectionPanel — native `<input type=checkbox>` -> `<wa-checkbox>`.** Eliminates the `accent-color: var(--wa-color-focus)` workaround.
- **AgentSelectionPanel — `--texra-list-activeSelectionForeground` / `--texra-inputValidation-errorBackground` -> `--wa-color-text-normal` / `--wa-color-danger-fill-quiet`.** Drops the hex/rgba defensive fallbacks.
- **RequestPanels — carousel `<button>` -> `<wa-button appearance="plain" size="small">`.** Lets us delete the 24-line `.external-inquiry-requests__nav-btn{,:hover,:disabled}` block from `requestPanelStyles.ts`.

Audited but left alone: `LogList` / `RequestPanelsState` (already declarative; the imperative bits are valid event-delegation/scroll side-effects), `TerminalOutput` / `TexraDiffView` (xterm.js / Monaco wrappers — imperative is intrinsic), `desktopOnboarding` (already a `wa-dialog`), `desktopCommandPalette` (a non-Lit factory that converting would require a new abstraction — out of scope), `ModelsTab` / `HistoryItem` (no high-impact targets remaining).

Net: **+82 / -107** across 4 files.

## Test plan

- [x] `npm run typecheck` — only pre-existing `@openrouter/sdk/models` and `electron`/`paths.ts` baseline errors.
- [x] `cd packages/desktop && npx vite build --mode development` — clean (`built in 1.64s`).
- [x] `npx vitest run` — 313 pass / 5 fail; failures match origin/main baseline (desktop theme tokens, ElectronCompositionRoot PATH, ElectronRendererShell command-palette).
- [ ] Manual smoke: LaTeX tab copy button flashes "Copied!", number/select fields commit values, inline criticism switch toggles.
- [ ] Manual smoke: Agent picker checkboxes still toggle visibility without selecting the row.
- [ ] Manual smoke: External-inquiry carousel prev/next buttons disable at endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI refactor that swaps native controls for Web Awesome components and changes event/value handling (copy feedback, switches, inputs/selects), which could introduce subtle behavior or styling regressions in these webviews.
> 
> **Overview**
> Moves progress/settings webviews toward *native Web Awesome patterns*: replaces external-inquiry carousel nav buttons with `wa-button` and drops the now-unneeded custom nav-button CSS.
> 
> In `LaTeXTab`, replaces native form controls with `wa-input`/`wa-select`/`wa-option`/`wa-switch`, updates success/error icon and copy-success styling to direct `--wa-*` tokens, and makes copy-to-clipboard feedback declarative via a `@state` `copiedCommand` (with timer cleanup on disconnect) instead of imperatively mutating DOM.
> 
> In `AgentSelectionPanel`, replaces the list checkbox with `wa-checkbox` and updates selection/danger styling to use `--wa-*` tokens (removing older `--texra-*`/fallback color bridges).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f5588ef6eefffbf9bd666e8ee1fc3ed01abded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->