### PR TITLE
chore(docs): drop duplicate isCustomElement from VitePress enhanceApp

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -22,16 +22,9 @@ async function ensureWebAwesome() {
 export default {
   ...DefaultTheme,
   enhanceApp({ app }) {
-    // Tell Vue's template compiler that <wa-icon> is a native custom element
-    // so it doesn't try to resolve it as a Vue component.
-    app.config.compilerOptions ??= {};
-    const existingIsCustomElement = app.config.compilerOptions.isCustomElement;
-    app.config.compilerOptions.isCustomElement = (tag) => {
-      if (tag.startsWith('wa-')) return true;
-      return existingIsCustomElement ? existingIsCustomElement(tag) : false;
-    };
-
-    // Register custom Vue components.
+    // Note: `isCustomElement: tag => tag.startsWith('wa-')` is configured
+    // at build time in `docs/.vitepress/config.js` under
+    // `vite.vue.template.compilerOptions` so SSR also recognises wa-* tags.
     app.component('LaunchPage', LaunchPage);
 
     // Side-effect: load WA icon component + register texra library on the


### PR DESCRIPTION
Closes #3709 fully — build-time config already in place from #3747; runtime duplicate in enhanceApp removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that removes redundant runtime Vue compiler configuration; behavior now relies solely on the existing build-time Vite config, which could affect rendering if that config is misconfigured.
> 
> **Overview**
> Removes the runtime `enhanceApp` override that marked `wa-*` tags as Vue custom elements, eliminating duplicate configuration in the VitePress theme.
> 
> Adds a note clarifying that `isCustomElement: tag => tag.startsWith('wa-')` is handled in `docs/.vitepress/config.js` at build time so SSR and client builds consistently recognize Web Awesome custom elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c688e0fbdca58441f5af5664ab172769e3697d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->