### PR TITLE
fix(zod): restore async semantics in migrated registry handlers (closes #3782) + batch 3 (#3781 partial)

### DIFF
--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -27,12 +27,21 @@ import {
   handleFixCompilation as latexFixCompilation,
   handleGetTeXCount as latexGetTeXCount,
 } from '@commands/latex/latexCommands';
-import { handleCountPdfPages as latexCountPdfPages } from '@commands/latex/imageCommands';
+import {
+  handleCountPdfPages as latexCountPdfPages,
+  handleEncodeImageToBase64 as latexEncodeImageToBase64,
+  handleConvertPdfToImages as latexConvertPdfToImages,
+} from '@commands/latex/imageCommands';
 import {
   handleShowLinterMessages as latexShowLinterMessages,
   handleCountLinterMessages as latexCountLinterMessages,
 } from '@commands/latex/linterCommands';
-import { handleExtractFigurePaths as latexExtractFigurePaths } from '@commands/latex/figCommands';
+import {
+  handleExtractFigurePaths as latexExtractFigurePaths,
+  handleExtractTikzFigures as latexExtractTikzFigures,
+  handleCompileTikzFigures as latexCompileTikzFigures,
+} from '@commands/latex/figCommands';
+import { cloneOverleafProject as gitCloneOverleafProject } from '@commands/git/gitCommands';
 import { openProgressViewInTab as progressOpenInTab } from '@commands/progress/progressViewCommands';
 import { openDoc as sysOpenDoc } from '@commands/system/helpCommands';
 import { openGettingStarted as sysOpenGettingStarted } from '@commands/system/walkthroughCommands';
@@ -113,6 +122,16 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.showLinterMessages'
   | 'texra.countLinterMessages'
   | 'texra.extractFigurePaths'
+  // Batch 3 (#3781) — additional no-arg commands. Each handler runs
+  // its own user prompt internally (file picker, input box) so the
+  // VS Code call site doesn't pass arguments. The `cloneOverleafProject`
+  // entry needs `vscode.ExtensionContext` for `secrets` access; that's
+  // captured as a closure inside the action factory below.
+  | 'texra.encodeImageToBase64'
+  | 'texra.convertPdfToImages'
+  | 'texra.extractTikzFigures'
+  | 'texra.compileTikzFigures'
+  | 'texra.cloneOverleafProject'
 >;
 
 /**
@@ -152,6 +171,16 @@ export interface ExtensionCommandActions {
   showLinterMessages(): Promise<void>;
   countLinterMessages(): Promise<void>;
   extractFigurePaths(): Promise<void>;
+  // Batch 3 (#3781). The image/PDF handlers return data to
+  // `executeCommand` callers (palette invocations don't consume the
+  // value, but the existing return-type surface is preserved). The
+  // registry's typed return is `Promise<boolean>`, so handlers below
+  // discard the data values after awaiting.
+  encodeImageToBase64(): Promise<string | undefined>;
+  convertPdfToImages(): Promise<string[] | string | undefined>;
+  extractTikzFigures(): Promise<void>;
+  compileTikzFigures(): Promise<void>;
+  cloneOverleafProject(): Promise<void>;
 }
 
 export function createExtensionCommandActions(
@@ -210,7 +239,25 @@ export function createExtensionCommandActions(
     showLinterMessages: latexShowLinterMessages,
     countLinterMessages: latexCountLinterMessages,
     extractFigurePaths: latexExtractFigurePaths,
+    encodeImageToBase64: latexEncodeImageToBase64,
+    convertPdfToImages: latexConvertPdfToImages,
+    extractTikzFigures: latexExtractTikzFigures,
+    compileTikzFigures: latexCompileTikzFigures,
+    cloneOverleafProject: () => gitCloneOverleafProject(context),
   };
+}
+
+/**
+ * Dispatch a no-arg `actions.X()` call through the registry while
+ * preserving async semantics. Sync handlers that miss this helper
+ * regressed in #3778 — the original `void actions.X(); return true;`
+ * shape fired-and-forgot the promise, swallowing rejections (#3782).
+ *
+ * Wrap promise-returning actions through `awaitTrue` so the dispatcher
+ * actually awaits the work and surfaces failures.
+ */
+function awaitTrue(p: Promise<unknown> | Thenable<unknown>): Promise<boolean> {
+  return Promise.resolve(p).then(() => true);
 }
 
 const EXTENSION_COMMAND_HANDLERS = {
@@ -242,76 +289,29 @@ const EXTENSION_COMMAND_HANDLERS = {
     actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
     return true;
   },
-  'texra.openSettings': (actions) => {
-    void actions.openWorkbenchSettings();
-    return true;
-  },
-  'texra.mainView.reset': (actions) => {
-    void actions.resetMainView();
-    return true;
-  },
-  'texra.cleanOutput': (actions) => {
-    void actions.cleanOutput();
-    return true;
-  },
-  'texra.cleanBuild': (actions) => {
-    void actions.cleanBuild();
-    return true;
-  },
-  'texra.indentTeX': (actions) => {
-    void actions.indentTeX();
-    return true;
-  },
-  'texra.auth.signIn': (actions) => {
-    void actions.signIn();
-    return true;
-  },
-  'texra.auth.signOut': (actions) => {
-    void actions.signOut();
-    return true;
-  },
-  'texra.auth.viewProfile': (actions) => {
-    void actions.viewProfile();
-    return true;
-  },
-  'texra.runSetupAssistant': (actions) => {
-    void actions.runSetupAssistant();
-    return true;
-  },
-  'texra.openGettingStarted': (actions) => {
-    void actions.openGettingStarted();
-    return true;
-  },
-  'texra.createSampleProject': (actions) => {
-    void actions.createSampleProject();
-    return true;
-  },
-  'texra.downloadArXivSource': (actions) => {
-    void actions.downloadArXivSource();
-    return true;
-  },
-  'texra.testConnection': (actions) => {
-    void actions.testConnection();
-    return true;
-  },
-  'texra.testAgentLoading': (actions) => {
-    void actions.testAgentLoading();
-    return true;
-  },
-  'texra.loadSpecificAgent': (actions) => {
-    void actions.loadSpecificAgent();
-    return true;
-  },
-  'texra.openProgressViewInTab': (actions) => {
-    void actions.openProgressViewInTab();
-    return true;
-  },
+  'texra.openSettings': (actions) => awaitTrue(actions.openWorkbenchSettings()),
+  'texra.mainView.reset': (actions) => awaitTrue(actions.resetMainView()),
+  'texra.cleanOutput': (actions) => awaitTrue(actions.cleanOutput()),
+  'texra.cleanBuild': (actions) => awaitTrue(actions.cleanBuild()),
+  'texra.indentTeX': (actions) => awaitTrue(actions.indentTeX()),
+  'texra.auth.signIn': (actions) => awaitTrue(actions.signIn()),
+  'texra.auth.signOut': (actions) => awaitTrue(actions.signOut()),
+  'texra.auth.viewProfile': (actions) => awaitTrue(actions.viewProfile()),
+  'texra.runSetupAssistant': (actions) => awaitTrue(actions.runSetupAssistant()),
+  'texra.openGettingStarted': (actions) =>
+    awaitTrue(actions.openGettingStarted()),
+  'texra.createSampleProject': (actions) =>
+    awaitTrue(actions.createSampleProject()),
+  'texra.downloadArXivSource': (actions) =>
+    awaitTrue(actions.downloadArXivSource()),
+  'texra.testConnection': (actions) => awaitTrue(actions.testConnection()),
+  'texra.testAgentLoading': (actions) => awaitTrue(actions.testAgentLoading()),
+  'texra.loadSpecificAgent': (actions) => awaitTrue(actions.loadSpecificAgent()),
+  'texra.openProgressViewInTab': (actions) =>
+    awaitTrue(actions.openProgressViewInTab()),
   'texra.openDoc': definedHandler(
     z.string(),
-    (actions: ExtensionCommandActions, page) => {
-      void actions.openDoc(page);
-      return true;
-    },
+    (actions: ExtensionCommandActions, page) => awaitTrue(actions.openDoc(page)),
   ),
   'texra.stopAgent': definedHandler(
     StreamTabIdSchema,
@@ -322,55 +322,34 @@ const EXTENSION_COMMAND_HANDLERS = {
   ),
   'texra.compactResponse': definedHandler(
     StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) => {
-      void actions.compactResponse(streamId);
-      return true;
-    },
+    (actions: ExtensionCommandActions, streamId) =>
+      awaitTrue(actions.compactResponse(streamId)),
   ),
-  'texra.parseXml': (actions) => {
-    void actions.parseXml();
-    return true;
-  },
-  'texra.parseYaml': (actions) => {
-    void actions.parseYaml();
-    return true;
-  },
-  'texra.testTextEditor': (actions) => {
-    void actions.testTextEditor();
-    return true;
-  },
-  'texra.indentCurrentTeX': (actions) => {
-    void actions.indentCurrentTeX();
-    return true;
-  },
-  'texra.applyReplacements': (actions) => {
-    void actions.applyReplacements();
-    return true;
-  },
-  'texra.fixCompilation': (actions) => {
-    void actions.fixCompilation();
-    return true;
-  },
-  'texra.getTeXCount': (actions) => {
-    void actions.getTeXCount();
-    return true;
-  },
-  'texra.countPdfPages': (actions) => {
-    void actions.countPdfPages();
-    return true;
-  },
-  'texra.showLinterMessages': (actions) => {
-    void actions.showLinterMessages();
-    return true;
-  },
-  'texra.countLinterMessages': (actions) => {
-    void actions.countLinterMessages();
-    return true;
-  },
-  'texra.extractFigurePaths': (actions) => {
-    void actions.extractFigurePaths();
-    return true;
-  },
+  'texra.parseXml': (actions) => awaitTrue(actions.parseXml()),
+  'texra.parseYaml': (actions) => awaitTrue(actions.parseYaml()),
+  'texra.testTextEditor': (actions) => awaitTrue(actions.testTextEditor()),
+  'texra.indentCurrentTeX': (actions) => awaitTrue(actions.indentCurrentTeX()),
+  'texra.applyReplacements': (actions) => awaitTrue(actions.applyReplacements()),
+  'texra.fixCompilation': (actions) => awaitTrue(actions.fixCompilation()),
+  'texra.getTeXCount': (actions) => awaitTrue(actions.getTeXCount()),
+  'texra.countPdfPages': (actions) => awaitTrue(actions.countPdfPages()),
+  'texra.showLinterMessages': (actions) =>
+    awaitTrue(actions.showLinterMessages()),
+  'texra.countLinterMessages': (actions) =>
+    awaitTrue(actions.countLinterMessages()),
+  'texra.extractFigurePaths': (actions) =>
+    awaitTrue(actions.extractFigurePaths()),
+  // Batch 3 (#3781).
+  'texra.encodeImageToBase64': (actions) =>
+    awaitTrue(actions.encodeImageToBase64()),
+  'texra.convertPdfToImages': (actions) =>
+    awaitTrue(actions.convertPdfToImages()),
+  'texra.extractTikzFigures': (actions) =>
+    awaitTrue(actions.extractTikzFigures()),
+  'texra.compileTikzFigures': (actions) =>
+    awaitTrue(actions.compileTikzFigures()),
+  'texra.cloneOverleafProject': (actions) =>
+    awaitTrue(actions.cloneOverleafProject()),
 } as const satisfies Record<
   Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
   // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry
@@ -401,7 +380,11 @@ const EXTENSION_PARAMETERIZED_HANDLERS = {
 /**
  * Register every command in the shared registry against `vscode.commands`,
  * routing each invocation through `dispatchCommandFromRegistry` so the
- * dispatch path is identical to the desktop's.
+ * dispatch path is identical to the desktop's. The registered callback
+ * returns the dispatch result (a `boolean | Promise<boolean>`) so VS Code
+ * forwards the underlying promise to `executeCommand` callers — async
+ * rejections propagate instead of being swallowed (the bug fixed by
+ * #3782).
  */
 export function registerExtensionCommandRegistry(
   context: vscode.ExtensionContext,
@@ -411,7 +394,7 @@ export function registerExtensionCommandRegistry(
     keyof typeof EXTENSION_COMMAND_HANDLERS
   >) {
     context.subscriptions.push(
-      vscode.commands.registerCommand(id, (rawArg?: unknown) => {
+      vscode.commands.registerCommand(id, (rawArg?: unknown) =>
         dispatchCommandFromRegistry(
           id,
           EXTENSION_COMMAND_HANDLERS,
@@ -422,8 +405,8 @@ export function registerExtensionCommandRegistry(
             );
           },
           rawArg,
-        );
-      }),
+        ),
+      ),
     );
   }
 

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -32,6 +32,13 @@ export const gitCommands = {
 
 export function registerGitCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
+    // `isGitRepository`, `getRecentCommits`, and `findCommitInHistory`
+    // return values to `executeCommand` callers (sync `boolean`,
+    // `string[] | null`, `string | null` respectively) and accept
+    // optional positional arguments — they keep their per-command
+    // registration. `texra.cloneOverleafProject` migrated through the
+    // shared command registry in #3781 batch 3 (see
+    // `extensionCommandSurface.ts`).
     vscode.commands.registerCommand(
       gitCommands.isGitRepository,
       isGitRepository,
@@ -44,11 +51,10 @@ export function registerGitCommands(context: vscode.ExtensionContext): void {
       gitCommands.findCommitInHistory,
       findCommitInHistory,
     ),
-    vscode.commands.registerCommand(gitCommands.cloneOverleafProject, () =>
-      cloneOverleafProject(context),
-    ),
   );
 }
+
+export { cloneOverleafProject };
 
 /**
  * Check if the workspace (or a given path) is inside a git repository.

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -40,21 +40,14 @@ async function runLaTeXCommand(
   }
 }
 
-export function registerFigureCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    // `texra.extractFigurePaths` is registered through
-    // `extensionCommandSurface` (see #3775). The remaining tikz commands
-    // stay here for now — same no-arg shape, but #3775 batched only one
-    // entry per file to keep the diff focused.
-    vscode.commands.registerCommand(
-      figureCommands.extractTikzFigures,
-      handleExtractTikzFigures,
-    ),
-    vscode.commands.registerCommand(
-      figureCommands.compileTikzFigures,
-      handleCompileTikzFigures,
-    ),
-  );
+export function registerFigureCommands(
+  _context: vscode.ExtensionContext,
+): void {
+  // `texra.extractFigurePaths` (#3775) and the tikz commands
+  // (`texra.extractTikzFigures`, `texra.compileTikzFigures`, batch 3 in
+  // #3781) are registered through `extensionCommandSurface`. This stub
+  // is kept so `commands.ts` can keep its existing call site; the
+  // exported handlers below are referenced by the registry's actions.
 }
 
 export async function handleExtractFigurePaths(): Promise<void> {
@@ -91,7 +84,7 @@ export async function handleExtractFigurePaths(): Promise<void> {
   );
 }
 
-async function handleExtractTikzFigures(): Promise<void> {
+export async function handleExtractTikzFigures(): Promise<void> {
   await runLaTeXCommand(
     'extract TikZ figures',
     'extractTikzFigures',
@@ -134,7 +127,7 @@ async function handleExtractTikzFigures(): Promise<void> {
   );
 }
 
-async function handleCompileTikzFigures(): Promise<void> {
+export async function handleCompileTikzFigures(): Promise<void> {
   await runLaTeXCommand(
     'compile TikZ figures',
     'compileTikzFigures',

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -16,20 +16,12 @@ logger.initialize(CHANNEL);
 
 const PDF_FILTERS = { 'PDF files': ['pdf'] };
 
-export function registerImageCommands(context: vscode.ExtensionContext) {
-  context.subscriptions.push(
-    // `texra.countPdfPages` is registered through `extensionCommandSurface`
-    // (see #3775). The remaining per-command registrations stay here
-    // because they return values to `executeCommand` callers.
-    vscode.commands.registerCommand(
-      'texra.encodeImageToBase64',
-      handleEncodeImageToBase64,
-    ),
-    vscode.commands.registerCommand(
-      'texra.convertPdfToImages',
-      handleConvertPdfToImages,
-    ),
-  );
+export function registerImageCommands(_context: vscode.ExtensionContext) {
+  // `texra.countPdfPages`, `texra.encodeImageToBase64`, and
+  // `texra.convertPdfToImages` are now registered through
+  // `extensionCommandSurface` (see #3775 / #3781 batch 3). This stub
+  // remains so `commands.ts` can keep its existing call site; the
+  // exported handlers above are referenced by the registry's actions.
 }
 
 export async function handleCountPdfPages(): Promise<void> {
@@ -59,7 +51,7 @@ export async function handleCountPdfPages(): Promise<void> {
   }
 }
 
-async function handleEncodeImageToBase64(): Promise<string | undefined> {
+export async function handleEncodeImageToBase64(): Promise<string | undefined> {
   try {
     const selection = await dialogUtils.selectFileFromWorkspace({
       openLabel: 'Select file',
@@ -94,7 +86,7 @@ async function handleEncodeImageToBase64(): Promise<string | undefined> {
   }
 }
 
-async function handleConvertPdfToImages(): Promise<
+export async function handleConvertPdfToImages(): Promise<
   string[] | string | undefined
 > {
   try {

--- a/src/shared/commands/registry.ts
+++ b/src/shared/commands/registry.ts
@@ -4,23 +4,34 @@ import type { z } from 'zod';
 /**
  * Handler for a registry-dispatched command.
  *
- * No-arg commands keep the legacy callable shape for backward compatibility
- * (the existing 10 view-routing handlers and the desktop registry are all
- * no-arg). Parameterized commands declare a Zod schema for their arguments
- * via `definedHandler` — the dispatcher parses the raw arg at the boundary
- * and only calls `run` once parsing succeeds, keeping handlers free of
- * parsing boilerplate.
+ * Handlers may be sync (return `boolean`) or async (return
+ * `Promise<boolean>`). The dispatcher returns whatever the handler
+ * returns, so async work performed by the handler is observable to
+ * callers — they can `await` the dispatch and surface rejections.
+ *
+ * Returning `void`-ish promises is unsafe inside a handler: the
+ * dispatcher would settle before the work finished, swallowing errors
+ * (the bug fixed by #3782). Handlers that perform async work must
+ * either `return actions.X()` (let the dispatcher forward the promise)
+ * or `await` and return `true`.
+ *
+ * No-arg commands keep the legacy callable shape for backward
+ * compatibility (the existing 10 view-routing handlers and the desktop
+ * registry are all no-arg). Parameterized commands declare a Zod schema
+ * for their arguments via `definedHandler` — the dispatcher parses the
+ * raw arg at the boundary and only calls `run` once parsing succeeds,
+ * keeping handlers free of parsing boilerplate.
  *
  * The legacy shape is preserved as a callable so existing entries like
  * `(actions) => actions.showSettings()` still type-check; the new shape
  * is an object with `run` + `argsSchema`.
  */
 export type CommandHandler<TActions, TArgs = unknown> =
-  | ((actions: TActions) => boolean)
+  | ((actions: TActions) => boolean | Promise<boolean>)
   | TypedCommandHandler<TActions, TArgs>;
 
 export interface TypedCommandHandler<TActions, TArgs> {
-  run: (actions: TActions, args: TArgs) => boolean;
+  run: (actions: TActions, args: TArgs) => boolean | Promise<boolean>;
   argsSchema: z.ZodType<TArgs>;
 }
 
@@ -46,18 +57,25 @@ type CommandHandlerMap<TId extends string, TActions> = Partial<
  */
 export function definedHandler<TActions, TArgs>(
   argsSchema: z.ZodType<TArgs>,
-  run: (actions: TActions, args: TArgs) => boolean,
+  run: (actions: TActions, args: TArgs) => boolean | Promise<boolean>,
 ): TypedCommandHandler<TActions, TArgs> {
   return { run, argsSchema };
 }
 
+/**
+ * Dispatch a command through its registered handler. Returns the
+ * handler's result directly — sync handlers settle immediately;
+ * async handlers return a promise that callers can `await` so
+ * rejections propagate (rather than the fire-and-forget pattern that
+ * regressed in #3778 and was caught in #3782).
+ */
 export function dispatchCommandFromRegistry<TId extends string, TActions>(
   id: TId,
   registry: CommandHandlerMap<TId, TActions>,
   actions: TActions,
   onUnhandled?: (id: TId) => void,
   rawArgs?: unknown,
-): boolean {
+): boolean | Promise<boolean> {
   const handler = registry[id];
   if (!handler) {
     onUnhandled?.(id);

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -15,78 +15,51 @@ import { StreamTabIdSchema } from '@shared/schemas/identifiers';
 // can't import the real `extensionCommandSurface.ts` from a vitest run
 // because it transitively pulls in `vscode`. The point of this test is
 // not to re-test the dispatcher (covered in CommandRegistry.vitest.ts);
-// it's to lock in that each newly migrated id (#3771, #3775) calls the
-// right `actions.*` method, which is what would silently regress if
-// someone re-wires the handler map.
+// it's to lock in that each newly migrated id (#3771, #3775, #3781)
+// calls the right `actions.*` method, AND that async failures
+// propagate through the dispatcher (regression guard for #3782).
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
+function awaitTrue(p: Promise<unknown> | Thenable<unknown>): Promise<boolean> {
+  return Promise.resolve(p).then(() => true);
+}
+
 const HANDLERS = {
-  'texra.cleanOutput': (actions: ExtensionCommandActions) => {
-    void actions.cleanOutput();
-    return true;
-  },
-  'texra.cleanBuild': (actions: ExtensionCommandActions) => {
-    void actions.cleanBuild();
-    return true;
-  },
-  'texra.indentTeX': (actions: ExtensionCommandActions) => {
-    void actions.indentTeX();
-    return true;
-  },
-  'texra.auth.signIn': (actions: ExtensionCommandActions) => {
-    void actions.signIn();
-    return true;
-  },
-  'texra.auth.signOut': (actions: ExtensionCommandActions) => {
-    void actions.signOut();
-    return true;
-  },
-  'texra.auth.viewProfile': (actions: ExtensionCommandActions) => {
-    void actions.viewProfile();
-    return true;
-  },
+  'texra.cleanOutput': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.cleanOutput()),
+  'texra.cleanBuild': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.cleanBuild()),
+  'texra.indentTeX': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.indentTeX()),
+  'texra.auth.signIn': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.signIn()),
+  'texra.auth.signOut': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.signOut()),
+  'texra.auth.viewProfile': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.viewProfile()),
   'texra.showMemory': (actions: ExtensionCommandActions) => {
     actions.showSettings(SETTINGS_TAB.MEMORY);
     return true;
   },
