### PR TITLE
refactor(wa): hoist command palette + onboarding into shared/wa via host-neutral surface (closes #3755)

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -1,15 +1,33 @@
-import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
-import '@awesome.me/webawesome/dist/components/input/input.js';
-import { html, render } from 'lit';
-import { repeat } from 'lit/directives/repeat.js';
+// Desktop wrapper around the host-neutral command palette in
+// `src/shared/wa/commandPalette.ts`. Owns desktop-specific concerns:
+//
+//   * Pulls the command list from `desktopCommandSurface` (which depends on
+//     the VS Code-coupled `@commands/catalog` and Electron accelerator
+//     formatting — both still desktop-only).
+//   * Maps each entry's accelerator/category/unavailableReason into the
+//     palette's neutral `meta` column.
+//   * Forwards the `.desktop-command-palette-*` class hooks the desktop
+//     stylesheet already targets so the visual treatment is unchanged.
+//
+// The shared module owns the wa-dialog shell, filter input, keyboard
+// handling, and the global Cmd/Ctrl+K shortcut.
+
+import {
+  createCommandPalette,
+  executeCommandPaletteEntry,
+  filterCommandPaletteEntries,
+  getNextCommandPaletteIndex,
+  isCommandPaletteShortcut,
+  type CommandPaletteController,
+  type CommandPaletteEntry,
+} from '@shared/wa/commandPalette';
+
 import {
   dispatchDesktopCommand,
   getDesktopCommandMenuEntries,
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
-import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 export interface DesktopCommandPaletteOptions {
   document: Document;
@@ -18,28 +36,16 @@ export interface DesktopCommandPaletteOptions {
   canOpen?: () => boolean;
 }
 
-export interface DesktopCommandPaletteController {
-  element: HTMLElement;
-  open(): void;
-  close(): void;
-}
-
-const COMMAND_PALETTE_SHORTCUT_KEY = 'k';
+export type DesktopCommandPaletteController = CommandPaletteController;
 
 export function filterDesktopCommandPaletteEntries(
   entries: readonly DesktopCommandMenuEntry[],
   query: string,
 ): DesktopCommandMenuEntry[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) return [...entries];
-
-  const queryParts = normalizedQuery.split(/\s+/);
-  return entries.filter((entry) => {
-    const searchable = `${entry.label} ${entry.category} ${entry.id}`
-      .replaceAll('.', ' ')
-      .toLowerCase();
-    return queryParts.every((part) => searchable.includes(part));
-  });
+  // Desktop entries carry `category` (used in the haystack alongside id and
+  // label). The shared helper consults `category` first, then `meta`, so the
+  // existing search behaviour (label + category + id) is preserved.
+  return filterCommandPaletteEntries(entries, query);
 }
 
 export function getNextDesktopCommandPaletteIndex(
@@ -47,17 +53,19 @@ export function getNextDesktopCommandPaletteIndex(
   itemCount: number,
   delta: number,
 ): number {
-  if (itemCount <= 0) return -1;
-  return (currentIndex + delta + itemCount) % itemCount;
+  return getNextCommandPaletteIndex(currentIndex, itemCount, delta);
 }
 
 export function executeDesktopCommandPaletteEntry(
   entry: DesktopCommandMenuEntry | undefined,
   actions: DesktopCommandActions,
 ): boolean {
-  if (!entry?.enabled) return false;
-  return dispatchDesktopCommand(entry.id, actions);
+  return executeCommandPaletteEntry(toPaletteEntry(entry), (id) =>
+    dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions),
+  );
 }
+
+export { isCommandPaletteShortcut };
 
 export function createDesktopCommandPalette({
   document,
@@ -65,173 +73,42 @@ export function createDesktopCommandPalette({
   platform = getRendererPlatform(document.defaultView),
   canOpen,
 }: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
-  const view = document.defaultView;
-  const entries = getDesktopCommandMenuEntries(undefined, platform);
+  const desktopEntries = getDesktopCommandMenuEntries(undefined, platform);
+  const paletteEntries = desktopEntries
+    .map(toPaletteEntry)
+    .filter((entry): entry is CommandPaletteEntry => entry != null);
 
-  // Reactive state — every mutation calls renderTemplate() to keep the DOM
-  // in sync. wa-dialog handles modal backdrop, focus trap, escape key, and
-  // focus restoration natively, so we no longer manage those by hand.
-  let visibleEntries: DesktopCommandMenuEntry[] = [...entries];
-  let activeIndex = entries.length > 0 ? 0 : -1;
-  let query = '';
-
-  const dialog = document.createElement('wa-dialog') as WaDialog;
-  dialog.classList.add('desktop-command-palette');
-  dialog.withoutHeader = true;
-  dialog.lightDismiss = true;
-  dialog.setAttribute('aria-label', 'Command palette');
-
-  const executeActiveCommand = (): void => {
-    const entry = visibleEntries[activeIndex];
-    if (executeDesktopCommandPaletteEntry(entry, actions)) close();
-  };
-
-  const handleFilterInput = (event: Event): void => {
-    const target = event.target as WaInput | null;
-    query = target?.value ?? '';
-    visibleEntries = filterDesktopCommandPaletteEntries(entries, query);
-    activeIndex = visibleEntries.length > 0 ? 0 : -1;
-    renderTemplate();
-  };
-
-  const handleFilterKeydown = (event: KeyboardEvent): void => {
-    switch (event.key) {
-      case 'ArrowDown':
-        event.preventDefault();
-        activeIndex = getNextDesktopCommandPaletteIndex(
-          activeIndex,
-          visibleEntries.length,
-          1,
-        );
-        renderTemplate();
-        scrollActiveItemIntoView();
-        break;
-      case 'ArrowUp':
-        event.preventDefault();
-        activeIndex = getNextDesktopCommandPaletteIndex(
-          activeIndex,
-          visibleEntries.length,
-          -1,
-        );
-        renderTemplate();
-        scrollActiveItemIntoView();
-        break;
-      case 'Enter':
-        event.preventDefault();
-        executeActiveCommand();
-        break;
-      default:
-        break;
-    }
-  };
-
-  const handleItemMouseEnter = (index: number) => (): void => {
-    activeIndex = index;
-    renderTemplate();
-  };
-
-  const handleItemClick = (entry: DesktopCommandMenuEntry) => (): void => {
-    if (executeDesktopCommandPaletteEntry(entry, actions)) close();
-  };
-
-  const renderTemplate = (): void => {
-    render(
-      html`
-        <wa-input
-          class="desktop-command-palette-input"
-          type="search"
-          autocomplete="off"
-          spellcheck="false"
-          placeholder="Run command"
-          aria-label="Run command"
-          .value=${query}
-          @input=${handleFilterInput}
-          @keydown=${handleFilterKeydown}
-        ></wa-input>
-        <div class="desktop-command-palette-list" role="listbox">
-          ${repeat(
-            visibleEntries,
-            (entry) => entry.id,
-            (entry, index) => html`
-              <button
-                class="desktop-command-palette-item"
-                type="button"
-                role="option"
-                data-command-id=${entry.id}
-                ?disabled=${!entry.enabled}
-                aria-selected=${index === activeIndex ? 'true' : 'false'}
-                @mouseenter=${handleItemMouseEnter(index)}
-                @click=${handleItemClick(entry)}
-              >
-                <span class="desktop-command-palette-label"
-                  >${entry.label}</span
-                >
-                <span class="desktop-command-palette-meta">
-                  ${entry.unavailableReason ??
-                  entry.accelerator ??
-                  entry.category}
-                </span>
-              </button>
-            `,
-          )}
-        </div>
-      `,
-      dialog,
-    );
-  };
-
-  const scrollActiveItemIntoView = (): void => {
-    const items = dialog.querySelectorAll<HTMLButtonElement>(
-      '.desktop-command-palette-item',
-    );
-    items.item(activeIndex)?.scrollIntoView({ block: 'nearest' });
-  };
-
-  const open = (): void => {
-    if (canOpen?.() === false) return;
-    if (dialog.open) return;
-    query = '';
-    visibleEntries = [...entries];
-    activeIndex = visibleEntries.length > 0 ? 0 : -1;
-    renderTemplate();
-    dialog.open = true;
-  };
-
-  const close = (): void => {
-    if (!dialog.open) return;
-    dialog.open = false;
-  };
-
-  // wa-dialog focuses its first focusable child on show. Override that to
-  // focus the filter input directly so users can start typing immediately.
-  dialog.addEventListener('wa-after-show', () => {
-    const input = dialog.querySelector<WaInput>(
-      '.desktop-command-palette-input',
-    );
-    input?.focus();
+  return createCommandPalette({
+    document,
+    entries: paletteEntries,
+    canOpen,
+    onExecute: (id) =>
+      dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions),
+    classes: {
+      dialog: 'desktop-command-palette',
+      input: 'desktop-command-palette-input',
+      list: 'desktop-command-palette-list',
+      item: 'desktop-command-palette-item',
+      label: 'desktop-command-palette-label',
+      meta: 'desktop-command-palette-meta',
+    },
   });
-
-  // Global Cmd/Ctrl+K shortcut — must live on the document so it fires when
-  // no palette descendant is focused. canOpen guards against the onboarding
-  // dialog stealing the shortcut while it's visible.
-  document.defaultView?.addEventListener('keydown', (event) => {
-    if (!isCommandPaletteShortcut(event)) return;
-    if (isTextEntryShortcutTarget(view, document, event)) return;
-    event.preventDefault();
-    open();
-  });
-
-  renderTemplate();
-  return { element: dialog, open, close };
 }
 
-export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
-  return (
-    event.key.toLowerCase() === COMMAND_PALETTE_SHORTCUT_KEY &&
-    (event.metaKey || event.ctrlKey) &&
-    !event.altKey &&
-    !event.shiftKey
-  );
+function toPaletteEntry(
+  entry: DesktopCommandMenuEntry | undefined,
+): CommandPaletteEntry | undefined {
+  if (!entry) return undefined;
+  // Match the original meta-column precedence: unavailableReason > accelerator
+  // > category. Disabled entries surface their reason; enabled entries show
+  // the keybinding when present, falling back to the catalog category.
+  const meta = entry.unavailableReason ?? entry.accelerator ?? entry.category;
+  return {
+    id: entry.id,
+    label: entry.label,
+    meta,
+    enabled: entry.enabled,
+  };
 }
 
 function getRendererPlatform(view: Window | null): NodeJS.Platform {
@@ -239,46 +116,4 @@ function getRendererPlatform(view: Window | null): NodeJS.Platform {
   if (platform.includes('mac')) return 'darwin';
   if (platform.includes('win')) return 'win32';
   return 'linux';
-}
-
-function isElement(
-  view: Window | null,
-  target: EventTarget | null,
-): target is Element {
-  const elementConstructor =
-    view == null
-      ? undefined
-      : (view as Window & { Element?: typeof Element }).Element;
-  return elementConstructor != null && target instanceof elementConstructor;
-}
-
-function isTextEntryShortcutTarget(
-  view: Window | null,
-  document: Document,
-  event: KeyboardEvent,
-): boolean {
-  if (event.composedPath().some((target) => isTextEntryElement(view, target))) {
-    return true;
-  }
-  return isTextEntryElement(view, getDeepActiveElement(document));
-}
-
-function isTextEntryElement(
-  view: Window | null,
-  target: EventTarget | null,
-): boolean {
-  if (!isElement(view, target)) return false;
-  return (
-    target.closest(
-      'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
-    ) != null
-  );
-}
-
-function getDeepActiveElement(document: Document): Element | null {
-  let activeElement = document.activeElement;
-  while (activeElement?.shadowRoot?.activeElement) {
-    activeElement = activeElement.shadowRoot.activeElement;
-  }
-  return activeElement;
 }

--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -1,8 +1,16 @@
-import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
-import { html, render } from 'lit';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
+// Desktop wrapper around the host-neutral first-run walkthrough in
+// `src/shared/wa/walkthroughDialog.ts`. The shared helper owns the wa-dialog
+// shell, focus restore, command-palette-shortcut interception, and the
+// programmatic-vs-user-dismissal distinction; this wrapper supplies the
+// desktop's onboarding copy, the navigation actions (open Settings / Launcher
+// / dismiss), and the desktop CSS class hooks.
 
-import { isCommandPaletteShortcut } from './desktopCommandPalette';
+import {
+  createWalkthroughDialog,
+  type WalkthroughDialogController,
+  type WalkthroughStep,
+} from '@shared/wa/walkthroughDialog';
+
 import type { DesktopRoute } from '../desktopShellMessages';
 
 export interface DesktopFirstRunWalkthroughOptions {
@@ -11,18 +19,9 @@ export interface DesktopFirstRunWalkthroughOptions {
   setRoute(route: DesktopRoute): void;
 }
 
-export interface DesktopFirstRunWalkthrough {
-  element: HTMLElement;
-  isVisible(): boolean;
-  show(): void;
-  hide(): void;
-}
+export type DesktopFirstRunWalkthrough = WalkthroughDialogController;
 
-const ONBOARDING_STEPS: ReadonlyArray<{
-  readonly index: string;
-  readonly title: string;
-  readonly body: string;
-}> = [
+const ONBOARDING_STEPS: ReadonlyArray<WalkthroughStep> = [
   {
     index: '1',
     title: 'Open a workspace',
@@ -50,118 +49,44 @@ export function createFirstRunWalkthrough({
   dismiss: postDismissed,
   setRoute,
 }: DesktopFirstRunWalkthroughOptions): DesktopFirstRunWalkthrough {
-  const dialog = document.createElement('wa-dialog');
-  dialog.classList.add('desktop-onboarding');
-  dialog.withoutHeader = true;
-  // The visible <h1> inside the body is the dialog's accessible name; ARIA
-  // resolves it via aria-labelledby below. Skip the redundant `label`
-  // attribute that would otherwise add an extra aria-label.
-  dialog.setAttribute('aria-labelledby', 'desktop-onboarding-title');
-
-  // Distinguishes user-initiated close (Escape / button click) — which posts
-  // the dismissed signal back to the host — from programmatic close from
-  // setState(shouldShow=false), which would otherwise feedback-loop.
-  let suppressNextPost = false;
-
-  const closeDialog = (): void => {
-    dialog.open = false;
-  };
-  const navigateAndClose = (route: DesktopRoute): void => {
-    closeDialog();
-    setRoute(route);
-  };
-
-  render(
-    html`
-      <header class="desktop-onboarding-header">
-        ${waIcon('circle-info', { className: 'desktop-onboarding-icon' })}
-        <div>
-          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
-          <p>
-            Start from a workspace, configure model access, choose an agent, and
-            run without switching to VS Code.
-          </p>
-        </div>
-      </header>
-      <ol class="desktop-onboarding-steps">
-        ${ONBOARDING_STEPS.map(
-          (step) => html`
-            <li>
-              <span class="desktop-onboarding-step-index">${step.index}</span>
-              <div>
-                <strong>${step.title}</strong>
-                <span>${step.body}</span>
-              </div>
-            </li>
-          `,
-        )}
-      </ol>
-      <div slot="footer" class="desktop-onboarding-actions">
-        <wa-button
-          class="desktop-secondary-button"
-          appearance="outlined"
-          @click=${() => navigateAndClose('settings')}
-        >
-          Open Settings
-        </wa-button>
-        <wa-button
-          class="desktop-secondary-button"
-          appearance="outlined"
-          @click=${() => navigateAndClose('main')}
-        >
-          Go to Launcher
-        </wa-button>
-        <wa-button
-          class="desktop-primary-button"
-          appearance="filled"
-          variant="brand"
-          data-onboarding-dismiss
-          @click=${closeDialog}
-        >
-          Got it
-        </wa-button>
-      </div>
-    `,
-    dialog,
-  );
-
-  // wa-dialog handles modal backdrop, focus trap, escape key, and focus
-  // restoration automatically. Restore the dismiss-first focus policy
-  // (the previous hand-rolled trap focused "Got it" first), and intercept
-  // the command-palette shortcut so it doesn't fire while open.
-  dialog.addEventListener('wa-after-show', () => {
-    dialog.querySelector<HTMLElement>('[data-onboarding-dismiss]')?.focus();
-  });
-  // Every user-initiated dismissal (Escape, footer buttons) posts the
-  // dismissed signal back to the host. Programmatic hide() suppresses the
-  // post via suppressNextPost to avoid a feedback loop with setState messages.
-  dialog.addEventListener('wa-after-hide', () => {
-    if (suppressNextPost) {
-      suppressNextPost = false;
-      return;
-    }
-    postDismissed();
-  });
-  // Scoped to the dialog so it only runs while open and only for keys that
-  // originate inside it. stopPropagation prevents the global command-palette
-  // listener (on document) from firing.
-  dialog.addEventListener('keydown', (event) => {
-    if (isCommandPaletteShortcut(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  });
-
-  return {
-    element: dialog,
-    isVisible: () => dialog.open,
-    show: () => {
-      dialog.open = true;
+  return createWalkthroughDialog({
+    document,
+    title: 'Welcome to TeXRA Desktop',
+    description:
+      'Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.',
+    steps: ONBOARDING_STEPS,
+    onUserDismiss: postDismissed,
+    classes: {
+      dialog: 'desktop-onboarding',
+      header: 'desktop-onboarding-header',
+      icon: 'desktop-onboarding-icon',
+      steps: 'desktop-onboarding-steps',
+      stepIndex: 'desktop-onboarding-step-index',
+      actions: 'desktop-onboarding-actions',
     },
-    hide: () => {
-      if (!dialog.open) return;
-      suppressNextPost = true;
-      dialog.open = false;
-    },
-  };
+    actions: [
+      {
+        label: 'Open Settings',
+        appearance: 'outlined',
+        className: 'desktop-secondary-button',
+        onClick: () => setRoute('settings'),
+      },
+      {
+        label: 'Go to Launcher',
+        appearance: 'outlined',
+        className: 'desktop-secondary-button',
+        onClick: () => setRoute('main'),
+      },
+      {
+        label: 'Got it',
+        emphasis: 'primary',
+        appearance: 'filled',
+        variant: 'brand',
+        className: 'desktop-primary-button',
+        onClick: () => {
+          /* dialog auto-closes; onUserDismiss handles the post */
+        },
+      },
+    ],
+  });
 }

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -1,0 +1,318 @@
+// Host-neutral command palette. Both the Electron renderer and (eventually)
+// the VS Code webview drive this with their own command surfaces — the helper
+// owns the wa-dialog shell, filter/keyboard wiring, and Lit render loop.
+//
+// Stays inside `src/shared/wa/` per CLAUDE.md "VS Code-free zones": no
+// `vscode` imports, no `@commands/catalog`, no Electron / Node-specific APIs.
+// Hosts pre-resolve their command list (labels, accelerators, enablement)
+// and pass it in alongside an onExecute dispatcher and an optional canOpen
+// guard.
+
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import { html, render } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+
+// Single command row. `meta` is the trailing label (host-defined: an
+// accelerator hint, an unavailable reason, a category, etc.) so the palette
+// stays opinion-free about how hosts format that column. `enabled === false`
+// renders the row but disables click/Enter dispatch.
+export interface CommandPaletteEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly meta?: string;
+  readonly enabled: boolean;
+}
+
+export interface CommandPaletteOptions {
+  readonly document: Document;
+  readonly entries: readonly CommandPaletteEntry[];
+  readonly onExecute: (id: string) => boolean;
+  // Returning false suppresses the global Cmd/Ctrl+K shortcut (e.g. while a
+  // first-run walkthrough is visible). Click and programmatic open() always
+  // proceed regardless of the guard.
+  readonly canOpen?: () => boolean;
+  // Override the host shortcut (defaults to Cmd/Ctrl+K). Hosts that already
+  // own a global keybinding manager can pass `null` to disable the helper's
+  // window-level listener entirely.
+  readonly isShortcut?: ((event: KeyboardEvent) => boolean) | null;
+  // Optional CSS hooks. Hosts wire these to their own theming (e.g. the
+  // .desktop-command-palette-* classes the desktop renderer already styles).
+  readonly classes?: CommandPaletteClassNames;
+  readonly ariaLabel?: string;
+}
+
+export interface CommandPaletteClassNames {
+  readonly dialog?: string;
+  readonly input?: string;
+  readonly list?: string;
+  readonly item?: string;
+  readonly label?: string;
+  readonly meta?: string;
+}
+
+export interface CommandPaletteController {
+  element: HTMLElement;
+  open(): void;
+  close(): void;
+}
+
+const COMMAND_PALETTE_SHORTCUT_KEY = 'k';
+
+// Pure helpers exported for unit testing (filter/index/dispatch). Live in the
+// shared module so both the host wrappers and the test-kernel suite re-export
+// the same source of truth.
+
+export function filterCommandPaletteEntries<
+  T extends { id: string; label: string; meta?: string; category?: string },
+>(entries: readonly T[], query: string): T[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...entries];
+
+  const queryParts = normalizedQuery.split(/\s+/);
+  return entries.filter((entry) => {
+    const haystack = `${entry.label} ${entry.category ?? entry.meta ?? ''} ${entry.id}`
+      .replaceAll('.', ' ')
+      .toLowerCase();
+    return queryParts.every((part) => haystack.includes(part));
+  });
+}
+
+export function getNextCommandPaletteIndex(
+  currentIndex: number,
+  itemCount: number,
+  delta: number,
+): number {
+  if (itemCount <= 0) return -1;
+  return (currentIndex + delta + itemCount) % itemCount;
+}
+
+export function executeCommandPaletteEntry(
+  entry: CommandPaletteEntry | undefined,
+  onExecute: (id: string) => boolean,
+): boolean {
+  if (!entry?.enabled) return false;
+  return onExecute(entry.id);
+}
+
+export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
+  return (
+    event.key.toLowerCase() === COMMAND_PALETTE_SHORTCUT_KEY &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
+export function createCommandPalette({
+  document,
+  entries,
+  onExecute,
+  canOpen,
+  isShortcut = isCommandPaletteShortcut,
+  classes,
+  ariaLabel = 'Command palette',
+}: CommandPaletteOptions): CommandPaletteController {
+  const view = document.defaultView;
+
+  // Reactive state — every mutation calls renderTemplate() to keep the DOM
+  // in sync. wa-dialog handles modal backdrop, focus trap, escape key, and
+  // focus restoration natively, so we no longer manage those by hand.
+  let visibleEntries: CommandPaletteEntry[] = [...entries];
+  let activeIndex = entries.length > 0 ? 0 : -1;
+  let query = '';
+
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  if (classes?.dialog) dialog.classList.add(classes.dialog);
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = true;
+  dialog.setAttribute('aria-label', ariaLabel);
+
+  const executeActiveCommand = (): void => {
+    const entry = visibleEntries[activeIndex];
+    if (executeCommandPaletteEntry(entry, onExecute)) close();
+  };
+
+  const handleFilterInput = (event: Event): void => {
+    const target = event.target as WaInput | null;
+    query = target?.value ?? '';
+    visibleEntries = filterCommandPaletteEntries(entries, query);
+    activeIndex = visibleEntries.length > 0 ? 0 : -1;
+    renderTemplate();
+  };
+
+  const handleFilterKeydown = (event: KeyboardEvent): void => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        activeIndex = getNextCommandPaletteIndex(
+          activeIndex,
+          visibleEntries.length,
+          1,
+        );
+        renderTemplate();
+        scrollActiveItemIntoView();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        activeIndex = getNextCommandPaletteIndex(
+          activeIndex,
+          visibleEntries.length,
+          -1,
+        );
+        renderTemplate();
+        scrollActiveItemIntoView();
+        break;
+      case 'Enter':
+        event.preventDefault();
+        executeActiveCommand();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleItemMouseEnter = (index: number) => (): void => {
+    activeIndex = index;
+    renderTemplate();
+  };
+
+  const handleItemClick = (entry: CommandPaletteEntry) => (): void => {
+    if (executeCommandPaletteEntry(entry, onExecute)) close();
+  };
+
+  const inputClass = classes?.input;
+  const listClass = classes?.list;
+  const itemClass = classes?.item;
+  const labelClass = classes?.label;
+  const metaClass = classes?.meta;
+
+  const renderTemplate = (): void => {
+    render(
+      html`
+        <wa-input
+          class=${inputClass ?? ''}
+          type="search"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="Run command"
+          aria-label="Run command"
+          .value=${query}
+          @input=${handleFilterInput}
+          @keydown=${handleFilterKeydown}
+        ></wa-input>
+        <div class=${listClass ?? ''} role="listbox">
+          ${repeat(
+            visibleEntries,
+            (entry) => entry.id,
+            (entry, index) => html`
+              <button
+                class=${itemClass ?? ''}
+                type="button"
+                role="option"
+                data-command-id=${entry.id}
+                ?disabled=${!entry.enabled}
+                aria-selected=${index === activeIndex ? 'true' : 'false'}
+                @mouseenter=${handleItemMouseEnter(index)}
+                @click=${handleItemClick(entry)}
+              >
+                <span class=${labelClass ?? ''}>${entry.label}</span>
+                <span class=${metaClass ?? ''}>${entry.meta ?? ''}</span>
+              </button>
+            `,
+          )}
+        </div>
+      `,
+      dialog,
+    );
+  };
+
+  const scrollActiveItemIntoView = (): void => {
+    if (!itemClass) return;
+    const items = dialog.querySelectorAll<HTMLButtonElement>(`.${itemClass}`);
+    items.item(activeIndex)?.scrollIntoView({ block: 'nearest' });
+  };
+
+  const open = (): void => {
+    if (canOpen?.() === false) return;
+    if (dialog.open) return;
+    query = '';
+    visibleEntries = [...entries];
+    activeIndex = visibleEntries.length > 0 ? 0 : -1;
+    renderTemplate();
+    dialog.open = true;
+  };
+
+  const close = (): void => {
+    if (!dialog.open) return;
+    dialog.open = false;
+  };
+
+  // wa-dialog focuses its first focusable child on show. Override that to
+  // focus the filter input directly so users can start typing immediately.
+  dialog.addEventListener('wa-after-show', () => {
+    const input = inputClass
+      ? dialog.querySelector<WaInput>(`.${inputClass}`)
+      : dialog.querySelector<WaInput>('wa-input');
+    input?.focus();
+  });
+
+  // Global Cmd/Ctrl+K shortcut — must live on the document so it fires when
+  // no palette descendant is focused. canOpen guards against modal dialogs
+  // (e.g. the onboarding walkthrough) stealing the shortcut while visible.
+  if (isShortcut) {
+    document.defaultView?.addEventListener('keydown', (event) => {
+      if (!isShortcut(event)) return;
+      if (isTextEntryShortcutTarget(view, document, event)) return;
+      event.preventDefault();
+      open();
+    });
+  }
+
+  renderTemplate();
+  return { element: dialog, open, close };
+}
+
+function isElement(
+  view: Window | null,
+  target: EventTarget | null,
+): target is Element {
+  const elementConstructor =
+    view == null
+      ? undefined
+      : (view as Window & { Element?: typeof Element }).Element;
+  return elementConstructor != null && target instanceof elementConstructor;
+}
+
+function isTextEntryShortcutTarget(
+  view: Window | null,
+  document: Document,
+  event: KeyboardEvent,
+): boolean {
+  if (event.composedPath().some((target) => isTextEntryElement(view, target))) {
+    return true;
+  }
+  return isTextEntryElement(view, getDeepActiveElement(document));
+}
+
+function isTextEntryElement(
+  view: Window | null,
+  target: EventTarget | null,
+): boolean {
+  if (!isElement(view, target)) return false;
+  return (
+    target.closest(
+      'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+    ) != null
+  );
+}
+
+function getDeepActiveElement(document: Document): Element | null {
+  let activeElement = document.activeElement;
+  while (activeElement?.shadowRoot?.activeElement) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
+  return activeElement;
+}

--- a/src/shared/wa/walkthroughDialog.ts
+++ b/src/shared/wa/walkthroughDialog.ts
@@ -1,0 +1,188 @@
+// Host-neutral first-run walkthrough dialog. Hosts supply the heading copy,
+// numbered steps, and footer actions; the helper owns wa-dialog wiring,
+// focus restore, and the user-vs-programmatic dismissal distinction.
+//
+// Stays inside `src/shared/wa/` per CLAUDE.md "VS Code-free zones": no
+// `vscode` imports, no Electron-specific APIs. The desktop renderer wraps
+// this with its DESKTOP_ONBOARDING IPC + DesktopRoute concerns; future
+// extension webviews will wrap it with their own walkthrough commands.
+
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import { html, nothing, render, type TemplateResult } from 'lit';
+
+import { isCommandPaletteShortcut } from './commandPalette';
+import { waIcon, type TeXRAIconName } from './webAwesomeIcons';
+
+export interface WalkthroughStep {
+  readonly index: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface WalkthroughAction {
+  readonly label: string;
+  readonly onClick: () => void;
+  // The "primary" action also serves as the initial focus target on show —
+  // restoring the original "Got it"-first focus policy.
+  readonly emphasis?: 'primary' | 'secondary';
+  readonly className?: string;
+  readonly appearance?: 'filled' | 'outlined' | 'plain';
+  readonly variant?: 'brand' | 'neutral';
+}
+
+export interface WalkthroughDialogOptions {
+  readonly document: Document;
+  readonly title: string;
+  readonly description: string;
+  readonly steps: readonly WalkthroughStep[];
+  readonly actions: readonly WalkthroughAction[];
+  // Called on every user-initiated dismissal (Escape, primary button, etc.).
+  // Programmatic hide() suppresses this callback to avoid feedback loops with
+  // host state-sync messages.
+  readonly onUserDismiss: () => void;
+  readonly icon?: TeXRAIconName;
+  readonly classes?: WalkthroughDialogClassNames;
+}
+
+export interface WalkthroughDialogClassNames {
+  readonly dialog?: string;
+  readonly header?: string;
+  readonly icon?: string;
+  readonly steps?: string;
+  readonly stepIndex?: string;
+  readonly actions?: string;
+}
+
+export interface WalkthroughDialogController {
+  element: HTMLElement;
+  isVisible(): boolean;
+  show(): void;
+  hide(): void;
+}
+
+const TITLE_ID = 'shared-walkthrough-title';
+
+export function createWalkthroughDialog({
+  document,
+  title,
+  description,
+  steps,
+  actions,
+  onUserDismiss,
+  icon = 'circle-info',
+  classes,
+}: WalkthroughDialogOptions): WalkthroughDialogController {
+  const dialog = document.createElement('wa-dialog');
+  if (classes?.dialog) dialog.classList.add(classes.dialog);
+  dialog.withoutHeader = true;
+  // The visible <h1> inside the body is the dialog's accessible name; ARIA
+  // resolves it via aria-labelledby below. Skip the redundant `label`
+  // attribute that would otherwise add an extra aria-label.
+  dialog.setAttribute('aria-labelledby', TITLE_ID);
+
+  // Distinguishes user-initiated close (Escape / button click) — which fires
+  // the dismissed callback back to the host — from programmatic close from
+  // hide(), which would otherwise feedback-loop with host state syncs.
+  let suppressNextPost = false;
+
+  const closeDialog = (): void => {
+    dialog.open = false;
+  };
+
+  const headerClass = classes?.header;
+  const iconClass = classes?.icon;
+  const stepsClass = classes?.steps;
+  const stepIndexClass = classes?.stepIndex;
+  const actionsClass = classes?.actions;
+
+  const actionTemplate = (action: WalkthroughAction): TemplateResult => html`
+    <wa-button
+      class=${action.className ?? ''}
+      appearance=${action.appearance ?? 'outlined'}
+      variant=${action.variant ?? 'neutral'}
+      ?data-walkthrough-primary=${action.emphasis === 'primary'}
+      @click=${() => {
+        action.onClick();
+        closeDialog();
+      }}
+    >
+      ${action.label}
+    </wa-button>
+  `;
+
+  render(
+    html`
+      <header class=${headerClass ?? ''}>
+        ${waIcon(icon, { className: iconClass })}
+        <div>
+          <h1 id=${TITLE_ID}>${title}</h1>
+          <p>${description}</p>
+        </div>
+      </header>
+      <ol class=${stepsClass ?? ''}>
+        ${steps.map(
+          (step) => html`
+            <li>
+              <span class=${stepIndexClass ?? ''}>${step.index}</span>
+              <div>
+                <strong>${step.title}</strong>
+                <span>${step.body}</span>
+              </div>
+            </li>
+          `,
+        )}
+      </ol>
+      ${actions.length > 0
+        ? html`
+            <div slot="footer" class=${actionsClass ?? ''}>
+              ${actions.map(actionTemplate)}
+            </div>
+          `
+        : nothing}
+    `,
+    dialog,
+  );
+
+  // wa-dialog handles modal backdrop, focus trap, escape key, and focus
+  // restoration automatically. Reapply the previous "primary action focused
+  // first" policy so keyboard users can dismiss with one Enter, and intercept
+  // the command-palette shortcut so it does not fire while the dialog is open.
+  dialog.addEventListener('wa-after-show', () => {
+    dialog
+      .querySelector<HTMLElement>('[data-walkthrough-primary]')
+      ?.focus();
+  });
+  // Every user-initiated dismissal (Escape, footer buttons) posts the
+  // dismissed signal back to the host. Programmatic hide() suppresses the
+  // post via suppressNextPost to avoid a feedback loop with state messages.
+  dialog.addEventListener('wa-after-hide', () => {
+    if (suppressNextPost) {
+      suppressNextPost = false;
+      return;
+    }
+    onUserDismiss();
+  });
+  // Scoped to the dialog so it only runs while open and only for keys that
+  // originate inside it. stopPropagation prevents the global command-palette
+  // listener (on document) from firing.
+  dialog.addEventListener('keydown', (event) => {
+    if (isCommandPaletteShortcut(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  });
+
+  return {
+    element: dialog,
+    isVisible: () => dialog.open,
+    show: () => {
+      dialog.open = true;
+    },
+    hide: () => {
+      if (!dialog.open) return;
+      suppressNextPost = true;
+      dialog.open = false;
+    },
+  };
+}

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -21,6 +21,13 @@ function readRendererOnboarding(): string {
   );
 }
 
+function readSharedWalkthroughDialog(): string {
+  return readFileSync(
+    repoPath('src/shared/wa/walkthroughDialog.ts'),
+    'utf8',
+  );
+}
+
 describe('desktop renderer shell', () => {
   it('mounts the reused launcher, progress, and settings Lit apps', () => {
     const rendererMain = readRendererMain();
@@ -44,13 +51,16 @@ describe('desktop renderer shell', () => {
   it('provides persistent shell controls for returning between routes', () => {
     const rendererMain = readRendererMain();
 
-    expect(rendererMain).toContain("{ route: 'main', label: 'Launcher' }");
-    expect(rendererMain).toContain("{ route: 'progress', label: 'Progress' }");
-    expect(rendererMain).toContain("{ route: 'settings', label: 'Settings' }");
-    expect(rendererMain).toContain("{ route: 'logs', label: 'Logs' }");
-    expect(rendererMain).toContain('data-route-button=${route}');
-    expect(rendererMain).toContain("button.addEventListener('click'");
-    expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
+    // The chrome was simplified to show only Settings + Logs as icon
+    // buttons; other routes are reachable through the command palette and
+    // the "Back to Launcher" affordance. CHROME_ICON_BUTTONS keeps both
+    // lists aligned so future contributors update them together.
+    expect(rendererMain).toContain('CHROME_ICON_BUTTONS');
+    expect(rendererMain).toContain("route: 'settings'");
+    expect(rendererMain).toContain("route: 'logs'");
+    expect(rendererMain).toContain('data-route-button=${spec.route}');
+    expect(rendererMain).toContain('aria-pressed=${String(currentRoute');
+    expect(rendererMain).toContain('toggleRoute');
   });
 
   it('mounts a persistent workspace explorer sidebar', () => {
@@ -67,7 +77,11 @@ describe('desktop renderer shell', () => {
     const rendererMain = readRendererMain();
 
     expect(rendererMain).toContain('createDesktopCommandPalette');
-    expect(rendererMain).toContain('data-command-palette-button');
+    // The chrome exposes a "Commands" button that opens the palette via the
+    // module-scoped commandPalette controller. Earlier revisions used a
+    // data-command-palette-button hook; the WA migration switched to a
+    // direct @click=${openCommandPalette} binding instead.
+    expect(rendererMain).toContain('openCommandPalette');
     expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
     expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
   });
@@ -75,6 +89,7 @@ describe('desktop renderer shell', () => {
   it('mounts desktop-only first-run onboarding controls', () => {
     const rendererMain = readRendererMain();
     const rendererOnboarding = readRendererOnboarding();
+    const sharedWalkthrough = readSharedWalkthroughDialog();
 
     expect(rendererMain).toContain('createFirstRunWalkthrough');
     expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE');
@@ -86,17 +101,22 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain(
       'canOpen: () => !firstRunWalkthrough?.isVisible()',
     );
-    // wa-dialog handles focus trap, escape, and modal backdrop natively.
-    // Assert the dialog wiring + the one custom keydown interceptor.
-    expect(rendererOnboarding).toContain("document.createElement('wa-dialog')");
-    expect(rendererOnboarding).toContain(
+    // The desktop wrapper now delegates wa-dialog wiring to the host-neutral
+    // helper in `src/shared/wa/walkthroughDialog.ts`. The wrapper supplies
+    // copy + classes; the shared helper owns the dialog lifecycle so both
+    // hosts (extension webview + Electron renderer) share the same focus,
+    // dismiss, and shortcut-interception behavior.
+    expect(rendererOnboarding).toContain('createWalkthroughDialog');
+    expect(rendererOnboarding).toContain('Welcome to TeXRA Desktop');
+    expect(sharedWalkthrough).toContain("document.createElement('wa-dialog')");
+    expect(sharedWalkthrough).toContain(
       "dialog.addEventListener('wa-after-show'",
     );
-    expect(rendererOnboarding).toContain(
+    expect(sharedWalkthrough).toContain(
       "dialog.addEventListener('wa-after-hide'",
     );
-    expect(rendererOnboarding).toContain("dialog.addEventListener('keydown'");
-    expect(rendererOnboarding).toContain('isCommandPaletteShortcut(event)');
+    expect(sharedWalkthrough).toContain("dialog.addEventListener('keydown'");
+    expect(sharedWalkthrough).toContain('isCommandPaletteShortcut(event)');
   });
 
   it('mounts an in-app log viewer with copy and export actions', () => {


### PR DESCRIPTION
## Summary

Hoists `desktopCommandPalette` and `desktopOnboarding` into `src/shared/wa/` via a host-neutral command surface so the extension webview can adopt the same wa-dialog modals.

- New `src/shared/wa/commandPalette.ts` owns the wa-dialog shell, filter input, arrow/Enter wiring, and global Cmd/Ctrl+K shortcut. Hosts pass a pre-resolved `entries` array, an `onExecute` dispatcher, optional `canOpen` guard, and class-name hooks. No `vscode` / Electron imports per the CLAUDE.md "VS Code-free zones" rule.
- New `src/shared/wa/walkthroughDialog.ts` owns wa-dialog focus, user-vs-programmatic dismissal, and command-palette-shortcut interception. Hosts supply title / description / steps / actions.
- Desktop wrappers shrink to thin shells: `desktopCommandPalette.ts` pulls entries from `desktopCommandSurface` (which keeps the Electron accelerator + `@commands/catalog` coupling) and forwards `.desktop-command-palette-*` class hooks; `desktopOnboarding.ts` supplies the desktop copy, Settings / Launcher / Got it actions, and `.desktop-onboarding-*` class hooks.
- CSS unchanged (class hooks are forwarded), e2e "Got it" selector unchanged, IPC and command catalog unchanged.

## Test plan

- [x] `npx vitest run src/test-kernel/desktop/DesktopCommandPalette.vitest.mts` — 10/10 pass against the new wrapper (filter, index wrap, disabled gate, shortcut shape, render + Enter dispatch, click dispatch, arrow nav, canOpen, text-entry guard, wa-input shadow root).
- [x] `npx vitest run src/test-kernel/desktop/ElectronRendererShell.vitest.mts` — 7/7 pass; pre-existing failures (`data-command-palette-button`, `Launcher`/`Progress` route labels) are now corrected to match the WA chrome simplification, and walkthrough wa-dialog wiring assertions point at the shared module.
- [x] `npx vite build --mode development` in `packages/desktop` — clean.
- [x] `npm run lint` — no new warnings in changed files (only pre-existing import-order warnings elsewhere).
- [x] `npm run typecheck` — no new errors in changed files (pre-existing `@openrouter/sdk/models` and `electron`-types errors are unrelated).
- [ ] `pnpm --filter @texra/desktop test:e2e` — verify Cmd+K still opens the palette and the walkthrough still dismisses via "Got it".

Closes #3755.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it centralizes keyboard shortcuts, focus behavior, and dismissal semantics into new shared dialog helpers, which can subtly change UX or event handling across hosts.
> 
> **Overview**
> Refactors the desktop renderer’s command palette and first-run onboarding to delegate all `wa-dialog` rendering, keyboard handling (including Cmd/Ctrl+K), filtering/navigation, and focus management to new host-neutral helpers in `src/shared/wa`.
> 
> `desktopCommandPalette.ts` and `desktopOnboarding.ts` are reduced to thin wrappers that supply desktop-specific command entries/callbacks, copy, and CSS class hooks (including mapping desktop accelerator/category/unavailable reasons into a neutral `meta` column).
> 
> Updates desktop renderer shell tests to assert the new shared walkthrough implementation and reflect the simplified desktop chrome interactions (e.g., palette opened via `openCommandPalette`, and route buttons constrained to Settings/Logs icon buttons).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b8ab82d5c694b8db73c3ff864f6ad1bc33d120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->