### PR TITLE
fix(wa): migrate progressView vscode-single-select + reconcile desktop chrome tokens (#3677, #3689)

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -81,8 +81,11 @@
   --wa-color-text-preformat: var(--desktop-color-input-foreground);
   --wa-color-text-placeholder: var(--desktop-color-placeholder);
   --wa-color-surface-default: var(--desktop-color-background);
-  --wa-color-surface-raised: var(--desktop-color-sidebar);
-  --wa-color-surface-lowered: var(--desktop-color-sidebar-header);
+  /* Mirror the extension bridge in common.css: `surface-lowered` is the
+     sidebar surface (consumers like .desktop-nav and .desktop-explorer rely
+     on this), `surface-raised` is the slightly darker elevated/hover band. */
+  --wa-color-surface-raised: var(--desktop-color-sidebar-header);
+  --wa-color-surface-lowered: var(--desktop-color-sidebar);
   --wa-color-surface-border: var(--desktop-color-border);
   --wa-color-surface-shadow: var(--desktop-color-shadow);
 
@@ -125,11 +128,15 @@
   --wa-color-success-border-quiet: light-dark(#1a7f37, #73c991);
   --wa-color-success-on-quiet: light-dark(#1a7f37, #73c991);
 
-  /* Neutral variant. */
-  --wa-color-neutral-fill-quiet: light-dark(#eaeef2, #222222);
+  /* Neutral variant — mirrors the extension bridge in common.css where
+     `neutral-fill-quiet` maps to `--vscode-button-secondaryBackground`.
+     Source from `--desktop-color-button-secondary` so secondary buttons
+     and quiet surfaces (e.g. .desktop-command-button, .desktop-folder-button)
+     match the prior --texra-button-secondaryBackground value. */
+  --wa-color-neutral-fill-quiet: var(--desktop-color-button-secondary);
   --wa-color-neutral-border-quiet: light-dark(#d0d7de, #2b2b2b);
   --wa-color-neutral-on-quiet: light-dark(#1f2328, #d4d4d4);
-  --wa-color-neutral-fill-loud: light-dark(#eaeef2, #222222);
+  --wa-color-neutral-fill-loud: var(--desktop-color-button-secondary-hover);
   --wa-color-neutral-border-loud: light-dark(#d0d7de, #2b2b2b);
   --wa-color-neutral-on-loud: light-dark(#1f2328, #d4d4d4);
 

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -2,7 +2,7 @@
 
 /**
  * Type for radio-group-like components that expose a value property.
- * Used for wa-radio-group / vscode-radio-group / vscode-single-select.
+ * Used for wa-radio-group / vscode-radio-group.
  */
 export type VSCodeValueElement = HTMLElement & { value?: string };
 


### PR DESCRIPTION
## Summary

Closes #3677 and fixes #3689 in one PR.

### #3677 — progressView vscode-single-select consumers

Already complete via prior PRs (#3669 and follow-ups). Audit of `packages/extension/src/progressView/` finds zero remaining usages of `<vscode-single-select>` / `<vscode-option>` / the `@vscode-elements/elements/dist/vscode-single-select` import. `ProposalRequestPanel.ts` and `WorkflowToolUseFollowupSection.ts` (the two files called out in the issue) already use `<wa-select>` + `<wa-option>` with the canonical pattern.

The only remaining trace was a stale doc-comment in `progressView/frontend/utils.ts` mentioning `vscode-single-select` as a use-case for `VSCodeValueElement` — dropped.

### #3689 — Desktop chrome WA token mappings

The `--wa-*` desktop bridge in `themeTokens.css` had two mappings that diverged from the extension's `common.css` semantic and produced visible deltas vs. the pre-#3681 colors:

- `--wa-color-surface-lowered` was bridged to `--desktop-color-sidebar-header` (#eaeef2 / #222222) but the extension treats `surface-lowered` as the sidebar surface (`--vscode-sideBar-background`). `.desktop-nav` and `.desktop-explorer` consequently rendered with the darker hover-band color instead of the prior `--texra-sideBar-background` (which mapped to `--desktop-color-sidebar`, #f6f8fa / #181818).
- `--wa-color-neutral-fill-quiet` was a literal `light-dark(#eaeef2, #222222)` but the extension treats it as `--vscode-button-secondaryBackground`. `.desktop-command-button`, `.desktop-folder-button`, and `.desktop-secondary-button` consequently rendered with the wrong dark-mode value (`#222222` instead of `--desktop-color-button-secondary`'s `#313131`).

**Fix:** align the desktop bridge with the extension's semantic mapping:

- Swap `--wa-color-surface-lowered` ↔ `--wa-color-surface-raised` so lowered = sidebar (matches extension), raised = sidebar-header (preserves visible hover differentiation).
- Source `--wa-color-neutral-fill-quiet` from `--desktop-color-button-secondary`, and `--wa-color-neutral-fill-loud` from `--desktop-color-button-secondary-hover`.

No new WA tokens introduced; no consumer-side rule churn — the change is entirely in the bridge file.

## Test plan

- [x] `npm run typecheck` — only pre-existing errors (electron module resolution, openrouter SDK module resolution); identical on main.
- [x] `cd packages/desktop && npx vite build --mode development` — builds clean.
- [ ] Manual visual check on desktop light + dark themes: `.desktop-nav` and `.desktop-explorer` should show the sidebar color (#f6f8fa / #181818), not the slightly-darker header band.
- [ ] Manual visual check: secondary chrome buttons (`.desktop-command-button`, `.desktop-folder-button`, `.desktop-secondary-button`) should match `--desktop-color-button-secondary` (#f6f8fa / #313131); hover states should be visibly distinct.
- [ ] Spot-check that existing `--wa-color-surface-raised` consumers (icon-button hovers, .desktop-explorer-selection) still read as the right elevated band against the new sidebar surface.

Closes #3677
Closes #3689

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global desktop `--wa-*` theme token mappings, which can subtly affect colors across many UI surfaces (sidebar, hover bands, secondary buttons). No behavior, security, or data-flow logic is modified.
> 
> **Overview**
> Aligns the desktop Web Awesome theme-token bridge (`themeTokens.css`) with the extension’s semantics by **swapping** `--wa-color-surface-lowered`/`--wa-color-surface-raised` to restore the expected sidebar vs. elevated/hover surfaces.
> 
> Updates neutral fills so `--wa-color-neutral-fill-quiet` and `--wa-color-neutral-fill-loud` source from the desktop secondary button palette (and hover), fixing secondary button/quiet-surface colors (especially in dark mode).
> 
> Removes a stale `vscode-single-select` mention from the progress view frontend `VSCodeValueElement` doc comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950b02f05f62754f19ed4d42ea8a8e445528051e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->