### PR TITLE
fix(wa): use ui-sans-serif/system-ui for native OS font

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -65,10 +65,15 @@
 :root,
 .wa-light,
 .wa-dark .wa-invert {
-  /* Typography. */
-  --wa-font-family-body: var(--desktop-font-family);
-  --wa-font-family-heading: var(--desktop-font-family);
-  --wa-font-family-mono: 'SF Mono', Monaco, monospace;
+  /* Typography — `--desktop-font-family` is intentionally undefined.
+     Lead with `ui-sans-serif` / `system-ui` so the OS picks its native UI
+     font on every platform (San Francisco on macOS, Segoe UI on Windows,
+     etc.), with explicit named fallbacks for older browsers. */
+  --wa-font-family-body: ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --wa-font-family-heading: var(--wa-font-family-body);
+  --wa-font-family-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
   --wa-font-size-m: var(--desktop-font-size);
   --wa-font-weight-normal: var(--desktop-font-weight);
   --wa-editor-font-size: var(--desktop-font-size);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -183,10 +183,15 @@
   --wa-color-terminal-ansi-bright-white: var(--vscode-terminal-ansiBrightWhite);
   --wa-color-terminal-ansi-bright-yellow: var(--vscode-terminal-ansiBrightYellow);
 
-  /* Typography. */
-  --wa-font-family-body: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  --wa-font-family-heading: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  --wa-font-family-mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  /* Typography. Lead with `ui-sans-serif` / `system-ui` so the OS picks
+     its native UI font on every platform; `--vscode-font-family` (when
+     present) merely refines that. Avoids the "almost native but slightly
+     off" look from a hardcoded Apple/BlinkMac fallback chain. */
+  --wa-font-family-body: var(--vscode-font-family),
+    ui-sans-serif, system-ui, sans-serif;
+  --wa-font-family-heading: var(--wa-font-family-body);
+  --wa-font-family-mono: var(--vscode-editor-font-family),
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --wa-font-size-m: var(--vscode-font-size, 13px);
   --wa-font-weight-normal: var(--vscode-font-weight, 400);
   --wa-editor-font-size: var(--vscode-editor-font-size, 13px);


### PR DESCRIPTION
## Summary
The desktop bridge referenced an undefined `--desktop-font-family` so `--wa-font-family-body` had no value — Electron fell back to the browser default (often Times New Roman). The extension bridge led with `-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif` which works but is the older fallback chain.

Both bridges now lead with `ui-sans-serif, system-ui, ...`:
- macOS: San Francisco UI
- Windows: Segoe UI
- Linux: GNOME/KDE default

Extension still prefixes with `--vscode-font-family` so VS Code's chosen font wins inside the webview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only typography token changes that affect font selection/rendering but not application logic or data handling.
> 
> **Overview**
> Fixes font selection in the Web Awesome token bridges for both Desktop and the VS Code extension.
> 
> Desktop now defines `--wa-font-family-body/heading/mono` with `ui-sans-serif`/`system-ui` (avoiding the previously undefined `--desktop-font-family`), and the extension updates its font-family stack to prefer `--vscode-font-family` then native `ui-sans-serif/system-ui`, with an updated monospace fallback chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52220ba211944e33459678625b309c15f4cce035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->