### PR TITLE
fix(wa): dark-theme readability + Run button slimmer + workflow files default-open

### DIFF
--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -18,7 +18,14 @@
 .wa-dark .wa-invert {
   /* ── Web Awesome surface / text tokens (light + default) ────────────── */
   --wa-color-text-normal: var(--vscode-editor-foreground, var(--vscode-foreground));
-  --wa-color-text-quiet: var(--vscode-descriptionForeground);
+  /* Some VS Code themes (notably dark) set descriptionForeground too dim to
+     read against tinted surface cards. Mix at least 65% of the normal text
+     color in to guarantee a readable contrast in every theme. */
+  --wa-color-text-quiet: color-mix(
+    in srgb,
+    var(--vscode-editor-foreground, var(--vscode-foreground)) 70%,
+    transparent
+  );
   --wa-color-text-link: var(--vscode-textLink-foreground);
 
   --wa-color-surface-default: var(--vscode-editor-background);

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1898,6 +1898,7 @@ export class MainApp extends MainAppBase {
 
   render(): TemplateResult {
     const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
+    const isWorkflow = this.sessionType.get() === SESSION_TYPES.WORKFLOW;
     const fileSelectionClasses = classMap({
       'file-selection-group': true,
       'file-selection-group--disabled': isToolUse,
@@ -2015,7 +2016,10 @@ export class MainApp extends MainAppBase {
             ? nothing
             : html`
                 <div class="section-separator" role="presentation"></div>
-                <wa-details class="file-selection-details">
+                <wa-details
+                  class="file-selection-details"
+                  ?open=${isWorkflow}
+                >
                   <span slot="summary" class="file-selection-summary">
                     <wa-icon
                       library=${TEXRA_ICON_LIBRARY}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -307,7 +307,8 @@ export class InstructionPanel extends LitElement {
 
       wa-button.execute-button::part(base) {
         min-width: 64px;
-        min-height: 30px;
+        min-height: 24px;
+        height: 24px;
         padding: 0 var(--wa-space-s);
         gap: var(--wa-space-2xs);
         border-radius: var(--wa-border-radius-m);


### PR DESCRIPTION
Three small UX fixes:

1. **Dark-theme description contrast**: VS Code's dark themes set `--vscode-descriptionForeground` so dim it disappears against tinted surface cards (preset cards, settings rows). Override `--wa-color-text-quiet` to `color-mix(srgb, --vscode-editor-foreground 70%, transparent)` so quiet text stays legible in every theme.
2. **Run button slimmer**: 30px → 24px to match the rest of the launcher toolbar.
3. **Workflow mode auto-opens Files**: the Files `wa-details` collapses by default in interactive mode but `?open=${isWorkflow}` auto-expands when sessionType=workflow since file selection drives the workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to styling and default expansion state; no changes to execution, persistence, or backend messaging.
> 
> **Overview**
> Improves webview readability in dark VS Code themes by redefining `--wa-color-text-quiet` as a `color-mix` of normal foreground and transparency instead of relying directly on `--vscode-descriptionForeground`.
> 
> Tweaks launcher UX by making the InstructionPanel Run button 24px tall (down from 30px) and default-expanding the Files `wa-details` section when `sessionType` is `WORKFLOW` (still hidden for tool-use sessions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5e2d126dda5eb8960f7016a88eedb2553097e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->