### PR TITLE
refactor(shared): more frontend/backend sharing + extension verification (closes #3598, #3627)

### DIFF
--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -1,0 +1,57 @@
+# Manual Verification Matrix
+
+Use this checklist after touching shared frontend code (`src/shared/`,
+`src/common/webview/`, `packages/extension/src/{webview,progressView,settingsView}/frontend/`,
+`packages/desktop/src/renderer/`) to confirm each major surface still mounts
+in both hosts.
+
+The Playwright suite under `packages/desktop/tests/e2e/` covers the desktop
+shell automatically; there is no equivalent for the VS Code webview because
+Mocha would need the VS Code test environment. The matrix below describes
+what to check by hand for the extension.
+
+## Quick automated pass
+
+```bash
+# Type checking — must be clean ON FILES YOU TOUCHED. Pre-existing errors
+# (e.g. `@openrouter/sdk/models`) are unrelated.
+npm run typecheck
+
+# Vitest suite — host-neutral logic + Electron-facing helpers.
+npx vitest run
+
+# Desktop renderer build — must succeed (Vite).
+cd packages/desktop && npx vite build --mode development
+
+# Playwright Electron smoke — launches the desktop app, swaps routes,
+# captures screenshots, exercises the command palette.
+cd packages/desktop && pnpm exec playwright test
+```
+
+## Surfaces to confirm by hand
+
+| Surface | Extension (VS Code) | Desktop (Electron) |
+| --- | --- | --- |
+| Launcher (main view) | Open the TeXRA sidebar; the launcher renders with agent + model pickers. | `pnpm --filter @texra/desktop start` and confirm the launcher mounts on the `main` route. |
+| Progress board | Run a tiny agent; the Progress view shows the stream as it ticks. | Run a tiny agent; switch to Progress (chrome icon button) and confirm the same stream appears. |
+| Settings tabs | Open `TeXRA: Open Settings`; cycle tabs (History, Memory, Models, Agents, Multi-Agent, LaTeX, Tools). | Click the Settings chrome icon; cycle the same tabs. |
+| Onboarding / walkthrough | First install: VS Code's native walkthrough opens. | First launch: the in-renderer first-run dialog opens; "Got it" persists dismissal. |
+| Command palette | VS Code's native palette (`Cmd/Ctrl+Shift+P`) lists `TeXRA: …` commands. | The renderer's palette (`Cmd/Ctrl+K` or chrome "Commands" button) lists the same actions. |
+| Theme switching | Toggle VS Code light/dark/HC; the webviews follow within ~200ms. | Toggle the OS theme; the renderer follows within ~200ms (`nativeTheme` 'updated' → `applyHostBodyTheme()`). |
+| Workspace explorer | n/a — VS Code's native explorer drives selection. | Confirm the desktop explorer lists files and supports double-click → "Use as input/reference/...". |
+
+## Files that should never diverge between hosts
+
+These have been consolidated and must stay shared. If you find yourself
+re-implementing one of these per host, push the new code into
+`src/shared/wa/` instead.
+
+- Theme body classes + WA color scheme: `src/shared/wa/hostTheme.ts`
+- WA color scheme observer: `src/shared/wa/waColorScheme.ts`
+- Action button helper: `src/shared/wa/actionButtons.ts`
+- Empty state helper: `src/shared/wa/emptyState.ts`
+- Walkthrough dialog: `src/shared/wa/walkthroughDialog.ts`
+- Command palette shell: `src/shared/wa/commandPalette.ts`
+- Persisted state: `src/shared/state/PersistedState.ts`
+- Host bridge: `src/shared/hostBridge.ts`
+- Settings tabs: `src/shared/schemas/settingsViewMessages.ts` (`SETTINGS_TAB`)

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -11,7 +11,10 @@ import { html, nothing, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderEmptyState } from '@shared/wa/emptyState';
-import { setWaColorScheme } from '@shared/wa/waColorScheme';
+import {
+  applyHostBodyTheme,
+  getWindowTargetOrigin,
+} from '@shared/wa/hostTheme';
 import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 import { COMMON_COMMANDS } from '@common/webview/commands';
@@ -519,27 +522,10 @@ function applyDesktopTheme(theme: DesktopThemeKind): void {
   // Body and html classList mutation is OK here: those elements live OUTSIDE
   // the Lit-rendered desktop shell, so the next `rerenderShell()` cannot stomp
   // these classes. Theme state is intentionally not part of the shell template.
-  document.body.classList.remove(
-    'vscode-light',
-    'vscode-dark',
-    'vscode-high-contrast',
-    'texra-light',
-    'texra-dark',
-    'texra-high-contrast',
-  );
-  document.body.classList.add(`vscode-${theme}`, `texra-${theme}`);
-  document.body.dataset.vscodeThemeKind = theme;
-  // Apply Web Awesome's native color-scheme class on the document root so
-  // WA's --wa-* dark-mode overrides activate. Shared helper keeps the class
-  // set + ordering in lockstep with the VS Code BaseWebviewApp path.
-  setWaColorScheme(theme !== 'light');
-}
-
-function getWindowTargetOrigin(): string {
-  // Electron loads this renderer over file://, where origin is "null".
-  return window.location.origin && window.location.origin !== 'null'
-    ? window.location.origin
-    : '*';
+  // The shared helper keeps the class set + ordering in lockstep with the
+  // VS Code BaseWebviewApp path so any future addition (e.g. wa-high-contrast)
+  // does not need parallel edits across hosts.
+  applyHostBodyTheme(theme);
 }
 
 function logViewerTemplate(state: LogViewerState): TemplateResult {

--- a/packages/desktop/tests/e2e/README.md
+++ b/packages/desktop/tests/e2e/README.md
@@ -34,6 +34,14 @@ Each launch passes `--texra-workspace <tmpdir>` so the app doesn't pop the
 "open folder" dialog. Pass `workspacePath` to `launchTexraApp()` if a
 specific layout is required.
 
+## Cross-package imports
+
+Playwright's ESM loader cannot resolve a relative `.js` import of a TS file
+from `src/shared/...` (it sees the `.js` suffix and treats the resolved
+module as CommonJS, then fails on named exports). To stay safe, prefer
+inlining constants the suite needs from the shared schemas with a comment
+pointing back at the source of truth.
+
 ## macOS keychain caveat
 
 The harness sets `TEXRA_DISABLE_KEYCHAIN=1` (see `electronApp.ts`) which the

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -2,12 +2,19 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 
-import { SETTINGS_TAB } from '../../../../src/shared/schemas/settingsViewMessages.js';
 import {
   closeTexraApp,
   launchTexraApp,
   type LaunchedApp,
 } from './electronApp.js';
+
+// Mirror of `SETTINGS_TAB.MULTI_AGENT` from
+// `src/shared/schemas/settingsViewMessages.ts`. Inlined because the cross-
+// package TS import via Playwright's ESM loader trips over the `.js` suffix
+// resolving to a CommonJS-shaped module ("Named export 'SETTINGS_TAB' not
+// found") and fails the entire test discovery. The settings tab order is
+// stable; if it changes, both the schema and this constant must update.
+const MULTI_AGENT_TAB_INDEX = 4;
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCREENSHOTS_DIR = join(HERE, '__screenshots__');
@@ -76,9 +83,9 @@ test('progress screenshot', async () => {
 test('settings screenshot', async () => {
   await setRoute('settings');
   // Open the Multi-Agent settings tab — the most visually rich area.
-  // Use the centralized SETTINGS_TAB constant so this can't silently break
-  // when the tab order changes.
-  const multiAgentTabIndex = SETTINGS_TAB.MULTI_AGENT;
+  // Pinned to the inlined constant above (kept in sync with
+  // `SETTINGS_TAB.MULTI_AGENT` in `src/shared/schemas/settingsViewMessages.ts`).
+  const multiAgentTabIndex = MULTI_AGENT_TAB_INDEX;
   await launched.page.evaluate((tabIndex) => {
     window.postMessage({ command: 'setTab', tabIndex }, '*');
   }, multiAgentTabIndex);
@@ -88,4 +95,51 @@ test('settings screenshot', async () => {
     fullPage: false,
   });
   expect(launched.page.url()).toBeTruthy();
+});
+
+/**
+ * Smoke-test the command palette: click the chrome "Commands" button, confirm
+ * a wa-dialog opened with at least one entry, then dismiss with Escape. This
+ * doesn't capture a screenshot — the goal is to verify the host-neutral
+ * `commandPalette` helper still wires up against the desktop's command
+ * surface end-to-end (regression guard for #3627).
+ */
+test('command palette opens and dismisses', async () => {
+  await setRoute('main');
+  // The chrome "Commands" button lives in `desktop-nav`. Click it via DOM
+  // so test does not depend on screen coordinates / animation timing.
+  const opened = await launched.page.evaluate(() => {
+    const btn = document.querySelector<HTMLElement>('.desktop-command-button');
+    if (!btn) return false;
+    btn.click();
+    return true;
+  });
+  expect(opened).toBe(true);
+  await launched.page.waitForTimeout(300);
+  // Wait for the wa-dialog to be present and have at least one palette entry.
+  const entryCount = await launched.page.evaluate(() => {
+    const dialog = document.querySelector<HTMLElement>(
+      '.desktop-command-palette',
+    );
+    if (!dialog) return -1;
+    // Entries are rendered as buttons inside the palette body; falling back
+    // to any clickable item lets the test survive class-name churn.
+    const entries = dialog.querySelectorAll(
+      'button, [role="option"], .desktop-command-palette-entry',
+    );
+    return entries.length;
+  });
+  expect(entryCount).toBeGreaterThan(0);
+  // Dismiss with Escape and verify the dialog closes.
+  await launched.page.keyboard.press('Escape');
+  await launched.page.waitForTimeout(200);
+  const closed = await launched.page.evaluate(() => {
+    const dialog = document.querySelector<HTMLElement>(
+      '.desktop-command-palette',
+    );
+    if (!dialog) return true;
+    // wa-dialog uses an `open` attribute; absence means closed.
+    return dialog.getAttribute('open') == null;
+  });
+  expect(closed).toBe(true);
 });

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -15,6 +15,7 @@ import { themeContext } from '@shared/contexts/themeContext';
 // Local imports - webview commands
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { setWaColorScheme } from '@shared/wa/waColorScheme';
+import { themeIsDark } from '@shared/wa/hostTheme';
 
 /**
  * Base class for Lit-powered webview apps.
@@ -77,10 +78,14 @@ export abstract class BaseWebviewApp<TMessage = any> extends LitElement {
     // 'high-contrast' renders against the active OS color-scheme — pick dark
     // unless the body class explicitly signals light HC. Defer the actual
     // class swap to the shared helper so the class set + ordering stays in
-    // one place across hosts.
+    // one place across hosts. Reuse `themeIsDark()` for the typed ('dark' /
+    // 'high-contrast') case so the dark-detection rule lives next to the
+    // desktop renderer's path in @shared/wa/hostTheme.
+    const isTypedDark =
+      (theme === 'dark' || theme === 'light' || theme === 'high-contrast') &&
+      themeIsDark(theme);
     const wantsDark =
-      theme === 'dark' ||
-      theme === 'high-contrast' ||
+      isTypedDark ||
       document.body.classList.contains('vscode-dark') ||
       document.body.classList.contains('vscode-high-contrast');
     setWaColorScheme(wantsDark);

--- a/src/shared/wa/hostTheme.ts
+++ b/src/shared/wa/hostTheme.ts
@@ -1,0 +1,63 @@
+// Host-neutral helpers for applying theme classes onto <body> + <html>.
+//
+// Both hosts (VS Code BaseWebviewApp and the Electron renderer) used to
+// hand-roll body.classList mutation + setWaColorScheme() in lockstep. Keep
+// the class names + ordering in one place so any future addition (e.g.
+// `wa-high-contrast`) doesn't need parallel edits across hosts.
+
+import type { Theme } from '@shared/schemas/commonViewMessages';
+import { setWaColorScheme } from './waColorScheme';
+
+const VSCODE_THEME_CLASSES = [
+  'vscode-light',
+  'vscode-dark',
+  'vscode-high-contrast',
+] as const;
+
+const TEXRA_THEME_CLASSES = [
+  'texra-light',
+  'texra-dark',
+  'texra-high-contrast',
+] as const;
+
+/**
+ * Convert a `Theme` kind to whether it should render as dark.
+ * 'high-contrast' is treated as dark (matches the desktop theme tokens
+ * and VS Code's dark-on-dark default for high-contrast themes).
+ */
+export function themeIsDark(theme: Theme): boolean {
+  return theme === 'dark' || theme === 'high-contrast';
+}
+
+/**
+ * Apply Electron-renderer-style host theme classes:
+ *   - removes any prior `vscode-*` / `texra-*` body classes
+ *   - adds `vscode-<kind>` AND `texra-<kind>`
+ *   - sets `body.dataset.vscodeThemeKind`
+ *   - swaps the `wa-light`/`wa-dark` class on <html> via setWaColorScheme()
+ *
+ * Equivalent to the desktop's `applyDesktopTheme()` and the VS Code
+ * `BaseWebviewApp.onThemeChange()` body manipulation, just centralised.
+ */
+export function applyHostBodyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') return;
+  const body = document.body;
+  if (!body) return;
+  body.classList.remove(...VSCODE_THEME_CLASSES, ...TEXRA_THEME_CLASSES);
+  body.classList.add(`vscode-${theme}`, `texra-${theme}`);
+  body.dataset.vscodeThemeKind = theme;
+  setWaColorScheme(themeIsDark(theme));
+}
+
+/**
+ * Resolve a `targetOrigin` suitable for `window.postMessage`. Electron loads
+ * the desktop renderer over `file://`, where `window.location.origin` is the
+ * literal string `"null"`. In that case we have to pass `"*"` to avoid the
+ * browser dropping the message. VS Code webviews load over `vscode-webview://`
+ * with a real origin and pass that through.
+ */
+export function getWindowTargetOrigin(): string {
+  if (typeof window === 'undefined') return '*';
+  const { origin } = window.location;
+  return origin && origin !== 'null' ? origin : '*';
+}

--- a/src/test-kernel/desktop/HostTheme.vitest.mts
+++ b/src/test-kernel/desktop/HostTheme.vitest.mts
@@ -1,0 +1,90 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Subject under test - the host-neutral theme helpers shared between the
+// VS Code BaseWebviewApp and the Electron renderer.
+import {
+  applyHostBodyTheme,
+  getWindowTargetOrigin,
+  themeIsDark,
+} from '@shared/wa/hostTheme';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+};
+
+function installDom(url: string): JSDOM {
+  const dom = new JSDOM('<!doctype html><body></body>', { url });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  return dom;
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+}
+
+describe('themeIsDark', () => {
+  it('treats dark and high-contrast as dark', () => {
+    expect(themeIsDark('dark')).toBe(true);
+    expect(themeIsDark('high-contrast')).toBe(true);
+    expect(themeIsDark('light')).toBe(false);
+  });
+});
+
+describe('applyHostBodyTheme', () => {
+  beforeEach(() => {
+    installDom('http://localhost/');
+  });
+  afterEach(() => {
+    restoreDom();
+  });
+
+  it('replaces stale vscode-* / texra-* body classes', () => {
+    const body = globalThis.document.body;
+    body.classList.add('vscode-light', 'texra-light', 'unrelated-class');
+    applyHostBodyTheme('dark');
+    expect(body.classList.contains('vscode-dark')).toBe(true);
+    expect(body.classList.contains('texra-dark')).toBe(true);
+    expect(body.classList.contains('vscode-light')).toBe(false);
+    expect(body.classList.contains('texra-light')).toBe(false);
+    // Caller-set classes that aren't theme-related must not be touched.
+    expect(body.classList.contains('unrelated-class')).toBe(true);
+    expect(body.dataset.vscodeThemeKind).toBe('dark');
+  });
+
+  it('toggles wa-light/wa-dark on <html> via the shared helper', () => {
+    const root = globalThis.document.documentElement;
+    applyHostBodyTheme('light');
+    expect(root.classList.contains('wa-light')).toBe(true);
+    expect(root.classList.contains('wa-dark')).toBe(false);
+    applyHostBodyTheme('dark');
+    expect(root.classList.contains('wa-dark')).toBe(true);
+    expect(root.classList.contains('wa-light')).toBe(false);
+    applyHostBodyTheme('high-contrast');
+    // High-contrast resolves to dark (matches desktop theme tokens).
+    expect(root.classList.contains('wa-dark')).toBe(true);
+  });
+});
+
+describe('getWindowTargetOrigin', () => {
+  afterEach(() => {
+    restoreDom();
+  });
+
+  it('returns the origin when loaded over http(s)://', () => {
+    installDom('http://localhost:5173/');
+    expect(getWindowTargetOrigin()).toBe('http://localhost:5173');
+  });
+
+  it('falls back to "*" when loaded over file:// (origin === "null")', () => {
+    installDom('file:///path/to/index.html');
+    // JSDOM returns the literal string "null" for file:// URLs, matching
+    // Chromium's behaviour. The helper must not pass that through to
+    // window.postMessage or messages get silently dropped.
+    expect(getWindowTargetOrigin()).toBe('*');
+  });
+});


### PR DESCRIPTION
## Summary

- Consolidate host body theme management into `src/shared/wa/hostTheme.ts` so both VS Code (`BaseWebviewApp.onThemeChange`) and the Electron renderer (`applyDesktopTheme`) reuse the same `applyHostBodyTheme` / `themeIsDark` / `getWindowTargetOrigin` helpers — the body classList mutation + setWaColorScheme dance no longer drifts per host.
- Extend the Playwright e2e suite with a `command palette opens and dismisses` smoke test, exercising the host-neutral palette end-to-end.
- Fix a pre-existing e2e harness regression: Playwright's ESM loader cannot resolve a relative `.js` import of a TS file from `src/shared/...` (sees `.js`, treats it as CJS, fails on named exports). Inlined `SETTINGS_TAB.MULTI_AGENT` with a comment pointing back at the schema. Documented the constraint in `tests/e2e/README.md`.
- Add `docs/dev/verification.md` documenting the manual verification matrix (launcher, progress, settings, onboarding, command palette, theme switching, workspace explorer) for both hosts plus the automated commands that gate it (typecheck, vitest, vite build, playwright).
- Add `src/test-kernel/desktop/HostTheme.vitest.mts` (5 tests) covering the new shared helpers under jsdom — body class swap, wa-light/wa-dark toggle, `file://` origin fallback.

## Verification

- [x] `npm run typecheck` clean on touched files (only 2 pre-existing `.mts` errors in `ElectronSecretsBootstrap.vitest.mts`).
- [x] `cd packages/desktop && npx vite build --mode development` succeeds in 1.42s.
- [x] `cd packages/desktop && pnpm test:e2e` passes — 4 tests including the new command palette test (was 0 tests before due to a separate import resolution bug also fixed here).
- [x] `npx vitest run` reports 338 passed / 2 pre-existing theme-token failures (DesktopThemeTokens.vitest.mts unrelated to this change).

## Test plan

- [ ] Manually verify the desktop launcher, progress board, settings tabs, and command palette still mount.
- [ ] Toggle the OS theme; confirm the desktop renderer's body classes update via the new shared helper.
- [ ] Open the VS Code extension webview and confirm theme switching still works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Theme class application and `window.postMessage` targetOrigin handling are refactored into shared code used by both VS Code webviews and the Electron renderer, so regressions could impact theming or cross-surface messaging in both hosts. Added tests mitigate this, but it still touches shared UI plumbing.
> 
> **Overview**
> **Consolidates host theming logic** by introducing `src/shared/wa/hostTheme.ts` and switching the Electron renderer to use `applyHostBodyTheme()`/`getWindowTargetOrigin()` instead of local body class + origin handling, reducing drift between desktop and VS Code paths.
> 
> **Tightens theme dark-mode detection** in `BaseWebviewApp.onThemeChange()` by reusing the shared `themeIsDark()` helper when the theme is a typed `Theme` value.
> 
> **Improves desktop Playwright coverage and stability** by inlining the Multi-Agent settings tab index (avoiding an ESM/CJS import resolution failure) and adding a new smoke test that opens and dismisses the desktop command palette.
> 
> **Adds developer guidance and unit tests**: a new manual verification checklist (`docs/dev/verification.md`) and Vitest coverage for the new host theme helpers under JSDOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f47cd00ac470ca0de183f3f6bbc6fd9176a90ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->