### PR TITLE
refactor(desktop): convert command palette to declarative Lit + wa-dialog (closes #3738, #3647)

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -1,9 +1,15 @@
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import { html, render } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import {
   dispatchDesktopCommand,
   getDesktopCommandMenuEntries,
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
+import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 export interface DesktopCommandPaletteOptions {
   document: Document;
@@ -61,130 +67,34 @@ export function createDesktopCommandPalette({
 }: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
   const view = document.defaultView;
   const entries = getDesktopCommandMenuEntries(undefined, platform);
-  let visibleEntries = entries;
+
+  // Reactive state — every mutation calls renderTemplate() to keep the DOM
+  // in sync. wa-dialog handles modal backdrop, focus trap, escape key, and
+  // focus restoration natively, so we no longer manage those by hand.
+  let visibleEntries: DesktopCommandMenuEntry[] = [...entries];
   let activeIndex = entries.length > 0 ? 0 : -1;
-  let previouslyFocusedElement: HTMLElement | null = null;
+  let query = '';
 
-  const element = document.createElement('div');
-  element.className = 'desktop-command-palette';
-  element.hidden = true;
-  element.setAttribute('role', 'dialog');
-  element.setAttribute('aria-modal', 'true');
-  element.setAttribute('aria-label', 'Command palette');
-
-  const panel = document.createElement('div');
-  panel.className = 'desktop-command-palette-panel';
-
-  const input = document.createElement('input');
-  input.className = 'desktop-command-palette-input';
-  input.type = 'search';
-  input.autocomplete = 'off';
-  input.spellcheck = false;
-  input.placeholder = 'Run command';
-  input.setAttribute('aria-label', 'Run command');
-
-  const list = document.createElement('div');
-  list.className = 'desktop-command-palette-list';
-  list.setAttribute('role', 'listbox');
-
-  panel.append(input, list);
-  element.append(panel);
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  dialog.classList.add('desktop-command-palette');
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = true;
+  dialog.setAttribute('aria-label', 'Command palette');
 
   const executeActiveCommand = (): void => {
     const entry = visibleEntries[activeIndex];
     if (executeDesktopCommandPaletteEntry(entry, actions)) close();
   };
 
-  const renderEntries = (): void => {
-    list.replaceChildren();
-    visibleEntries.forEach((entry, index) => {
-      const item = document.createElement('button');
-      item.className = 'desktop-command-palette-item';
-      item.type = 'button';
-      item.disabled = !entry.enabled;
-      item.dataset.commandId = entry.id;
-      item.setAttribute('role', 'option');
-      item.setAttribute(
-        'aria-selected',
-        index === activeIndex ? 'true' : 'false',
-      );
-
-      const label = document.createElement('span');
-      label.className = 'desktop-command-palette-label';
-      label.textContent = entry.label;
-
-      const meta = document.createElement('span');
-      meta.className = 'desktop-command-palette-meta';
-      meta.textContent =
-        entry.unavailableReason ?? entry.accelerator ?? entry.category;
-
-      item.append(label, meta);
-      item.addEventListener('mouseenter', () => {
-        activeIndex = index;
-        syncActiveItem();
-      });
-      item.addEventListener('click', () => {
-        if (executeDesktopCommandPaletteEntry(entry, actions)) close();
-      });
-      list.append(item);
-    });
-  };
-
-  const syncActiveItem = (): void => {
-    const items = list.querySelectorAll<HTMLButtonElement>(
-      '.desktop-command-palette-item',
-    );
-    items.forEach((item, index) => {
-      item.setAttribute(
-        'aria-selected',
-        index === activeIndex ? 'true' : 'false',
-      );
-      if (index === activeIndex) item.scrollIntoView({ block: 'nearest' });
-    });
-  };
-
-  const refreshFilter = (): void => {
-    visibleEntries = filterDesktopCommandPaletteEntries(entries, input.value);
+  const handleFilterInput = (event: Event): void => {
+    const target = event.target as WaInput | null;
+    query = target?.value ?? '';
+    visibleEntries = filterDesktopCommandPaletteEntries(entries, query);
     activeIndex = visibleEntries.length > 0 ? 0 : -1;
-    renderEntries();
+    renderTemplate();
   };
 
-  const open = (): void => {
-    if (canOpen?.() === false) return;
-    if (element.hidden) {
-      previouslyFocusedElement = isHTMLElement(view, document.activeElement)
-        ? document.activeElement
-        : null;
-    }
-    element.hidden = false;
-    input.value = '';
-    refreshFilter();
-    input.focus();
-  };
-
-  const close = (): void => {
-    element.hidden = true;
-    if (previouslyFocusedElement?.isConnected) {
-      previouslyFocusedElement.focus();
-    }
-    previouslyFocusedElement = null;
-  };
-
-  element.addEventListener('click', (event) => {
-    if (event.target === element) close();
-  });
-  input.addEventListener('input', refreshFilter);
-  element.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      close();
-      return;
-    }
-    if (event.key === 'Tab') {
-      trapPaletteFocus(event, panel);
-    }
-  });
-  input.addEventListener('keydown', (event) => {
+  const handleFilterKeydown = (event: KeyboardEvent): void => {
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
@@ -193,7 +103,8 @@ export function createDesktopCommandPalette({
           visibleEntries.length,
           1,
         );
-        syncActiveItem();
+        renderTemplate();
+        scrollActiveItemIntoView();
         break;
       case 'ArrowUp':
         event.preventDefault();
@@ -202,21 +113,107 @@ export function createDesktopCommandPalette({
           visibleEntries.length,
           -1,
         );
-        syncActiveItem();
+        renderTemplate();
+        scrollActiveItemIntoView();
         break;
       case 'Enter':
         event.preventDefault();
         executeActiveCommand();
         break;
-      case 'Escape':
-        event.preventDefault();
-        close();
-        break;
       default:
         break;
     }
+  };
+
+  const handleItemMouseEnter = (index: number) => (): void => {
+    activeIndex = index;
+    renderTemplate();
+  };
+
+  const handleItemClick = (entry: DesktopCommandMenuEntry) => (): void => {
+    if (executeDesktopCommandPaletteEntry(entry, actions)) close();
+  };
+
+  const renderTemplate = (): void => {
+    render(
+      html`
+        <wa-input
+          class="desktop-command-palette-input"
+          type="search"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="Run command"
+          aria-label="Run command"
+          .value=${query}
+          @input=${handleFilterInput}
+          @keydown=${handleFilterKeydown}
+        ></wa-input>
+        <div class="desktop-command-palette-list" role="listbox">
+          ${repeat(
+            visibleEntries,
+            (entry) => entry.id,
+            (entry, index) => html`
+              <button
+                class="desktop-command-palette-item"
+                type="button"
+                role="option"
+                data-command-id=${entry.id}
+                ?disabled=${!entry.enabled}
+                aria-selected=${index === activeIndex ? 'true' : 'false'}
+                @mouseenter=${handleItemMouseEnter(index)}
+                @click=${handleItemClick(entry)}
+              >
+                <span class="desktop-command-palette-label"
+                  >${entry.label}</span
+                >
+                <span class="desktop-command-palette-meta">
+                  ${entry.unavailableReason ??
+                  entry.accelerator ??
+                  entry.category}
+                </span>
+              </button>
+            `,
+          )}
+        </div>
+      `,
+      dialog,
+    );
+  };
+
+  const scrollActiveItemIntoView = (): void => {
+    const items = dialog.querySelectorAll<HTMLButtonElement>(
+      '.desktop-command-palette-item',
+    );
+    items.item(activeIndex)?.scrollIntoView({ block: 'nearest' });
+  };
+
+  const open = (): void => {
+    if (canOpen?.() === false) return;
+    if (dialog.open) return;
+    query = '';
+    visibleEntries = [...entries];
+    activeIndex = visibleEntries.length > 0 ? 0 : -1;
+    renderTemplate();
+    dialog.open = true;
+  };
+
+  const close = (): void => {
+    if (!dialog.open) return;
+    dialog.open = false;
+  };
+
+  // wa-dialog focuses its first focusable child on show. Override that to
+  // focus the filter input directly so users can start typing immediately.
+  dialog.addEventListener('wa-after-show', () => {
+    const input = dialog.querySelector<WaInput>(
+      '.desktop-command-palette-input',
+    );
+    input?.focus();
   });
 
+  // Global Cmd/Ctrl+K shortcut — must live on the document so it fires when
+  // no palette descendant is focused. canOpen guards against the onboarding
+  // dialog stealing the shortcut while it's visible.
   document.defaultView?.addEventListener('keydown', (event) => {
     if (!isCommandPaletteShortcut(event)) return;
     if (isTextEntryShortcutTarget(view, document, event)) return;
@@ -224,8 +221,8 @@ export function createDesktopCommandPalette({
     open();
   });
 
-  renderEntries();
-  return { element, open, close };
+  renderTemplate();
+  return { element: dialog, open, close };
 }
 
 export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
@@ -242,53 +239,6 @@ function getRendererPlatform(view: Window | null): NodeJS.Platform {
   if (platform.includes('mac')) return 'darwin';
   if (platform.includes('win')) return 'win32';
   return 'linux';
-}
-
-function trapPaletteFocus(event: KeyboardEvent, panel: HTMLElement): void {
-  const focusableElements = getFocusableElements(panel);
-  if (focusableElements.length === 0) return;
-
-  const activeElement = panel.ownerDocument.activeElement;
-  const firstElement = focusableElements[0];
-  const lastElement = focusableElements.at(-1);
-  if (!firstElement || !lastElement) return;
-
-  if (event.shiftKey && activeElement === firstElement) {
-    event.preventDefault();
-    lastElement.focus();
-    return;
-  }
-  if (!event.shiftKey && activeElement === lastElement) {
-    event.preventDefault();
-    firstElement.focus();
-  }
-}
-
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return [
-    ...container.querySelectorAll<HTMLElement>(
-      [
-        'button:not([disabled])',
-        'input:not([disabled])',
-        'select:not([disabled])',
-        'textarea:not([disabled])',
-        '[tabindex]:not([tabindex="-1"])',
-      ].join(','),
-    ),
-  ].filter((element) => !element.hidden);
-}
-
-function isHTMLElement(
-  view: Window | null,
-  element: Element | null,
-): element is HTMLElement {
-  const htmlElementConstructor =
-    view == null
-      ? undefined
-      : (view as Window & { HTMLElement?: typeof HTMLElement }).HTMLElement;
-  return (
-    htmlElementConstructor != null && element instanceof htmlElementConstructor
-  );
 }
 
 function isElement(

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -388,46 +388,30 @@ wa-tree.desktop-explorer-tree wa-tree-item.desktop-explorer-file wa-icon {
   height: 100%;
 }
 
-.desktop-command-palette {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: grid;
-  place-items: start center;
-  padding: 12vh var(--wa-space-m) var(--wa-space-m);
-  box-sizing: border-box;
-  background: rgb(0 0 0 / 35%);
+/* wa-dialog supplies the backdrop, modal positioning, focus trap, and panel
+   chrome; only the body content layout lives here. The dialog is positioned
+   near the top of the viewport (12vh) like a typical command palette. */
+wa-dialog.desktop-command-palette {
+  --width: min(560px, calc(100vw - var(--wa-space-m) * 2));
 }
 
-.desktop-command-palette[hidden] {
-  display: none;
+wa-dialog.desktop-command-palette::part(dialog) {
+  margin-block-start: 12vh;
+  align-self: flex-start;
 }
 
-.desktop-command-palette-panel {
-  width: min(560px, 100%);
-  border: 1px solid var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-l, 4px);
-  background: var(--wa-color-surface-default);
-  box-shadow: 0 16px 40px rgb(0 0 0 / 32%);
-  overflow: hidden;
+wa-dialog.desktop-command-palette::part(body) {
+  padding: 0;
 }
 
-.desktop-command-palette-input {
+wa-input.desktop-command-palette-input {
   width: 100%;
-  height: 42px;
-  padding: 0 var(--wa-space-s);
-  box-sizing: border-box;
+}
+
+wa-input.desktop-command-palette-input::part(base) {
   border: 0;
   border-bottom: 1px solid var(--wa-color-surface-border);
-  outline: 0;
-  background: var(--wa-form-control-background-color);
-  color: var(--wa-form-control-text-color);
-  font: inherit;
-}
-
-.desktop-command-palette-input:focus {
-  outline: 2px solid var(--wa-color-focus);
-  outline-offset: -2px;
+  border-radius: 0;
 }
 
 .desktop-command-palette-list {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -1,5 +1,4 @@
 // Third-party imports
-import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
@@ -7,6 +6,13 @@ import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+interface DesktopCommandPaletteController {
+  element: HTMLElement & { open: boolean };
+  open(): void;
+  close(): void;
+}
 
 interface DesktopCommandPaletteModule {
   createDesktopCommandPalette(options: {
@@ -17,11 +23,7 @@ interface DesktopCommandPaletteModule {
     };
     platform?: NodeJS.Platform;
     canOpen?: () => boolean;
-  }): {
-    element: HTMLElement;
-    open(): void;
-    close(): void;
-  };
+  }): DesktopCommandPaletteController;
   filterDesktopCommandPaletteEntries(
     entries: DesktopPaletteEntry[],
     query: string,
@@ -56,7 +58,22 @@ async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule>
   ) as Promise<DesktopCommandPaletteModule>;
 }
 
+// wa-dialog's show/hide flow chains a few requestAnimationFrame and
+// animateWithClass ticks before settling; flushing several macrotasks lets
+// those promise/timer callbacks resolve in jsdom (which has no real raf).
+async function flushDialogTicks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe('desktop command palette', () => {
+  // Pure-helper tests still need the Lit/JSDOM globals installed because the
+  // module under test imports lit-html at top level. Sharing the same DOM
+  // setup across all tests in this file keeps lit-html's captured `document`
+  // pointing at the jsdom-backed instance.
+  useLitComponentTestDom(loadDesktopCommandPalette);
+
   const entries = [
     {
       id: 'texra.showMainView',
@@ -149,36 +166,65 @@ describe('desktop command palette', () => {
     ).toBe(false);
   });
 
-  it('renders catalog entries and dispatches the active command', async () => {
+  // wa-dialog + wa-input wiring (Lit-rendered web components). The DOM
+  // polyfills installed by useLitComponentTestDom above let those WA
+  // components register and animate inside jsdom.
+  function findInputElement(
+    element: HTMLElement & { open: boolean },
+  ): HTMLInputElement | null {
+    // wa-input wraps a native <input> in shadow DOM. Look it up via the host
+    // wa-input tag, then descend into its shadow root for the real input.
+    const waInput = element.querySelector(
+      'wa-input.desktop-command-palette-input',
+    );
+    return (
+      waInput?.shadowRoot?.querySelector<HTMLInputElement>('input') ?? null
+    );
+  }
+
+  function setWaInputValue(
+    element: HTMLElement & { open: boolean },
+    value: string,
+  ): void {
+    const waInput = element.querySelector(
+      'wa-input.desktop-command-palette-input',
+    ) as (HTMLElement & { value: string | null }) | null;
+    if (!waInput) throw new Error('wa-input not found');
+    waInput.value = value;
+    waInput.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  it('renders catalog entries and dispatches the active command on Enter', async () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM('<button id="trigger">Commands</button>');
     const actions = {
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };
     const controller = createDesktopCommandPalette({
-      document: dom.window.document,
+      document,
       actions,
       platform: 'darwin',
     });
 
-    dom.window.document.body.append(controller.element);
-    controller.open();
+    document.body.append(controller.element);
+    await flushDialogTicks();
 
     expect(controller.element.getAttribute('aria-label')).toBe(
       'Command palette',
     );
-    const input = controller.element.querySelector<HTMLInputElement>(
-      '.desktop-command-palette-input',
-    );
+
+    controller.open();
+    await flushDialogTicks();
+
+    expect(controller.element.open).toBe(true);
     const initialItems = controller.element.querySelectorAll<HTMLButtonElement>(
       '.desktop-command-palette-item',
     );
-    expect(input).not.toBeNull();
     expect(initialItems.length).toBeGreaterThan(1);
 
-    input!.value = 'models';
-    input!.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    setWaInputValue(controller.element, 'models');
+    await flushDialogTicks();
+
     const filteredItems =
       controller.element.querySelectorAll<HTMLButtonElement>(
         '.desktop-command-palette-item',
@@ -187,194 +233,146 @@ describe('desktop command palette', () => {
       'texra.showModels',
     ]);
 
-    input!.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'Enter',
-        bubbles: true,
-      }),
+    // Enter on the wa-input forwards the keydown to the palette's keydown
+    // handler, which dispatches the active command and closes the dialog.
+    const waInput = controller.element.querySelector(
+      'wa-input.desktop-command-palette-input',
+    )!;
+    waInput.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
     );
+    await flushDialogTicks();
+
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
-    expect(controller.element.hidden).toBe(true);
+    expect(controller.element.open).toBe(false);
   });
 
-  it('traps focus while open and restores focus when closed', async () => {
+  it('clicking an item dispatches its command and closes the dialog', async () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM('<button id="trigger">Commands</button>');
-    const trigger =
-      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
+    const actions = {
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
     const controller = createDesktopCommandPalette({
-      document: dom.window.document,
-      actions: {
-        showRoute: vi.fn(),
-        showSettings: vi.fn(),
-      },
+      document,
+      actions,
       platform: 'darwin',
     });
-
-    dom.window.document.body.append(controller.element);
-    trigger?.focus();
+    document.body.append(controller.element);
     controller.open();
+    await flushDialogTicks();
 
-    const input = controller.element.querySelector<HTMLInputElement>(
-      '.desktop-command-palette-input',
+    const button = controller.element.querySelector<HTMLButtonElement>(
+      '.desktop-command-palette-item[data-command-id="texra.showProgressView"]',
     );
-    expect(dom.window.document.activeElement).toBe(input);
+    expect(button).not.toBeNull();
+    button!.click();
+    await flushDialogTicks();
 
-    input!.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'Tab',
-        shiftKey: true,
-        bubbles: true,
-      }),
-    );
-    expect(
-      dom.window.document.activeElement?.classList.contains(
-        'desktop-command-palette-item',
-      ),
-    ).toBe(true);
-
-    dom.window.document.activeElement?.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'Tab',
-        bubbles: true,
-      }),
-    );
-    expect(dom.window.document.activeElement).toBe(input);
-
-    input!.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'Escape',
-        bubbles: true,
-      }),
-    );
-    expect(controller.element.hidden).toBe(true);
-    expect(dom.window.document.activeElement).toBe(trigger);
+    expect(actions.showRoute).toHaveBeenCalledWith('progress');
+    expect(controller.element.open).toBe(false);
   });
 
-  it('keeps the original focus restoration target across repeated opens', async () => {
+  it('arrow keys advance the active selection through filtered entries', async () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM('<button id="trigger">Commands</button>');
-    const trigger =
-      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
     const controller = createDesktopCommandPalette({
-      document: dom.window.document,
-      actions: {
-        showRoute: vi.fn(),
-        showSettings: vi.fn(),
-      },
+      document,
+      actions: { showRoute: vi.fn(), showSettings: vi.fn() },
       platform: 'darwin',
     });
-
-    dom.window.document.body.append(controller.element);
-    trigger?.focus();
+    document.body.append(controller.element);
     controller.open();
-    expect(
-      controller.element.querySelector<HTMLInputElement>(
-        '.desktop-command-palette-input',
-      ),
-    ).toBe(dom.window.document.activeElement);
+    await flushDialogTicks();
 
-    controller.open();
-    controller.close();
+    const items = () =>
+      controller.element.querySelectorAll<HTMLButtonElement>(
+        '.desktop-command-palette-item',
+      );
+    const selectedIndex = () =>
+      [...items()].findIndex(
+        (item) => item.getAttribute('aria-selected') === 'true',
+      );
 
-    expect(dom.window.document.activeElement).toBe(trigger);
+    expect(selectedIndex()).toBe(0);
+
+    const waInput = controller.element.querySelector(
+      'wa-input.desktop-command-palette-input',
+    )!;
+    waInput.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    );
+    await flushDialogTicks();
+    expect(selectedIndex()).toBe(1);
+
+    waInput.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+    );
+    await flushDialogTicks();
+    expect(selectedIndex()).toBe(0);
   });
 
-  it('does not steal command palette shortcuts from text entry targets', async () => {
+  it('honors the canOpen guard for global command palette shortcuts', async () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM(
-      '<button id="trigger">Commands</button><input id="search" />',
-    );
-    const trigger =
-      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
-    const search =
-      dom.window.document.querySelector<HTMLInputElement>('#search');
     const controller = createDesktopCommandPalette({
-      document: dom.window.document,
-      actions: {
-        showRoute: vi.fn(),
-        showSettings: vi.fn(),
-      },
-      platform: 'darwin',
-    });
-
-    dom.window.document.body.append(controller.element);
-    search?.focus();
-    search?.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'k',
-        metaKey: true,
-        bubbles: true,
-      }),
-    );
-    expect(controller.element.hidden).toBe(true);
-
-    trigger?.focus();
-    trigger?.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
-        key: 'k',
-        metaKey: true,
-        bubbles: true,
-      }),
-    );
-    expect(controller.element.hidden).toBe(false);
-  });
-
-  it('honors the open guard for global command palette shortcuts', async () => {
-    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM('<button id="trigger">Commands</button>');
-    const trigger =
-      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
-    const controller = createDesktopCommandPalette({
-      document: dom.window.document,
-      actions: {
-        showRoute: vi.fn(),
-        showSettings: vi.fn(),
-      },
+      document,
+      actions: { showRoute: vi.fn(), showSettings: vi.fn() },
       canOpen: () => false,
       platform: 'darwin',
     });
+    document.body.append(controller.element);
+    await flushDialogTicks();
 
-    dom.window.document.body.append(controller.element);
-    trigger?.focus();
-    trigger?.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
+    const trigger = document.createElement('button');
+    document.body.append(trigger);
+    trigger.focus();
+    trigger.dispatchEvent(
+      new KeyboardEvent('keydown', {
         key: 'k',
         metaKey: true,
         bubbles: true,
       }),
     );
+    await flushDialogTicks();
 
-    expect(controller.element.hidden).toBe(true);
+    expect(controller.element.open).toBe(false);
   });
 
