### PR TITLE
refactor(zod): consolidate command registrations + main-view IPC schema (closes #3693, #3694, #3692)

### DIFF
--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,13 +1,10 @@
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
+import { type SwitchViewTarget } from '@shared/schemas/commonViewMessages';
 import {
-  SwitchViewMessageSchema,
-  type SwitchViewTarget,
-} from '@shared/schemas/commonViewMessages';
-import {
-  OpenAgentDirectoryMessageSchema,
-  OpenAgentSettingsMessageSchema,
+  MainViewInboundMessageSchema,
+  type MainViewInboundMessage,
 } from '@shared/schemas/mainView';
 import {
   SETTINGS_TAB,
@@ -65,21 +62,6 @@ const SWITCH_VIEW_ROUTES = {
   progress: 'progress',
   dashboard: 'settings',
 } satisfies Record<SwitchViewTarget, DesktopRoute>;
-
-function getAgentSettingsSubTab(
-  message: DesktopCommandMessage,
-): AgentCategory | undefined {
-  const result = OpenAgentSettingsMessageSchema.safeParse(message);
-  if (!result.success) return undefined;
-  return result.data.sessionType === AGENT_CATEGORY.TOOL_USE
-    ? AGENT_CATEGORY.TOOL_USE
-    : undefined;
-}
-
-function getCustomDirSet(message: DesktopCommandMessage): boolean {
-  const result = OpenAgentDirectoryMessageSchema.safeParse(message);
-  return result.success && result.data.customDirSet === true;
-}
 
 export function createDesktopShellActions(
   renderer: DesktopRenderer,
@@ -169,6 +151,81 @@ export function createDesktopShellActions(
   };
 }
 
+/**
+ * Dispatch a fully-validated `MainViewInboundMessage` against the shell
+ * actions. The discriminated-union narrowing means each case sees a
+ * fully-typed payload — no per-handler `safeParse` calls are needed.
+ *
+ * Returns `true` when the message was claimed by a shell handler, `false`
+ * when the variant is recognised by the schema but has no shell mapping
+ * (e.g. EXECUTE, file-selection, banner toggles — those are handled by
+ * sibling IPC adapters in the dispatcher chain).
+ */
+function dispatchMainViewInboundOnShell(
+  message: MainViewInboundMessage,
+  actions: DesktopShellActions,
+): boolean {
+  switch (message.command) {
+    case COMMON_COMMANDS.SWITCH_VIEW:
+      actions.showRoute(SWITCH_VIEW_ROUTES[message.view]);
+      return true;
+    case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
+      actions.showSettings();
+      return true;
+    case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
+      actions.showSettings(
+        SETTINGS_TAB.AGENTS,
+        message.sessionType === AGENT_CATEGORY.TOOL_USE
+          ? AGENT_CATEGORY.TOOL_USE
+          : undefined,
+      );
+      return true;
+    case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
+      actions.showSettings(SETTINGS_TAB.MODELS);
+      return true;
+    case MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER:
+      actions.signIn();
+      return true;
+    case MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY:
+    case MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY:
+      actions.showSettings(SETTINGS_TAB.MODELS);
+      return true;
+    case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
+      actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
+      return true;
+    case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
+      actions.openAgentDirectory(message.customDirSet === true);
+      return true;
+    case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
+      actions.setRecentCommitsUnavailable();
+      return true;
+    default:
+      return false;
+  }
+}
+
+function dispatchDesktopLocalOnShell(
+  message: DesktopCommandMessage,
+  actions: DesktopShellActions,
+): boolean {
+  switch (message.command) {
+    case DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER:
+      actions.openLogFolder?.();
+      return true;
+    case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
+      actions.openWorkspaceFolder?.();
+      return true;
+    case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
+      actions.showFirstRunWalkthrough?.();
+      return true;
+    case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
+      actions.openDesktopDocs?.();
+      return true;
+    default:
+      return false;
+  }
+}
+
 export function createDesktopShellIpc(
   renderer: DesktopRenderer,
   options: DesktopShellIpcOptions = {},
@@ -178,61 +235,20 @@ export function createDesktopShellIpc(
       ? options.actions
       : createDesktopShellActions(renderer, options);
 
-  function postRouteForSwitchView(message: DesktopCommandMessage) {
-    const result = SwitchViewMessageSchema.safeParse(message);
-    if (!result.success) return;
-    actions.showRoute(SWITCH_VIEW_ROUTES[result.data.view]);
-  }
-
   return {
     handleMessage(message: DesktopCommandMessage): boolean {
-      switch (message.command) {
-        case COMMON_COMMANDS.SWITCH_VIEW:
-          postRouteForSwitchView(message);
-          return true;
-        case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
-          actions.showSettings();
-          return true;
-        case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
-          actions.showSettings(
-            SETTINGS_TAB.AGENTS,
-            getAgentSettingsSubTab(message),
-          );
-          return true;
-        case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
-          actions.showSettings(SETTINGS_TAB.MODELS);
-          return true;
-        case MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER:
-          actions.signIn();
-          return true;
-        case MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY:
-        case MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY:
-          actions.showSettings(SETTINGS_TAB.MODELS);
-          return true;
-        case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
-          actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
-          return true;
-        case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
-          actions.openAgentDirectory(getCustomDirSet(message));
-          return true;
-        case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
-          actions.setRecentCommitsUnavailable();
-          return true;
-        case DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER:
-          actions.openLogFolder?.();
-          return true;
-        case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
-          actions.openWorkspaceFolder?.();
-          return true;
-        case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
-          actions.showFirstRunWalkthrough?.();
-          return true;
-        case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
-          actions.openDesktopDocs?.();
-          return true;
-        default:
-          return false;
+      // Single discriminated-union parse at the entry point. Every shell
+      // case below operates on the narrowed variant — no scattered
+      // per-handler `safeParse` calls.
+      const parsed = MainViewInboundMessageSchema.safeParse(message);
+      if (parsed.success) {
+        return dispatchMainViewInboundOnShell(parsed.data, actions);
       }
+      // Desktop-local commands (open log folder, walkthrough, docs) are
+      // not part of the main-view inbound union — they originate from the
+      // native menu, not the renderer schema — so they are handled
+      // separately as a fallback after the union parse fails.
+      return dispatchDesktopLocalOnShell(message, actions);
     },
   };
 }

--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -39,12 +39,19 @@ import {
   registerWalkthroughCommands,
 } from '@commands/system';
 import { registerStateRestoreCommand } from '@commands/history';
-import { registerSettingsViewCommands } from '@commands/settings';
+import {
+  registerSettingsViewCommands,
+  initializeSettingsViewProvider,
+} from '@commands/settings';
 import { registerAuthCommands } from '@commands/auth';
 import { registerSetupAssistantCommand } from '@commands/setup';
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerGitCommands } from '@commands/git/gitCommands';
 import { registerProgressViewCommands } from '@commands/progress/progressViewCommands';
+import {
+  createExtensionCommandActions,
+  registerExtensionCommandRegistry,
+} from '@commands/extensionCommandSurface';
 
 // Local file imports
 import { MainViewProvider } from './MainViewProvider';
@@ -89,6 +96,17 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerSampleProjectCommands(context);
   registerWalkthroughCommands(context);
   registerSetupAssistantCommand(context);
+
+  // Settings tab routes, workbench-settings shortcut, and main-view reset
+  // share their dispatch shape with the desktop registry, so they're
+  // registered through the shared `dispatchCommandFromRegistry` helper
+  // rather than per-command `registerCommand` call sites. The remaining
+  // commands stay on the per-command pattern for now (tracked in #3693).
+  const settingsViewProvider = initializeSettingsViewProvider(context);
+  registerExtensionCommandRegistry(
+    context,
+    createExtensionCommandActions(settingsViewProvider),
+  );
 
   mainViewProviderInstance = new MainViewProvider(context);
   context.subscriptions.push(

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -1,0 +1,180 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import {
+  dispatchCommandFromRegistry,
+  type CommandHandler,
+} from '@shared/commands/registry';
+import {
+  SETTINGS_TAB,
+  type SettingsTab,
+} from '@shared/schemas/settingsViewMessages';
+import { type AgentCategory } from '@shared/schemas/agent';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import { SETTINGS_QUERY } from '@utils/config';
+import { getMainWebview } from '@frontend/system/commandUtils';
+
+import type { CommandId } from './catalog';
+import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
+
+const RESET_CHANNEL = 'mainViewCommands';
+
+/**
+ * Subset of `CommandId` whose registration is now driven by the shared
+ * `dispatchCommandFromRegistry` helper. Any new entry must also exist in
+ * `commandCatalog` so the shared catalog stays the source of truth.
+ *
+ * The desktop registry (`packages/desktop/src/desktopCommandSurface.ts`)
+ * dispatches the same IDs through the same helper — this is deliberate
+ * so adding a new view-routing command is a single registry entry per
+ * host, not a parallel `vscode.commands.registerCommand` call site.
+ */
+export type ExtensionRegistryCommandId = Extract<
+  CommandId,
+  | 'texra.showSettingsView'
+  | 'texra.showDashboard'
+  | 'texra.showMemory'
+  | 'texra.showAgentHistory'
+  | 'texra.showModels'
+  | 'texra.showAgents'
+  | 'texra.showTools'
+  | 'texra.showMultiAgent'
+  | 'texra.openSettings'
+  | 'texra.mainView.reset'
+>;
+
+/**
+ * Capabilities the registry handlers need from the extension host. Mirrors
+ * `DesktopCommandActions` in shape — both register parallel handler maps
+ * over the same `CommandId` union with their host-specific actions.
+ */
+export interface ExtensionCommandActions {
+  showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
+  resetMainView(): Promise<void>;
+  openWorkbenchSettings(): Thenable<unknown>;
+}
+
+export function createExtensionCommandActions(
+  settingsViewProvider: SettingsViewProvider,
+): ExtensionCommandActions {
+  return {
+    showSettings(tabIndex, agentSubTab) {
+      void settingsViewProvider.showSettingsView(tabIndex, agentSubTab);
+    },
+    async resetMainView() {
+      const webviewView = await getMainWebview(RESET_CHANNEL);
+      if (!webviewView) {
+        void vscode.window.showWarningMessage(
+          'Main view is not available. Please ensure the TeXRA view is open.',
+        );
+        return;
+      }
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state: {},
+        isResetOperation: true,
+      });
+    },
+    openWorkbenchSettings() {
+      return vscode.commands.executeCommand(
+        'workbench.action.openSettings',
+        SETTINGS_QUERY.EXTENSION,
+      );
+    },
+  };
+}
+
+const EXTENSION_COMMAND_HANDLERS = {
+  'texra.showSettingsView': (actions) => {
+    actions.showSettings();
+    return true;
+  },
+  'texra.showDashboard': (actions) => {
+    actions.showSettings();
+    return true;
+  },
+  'texra.showMemory': (actions) => {
+    actions.showSettings(SETTINGS_TAB.MEMORY);
+    return true;
+  },
+  'texra.showAgentHistory': (actions) => {
+    actions.showSettings(SETTINGS_TAB.HISTORY);
+    return true;
+  },
+  'texra.showModels': (actions) => {
+    actions.showSettings(SETTINGS_TAB.MODELS);
+    return true;
+  },
+  'texra.showTools': (actions) => {
+    actions.showSettings(SETTINGS_TAB.TOOLS);
+    return true;
+  },
+  'texra.showMultiAgent': (actions) => {
+    actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
+    return true;
+  },
+  'texra.openSettings': (actions) => {
+    void actions.openWorkbenchSettings();
+    return true;
+  },
+  'texra.mainView.reset': (actions) => {
+    void actions.resetMainView();
+    return true;
+  },
+} as const satisfies Record<
+  Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
+  CommandHandler<ExtensionCommandActions>
+>;
+
+// `texra.showAgents` accepts an optional `AgentCategory` argument from
+// `executeCommand` callers, so it can't share the no-arg `CommandHandler`
+// signature. It's still routed through the same actions interface — the
+// only difference is that the VS Code registration forwards the argument.
+const EXTENSION_PARAMETERIZED_HANDLERS = {
+  'texra.showAgents': (actions, subTab?: AgentCategory) => {
+    actions.showSettings(SETTINGS_TAB.AGENTS, subTab);
+  },
+} satisfies Record<
+  Extract<ExtensionRegistryCommandId, 'texra.showAgents'>,
+  (actions: ExtensionCommandActions, arg?: AgentCategory) => void
+>;
+
+/**
+ * Register every command in the shared registry against `vscode.commands`,
+ * routing each invocation through `dispatchCommandFromRegistry` so the
+ * dispatch path is identical to the desktop's.
+ */
+export function registerExtensionCommandRegistry(
+  context: vscode.ExtensionContext,
+  actions: ExtensionCommandActions,
+): void {
+  for (const id of Object.keys(EXTENSION_COMMAND_HANDLERS) as ReadonlyArray<
+    keyof typeof EXTENSION_COMMAND_HANDLERS
+  >) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(id, () => {
+        dispatchCommandFromRegistry(
+          id,
+          EXTENSION_COMMAND_HANDLERS,
+          actions,
+          (unhandledId) => {
+            console.error(
+              `[extension] dispatch: unhandled command ${unhandledId}`,
+            );
+          },
+        );
+      }),
+    );
+  }
+
+  for (const id of Object.keys(
+    EXTENSION_PARAMETERIZED_HANDLERS,
+  ) as ReadonlyArray<keyof typeof EXTENSION_PARAMETERIZED_HANDLERS>) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(id, (arg?: AgentCategory) => {
+        EXTENSION_PARAMETERIZED_HANDLERS[id](actions, arg);
+      }),
+    );
+  }
+}

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 // Local imports
 import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
