### PR TITLE
fix(desktop): hoist logViewerState above renderLogViewer + drop stale token test

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -221,6 +221,16 @@ function rerenderShell(): void {
   render(shellTemplate(), appRoot);
 }
 
+interface LogViewerState {
+  meta: string;
+  text: string;
+}
+
+let logViewerState: LogViewerState = {
+  meta: 'Recent redacted log entries appear here.',
+  text: 'Open Logs to load recent entries.',
+};
+
 // Render the log viewer template into its dedicated container so that
 // re-renders driven by log-snapshot updates do not stomp the shell.
 renderLogViewer();
@@ -403,16 +413,6 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
   );
   return container;
 }
-
-interface LogViewerState {
-  meta: string;
-  text: string;
-}
-
-let logViewerState: LogViewerState = {
-  meta: 'Recent redacted log entries appear here.',
-  text: 'Open Logs to load recent entries.',
-};
 
 function logViewerTemplate(state: LogViewerState): TemplateResult {
   const action = (

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
@@ -53,9 +53,6 @@ describe('desktop theme tokens', () => {
         .getPropertyValue('--vscode-settings-textInputBackground')
         .trim(),
     ).toBe('var(--wa-form-control-background-color)');
-    expect(rootStyle.getPropertyValue('--texra-input-background').trim()).toBe(
-      'var(--wa-form-control-background-color)',
-    );
     expect(
       rootStyle.getPropertyValue('--wa-form-control-background-color').trim(),
     ).toMatch(/^light-dark\(#ffffff,\s*#313131\)$/);


### PR DESCRIPTION
## Summary
1. **TDZ bug from #3733** — `renderLogViewer()` runs at module top but `let logViewerState` was declared ~200 lines below, putting it in the temporal dead zone at first render. The error surfaces as `TypeError: Cannot read properties of undefined (reading 'meta')`, which #3743's bootstrap try/catch turns into the fallback 'TeXRA could not start' panel — masking the real bug behind a keychain-shaped error message. Hoist the interface and initial value above the call.

2. **Stale token test** — `DesktopThemeTokens.vitest.mts` still asserted `--texra-input-background` resolves to a WA token, but #3741 retired all `--texra-*` shims. Drop the assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small initialization ordering fix in the desktop renderer and a test-only cleanup; behavior change is limited to preventing an early-render crash and aligning tests with current CSS tokens.
> 
> **Overview**
> Fixes a desktop renderer startup crash by hoisting `LogViewerState`/`logViewerState` initialization above the initial `renderLogViewer()` call, avoiding a temporal-dead-zone/undefined state on first render.
> 
> Cleans up the desktop theme token test by removing the stale assertion for the retired `--texra-input-background` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b92f19dc775d0f6746b74a649e91c2c50e9377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->