### PR TITLE
refactor(wa): audit and remove non-meaningful hover states

### DIFF
--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -89,15 +89,6 @@ export class PlanView extends LitElement {
         border-radius: var(--border-radius-small);
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
-        transition: background-color 140ms ease;
-      }
-
-      .plan-step:hover {
-        background-color: color-mix(
-          in srgb,
-          var(--wa-color-neutral-fill-quiet) 50%,
-          transparent
-        );
       }
 
       .plan-step__number {
@@ -167,10 +158,6 @@ export class PlanView extends LitElement {
         );
         box-shadow: inset 2px 0 0
           color-mix(in srgb, var(--wa-color-brand-fill-loud) 50%, transparent);
-      }
-
-      .plan-step--in-progress:hover {
-        background-color: var(--wa-color-brand-fill-quiet);
       }
 
       .plan-step--in-progress .plan-step__icon {

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -193,10 +193,6 @@ export class StreamHeader extends LitElement {
         position: relative;
       }
 
-      .status-indicator:hover {
-        opacity: var(--opacity-full);
-      }
-
       /* Tooltip on hover */
       .status-indicator::after {
         content: attr(data-status);

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -103,10 +103,6 @@ export const profileViewStyles: CSSResult = css`
     top: 0;
   }
 
-  .provider-keys-table tbody tr:hover {
-    background: var(--wa-color-neutral-fill-quiet);
-  }
-
   /* Profile-specific badge modifiers (base category styles from @shared/styles) */
   .category-badge {
     text-transform: capitalize;
@@ -420,9 +416,12 @@ export const profileViewStyles: CSSResult = css`
     text-align: left;
   }
 
-  .provider-group-header:hover {
-    background: var(--wa-color-neutral-fill-quiet);
-  }
+  /*
+   * No hover on .provider-group-header itself — only the inner
+   * .provider-group-toggle button is the click target. Hovering the
+   * surrounding header (which also contains key-action buttons) would
+   * misleadingly suggest the whole row is clickable.
+   */
 
   .provider-group-toggle {
     display: flex;
@@ -436,6 +435,10 @@ export const profileViewStyles: CSSResult = css`
     cursor: pointer;
     font: inherit;
     text-align: left;
+  }
+
+  .provider-group-toggle:hover {
+    background: var(--wa-color-neutral-fill-quiet);
   }
 
   .provider-group-toggle:focus-visible {
@@ -497,10 +500,6 @@ export const profileViewStyles: CSSResult = css`
     align-items: center;
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     gap: var(--wa-space-xs);
-  }
-
-  .model-row:hover {
-    background: var(--wa-color-neutral-fill-quiet);
   }
 
   .model-row wa-checkbox {

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -42,11 +42,6 @@ export class ToolCard extends LitElement {
           --wa-color-surface-default,
           var(--wa-color-surface-lowered)
         );
-        transition: border-color var(--transition-fast);
-      }
-
-      .tool-card:hover {
-        border-color: var(--wa-color-focus);
       }
 
       .tool-header {

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -201,11 +201,6 @@ export const multiFilesStyles = css`
     justify-content: space-between;
     align-items: center;
     border-radius: var(--border-radius-small);
-    transition: background-color var(--transition-fast);
-  }
-
-  .file-item:hover {
-    background-color: var(--wa-color-neutral-fill-quiet);
   }
 
   .file-name {


### PR DESCRIPTION
## Summary

User feedback (verbatim): *"not every hover is meaningful. audit them."*

Recent design polish passes added `:hover` styling to many surfaces — some on real click targets (great), some on static elements that just twitch when you mouse past them (noise). Hover should signal *"this will respond when you interact"*, not decorate every card.

Audited 86 `:hover` rules across webview/progressView/settings/desktop/shared styles. Picked 7 highest-impact removals + 1 reattachment (header → toggle). Skipped the rest because they target real click affordances (selection rows, expanders, link buttons, reveal-on-hover delete buttons, banner CTAs, the Run button, etc.).

## Removed

- **`tool-card:hover` border-color flash** (`tools/ToolCard.ts`) — settings display card, not clickable.
- **`plan-step:hover`** and **`plan-step--in-progress:hover`** background tints (`PlanView.ts`) — read-only plan list; in-progress already has its own visual cue.
- **`provider-keys-table tbody tr:hover`** (`profile/styles.ts`) — table rows aren't clickable; only the buttons inside cells act.
- **`provider-group-header:hover`** (`profile/styles.ts`) — header wraps both the toggle button and the key-action buttons, so the hover scope was misleading. Moved the affordance onto `.provider-group-toggle` (the actual click target).
- **`model-row:hover`** (`profile/styles.ts`) — row contains a `wa-checkbox` + metadata; the row itself doesn't toggle.
- **`file-item:hover` background tint** (`webview/frontend/styles/fileSelectStyles.ts`) — unlike `OutputFilesSection`, this variant keeps the remove button always visible, so the hover isn't revealing anything.
- **`status-indicator:hover { opacity: full }`** (`StreamHeader.ts`) — kept the `::after` tooltip-reveal rule (meaningful), dropped the redundant opacity bump on a 8px decorative dot.

## Kept (sample, verified meaningful)

`preset-card`, `agent-list-item`, `log-group-header`, `tab-container` family, `file-item` in `OutputFilesSection` (reveals remove btn), `task-name--clickable`, `details-summary` rows, `.clickable`/`.file-link`/`.parent-link`/btn variants, `wa-tab` strip, all `desktop-*-button` overrides, banner action buttons, Run button glow, status-indicator tooltip reveal.

## Test plan

- [x] `npm run typecheck` — pre-existing baseline errors only (electron/openrouter type resolution); no new errors from this change.
- [x] `cd packages/desktop && npx vite build --mode development` — clean build (1.44s).
- [ ] Visual: hover over a settings tool card / plan step / model row / provider key row → no longer flashes. Hover over `.provider-group-toggle` button → still highlights. Status dot in stream header → tooltip still appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS adjustments that remove/retarget hover affordances; main risk is minor UX regression if any removed hover was relied on as an interaction cue.
> 
> **Overview**
> Reduces UI “twitch” by removing several `:hover` visual treatments on non-clickable surfaces across the extension webviews (plan steps, tool cards, provider key table rows, model rows, file-select items, and the stream status dot), while keeping meaningful hover behaviors like tooltips.
> 
> In the profile model/provider UI, the hover highlight is **moved** from the broader `.provider-group-header` wrapper to the actual clickable `.provider-group-toggle` button to better match the real interaction target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f1889cb50d5efc8182fe40439393e814e73ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->