### PR TITLE
refactor(wa): zod/Lit/WA-native sweep + extension/desktop consolidation

### DIFF
--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -10,8 +10,9 @@ import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -39,7 +40,7 @@ export class LatexdiffResults extends LitElement {
         margin: var(--wa-space-2xs) 0;
       }
 
-      details {
+      wa-details {
         margin: 0;
       }
 
@@ -139,17 +140,11 @@ export class LatexdiffResults extends LitElement {
         : `Latexdiff results (${this.entries.length})`;
 
     return html`
-      <details open>
-        <summary class="details-summary">
-          <wa-icon
-            library="texra"
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
+      <wa-details open>
+        <span slot="summary" class="details-summary">
           <wa-icon library="texra" name="diff" aria-hidden="true"></wa-icon>
           <span>${summaryText}</span>
-        </summary>
+        </span>
         <ul
           class="latexdiff-content"
           data-log-id=${this.logId}
@@ -162,7 +157,7 @@ export class LatexdiffResults extends LitElement {
             (entry) => this.renderEntry(entry),
           )}
         </ul>
-      </details>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -13,8 +13,9 @@ import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import {
@@ -90,18 +91,12 @@ export class RetryRequestPanel extends BaseRequestPanel {
           )}
           ${detailsText
             ? html`
-                <details class="retry-request__error-details">
-                  <summary class="retry-request__error-summary">
-                    <wa-icon
-                      library="texra"
-                      name="chevron-right"
-                      class="toggle-icon"
-                      aria-hidden="true"
-                    ></wa-icon>
+                <wa-details class="retry-request__error-details">
+                  <span slot="summary" class="retry-request__error-summary">
                     Error details
-                  </summary>
+                  </span>
                   <div class="retry-request__error-body">${detailsText}</div>
-                </details>
+                </wa-details>
               `
             : nothing}
         </div>

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -9,8 +9,9 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -33,7 +34,7 @@ export class StatisticsPanel extends LitElement {
         margin: var(--wa-space-2xs) 0;
       }
 
-      details {
+      wa-details {
         margin: 0;
       }
 
@@ -80,14 +81,8 @@ export class StatisticsPanel extends LitElement {
     }
 
     return html`
-      <details>
-        <summary class="details-summary">
-          <wa-icon
-            library="texra"
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
+      <wa-details>
+        <span slot="summary" class="details-summary">
           <wa-icon
             library="texra"
             name="graph"
@@ -95,7 +90,7 @@ export class StatisticsPanel extends LitElement {
             aria-hidden="true"
           ></wa-icon>
           <span>Statistics</span>
-        </summary>
+        </span>
         <div class="statistics-content" data-log-id=${this.logId}>
           ${repeat(
             this.items,
@@ -112,7 +107,7 @@ export class StatisticsPanel extends LitElement {
             `,
           )}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -9,8 +9,11 @@ import { customElement, property } from 'lit/decorators.js';
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/radio/radio.js';
+import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+import type WaRadioGroup from '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
@@ -28,7 +31,7 @@ export class ApiAccessSection extends LitElement {
   @property({ attribute: false }) mode: 'included' | 'personal' = 'personal';
 
   private handleModeChange(event: Event): void {
-    const target = event.currentTarget as HTMLInputElement | null;
+    const target = event.currentTarget as WaRadioGroup | null;
     const mode = target?.value === 'included' ? 'included' : 'personal';
     if (mode !== this.mode) {
       this.dispatchEvent(ProfileViewEvents.setApiAccessMode({ mode }));
@@ -39,15 +42,13 @@ export class ApiAccessSection extends LitElement {
     return html`
       <div class="api-access-section">
         <h2>Model Access</h2>
-        <div class="api-access-options">
-          <label class="api-access-option">
-            <input
-              type="radio"
-              name="apiAccessMode"
-              value="included"
-              .checked=${this.mode === 'included'}
-              @change=${this.handleModeChange}
-            />
+        <wa-radio-group
+          class="api-access-options"
+          name="apiAccessMode"
+          .value=${this.mode}
+          @change=${this.handleModeChange}
+        >
+          <wa-radio class="api-access-option" value="included">
             <span class="option-content">
               <span class="option-title">Use Included Access</span>
               <span class="option-description"
@@ -57,15 +58,8 @@ export class ApiAccessSection extends LitElement {
                 avoid relay caps.</span
               >
             </span>
-          </label>
-          <label class="api-access-option">
-            <input
-              type="radio"
-              name="apiAccessMode"
-              value="personal"
-              .checked=${this.mode === 'personal'}
-              @change=${this.handleModeChange}
-            />
+          </wa-radio>
+          <wa-radio class="api-access-option" value="personal">
             <span class="option-content">
               <span class="option-title">Use My Own Keys</span>
               <span class="option-description"
@@ -74,8 +68,8 @@ export class ApiAccessSection extends LitElement {
                 outside Included Access.</span
               >
             </span>
-          </label>
-        </div>
+          </wa-radio>
+        </wa-radio-group>
         ${this.mode === 'included'
           ? html`
               <div class="api-access-support">

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -5,6 +5,9 @@
 
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
@@ -34,28 +37,16 @@ export class ProviderKeyModal extends LitElement {
         line-height: var(--line-height-normal);
       }
 
-      label {
+      .provider-key-label {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-2xs);
         font-weight: var(--font-weight-medium);
       }
 
-      input {
+      wa-input.provider-key-input {
+        display: block;
         width: 100%;
-        box-sizing: border-box;
-        height: var(--height-control);
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
-        color: var(--wa-form-control-text-color);
-        background: var(--wa-form-control-background-color);
-        border: var(--border-thin) solid var(--wa-form-control-border-color);
-        border-radius: var(--border-radius);
-        font: inherit;
-      }
-
-      input:focus {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: 1px;
       }
 
       .provider-key-error {
@@ -70,39 +61,6 @@ export class ProviderKeyModal extends LitElement {
         justify-content: flex-end;
         gap: var(--wa-space-xs);
       }
-
-      /* Action buttons share base layout; variants set color + background */
-      .provider-key-actions button {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        min-height: var(--height-button);
-        padding: var(--wa-space-2xs) var(--wa-space-s);
-        border-radius: var(--border-radius);
-        border: var(--border-thin) solid transparent;
-        font: inherit;
-        cursor: pointer;
-      }
-
-      .provider-key-primary {
-        color: var(--wa-color-brand-on-loud);
-        background: var(--wa-color-brand-fill-loud);
-        border-color: var(--wa-color-brand-fill-loud);
-      }
-
-      .provider-key-primary:hover {
-        background: var(--wa-color-button-hover);
-      }
-
-      .provider-key-secondary {
-        color: var(--wa-color-text-normal);
-        background: transparent;
-        border-color: var(--color-border);
-      }
-
-      .provider-key-secondary:hover {
-        background: var(--wa-color-neutral-fill-quiet);
-      }
     `,
   ];
 
@@ -112,7 +70,7 @@ export class ProviderKeyModal extends LitElement {
   @state() private value = '';
   @state() private error = '';
 
-  @query('input') private keyInput?: HTMLInputElement;
+  @query('wa-input.provider-key-input') private keyInput?: WaInput;
 
   // Drives wa-dialog's `open` reactive property; toggled by close() so the
   // dialog plays its hide animation and dispatches wa-after-hide.
@@ -153,7 +111,7 @@ export class ProviderKeyModal extends LitElement {
   }
 
   private handleInput(event: Event): void {
-    this.value = (event.target as HTMLInputElement).value;
+    this.value = (event.target as WaInput).value ?? '';
     if (this.error) {
       this.error = '';
     }
@@ -195,34 +153,37 @@ export class ProviderKeyModal extends LitElement {
             The key is stored by TeXRA on this device and is not shown again
             after saving.
           </p>
-          <label>
+          <label class="provider-key-label">
             ${displayName} API key
-            <input
+            <wa-input
+              class="provider-key-input"
               type="password"
               autocomplete="off"
               spellcheck="false"
               .value=${this.value}
               @input=${this.handleInput}
-            />
+            ></wa-input>
           </label>
           <p class="provider-key-error" aria-live="polite">${this.error}</p>
         </form>
         <div slot="footer" class="provider-key-actions">
-          <button
-            class="provider-key-secondary"
+          <wa-button
+            appearance="outlined"
+            variant="neutral"
             type="button"
             @click=${this.handleCancelClick}
           >
             Cancel
-          </button>
-          <button
-            class="provider-key-primary"
+          </wa-button>
+          <wa-button
+            appearance="filled"
+            variant="brand"
             type="submit"
             form="provider-key-form"
           >
-            <wa-icon library="texra" name="key"></wa-icon>
+            <wa-icon library="texra" name="key" slot="start"></wa-icon>
             Save Key
-          </button>
+          </wa-button>
         </div>
       </wa-dialog>
     `;

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -141,36 +141,30 @@ export const profileViewStyles: CSSResult = css`
     line-height: var(--line-height-normal);
   }
 
-  .api-access-options {
+  /* wa-radio-group provides layout + keyboard navigation; the per-option card
+     chrome (border, background, hover) is rendered on each <wa-radio>. */
+  wa-radio-group.api-access-options {
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-xs);
   }
 
-  .api-access-option {
-    display: flex;
+  wa-radio.api-access-option {
     align-items: flex-start;
-    gap: var(--wa-space-xs);
     padding: var(--wa-space-xs);
     background: var(--wa-form-control-background-color);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
-    cursor: pointer;
     transition: border-color var(--transition-normal);
   }
 
-  .api-access-option:hover {
+  wa-radio.api-access-option:hover {
     border-color: var(--wa-color-focus);
   }
 
-  .api-access-option:has(input:checked) {
+  wa-radio.api-access-option[checked] {
     border-color: var(--wa-color-focus);
     background: var(--wa-color-neutral-fill-quiet);
-  }
-
-  .api-access-option input[type='radio'] {
-    margin-top: var(--wa-space-3xs);
-    accent-color: var(--wa-color-focus);
   }
 
   .api-access-support {

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -39,7 +39,9 @@ describe('ProviderKeyModal', () => {
       submitted.push((event as CustomEvent).detail);
     });
 
-    const input = modal.shadowRoot!.querySelector('input')!;
+    const input = modal.shadowRoot!.querySelector(
+      'wa-input',
+    ) as HTMLElement & { value: string };
     input.value = '  sk-test  ';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     modal
@@ -71,12 +73,17 @@ describe('ProviderKeyModal', () => {
       submitted += 1;
     });
 
-    const input = modal.shadowRoot!.querySelector('input')!;
+    const input = modal.shadowRoot!.querySelector(
+      'wa-input',
+    ) as HTMLElement & { value: string };
     input.value = 'sk-cancel';
     input.dispatchEvent(new Event('input', { bubbles: true }));
-    modal
-      .shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-secondary')!
-      .click();
+    // First wa-button in the footer is "Cancel" (outlined / neutral); clicking
+    // it triggers the user-initiated close path that fires provider-key-cancel.
+    const cancelButton = modal
+      .shadowRoot!.querySelectorAll<HTMLElement>('wa-button')
+      .item(0);
+    cancelButton.click();
     await flushDialogTicks();
 
     expect(cancelled).toBe(1);
@@ -105,7 +112,9 @@ describe('ProviderKeyModal', () => {
       cancelled += 1;
     });
 
-    const input = modal.shadowRoot!.querySelector('input')!;
+    const input = modal.shadowRoot!.querySelector(
+      'wa-input',
+    ) as HTMLElement & { value: string };
     input.value = 'sk-after-submit';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     modal


### PR DESCRIPTION
## Summary

Sweep across settings and progress views to swap remaining raw HTML form/disclosure widgets for their Web Awesome equivalents, deleting hand-rolled CSS and chevron toggles.

- **ApiAccessSection** — two `<input type=\"radio\">` cards → `<wa-radio-group>` + `<wa-radio>`. Drops `input[type='radio']` styling and the `:has(input:checked)` hack; per-card hover / checked state now keys off `[checked]` on the radio element. (Settings)
- **ProviderKeyModal** — `<input type=\"password\">` → `<wa-input type=\"password\">`; both footer buttons → `<wa-button>` (outlined/neutral + filled/brand with `slot=\"start\"` for the icon). Deletes ~50 lines of bespoke input/button CSS. (Settings)
- **StatisticsPanel** — `<details>` → `<wa-details>`, summary moved to `slot=\"summary\"`, manual `chevron-right` toggle icon removed (wa-details renders its own).
- **LatexdiffResults** — `<details open>` → `<wa-details open>`, same chevron cleanup.
- **RetryRequestPanel** — error-details `<details>` → `<wa-details>`, slotted summary, chevron icon dropped.
- **ProviderKeyModal vitest** — updated to query `wa-input` and the first footer `wa-button` so the in-DOM submit / cancel paths still cover the new components.

### Did this cross the extension/desktop boundary?

No. All conversions live in `packages/extension/`. The desktop renderer already uses `<wa-dialog>` and `<wa-button>` natively; nothing here changes desktop chrome.

### Deferred (per scope guidance)

- **`desktopCommandPalette` / `desktopOnboarding`** are desktop-only today. Hoisting them into `src/shared/wa/` would require a host-neutral command surface; better as its own PR.
- **`z.custom<>` sites** (`ProviderMessage`, `ToolDefinition.zodSchema`, `AgentWorkspaceState.contentBlocks`) wrap external SDK type unions (Anthropic, OpenAI, Google, OpenRouter, Zod's own `ZodType`). Documented intentional uses.
- **`.toggle-icon` `<button>`s** in `OutputFilesSection` / `FileSelectGroup` are 22px-tall hand-shaped toggles whose layout would change under `<wa-button>` — preserving look-and-feel was the higher priority.

## Test plan

- [x] `npm run typecheck` — same baseline failures as `origin/main` (electron / @openrouter/sdk/models / `paths.ts`); no new errors in the modified files.
- [x] `cd packages/desktop && npx vite build --mode development` — clean build.
- [x] `npx vitest run` — `6 failed | 322 passed` matches the `origin/main` baseline (`6 failed | 319 passed`); the 3 ProviderKeyModal tests now pass under the new wa-input / wa-button selectors.
- [ ] Smoke the Settings → Profile → Model Access radios and the \"Set provider key\" dialog in the extension host.
- [ ] Smoke the Statistics, Latexdiff, and Retry-error disclosures in the progress view (open/close, chevron rotation, slotted summary alignment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps native `details`/`input`/`button` elements for Web Awesome equivalents; main risk is minor regressions in disclosure toggling, form events, and styling.
> 
> **Overview**
> Replaces remaining native HTML disclosure and form controls in the extension settings/progress views with Web Awesome components.
> 
> Progress view panels (`LatexdiffResults`, `StatisticsPanel`, `RetryRequestPanel`) migrate from `<details>/<summary>` to `<wa-details>` with slotted summaries and remove the manual chevron toggle icon.
> 
> Settings profile UI updates `ApiAccessSection` from raw radio inputs to `<wa-radio-group>/<wa-radio>` (with CSS updated to use `[checked]`), and updates `ProviderKeyModal` to use `<wa-input>` plus `<wa-button>`s while deleting bespoke input/button styling; associated vitests are updated to query the new components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e15efdfcc4f9dd55a8f509f878552e4d126eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->