-import type { AgentCategory } from '@shared/schemas/agent';
 
 export const settingsViewCommands = {
   showSettingsView: 'texra.showSettingsView',
@@ -30,6 +29,10 @@ export function initializeSettingsViewProvider(
   return settingsViewProvider;
 }
 
+export function getSettingsViewProvider(): SettingsViewProvider | null {
+  return settingsViewProvider;
+}
+
 export async function showSettingsView(): Promise<void> {
   if (!settingsViewProvider) {
     void vscode.window.showErrorMessage(
@@ -40,40 +43,19 @@ export async function showSettingsView(): Promise<void> {
   await settingsViewProvider.showSettingsView();
 }
 
+/**
+ * Most settings view-routing commands are now registered through the
+ * shared command registry in `extensionCommandSurface.ts` (mirroring the
+ * desktop's `DESKTOP_COMMAND_HANDLERS`). The remaining per-command
+ * registration here covers `texra.showGitSettings`, which is not yet on
+ * the desktop's menu surface so it stays VS Code-only for now.
+ */
 export function registerSettingsViewCommands(
   context: vscode.ExtensionContext,
 ): void {
   initializeSettingsViewProvider(context);
 
   context.subscriptions.push(
-    // Primary commands
-    vscode.commands.registerCommand(settingsViewCommands.showSettingsView, () =>
-      settingsViewProvider?.showSettingsView(),
-    ),
-    vscode.commands.registerCommand(settingsViewCommands.showDashboard, () =>
-      settingsViewProvider?.showSettingsView(),
-    ),
-    // Tab-specific commands
-    vscode.commands.registerCommand(settingsViewCommands.showMemory, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.MEMORY),
-    ),
-    vscode.commands.registerCommand(settingsViewCommands.showHistory, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.HISTORY),
-    ),
-    vscode.commands.registerCommand(settingsViewCommands.showModels, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.MODELS),
-    ),
-    vscode.commands.registerCommand(
-      settingsViewCommands.showAgents,
-      (subTab?: AgentCategory) =>
-        settingsViewProvider?.showSettingsView(SETTINGS_TAB.AGENTS, subTab),
-    ),
-    vscode.commands.registerCommand(settingsViewCommands.showTools, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.TOOLS),
-    ),
-    vscode.commands.registerCommand(settingsViewCommands.showMultiAgent, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.MULTI_AGENT),
-    ),
     vscode.commands.registerCommand(settingsViewCommands.showGitSettings, () =>
       settingsViewProvider?.showSettingsView(SETTINGS_TAB.GIT),
     ),

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -25,26 +25,15 @@ export const mainViewCommands = {
 
 /**
  * Registers main view commands for the extension.
+ *
+ * `texra.mainView.reset` is now registered through the shared command
+ * registry in `extensionCommandSurface.ts` (the desktop side already
+ * dispatches the same command via `DESKTOP_COMMAND_HANDLERS`).
  */
 export function registerMainViewCommands(
   context: vscode.ExtensionContext,
 ): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand(mainViewCommands.reset, async () => {
-      const webviewView = await getMainWebview(CHANNEL);
-      if (!webviewView) {
-        vscode.window.showWarningMessage(
-          'Main view is not available. Please ensure the TeXRA view is open.',
-        );
-        return;
-      }
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-        state: {},
-        isResetOperation: true,
-      });
-    }),
-
     vscode.commands.registerCommand(
       mainViewCommands.refreshModelOptions,
       async () => {

--- a/packages/extension/src/commands/system/settingsCommands.ts
+++ b/packages/extension/src/commands/system/settingsCommands.ts
@@ -1,22 +1,22 @@
 // Third-party imports
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 
 // Local imports - utils
-import { SETTINGS_QUERY } from '@utils/config';
+// Path constant kept here so other modules continue to import it without
+// pulling in the (now-empty) command registration shim.
 
 export const settingsCommands = {
   openSettings: 'texra.openSettings',
 };
 
+/**
+ * `texra.openSettings` is now registered through the shared command
+ * registry in `extensionCommandSurface.ts`. This stub is kept for the
+ * existing `registerSettingsCommands(context)` call site; once every
+ * caller migrates to the shared registry, the function can be deleted.
+ */
 export function registerSettingsCommands(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(settingsCommands.openSettings, () =>
-      vscode.commands.executeCommand(
-        'workbench.action.openSettings',
-        SETTINGS_QUERY.EXTENSION,
-      ),
-    ),
-  );
+  /* registration handled by extensionCommandSurface */
 }

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -266,6 +266,29 @@ describe('desktop IPC adapters', () => {
     expect(postToRenderer).not.toHaveBeenCalled();
   });
 
+  it('rejects shell payloads that fail the MainView inbound schema', async () => {
+    const { createDesktopShellIpc } = await loadDesktopShellIpc();
+    const postToRenderer = vi.fn();
+    const shellIpc = createDesktopShellIpc({ postToRenderer });
+
+    // SWITCH_VIEW with an invalid `view` value fails the discriminated-union
+    // parse and is no longer dispatched as a real switch — i.e. the single
+    // entry-point parse is the validation boundary, not per-handler reads.
+    expect(
+      shellIpc.handleMessage({
+        command: COMMON_COMMANDS.SWITCH_VIEW,
+        view: 'not-a-real-route',
+      }),
+    ).toBe(false);
+    expect(postToRenderer).not.toHaveBeenCalled();
+
+    // Unknown command falls through entirely (neither a main-view variant
+    // nor a desktop-local command) so the dispatcher chain can keep walking.
+    expect(
+      shellIpc.handleMessage({ command: 'texra.totallyUnknown' }),
+    ).toBe(false);
+  });
+
   it('keeps execution forwarding in the execution adapter', async () => {
     const { createDesktopExecutionIpc } = await loadDesktopExecutionIpc();
     const executeMessage = {


### PR DESCRIPTION
## Summary

Two parallel zod-side cleanups against the shapes #3662 introduced. Both deferred follow-ups from #3692 land in one PR.

### Task 2 — desktop shell IPC consumes `MainViewInboundMessageSchema` end-to-end (#3694)

`packages/desktop/src/main/desktopShellIpc.ts` now runs `MainViewInboundMessageSchema.safeParse(message)` once at the dispatch boundary. The switch below operates on the narrowed discriminated-union variant with full type narrowing — every shell case now sees a fully-typed payload. Removed:

- `getAgentSettingsSubTab` (was `OpenAgentSettingsMessageSchema.safeParse` per call)
- `getCustomDirSet` (was `OpenAgentDirectoryMessageSchema.safeParse` per call)
- `postRouteForSwitchView` (was `SwitchViewMessageSchema.safeParse` inside the dispatch loop)

`OpenAgentSettingsMessageSchema` / `OpenAgentDirectoryMessageSchema` named exports stay — they continue to compose into `MainViewInboundMessageSchema` rather than being parsed independently. Desktop-local commands (open-log-folder, walkthrough, docs) fall through after the union parse fails since they originate from the native menu, not the renderer schema.

### Task 1 — extension command registrations on the shared registry (#3693)

Adds `packages/extension/src/commands/extensionCommandSurface.ts` — a `CommandHandler` map keyed by `CommandId` that mirrors the desktop's `DESKTOP_COMMAND_HANDLERS`. Both hosts now dispatch through the same `dispatchCommandFromRegistry` helper. Migrated 10 view-routing commands off per-call-site `vscode.commands.registerCommand`:

`texra.showSettingsView`, `texra.showDashboard`, `texra.showMemory`, `texra.showAgentHistory`, `texra.showModels`, `texra.showAgents`, `texra.showTools`, `texra.showMultiAgent`, `texra.openSettings`, `texra.mainView.reset`

These are the same commands the desktop already routes through the registry, so adding a new view-routing command is now **one entry per host** instead of two parallel registration sites.

### Deferred for follow-up

The remaining ~80 extension commands stay on the per-command `registerCommand` pattern. They take richer arguments (URIs, agent config, edit ranges, etc.) than the no-arg `CommandHandler<TActions>` signature can carry. Migration candidates the next pass should consider: housekeeping (`pack`/`clean*`), latex (`indentTeX`, `compare`), auth (`signIn`/`signOut`/`viewProfile`), and agent execution. `texra.showGitSettings` stays VS Code-only since the desktop menu surface doesn't expose it yet.

### Test plan
- [x] `npm run typecheck` — no new errors (pre-existing `electron`/`@openrouter/sdk` resolution issues are on origin/main too)
- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `cd packages/desktop && npx vite build --mode development` — clean
- [x] `npx vitest run` — 331/335 pass (4 pre-existing failures on `DesktopThemeTokens` + `ElectronCompositionRoot`, verified against bare origin/main)
- [x] New shell IPC test verifies invalid `SWITCH_VIEW.view` is rejected at the boundary
- [ ] Manual smoke (extension): command palette still surfaces every migrated id
- [ ] Manual smoke (desktop): open agent settings, open agent directory, switch view, run an agent

Closes #3692 (parent tracker — both child issues now resolved).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires desktop main-view IPC dispatch and migrates several VS Code commands to a new shared registry path, which could break navigation/settings routing if any command IDs or payloads drift.
> 
> **Overview**
> Refactors desktop shell IPC to **validate renderer messages once at the boundary** via `MainViewInboundMessageSchema`, then dispatches using discriminated-union narrowing; desktop-local menu commands are handled in a separate fallback, and invalid/unknown payloads now cleanly fall through.
> 
> Moves a set of extension view-routing commands (settings tab routes, `openSettings`, and `mainView.reset`) to a new `extensionCommandSurface` that dispatches through the shared `dispatchCommandFromRegistry` helper (mirroring desktop), leaving only VS Code–only routes like `texra.showGitSettings` on per-command registration, and adds a test asserting invalid `SWITCH_VIEW` payloads are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39563284f55dce6baecfe23c44a861410f6a19a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->