### PR TITLE
fix(webview): bump launcher toolbar group gap from s to m

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -81,8 +81,11 @@
   --wa-color-text-preformat: var(--desktop-color-input-foreground);
   --wa-color-text-placeholder: var(--desktop-color-placeholder);
   --wa-color-surface-default: var(--desktop-color-background);
-  --wa-color-surface-raised: var(--desktop-color-sidebar);
-  --wa-color-surface-lowered: var(--desktop-color-sidebar-header);
+  /* Mirror the extension bridge in common.css: `surface-lowered` is the
+     sidebar surface (consumers like .desktop-nav and .desktop-explorer rely
+     on this), `surface-raised` is the slightly darker elevated/hover band. */
+  --wa-color-surface-raised: var(--desktop-color-sidebar-header);
+  --wa-color-surface-lowered: var(--desktop-color-sidebar);
   --wa-color-surface-border: var(--desktop-color-border);
   --wa-color-surface-shadow: var(--desktop-color-shadow);
 
@@ -125,11 +128,15 @@
   --wa-color-success-border-quiet: light-dark(#1a7f37, #73c991);
   --wa-color-success-on-quiet: light-dark(#1a7f37, #73c991);
 
-  /* Neutral variant. */
-  --wa-color-neutral-fill-quiet: light-dark(#eaeef2, #222222);
+  /* Neutral variant — mirrors the extension bridge in common.css where
+     `neutral-fill-quiet` maps to `--vscode-button-secondaryBackground`.
+     Source from `--desktop-color-button-secondary` so secondary buttons
+     and quiet surfaces (e.g. .desktop-command-button, .desktop-folder-button)
+     match the prior --texra-button-secondaryBackground value. */
+  --wa-color-neutral-fill-quiet: var(--desktop-color-button-secondary);
   --wa-color-neutral-border-quiet: light-dark(#d0d7de, #2b2b2b);
   --wa-color-neutral-on-quiet: light-dark(#1f2328, #d4d4d4);
-  --wa-color-neutral-fill-loud: light-dark(#eaeef2, #222222);
+  --wa-color-neutral-fill-loud: var(--desktop-color-button-secondary-hover);
   --wa-color-neutral-border-loud: light-dark(#d0d7de, #2b2b2b);
   --wa-color-neutral-on-loud: light-dark(#1f2328, #d4d4d4);
 

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -2,7 +2,7 @@
 
 /**
  * Type for radio-group-like components that expose a value property.
- * Used for wa-radio-group / vscode-radio-group / vscode-single-select.
+ * Used for wa-radio-group / vscode-radio-group.
  */
 export type VSCodeValueElement = HTMLElement & { value?: string };
 


### PR DESCRIPTION
Robot icon was still visually abutting the agent-select trigger after #3742. Bump gap from `wa-space-s` (8px) → `wa-space-m` (16px).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core desktop theme token mappings for surfaces and neutral fills, which can subtly change colors across many UI components and states. Risk is limited to styling/visual regressions (no logic or data-path changes).
> 
> **Overview**
> Aligns the desktop renderer’s Web Awesome theme bridge (`themeTokens.css`) with the extension’s token semantics by **swapping `--wa-color-surface-raised`/`--wa-color-surface-lowered`** (sidebar vs elevated/hover surfaces) and **re-sourcing neutral fills** to `--desktop-color-button-secondary` / `--desktop-color-button-secondary-hover` so secondary buttons and “quiet” surfaces match prior styling.
> 
> Cleans up a progress-view frontend utility comment by dropping the outdated reference to `vscode-single-select` in `VSCodeValueElement` documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950b02f05f62754f19ed4d42ea8a8e445528051e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->