-  'texra.runSetupAssistant': (actions: ExtensionCommandActions) => {
-    void actions.runSetupAssistant();
-    return true;
-  },
-  'texra.openGettingStarted': (actions: ExtensionCommandActions) => {
-    void actions.openGettingStarted();
-    return true;
-  },
-  'texra.createSampleProject': (actions: ExtensionCommandActions) => {
-    void actions.createSampleProject();
-    return true;
-  },
-  'texra.downloadArXivSource': (actions: ExtensionCommandActions) => {
-    void actions.downloadArXivSource();
-    return true;
-  },
-  'texra.testConnection': (actions: ExtensionCommandActions) => {
-    void actions.testConnection();
-    return true;
-  },
-  'texra.testAgentLoading': (actions: ExtensionCommandActions) => {
-    void actions.testAgentLoading();
-    return true;
-  },
-  'texra.loadSpecificAgent': (actions: ExtensionCommandActions) => {
-    void actions.loadSpecificAgent();
-    return true;
-  },
-  'texra.openProgressViewInTab': (actions: ExtensionCommandActions) => {
-    void actions.openProgressViewInTab();
-    return true;
-  },
+  'texra.runSetupAssistant': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.runSetupAssistant()),
+  'texra.openGettingStarted': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.openGettingStarted()),
+  'texra.createSampleProject': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.createSampleProject()),
+  'texra.downloadArXivSource': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.downloadArXivSource()),
+  'texra.testConnection': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.testConnection()),
+  'texra.testAgentLoading': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.testAgentLoading()),
+  'texra.loadSpecificAgent': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.loadSpecificAgent()),
+  'texra.openProgressViewInTab': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.openProgressViewInTab()),
   'texra.openDoc': definedHandler(
     z.string(),
-    (actions: ExtensionCommandActions, page) => {
-      void actions.openDoc(page);
-      return true;
-    },
+    (actions: ExtensionCommandActions, page) => awaitTrue(actions.openDoc(page)),
   ),
   'texra.stopAgent': definedHandler(
     StreamTabIdSchema,
@@ -97,56 +70,43 @@ const HANDLERS = {
   ),
   'texra.compactResponse': definedHandler(
     StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) => {
-      void actions.compactResponse(streamId);
-      return true;
-    },
+    (actions: ExtensionCommandActions, streamId) =>
+      awaitTrue(actions.compactResponse(streamId)),
   ),
   // Batch 2 (#3775) — no-arg host-context commands.
