### PR TITLE
fix(wa): address bot-review findings on session PRs (#3747–#3761)

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -316,6 +316,18 @@ function renderBootstrapFallback(error: unknown): void {
                 try {
                   renderLogViewer();
                   rerenderShell();
+                  // Clear the bootstrap-failed latch so chrome icon buttons
+                  // (Settings, Logs, etc.) can drive `setRoute()` →
+                  // `rerenderShell()` after recovery. Without this, the
+                  // `if (bootstrapFailed) return;` guard in setRoute makes
+                  // chrome navigation silently do nothing even though the
+                  // shell is mounted.
+                  bootstrapFailed = false;
+                  // Drive the same minimal post-mount IPC the original boot
+                  // path runs so the recovered shell isn't permanently empty
+                  // (workspace tree + onboarding state).
+                  requestWorkspaceTree();
+                  postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
                 } catch (recoveryError) {
                   console.error(
                     'TeXRA desktop renderer recovery failed',

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,6 +27,12 @@ export interface LaunchedApp {
   app: ElectronApplication;
   page: Page;
   workspacePath: string;
+  /**
+   * True when `launchTexraApp()` allocated a temp workspace itself (caller
+   * did not supply one). `closeTexraApp()` cleans this up so repeated CI
+   * runs do not litter the system temp directory.
+   */
+  ownsWorkspace: boolean;
 }
 
 /**
@@ -51,6 +57,7 @@ export async function launchTexraApp(
     );
   }
 
+  const ownsWorkspace = options.workspacePath === undefined;
   const workspacePath =
     options.workspacePath ?? mkdtempSync(join(tmpdir(), 'texra-e2e-'));
 
@@ -70,9 +77,20 @@ export async function launchTexraApp(
   await page.setViewportSize({ width: 1280, height: 800 });
   // Wait for the renderer root to mount before tests interact.
   await page.waitForSelector('#app', { state: 'attached' });
-  return { app, page, workspacePath };
+  return { app, page, workspacePath, ownsWorkspace };
 }
 
 export async function closeTexraApp(launched: LaunchedApp): Promise<void> {
   await launched.app.close();
+  // Clean up the auto-allocated temp workspace so repeated test runs do not
+  // accumulate `/tmp/texra-e2e-*` directories. If the caller supplied a
+  // workspace path, leave it alone — the caller owns its lifecycle.
+  if (launched.ownsWorkspace) {
+    try {
+      rmSync(launched.workspacePath, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup. A stale temp dir is preferable to a noisy
+      // teardown failure that masks the real test outcome.
+    }
+  }
 }

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 
+import { SETTINGS_TAB } from '../../../../src/shared/schemas/settingsViewMessages.js';
 import {
   closeTexraApp,
   launchTexraApp,
@@ -75,11 +76,12 @@ test('progress screenshot', async () => {
 test('settings screenshot', async () => {
   await setRoute('settings');
   // Open the Multi-Agent settings tab — the most visually rich area.
-  // SETTINGS_TAB_ORDER index 4 = 'MULTI_AGENT'
-  // (see src/shared/schemas/settingsViewMessages.ts).
-  await launched.page.evaluate(() => {
-    window.postMessage({ command: 'setTab', tabIndex: 4 }, '*');
-  });
+  // Use the centralized SETTINGS_TAB constant so this can't silently break
+  // when the tab order changes.
+  const multiAgentTabIndex = SETTINGS_TAB.MULTI_AGENT;
+  await launched.page.evaluate((tabIndex) => {
+    window.postMessage({ command: 'setTab', tabIndex }, '*');
+  }, multiAgentTabIndex);
   await launched.page.waitForTimeout(500);
   await launched.page.screenshot({
     path: join(SCREENSHOTS_DIR, 'settings.png'),

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -2032,8 +2032,21 @@ export class MainApp extends MainAppBase {
                 <wa-details
                   class="file-selection-details"
                   ?open=${this.fileSelectionOpen.get()}
-                  @wa-show=${() => this.fileSelectionOpen.set(true)}
-                  @wa-hide=${() => this.fileSelectionOpen.set(false)}
+                  @wa-show=${(event: Event) => {
+                    // Filter by event source: child wa-dropdown components
+                    // inside the panel also emit wa-show/wa-hide which bubble
+                    // up. Without this guard, opening any dropdown inside
+                    // the Files panel re-flips fileSelectionOpen on the next
+                    // dropdown close (see webawesome#1540).
+                    if (event.target === event.currentTarget) {
+                      this.fileSelectionOpen.set(true);
+                    }
+                  }}
+                  @wa-hide=${(event: Event) => {
+                    if (event.target === event.currentTarget) {
+                      this.fileSelectionOpen.set(false);
+                    }
+                  }}
                 >
                   <span slot="summary" class="file-selection-summary">
                     <wa-icon


### PR DESCRIPTION
## Summary

Triaged Cursor Bugbot + Copilot findings on the most recent session of 13 merged PRs (#3747–#3761) and applied the genuine must-fix items. Stale findings (already addressed by later PRs in the same burst) and stylistic suggestions were filtered out.

## Must-fix findings addressed

- **Desktop renderer recovery** (#3752, Cursor High) — `Continue without saved secrets` now flips `bootstrapFailed` back to `false` on success and re-runs the minimal post-mount IPC (`requestWorkspaceTree` + onboarding state), so chrome navigation buttons work after recovery instead of silently no-oping past the `if (bootstrapFailed) return` guard in `setRoute`.
- **File panel collapse** (#3752, Cursor High) — the `wa-details` `wa-show` / `wa-hide` listeners on the Files panel now filter by event source, preventing child `wa-dropdown` event bubbling (webawesome#1540) from collapsing the entire Files panel whenever a tool-config / auto-extract dropdown closes.
- **Settings e2e tab index** (#3757, Copilot) — replace hardcoded `tabIndex: 4` with `SETTINGS_TAB.MULTI_AGENT` so screenshot tests cannot silently target the wrong tab if `SETTINGS_TAB_ORDER` changes.
- **E2E temp workspace cleanup** (#3757, Copilot) — track ownership of auto-allocated `/tmp/texra-e2e-*` workspaces and remove them in `closeTexraApp()` so repeated CI runs do not litter the temp dir.

## Findings triaged as stale

- #3747 Vue compiler config nested under wrong key — already fixed by #3761.
- #3750 Missing `var()` fallback for `--wa-font-family-*` — current main keeps fallbacks inside `var()` (#3754 follow-up).

## Findings triaged as defer

- #3751 command palette `open()` early-return / `currentTarget` — minor UX/style.
- #3753 wa-radio `?checked` binding — radio-group sets `checked` reflectively; CSS works.
- #3759 ElectronSecretsModule typing fidelity — test typing nuance.
- #3760 onboarding dismissal timing — e2e flake risk only.
- Various Copilot comment-wording nits.

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing openrouter/electron-types failures unchanged).
- [x] `cd packages/desktop && npx vite build --mode development` — built in ~1.5s, clean.
- [x] `npx vitest run` — 328/334 pass; the 6 failing tests are identical to origin/main (`DesktopThemeTokens`, `ElectronCompositionRoot`, `ElectronRendererShell` — pre-existing, unrelated to these fixes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted fixes to renderer recovery state, a WebAwesome event-bubbling edge case, and e2e test robustness/cleanup with minimal behavior change outside those scenarios.
> 
> **Overview**
> Fixes desktop renderer recovery so choosing **“Continue without saved secrets”** clears the `bootstrapFailed` latch and re-runs minimal post-mount IPC (workspace tree + onboarding state), restoring chrome navigation and preventing an empty recovered shell.
> 
> Hardens UX and tests: the extension’s Files panel `wa-details` now ignores bubbled `wa-show/wa-hide` from nested dropdowns to prevent unintended collapses, e2e screenshots use `SETTINGS_TAB.MULTI_AGENT` instead of a hardcoded index, and the e2e Electron harness tracks/removes auto-created temp workspaces on teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e516c9dd88402a84b4f6ebf9c1c6d69fc8246f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->