### PR TITLE
fix(desktop): hoist logViewerState above bootstrap to fix TDZ crash

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -277,6 +277,16 @@ function renderBootstrapFallback(error: unknown): void {
   );
 }
 
+interface LogViewerState {
+  meta: string;
+  text: string;
+}
+
+let logViewerState: LogViewerState = {
+  meta: 'Recent redacted log entries appear here.',
+  text: 'Open Logs to load recent entries.',
+};
+
 let bootstrapFailed = false;
 try {
   // Render the log viewer template into its dedicated container so that
@@ -484,16 +494,6 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
   );
   return container;
 }
-
-interface LogViewerState {
-  meta: string;
-  text: string;
-}
-
-let logViewerState: LogViewerState = {
-  meta: 'Recent redacted log entries appear here.',
-  text: 'Open Logs to load recent entries.',
-};
 
 function logViewerTemplate(state: LogViewerState): TemplateResult {
   const action = (

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.mts
@@ -53,9 +53,6 @@ describe('desktop theme tokens', () => {
         .getPropertyValue('--vscode-settings-textInputBackground')
         .trim(),
     ).toBe('var(--wa-form-control-background-color)');
-    expect(rootStyle.getPropertyValue('--texra-input-background').trim()).toBe(
-      'var(--wa-form-control-background-color)',
-    );
     expect(
       rootStyle.getPropertyValue('--wa-form-control-background-color').trim(),
     ).toMatch(/^light-dark\(#ffffff,\s*#313131\)$/);


### PR DESCRIPTION
## Summary
The 'TeXRA could not start — Cannot read properties of undefined (reading meta)' panel was caused by a temporal-dead-zone bug, NOT a keychain failure as the message implies.

#3733 moved `renderLogViewer()` to module top during the declarative refactor, but left `let logViewerState` declared 200+ lines below. The first `renderLogViewer()` call hits TDZ → `logViewerState` is undefined → `state.meta` throws → #3743's bootstrap try/catch shows the keychain-shaped fallback.

**Fix:** hoist the `LogViewerState` interface and its initial value above the bootstrap try block.

**Also:** drop the stale `--texra-input-background` assertion in `DesktopThemeTokens.vitest.mts` (token retired in #3741).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a declaration-order fix to prevent a renderer bootstrap crash, plus a minor test expectation cleanup with no runtime behavior change beyond avoiding the error.
> 
> **Overview**
> Fixes a desktop renderer startup crash by hoisting `LogViewerState` and the initial `logViewerState` above the initial `renderLogViewer()` bootstrap call, avoiding a temporal-dead-zone/undefined state access.
> 
> Updates the desktop theme token test to remove a stale assertion for the retired `--texra-input-background` CSS variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028aad76c68e45b2c7ff05fd4af8fbeb90906b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->