-  'texra.parseXml': (actions: ExtensionCommandActions) => {
-    void actions.parseXml();
-    return true;
-  },
-  'texra.parseYaml': (actions: ExtensionCommandActions) => {
-    void actions.parseYaml();
-    return true;
-  },
-  'texra.testTextEditor': (actions: ExtensionCommandActions) => {
-    void actions.testTextEditor();
-    return true;
-  },
-  'texra.indentCurrentTeX': (actions: ExtensionCommandActions) => {
-    void actions.indentCurrentTeX();
-    return true;
-  },
-  'texra.applyReplacements': (actions: ExtensionCommandActions) => {
-    void actions.applyReplacements();
-    return true;
-  },
-  'texra.fixCompilation': (actions: ExtensionCommandActions) => {
-    void actions.fixCompilation();
-    return true;
-  },
-  'texra.getTeXCount': (actions: ExtensionCommandActions) => {
-    void actions.getTeXCount();
-    return true;
-  },
-  'texra.countPdfPages': (actions: ExtensionCommandActions) => {
-    void actions.countPdfPages();
-    return true;
-  },
-  'texra.showLinterMessages': (actions: ExtensionCommandActions) => {
-    void actions.showLinterMessages();
-    return true;
-  },
-  'texra.countLinterMessages': (actions: ExtensionCommandActions) => {
-    void actions.countLinterMessages();
-    return true;
-  },
-  'texra.extractFigurePaths': (actions: ExtensionCommandActions) => {
-    void actions.extractFigurePaths();
-    return true;
-  },
+  'texra.parseXml': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.parseXml()),
+  'texra.parseYaml': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.parseYaml()),
+  'texra.testTextEditor': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.testTextEditor()),
+  'texra.indentCurrentTeX': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.indentCurrentTeX()),
+  'texra.applyReplacements': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.applyReplacements()),
+  'texra.fixCompilation': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.fixCompilation()),
+  'texra.getTeXCount': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.getTeXCount()),
+  'texra.countPdfPages': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.countPdfPages()),
+  'texra.showLinterMessages': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.showLinterMessages()),
+  'texra.countLinterMessages': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.countLinterMessages()),
+  'texra.extractFigurePaths': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.extractFigurePaths()),
+  // Batch 3 (#3781) — additional no-arg commands; same async pattern.
+  'texra.encodeImageToBase64': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.encodeImageToBase64()),
+  'texra.convertPdfToImages': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.convertPdfToImages()),
+  'texra.extractTikzFigures': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.extractTikzFigures()),
+  'texra.compileTikzFigures': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.compileTikzFigures()),
+  'texra.cloneOverleafProject': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.cloneOverleafProject()),
   // The typed handlers carry their own argument shapes via
   // `definedHandler`. Matching the registry map's per-entry TArgs widening
   // (`any`) keeps inference per entry without unifying every entry on
