### PR TITLE
fix(webview): narrow agent/model dropdown widths

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -99,13 +99,13 @@ export class InstructionPanel extends LitElement {
     css`
       :host {
         display: block;
-        --agent-select-min-width: 8rem;
-        --agent-select-max-width: min(13rem, calc(100vw - 9rem));
-        --model-select-min-width: 8rem;
-        --model-select-max-width: min(15rem, calc(100vw - 9rem));
-        --agent-model-listbox-min-width: 17rem;
+        --agent-select-min-width: 6rem;
+        --agent-select-max-width: min(11rem, calc(100vw - 9rem));
+        --model-select-min-width: 6rem;
+        --model-select-max-width: min(13rem, calc(100vw - 9rem));
+        --agent-model-listbox-min-width: 12rem;
         --agent-model-listbox-max-width: min(
-          26rem,
+          20rem,
           calc(100vw - var(--wa-space-l))
         );
       }


### PR DESCRIPTION
Listboxes were 17rem min / 26rem max — much wider than triggers. Tighten to 12-20rem listbox + 6-13rem triggers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only tweaks to dropdown/listbox sizing in the webview, with no behavioral or data-flow changes.
> 
> **Overview**
> Tightens the agent/model picker layout in `InstructionPanel` by reducing the min/max widths for the select triggers and their listboxes, bringing the dropdown popovers closer to the trigger widths (narrower min/max constraints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e02688776ddc88cd1df76f365d41191404a34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->