### PR TITLE
fix(wa): address bot-review findings on session PRs (#3733-#3745)

### DIFF
--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -14,7 +14,7 @@ export const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
   'TeXRA cannot store secrets securely because Electron is using Linux basic_text storage. Set up a system keyring such as GNOME Keyring/libsecret or KWallet, then restart TeXRA. Environment variables still work for API keys.';
 
 export const KEYCHAIN_DENIED_WARNING_MESSAGE =
-  'TeXRA could not read its saved secrets because the system keychain prompt was denied. Saved API keys and sign-in sessions will not be available until you allow access. Restart TeXRA after granting access to retry.';
+  'TeXRA could not decrypt its saved secrets. This usually happens when the system keychain prompt was denied, but it can also occur with corrupted entries or rotated encryption keys. Saved API keys and sign-in sessions will not be available until decryption succeeds. Restart TeXRA after granting keychain access (or re-saving secrets) to retry.';
 
 const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
   'Electron safeStorage is unavailable for secret writes.';
@@ -123,8 +123,11 @@ export class ElectronSecrets implements PlatformSecrets {
  * prompting.
  *
  * Safe to call multiple times — the first invocation does the work and the
- * rest are no-ops. Returns `true` when the prompt was attempted, `false` when
- * `safeStorage` is unavailable (e.g., Linux without a configured keyring).
+ * rest are no-ops. Returns `true` when the prewarm encrypt succeeded; returns
+ * `false` when `safeStorage.isEncryptionAvailable()` is false (e.g., Linux
+ * without a configured keyring) or when the encrypt itself threw (e.g., the
+ * user denied the OS keychain prompt). The latch is only set on success so
+ * the caller can retry on a subsequent boot once permissions change.
  */
 let keychainPrewarmed = false;
 export async function prewarmElectronKeychain(): Promise<boolean> {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -26,7 +26,6 @@ import '@settingsView/frontend';
 import '@webview/frontend';
 
 import {
-  DesktopRouteSchema,
   DesktopSetRouteMessageSchema,
   type DesktopRoute,
   type DesktopSetRouteMessage,
@@ -63,8 +62,6 @@ interface WorkspaceTreeNode {
   categories?: string[];
 }
 
-const DESKTOP_ROUTES = DesktopRouteSchema.options;
-
 const root = document.querySelector<HTMLElement>('#app');
 
 if (root == null) {
@@ -80,6 +77,54 @@ const appRoot = root;
 let currentRoute: DesktopRoute = 'main';
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 let selectedExplorerFile = '';
+
+// Empty-workspace copy + placeholder factory live up here so the no-workspace
+// path below can read them without hitting the temporal dead zone — `let`/
+// `const` declarations declared further down would throw `ReferenceError`
+// during module evaluation if the no-workspace branch is taken.
+const EMPTY_WORKSPACE_COPY = {
+  launcher: {
+    title: 'Open a folder to use the launcher',
+    body: 'TeXRA desktop needs a workspace before it can discover files, run agents, and place outputs.',
+  },
+  progress: {
+    title: 'Open a folder to view workspace progress',
+    body: 'Progress details are tied to workspace runs. Start from a workspace to restore and follow sessions here.',
+  },
+} as const;
+
+function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
+  const container = document.createElement('section');
+  container.className = 'desktop-empty-workspace';
+  const { title, body } = EMPTY_WORKSPACE_COPY[kind];
+  render(
+    renderEmptyState({
+      className: 'desktop-empty-workspace-panel',
+      icon: 'folder-open',
+      title,
+      body,
+      headingTag: 'h1',
+      actions: [
+        {
+          label: 'Open Folder',
+          appearance: 'filled',
+          variant: 'brand',
+          className: 'desktop-primary-button',
+          onClick: () =>
+            postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
+        },
+        {
+          label: 'Logs',
+          appearance: 'outlined',
+          className: 'desktop-secondary-button',
+          onClick: () => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
+        },
+      ],
+    }),
+    container,
+  );
+  return container;
+}
 
 // Standalone web components are instantiated once and slotted into the shell
 // template via Lit's DOM-node interpolation. Lit preserves these nodes across
@@ -258,13 +303,26 @@ function renderBootstrapFallback(error: unknown): void {
             <wa-button
               appearance="outlined"
               @click=${() => {
-                // Hide the fallback so the partial shell (if any) becomes
-                // visible. The renderer can still drive routes via the
-                // command palette even when secrets are unavailable.
-                const node = appRoot.querySelector(
-                  '.desktop-bootstrap-fallback',
-                );
-                if (node instanceof HTMLElement) node.hidden = true;
+                // The fallback is rendered directly into `appRoot`, replacing
+                // the shell. Hiding the node would leave a blank window —
+                // instead, attempt a fresh shell render so the user gets a
+                // usable UI even though saved secrets are unavailable. If
+                // the second mount also throws, re-render the fallback so
+                // the user can still reload. (Command palette / walkthrough
+                // are only wired during the original boot when
+                // `bootstrapFailed` was false; they remain unavailable on
+                // this recovery path, which is by design — the user can
+                // still navigate via the chrome icon buttons.)
+                try {
+                  renderLogViewer();
+                  rerenderShell();
+                } catch (recoveryError) {
+                  console.error(
+                    'TeXRA desktop renderer recovery failed',
+                    recoveryError,
+                  );
+                  renderBootstrapFallback(recoveryError);
+                }
               }}
             >
               Continue without saved secrets
@@ -449,50 +507,6 @@ function getWindowTargetOrigin(): string {
   return window.location.origin && window.location.origin !== 'null'
     ? window.location.origin
     : '*';
-}
-
-const EMPTY_WORKSPACE_COPY = {
-  launcher: {
-    title: 'Open a folder to use the launcher',
-    body: 'TeXRA desktop needs a workspace before it can discover files, run agents, and place outputs.',
-  },
-  progress: {
-    title: 'Open a folder to view workspace progress',
-    body: 'Progress details are tied to workspace runs. Start from a workspace to restore and follow sessions here.',
-  },
-} as const;
-
-function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
-  const container = document.createElement('section');
-  container.className = 'desktop-empty-workspace';
-  const { title, body } = EMPTY_WORKSPACE_COPY[kind];
-  render(
-    renderEmptyState({
-      className: 'desktop-empty-workspace-panel',
-      icon: 'folder-open',
-      title,
-      body,
-      headingTag: 'h1',
-      actions: [
-        {
-          label: 'Open Folder',
-          appearance: 'filled',
-          variant: 'brand',
-          className: 'desktop-primary-button',
-          onClick: () =>
-            postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
-        },
-        {
-          label: 'Logs',
-          appearance: 'outlined',
-          className: 'desktop-secondary-button',
-          onClick: () => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
-        },
-      ],
-    }),
-    container,
-  );
-  return container;
 }
 
 function logViewerTemplate(state: LogViewerState): TemplateResult {

--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -18,7 +18,7 @@ export class TerminalCommandStrip extends LitElement {
       padding: var(--wa-space-2xs) var(--wa-space-s);
       margin: 0 0 var(--wa-space-2xs) 0;
       background: var(
-        --texra-terminal-background,
+        --wa-color-terminal-background,
         var(--wa-color-surface-default, transparent)
       );
       color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -59,7 +59,7 @@ export const codeBlockStyles = css`
 
     &:hover {
       background-color: var(
-        --texra-toolbar-hoverBackground,
+        --wa-color-toolbar-hover,
         rgba(90, 93, 94, 0.31)
       );
       color: var(--wa-color-text-normal);

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -282,7 +282,7 @@ export const logEntryStyles = css`
     );
     font-size: var(--wa-editor-font-size, var(--font-size));
     background-color: var(
-      --texra-terminal-background,
+      --wa-color-terminal-background,
       var(--wa-color-surface-default, transparent)
     );
     color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -957,7 +957,11 @@ export class LaTeXTab extends LitElement {
             max=${opts.max ?? nothing}
             .value=${String(effective)}
             @change=${(e: Event) => {
-              const raw = Number((e.target as WaInput).value);
+              const value = (e.target as WaInput).value;
+              // Treat a cleared field as "no change" — `Number('')` would
+              // silently coerce to 0/min and overwrite the saved value.
+              if (typeof value !== 'string' || value.trim() === '') return;
+              const raw = Number(value);
               if (Number.isNaN(raw)) return;
               // Coerce to integer first — paste / spinner can produce decimals
               // that the backend `.int()` schema would silently reject.

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -175,6 +175,14 @@ export class MainApp extends MainAppBase {
   private readonly checkboxValues = signal<CheckboxValues>({
     ...DEFAULT_CHECKBOX_VALUES,
   });
+  // Tracks whether the workflow Files <wa-details> is open. Initialized to
+  // match the initial session type and updated imperatively from
+  // wa-show/wa-hide so user toggles survive across re-renders. Without this,
+  // binding `?open=${isWorkflow}` would force the section open on every render
+  // pass, defeating user collapses.
+  private readonly fileSelectionOpen = signal(
+    DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW,
+  );
   private readonly isRecording = signal(false);
   private readonly isPolishing = signal(false);
   private readonly modelOptions = signal<ModelOptionData[]>([]);
@@ -459,6 +467,7 @@ export class MainApp extends MainAppBase {
     const state = this.stateManager.getState();
 
     this.sessionType.set(state.sessionType);
+    this.fileSelectionOpen.set(state.sessionType === SESSION_TYPES.WORKFLOW);
     this.workflowAgent.set(state.workflowAgent);
     this.toolUseAgent.set(state.toolUseAgent);
     this.model.set(state.model);
@@ -1202,6 +1211,11 @@ export class MainApp extends MainAppBase {
 
     this.swapModeInstruction(prev, parsed);
     this.sessionType.set(parsed);
+    // Auto-open the Files <wa-details> when the user enters workflow mode,
+    // and auto-close when leaving. This is the one-shot behavior the bound
+    // `?open` template expression used to encode — but tracking it here
+    // means subsequent user collapses survive re-renders.
+    this.fileSelectionOpen.set(parsed === SESSION_TYPES.WORKFLOW);
     this.refreshInstructionPlaceholder(false);
     if (parsed === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive.set(false);
@@ -1898,7 +1912,6 @@ export class MainApp extends MainAppBase {
 
   render(): TemplateResult {
     const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
-    const isWorkflow = this.sessionType.get() === SESSION_TYPES.WORKFLOW;
     const fileSelectionClasses = classMap({
       'file-selection-group': true,
       'file-selection-group--disabled': isToolUse,
@@ -2018,7 +2031,9 @@ export class MainApp extends MainAppBase {
                 <div class="section-separator" role="presentation"></div>
                 <wa-details
                   class="file-selection-details"
-                  ?open=${isWorkflow}
+                  ?open=${this.fileSelectionOpen.get()}
+                  @wa-show=${() => this.fileSelectionOpen.set(true)}
+                  @wa-hide=${() => this.fileSelectionOpen.set(false)}
                 >
                   <span slot="summary" class="file-selection-summary">
                     <wa-icon

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -8,8 +8,7 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   padding: 'var(--wa-space-2xs, 4px) var(--wa-space-xs, 8px)',
   fontSize: 'var(--wa-font-size-m, 13px)',
   fontFamily: 'var(--wa-font-family-body, system-ui), system-ui',
-  color:
-    'var(--wa-color-text-normal, var(--wa-color-text-normal))',
+  color: 'var(--wa-color-text-normal)',
   background:
     'var(--wa-color-surface-raised, var(--wa-color-surface-default))',
   border:

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -42,7 +42,7 @@ export const categoryBadgeStyles: CSSResult = css`
   .category-badge.tooluse,
   .category-badge.tool-use {
     background-color: var(
-      --texra-editorWarning-background,
+      --wa-color-warning-fill-quiet,
       rgba(255, 204, 0, 0.15)
     );
     color: var(--wa-color-warning-on-quiet, #cca700);
@@ -52,7 +52,7 @@ export const categoryBadgeStyles: CSSResult = css`
 export const searchHighlightStyles: CSSResult = css`
   mark {
     background-color: var(
-      --texra-editor-findMatchHighlightBackground,
+      --wa-color-editor-find-match-highlight,
       #ffef0b80
     );
     color: var(--wa-color-editor-find-match-highlight-fg, inherit);

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -132,7 +132,7 @@ export const commonViewStyles: CSSResult = css`
   .panel-collapsible::part(header) {
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     background-color: var(--wa-color-surface-lowered, transparent);
-    color: var(--wa-color-text-normal, var(--wa-color-text-normal));
+    color: var(--wa-color-text-normal);
   }
 
   /* "body" part is used by vscode-collapsible; "content" part by wa-details. */


### PR DESCRIPTION
## Summary

Triaged bot reviews (Cursor Bugbot, Copilot, Claude Code Review) on the recently merged WebAwesome migration PRs (#3733-#3745) and applied the must-fix findings. Stylistic / preference findings were deferred; stale findings already addressed by later PRs in the same series were verified against current `main` and skipped.

## Findings addressed

### `packages/desktop/src/renderer/main.ts`
- **#3733 (Copilot + Cursor) — TDZ on no-workspace path.** `mainView` / `progressView` could call `createNoWorkspacePlaceholder()` (which reads `EMPTY_WORKSPACE_COPY`) before either was declared, throwing a `ReferenceError` during module init. Hoisted both above the first call site. (`packages/desktop/src/renderer/main.ts:81-119` placeholder block; original definitions removed at the bottom of the module.)
- **#3733 (Cursor) — `DESKTOP_ROUTES` dead code.** Removed the unused constant and the now-unused `DesktopRouteSchema` import. (`packages/desktop/src/renderer/main.ts:28-32`)
- **#3743 (Copilot + Cursor) — "Continue without saved secrets" left a blank page.** The fallback panel is rendered directly into `appRoot`, so just hiding the node leaves nothing behind. The button now attempts a fresh `renderLogViewer()` + `rerenderShell()` and re-renders the fallback if recovery itself fails. (`packages/desktop/src/renderer/main.ts:303-326`)

### `packages/desktop/src/main/platform/electronSecrets.ts`
- **#3743 (Copilot) — Misleading `KEYCHAIN_DENIED_WARNING_MESSAGE`.** The warning is shown for any `safeStorage.decryptString` exception, including corrupted entries / rotated keys, not just denial. Broadened the wording. (`electronSecrets.ts:16-17`)
- **#3743 (Copilot) — `prewarmElectronKeychain()` JSDoc inaccurate.** Doc said `false` only when `safeStorage` is unavailable, but the function also returns `false` when `encryptString` throws. Doc updated to match. (`electronSecrets.ts:117-128`)

### `packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts`
- **#3736 (Copilot + Cursor) — Empty number input silently coerced to min.** `Number('')` is `0`, so clearing a field used to silently dispatch `min`. Now returns early on empty/whitespace before parsing. (`LaTeXTab.ts:960-973`)

### `packages/extension/src/webview/frontend/MainApp.ts`
- **#3737 (Copilot) — `?open=${isWorkflow}` re-applied open=true on every render.** Replaced with a `fileSelectionOpen` signal initialized on session-type transitions and synchronized with `wa-show` / `wa-hide`, so user collapses now survive subsequent re-renders. (`MainApp.ts:181-188`, `1206-1228`, `2017-2025`)

### Stale `--texra-*` token references after PR #3741
- **#3741 (Copilot + Cursor)** — These references would silently fall through to their hard-coded fallbacks because the `--texra-*` token layer was retired:
  - `--texra-terminal-background` -> `--wa-color-terminal-background` (`TerminalCommandStrip.ts:21`, `logEntryStyles.ts:285`)
  - `--texra-toolbar-hoverBackground` -> `--wa-color-toolbar-hover` (`codeBlockStyles.ts:62`)
  - `--texra-editorWarning-background` -> `--wa-color-warning-fill-quiet` (`badgeStyles.ts:45`)
  - `--texra-editor-findMatchHighlightBackground` -> `--wa-color-editor-find-match-highlight` (`badgeStyles.ts:55`)
- **#3741 (Copilot) — Redundant self-fallback.** `var(--wa-color-text-normal, var(--wa-color-text-normal))` collapsed to a single `var(...)` in `TooltipController.ts:11` and `commonViewStyles.ts:135`.

## Findings deferred (stylistic / non-bug)

- #3734 — `AgentsTab.ts` direct WA imports vs `@shared/wa/tabs` barrel (works either way; consistent within the file).
- #3734 — Misleading "codicon glyphs" comment in `StreamTabs.ts` (cosmetic).
- #3735 — Quiet-variant tokens missing from HC override block (large, follow-up worthy of its own PR).
- #3735 — Pre-WA-token-rounding fallback values in `bannerStyles` etc. (inert when `common.css` loads first).
- #3737 — Fixed `height: 24px` on execute button (intended density choice).
- #3740 — Plan step / tooltip transition tweaks (preference).
- #3742 — `--wa-space-s` vs `--wa-space-xs` (matches actual production rendering, only the PR description wording was off).

## Test plan

- [x] `npm run typecheck` — no new errors. (Pre-existing OpenRouter SDK / Electron typings errors are present on origin/main and untouched.)
- [x] `cd packages/desktop && npx vite build --mode development` — clean build.
- [x] `npx vitest run` — 322 pass / 6 fail; the 6 failures match origin/main exactly (not introduced by this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly targeted bug fixes, but touches desktop renderer bootstrap/recovery and Electron keychain handling, which can affect startup behavior and access to persisted secrets.
> 
> **Overview**
> Fixes several post-WebAwesome migration regressions across desktop and webviews.
> 
> Desktop: avoids a no-workspace module-init crash by hoisting the empty-workspace placeholder helpers, removes unused route schema wiring, and makes the “Continue without saved secrets” bootstrap fallback attempt a fresh `renderLogViewer()` + `rerenderShell()` (re-falling back on error) instead of hiding the only rendered UI.
> 
> Secrets + UI polish: broadens the keychain decrypt warning copy and clarifies `prewarmElectronKeychain()`’s success/failed-prewarm semantics; prevents cleared numeric inputs in `LaTeXTab` from coercing to 0/min; persists the workflow Files panel open/closed state via a `fileSelectionOpen` signal; and updates remaining retired `--texra-*` CSS tokens to `--wa-*` equivalents (plus removes redundant `var()` self-fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a82b6dbec173e2a82b8e1c9f8b7ecea5c648b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->