### PR TITLE
fix(webview): widen launcher toolbar group gap to prevent overlap

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -249,7 +249,7 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer {
         display: flex;
         align-items: center;
-        gap: var(--wa-space-2xs);
+        gap: var(--wa-space-s);
         flex: 1 1 auto;
         flex-wrap: wrap;
         min-width: 0;


### PR DESCRIPTION
Robot icon was visually overlapping the agent-select text. Bumped `.model-selection-footer` gap from `2xs` (4px) to `s` (8px) so the agent and model groups stay separated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only spacing tweak in the webview toolbar; main impact is minor layout change on narrow widths.
> 
> **Overview**
> Adjusts the webview instruction panel footer layout by increasing the `.model-selection-footer` flex `gap` from `--wa-space-2xs` to `--wa-space-s`, preventing the agent/model select groups (and icons) from visually overlapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76a61b01965cf22b4400dbedac0085a8993f196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->