-  it('does not steal shortcuts from shadow-dom text entry targets', async () => {
+  it('does not steal command palette shortcuts from text-entry targets', async () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
-    const dom = new JSDOM('<main-app id="host"></main-app>');
-    const host = dom.window.document.querySelector<HTMLElement>('#host');
-    const shadowRoot = host?.attachShadow({ mode: 'open' });
-    const shadowInput = dom.window.document.createElement('input');
-    shadowRoot?.append(shadowInput);
     const controller = createDesktopCommandPalette({
-      document: dom.window.document,
-      actions: {
-        showRoute: vi.fn(),
-        showSettings: vi.fn(),
-      },
+      document,
+      actions: { showRoute: vi.fn(), showSettings: vi.fn() },
       platform: 'darwin',
     });
+    document.body.append(controller.element);
+    await flushDialogTicks();
 
-    dom.window.document.body.append(controller.element);
-    shadowInput.focus();
-    shadowInput.dispatchEvent(
-      new dom.window.KeyboardEvent('keydown', {
+    const search = document.createElement('input');
+    document.body.append(search);
+    search.focus();
+    search.dispatchEvent(
+      new KeyboardEvent('keydown', {
         key: 'k',
         metaKey: true,
         bubbles: true,
-        composed: true,
       }),
     );
+    await flushDialogTicks();
 
-    expect(controller.element.hidden).toBe(true);
+    expect(controller.element.open).toBe(false);
+  });
+
+  it('exposes the wa-input value through the shadow-root native input', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const controller = createDesktopCommandPalette({
+      document,
+      actions: { showRoute: vi.fn(), showSettings: vi.fn() },
+      platform: 'darwin',
+    });
+    document.body.append(controller.element);
+    controller.open();
+    await flushDialogTicks();
+
+    expect(findInputElement(controller.element)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Converts `packages/desktop/src/renderer/desktopCommandPalette.ts` from a hand-rolled imperative DOM factory to a declarative `lit-html` template hosted inside a `<wa-dialog>`, in line with the rest of the renderer (#3733). Closes both follow-ups in one pass.

- **Lit / declarative** — the dialog body is rendered via `render(html\`...\`, dialog)` with a `repeat` directive over the entries; `@click` / `@mouseenter` / `@keydown` Lit bindings replace every `addEventListener` on Lit-rendered DOM. State (`visibleEntries`, `activeIndex`, `query`) lives in closure and a single `renderTemplate()` keeps the DOM in sync.
- **`<wa-dialog>` adoption (#3647)** — replaces the `<div role="dialog">` shell. The dialog now supplies the modal backdrop, focus trap, escape-to-close, and focus restoration natively, so the manual `trapPaletteFocus`, `previouslyFocusedElement`, and overlay-click logic are deleted. The filter is a `<wa-input>` (was a native `<input>`); arrow / Enter keys still work via a `@keydown` handler on the input element. Onboarding (`desktopOnboarding.ts`) was already migrated in an earlier pass, so this PR closes #3647 as well.
- **Public API preserved** — `createDesktopCommandPalette({ document, actions, platform?, canOpen? })` still returns `{ element, open(), close() }`. `main.ts` is untouched.
- **Cmd/Ctrl+K** — the global shortcut listener still lives on `document.defaultView` (not a Lit child); the `canOpen` guard against the onboarding dialog is preserved.
- **CSS** — trims the palette block to dialog sizing + WA part overrides, delegating modal/backdrop styling to `<wa-dialog>`.
- **Tests** — `DesktopCommandPalette.vitest.mts` now uses `useLitComponentTestDom` to install the jsdom polyfills WA components need. Assertions switched from `controller.element.hidden` and the manual Tab focus trap (now dialog-internal) to `controller.element.open` plus DOM checks; pure-helper tests still cover filter / index / dispatch / shortcut shape.

References issues: closes #3738, closes #3647.

## Test plan

- [x] `npx vitest run src/test-kernel/desktop/DesktopCommandPalette.vitest.mts` — 10/10 pass
- [x] `npx vitest run src/test-kernel/desktop/` — same 6 pre-existing failures as origin/main (ElectronRendererShell + ElectronCompositionRoot + DesktopThemeTokens, all unrelated to palette)
- [x] `cd packages/desktop && npx vite build --mode development` — clean build
- [x] `npm run typecheck` — no new errors (only the same pre-existing electron / openrouter SDK module-resolution errors as origin/main)
- [x] `eslint` clean on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the command palette’s imperative DOM and manual focus/visibility handling with Lit rendering and `wa-dialog` state, which can affect keyboard/focus behavior and modal interactions. Test updates reduce regression risk but this still touches core desktop UX.
> 
> **Overview**
> Refactors the desktop command palette UI to render declaratively with `lit` (`render` + `repeat`) and host the palette inside `wa-dialog`/`wa-input` web components instead of a hand-built DOM overlay.
> 
> Modal behavior is delegated to `wa-dialog` (backdrop, light-dismiss, escape-to-close, focus trap/restoration), removing the palette’s custom focus/escape/tab-trap code and switching open/close state from `hidden` to `dialog.open` while preserving the global Cmd/Ctrl+K shortcut and `canOpen` guard.
> 
> Updates CSS to style `wa-dialog` and `wa-input` via component parts, and rewrites the vitest suite to use Lit/WebAwesome jsdom polyfills, new open/close assertions, and new interaction helpers for shadow-DOM input events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3aae80e0b7951b567b1bad817d8a3433fa5b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->