### PR TITLE
refactor(agent): inline trivial factory wrappers (closes #3746)

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -7,7 +7,6 @@ import {
 import {
   DEFAULT_TOTALS,
   RunUsageAccumulatorJSONSchema,
-  createUsageAccumulator,
   recordNormalizedUsage,
 } from './RunUsageAccumulator';
 export const ConversationRoundStateSnapshotSchema = z.object({
@@ -51,7 +50,10 @@ export function createRunState(): AgentRunStateSnapshot {
   return {
     totalRounds: 0,
     totalResponseTimeMs: 0,
-    usageAccumulator: createUsageAccumulator(),
+    usageAccumulator: {
+      totals: { ...DEFAULT_TOTALS },
+      normalizedSnapshots: [],
+    },
   };
 }
 

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -69,11 +69,6 @@ export type RunUsageAccumulatorJSON = z.output<
 // Standalone functions operating on RunUsageAccumulatorJSON
 // ============================================================================
 
-/** Create a fresh accumulator (all zeros). */
-export function createUsageAccumulator(): RunUsageAccumulatorJSON {
-  return { totals: { ...DEFAULT_TOTALS }, normalizedSnapshots: [] };
-}
-
 /** Record a normalized usage entry. Mutates acc in place. */
 export function recordNormalizedUsage(
   acc: RunUsageAccumulatorJSON,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -35,29 +35,21 @@ export interface CreateRunContextOptions {
 
 const noopLog = (): void => undefined;
 
-function createRunLogger(logger?: Partial<RunLogger>): RunLogger {
-  return Object.freeze({
-    debug: logger?.debug ?? noopLog,
-    info: logger?.info ?? noopLog,
-    warn: logger?.warn ?? noopLog,
-    error: logger?.error ?? noopLog,
-  });
-}
-
-function createApprovalHandlers(
-  approvals?: ApprovalHandlers,
-): ApprovalHandlers {
-  return Object.freeze({ ...approvals });
-}
-
 export function createRunContext(options: CreateRunContextOptions): RunContext {
   if (options.runtimeHost == null) {
     throw new Error('createRunContext requires an explicit runtimeHost');
   }
 
+  const { logger, approvals } = options;
+
   return Object.freeze({
     runtimeHost: options.runtimeHost,
-    logger: createRunLogger(options.logger),
-    approvals: createApprovalHandlers(options.approvals),
+    logger: Object.freeze({
+      debug: logger?.debug ?? noopLog,
+      info: logger?.info ?? noopLog,
+      warn: logger?.warn ?? noopLog,
+      error: logger?.error ?? noopLog,
+    }),
+    approvals: Object.freeze({ ...approvals }),
   });
 }


### PR DESCRIPTION
## Summary

Resolves #3746 by removing three discouraged factory patterns flagged by CLAUDE.md ("Discouraged Factory Patterns" + "Flattening Abstraction Layers"):

- **`createApprovalHandlers`** (`src/agent/runtime/RunContext.ts`) — trivial identity factory (`Object.freeze({ ...approvals })`) called once. Inlined into `createRunContext`.
- **`createRunLogger`** (`src/agent/runtime/RunContext.ts`) — two-layer factory called only from `createRunContext`. Inlined into `createRunContext`.
- **`createUsageAccumulator`** (`src/agent/core/RunUsageAccumulator.ts`) — single-caller zero-state helper duplicating defaults already declared by `RunUsageAccumulatorJSONSchema.prefault(...)`. Deleted; `createRunState` (in `AgentState.ts`) now uses an inline literal so the schema prefault and runtime initializer share one canonical shape.

No behavior change. Net diff: 13 insertions, 24 deletions across 3 files.

## Verified

- `createInterruptCallbacks` was inspected and kept (captures meaningful closure state for `isInterrupted`/`abortController`).
- `createRoundProgressCallback`, `createOutputState`, `createMergeOutputFileLocationGetter`, `createResponseCycleFlow`, `createToolUseCycleFlow` were inspected and kept (multiple callers, closure capture, or DRY-justified).
- `npm run typecheck` produces only the pre-existing baseline errors (electron module, `@openrouter/sdk/models` resolution) — no new errors introduced.
- `npx vitest run` reports the same 4 pre-existing failures as origin/main (desktop theme tokens, missing `fix-path` package); no regressions.

## Test plan

- [ ] CI typecheck remains at the pre-existing baseline (no new errors)
- [ ] CI vitest remains at the pre-existing baseline (no new failures)
- [ ] Smoke: agent execution still freezes `runContext.approvals`/`runContext.logger` (visual code review)
- [ ] Smoke: `createRunState()` returns the same zero-state shape as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes small wrapper factory functions and inlines their equivalent object literals; behavior should remain the same aside from potential subtle object-shape/reference differences.
> 
> **Overview**
> Removes three trivial factory helpers and inlines their logic at the call sites.
> 
> `createRunContext` now directly builds and freezes the `logger` (defaulting to no-op methods) and `approvals` objects, and `createRunState` now constructs the zeroed `usageAccumulator` literal instead of calling `createUsageAccumulator`, which is deleted from `RunUsageAccumulator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155ffa1de9937b2d931be97a54e16d367970965d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->