### PR TITLE
fix(wa): bot-review findings on #3762/#3763 + native/consolidation audit

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -107,6 +107,10 @@ function toPaletteEntry(
     id: entry.id,
     label: entry.label,
     meta,
+    // Always include `category` so the palette filter can match it even when
+    // `meta` is occupied by an accelerator or unavailable-reason — restoring
+    // the original imperative haystack which always carried `category`.
+    category: entry.category,
     enabled: entry.enabled,
   };
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -9,7 +9,9 @@ import '@awesome.me/webawesome/dist/components/tree-item/tree-item.js';
 import type WaTreeItem from '@awesome.me/webawesome/dist/components/tree-item/tree-item.js';
 import { html, nothing, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderEmptyState } from '@shared/wa/emptyState';
+import { setWaColorScheme } from '@shared/wa/waColorScheme';
 import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 import { COMMON_COMMANDS } from '@common/webview/commands';
@@ -333,6 +335,14 @@ function renderBootstrapFallback(error: unknown): void {
                     'TeXRA desktop renderer recovery failed',
                     recoveryError,
                   );
+                  // Recovery render threw — the shell is NOT mounted, so
+                  // restore the bootstrap-failed latch so subsequent
+                  // navigation guards still treat boot as broken. Without
+                  // this, a successful `bootstrapFailed = false` followed
+                  // by a thrown `rerenderShell()` would leave the latch
+                  // in an inconsistent "recovered" state while the actual
+                  // DOM is back in the fallback.
+                  bootstrapFailed = true;
                   renderBootstrapFallback(recoveryError);
                 }
               }}
