### PR TITLE
fix(wa): tighter launcher density + strict VS Code font in extension

### DIFF
--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -183,15 +183,26 @@
   --wa-color-terminal-ansi-bright-white: var(--vscode-terminal-ansiBrightWhite);
   --wa-color-terminal-ansi-bright-yellow: var(--vscode-terminal-ansiBrightYellow);
 
-  /* Typography. Lead with `ui-sans-serif` / `system-ui` so the OS picks
-     its native UI font on every platform; `--vscode-font-family` (when
-     present) merely refines that. Avoids the "almost native but slightly
-     off" look from a hardcoded Apple/BlinkMac fallback chain. */
-  --wa-font-family-body: var(--vscode-font-family),
-    ui-sans-serif, system-ui, sans-serif;
+  /* Typography. Inside the VS Code extension webview, always inherit
+     VS Code's chosen UI font so the webview matches the host chrome.
+     The `var()` fallback only fires if the var is somehow unset (e.g.,
+     in a unit-test polyfill). */
+  --wa-font-family-body: var(
+    --vscode-font-family,
+    ui-sans-serif,
+    system-ui,
+    sans-serif
+  );
   --wa-font-family-heading: var(--wa-font-family-body);
-  --wa-font-family-mono: var(--vscode-editor-font-family),
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --wa-font-family-mono: var(
+    --vscode-editor-font-family,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace
+  );
   --wa-font-size-m: var(--vscode-font-size, 13px);
   --wa-font-weight-normal: var(--vscode-font-weight, 400);
   --wa-editor-font-size: var(--vscode-editor-font-size, 13px);

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -114,10 +114,10 @@ export class InstructionPanel extends LitElement {
         display: flex;
         flex-direction: column;
         position: relative;
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        padding: var(--wa-space-3xs) var(--wa-space-xs);
         background-color: var(--background-color);
         border-radius: var(--border-radius);
-        margin-bottom: var(--wa-space-2xs);
+        margin-bottom: var(--wa-space-3xs);
         border: var(--border-thin) solid var(--color-border);
         transition: border-color 160ms ease;
       }
@@ -227,7 +227,7 @@ export class InstructionPanel extends LitElement {
 
       wa-textarea#instruction {
         width: 100%;
-        margin: var(--wa-space-2xs) 0;
+        margin: var(--wa-space-3xs) 0;
         font-family: var(--wa-font-family-mono);
         font-size: var(--font-size);
       }
@@ -249,7 +249,7 @@ export class InstructionPanel extends LitElement {
       .model-selection-footer {
         display: flex;
         align-items: center;
-        gap: var(--wa-space-s);
+        gap: var(--wa-space-m);
         flex: 1 1 auto;
         flex-wrap: wrap;
         min-width: 0;


### PR DESCRIPTION
## Summary
1. **VS Code font priority** — extension webview should always inherit VS Code's chosen UI font. Use `var(--vscode-font-family, ...)` with the system stack only as a fallback when the var is unset (e.g., unit-test polyfills) — not as a sibling list after.
2. **Tighter launcher box** — `.instruction-box` padding-block `2xs` → `3xs` (4px → 2px) and margin-bottom likewise; `wa-textarea#instruction` margin `2xs 0` → `3xs 0`.
3. **Toolbar group gap** — `.model-selection-footer` gap `s` → `m` (8px → 16px) so the robot icon stops abutting the agent select chevron.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling changes (font token fallback behavior and small spacing tweaks) with no logic or data-flow impact.
> 
> **Overview**
> Ensures the extension webview typography more strictly follows VS Code by defining `--wa-font-family-body`/`--wa-font-family-mono` via `var(--vscode-*-font-family, ...)` fallbacks instead of a sibling font list.
> 
> Tightens the `InstructionPanel` launcher density by reducing `.instruction-box` and `wa-textarea#instruction` vertical spacing, and increases `.model-selection-footer` gap to prevent the model settings icon from crowding the adjacent select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5664013f78b226ba2d852f1a61e84e52eec0851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->