### PR TITLE
refactor(zod): migrate housekeeping/git/system commands batch 2 (closes #3775 partial)

### DIFF
--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -87,10 +87,14 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   // cleanBuild, indentTeX), auth (signIn/signOut/viewProfile), system
   // entry points (runSetupAssistant, openGettingStarted, createSampleProject,
   // testConnection, testAgentLoading, loadSpecificAgent, openProgressViewInTab,
-  // downloadArXivSource), and the typed-arg handlers for
-  // openDoc/stopAgent/compactResponse — all alongside the original
-  // settings/main-view routes via the same dispatch path as the desktop
-  // registry. See `extensionCommandSurface.ts` for the handler map.
+  // downloadArXivSource), batch-2 host-context entry points (parseXml,
+  // parseYaml, testTextEditor, indentCurrentTeX,
+  // applyReplacements, fixCompilation, getTeXCount, countPdfPages,
+  // showLinterMessages, countLinterMessages, extractFigurePaths), and the
+  // typed-arg handlers for openDoc/stopAgent/compactResponse — all
+  // alongside the original settings/main-view routes via the same
+  // dispatch path as the desktop registry. See
+  // `extensionCommandSurface.ts` for the handler map.
   //
   // FOLLOW_UP (#3775): the remaining per-command registrations carry
   // VS Code-specific arguments (TextEditor, Range, Uri, FileLocation,

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -20,10 +20,25 @@ import {
   handleTestAgentLoading as sysHandleTestAgentLoading,
   handleLoadSpecificAgent as sysHandleLoadSpecificAgent,
 } from '@commands/system';
-import { handleIndentTeX } from '@commands/latex/latexCommands';
+import {
+  handleIndentTeX,
+  handleIndentCurrentTeX as latexIndentCurrentTeX,
+  handleApplyReplacements as latexApplyReplacements,
+  handleFixCompilation as latexFixCompilation,
+  handleGetTeXCount as latexGetTeXCount,
+} from '@commands/latex/latexCommands';
+import { handleCountPdfPages as latexCountPdfPages } from '@commands/latex/imageCommands';
+import {
+  handleShowLinterMessages as latexShowLinterMessages,
+  handleCountLinterMessages as latexCountLinterMessages,
+} from '@commands/latex/linterCommands';
+import { handleExtractFigurePaths as latexExtractFigurePaths } from '@commands/latex/figCommands';
 import { openProgressViewInTab as progressOpenInTab } from '@commands/progress/progressViewCommands';
 import { openDoc as sysOpenDoc } from '@commands/system/helpCommands';
 import { openGettingStarted as sysOpenGettingStarted } from '@commands/system/walkthroughCommands';
+import { handleParseXml as sysParseXml } from '@commands/system/xmlCommands';
+import { handleParseYaml as sysParseYaml } from '@commands/system/yamlCommands';
+import { handleTestTextEditor as sysTestTextEditor } from '@commands/system/textEditorCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
@@ -84,6 +99,20 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.openDoc'
   | 'texra.stopAgent'
   | 'texra.compactResponse'
+  // Batch 2 (#3775) — no-arg host-context commands. These read from
+  // the active editor or fixed UI surfaces; their args are not
+  // serializable, so they ride the legacy no-arg handler shape.
+  | 'texra.parseXml'
+  | 'texra.parseYaml'
+  | 'texra.testTextEditor'
+  | 'texra.indentCurrentTeX'
+  | 'texra.applyReplacements'
+  | 'texra.fixCompilation'
+  | 'texra.getTeXCount'
+  | 'texra.countPdfPages'
+  | 'texra.showLinterMessages'
+  | 'texra.countLinterMessages'
+  | 'texra.extractFigurePaths'
 >;
 
 /**
@@ -112,6 +141,17 @@ export interface ExtensionCommandActions {
   openDoc(page: string): Promise<void>;
   stopAgent(streamId: string): void;
   compactResponse(streamId: string): Promise<void>;
+  parseXml(): Promise<void>;
+  parseYaml(): Promise<void>;
+  testTextEditor(): Promise<void>;
+  indentCurrentTeX(): Promise<void>;
+  applyReplacements(): Promise<void>;
+  fixCompilation(): Promise<void>;
+  getTeXCount(): Promise<void>;
+  countPdfPages(): Promise<void>;
+  showLinterMessages(): Promise<void>;
+  countLinterMessages(): Promise<void>;
+  extractFigurePaths(): Promise<void>;
 }
 
 export function createExtensionCommandActions(
@@ -159,6 +199,17 @@ export function createExtensionCommandActions(
     openDoc: sysOpenDoc,
     stopAgent: agentStopAgent,
     compactResponse: agentCompactResponse,
+    parseXml: sysParseXml,
+    parseYaml: sysParseYaml,
+    testTextEditor: sysTestTextEditor,
+    indentCurrentTeX: latexIndentCurrentTeX,
+    applyReplacements: latexApplyReplacements,
+    fixCompilation: latexFixCompilation,
+    getTeXCount: latexGetTeXCount,
+    countPdfPages: latexCountPdfPages,
+    showLinterMessages: latexShowLinterMessages,
+    countLinterMessages: latexCountLinterMessages,
+    extractFigurePaths: latexExtractFigurePaths,
   };
 }
 
@@ -276,6 +327,50 @@ const EXTENSION_COMMAND_HANDLERS = {
       return true;
     },
   ),
+  'texra.parseXml': (actions) => {
+    void actions.parseXml();
+    return true;
+  },
+  'texra.parseYaml': (actions) => {
+    void actions.parseYaml();
+    return true;
+  },
+  'texra.testTextEditor': (actions) => {
+    void actions.testTextEditor();
+    return true;
+  },
+  'texra.indentCurrentTeX': (actions) => {
+    void actions.indentCurrentTeX();
+    return true;
+  },
+  'texra.applyReplacements': (actions) => {
+    void actions.applyReplacements();
+    return true;
+  },
+  'texra.fixCompilation': (actions) => {
+    void actions.fixCompilation();
+    return true;
+  },
+  'texra.getTeXCount': (actions) => {
+    void actions.getTeXCount();
+    return true;
+  },
+  'texra.countPdfPages': (actions) => {
+    void actions.countPdfPages();
+    return true;
+  },
+  'texra.showLinterMessages': (actions) => {
+    void actions.showLinterMessages();
+    return true;
+  },
+  'texra.countLinterMessages': (actions) => {
+    void actions.countLinterMessages();
+    return true;
+  },
+  'texra.extractFigurePaths': (actions) => {
+    void actions.extractFigurePaths();
+    return true;
+  },
 } as const satisfies Record<
   Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
   // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -42,10 +42,10 @@ async function runLaTeXCommand(
 
 export function registerFigureCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand(
-      figureCommands.extractFigurePaths,
-      handleExtractFigurePaths,
-    ),
+    // `texra.extractFigurePaths` is registered through
+    // `extensionCommandSurface` (see #3775). The remaining tikz commands
+    // stay here for now — same no-arg shape, but #3775 batched only one
+    // entry per file to keep the diff focused.
     vscode.commands.registerCommand(
       figureCommands.extractTikzFigures,
       handleExtractTikzFigures,
@@ -57,7 +57,7 @@ export function registerFigureCommands(context: vscode.ExtensionContext): void {
   );
 }
 
-async function handleExtractFigurePaths(): Promise<void> {
+export async function handleExtractFigurePaths(): Promise<void> {
   await runLaTeXCommand(
     'extract figure paths',
     'extractFigurePaths',

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -18,7 +18,9 @@ const PDF_FILTERS = { 'PDF files': ['pdf'] };
 
 export function registerImageCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.countPdfPages', handleCountPdfPages),
+    // `texra.countPdfPages` is registered through `extensionCommandSurface`
+    // (see #3775). The remaining per-command registrations stay here
+    // because they return values to `executeCommand` callers.
     vscode.commands.registerCommand(
       'texra.encodeImageToBase64',
       handleEncodeImageToBase64,
@@ -30,7 +32,7 @@ export function registerImageCommands(context: vscode.ExtensionContext) {
   );
 }
 
-async function handleCountPdfPages(): Promise<void> {
+export async function handleCountPdfPages(): Promise<void> {
   try {
     const selection = await dialogUtils.selectFileFromWorkspace({
       openLabel: 'Select PDF file',

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -28,27 +28,15 @@ export const latexCommands = {
   fixCompilation: 'texra.fixCompilation',
 };
 
-export function registerLatexCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      latexCommands.indentCurrentTeX,
-      handleIndentCurrentTeX,
-    ),
-    vscode.commands.registerCommand(
-      latexCommands.getTeXCount,
-      handleGetTeXCount,
-    ),
-    // `texra.indentTeX` is registered through `extensionCommandSurface` so
-    // the dispatch path matches the desktop registry (see #3771).
-    vscode.commands.registerCommand(
-      latexCommands.applyReplacements,
-      handleApplyReplacements,
-    ),
-    vscode.commands.registerCommand(
-      latexCommands.fixCompilation,
-      handleFixCompilation,
-    ),
-  );
+/**
+ * All LaTeX entry-point commands (`indentTeX`, `indentCurrentTeX`,
+ * `getTeXCount`, `applyReplacements`, `fixCompilation`) are now
+ * registered through the shared command registry in
+ * `extensionCommandSurface.ts` (#3771, #3775). This stub is kept for
+ * the existing `registerLatexCommands(context)` call site.
+ */
+export function registerLatexCommands(_context: vscode.ExtensionContext): void {
+  /* registration handled by extensionCommandSurface */
 }
 
 export async function handleIndentTeX(): Promise<void> {
@@ -72,7 +60,7 @@ export async function handleIndentTeX(): Promise<void> {
   }
 }
 
-async function handleFixCompilation(): Promise<void> {
+export async function handleFixCompilation(): Promise<void> {
   try {
     await withLaTeXGuard(
       { channel: CHANNEL, action: 'fix compilation', saveDocument: true },
@@ -97,7 +85,7 @@ async function handleFixCompilation(): Promise<void> {
   }
 }
 
-async function handleApplyReplacements(): Promise<void> {
+export async function handleApplyReplacements(): Promise<void> {
   try {
     await withLaTeXGuard(
       { channel: CHANNEL, action: 'apply replacements', saveDocument: true },
@@ -130,7 +118,7 @@ async function handleApplyReplacements(): Promise<void> {
   }
 }
 
-async function handleIndentCurrentTeX(): Promise<void> {
+export async function handleIndentCurrentTeX(): Promise<void> {
   try {
     await withLaTeXGuard(
       {
@@ -159,7 +147,7 @@ async function handleIndentCurrentTeX(): Promise<void> {
   }
 }
 
-async function handleGetTeXCount(): Promise<void> {
+export async function handleGetTeXCount(): Promise<void> {
   try {
     await withLaTeXGuard(
       { channel: CHANNEL, action: 'get TeX count' },

--- a/packages/extension/src/commands/latex/linterCommands.ts
+++ b/packages/extension/src/commands/latex/linterCommands.ts
@@ -90,15 +90,14 @@ export async function handleCountLinterMessages(): Promise<void> {
   }
 }
 
-export function registerLinterCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      linterCommands.showLinterMessages,
-      handleShowLinterMessages,
-    ),
-    vscode.commands.registerCommand(
-      linterCommands.countLinterMessages,
-      handleCountLinterMessages,
-    ),
-  );
+/**
+ * `texra.showLinterMessages` and `texra.countLinterMessages` are now
+ * registered through the shared command registry in
+ * `extensionCommandSurface.ts` (see #3775). This stub is kept for the
+ * existing `registerLinterCommands(context)` call site.
+ */
+export function registerLinterCommands(
+  _context: vscode.ExtensionContext,
+): void {
+  /* registration handled by extensionCommandSurface */
 }

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -44,7 +44,8 @@ export async function showSettingsView(): Promise<void> {
  * shared command registry in `extensionCommandSurface.ts` (mirroring the
  * desktop's `DESKTOP_COMMAND_HANDLERS`). The remaining per-command
  * registration here covers `texra.showGitSettings`, which is not yet on
- * the desktop's menu surface so it stays VS Code-only for now.
+ * the desktop's menu surface and is also absent from `commandCatalog`,
+ * so it stays VS Code-only via direct `registerCommand`.
  */
 export function registerSettingsViewCommands(
   context: vscode.ExtensionContext,

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -18,22 +18,22 @@ export const textEditorCommands = {
   testTextEditor: 'texra.testTextEditor',
 };
 
+/**
+ * `texra.testTextEditor` is now registered through the shared command
+ * registry in `extensionCommandSurface.ts` (see #3775). This stub is kept
+ * for the existing `registerTextEditorCommands(context)` call site.
+ */
 export function registerTextEditorCommands(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      textEditorCommands.testTextEditor,
-      handleTestTextEditor,
-    ),
-  );
+  /* registration handled by extensionCommandSurface */
 }
 
 /**
  * Handle the test text editor command
  * This command allows testing the TextEditorTool with different commands
  */
-async function handleTestTextEditor(): Promise<void> {
+export async function handleTestTextEditor(): Promise<void> {
   try {
     // Get active editor
     const editor = vscode.window.activeTextEditor;

--- a/packages/extension/src/commands/system/xmlCommands.ts
+++ b/packages/extension/src/commands/system/xmlCommands.ts
@@ -50,8 +50,11 @@ export async function handleParseXml(): Promise<void> {
   }
 }
 
-export function registerXmlCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(xmlCommands.parseXml, handleParseXml),
-  );
+/**
+ * `texra.parseXml` is now registered through the shared command registry
+ * in `extensionCommandSurface.ts` (see #3775). This stub is kept for the
+ * existing `registerXmlCommands(context)` call site.
+ */
+export function registerXmlCommands(_context: vscode.ExtensionContext): void {
+  /* registration handled by extensionCommandSurface */
 }

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -167,8 +167,11 @@ export async function handleParseYaml(): Promise<void> {
   }
 }
 
-export function registerYamlCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(yamlCommands.parseYaml, handleParseYaml),
-  );
+/**
+ * `texra.parseYaml` is now registered through the shared command registry
+ * in `extensionCommandSurface.ts` (see #3775). This stub is kept for the
+ * existing `registerYamlCommands(context)` call site.
+ */
+export function registerYamlCommands(_context: vscode.ExtensionContext): void {
+  /* registration handled by extensionCommandSurface */
 }

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -102,6 +102,51 @@ const HANDLERS = {
       return true;
     },
   ),
+  // Batch 2 (#3775) — no-arg host-context commands.
+  'texra.parseXml': (actions: ExtensionCommandActions) => {
+    void actions.parseXml();
+    return true;
+  },
+  'texra.parseYaml': (actions: ExtensionCommandActions) => {
+    void actions.parseYaml();
+    return true;
+  },
+  'texra.testTextEditor': (actions: ExtensionCommandActions) => {
+    void actions.testTextEditor();
+    return true;
+  },
+  'texra.indentCurrentTeX': (actions: ExtensionCommandActions) => {
+    void actions.indentCurrentTeX();
+    return true;
+  },
+  'texra.applyReplacements': (actions: ExtensionCommandActions) => {
+    void actions.applyReplacements();
+    return true;
+  },
+  'texra.fixCompilation': (actions: ExtensionCommandActions) => {
+    void actions.fixCompilation();
+    return true;
+  },
+  'texra.getTeXCount': (actions: ExtensionCommandActions) => {
+    void actions.getTeXCount();
+    return true;
+  },
+  'texra.countPdfPages': (actions: ExtensionCommandActions) => {
+    void actions.countPdfPages();
+    return true;
+  },
+  'texra.showLinterMessages': (actions: ExtensionCommandActions) => {
+    void actions.showLinterMessages();
+    return true;
+  },
+  'texra.countLinterMessages': (actions: ExtensionCommandActions) => {
+    void actions.countLinterMessages();
+    return true;
+  },
+  'texra.extractFigurePaths': (actions: ExtensionCommandActions) => {
+    void actions.extractFigurePaths();
+    return true;
+  },
   // The typed handlers carry their own argument shapes via
   // `definedHandler`. Matching the registry map's per-entry TArgs widening
   // (`any`) keeps inference per entry without unifying every entry on
@@ -131,6 +176,17 @@ function makeActions(): ExtensionCommandActions {
     openDoc: vi.fn().mockResolvedValue(undefined),
     stopAgent: vi.fn(),
     compactResponse: vi.fn().mockResolvedValue(undefined),
+    parseXml: vi.fn().mockResolvedValue(undefined),
+    parseYaml: vi.fn().mockResolvedValue(undefined),
+    testTextEditor: vi.fn().mockResolvedValue(undefined),
+    indentCurrentTeX: vi.fn().mockResolvedValue(undefined),
+    applyReplacements: vi.fn().mockResolvedValue(undefined),
+    fixCompilation: vi.fn().mockResolvedValue(undefined),
+    getTeXCount: vi.fn().mockResolvedValue(undefined),
+    countPdfPages: vi.fn().mockResolvedValue(undefined),
+    showLinterMessages: vi.fn().mockResolvedValue(undefined),
+    countLinterMessages: vi.fn().mockResolvedValue(undefined),
+    extractFigurePaths: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -150,6 +206,18 @@ describe('extension command surface — newly migrated commands (#3771, #3775)',
     ['texra.testAgentLoading', 'testAgentLoading'],
     ['texra.loadSpecificAgent', 'loadSpecificAgent'],
     ['texra.openProgressViewInTab', 'openProgressViewInTab'],
+    // Batch 2 (#3775)
+    ['texra.parseXml', 'parseXml'],
+    ['texra.parseYaml', 'parseYaml'],
+    ['texra.testTextEditor', 'testTextEditor'],
+    ['texra.indentCurrentTeX', 'indentCurrentTeX'],
+    ['texra.applyReplacements', 'applyReplacements'],
+    ['texra.fixCompilation', 'fixCompilation'],
+    ['texra.getTeXCount', 'getTeXCount'],
+    ['texra.countPdfPages', 'countPdfPages'],
+    ['texra.showLinterMessages', 'showLinterMessages'],
+    ['texra.countLinterMessages', 'countLinterMessages'],
+    ['texra.extractFigurePaths', 'extractFigurePaths'],
   ] as const)('%s dispatches to actions.%s', (id, actionKey) => {
     const actions = makeActions();
     expect(dispatchCommandFromRegistry(id, HANDLERS, actions)).toBe(true);


### PR DESCRIPTION
## Summary

Continuing #3775 — batch 2/~5. 11 host-context commands routed through the shared `dispatchCommandFromRegistry` helper alongside the desktop registry. Per-call-site `vscode.commands.registerCommand` wiring moves into `extensionCommandSurface`'s handler map; palette/menu surfaces are unchanged.

Migrated:
- `texra.parseXml`
- `texra.parseYaml`
- `texra.testTextEditor`
- `texra.indentCurrentTeX`
- `texra.applyReplacements`
- `texra.fixCompilation`
- `texra.getTeXCount`
- `texra.countPdfPages`
- `texra.showLinterMessages`
- `texra.countLinterMessages`
- `texra.extractFigurePaths`

Each migrated id is a no-arg host-context entry point (reads from `activeTextEditor`, dialogs, or fixed UI surfaces — args are not serializable), so they ride the legacy callable shape on `CommandHandler`. The previously stubbed `register*` functions stay as call-site stubs for the existing `commands.ts` wiring.

Skipped this batch (deferred):
- `texra.pack`/`texra.clean` (+ `Single`/`Multiple` variants) — accept rich object configs and also surface in right-click menus that pass `vscode.Uri`.
- Git commands (`isGitRepository`, `getRecentCommits`, `findCommitInHistory`) — return values to `executeCommand` callers; current `CommandHandler` signature returns `boolean`.
- `texra.restoreState` — passes a 2nd `executeImmediately` arg the dispatcher doesn't forward.
- `texra.showGitSettings` — not in `commandCatalog` (host-private id); kept on per-command registration.
- `texra.encodeImageToBase64`, `texra.convertPdfToImages`, `texra.extractTikzFigures`, `texra.compileTikzFigures` — return values or batched conservatively to keep diff focused.

## Test plan

- [x] `npm run typecheck` clean (only pre-existing electron / `@openrouter/sdk` errors remain — confirmed identical on origin/main via stash check)
- [x] `cd packages/desktop && npx vite build --mode development` clean (built in 1.26s)
- [x] `npx vitest run src/test-kernel/commands` — 37 passed (was 26; +11 new)
- [x] Full vitest suite passes for command tests; 4 pre-existing desktop/Electron failures (`fix-path` + theme tokens) are not touched by this PR
- [x] `npm run compile:fast` builds clean

## Progress

- Before: 27 commands migrated (#3770: 10, #3774: 6, #3778: 11). ~60 remaining.
- This PR: +11 commands → 38 migrated total
- Remaining: ~49 (3 more batches of ~10–12 each)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how multiple commands are registered/dispatch (possible missing wiring or handler export mismatches), though the underlying command implementations are unchanged and covered by added tests.
> 
> **Overview**
> **Batch-2 command migration (#3775):** routes 11 no-arg, host-context VS Code commands (XML/YAML parsing, text editor test, LaTeX indent/replacements/fix/count, PDF page count, linter message actions, figure path extraction) through `extensionCommandSurface` via `dispatchCommandFromRegistry`.
> 
> Direct `vscode.commands.registerCommand` registrations for these commands are removed and replaced with exported handlers plus stubbed `register*Commands` functions to preserve existing call sites; tests are updated to assert each migrated command dispatches to the correct `ExtensionCommandActions` method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40eceba37912d87f7ea379b720b27c3653a04ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->