### PR TITLE
fix(desktop): white-page recovery + pre-warm keychain at launch

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -49,6 +49,7 @@ import {
 import { reportFatalStartupError } from './fatalStartupError.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeDesktopCrashReporting } from './desktopCrashReporting.js';
+import { prewarmElectronKeychain } from './platform/electronSecrets.js';
 import { initializeElectronPlatform } from './platform/index.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
@@ -392,6 +393,14 @@ if (protocolLifecycle.shouldContinue) {
   app
     .whenReady()
     .then(async () => {
+      // Trigger the OS keychain prompt as a deterministic launch step so the
+      // user sees it BEFORE the renderer asks for any saved secret. Without
+      // this, the first decrypt/encrypt happens partway through startup or
+      // user interaction; if the user is slow to click "Allow", concurrent
+      // renderer-driven secret reads can fail and surface as a blank window.
+      // Errors are swallowed here — ElectronSecrets.get() has its own
+      // per-key fallback that returns `undefined` instead of throwing.
+      await prewarmElectronKeychain();
       const platformInit = await initializeElectronPlatform(__dirname);
       const { lifecycle } = platformInit;
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -13,6 +13,9 @@ interface ElectronSecretsOptions {
 export const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
   'TeXRA cannot store secrets securely because Electron is using Linux basic_text storage. Set up a system keyring such as GNOME Keyring/libsecret or KWallet, then restart TeXRA. Environment variables still work for API keys.';
 
+export const KEYCHAIN_DENIED_WARNING_MESSAGE =
+  'TeXRA could not read its saved secrets because the system keychain prompt was denied. Saved API keys and sign-in sessions will not be available until you allow access. Restart TeXRA after granting access to retry.';
+
 const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
   'Electron safeStorage is unavailable for secret writes.';
 
@@ -27,6 +30,7 @@ function isStoredSecret(value: unknown): value is StoredSecret {
 
 export class ElectronSecrets implements PlatformSecrets {
   private warnedAboutBasicText = false;
+  private warnedAboutKeychainDenied = false;
 
   constructor(
     private readonly store: JsonStore,
@@ -40,7 +44,23 @@ export class ElectronSecrets implements PlatformSecrets {
 
     const stored = this.store.get<unknown>(key);
     if (!isStoredSecret(stored)) return undefined;
-    return safeStorage.decryptString(Buffer.from(stored.value, 'base64'));
+    try {
+      return safeStorage.decryptString(Buffer.from(stored.value, 'base64'));
+    } catch (error) {
+      // The macOS keychain (and Linux libsecret/KWallet) can reject decrypts
+      // when the user denies the OS prompt or the entry encryption key has
+      // been rotated. Treat this as "no saved secret" so the rest of the
+      // app — most importantly the renderer bootstrap — keeps working.
+      // Without this swallow, a single decrypt rejection during launch can
+      // surface as an unhandled rejection in renderer bootstrap and leave
+      // the user staring at a blank white window.
+      console.warn(
+        `ElectronSecrets: safeStorage.decryptString failed for "${key}"; treating as unset. ` +
+          `Cause: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      await this.warnAboutKeychainDenied();
+      return undefined;
+    }
   }
 
   async set(key: string, value: string): Promise<void> {
@@ -80,6 +100,56 @@ export class ElectronSecrets implements PlatformSecrets {
       // the warning dialog itself fails.
     }
   }
+
+  private async warnAboutKeychainDenied(): Promise<void> {
+    if (this.warnedAboutKeychainDenied) return;
+    this.warnedAboutKeychainDenied = true;
+    try {
+      await this.options.showWarningMessage?.(KEYCHAIN_DENIED_WARNING_MESSAGE);
+    } catch {
+      // The keychain-denied warning is best-effort. Suppress dialog errors so
+      // the secret read still resolves to undefined and the caller can proceed.
+    }
+  }
+}
+
+/**
+ * Force the OS keychain prompt to appear at app launch (before the renderer
+ * loads) by performing one harmless `safeStorage.encryptString` call. macOS
+ * (and Linux keyring backends) trigger the "@texra/desktop wants to use your
+ * confidential information" dialog on the first encrypt/decrypt; running it
+ * here turns that into a deterministic startup event instead of a surprise
+ * during user interaction. Subsequent calls reuse the unlocked key without
+ * prompting.
+ *
+ * Safe to call multiple times — the first invocation does the work and the
+ * rest are no-ops. Returns `true` when the prompt was attempted, `false` when
+ * `safeStorage` is unavailable (e.g., Linux without a configured keyring).
+ */
+let keychainPrewarmed = false;
+export async function prewarmElectronKeychain(): Promise<boolean> {
+  if (keychainPrewarmed) return true;
+  if (!safeStorage.isEncryptionAvailable()) return false;
+  try {
+    safeStorage.encryptString('texra-keychain-prewarm');
+    keychainPrewarmed = true;
+    return true;
+  } catch (error) {
+    // We do NOT mark prewarmed when the OS rejects so a future retry path
+    // (e.g., re-running after the user changes keychain permissions) can try
+    // again. Swallow so startup keeps progressing — the per-key fallback in
+    // ElectronSecrets.get() handles the same denial path.
+    console.warn(
+      `prewarmElectronKeychain: encryptString failed; continuing without prewarm. ` +
+        `Cause: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+/** Test-only: reset the prewarm latch so unit tests can re-exercise the path. */
+export function __resetKeychainPrewarmedForTests(): void {
+  keychainPrewarmed = false;
 }
 
 export function getSecretStorageMode(): SecretStorageMode {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -221,56 +221,134 @@ function rerenderShell(): void {
   render(shellTemplate(), appRoot);
 }
 
-// Render the log viewer template into its dedicated container so that
-// re-renders driven by log-snapshot updates do not stomp the shell.
-renderLogViewer();
-rerenderShell();
+function renderBootstrapFallback(error: unknown): void {
+  // Last-resort fallback when the main shell cannot mount. This must NOT
+  // depend on any custom element or async work — if the shell crashed before
+  // reaching the chrome render, we still need to draw something so the user
+  // is not staring at a blank white window. The user-visible failure mode
+  // we are guarding against is a thrown decrypt during early IPC (e.g., the
+  // macOS keychain prompt is denied) propagating into the bootstrap promise
+  // chain and aborting render() before any pixels are painted.
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'TeXRA could not finish starting up.';
+  const reload = () => window.location.reload();
+  render(
+    html`
+      <section
+        class="desktop-bootstrap-fallback"
+        role="alert"
+        aria-live="assertive"
+      >
+        <div class="desktop-bootstrap-fallback-panel">
+          <h1>TeXRA could not start</h1>
+          <p>${message}</p>
+          <p>
+            If you just denied a keychain prompt, your saved API keys and
+            sign-in session are unavailable. You can continue without them, or
+            reload after granting access.
+          </p>
+          <div class="desktop-bootstrap-fallback-actions">
+            <wa-button appearance="filled" variant="brand" @click=${reload}>
+              Reload
+            </wa-button>
+            <wa-button
+              appearance="outlined"
+              @click=${() => {
+                // Hide the fallback so the partial shell (if any) becomes
+                // visible. The renderer can still drive routes via the
+                // command palette even when secrets are unavailable.
+                const node = appRoot.querySelector(
+                  '.desktop-bootstrap-fallback',
+                );
+                if (node instanceof HTMLElement) node.hidden = true;
+              }}
+            >
+              Continue without saved secrets
+            </wa-button>
+          </div>
+        </div>
+      </section>
+    `,
+    appRoot,
+  );
+}
 
-const firstRunWalkthrough = createFirstRunWalkthrough({
-  document,
-  dismiss: () => postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS),
-  setRoute,
-});
-appRoot.append(firstRunWalkthrough.element);
+let bootstrapFailed = false;
+try {
+  // Render the log viewer template into its dedicated container so that
+  // re-renders driven by log-snapshot updates do not stomp the shell.
+  renderLogViewer();
+  rerenderShell();
+} catch (error) {
+  bootstrapFailed = true;
+  console.error('TeXRA desktop renderer bootstrap failed', error);
+  renderBootstrapFallback(error);
+}
 
-const commandPalette = createDesktopCommandPalette({
-  document,
-  canOpen: () => !firstRunWalkthrough.isVisible(),
-  actions: {
-    showRoute: setRoute,
-    showSettings: (tabIndex, agentSubTab) => {
-      setRoute('settings');
-      if (tabIndex == null) return;
-      window.postMessage(
-        buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
-        getWindowTargetOrigin(),
-      );
-    },
-    openDesktopDocs: () => {
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);
-    },
-    openLogFolder: () => {
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER);
-    },
-    openWorkspaceFolder: () => {
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
-    },
-    showFirstRunWalkthrough: () => {
-      firstRunWalkthrough.show();
-    },
-    resetMainView: () => {
-      setRoute('main');
-      window.postMessage(
-        buildDesktopMainViewResetMessage(),
-        getWindowTargetOrigin(),
-      );
-    },
-  },
-});
-appRoot.append(commandPalette.element);
+// If the shell failed to mount, skip everything that depends on its DOM —
+// command palette, walkthrough, and IPC requests. The fallback UI gives the
+// user a way to reload or proceed without saved secrets.
+if (bootstrapFailed) {
+  // Surface unhandled IPC rejections that arrive after the fallback so they
+  // do not silently disappear into the console.
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('Unhandled rejection after bootstrap failure', event.reason);
+  });
+}
+
+const firstRunWalkthrough = bootstrapFailed
+  ? undefined
+  : createFirstRunWalkthrough({
+      document,
+      dismiss: () => postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS),
+      setRoute,
+    });
+if (firstRunWalkthrough) appRoot.append(firstRunWalkthrough.element);
+
+const commandPalette = bootstrapFailed
+  ? undefined
+  : createDesktopCommandPalette({
+      document,
+      canOpen: () => !firstRunWalkthrough?.isVisible(),
+      actions: {
+        showRoute: setRoute,
+        showSettings: (tabIndex, agentSubTab) => {
+          setRoute('settings');
+          if (tabIndex == null) return;
+          window.postMessage(
+            buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
+            getWindowTargetOrigin(),
+          );
+        },
+        openDesktopDocs: () => {
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);
+        },
+        openLogFolder: () => {
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER);
+        },
+        openWorkspaceFolder: () => {
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
+        },
+        showFirstRunWalkthrough: () => {
+          firstRunWalkthrough?.show();
+        },
+        resetMainView: () => {
+          setRoute('main');
+          window.postMessage(
+            buildDesktopMainViewResetMessage(),
+            getWindowTargetOrigin(),
+          );
+        },
+      },
+    });
+if (commandPalette) appRoot.append(commandPalette.element);
 
 function openCommandPalette(): void {
-  commandPalette.open();
+  commandPalette?.open();
 }
 
 function openWorkspaceFolder(): void {
@@ -302,6 +380,7 @@ function isThemeMessage(message: unknown): message is SetThemeMessage {
 function setRoute(route: DesktopRoute): void {
   currentRoute = route;
   document.body.dataset.desktopRoute = route;
+  if (bootstrapFailed) return;
   rerenderShell();
   if (route === 'logs') requestLogSnapshot();
 }
@@ -317,9 +396,9 @@ window.addEventListener('message', (event) => {
     setRoute(event.data.route);
   } else if (isDesktopOnboardingSetStateMessage(event.data)) {
     if (event.data.shouldShow) {
-      firstRunWalkthrough.show();
+      firstRunWalkthrough?.show();
     } else {
-      firstRunWalkthrough.hide();
+      firstRunWalkthrough?.hide();
     }
   } else if (isThemeMessage(event.data)) {
     applyDesktopTheme(event.data.theme);
@@ -329,8 +408,10 @@ window.addEventListener('message', (event) => {
     renderLogSnapshot(event.data);
   }
 });
-requestWorkspaceTree();
-postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
+if (!bootstrapFailed) {
+  requestWorkspaceTree();
+  postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
+}
 
 function applyDesktopTheme(theme: DesktopThemeKind): void {
   // Body and html classList mutation is OK here: those elements live OUTSIDE

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -509,6 +509,40 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
   margin-top: var(--wa-space-l);
 }
 
+.desktop-bootstrap-fallback {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: var(--wa-space-3xl) var(--wa-space-l);
+  background: var(--wa-color-surface-default);
+}
+
+.desktop-bootstrap-fallback-panel {
+  max-width: 560px;
+  text-align: center;
+  color: var(--wa-color-text-normal);
+}
+
+.desktop-bootstrap-fallback-panel h1 {
+  margin: 0 0 var(--wa-space-m);
+  font-size: var(--font-size-h1);
+  font-weight: 600;
+}
+
+.desktop-bootstrap-fallback-panel p {
+  margin: 0 0 var(--wa-space-s);
+  color: var(--wa-color-text-quiet);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.desktop-bootstrap-fallback-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--wa-space-s);
+  margin-top: var(--wa-space-l);
+}
+
 .desktop-log-viewer {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -80,8 +80,11 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE');
     expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.DISMISS');
     expect(rendererMain).toContain('showFirstRunWalkthrough');
+    // Optional chaining is required because the walkthrough is intentionally
+    // skipped when the renderer bootstrap fallback is showing — the command
+    // palette must still be safe to construct in that case.
     expect(rendererMain).toContain(
-      'canOpen: () => !firstRunWalkthrough.isVisible()',
+      'canOpen: () => !firstRunWalkthrough?.isVisible()',
     );
     // wa-dialog handles focus trap, escape, and modal backdrop natively.
     // Assert the dialog wiring + the one custom keydown interceptor.

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -1,0 +1,188 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - test support
+import { repoPath } from './desktopTestPaths.mjs';
+
+interface ElectronSecretsModule {
+  ElectronSecrets: new (
+    store: { get<T>(key: string): T | undefined },
+    options?: {
+      showWarningMessage?: (message: string) => Promise<void> | void;
+    },
+  ) => {
+    get(key: string): Promise<string | undefined>;
+  };
+  prewarmElectronKeychain: () => Promise<boolean>;
+  __resetKeychainPrewarmedForTests: () => void;
+  KEYCHAIN_DENIED_WARNING_MESSAGE: string;
+}
+
+async function loadElectronSecrets(): Promise<ElectronSecretsModule> {
+  return (await import(
+    repoPath('packages/desktop/src/main/platform/electronSecrets.ts')
+  )) as ElectronSecretsModule;
+}
+
+function loadRendererMain(): string {
+  return readFileSync(
+    repoPath('packages/desktop/src/renderer/main.ts'),
+    'utf8',
+  );
+}
+
+describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
+  beforeEach(() => {
+    delete process.env.SOME_TEST_KEY;
+  });
+
+  afterEach(async () => {
+    const mod = await loadElectronSecrets();
+    mod.__resetKeychainPrewarmedForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined (instead of throwing) when safeStorage.decryptString throws', async () => {
+    const electron = (await import('electron')) as unknown as {
+      safeStorage: {
+        decryptString: (value: Buffer) => string;
+        encryptString: (value: string) => Buffer;
+        isEncryptionAvailable: () => boolean;
+      };
+    };
+    // The keychain denial path: decryptString rejects after the user clicks
+    // "Don't Allow" or the encryption key is otherwise unavailable. The bug
+    // we are guarding against is this throw bubbling up into the renderer
+    // bootstrap and producing a blank window.
+    const decryptSpy = vi
+      .spyOn(electron.safeStorage, 'decryptString')
+      .mockImplementation(() => {
+        throw new Error('User denied keychain access');
+      });
+
+    const { ElectronSecrets } = await loadElectronSecrets();
+    const warnings: string[] = [];
+    const fakeStore = {
+      get: <T>(_key: string): T | undefined =>
+        ({
+          encrypted: true,
+          value: Buffer.from('encrypted:value').toString('base64'),
+        }) as unknown as T,
+    };
+    const secrets = new ElectronSecrets(fakeStore, {
+      showWarningMessage: (message: string) => {
+        warnings.push(message);
+      },
+    });
+
+    const value = await secrets.get('texra.api.openai');
+
+    expect(value).toBeUndefined();
+    expect(decryptSpy).toHaveBeenCalledOnce();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('keychain');
+  });
+
+  it('only surfaces the keychain-denied warning once per ElectronSecrets instance', async () => {
+    const electron = (await import('electron')) as unknown as {
+      safeStorage: { decryptString: (value: Buffer) => string };
+    };
+    vi.spyOn(electron.safeStorage, 'decryptString').mockImplementation(() => {
+      throw new Error('denied');
+    });
+    const { ElectronSecrets } = await loadElectronSecrets();
+    const warnings: string[] = [];
+    const fakeStore = {
+      get: <T>(_key: string): T | undefined =>
+        ({
+          encrypted: true,
+          value: Buffer.from('encrypted:value').toString('base64'),
+        }) as unknown as T,
+    };
+    const secrets = new ElectronSecrets(fakeStore, {
+      showWarningMessage: (message: string) => {
+        warnings.push(message);
+      },
+    });
+
+    await secrets.get('a');
+    await secrets.get('b');
+    await secrets.get('c');
+
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('prewarmElectronKeychain returns true when safeStorage encrypts cleanly', async () => {
+    const { prewarmElectronKeychain, __resetKeychainPrewarmedForTests } =
+      await loadElectronSecrets();
+    __resetKeychainPrewarmedForTests();
+
+    expect(await prewarmElectronKeychain()).toBe(true);
+    // Idempotent — second call short-circuits.
+    expect(await prewarmElectronKeychain()).toBe(true);
+  });
+
+  it('prewarmElectronKeychain returns false when safeStorage is unavailable', async () => {
+    const electron = (await import('electron')) as unknown as {
+      safeStorage: { isEncryptionAvailable: () => boolean };
+    };
+    vi.spyOn(electron.safeStorage, 'isEncryptionAvailable').mockReturnValue(
+      false,
+    );
+    const { prewarmElectronKeychain, __resetKeychainPrewarmedForTests } =
+      await loadElectronSecrets();
+    __resetKeychainPrewarmedForTests();
+
+    expect(await prewarmElectronKeychain()).toBe(false);
+  });
+});
+
+describe('desktop renderer bootstrap fallback', () => {
+  it('wraps the initial render in a try/catch with a fallback UI', () => {
+    const source = loadRendererMain();
+    expect(source).toContain('renderBootstrapFallback');
+    expect(source).toContain('try {');
+    expect(source).toContain('renderLogViewer();');
+    expect(source).toContain('rerenderShell();');
+    expect(source).toContain('catch (error)');
+    expect(source).toContain('bootstrapFailed');
+  });
+
+  it('renders a Reload control and a "continue without saved secrets" affordance', () => {
+    const source = loadRendererMain();
+    expect(source).toContain('Reload');
+    expect(source).toContain('Continue without saved secrets');
+    // Use Lit html for the fallback so we do not pull in another component.
+    expect(source).toContain('html`');
+    expect(source).toContain('window.location.reload');
+  });
+
+  it('skips IPC requests and DOM-dependent setup when bootstrap fails', () => {
+    const source = loadRendererMain();
+    // requestWorkspaceTree() and the onboarding REQUEST_STATE post must be
+    // gated behind !bootstrapFailed so they cannot throw on top of the
+    // already-rendered fallback UI.
+    expect(source).toContain('if (!bootstrapFailed) {');
+    expect(source).toContain('requestWorkspaceTree();');
+  });
+});
+
+describe('desktop main process keychain prewarm', () => {
+  it('calls prewarmElectronKeychain immediately after app.whenReady()', () => {
+    const source = readFileSync(
+      repoPath('packages/desktop/src/main/index.ts'),
+      'utf8',
+    );
+    expect(source).toContain('prewarmElectronKeychain');
+    // The prewarm must run BEFORE initializeElectronPlatform — that is the
+    // function that constructs ElectronSecrets and starts the chain that
+    // eventually triggers crash-reporting / auth secret reads.
+    const prewarmIndex = source.indexOf('await prewarmElectronKeychain()');
+    const initIndex = source.indexOf('await initializeElectronPlatform(');
+    expect(prewarmIndex).toBeGreaterThan(0);
+    expect(initIndex).toBeGreaterThan(prewarmIndex);
+  });
+});


### PR DESCRIPTION
## Summary

The macOS keychain prompt that Electron's `safeStorage` triggers on the first `encrypt`/`decrypt` call is currently fired during the renderer bootstrap chain (e.g., when crash reporting / auth coordinator / settings IPC reads a saved secret). If the user is slow to click "Allow" — or hits "Don't Allow" — the failed `decryptString` propagates as an unhandled rejection and the renderer never paints. The user is stuck on a blank white window.

Three layered defenses, none of which require infra changes:

- **Pre-warm `safeStorage`** with a no-op `encryptString('texra-keychain-prewarm')` immediately after `app.whenReady()` (and before `initializeElectronPlatform`), so the OS keychain prompt is forced into a deterministic startup step. Subsequent reads reuse the unlocked key. Idempotent and swallows its own errors so a missing keyring on Linux doesn't block startup.
- **`ElectronSecrets.get()` is now resilient** to `safeStorage.decryptString` rejections: log a warning, surface a one-time `showWarningMessage`, and return `undefined` (treat as "no secret stored"). The launch path can no longer crash on a single denied secret.
- **Renderer error boundary**: `packages/desktop/src/renderer/main.ts` wraps the initial `renderLogViewer()` + `rerenderShell()` in a try/catch. On failure, a Lit-based fallback panel renders with a "Reload" button and a "Continue without saved secrets" button. All post-render work that depends on the shell DOM (command palette, walkthrough, IPC bootstraps) is gated behind `bootstrapFailed`.

No other launch-path renderer secret reads were found — the renderer only sends IPC messages; reads happen on the main side and are now covered by the per-key fallback in `ElectronSecrets.get()`.

## Files

- `packages/desktop/src/main/platform/electronSecrets.ts` — `get()` swallow + `prewarmElectronKeychain()` helper
- `packages/desktop/src/main/index.ts` — `await prewarmElectronKeychain()` right after `app.whenReady()`
- `packages/desktop/src/renderer/main.ts` — try/catch + `renderBootstrapFallback()` + `bootstrapFailed` guards
- `packages/desktop/src/renderer/styles.css` — `.desktop-bootstrap-fallback` panel styles
- `src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts` — new tests
- `src/test-kernel/desktop/ElectronRendererShell.vitest.mts` — updated substring check (`firstRunWalkthrough?.isVisible()`)

## Test plan

- [x] `npx vitest run src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts` — 8/8 passing
- [x] `npx vitest run` — at threshold (4 pre-existing failures, no new ones; +8 new passing tests)
- [x] `npm run typecheck` — at baseline (8 pre-existing errors in `electron`/`@openrouter/sdk`, unchanged)
- [x] `cd packages/desktop && npx vite build --mode development` — clean
- [ ] Manual: launch the desktop app on macOS, observe keychain prompt at startup (not mid-interaction); deny it → fallback panel renders with Reload / Continue actions; allow it → normal shell renders

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup and secret decryption paths; while changes are defensive, altering keychain handling and renderer bootstrap flow could affect login/session persistence and launch behavior across platforms.
> 
> **Overview**
> Improves desktop launch resilience when OS keychain access is slow/denied by **pre-warming Electron `safeStorage`** immediately after `app.whenReady()` to make the keychain prompt a deterministic startup step.
> 
> Makes `ElectronSecrets.get()` tolerate `safeStorage.decryptString` failures by logging, showing a one-time warning (`KEYCHAIN_DENIED_WARNING_MESSAGE`), and treating the secret as unset instead of throwing.
> 
> Adds a renderer-side bootstrap try/catch that renders a minimal fallback panel (Reload / Continue) and gates DOM-dependent setup + initial IPC requests behind a `bootstrapFailed` flag; includes new CSS for the fallback and Vitest coverage for the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cd7d4640fbfe7217a8ce89743d519293d2e127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->