@@ -520,10 +530,9 @@ function applyDesktopTheme(theme: DesktopThemeKind): void {
   document.body.classList.add(`vscode-${theme}`, `texra-${theme}`);
   document.body.dataset.vscodeThemeKind = theme;
   // Apply Web Awesome's native color-scheme class on the document root so
-  // WA's --wa-* dark-mode overrides activate (per WA theming model).
-  const docRoot = document.documentElement;
-  docRoot.classList.remove('wa-light', 'wa-dark');
-  docRoot.classList.add(theme === 'light' ? 'wa-light' : 'wa-dark');
+  // WA's --wa-* dark-mode overrides activate. Shared helper keeps the class
+  // set + ordering in lockstep with the VS Code BaseWebviewApp path.
+  setWaColorScheme(theme !== 'light');
 }
 
 function getWindowTargetOrigin(): string {
@@ -534,20 +543,21 @@ function getWindowTargetOrigin(): string {
 }
 
 function logViewerTemplate(state: LogViewerState): TemplateResult {
+  // Shared labeled-action button (icon + text, outlined, small) — used to be
+  // hand-rolled here; reuse the helper so we get consistent class names,
+  // aria-label fallback, and class composition with the rest of the codebase.
   const action = (
     icon: 'rotate-right' | 'copy' | 'download' | 'folder-open',
     label: string,
     onClick: () => void,
-  ): TemplateResult => html`
-    <wa-button
-      class="desktop-secondary-button"
-      appearance="outlined"
-      size="small"
-      @click=${onClick}
-    >
-      ${waIcon(icon, { slot: 'start' })} ${label}
-    </wa-button>
-  `;
+  ): TemplateResult =>
+    renderLabeledActionButton({
+      icon,
+      text: label,
+      className: 'desktop-secondary-button',
+      appearance: 'outlined',
+      onClick,
+    });
   return html`
     <section class="desktop-log-viewer">
       <header class="desktop-log-viewer-header">

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -14,6 +14,7 @@ import { themeContext } from '@shared/contexts/themeContext';
 
 // Local imports - webview commands
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
+import { setWaColorScheme } from '@shared/wa/waColorScheme';
 
 /**
  * Base class for Lit-powered webview apps.
@@ -73,16 +74,16 @@ export abstract class BaseWebviewApp<TMessage = any> extends LitElement {
   protected onThemeChange(theme: string): void {
     this.theme = theme;
     document.body.className = theme;
-    const root = document.documentElement;
-    root.classList.remove('wa-light', 'wa-dark');
     // 'high-contrast' renders against the active OS color-scheme — pick dark
-    // unless the body class explicitly signals light HC.
+    // unless the body class explicitly signals light HC. Defer the actual
+    // class swap to the shared helper so the class set + ordering stays in
+    // one place across hosts.
     const wantsDark =
       theme === 'dark' ||
       theme === 'high-contrast' ||
       document.body.classList.contains('vscode-dark') ||
       document.body.classList.contains('vscode-high-contrast');
-    root.classList.add(wantsDark ? 'wa-dark' : 'wa-light');
+    setWaColorScheme(wantsDark);
   }
 
   /**

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -58,9 +58,20 @@ export type ExtendedFileType = z.infer<typeof ExtendedFileTypeSchema>;
 // Option Data Schemas
 // ============================================================
 
-export const ModelOptionDataSchema = z.object({
+/**
+ * Shared base for picker option rows (`<wa-select>`-style entries). Both the
+ * model and agent picker shapes carry an opaque `value` (the id sent back to
+ * the host) and a user-facing `label`. Consolidating this base via `.extend()`
+ * keeps the two field names in lockstep — historically a typo in either schema
+ * would have silently broken option matching in only one picker.
+ */
+export const PickerOptionBaseSchema = z.object({
   value: z.string(),
   label: z.string(),
+});
+export type PickerOptionBase = z.infer<typeof PickerOptionBaseSchema>;
+
+export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),
@@ -70,9 +81,7 @@ export const ModelOptionDataSchema = z.object({
 });
 export type ModelOptionData = z.infer<typeof ModelOptionDataSchema>;
 
-export const AgentOptionDataSchema = z.object({
-  value: z.string(),
-  label: z.string(),
+export const AgentOptionDataSchema = PickerOptionBaseSchema.extend({
   isToolUse: z.boolean().optional(),
   isOrchestrator: z.boolean().optional(),
   isRemote: z.boolean().optional(),

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -17,12 +17,16 @@ import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js'
 
 // Single command row. `meta` is the trailing label (host-defined: an
 // accelerator hint, an unavailable reason, a category, etc.) so the palette
-// stays opinion-free about how hosts format that column. `enabled === false`
+// stays opinion-free about how hosts format that column. `category` is an
+// optional, separate field that hosts can include in the search haystack
+// without displaying — useful when `meta` is reserved for an accelerator
+// but the row should still match category-name queries. `enabled === false`
 // renders the row but disables click/Enter dispatch.
 export interface CommandPaletteEntry {
   readonly id: string;
   readonly label: string;
   readonly meta?: string;
+  readonly category?: string;
   readonly enabled: boolean;
 }
 
@@ -30,9 +34,11 @@ export interface CommandPaletteOptions {
   readonly document: Document;
   readonly entries: readonly CommandPaletteEntry[];
   readonly onExecute: (id: string) => boolean;
-  // Returning false suppresses the global Cmd/Ctrl+K shortcut (e.g. while a
-  // first-run walkthrough is visible). Click and programmatic open() always
-  // proceed regardless of the guard.
+  // Returning false suppresses ALL palette opens — both the global
+  // Cmd/Ctrl+K shortcut and any direct `controller.open()` call (e.g. while
+  // a first-run walkthrough is visible). The guard runs at the entry of
+  // open(), so hosts that want shortcut-only suppression should pass a
+  // custom `isShortcut` instead.
   readonly canOpen?: () => boolean;
   // Override the host shortcut (defaults to Cmd/Ctrl+K). Hosts that already
   // own a global keybinding manager can pass `null` to disable the helper's
@@ -73,7 +79,13 @@ export function filterCommandPaletteEntries<
 
   const queryParts = normalizedQuery.split(/\s+/);
   return entries.filter((entry) => {
-    const haystack = `${entry.label} ${entry.category ?? entry.meta ?? ''} ${entry.id}`
+    // Include both `category` and `meta` (separated by a space) so hosts that
+    // reserve `meta` for an accelerator/reason can still surface a row by
+    // category-name match. Empty/undefined fields collapse to '' and don't
+    // affect matching.
+    const category = entry.category ?? '';
+    const meta = entry.meta ?? '';
+    const haystack = `${entry.label} ${category} ${meta} ${entry.id}`
       .replaceAll('.', ' ')
       .toLowerCase();
     return queryParts.every((part) => haystack.includes(part));
@@ -230,8 +242,11 @@ export function createCommandPalette({
   };
 
   const scrollActiveItemIntoView = (): void => {
-    if (!itemClass) return;
-    const items = dialog.querySelectorAll<HTMLButtonElement>(`.${itemClass}`);
+    // Prefer the host-supplied class selector when provided; otherwise fall
+    // back to the role attribute every rendered row carries (`role="option"`)
+    // so arrow navigation still scrolls when no `classes.item` was passed.
+    const selector = itemClass ? `.${itemClass}` : '[role="option"]';
+    const items = dialog.querySelectorAll<HTMLElement>(selector);
     items.item(activeIndex)?.scrollIntoView({ block: 'nearest' });
   };
 

--- a/src/shared/wa/waColorScheme.ts
+++ b/src/shared/wa/waColorScheme.ts
@@ -56,6 +56,20 @@ function syncWaClass(): void {
   }
 }
 
+/**
+ * Imperatively swap the `wa-light`/`wa-dark` class on `<html>` to match the
+ * provided dark/light intent. Both hosts (VS Code BaseWebviewApp and the
+ * Electron renderer) used to hand-roll this two-line dance; centralising it
+ * here keeps the class names + ordering in one place so any future addition
+ * (e.g. `wa-high-contrast`) doesn't need parallel edits.
+ */
+export function setWaColorScheme(dark: boolean): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.classList.remove('wa-light', 'wa-dark');
+  root.classList.add(dark ? 'wa-dark' : 'wa-light');
+}
+
 export function applyInitialWaColorScheme(): void {
   if (typeof document === 'undefined') return;
   syncWaClass();

--- a/src/shared/wa/walkthroughDialog.ts
+++ b/src/shared/wa/walkthroughDialog.ts
@@ -61,7 +61,20 @@ export interface WalkthroughDialogController {
   hide(): void;
 }
 
-const TITLE_ID = 'shared-walkthrough-title';
+// Per-instance counter fallback for environments without crypto.randomUUID
+// (older webviews). Each createWalkthroughDialog() call grabs a unique id so
+// two co-existing dialogs cannot collide on aria-labelledby.
+let walkthroughTitleCounter = 0;
+
+function nextWalkthroughTitleId(): string {
+  const cryptoApi: Crypto | undefined =
+    typeof crypto !== 'undefined' ? crypto : undefined;
+  if (typeof cryptoApi?.randomUUID === 'function') {
+    return `walkthrough-title-${cryptoApi.randomUUID()}`;
+  }
+  walkthroughTitleCounter += 1;
+  return `walkthrough-title-${walkthroughTitleCounter}`;
+}
 
 export function createWalkthroughDialog({
   document,
@@ -73,13 +86,14 @@ export function createWalkthroughDialog({
   icon = 'circle-info',
   classes,
 }: WalkthroughDialogOptions): WalkthroughDialogController {
+  const titleId = nextWalkthroughTitleId();
   const dialog = document.createElement('wa-dialog');
   if (classes?.dialog) dialog.classList.add(classes.dialog);
   dialog.withoutHeader = true;
   // The visible <h1> inside the body is the dialog's accessible name; ARIA
   // resolves it via aria-labelledby below. Skip the redundant `label`
   // attribute that would otherwise add an extra aria-label.
-  dialog.setAttribute('aria-labelledby', TITLE_ID);
+  dialog.setAttribute('aria-labelledby', titleId);
 
   // Distinguishes user-initiated close (Escape / button click) — which fires
   // the dismissed callback back to the host — from programmatic close from
@@ -116,7 +130,7 @@ export function createWalkthroughDialog({
       <header class=${headerClass ?? ''}>
         ${waIcon(icon, { className: iconClass })}
         <div>
-          <h1 id=${TITLE_ID}>${title}</h1>
+          <h1 id=${titleId}>${title}</h1>
           <p>${description}</p>
         </div>
       </header>


### PR DESCRIPTION
## Summary

Addresses outstanding bot-review findings on #3762 (cursor) and #3763 (Copilot + cursor), then continues the native-coding audit / extension-vs-desktop consolidation pass.

### Bot review fixes

- **desktop main.ts (#3762):** the "Continue without saved secrets" recovery path used to set `bootstrapFailed = false` and call `rerenderShell()`. If that recovery render itself threw, the catch never restored the latch, leaving `bootstrapFailed = false` even though the DOM had reverted to the fallback. The catch now re-asserts `bootstrapFailed = true` before re-rendering the bootstrap fallback.
- **commandPalette.ts canOpen doc (#3763 Copilot):** `canOpen` runs at the top of `open()`, so it suppresses every open call (shortcut, click, programmatic). Doc updated to say so explicitly and to point hosts at a custom `isShortcut` for shortcut-only suppression.
- **commandPalette.ts scrollActiveItemIntoView (#3763 Copilot):** when no `classes.item` is supplied, arrow navigation moved the active index without scrolling. Now falls back to `[role="option"]` (the role every rendered row already carries).
- **walkthroughDialog.ts aria-labelledby (#3763 Copilot):** static `TITLE_ID` could collide if two dialogs co-existed. Now generates a per-instance id via `crypto.randomUUID()` with a counter fallback for environments without it.
- **desktopCommandPalette.ts filter haystack (#3763 cursor):** the desktop wrapper packed `unavailableReason ?? accelerator ?? category` into `meta`, but the shared filter consulted `category ?? meta ?? ''`, dropping `category` whenever an accelerator was present. `CommandPaletteEntry` now carries `category` separately, the shared filter combines both fields with a space, and the wrapper passes both through — restoring the original imperative haystack.

### Consolidation (Task 2)

- **Theme bridge (extension + desktop):** both hosts hand-rolled `wa-light`/`wa-dark` swap on `<html>`. Hoisted into `setWaColorScheme(dark)` in `src/shared/wa/waColorScheme.ts`; `BaseWebviewApp.onThemeChange()` and the desktop `applyDesktopTheme()` now both call it.
- **Action button helper:** the desktop log viewer used a local `action()` template that exactly duplicated `renderLabeledActionButton`. Replaced with the shared helper (CSS still keys off `.desktop-secondary-button`, which the helper composes alongside the shared `action-button` class).
- **Zod schema composition:** `ModelOptionDataSchema` and `AgentOptionDataSchema` both started with `value: z.string(), label: z.string()`. Extracted `PickerOptionBaseSchema` and use `.extend()` so the picker base stays canonical and a typo in either schema would no longer silently break only one picker.

## Test plan

- [x] `npm run typecheck` — clean except for pre-existing OpenRouter SDK + electron type errors (unchanged from `origin/main`).
- [x] `cd packages/desktop && npx vite build --mode development` — clean (1.0s).
- [x] `npx vitest run` — 4 pre-existing failures in `DesktopThemeTokens` / `ElectronCompositionRoot` (missing `fix-path` / theme-token regex), present on `origin/main`. All 330 other tests pass.
- [ ] `cd packages/desktop && pnpm test:e2e` — pre-existing Playwright module-resolution error (`SETTINGS_TAB` named export not found) reproduces on `origin/main`; not introduced by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared UI primitives (command palette, walkthrough dialog, theme class handling) and the desktop renderer bootstrap recovery path, which could affect navigation and theming across hosts if regressions slip in.
> 
> **Overview**
> Improves reliability and consistency of Web Awesome UI helpers across the Electron desktop renderer and shared webview code.
> 
> Fixes command-palette matching and behavior by **adding an explicit `category` field** to entries, updating filtering to search `label` + `category` + `meta` + `id`, clarifying that `canOpen` blocks *all* opens, and ensuring arrow-key navigation scrolls even when no item class is provided.
> 
> Hardens desktop bootstrap recovery by restoring the `bootstrapFailed` latch if the recovery re-render throws, centralizes `wa-light`/`wa-dark` swapping via `setWaColorScheme()` (used by both desktop and `BaseWebviewApp`), replaces a hand-rolled log-viewer action button with the shared `renderLabeledActionButton`, and deduplicates picker option schemas via a shared `PickerOptionBaseSchema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9c644bab06873a73ede2d70c55dc589522f8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->