@@ -187,10 +147,15 @@ function makeActions(): ExtensionCommandActions {
     showLinterMessages: vi.fn().mockResolvedValue(undefined),
     countLinterMessages: vi.fn().mockResolvedValue(undefined),
     extractFigurePaths: vi.fn().mockResolvedValue(undefined),
+    encodeImageToBase64: vi.fn().mockResolvedValue(undefined),
+    convertPdfToImages: vi.fn().mockResolvedValue(undefined),
+    extractTikzFigures: vi.fn().mockResolvedValue(undefined),
+    compileTikzFigures: vi.fn().mockResolvedValue(undefined),
+    cloneOverleafProject: vi.fn().mockResolvedValue(undefined),
   };
 }
 
-describe('extension command surface — newly migrated commands (#3771, #3775)', () => {
+describe('extension command surface — newly migrated commands (#3771, #3775, #3781)', () => {
   it.each([
     ['texra.cleanOutput', 'cleanOutput'],
     ['texra.cleanBuild', 'cleanBuild'],
@@ -218,9 +183,17 @@ describe('extension command surface — newly migrated commands (#3771, #3775)',
     ['texra.showLinterMessages', 'showLinterMessages'],
     ['texra.countLinterMessages', 'countLinterMessages'],
     ['texra.extractFigurePaths', 'extractFigurePaths'],
-  ] as const)('%s dispatches to actions.%s', (id, actionKey) => {
+    // Batch 3 (#3781)
+    ['texra.encodeImageToBase64', 'encodeImageToBase64'],
+    ['texra.convertPdfToImages', 'convertPdfToImages'],
+    ['texra.extractTikzFigures', 'extractTikzFigures'],
+    ['texra.compileTikzFigures', 'compileTikzFigures'],
+    ['texra.cloneOverleafProject', 'cloneOverleafProject'],
+  ] as const)('%s dispatches to actions.%s', async (id, actionKey) => {
     const actions = makeActions();
-    expect(dispatchCommandFromRegistry(id, HANDLERS, actions)).toBe(true);
+    const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
+    // Async handlers return a promise; awaiting must resolve to `true`.
+    await expect(Promise.resolve(result)).resolves.toBe(true);
     expect(actions[actionKey]).toHaveBeenCalledOnce();
   });
 
@@ -234,17 +207,16 @@ describe('extension command surface — newly migrated commands (#3771, #3775)',
     );
   });
 
-  it('texra.openDoc forwards parsed page argument', () => {
+  it('texra.openDoc forwards parsed page argument', async () => {
     const actions = makeActions();
-    expect(
-      dispatchCommandFromRegistry(
-        'texra.openDoc',
-        HANDLERS,
-        actions,
-        undefined,
-        'getting-started',
-      ),
-    ).toBe(true);
+    const result = dispatchCommandFromRegistry(
+      'texra.openDoc',
+      HANDLERS,
+      actions,
+      undefined,
+      'getting-started',
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
     expect(actions.openDoc).toHaveBeenCalledExactlyOnceWith('getting-started');
   });
 
@@ -276,17 +248,16 @@ describe('extension command surface — newly migrated commands (#3771, #3775)',
     expect(actions.stopAgent).toHaveBeenCalledExactlyOnceWith('stream-1');
   });
 
-  it('texra.compactResponse forwards parsed streamId', () => {
+  it('texra.compactResponse forwards parsed streamId', async () => {
     const actions = makeActions();
-    expect(
-      dispatchCommandFromRegistry(
-        'texra.compactResponse',
-        HANDLERS,
-        actions,
-        undefined,
-        'stream-2',
-      ),
-    ).toBe(true);
+    const result = dispatchCommandFromRegistry(
+      'texra.compactResponse',
+      HANDLERS,
+      actions,
+      undefined,
+      'stream-2',
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
     expect(actions.compactResponse).toHaveBeenCalledExactlyOnceWith('stream-2');
   });
 
@@ -302,5 +273,44 @@ describe('extension command surface — newly migrated commands (#3771, #3775)',
       ),
     ).toBe(false);
     expect(actions.compactResponse).not.toHaveBeenCalled();
+  });
+
+  // Regression guard for #3782: the migrated handlers must propagate
+  // async rejections instead of swallowing them through `void
+  // actions.X(); return true;`. Each asserted handler returns a
+  // promise that rejects — the dispatcher should surface the same
+  // rejection so VS Code's `executeCommand` callers (and the bot
+  // reviewer that filed #3782) actually see the failure.
+  describe('async rejection propagation (regression guard for #3782)', () => {
+    it.each([
+      ['texra.cleanOutput', 'cleanOutput'],
+      ['texra.signIn'.replace('signIn', 'auth.signIn'), 'signIn'],
+      ['texra.encodeImageToBase64', 'encodeImageToBase64'],
+      ['texra.cloneOverleafProject', 'cloneOverleafProject'],
+    ] as const)('%s rejection bubbles up', async (id, actionKey) => {
+      const actions = makeActions();
+      const failure = new Error(`boom-${actionKey}`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (actions[actionKey] as any).mockRejectedValueOnce(failure);
+
+      const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
+      await expect(Promise.resolve(result)).rejects.toBe(failure);
+    });
+
+    it('typed handler texra.compactResponse rejection bubbles up', async () => {
+      const actions = makeActions();
+      const failure = new Error('boom-compactResponse');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (actions.compactResponse as any).mockRejectedValueOnce(failure);
+
+      const result = dispatchCommandFromRegistry(
+        'texra.compactResponse',
+        HANDLERS,
+        actions,
+        undefined,
+        'stream-3',
+      );
+      await expect(Promise.resolve(result)).rejects.toBe(failure);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Async fix (#3782)**: #3778 broke async semantics — migrated handlers used `void actions.X(); return true;`, which fires-and-forgets and swallows rejections. Extend `CommandHandler` to allow `boolean | Promise<boolean>`, have `dispatchCommandFromRegistry` forward the handler's result directly, and rewrite every migrated handler to await its action through a small `awaitTrue` helper. The `vscode.commands.registerCommand` callback also returns the dispatch result so VS Code's `executeCommand` callers receive a real promise that rejects on failure.
- **Batch 3 (#3781 partial)**: five additional no-arg commands move onto the shared registry — `texra.encodeImageToBase64`, `texra.convertPdfToImages`, `texra.extractTikzFigures`, `texra.compileTikzFigures`, `texra.cloneOverleafProject`. Each handler runs its own user prompt internally; `cloneOverleafProject` captures `vscode.ExtensionContext` for `secrets` access via the action factory closure. Per-command registrations in `imageCommands.ts`, `figCommands.ts`, and `gitCommands.ts` are dropped (handlers stay exported and feed the registry's actions).

## Test plan

- [x] `npm run typecheck` clean (only pre-existing `electron`/`@openrouter/sdk` errors remain — confirmed by stashing the diff).
- [x] `cd packages/desktop && npx vite build --mode development` clean.
- [x] `npx vitest run src/test-kernel/commands/` — 47 passed.
- [x] Full `npx vitest run` — same 4 pre-existing desktop-platform failures (`fix-path` module / `--desktop-color-*` token rule) on origin/main; all 47 command-registry tests pass.
- [x] Extended `ExtensionCommandRegistry.vitest.ts`:
  - one `it.each` row per batch-3 command verifying dispatch routes to `actions.*`,
  - a regression-guard suite that `mockRejectedValueOnce`s several no-arg actions and the typed `compactResponse` handler, asserting the dispatcher's returned promise rejects with the same error (locks in #3782).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared command-dispatch typing/return semantics and rewires many VS Code command registrations, which could affect error propagation and behavior across multiple commands if miswired.
> 
> **Overview**
> Fixes a regression where registry-migrated extension commands were *fire-and-forget* (`void actions.X()`) and could silently swallow async failures. The shared registry now supports handlers returning `boolean | Promise<boolean>`, `dispatchCommandFromRegistry` forwards that result, and VS Code `registerCommand` callbacks return the dispatch result so `executeCommand` callers can await and see rejections.
> 
> Also migrates five additional no-arg commands onto the shared extension command registry: `texra.encodeImageToBase64`, `texra.convertPdfToImages`, `texra.extractTikzFigures`, `texra.compileTikzFigures`, and `texra.cloneOverleafProject` (capturing `ExtensionContext` for secrets). Per-command registrations for these are removed in `imageCommands`, `figCommands`, and `gitCommands`, handlers are exported for registry use, and tests are expanded to assert both routing and rejection propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6ad68773e10aaf96f51620023f73ac3459c331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->