### PR TITLE
fix(desktop): add quiet-variant WA tokens to high-contrast theme (closes #3756)

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -317,6 +317,33 @@ body.texra-high-contrast {
   --wa-color-list-active-fg: HighlightText;
   --wa-color-brand-on-loud: HighlightText;
   --wa-color-brand-border-loud: CanvasText;
+
+  /* Quiet variants for HC modes — without these, components fall back to
+     dark/light surface colors (low contrast against system Canvas).
+     Per the WCAG 1.4.11 + W3C high-contrast guidance, use the system
+     color keywords (Canvas/CanvasText/Highlight/Mark/ButtonFace) so the
+     OS palette dictates contrast. */
+  --wa-color-text-quiet: GrayText;
+
+  --wa-color-brand-fill-quiet: Canvas;
+  --wa-color-brand-border-quiet: Highlight;
+  --wa-color-brand-on-quiet: Highlight;
+
+  --wa-color-neutral-fill-quiet: ButtonFace;
+  --wa-color-neutral-border-quiet: CanvasText;
+  --wa-color-neutral-on-quiet: ButtonText;
+
+  --wa-color-warning-fill-quiet: Canvas;
+  --wa-color-warning-border-quiet: Mark;
+  --wa-color-warning-on-quiet: Mark;
+
+  --wa-color-danger-fill-quiet: Canvas;
+  --wa-color-danger-border-quiet: Mark;
+  --wa-color-danger-on-quiet: Mark;
+
+  --wa-color-success-fill-quiet: Canvas;
+  --wa-color-success-border-quiet: Highlight;
+  --wa-color-success-on-quiet: Highlight;
 }
 
 /* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes


### PR DESCRIPTION
Closes #3756. Adds the missing brand/neutral/warning/danger/success quiet variants in the HC override block so components don't fall back to dark/light surface colors in HC modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only token additions scoped to high-contrast mode; main risk is unintended color/contrast regressions for HC users.
> 
> **Overview**
> Fixes high-contrast theming by defining the missing `--wa-color-*-quiet` tokens (text, brand, neutral, warning, danger, success) in the desktop high-contrast override block.
> 
> These tokens now map to system color keywords (`Canvas`, `CanvasText`, `Highlight`, `Mark`, etc.) to keep contrast OS-driven and avoid WA components falling back to light/dark surface colors in HC modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcb58f9668b4100acbdfbf37320c530dce53bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->