### PR TITLE
refactor(wa): retire --vscode/--texra double bridge — only --wa- remains

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -141,7 +141,7 @@ wa-button.desktop-command-button {
   min-height: 0;
   border-right: 1px solid var(--wa-color-surface-border);
   background: var(--wa-color-surface-lowered);
-  color: var(--texra-sideBar-foreground);
+  color: var(--wa-color-text-normal);
 }
 
 .desktop-explorer-header {
@@ -278,19 +278,19 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
 }
 
 .desktop-explorer-category-dot[data-category='input'] {
-  background: var(--texra-charts-blue);
+  background: var(--wa-color-chart-blue);
 }
 
 .desktop-explorer-category-dot[data-category='reference'] {
-  background: var(--texra-charts-green);
+  background: var(--wa-color-chart-green);
 }
 
 .desktop-explorer-category-dot[data-category='auxiliary'] {
-  background: var(--texra-charts-yellow);
+  background: var(--wa-color-chart-yellow);
 }
 
 .desktop-explorer-category-dot[data-category='media'] {
-  background: var(--texra-charts-purple);
+  background: var(--wa-color-chart-purple);
 }
 
 .desktop-explorer-status,

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -1,19 +1,15 @@
 /**
  * Document-level theme tokens for the TeXRA desktop (Electron) renderer.
  *
- * Web Awesome native theming: --wa-* tokens are the single source of truth and
- * are sourced directly from the desktop's native --desktop-color-* palette.
- * The renderer entry (main.ts) imports the WA default theme stylesheet via
- * @shared/wa, and applyDesktopTheme() mirrors the active theme kind onto
- * <html class="wa-light|wa-dark"> so WA's color-scheme classes activate.
+ * Single token system: --wa-* tokens are the ONLY tokens consumer code
+ * references. They are sourced directly from the desktop's native
+ * --desktop-color-* palette below. There is no --texra-* shim layer and
+ * consumers never reference --vscode-* directly.
  *
- * --texra-* tokens remain as a thin compatibility alias layer for tokens that
- * have no clean WA equivalent (terminal ansi, symbol icons, charts, list rows,
- * git decoration, etc.) and a few legacy aliases consumers still reference.
- * They no longer round-trip through --wa-*.
- *
- * --vscode-* tokens are re-exported at the bottom so VS Code-styled CSS reused
- * in the desktop renderer keeps working without per-file rewrites.
+ * Niche palette tokens with no clean WA semantic equivalent (terminal ansi,
+ * symbol icons, charts, git decoration, debug tokens, diff editor, etc.) are
+ * promoted into the --wa-color-* namespace so the consumer surface stays
+ * uniform across both hosts.
  */
 
 :root {
@@ -64,42 +60,37 @@
   --desktop-color-error-background: light-dark(#ffebe9, #5a1d1d);
   --desktop-color-orange: light-dark(#bc4c00, #d18616);
   --desktop-color-yellow: light-dark(#bf8700, #cca700);
+  --desktop-color-purple: light-dark(#8250df, #c586c0);
   --desktop-color-terminal-selection: light-dark(#ddf4ff, #264f78);
-  --desktop-color-scrollbar: light-dark(
-    rgb(31 35 40 / 20%),
-    rgb(121 121 121 / 40%)
-  );
-  --desktop-color-scrollbar-hover: light-dark(
-    rgb(31 35 40 / 30%),
-    rgb(100 100 100 / 70%)
-  );
-  --desktop-color-scrollbar-active: light-dark(
-    rgb(31 35 40 / 45%),
-    rgb(191 191 191 / 40%)
-  );
 }
 
 /*
  * Web Awesome design-token bridge — single source of truth.
- * Sourced directly from the native --desktop-color-* palette above (no
- * intermediate --texra-* layer).
+ * Sourced directly from the native --desktop-color-* palette above.
  */
 :root,
 .wa-light,
 .wa-dark .wa-invert {
+  /* Typography. */
   --wa-font-family-body: var(--desktop-font-family);
   --wa-font-family-heading: var(--desktop-font-family);
   --wa-font-family-mono: 'SF Mono', Monaco, monospace;
   --wa-font-size-m: var(--desktop-font-size);
   --wa-font-weight-normal: var(--desktop-font-weight);
+  --wa-editor-font-size: var(--desktop-font-size);
 
+  /* Surface / text. */
   --wa-color-text-normal: var(--desktop-color-foreground);
   --wa-color-text-quiet: var(--desktop-color-muted);
   --wa-color-text-link: var(--desktop-color-accent);
+  --wa-color-text-link-active: var(--desktop-color-accent-hover);
+  --wa-color-text-preformat: var(--desktop-color-input-foreground);
+  --wa-color-text-placeholder: var(--desktop-color-placeholder);
   --wa-color-surface-default: var(--desktop-color-background);
   --wa-color-surface-raised: var(--desktop-color-sidebar);
   --wa-color-surface-lowered: var(--desktop-color-sidebar-header);
   --wa-color-surface-border: var(--desktop-color-border);
+  --wa-color-surface-shadow: var(--desktop-color-shadow);
 
   --wa-color-focus: var(--desktop-color-accent);
 
@@ -143,6 +134,104 @@
   --wa-color-neutral-border-loud: var(--desktop-color-border);
   --wa-color-neutral-on-loud: var(--desktop-color-foreground);
 
+  /* Buttons — niche tokens consumers still need. */
+  --wa-color-button-hover: var(--desktop-color-accent-hover);
+  --wa-color-button-border: transparent;
+  --wa-color-button-separator: rgb(255 255 255 / 40%);
+
+  /* Lists — no native WA equivalent yet (#3690). */
+  --wa-color-list-active-bg: var(--desktop-color-accent);
+  --wa-color-list-active-fg: #ffffff;
+  --wa-color-list-hover-bg: var(--desktop-color-list-hover);
+  --wa-color-list-warning-fg: var(--desktop-color-warning);
+
+  /* Menus. */
+  --wa-color-menu-background: var(--desktop-color-menu-background);
+  --wa-color-menu-border: var(--desktop-color-menu-border);
+  --wa-color-menu-foreground: var(--desktop-color-input-foreground);
+
+  /* Toolbar. */
+  --wa-color-toolbar-active: var(--desktop-color-toolbar-active);
+  --wa-color-toolbar-hover: var(--desktop-color-toolbar-hover);
+
+  /* Charts. */
+  --wa-color-chart-blue: var(--desktop-color-accent);
+  --wa-color-chart-green: var(--desktop-color-success);
+  --wa-color-chart-orange: var(--desktop-color-orange);
+  --wa-color-chart-red: var(--desktop-color-error);
+  --wa-color-chart-yellow: var(--desktop-color-yellow);
+  --wa-color-chart-purple: var(--desktop-color-purple);
+
+  /* Diff editor. */
+  --wa-color-diff-inserted: light-dark(rgb(46 160 67 / 15%), rgb(46 160 67 / 30%));
+  --wa-color-diff-removed: light-dark(rgb(248 81 73 / 15%), rgb(248 81 73 / 30%));
+
+  /* Git decoration. */
+  --wa-color-git-added: var(--desktop-color-success);
+  --wa-color-git-deleted: var(--desktop-color-error);
+  --wa-color-git-modified: var(--desktop-color-orange);
+
+  /* Debug token expressions. */
+  --wa-color-debug-name: var(--desktop-color-accent);
+  --wa-color-debug-number: var(--desktop-color-orange);
+  --wa-color-debug-string: var(--desktop-color-success);
+
+  /* Symbol icons. */
+  --wa-color-symbol-class: var(--desktop-color-orange);
+  --wa-color-symbol-constant: var(--desktop-color-accent);
+  --wa-color-symbol-function: var(--desktop-color-yellow);
+  --wa-color-symbol-keyword: var(--desktop-color-purple);
+  --wa-color-symbol-property: var(--desktop-color-accent);
+  --wa-color-symbol-variable: var(--desktop-color-input-foreground);
+
+  /* Editor surface details. */
+  --wa-color-editor-selection: var(--desktop-color-accent-subtle);
+  --wa-color-editor-inactive-selection: var(--desktop-color-accent-subtle);
+  --wa-color-editor-line-highlight: light-dark(rgb(31 35 40 / 6%), rgb(255 255 255 / 4%));
+  --wa-color-editor-find-match: light-dark(#fff8c5, #623315);
+  --wa-color-editor-find-match-highlight: light-dark(#ffe09c, #4a3219);
+  --wa-color-editor-find-match-highlight-fg: var(--desktop-color-foreground);
+
+  /* Tabs. */
+  --wa-color-tabs-background: var(--desktop-color-sidebar-header);
+  --wa-color-tabs-border: var(--desktop-color-border);
+
+  /* Block quote. */
+  --wa-color-blockquote-border: var(--desktop-color-accent);
+
+  /* Misc indicators. */
+  --wa-color-progress-bg: var(--desktop-color-accent);
+  --wa-color-status-warning-bg: var(--desktop-color-warning);
+  --wa-color-icon-info: var(--desktop-color-info);
+  --wa-color-activity-badge-bg: var(--desktop-color-accent);
+  --wa-color-badge-bg: var(--desktop-color-accent);
+
+  /* Testing icons. */
+  --wa-color-testing-passed: var(--desktop-color-success);
+  --wa-color-testing-failed: var(--desktop-color-error);
+
+  /* Terminal — full palette, no WA equivalent. */
+  --wa-color-terminal-background: var(--desktop-color-background);
+  --wa-color-terminal-foreground: var(--desktop-color-input-foreground);
+  --wa-color-terminal-selection-bg: var(--desktop-color-terminal-selection);
+  --wa-color-terminal-cursor: var(--desktop-color-input-foreground);
+  --wa-color-terminal-ansi-black: light-dark(#24292f, #000000);
+  --wa-color-terminal-ansi-blue: var(--desktop-color-accent);
+  --wa-color-terminal-ansi-cyan: light-dark(#1b7c83, #4ec9b0);
+  --wa-color-terminal-ansi-green: var(--desktop-color-success);
+  --wa-color-terminal-ansi-magenta: light-dark(#8250df, #c586c0);
+  --wa-color-terminal-ansi-red: var(--desktop-color-error);
+  --wa-color-terminal-ansi-white: light-dark(#6e7781, #cccccc);
+  --wa-color-terminal-ansi-yellow: var(--desktop-color-yellow);
+  --wa-color-terminal-ansi-bright-black: light-dark(#6e7781, #666666);
+  --wa-color-terminal-ansi-bright-blue: light-dark(#0550ae, #3794ff);
+  --wa-color-terminal-ansi-bright-cyan: light-dark(#1b7c83, #39cccc);
+  --wa-color-terminal-ansi-bright-green: var(--desktop-color-success);
+  --wa-color-terminal-ansi-bright-magenta: light-dark(#8250df, #d670d6);
+  --wa-color-terminal-ansi-bright-red: var(--desktop-color-error);
+  --wa-color-terminal-ansi-bright-white: light-dark(#ffffff, #ffffff);
+  --wa-color-terminal-ansi-bright-yellow: var(--desktop-color-yellow);
+
   /* Web Awesome canonical space scale — kept in sync with WA default theme. */
   --wa-space-scale: 1;
   --wa-space-3xs: calc(var(--wa-space-scale) * 0.125rem);
@@ -156,149 +245,6 @@
   --wa-space-3xl: calc(var(--wa-space-scale) * 3rem);
   --wa-space-4xl: calc(var(--wa-space-scale) * 4rem);
   --wa-space-5xl: calc(var(--wa-space-scale) * 5rem);
-}
-
-/*
- * --texra-* compatibility alias layer.
- * Wa-aligned aliases collapse to --wa-* tokens. Niche aliases (terminal,
- * symbol icons, charts, list rows) source --desktop-color-* directly.
- */
-:root {
-  /* Wa-aligned aliases. */
-  --texra-foreground: var(--wa-color-text-normal);
-  --texra-descriptionForeground: var(--wa-color-text-quiet);
-  --texra-icon-foreground: var(--wa-color-text-quiet);
-  --texra-editor-background: var(--wa-color-surface-default);
-  --texra-editor-foreground: var(--wa-color-text-normal);
-  --texra-editorWidget-background: var(--wa-color-surface-raised);
-  --texra-editorWidget-border: var(--wa-color-surface-border);
-  --texra-editorHoverWidget-background: var(--wa-color-surface-raised);
-  --texra-editorHoverWidget-border: var(--wa-color-surface-border);
-  --texra-editorHoverWidget-foreground: var(--wa-color-text-normal);
-  --texra-sideBar-background: var(--wa-color-surface-lowered);
-  --texra-sideBar-foreground: var(--wa-color-text-normal);
-  --texra-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
-  --texra-sideBarTitle-foreground: var(--wa-color-text-normal);
-  --texra-panel-border: var(--wa-color-surface-border);
-  --texra-panelSection-border: var(--wa-color-surface-border);
-  --texra-widget-border: var(--desktop-color-widget-border);
-  --texra-widget-shadow: var(--desktop-color-shadow);
-  --texra-textCodeBlock-background: var(--wa-color-surface-lowered);
-  --texra-textBlockQuote-background: var(--desktop-color-accent-subtle);
-  --texra-textBlockQuote-border: var(--desktop-color-accent);
-  --texra-textLink-foreground: var(--wa-color-text-link);
-  --texra-textLink-activeForeground: var(--desktop-color-accent-hover);
-  --texra-textPreformat-foreground: var(--desktop-color-input-foreground);
-  --texra-input-background: var(--wa-form-control-background-color);
-  --texra-input-foreground: var(--wa-form-control-text-color);
-  --texra-input-border: var(--wa-form-control-border-color);
-  --texra-input-placeholderForeground: var(--desktop-color-placeholder);
-  --texra-dropdown-border: var(--wa-form-control-border-color);
-  --texra-button-background: var(--wa-color-brand-fill-loud);
-  --texra-button-foreground: var(--wa-color-brand-on-loud);
-  --texra-button-border: transparent;
-  --texra-button-hoverBackground: var(--desktop-color-accent-hover);
-  --texra-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
-  --texra-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
-  --texra-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
-  --texra-button-separator: rgb(255 255 255 / 40%);
-  --texra-errorForeground: var(--wa-color-danger-on-quiet);
-  --texra-editorError-foreground: var(--wa-color-danger-on-quiet);
-  --texra-editorWarning-foreground: var(--wa-color-warning-on-quiet);
-  --texra-editorWarning-background: var(--wa-color-warning-fill-quiet);
-  --texra-editorInfo-foreground: var(--wa-color-brand-on-quiet);
-  --texra-editorInfo-background: var(--wa-color-brand-fill-quiet);
-  --texra-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --texra-editor-selectionBackground: var(--desktop-color-accent-subtle);
-  --texra-inputOption-activeBackground: var(--desktop-color-accent-subtle);
-  --texra-inputOption-activeBorder: var(--desktop-color-accent);
-  --texra-inputOption-activeForeground: var(--desktop-color-foreground);
-  --texra-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
-  --texra-inputValidation-errorBorder: var(--desktop-color-error);
-  --texra-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
-  --texra-inputValidation-infoBorder: var(--desktop-color-info);
-  --texra-inputValidation-infoForeground: var(--desktop-color-info);
-  --texra-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
-  --texra-inputValidation-warningBorder: var(--desktop-color-warning);
-  --texra-inputValidation-warningForeground: var(--desktop-color-warning);
-  --texra-progressBar-background: var(--desktop-color-accent);
-  --texra-statusBarItem-warningBackground: var(--desktop-color-warning);
-  --texra-notificationsInfoIcon-foreground: var(--desktop-color-info);
-  --texra-activityBarBadge-background: var(--desktop-color-accent);
-  --texra-badge-background: var(--desktop-color-accent);
-  --texra-badge-foreground: #ffffff;
-  --texra-toolbar-activeBackground: var(--desktop-color-toolbar-active);
-  --texra-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
-  --texra-toolbar-hoverOutline: var(--desktop-color-muted);
-  --texra-focusBorder: var(--wa-color-focus);
-
-  /* List/menu/scrollbar — no WA equivalent. */
-  --texra-list-activeSelectionBackground: var(--desktop-color-accent);
-  --texra-list-activeSelectionForeground: #ffffff;
-  --texra-list-focusOutline: var(--desktop-color-accent);
-  --texra-list-hoverForeground: var(--desktop-color-foreground);
-  --texra-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --texra-list-hoverBackground: var(--desktop-color-list-hover);
-  --texra-list-warningForeground: var(--desktop-color-warning);
-  --texra-menu-background: var(--desktop-color-menu-background);
-  --texra-menu-border: var(--desktop-color-menu-border);
-  --texra-menu-foreground: var(--desktop-color-input-foreground);
-  --texra-menu-selectionBackground: var(--desktop-color-accent);
-  --texra-menu-selectionForeground: #ffffff;
-  --texra-menu-separatorBackground: var(--desktop-color-menu-border);
-  --texra-scrollbar-shadow: var(--desktop-color-shadow);
-  --texra-scrollbarSlider-background: var(--desktop-color-scrollbar);
-  --texra-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
-  --texra-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
-
-  /* Charts — palette tokens with no WA equivalent. */
-  --texra-charts-blue: var(--desktop-color-accent);
-  --texra-charts-green: var(--desktop-color-success);
-  --texra-charts-orange: var(--desktop-color-orange);
-  --texra-charts-red: var(--desktop-color-error);
-  --texra-charts-yellow: var(--desktop-color-yellow);
-
-  /* Testing icons. */
-  --texra-testing-iconPassed: var(--desktop-color-success);
-  --texra-testing-iconFailed: var(--desktop-color-error);
-
-  /* Symbol icons — no WA equivalent. */
-  --texra-symbolIcon-classForeground: var(--desktop-color-orange);
-  --texra-symbolIcon-constantForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-functionForeground: var(--desktop-color-yellow);
-  --texra-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
-  --texra-symbolIcon-propertyForeground: var(--desktop-color-accent);
-  --texra-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
-
-  /* Terminal — no WA equivalent. */
-  --texra-terminal-background: var(--desktop-color-background);
-  --texra-terminal-foreground: var(--desktop-color-input-foreground);
-  --texra-terminal-selectionBackground: var(--desktop-color-terminal-selection);
-  --texra-terminalCursor-foreground: var(--desktop-color-input-foreground);
-  --texra-terminal-ansiBlack: light-dark(#24292f, #000000);
-  --texra-terminal-ansiBlue: var(--desktop-color-accent);
-  --texra-terminal-ansiBrightBlack: light-dark(#6e7781, #666666);
-  --texra-terminal-ansiBrightBlue: light-dark(#0550ae, #3794ff);
-  --texra-terminal-ansiBrightCyan: light-dark(#1b7c83, #39cccc);
-  --texra-terminal-ansiBrightGreen: var(--desktop-color-success);
-  --texra-terminal-ansiBrightMagenta: light-dark(#8250df, #d670d6);
-  --texra-terminal-ansiBrightRed: var(--desktop-color-error);
-  --texra-terminal-ansiBrightWhite: light-dark(#ffffff, #ffffff);
-  --texra-terminal-ansiBrightYellow: var(--desktop-color-yellow);
-  --texra-terminal-ansiCyan: light-dark(#1b7c83, #4ec9b0);
-  --texra-terminal-ansiGreen: var(--desktop-color-success);
-  --texra-terminal-ansiMagenta: light-dark(#8250df, #c586c0);
-  --texra-terminal-ansiRed: var(--desktop-color-error);
-  --texra-terminal-ansiWhite: light-dark(#6e7781, #cccccc);
-  --texra-terminal-ansiYellow: var(--desktop-color-yellow);
-
-  /* Legacy font/typography aliases. */
-  --texra-font-family: var(--wa-font-family-body);
-  --texra-font-family-monospace: var(--wa-font-family-mono);
-  --texra-font-size: var(--wa-font-size-m);
-  --texra-font-weight: var(--wa-font-weight-normal);
-  --texra-editor-font-family: var(--desktop-font-family);
-  --texra-editor-font-size: var(--desktop-font-size);
 }
 
 body.vscode-light,
@@ -340,171 +286,9 @@ body.texra-high-contrast {
   --desktop-color-warning: Mark;
   --desktop-color-info: Highlight;
   --desktop-color-success: Highlight;
-  --texra-button-foreground: HighlightText;
-  --texra-list-activeSelectionForeground: HighlightText;
-  --texra-menu-selectionForeground: HighlightText;
-  --texra-badge-foreground: HighlightText;
-  --texra-contrastBorder: CanvasText;
+  --wa-color-list-active-fg: HighlightText;
   --wa-color-brand-on-loud: HighlightText;
   --wa-color-brand-border-loud: CanvasText;
-}
-
-/*
- * VS Code variable re-exports for reused webview CSS.
- * Sourced from --desktop-color-* / --wa-* so existing rules referencing
- * --vscode-* still resolve in the desktop renderer.
- */
-:root {
-  --vscode-font-family: var(--wa-font-family-body);
-  --vscode-font-size: var(--wa-font-size-m);
-  --vscode-font-weight: var(--wa-font-weight-normal);
-  --vscode-foreground: var(--wa-color-text-normal);
-  --vscode-descriptionForeground: var(--wa-color-text-quiet);
-  --vscode-editor-background: var(--wa-color-surface-default);
-  --vscode-editor-font-family: var(--wa-font-family-mono);
-  --vscode-editor-font-size: var(--desktop-font-size);
-  --vscode-editor-foreground: var(--wa-color-text-normal);
-  --vscode-editor-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --vscode-editor-selectionBackground: var(--desktop-color-accent-subtle);
-  --vscode-editorError-foreground: var(--wa-color-danger-on-quiet);
-  --vscode-editorHoverWidget-background: var(--wa-color-surface-raised);
-  --vscode-editorHoverWidget-border: var(--wa-color-surface-border);
-  --vscode-editorHoverWidget-foreground: var(--wa-color-text-normal);
-  --vscode-editorInfo-background: var(--wa-color-brand-fill-quiet);
-  --vscode-editorInfo-foreground: var(--wa-color-brand-on-quiet);
-  --vscode-editorWarning-background: var(--wa-color-warning-fill-quiet);
-  --vscode-editorWarning-foreground: var(--wa-color-warning-on-quiet);
-  --vscode-editorWidget-background: var(--wa-color-surface-raised);
-  --vscode-editorWidget-border: var(--wa-color-surface-border);
-  --vscode-errorForeground: var(--wa-color-danger-on-quiet);
-  --vscode-focusBorder: var(--wa-color-focus);
-  --vscode-sideBar-background: var(--wa-color-surface-lowered);
-  --vscode-sideBar-foreground: var(--wa-color-text-normal);
-  --vscode-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
-  --vscode-sideBarTitle-foreground: var(--wa-color-text-normal);
-  --vscode-panel-border: var(--wa-color-surface-border);
-  --vscode-panel-background: var(--wa-color-surface-default);
-  --vscode-panelTitle-activeBorder: var(--wa-color-focus);
-  --vscode-panelTitle-activeForeground: var(--wa-color-text-normal);
-  --vscode-panelTitle-inactiveForeground: var(--wa-color-text-quiet);
-  --vscode-panelSection-border: var(--wa-color-surface-border);
-  --vscode-settings-headerBorder: var(--wa-color-surface-border);
-  --vscode-button-background: var(--wa-color-brand-fill-loud);
-  --vscode-button-border: transparent;
-  --vscode-button-foreground: var(--wa-color-brand-on-loud);
-  --vscode-button-hoverBackground: var(--desktop-color-accent-hover);
-  --vscode-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
-  --vscode-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
-  --vscode-button-secondaryHoverBackground: var(--desktop-color-button-secondary-hover);
-  --vscode-button-separator: rgb(255 255 255 / 40%);
-  --vscode-dropdown-background: var(--wa-form-control-background-color);
-  --vscode-dropdown-border: var(--wa-form-control-border-color);
-  --vscode-dropdown-foreground: var(--wa-form-control-text-color);
-  --vscode-input-background: var(--wa-form-control-background-color);
-  --vscode-input-border: var(--wa-form-control-border-color);
-  --vscode-input-foreground: var(--wa-form-control-text-color);
-  --vscode-input-placeholderForeground: var(--desktop-color-placeholder);
-  --vscode-inputOption-activeBackground: var(--desktop-color-accent-subtle);
-  --vscode-inputOption-activeBorder: var(--desktop-color-accent);
-  --vscode-inputOption-activeForeground: var(--desktop-color-foreground);
-  --vscode-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
-  --vscode-inputValidation-errorBorder: var(--desktop-color-error);
-  --vscode-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
-  --vscode-inputValidation-infoBorder: var(--desktop-color-info);
-  --vscode-inputValidation-infoForeground: var(--desktop-color-info);
-  --vscode-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
-  --vscode-inputValidation-warningBorder: var(--desktop-color-warning);
-  --vscode-inputValidation-warningForeground: var(--desktop-color-warning);
-  --vscode-textArea-background: var(--wa-form-control-background-color);
-  --vscode-textArea-border: var(--wa-form-control-border-color);
-  --vscode-textArea-foreground: var(--wa-form-control-text-color);
-  --vscode-textArea-placeholderForeground: var(--desktop-color-placeholder);
-  --vscode-checkbox-background: var(--wa-form-control-background-color);
-  --vscode-checkbox-border: var(--wa-form-control-border-color);
-  --vscode-checkbox-foreground: var(--wa-color-text-normal);
-  --vscode-settings-checkboxBackground: var(--wa-form-control-background-color);
-  --vscode-settings-checkboxBorder: var(--wa-form-control-border-color);
-  --vscode-settings-checkboxForeground: var(--wa-color-text-normal);
-  --vscode-settings-dropdownBackground: var(--wa-form-control-background-color);
-  --vscode-settings-dropdownBorder: var(--wa-form-control-border-color);
-  --vscode-settings-dropdownForeground: var(--wa-form-control-text-color);
-  --vscode-settings-dropdownListBorder: var(--wa-form-control-border-color);
-  --vscode-settings-textInputBackground: var(--wa-form-control-background-color);
-  --vscode-settings-textInputBorder: var(--wa-form-control-border-color);
-  --vscode-settings-textInputForeground: var(--wa-form-control-text-color);
-  --vscode-list-activeSelectionBackground: var(--desktop-color-accent);
-  --vscode-list-activeSelectionForeground: #ffffff;
-  --vscode-list-activeSelectionIconForeground: #ffffff;
-  --vscode-list-focusAndSelectionOutline: var(--desktop-color-accent);
-  --vscode-list-focusHighlightForeground: var(--wa-color-focus);
-  --vscode-list-focusOutline: var(--desktop-color-accent);
-  --vscode-list-highlightForeground: var(--wa-color-focus);
-  --vscode-list-hoverBackground: var(--wa-color-neutral-fill-quiet);
-  --vscode-list-hoverForeground: var(--desktop-color-foreground);
-  --vscode-list-inactiveSelectionBackground: var(--desktop-color-accent-subtle);
-  --vscode-list-warningForeground: var(--desktop-color-warning);
-  --vscode-menu-background: var(--desktop-color-menu-background);
-  --vscode-menu-border: var(--desktop-color-menu-border);
-  --vscode-menu-foreground: var(--desktop-color-input-foreground);
-  --vscode-menu-selectionBackground: var(--desktop-color-accent);
-  --vscode-menu-selectionBorder: var(--desktop-color-accent);
-  --vscode-menu-selectionForeground: #ffffff;
-  --vscode-menu-separatorBackground: var(--desktop-color-menu-border);
-  --vscode-toolbar-activeBackground: var(--desktop-color-toolbar-active);
-  --vscode-toolbar-hoverBackground: var(--desktop-color-toolbar-hover);
-  --vscode-toolbar-hoverOutline: var(--desktop-color-muted);
-  --vscode-widget-border: var(--desktop-color-widget-border);
-  --vscode-widget-shadow: var(--desktop-color-shadow);
-  --vscode-icon-foreground: var(--wa-color-text-quiet);
-  --vscode-badge-background: var(--wa-color-neutral-fill-quiet);
-  --vscode-badge-foreground: var(--wa-color-neutral-on-quiet);
-  --vscode-progressBar-background: var(--desktop-color-accent);
-  --vscode-textBlockQuote-background: var(--wa-color-surface-lowered);
-  --vscode-textBlockQuote-border: var(--desktop-color-accent);
-  --vscode-textCodeBlock-background: var(--desktop-color-sidebar);
-  --vscode-textLink-activeForeground: var(--desktop-color-accent-hover);
-  --vscode-textLink-foreground: var(--wa-color-text-link);
-  --vscode-textPreformat-foreground: var(--desktop-color-input-foreground);
-  --vscode-terminal-background: var(--desktop-color-background);
-  --vscode-terminal-foreground: var(--desktop-color-input-foreground);
-  --vscode-terminal-selectionBackground: var(--desktop-color-terminal-selection);
-  --vscode-terminalCursor-foreground: var(--desktop-color-input-foreground);
-  --vscode-terminal-ansiBlack: var(--texra-terminal-ansiBlack);
-  --vscode-terminal-ansiBlue: var(--desktop-color-accent);
-  --vscode-terminal-ansiBrightBlack: var(--texra-terminal-ansiBrightBlack);
-  --vscode-terminal-ansiBrightBlue: var(--texra-terminal-ansiBrightBlue);
-  --vscode-terminal-ansiBrightCyan: var(--texra-terminal-ansiBrightCyan);
-  --vscode-terminal-ansiBrightGreen: var(--desktop-color-success);
-  --vscode-terminal-ansiBrightMagenta: var(--texra-terminal-ansiBrightMagenta);
-  --vscode-terminal-ansiBrightRed: var(--desktop-color-error);
-  --vscode-terminal-ansiBrightWhite: var(--texra-terminal-ansiBrightWhite);
-  --vscode-terminal-ansiBrightYellow: var(--desktop-color-yellow);
-  --vscode-terminal-ansiCyan: var(--texra-terminal-ansiCyan);
-  --vscode-terminal-ansiGreen: var(--desktop-color-success);
-  --vscode-terminal-ansiMagenta: var(--texra-terminal-ansiMagenta);
-  --vscode-terminal-ansiRed: var(--desktop-color-error);
-  --vscode-terminal-ansiWhite: var(--texra-terminal-ansiWhite);
-  --vscode-terminal-ansiYellow: var(--desktop-color-yellow);
-  --vscode-testing-iconFailed: var(--wa-color-danger-fill-loud);
-  --vscode-testing-iconPassed: var(--wa-color-success-fill-loud);
-  --vscode-charts-blue: var(--desktop-color-accent);
-  --vscode-charts-green: var(--desktop-color-success);
-  --vscode-charts-orange: var(--desktop-color-orange);
-  --vscode-charts-red: var(--desktop-color-error);
-  --vscode-charts-yellow: var(--desktop-color-yellow);
-  --vscode-scrollbar-shadow: var(--desktop-color-shadow);
-  --vscode-scrollbarSlider-background: var(--desktop-color-scrollbar);
-  --vscode-scrollbarSlider-hoverBackground: var(--desktop-color-scrollbar-hover);
-  --vscode-scrollbarSlider-activeBackground: var(--desktop-color-scrollbar-active);
-  --vscode-activityBarBadge-background: var(--desktop-color-accent);
-  --vscode-notificationsInfoIcon-foreground: var(--desktop-color-info);
-  --vscode-statusBarItem-warningBackground: var(--desktop-color-warning);
-  --vscode-symbolIcon-classForeground: var(--desktop-color-orange);
-  --vscode-symbolIcon-constantForeground: var(--desktop-color-accent);
-  --vscode-symbolIcon-functionForeground: var(--desktop-color-yellow);
-  --vscode-symbolIcon-keywordForeground: light-dark(#8250df, #c586c0);
-  --vscode-symbolIcon-propertyForeground: var(--desktop-color-accent);
-  --vscode-symbolIcon-variableForeground: var(--desktop-color-input-foreground);
 }
 
 /* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -1,30 +1,33 @@
 /**
  * Document-level styles for TeXRA webviews (VS Code host).
  *
- * Web Awesome native theming: --wa-* tokens are the single source of truth and
- * are sourced directly from the host's --vscode-* variables. The webview entry
- * (index.ts under @shared/wa) imports the WA default theme stylesheet, and
- * MainApp / SettingsApp / ProgressApp mirror the VS Code theme kind onto
- * <html class="wa-light|wa-dark"> so WA's color-scheme classes activate.
+ * Single token system: --wa-* tokens are the ONLY tokens consumer code
+ * references. They are sourced directly from the host's --vscode-* variables
+ * exposed by the VS Code webview iframe. There is no --texra-* shim layer
+ * and consumers never reference --vscode-* directly.
  *
- * --texra-* tokens remain as a thin compatibility alias layer for tokens that
- * have no clean WA equivalent (terminal ansi, symbol icons, charts, list rows,
- * git decoration, etc.) and a few legacy aliases consumers still reference.
- * They no longer round-trip through --wa-*.
+ * Niche palette tokens with no clean WA semantic equivalent (terminal ansi,
+ * symbol icons, charts, git decoration, debug tokens, diff editor, etc.) are
+ * promoted into the --wa-color-* namespace so the consumer surface stays
+ * uniform.
  */
 
 :root,
 .wa-light,
 .wa-dark .wa-invert {
-  /* ── Web Awesome surface / text tokens (light + default) ────────────── */
+  /* ── Web Awesome surface / text tokens ──────────────────────────────── */
   --wa-color-text-normal: var(--vscode-editor-foreground, var(--vscode-foreground));
   --wa-color-text-quiet: var(--vscode-descriptionForeground);
   --wa-color-text-link: var(--vscode-textLink-foreground);
+  --wa-color-text-link-active: var(--vscode-textLink-activeForeground);
+  --wa-color-text-preformat: var(--vscode-textPreformat-foreground);
+  --wa-color-text-placeholder: var(--vscode-input-placeholderForeground);
 
   --wa-color-surface-default: var(--vscode-editor-background);
   --wa-color-surface-raised: var(--vscode-editorWidget-background);
   --wa-color-surface-lowered: var(--vscode-sideBar-background);
   --wa-color-surface-border: var(--vscode-panel-border, var(--vscode-widget-border));
+  --wa-color-surface-shadow: var(--vscode-widget-shadow);
 
   --wa-color-focus: var(--vscode-focusBorder);
 
@@ -74,12 +77,112 @@
   --wa-color-success-border-quiet: var(--vscode-inputValidation-infoBorder);
   --wa-color-success-on-quiet: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
 
+  /* Buttons — niche tokens consumers still need. */
+  --wa-color-button-hover: var(--vscode-button-hoverBackground);
+  --wa-color-button-border: var(--vscode-button-border, transparent);
+  --wa-color-button-separator: var(--vscode-button-separator, rgb(255 255 255 / 40%));
+
+  /* Lists — no native WA equivalent yet (#3690). */
+  --wa-color-list-active-bg: var(--vscode-list-activeSelectionBackground);
+  --wa-color-list-active-fg: var(--vscode-list-activeSelectionForeground);
+  --wa-color-list-hover-bg: var(--vscode-list-hoverBackground);
+  --wa-color-list-warning-fg: var(--vscode-list-warningForeground);
+
+  /* Menus. */
+  --wa-color-menu-background: var(--vscode-menu-background);
+  --wa-color-menu-border: var(--vscode-menu-border);
+  --wa-color-menu-foreground: var(--vscode-menu-foreground);
+
+  /* Toolbar. */
+  --wa-color-toolbar-active: var(--vscode-toolbar-activeBackground);
+  --wa-color-toolbar-hover: var(--vscode-toolbar-hoverBackground);
+
+  /* Charts — palette tokens with no WA equivalent. */
+  --wa-color-chart-blue: var(--vscode-charts-blue);
+  --wa-color-chart-green: var(--vscode-charts-green);
+  --wa-color-chart-orange: var(--vscode-charts-orange);
+  --wa-color-chart-red: var(--vscode-charts-red);
+  --wa-color-chart-yellow: var(--vscode-charts-yellow);
+  /* VS Code does not ship a charts.purple — fall back to keyword colour. */
+  --wa-color-chart-purple: light-dark(#8250df, #c586c0);
+
+  /* Diff editor. */
+  --wa-color-diff-inserted: var(--vscode-diffEditor-insertedTextBackground);
+  --wa-color-diff-removed: var(--vscode-diffEditor-removedTextBackground);
+
+  /* Git decoration. */
+  --wa-color-git-added: var(--vscode-gitDecoration-addedResourceForeground);
+  --wa-color-git-deleted: var(--vscode-gitDecoration-deletedResourceForeground);
+  --wa-color-git-modified: var(--vscode-gitDecoration-modifiedResourceForeground);
+
+  /* Debug token expressions. */
+  --wa-color-debug-name: var(--vscode-debugTokenExpression-name);
+  --wa-color-debug-number: var(--vscode-debugTokenExpression-number);
+  --wa-color-debug-string: var(--vscode-debugTokenExpression-string);
+
+  /* Symbol icons. */
+  --wa-color-symbol-class: var(--vscode-symbolIcon-classForeground);
+  --wa-color-symbol-constant: var(--vscode-symbolIcon-constantForeground);
+  --wa-color-symbol-function: var(--vscode-symbolIcon-functionForeground);
+  --wa-color-symbol-keyword: var(--vscode-symbolIcon-keywordForeground);
+  --wa-color-symbol-property: var(--vscode-symbolIcon-propertyForeground);
+  --wa-color-symbol-variable: var(--vscode-symbolIcon-variableForeground);
+
+  /* Editor surface details. */
+  --wa-color-editor-selection: var(--vscode-editor-selectionBackground);
+  --wa-color-editor-inactive-selection: var(--vscode-editor-inactiveSelectionBackground);
+  --wa-color-editor-line-highlight: var(--vscode-editor-lineHighlightBackground);
+  --wa-color-editor-find-match: var(--vscode-editor-findMatchBackground);
+  --wa-color-editor-find-match-highlight: var(--vscode-editor-findMatchHighlightBackground);
+  --wa-color-editor-find-match-highlight-fg: var(--vscode-editor-findMatchHighlightForeground);
+
+  /* Tabs. */
+  --wa-color-tabs-background: var(--vscode-editorGroupHeader-tabsBackground);
+  --wa-color-tabs-border: var(--vscode-editorGroupHeader-tabsBorder);
+
+  /* Block quote. */
+  --wa-color-blockquote-border: var(--vscode-textBlockQuote-border);
+
+  /* Misc indicators. */
+  --wa-color-progress-bg: var(--vscode-progressBar-background);
+  --wa-color-status-warning-bg: var(--vscode-statusBarItem-warningBackground);
+  --wa-color-icon-info: var(--vscode-notificationsInfoIcon-foreground);
+  --wa-color-activity-badge-bg: var(--vscode-activityBarBadge-background);
+  --wa-color-badge-bg: var(--vscode-badge-background);
+
+  /* Testing icons. */
+  --wa-color-testing-passed: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
+  --wa-color-testing-failed: var(--vscode-testing-iconFailed, var(--vscode-editorError-foreground));
+
+  /* Terminal — full palette, no WA equivalent. */
+  --wa-color-terminal-background: var(--vscode-terminal-background);
+  --wa-color-terminal-foreground: var(--vscode-terminal-foreground);
+  --wa-color-terminal-selection-bg: var(--vscode-terminal-selectionBackground);
+  --wa-color-terminal-cursor: var(--vscode-terminalCursor-foreground);
+  --wa-color-terminal-ansi-black: var(--vscode-terminal-ansiBlack);
+  --wa-color-terminal-ansi-blue: var(--vscode-terminal-ansiBlue);
+  --wa-color-terminal-ansi-cyan: var(--vscode-terminal-ansiCyan);
+  --wa-color-terminal-ansi-green: var(--vscode-terminal-ansiGreen);
+  --wa-color-terminal-ansi-magenta: var(--vscode-terminal-ansiMagenta);
+  --wa-color-terminal-ansi-red: var(--vscode-terminal-ansiRed);
+  --wa-color-terminal-ansi-white: var(--vscode-terminal-ansiWhite);
+  --wa-color-terminal-ansi-yellow: var(--vscode-terminal-ansiYellow);
+  --wa-color-terminal-ansi-bright-black: var(--vscode-terminal-ansiBrightBlack);
+  --wa-color-terminal-ansi-bright-blue: var(--vscode-terminal-ansiBrightBlue);
+  --wa-color-terminal-ansi-bright-cyan: var(--vscode-terminal-ansiBrightCyan);
+  --wa-color-terminal-ansi-bright-green: var(--vscode-terminal-ansiBrightGreen);
+  --wa-color-terminal-ansi-bright-magenta: var(--vscode-terminal-ansiBrightMagenta);
+  --wa-color-terminal-ansi-bright-red: var(--vscode-terminal-ansiBrightRed);
+  --wa-color-terminal-ansi-bright-white: var(--vscode-terminal-ansiBrightWhite);
+  --wa-color-terminal-ansi-bright-yellow: var(--vscode-terminal-ansiBrightYellow);
+
   /* Typography. */
   --wa-font-family-body: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
   --wa-font-family-heading: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
   --wa-font-family-mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
   --wa-font-size-m: var(--vscode-font-size, 13px);
   --wa-font-weight-normal: var(--vscode-font-weight, 400);
+  --wa-editor-font-size: var(--vscode-editor-font-size, 13px);
 
   /* Web Awesome canonical space scale. Mirrors the values from the WA default
      theme so consumers can rely on --wa-space-* even if the WA color-scheme
@@ -96,166 +199,6 @@
   --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
   --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
   --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
-}
-
-/*
- * --texra-* compatibility alias layer.
- *
- * These tokens fall into two buckets:
- *   1. Niche VS Code tokens with no clean WA equivalent (terminal ansi, symbol
- *      icons, charts, list rows, git decoration, debug tokens, diff editor).
- *      They remain texra-prefixed and source --vscode-* directly.
- *   2. Legacy aliases that map cleanly to a --wa-* token. New code should
- *      prefer the --wa-* token; these aliases exist to keep ~120 consumer
- *      files working without a churn-heavy single-PR migration.
- */
-:root {
-  /* Bucket 2 — wa-aligned aliases (prefer --wa-* in new code). */
-  --texra-foreground: var(--wa-color-text-normal);
-  --texra-descriptionForeground: var(--wa-color-text-quiet);
-  --texra-icon-foreground: var(--wa-color-text-quiet);
-  --texra-editor-background: var(--wa-color-surface-default);
-  --texra-editor-foreground: var(--wa-color-text-normal);
-  --texra-editorWidget-background: var(--wa-color-surface-raised);
-  --texra-editorWidget-border: var(--wa-color-surface-border);
-  --texra-editorHoverWidget-background: var(--wa-color-surface-raised);
-  --texra-editorHoverWidget-border: var(--wa-color-surface-border);
-  --texra-editorHoverWidget-foreground: var(--wa-color-text-normal);
-  --texra-sideBar-background: var(--wa-color-surface-lowered);
-  --texra-sideBar-foreground: var(--wa-color-text-normal);
-  --texra-sideBarSectionHeader-background: var(--wa-color-surface-lowered);
-  --texra-sideBarTitle-foreground: var(--wa-color-text-normal);
-  --texra-panel-border: var(--wa-color-surface-border);
-  --texra-panelSection-border: var(--wa-color-surface-border);
-  --texra-widget-border: var(--wa-color-surface-border);
-  --texra-textCodeBlock-background: var(--wa-color-surface-lowered);
-  --texra-textBlockQuote-background: var(--wa-color-surface-lowered);
-  --texra-textLink-foreground: var(--wa-color-text-link);
-  --texra-textLink-activeForeground: var(--vscode-textLink-activeForeground);
-  --texra-input-background: var(--wa-form-control-background-color);
-  --texra-input-foreground: var(--wa-form-control-text-color);
-  --texra-input-border: var(--wa-form-control-border-color);
-  --texra-input-placeholderForeground: var(--vscode-input-placeholderForeground);
-  --texra-dropdown-border: var(--wa-form-control-border-color);
-  --texra-button-secondaryBackground: var(--wa-color-neutral-fill-quiet);
-  --texra-button-secondaryForeground: var(--wa-color-neutral-on-quiet);
-  --texra-button-hoverBackground: var(--vscode-button-hoverBackground);
-  --texra-button-border: var(--vscode-button-border, transparent);
-  --texra-button-separator: var(--vscode-button-separator, rgb(255 255 255 / 40%));
-  --texra-errorForeground: var(--wa-color-danger-on-quiet);
-  --texra-editorError-foreground: var(--wa-color-danger-on-quiet);
-  --texra-editorWarning-foreground: var(--wa-color-warning-on-quiet);
-  --texra-editorWarning-background: var(--wa-color-warning-fill-quiet);
-  --texra-editorInfo-foreground: var(--wa-color-brand-on-quiet);
-  --texra-editorInfo-background: var(--wa-color-brand-fill-quiet);
-  --texra-inputValidation-errorBackground: var(--wa-color-danger-fill-quiet);
-  --texra-inputValidation-errorBorder: var(--vscode-inputValidation-errorBorder);
-  --texra-inputValidation-errorForeground: var(--wa-color-danger-on-quiet);
-  --texra-inputValidation-infoBackground: var(--wa-color-brand-fill-quiet);
-  --texra-inputValidation-infoBorder: var(--wa-color-brand-border-quiet);
-  --texra-inputValidation-infoForeground: var(--wa-color-brand-on-quiet);
-  --texra-inputValidation-warningBackground: var(--wa-color-warning-fill-quiet);
-  --texra-inputValidation-warningBorder: var(--wa-color-warning-border-quiet);
-  --texra-inputValidation-warningForeground: var(--wa-color-warning-on-quiet);
-  --texra-progressBar-background: var(--vscode-progressBar-background);
-  --texra-statusBarItem-warningBackground: var(--vscode-statusBarItem-warningBackground);
-  --texra-notificationsInfoIcon-foreground: var(--vscode-notificationsInfoIcon-foreground);
-  --texra-activityBarBadge-background: var(--vscode-activityBarBadge-background);
-  --texra-badge-background: var(--vscode-badge-background);
-  --texra-toolbar-activeBackground: var(--vscode-toolbar-activeBackground);
-  --texra-toolbar-hoverBackground: var(--vscode-toolbar-hoverBackground);
-  --texra-widget-shadow: var(--vscode-widget-shadow);
-  --texra-contrastBorder: var(--vscode-contrastBorder);
-  --texra-focusBorder: var(--wa-color-focus);
-
-  /* Bucket 1 — niche VS Code tokens with no clean WA equivalent. */
-  /* TODO(token-pass-3): WA does not yet expose list-row hover/selection
-     equivalents. Keep these texra aliases until WA introduces semantic tokens
-     for tree/list rows (or until consumers move to wa-tree::part(item) styling
-     hooks); see #3690. */
-  --texra-list-activeSelectionBackground: var(--vscode-list-activeSelectionBackground);
-  --texra-list-activeSelectionForeground: var(--vscode-list-activeSelectionForeground);
-  --texra-list-hoverBackground: var(--vscode-list-hoverBackground);
-  --texra-list-warningForeground: var(--vscode-list-warningForeground);
-
-  --texra-menu-background: var(--vscode-menu-background);
-  --texra-menu-border: var(--vscode-menu-border);
-  --texra-menu-foreground: var(--vscode-menu-foreground);
-
-  /* Charts — no WA equivalent. Keep as native palette tokens. */
-  --texra-charts-blue: var(--vscode-charts-blue);
-  --texra-charts-green: var(--vscode-charts-green);
-  --texra-charts-orange: var(--vscode-charts-orange);
-  --texra-charts-red: var(--vscode-charts-red);
-  --texra-charts-yellow: var(--vscode-charts-yellow);
-
-  /* Editor surface details — fine-grained tokens with no WA equivalent. */
-  --texra-editor-font-family: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
-  --texra-editor-font-size: var(--vscode-editor-font-size, 13px);
-  --texra-editor-findMatchBackground: var(--vscode-editor-findMatchBackground);
-  --texra-editor-findMatchHighlightBackground: var(--vscode-editor-findMatchHighlightBackground);
-  --texra-editor-findMatchHighlightForeground: var(--vscode-editor-findMatchHighlightForeground);
-  --texra-editor-inactiveSelectionBackground: var(--vscode-editor-inactiveSelectionBackground);
-  --texra-editor-lineHighlightBackground: var(--vscode-editor-lineHighlightBackground);
-  --texra-editor-selectionBackground: var(--vscode-editor-selectionBackground);
-  --texra-editorGroupHeader-tabsBackground: var(--vscode-editorGroupHeader-tabsBackground);
-  --texra-editorGroupHeader-tabsBorder: var(--vscode-editorGroupHeader-tabsBorder);
-  --texra-textBlockQuote-border: var(--vscode-textBlockQuote-border);
-  --texra-textPreformat-foreground: var(--vscode-textPreformat-foreground);
-
-  /* Diff editor — no WA equivalent. */
-  --texra-diffEditor-insertedTextBackground: var(--vscode-diffEditor-insertedTextBackground);
-  --texra-diffEditor-removedTextBackground: var(--vscode-diffEditor-removedTextBackground);
-
-  /* Git decoration — no WA equivalent. */
-  --texra-gitDecoration-addedResourceForeground: var(--vscode-gitDecoration-addedResourceForeground);
-  --texra-gitDecoration-deletedResourceForeground: var(--vscode-gitDecoration-deletedResourceForeground);
-  --texra-gitDecoration-modifiedResourceForeground: var(--vscode-gitDecoration-modifiedResourceForeground);
-
-  /* Debug token expressions — no WA equivalent. */
-  --texra-debugTokenExpression-name: var(--vscode-debugTokenExpression-name);
-  --texra-debugTokenExpression-number: var(--vscode-debugTokenExpression-number);
-  --texra-debugTokenExpression-string: var(--vscode-debugTokenExpression-string);
-
-  /* Symbol icons — no WA equivalent. */
-  --texra-symbolIcon-classForeground: var(--vscode-symbolIcon-classForeground);
-  --texra-symbolIcon-constantForeground: var(--vscode-symbolIcon-constantForeground);
-  --texra-symbolIcon-functionForeground: var(--vscode-symbolIcon-functionForeground);
-  --texra-symbolIcon-keywordForeground: var(--vscode-symbolIcon-keywordForeground);
-  --texra-symbolIcon-propertyForeground: var(--vscode-symbolIcon-propertyForeground);
-  --texra-symbolIcon-variableForeground: var(--vscode-symbolIcon-variableForeground);
-
-  /* Terminal — no WA equivalent. */
-  --texra-terminal-ansiBlack: var(--vscode-terminal-ansiBlack);
-  --texra-terminal-ansiBlue: var(--vscode-terminal-ansiBlue);
-  --texra-terminal-ansiBrightBlack: var(--vscode-terminal-ansiBrightBlack);
-  --texra-terminal-ansiBrightBlue: var(--vscode-terminal-ansiBrightBlue);
-  --texra-terminal-ansiBrightCyan: var(--vscode-terminal-ansiBrightCyan);
-  --texra-terminal-ansiBrightGreen: var(--vscode-terminal-ansiBrightGreen);
-  --texra-terminal-ansiBrightMagenta: var(--vscode-terminal-ansiBrightMagenta);
-  --texra-terminal-ansiBrightRed: var(--vscode-terminal-ansiBrightRed);
-  --texra-terminal-ansiBrightWhite: var(--vscode-terminal-ansiBrightWhite);
-  --texra-terminal-ansiBrightYellow: var(--vscode-terminal-ansiBrightYellow);
-  --texra-terminal-ansiCyan: var(--vscode-terminal-ansiCyan);
-  --texra-terminal-ansiGreen: var(--vscode-terminal-ansiGreen);
-  --texra-terminal-ansiMagenta: var(--vscode-terminal-ansiMagenta);
-  --texra-terminal-ansiRed: var(--vscode-terminal-ansiRed);
-  --texra-terminal-ansiWhite: var(--vscode-terminal-ansiWhite);
-  --texra-terminal-ansiYellow: var(--vscode-terminal-ansiYellow);
-  --texra-terminal-background: var(--vscode-terminal-background);
-  --texra-terminal-foreground: var(--vscode-terminal-foreground);
-  --texra-terminal-selectionBackground: var(--vscode-terminal-selectionBackground);
-  --texra-terminalCursor-foreground: var(--vscode-terminalCursor-foreground);
-
-  /* Testing icon colors. */
-  --texra-testing-iconFailed: var(--vscode-testing-iconFailed, var(--wa-color-danger-fill-loud));
-  --texra-testing-iconPassed: var(--vscode-testing-iconPassed, var(--wa-color-success-fill-loud));
-
-  /* Legacy alias kept for monospace consumers. */
-  --texra-font-family-monospace: var(--wa-font-family-mono);
-  --texra-font-family: var(--wa-font-family-body);
-  --texra-font-size: var(--wa-font-size-m);
-  --texra-font-weight: var(--wa-font-weight-normal);
 }
 
 body {

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -96,7 +96,7 @@ export class FileList extends LitElement {
 
       .files-container {
         padding: 0;
-        font-size: var(--texra-editor-font-size);
+        font-size: var(--wa-editor-font-size);
         overflow-y: auto;
         max-height: var(--height-large);
         flex-shrink: 0;
@@ -172,13 +172,13 @@ export class FileList extends LitElement {
       }
 
       .added {
-        color: var(--texra-charts-green, green);
+        color: var(--wa-color-chart-green, green);
         margin-left: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
       }
 
       .removed {
-        color: var(--texra-charts-red, red);
+        color: var(--wa-color-chart-red, red);
         margin-left: var(--wa-space-2xs);
         font-size: var(--font-size-sm);
       }

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -147,7 +147,7 @@ export class PlanView extends LitElement {
         background: var(--wa-color-neutral-fill-quiet);
         padding: var(--border-thin) var(--wa-space-xs);
         border-radius: var(--border-radius);
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
       }
 
       /* Status-specific styles */
@@ -174,11 +174,11 @@ export class PlanView extends LitElement {
       }
 
       .plan-step--in-progress .plan-step__icon {
-        color: var(--texra-progressBar-background);
+        color: var(--wa-color-progress-bg);
       }
 
       .plan-step--in-progress .plan-step__title {
-        color: var(--texra-progressBar-background);
+        color: var(--wa-color-progress-bg);
       }
 
       .plan-step--completed {

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -38,7 +38,7 @@ export class QueuedFollowUps extends LitElement {
       .queued-collapsible {
         border: var(--border-thin) solid var(--wa-color-brand-border-quiet);
         border-radius: var(--border-radius);
-        background-color: var(--texra-inputValidation-infoBackground);
+        background-color: var(--wa-color-brand-fill-quiet);
       }
 
       .queued-collapsible::part(header) {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -167,7 +167,7 @@ export class StreamTab extends LitElement {
       @keyframes pulse-border {
         0%,
         100% {
-          border-left-color: var(--texra-charts-orange, #d18616);
+          border-left-color: var(--wa-color-chart-orange, #d18616);
         }
         50% {
           border-left-color: transparent;
@@ -289,7 +289,7 @@ export class StreamTab extends LitElement {
           transparent
         );
         color: var(
-          --texra-list-activeSelectionForeground,
+          --wa-color-list-active-fg,
           var(--wa-color-text-normal)
         );
         box-shadow: inset 0 0 0 1px
@@ -307,7 +307,7 @@ export class StreamTab extends LitElement {
        */
       .tab-container.is-active * {
         color: var(
-          --texra-list-activeSelectionForeground,
+          --wa-color-list-active-fg,
           var(--wa-color-text-normal)
         );
       }

--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -21,17 +21,17 @@ export class TerminalCommandStrip extends LitElement {
         --texra-terminal-background,
         var(--wa-color-surface-default, transparent)
       );
-      color: var(--texra-terminal-foreground, var(--wa-color-text-normal));
+      color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
       border: var(--border-thin) solid var(--wa-color-surface-border, transparent);
       border-radius: var(--border-radius-small);
       font-family: var(
-        --texra-editor-font-family,
+        --wa-font-family-mono,
         ui-monospace,
         SFMono-Regular,
         Consolas,
         monospace
       );
-      font-size: var(--texra-editor-font-size, var(--font-size-sm));
+      font-size: var(--wa-editor-font-size, var(--font-size-sm));
       max-height: min(32vh, 320px);
       overflow: auto;
       white-space: pre;
@@ -44,7 +44,7 @@ export class TerminalCommandStrip extends LitElement {
     }
 
     .prompt {
-      color: var(--texra-terminal-ansiGreen, var(--color-success, #0a0));
+      color: var(--wa-color-terminal-ansi-green, var(--color-success, #0a0));
       font-weight: var(--font-weight-semibold);
       user-select: none;
     }

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -88,7 +88,7 @@ export class TodoList extends LitElement {
       }
 
       .todo-item--in-progress .todo-item__icon {
-        color: var(--texra-progressBar-background);
+        color: var(--wa-color-progress-bg);
       }
 
       .todo-item--completed {

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -26,7 +26,7 @@ const COMPACTION_THRESHOLD = 75;
 function fillColor(percent: number): string {
   if (percent <= 65) return 'var(--wa-color-success-on-quiet, #73c991)';
   if (percent <= 80) return 'var(--wa-color-warning-on-quiet, #cca700)';
-  return 'var(--texra-testing-iconFailed, #f48771)';
+  return 'var(--wa-color-testing-failed, #f48771)';
 }
 
 @customElement('usage-panel')

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -82,7 +82,7 @@ export class UserMessage extends LitElement {
       .user-message {
         padding: var(--wa-space-2xs);
         max-width: 85%;
-        background-color: var(--texra-editor-selectionBackground);
+        background-color: var(--wa-color-editor-selection);
         border: var(--border-thin) solid var(--wa-color-surface-border);
         border-radius: var(--border-radius);
       }
@@ -138,13 +138,13 @@ export class UserMessage extends LitElement {
         );
         border-radius: var(--border-radius-small);
         font-family: var(
-          --texra-editor-font-family,
+          --wa-font-family-mono,
           ui-monospace,
           SFMono-Regular,
           Consolas,
           monospace
         );
-        font-size: var(--texra-editor-font-size, var(--font-size-sm));
+        font-size: var(--wa-editor-font-size, var(--font-size-sm));
         line-height: 1.35;
       }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -47,27 +47,27 @@ const ACTION_CONFIG: Record<
   compaction: {
     icon: 'fold',
     label: 'Compacted',
-    color: 'var(--texra-charts-blue)',
+    color: 'var(--wa-color-chart-blue)',
   },
   clear_tool_uses: {
     icon: 'trash',
     label: 'Cleared Tool Uses',
-    color: 'var(--texra-charts-green)',
+    color: 'var(--wa-color-chart-green)',
   },
   clear_thinking: {
     icon: 'lightbulb',
     label: 'Cleared Thinking',
-    color: 'var(--texra-charts-green)',
+    color: 'var(--wa-color-chart-green)',
   },
   truncation: {
     icon: 'ellipsis',
     label: 'Truncated',
-    color: 'var(--texra-charts-orange)',
+    color: 'var(--wa-color-chart-orange)',
   },
   max_tokens_reduced: {
     icon: 'arrow-small-down',
     label: 'Max Tokens Reduced',
-    color: 'var(--texra-charts-yellow)',
+    color: 'var(--wa-color-chart-yellow)',
   },
 };
 

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -17,7 +17,7 @@ export const codeBlockStyles = css`
     align-items: center;
     justify-content: space-between;
     padding: var(--wa-space-3xs) var(--wa-space-2xs);
-    background-color: var(--texra-editorGroupHeader-tabsBackground);
+    background-color: var(--wa-color-tabs-background);
     border-bottom: var(--border-thin) solid var(--color-border);
     font-size: var(--font-size-xs);
   }
@@ -67,13 +67,13 @@ export const codeBlockStyles = css`
 
     &:active {
       background-color: var(
-        --texra-toolbar-activeBackground,
+        --wa-color-toolbar-active,
         rgba(99, 102, 103, 0.31)
       );
     }
 
     &.copied {
-      color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
+      color: var(--wa-color-git-added, #3fb950);
     }
 
     &:focus-visible {
@@ -109,7 +109,7 @@ export const codeBlockStyles = css`
   .hljs-keyword,
   .hljs-selector-tag,
   .hljs-tag {
-    color: var(--texra-symbolIcon-keywordForeground, var(--wa-color-text-link));
+    color: var(--wa-color-symbol-keyword, var(--wa-color-text-link));
   }
 
   .hljs-string,
@@ -117,21 +117,21 @@ export const codeBlockStyles = css`
   .hljs-regexp,
   .hljs-template-tag,
   .hljs-template-variable {
-    color: var(--texra-debugTokenExpression-string, #a31515);
+    color: var(--wa-color-debug-string, #a31515);
   }
 
   .hljs-number,
   .hljs-literal,
   .hljs-built_in,
   .hljs-type {
-    color: var(--texra-debugTokenExpression-number, #098658);
+    color: var(--wa-color-debug-number, #098658);
   }
 
   .hljs-variable,
   .hljs-params,
   .hljs-attr {
     color: var(
-      --texra-symbolIcon-variableForeground,
+      --wa-color-symbol-variable,
       var(--wa-color-text-normal)
     );
   }
@@ -139,19 +139,19 @@ export const codeBlockStyles = css`
   .hljs-function,
   .hljs-title,
   .hljs-title.function_ {
-    color: var(--texra-symbolIcon-functionForeground, #795e26);
+    color: var(--wa-color-symbol-function, #795e26);
   }
 
   .hljs-class .hljs-title,
   .hljs-title.class_,
   .hljs-title.class_.inherited__ {
-    color: var(--texra-symbolIcon-classForeground, #267f99);
+    color: var(--wa-color-symbol-class, #267f99);
   }
 
   .hljs-property,
   .hljs-name {
     color: var(
-      --texra-symbolIcon-propertyForeground,
+      --wa-color-symbol-property,
       var(--wa-color-text-normal)
     );
   }
@@ -170,17 +170,17 @@ export const codeBlockStyles = css`
   .hljs-meta,
   .hljs-meta .hljs-keyword,
   .hljs-meta .hljs-string {
-    color: var(--texra-symbolIcon-keywordForeground, #0000ff);
+    color: var(--wa-color-symbol-keyword, #0000ff);
   }
 
   .hljs-addition {
-    background-color: var(--texra-diffEditor-insertedTextBackground);
-    color: var(--texra-gitDecoration-addedResourceForeground, #22863a);
+    background-color: var(--wa-color-diff-inserted);
+    color: var(--wa-color-git-added, #22863a);
   }
 
   .hljs-deletion {
-    background-color: var(--texra-diffEditor-removedTextBackground);
-    color: var(--texra-gitDecoration-deletedResourceForeground, #b31d28);
+    background-color: var(--wa-color-diff-removed);
+    color: var(--wa-color-git-deleted, #b31d28);
   }
 
   .hljs-emphasis {
@@ -193,7 +193,7 @@ export const codeBlockStyles = css`
 
   .hljs-symbol,
   .hljs-bullet {
-    color: var(--texra-symbolIcon-constantForeground, #36acaa);
+    color: var(--wa-color-symbol-constant, #36acaa);
   }
 
   .hljs-link {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -36,11 +36,11 @@ export const groupStyles = css`
 
   .log-group-header {
     &.is-running {
-      border-left-color: var(--texra-statusBarItem-warningBackground);
+      border-left-color: var(--wa-color-status-warning-bg);
       box-shadow: inset 2px 0 0
         color-mix(
           in srgb,
-          var(--texra-statusBarItem-warningBackground) 35%,
+          var(--wa-color-status-warning-bg) 35%,
           transparent
         );
     }
@@ -57,7 +57,7 @@ export const groupStyles = css`
   .log-group-content {
     padding-left: var(--wa-space-2xs);
     border-left: var(--border-thin) dashed
-      var(--texra-editorGroupHeader-tabsBorder);
+      var(--wa-color-tabs-border);
   }
 
   .log-run {

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -38,8 +38,8 @@ export const logEntryStyles = css`
     gap: var(--wa-space-2xs);
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     margin: var(--wa-space-2xs) 0;
-    background: var(--texra-inputValidation-warningBackground);
-    border: var(--border-thin) solid var(--texra-inputValidation-warningBorder);
+    background: var(--wa-color-warning-fill-quiet);
+    border: var(--border-thin) solid var(--wa-color-warning-border-quiet);
     border-radius: var(--border-radius);
     color: var(--color-warning);
     font-style: italic;
@@ -209,11 +209,11 @@ export const logEntryStyles = css`
   }
 
   .level-debug {
-    color: var(--texra-debugTokenExpression-name, #4b9ef9);
+    color: var(--wa-color-debug-name, #4b9ef9);
   }
 
   .level-info {
-    color: var(--texra-notificationsInfoIcon-foreground, #75beff);
+    color: var(--wa-color-icon-info, #75beff);
   }
 
   .level-warn,
@@ -227,7 +227,7 @@ export const logEntryStyles = css`
   }
 
   .message-debug {
-    color: var(--texra-textPreformat-foreground, #a9b7c6);
+    color: var(--wa-color-text-preformat, #a9b7c6);
   }
 
   .message-info {
@@ -274,18 +274,18 @@ export const logEntryStyles = css`
      so their stdout/stderr reads like a terminal instead of a logger. */
   :host([terminal]) .log-container {
     font-family: var(
-      --texra-editor-font-family,
+      --wa-font-family-mono,
       ui-monospace,
       SFMono-Regular,
       Consolas,
       monospace
     );
-    font-size: var(--texra-editor-font-size, var(--font-size));
+    font-size: var(--wa-editor-font-size, var(--font-size));
     background-color: var(
       --texra-terminal-background,
       var(--wa-color-surface-default, transparent)
     );
-    color: var(--texra-terminal-foreground, var(--wa-color-text-normal));
+    color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
   }
 
   :host([terminal]) .log-line {
@@ -307,11 +307,11 @@ export const logEntryStyles = css`
   }
 
   :host([terminal]) .message-warn {
-    color: var(--texra-terminal-ansiYellow, var(--color-warning));
+    color: var(--wa-color-terminal-ansi-yellow, var(--color-warning));
   }
 
   :host([terminal]) .message-error {
-    color: var(--texra-terminal-ansiRed, var(--color-error));
+    color: var(--wa-color-terminal-ansi-red, var(--color-error));
   }
 
   /* Pre-formatted text nodes for terminal-mode streams.

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -95,11 +95,11 @@ export const toolUseStyles = css`
 
   .tool-use-in-progress > .details-summary :is(.tool-use-title, wa-icon),
   .tool-use-in-progress > .details-summary wa-spinner {
-    color: var(--texra-charts-yellow, #cca700);
+    color: var(--wa-color-chart-yellow, #cca700);
   }
 
   .tool-use-in-progress > .details-summary tool-timer {
-    color: var(--texra-charts-yellow, #cca700);
+    color: var(--wa-color-chart-yellow, #cca700);
   }
 
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
@@ -115,7 +115,7 @@ export const toolUseStyles = css`
 
   .tool-user-feedback {
     background-color: var(
-      --texra-inputValidation-infoBackground,
+      --wa-color-brand-fill-quiet,
       rgba(55, 148, 255, 0.1)
     );
     border-left-color: var(--wa-color-text-link, #3794ff);
@@ -174,15 +174,15 @@ export const toolUseStyles = css`
 
   /* Diff styles */
   .diff-add {
-    color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
+    color: var(--wa-color-git-added, #3fb950);
   }
 
   .diff-remove {
-    color: var(--texra-gitDecoration-deletedResourceForeground, #f85149);
+    color: var(--wa-color-git-deleted, #f85149);
   }
 
   .diff-hunk {
-    color: var(--texra-gitDecoration-modifiedResourceForeground, #d29922);
+    color: var(--wa-color-git-modified, #d29922);
   }
 
   .edit-diff-container {
@@ -207,18 +207,18 @@ export const toolUseStyles = css`
 
   .diff-inline-del {
     background-color: var(
-      --texra-diffEditor-removedTextBackground,
+      --wa-color-diff-removed,
       rgba(255, 0, 0, 0.2)
     );
-    color: var(--texra-gitDecoration-deletedResourceForeground, #f85149);
+    color: var(--wa-color-git-deleted, #f85149);
     text-decoration: line-through;
   }
 
   .diff-inline-add {
     background-color: var(
-      --texra-diffEditor-insertedTextBackground,
+      --wa-color-diff-inserted,
       rgba(0, 255, 0, 0.2)
     );
-    color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
+    color: var(--wa-color-git-added, #3fb950);
   }
 `;

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -35,7 +35,7 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-path {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-link);

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -154,7 +154,7 @@ export class AgentSelectionPanel extends LitElement {
       .agent-list-item.selected {
         background: var(--wa-color-brand-fill-quiet);
         color: var(
-          --texra-list-activeSelectionForeground,
+          --wa-color-list-active-fg,
           var(--wa-color-text-normal)
         );
         border-left-color: var(--wa-color-brand-fill-loud);
@@ -300,7 +300,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-detail-path {
         font-size: var(--font-size-xs);
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         color: var(--color-text-secondary);
         margin-bottom: var(--wa-space-s);
         overflow: hidden;

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -91,7 +91,7 @@ export class ProviderKeyModal extends LitElement {
       }
 
       .provider-key-primary:hover {
-        background: var(--texra-button-hoverBackground);
+        background: var(--wa-color-button-hover);
       }
 
       .provider-key-secondary {

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -35,7 +35,7 @@ export const profileViewStyles: CSSResult = css`
 
   .label {
     font-weight: var(--font-weight-bold);
-    color: var(--texra-textPreformat-foreground);
+    color: var(--wa-color-text-preformat);
     min-width: 80px;
   }
 
@@ -57,7 +57,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .profile-notice code {
-    font-family: var(--texra-editor-font-family, monospace), monospace;
+    font-family: var(--wa-font-family-mono, monospace), monospace;
     font-size: 0.95em;
     padding: 0 var(--wa-space-3xs);
     border-radius: var(--border-radius-small);
@@ -190,7 +190,7 @@ export const profileViewStyles: CSSResult = css`
   .api-access-support-icon {
     flex-shrink: 0;
     margin-top: var(--wa-space-3xs);
-    color: var(--texra-charts-red, var(--wa-color-danger-on-quiet));
+    color: var(--wa-color-chart-red, var(--wa-color-danger-on-quiet));
   }
 
   .api-access-support a {
@@ -199,7 +199,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .api-access-support a:hover {
-    color: var(--texra-textLink-activeForeground);
+    color: var(--wa-color-text-link-active);
     text-decoration: underline;
   }
 
@@ -587,7 +587,7 @@ export const profileViewStyles: CSSResult = css`
 
   .model-row-icon--warning {
     --_icon-color: var(
-      --texra-list-warningForeground,
+      --wa-color-list-warning-fg,
       var(--wa-color-warning-on-quiet)
     );
   }

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -65,7 +65,7 @@ export class Pagination extends LitElement {
       }
 
       .pagination-status {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         letter-spacing: 0.02em;
       }
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -92,10 +92,10 @@ export class ToolCard extends LitElement {
       }
 
       .tool-id-tag {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-xs);
         padding: var(--border-thin) var(--border-radius-large);
-        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
+        background: var(--wa-color-badge-bg, rgba(128, 128, 128, 0.15));
         color: var(--wa-color-neutral-on-quiet);
         border-radius: var(--border-radius);
       }
@@ -139,10 +139,10 @@ export class ToolCard extends LitElement {
         border-radius: var(--border-radius);
         white-space: nowrap;
         font-weight: var(--font-weight-medium);
-        color: var(--texra-charts-blue, #3794ff);
+        color: var(--wa-color-chart-blue, #3794ff);
         background: color-mix(
           in srgb,
-          var(--texra-charts-blue, #3794ff) 12%,
+          var(--wa-color-chart-blue, #3794ff) 12%,
           transparent
         );
       }

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -126,7 +126,7 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-dir-path {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         color: var(--wa-color-text-normal);
         overflow: hidden;
         text-overflow: ellipsis;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -229,12 +229,12 @@ export class LaTeXTab extends LitElement {
 
       .dependency-icon.installed,
       .setting-status-icon.is-set {
-        color: var(--texra-testing-iconPassed, #73c991);
+        color: var(--wa-color-testing-passed, #73c991);
       }
 
       .dependency-icon.missing,
       .setting-status-icon.not-set {
-        color: var(--texra-testing-iconFailed, #f48771);
+        color: var(--wa-color-testing-failed, #f48771);
       }
 
       .dependency-info {
@@ -288,7 +288,7 @@ export class LaTeXTab extends LitElement {
 
       .dependency-path {
         margin-top: var(--wa-space-3xs);
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
       }
@@ -308,7 +308,7 @@ export class LaTeXTab extends LitElement {
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius-small);
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);
         overflow: hidden;
@@ -317,8 +317,8 @@ export class LaTeXTab extends LitElement {
       }
 
       .copy-success {
-        color: var(--texra-testing-iconPassed, #73c991) !important;
-        border-color: var(--texra-testing-iconPassed, #73c991) !important;
+        color: var(--wa-color-testing-passed, #73c991) !important;
+        border-color: var(--wa-color-testing-passed, #73c991) !important;
       }
 
       /* Prerequisite hint uses wa-callout; only layout for actions row + the
@@ -368,14 +368,14 @@ export class LaTeXTab extends LitElement {
       }
 
       .setting-config-key {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         margin-bottom: var(--wa-space-2xs);
       }
 
       .setting-value {
-        font-family: var(--texra-editor-font-family, monospace), monospace;
+        font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-link);
       }

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -157,7 +157,7 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__available {
         fill: none;
-        stroke: var(--texra-testing-iconPassed, #73c991);
+        stroke: var(--wa-color-testing-passed, #73c991);
         stroke-width: 4;
         stroke-linecap: round;
         transition: stroke-dashoffset var(--transition-slow);
@@ -165,7 +165,7 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__missing {
         fill: none;
-        stroke: var(--texra-testing-iconFailed, #f48771);
+        stroke: var(--wa-color-testing-failed, #f48771);
         stroke-width: 4;
         stroke-linecap: round;
         transition: stroke-dashoffset var(--transition-slow);
@@ -188,11 +188,11 @@ export class ToolsTab extends LitElement {
       }
 
       .tools-stat-available {
-        color: var(--texra-testing-iconPassed, #73c991);
+        color: var(--wa-color-testing-passed, #73c991);
       }
 
       .tools-stat-missing {
-        color: var(--texra-testing-iconFailed, #f48771);
+        color: var(--wa-color-testing-failed, #f48771);
       }
 
       /* Base recheck-btn styles provided by .tab-action-btn in commonViewStyles */

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -269,7 +269,7 @@ export const dropdownStyles = css`
   .dropdown-container wa-button.has-options::part(base),
   wa-button.has-options::part(base) {
     box-shadow: inset 0 0 0 1px
-      var(--texra-inputValidation-infoBorder, var(--wa-color-focus));
+      var(--wa-color-brand-border-quiet, var(--wa-color-focus));
   }
 
   .dropdown-container .dropdown-menu {
@@ -279,9 +279,9 @@ export const dropdownStyles = css`
     right: auto;
     z-index: 100;
     display: block;
-    background-color: var(--texra-menu-background);
-    color: var(--texra-menu-foreground);
-    border: var(--border-thin) solid var(--texra-menu-border);
+    background-color: var(--wa-color-menu-background);
+    color: var(--wa-color-menu-foreground);
+    border: var(--border-thin) solid var(--wa-color-menu-border);
     border-radius: var(--border-radius);
     min-width: 160px;
   }

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -9,7 +9,7 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   fontSize: 'var(--wa-font-size-m, 13px)',
   fontFamily: 'var(--wa-font-family-body, system-ui), system-ui',
   color:
-    'var(--texra-editorHoverWidget-foreground, var(--wa-color-text-normal))',
+    'var(--wa-color-text-normal, var(--wa-color-text-normal))',
   background:
     'var(--wa-color-surface-raised, var(--wa-color-surface-default))',
   border:

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -55,13 +55,13 @@ export const searchHighlightStyles: CSSResult = css`
       --texra-editor-findMatchHighlightBackground,
       #ffef0b80
     );
-    color: var(--texra-editor-findMatchHighlightForeground, inherit);
+    color: var(--wa-color-editor-find-match-highlight-fg, inherit);
     padding: 0;
     border-radius: var(--border-radius-small);
   }
 
   mark[data-current='true'] {
-    background-color: var(--texra-editor-findMatchBackground, #ff8b0088);
+    background-color: var(--wa-color-editor-find-match, #ff8b0088);
     outline: var(--border-thin) solid var(--wa-color-focus);
   }
 `;

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -132,7 +132,7 @@ export const commonViewStyles: CSSResult = css`
   .panel-collapsible::part(header) {
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     background-color: var(--wa-color-surface-lowered, transparent);
-    color: var(--texra-sideBarTitle-foreground, var(--wa-color-text-normal));
+    color: var(--wa-color-text-normal, var(--wa-color-text-normal));
   }
 
   /* "body" part is used by vscode-collapsible; "content" part by wa-details. */
@@ -368,7 +368,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .tab-action-btn:active {
-    background: var(--texra-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+    background: var(--wa-color-toolbar-active, rgba(99, 102, 103, 0.31));
   }
 
   .tab-action-btn:focus-visible {
@@ -555,7 +555,7 @@ export const filledButtonStyles: CSSResult = css`
     font-family: inherit;
     color: var(--wa-color-brand-on-loud);
     background: var(--wa-color-brand-fill-loud);
-    border: var(--border-thin) solid var(--texra-button-border, transparent);
+    border: var(--border-thin) solid var(--wa-color-button-border, transparent);
     border-radius: var(--border-radius);
     cursor: pointer;
     transition:
@@ -564,7 +564,7 @@ export const filledButtonStyles: CSSResult = css`
   }
 
   .filled-button:hover {
-    background: var(--texra-button-hoverBackground);
+    background: var(--wa-color-button-hover);
   }
 
   .filled-button:active {

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -5,7 +5,7 @@ export const designTokens: CSSResult = css`
     /* Text colors */
     --color-text-secondary: var(--wa-color-text-quiet);
     --color-text-link: var(--wa-color-text-link);
-    --color-text-link-active: var(--texra-textLink-activeForeground);
+    --color-text-link-active: var(--wa-color-text-link-active);
 
     /* Background colors */
     --color-bg-secondary: var(--wa-color-surface-lowered);
@@ -17,14 +17,14 @@ export const designTokens: CSSResult = css`
     --color-success: var(--wa-color-success-on-quiet, #2ea043);
     --color-error: var(--wa-color-danger-on-quiet, #f14c4c);
     --color-warning: var(--wa-color-warning-on-quiet, #cca700);
-    --color-info: var(--texra-charts-blue, #3794ff);
-    --color-added: var(--texra-charts-green, #4caf50);
-    --color-removed: var(--texra-charts-red, #f44336);
+    --color-info: var(--wa-color-chart-blue, #3794ff);
+    --color-added: var(--wa-color-chart-green, #4caf50);
+    --color-removed: var(--wa-color-chart-red, #f44336);
 
     /* Component aliases */
     --background-color: var(--color-bg-secondary);
-    --text-color: var(--texra-sideBar-foreground);
-    --button-hover-background: var(--texra-button-hoverBackground);
+    --text-color: var(--wa-color-text-normal);
+    --button-hover-background: var(--wa-color-button-hover);
     --dropdown-border: var(--wa-form-control-border-color);
 
     /* Typography */

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -62,7 +62,7 @@ export const markdownStyles = css`
     margin-top: var(--wa-space-s);
     margin-bottom: var(--wa-space-2xs);
     border-left: var(--border-thick) solid
-      var(--texra-activityBarBadge-background);
+      var(--wa-color-activity-badge-bg);
     border-bottom: var(--border-thin) solid var(--color-border);
     padding-bottom: var(--wa-space-3xs);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
@@ -105,7 +105,7 @@ export const markdownStyles = css`
     border-radius: var(--border-radius);
     background-color: var(--wa-color-surface-lowered);
     border-left: var(--wa-space-3xs) solid
-      var(--texra-activityBarBadge-background);
+      var(--wa-color-activity-badge-bg);
     overflow-x: auto;
   }
 
@@ -118,7 +118,7 @@ export const markdownStyles = css`
 
   .markdown-content .latex-ref {
     font-family: var(--font-family);
-    color: var(--texra-symbolIcon-keywordForeground);
+    color: var(--wa-color-symbol-keyword);
   }
 
   .markdown-content a {
@@ -132,7 +132,7 @@ export const markdownStyles = css`
 
   .markdown-content blockquote {
     border-left: var(--border-thick) solid
-      var(--texra-activityBarBadge-background);
+      var(--wa-color-activity-badge-bg);
     margin: var(--wa-space-xs) 0;
     padding-left: var(--wa-space-l);
     color: var(--color-text-secondary);
@@ -150,7 +150,7 @@ export const markdownStyles = css`
     }
 
     th {
-      background-color: var(--texra-editor-lineHighlightBackground);
+      background-color: var(--wa-color-editor-line-highlight);
       text-align: left;
     }
   }
@@ -182,7 +182,7 @@ export const markdownStyles = css`
 
   .banner-content--scratchpad p:has(strong:first-child) {
     border-left: calc(var(--wa-space-2xs) - 1px) solid
-      var(--texra-notificationsInfoIcon-foreground);
+      var(--wa-color-icon-info);
     padding-left: var(--wa-space-xs);
   }
 

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -28,7 +28,7 @@ export const permissionCardStyles: CSSResult = css`
     width: min(92vw, 600px);
     max-height: min(80vh, 44rem);
     overflow: hidden;
-    box-shadow: 0 2px 8px var(--texra-widget-shadow, rgba(0, 0, 0, 0.24));
+    box-shadow: 0 2px 8px var(--wa-color-surface-shadow, rgba(0, 0, 0, 0.24));
   }
 
   .permission-header {
@@ -52,7 +52,7 @@ export const permissionCardStyles: CSSResult = css`
     padding: var(--wa-space-xs);
     background: var(--wa-color-surface-lowered);
     border-radius: var(--border-radius);
-    color: var(--texra-terminal-foreground);
+    color: var(--wa-color-terminal-foreground);
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size);
     white-space: pre-wrap;
@@ -94,12 +94,12 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .diff-added {
-    color: var(--texra-gitDecoration-addedResourceForeground, #89d185);
+    color: var(--wa-color-git-added, #89d185);
     font-weight: var(--font-weight-medium);
   }
 
   .diff-removed {
-    color: var(--texra-gitDecoration-deletedResourceForeground, #f48771);
+    color: var(--wa-color-git-deleted, #f48771);
     font-weight: var(--font-weight-medium);
   }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -70,7 +70,7 @@ export const requestPanelStyles: CSSResult = css`
     border: var(--border-thin) solid var(--wa-form-control-border-color);
     border-radius: var(--border-radius-large);
     background: var(--wa-color-surface-default);
-    box-shadow: 0 2px 8px var(--texra-widget-shadow, rgba(0, 0, 0, 0.12));
+    box-shadow: 0 2px 8px var(--wa-color-surface-shadow, rgba(0, 0, 0, 0.12));
     display: flex;
     flex-direction: column;
     gap: ${sp.medium};
@@ -160,7 +160,7 @@ export const requestPanelStyles: CSSResult = css`
   :is(${FEEDBACK_ACTIVE})
     :is(${ACTIONS})
     vscode-toolbar-button[data-action='reject']::part(control) {
-    color: var(--texra-inputValidation-warningBorder);
+    color: var(--wa-color-warning-border-quiet);
   }
 
   /* Shared badge base */
@@ -179,7 +179,7 @@ export const requestPanelStyles: CSSResult = css`
     border-left: var(--border-thick) solid var(--wa-color-text-normal);
   }
   .bash-approval-request {
-    border-left: var(--border-thick) solid var(--texra-terminal-ansiYellow);
+    border-left: var(--border-thick) solid var(--wa-color-terminal-ansi-yellow);
   }
   .retry-request {
     border-left: var(--border-thick) solid var(--color-warning);
@@ -261,7 +261,7 @@ export const requestPanelStyles: CSSResult = css`
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     border-left: var(--border-thin) solid
-      var(--texra-button-separator, var(--wa-form-control-border-color));
+      var(--wa-color-button-separator, var(--wa-form-control-border-color));
   }
 
   /* wa-dropdown handles its own popup positioning, but we still want
@@ -284,7 +284,7 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .bash-approval-requests__header wa-icon {
-    color: var(--texra-terminal-ansiYellow);
+    color: var(--wa-color-terminal-ansi-yellow);
   }
 
   .bash-approval-request__command {
@@ -293,7 +293,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .bash-approval-request__command .code-block {
-    border-left: var(--border-thick) solid var(--texra-terminal-ansiYellow);
+    border-left: var(--border-thick) solid var(--wa-color-terminal-ansi-yellow);
   }
 
   .bash-approval-request__command .code-block pre {
@@ -493,7 +493,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposal__file-name:hover {
     text-decoration: underline;
-    color: var(--texra-textLink-activeForeground, var(--wa-color-text-link));
+    color: var(--wa-color-text-link-active, var(--wa-color-text-link));
   }
 
   .workflow-proposal__file-name--readonly {
@@ -631,7 +631,7 @@ export const requestPanelStyles: CSSResult = css`
     background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     border-left: var(--border-thick) solid
-      var(--texra-textBlockQuote-border, var(--wa-color-focus));
+      var(--wa-color-blockquote-border, var(--wa-color-focus));
     line-height: var(--line-height-normal);
   }
 
@@ -767,7 +767,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__session-links-input::placeholder {
-    color: var(--texra-input-placeholderForeground);
+    color: var(--wa-color-text-placeholder);
   }
 
   .external-inquiry-request__session-links-hint {
@@ -817,7 +817,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__answer-input::placeholder {
-    color: var(--texra-input-placeholderForeground);
+    color: var(--wa-color-text-placeholder);
   }
 
   .external-inquiry-request__answer-hint {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -114,7 +114,7 @@ export const selectStyles: CSSResult = css`
   }
 
   wa-icon.clickable:hover {
-    color: var(--button-hover-background, var(--texra-button-hoverBackground));
+    color: var(--button-hover-background, var(--wa-color-button-hover));
   }
 
   wa-select::part(listbox) {


### PR DESCRIPTION
## Summary

- Retired the **double-bridge** token graph in both theme files. Consumer code now references **only** \`--wa-*\` tokens. The two bridge files (\`packages/extension/src/common/styles/common.css\` and \`packages/desktop/src/renderer/themeTokens.css\`) become pure WA theme override layers.
- **No more \`--texra-*\` shims** anywhere in the repo. **No more \`--vscode-*\` re-exports** in the desktop bridge for consumer use. Each bridge sources \`--wa-*\` directly from its native palette: extension from the host's \`--vscode-*\`, desktop from \`--desktop-color-*\`.
- Promoted niche palette tokens with no clean WA semantic equivalent into the \`--wa-color-*\` namespace so the consumer surface stays uniform.

## Bridge size

| File | Before | After | Diff |
| --- | ---: | ---: | ---: |
| \`packages/extension/src/common/styles/common.css\` | 279 | 221 | -58 |
| \`packages/desktop/src/renderer/themeTokens.css\` | 518 | 301 | -217 |
| **Total** | **797** | **522** | **-275** (~35% smaller) |

## Consumer counts (before / after)

- \`var(--vscode-*)\` in consumers: **105 → 0**
- \`var(--texra-*)\` in consumers: **57 → 0**
- \`var(--texra-*)\` repo-wide: **0** (the prefix no longer exists at all)

Both bridges define **131** \`--wa-*\` tokens each — the single source of truth that consumers reference.

## Tokens promoted into the \`--wa-color-*\` namespace

These had no semantic WA counterpart and previously lived under \`--texra-*\` or were referenced as raw \`--vscode-*\`:

- **Charts**: \`--wa-color-chart-{blue,green,orange,red,yellow,purple}\`
- **Symbol icons**: \`--wa-color-symbol-{class,constant,function,keyword,property,variable}\`
- **Terminal**: \`--wa-color-terminal-{background,foreground,cursor,selection-bg}\` plus full ansi palette \`--wa-color-terminal-ansi-{black,blue,cyan,green,magenta,red,white,yellow}\` (and 8 \`bright-*\` variants)
- **Diff editor**: \`--wa-color-diff-{inserted,removed}\`
- **Git decoration**: \`--wa-color-git-{added,deleted,modified}\`
- **Debug tokens**: \`--wa-color-debug-{name,number,string}\`
- **Editor surface**: \`--wa-color-editor-{selection,inactive-selection,line-highlight,find-match,find-match-highlight,find-match-highlight-fg}\`
- **Tabs**: \`--wa-color-tabs-{background,border}\`
- **Menus**: \`--wa-color-menu-{background,border,foreground}\`
- **Lists**: \`--wa-color-list-{active-bg,active-fg,hover-bg,warning-fg}\`
- **Toolbar**: \`--wa-color-toolbar-{active,hover}\`
- **Misc indicators**: \`--wa-color-{progress-bg,status-warning-bg,icon-info,activity-badge-bg,badge-bg,blockquote-border,testing-passed,testing-failed,text-preformat,text-link-active,text-placeholder,surface-shadow,button-hover,button-border,button-separator}\`
- **Editor font size**: \`--wa-editor-font-size\`

## Behavioural impact

Zero. Each \`--wa-*\` token resolves to the same upstream value it resolved to before — just one hop fewer (\`--wa-* → --vscode-*\` or \`--wa-* → --desktop-color-*\` directly, not \`--vscode-* → --texra-* → --wa-* → ...\`).

## Test plan

- [x] \`npm run typecheck\` — same baseline (8 pre-existing errors about \`electron\` / \`@openrouter/sdk\` modules; unrelated)
- [x] \`npm run compile:fast\` — clean (settingsView + webview Vite bundles built)
- [x] \`cd packages/desktop && npx vite build --mode development\` — clean
- [x] \`npm run lint\` — same baseline (28 pre-existing import-order warnings; unrelated)
- [x] \`grep var(--texra-\` in consumers → **0 hits**
- [x] \`grep var(--vscode-\` in consumers → **0 hits**
- [ ] Manual smoke in VS Code: light + dark + high-contrast themes
- [ ] Manual smoke in desktop: light + dark + high-contrast color-scheme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires theme/token plumbing across both the desktop renderer and VS Code webviews; mistakes would show up as widespread styling/contrast regressions (including high-contrast) rather than functional breakage.
> 
> **Overview**
> **Consolidates theming to a single `--wa-*` token surface** across the Electron desktop and VS Code webviews, removing the legacy `--texra-*` shim layer and (on desktop) dropping `--vscode-*` re-export support.
> 
> Desktop now defines a native `--desktop-color-*` palette and maps all required semantics (including previously “niche” tokens like charts/terminal/diff/git/debug/symbol icons) directly into `--wa-color-*`; high-contrast overrides are applied at the `--desktop-color-*` level.
> 
> Consumer CSS/components are updated repo-wide to reference the new `--wa-*` tokens (e.g., list selection, toolbar/menu, editor/terminal, chart colors, monospace/editor font sizing), with a few small tweaks to ensure selected-row foreground uses `--wa-color-list-active-fg`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17fb1d8f264b0d31b2641ce11e0fbff520698acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->