### PR TITLE
fix(wa): address bot-review findings on #3766-#3774

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -134,7 +134,7 @@ jobs:
           script: |
             const outcomeText = '${{ steps.claude-review.outcome }}';
             if (outcomeText === 'failure' || outcomeText === 'cancelled') {
-              github.rest.issues.createComment({
+              await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -106,7 +106,7 @@ jobs:
               console.log('No issue/PR number found, skipping comment');
               return;
             }
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -32,7 +32,7 @@ cd packages/desktop && pnpm exec playwright test
 
 | Surface | Extension (VS Code) | Desktop (Electron) |
 | --- | --- | --- |
-| Launcher (main view) | Open the TeXRA sidebar; the launcher renders with agent + model pickers. | `pnpm --filter @texra/desktop start` and confirm the launcher mounts on the `main` route. |
+| Launcher (main view) | Open the TeXRA sidebar; the launcher renders with agent + model pickers. | `pnpm --filter @texra/desktop dev` and confirm the launcher mounts on the `main` route. |
 | Progress board | Run a tiny agent; the Progress view shows the stream as it ticks. | Run a tiny agent; switch to Progress (chrome icon button) and confirm the same stream appears. |
 | Settings tabs | Open `TeXRA: Open Settings`; cycle tabs (History, Memory, Models, Agents, Multi-Agent, LaTeX, Tools). | Click the Settings chrome icon; cycle the same tabs. |
 | Onboarding / walkthrough | First install: VS Code's native walkthrough opens. | First launch: the in-renderer first-run dialog opens; "Got it" persists dismissal. |

--- a/docs/proposals/unified-output-protocol.md
+++ b/docs/proposals/unified-output-protocol.md
@@ -106,7 +106,7 @@ After all built-in agents are migrated:
 - Drop `MULTIPLE_SUFFIX`, `multiplePath`, `groupByBaseName` pairing logic, `preferMultiple` parameter from `agentRegistry.ts` and `agentLoad.ts`.
 - Drop the dual code paths in model handlers, `RemoteAgentLoader.ts`, `agentHandlers.ts`, `register.ts`.
 - Drop `hasMultiplePath` from `shared/schemas/settingsViewMessages.ts`.
-- Update `packages/extension/src/frontend/setup.ts` `LEGACY_AGENT_FILES` to clean stale `_multiple` files from GlobalStorage.
+- Update `src/agent/index/AgentDirectorySync.ts` `LEGACY_AGENT_FILES` to clean stale `_multiple` files from GlobalStorage.
 
 ### Phase 4: Legacy custom agents
 

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -29,10 +29,6 @@ export function initializeSettingsViewProvider(
   return settingsViewProvider;
 }
 
-export function getSettingsViewProvider(): SettingsViewProvider | null {
-  return settingsViewProvider;
-}
-
 export async function showSettingsView(): Promise<void> {
   if (!settingsViewProvider) {
     void vscode.window.showErrorMessage(

--- a/packages/extension/src/commands/system/settingsCommands.ts
+++ b/packages/extension/src/commands/system/settingsCommands.ts
@@ -2,8 +2,10 @@
 import type * as vscode from 'vscode';
 
 // Local imports - utils
-// Path constant kept here so other modules continue to import it without
-// pulling in the (now-empty) command registration shim.
+// The `settingsCommands.openSettings` id is kept here as a stable import
+// surface for other modules; the actual command is now registered via the
+// shared registry in `extensionCommandSurface.ts`. See the JSDoc on
+// `registerSettingsCommands` below.
 
 export const settingsCommands = {
   openSettings: 'texra.openSettings',

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -465,6 +465,14 @@ export class InstructionPanel extends LitElement {
         visibility: hidden;
         max-height: 0;
         overflow: hidden;
+        /*
+         * The visibility delay (200ms) MUST match the duration of
+         * --transition-normal (currently 0.2s ease, see
+         * src/shared/styles/litStyles.ts). CSS doesn't let us extract
+         * just the duration component from the var(), so the literal
+         * stays inline; if the token value changes, update this delay
+         * in lockstep.
+         */
         transition:
           opacity var(--transition-normal),
           max-height var(--transition-normal),


### PR DESCRIPTION
## Summary

Sweep of **must-fix** findings flagged by Cursor Bugbot and Copilot across the recent burst of WA-migration / settings-refactor PRs (#3766, #3767, #3769, #3770, #3772, #3773). Stylistic and stale findings are deferred; only real bugs / dead code / wrong docs are addressed here.

- **GitHub Actions (#3772):** add `await` to `github.rest.issues.createComment(...)` in both `claude.yml` and `claude-code-review.yml`. Without it the `actions/github-script` step can finish before the REST request resolves, silently dropping the quota-notification comment.
- **Settings commands (#3770):** drop unused `getSettingsViewProvider` export (orphan after the registry consolidation); replace the misleading "Path constant" comment in `commands/system/settingsCommands.ts` with one that actually describes what's preserved (the `settingsCommands.openSettings` id).
- **Docs:** fix stale `LEGACY_AGENT_FILES` path reference in `docs/proposals/unified-output-protocol.md` (now lives in `src/agent/index/AgentDirectorySync.ts`); fix `pnpm --filter @texra/desktop start` → `dev` in `docs/dev/verification.md` (no `start` script exists).
- **InstructionPanel cross-fade (#3769):** document the coupling between the literal `200ms` `visibility` delay and `--transition-normal` so a future token tweak doesn't silently break the cross-fade timing (cursor's "Low Severity" flag — kept the literal inline per the bannerStyles.ts pattern, added an explicit comment).

## Deferred / not addressed

- Copilot stylistic suggestions on `themeTokens.css` HC overrides (#3766): explicit overrides serve as defense-in-depth; keeping them.
- Copilot quota-error wording / `continue-on-error` scope on workflows: behavior matches intent (suppress non-fatal action failures); message wording change is cosmetic.
- BaseWebviewApp / hostTheme JSDoc drift (#3773): comment-only, narratively accurate enough; deferred to a doc-pass.
- Playwright `waitForTimeout` flake potential (#3773): tests pass cleanly today; rewrite belongs in a focused test-stability PR.

## Test plan

- [x] `npm run typecheck` — clean except 2 pre-existing `.mts` syntax errors on `ElectronSecretsBootstrap.vitest.mts` (also fail on `origin/main`).
- [x] `cd packages/desktop && npx vite build --mode development` — clean (1.5s build).
- [x] `npx vitest run` — 349/351 pass; 2 pre-existing failures in `DesktopThemeTokens.vitest.mts` also fail on `origin/main`, unrelated to this diff.
- [x] `cd packages/desktop && TEXRA_DISABLE_KEYCHAIN=1 pnpm exec playwright test` — 4/4 pass (launcher, progress, settings, command palette).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small workflow reliability fix (awaiting GitHub API call), minor dead-code/comment cleanup, and documentation/CSS comment updates with no behavioral change beyond ensuring comments reliably post.
> 
> **Overview**
> Fixes GitHub Actions Claude workflows so quota/rate-limit notification comments are reliably posted by awaiting `github.rest.issues.createComment`.
> 
> Cleans up extension settings command surface by removing an unused `getSettingsViewProvider` export and clarifying that `settingsCommands.openSettings` remains as a stable identifier while registration is handled via the shared registry.
> 
> Updates docs to reflect the correct desktop dev command and the new `LEGACY_AGENT_FILES` location, and adds an explicit note in `InstructionPanel` about keeping the 200ms `visibility` delay in sync with `--transition-normal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94804f3aad0419966c91330592d3317c3993fcec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->