### PR TITLE
refactor(zod): batch 4 — migrate settings/memory/multi-agent commands (closes #3781 partial)

### DIFF
--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -90,13 +90,15 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   // downloadArXivSource), batch-2 host-context entry points (parseXml,
   // parseYaml, testTextEditor, indentCurrentTeX,
   // applyReplacements, fixCompilation, getTeXCount, countPdfPages,
-  // showLinterMessages, countLinterMessages, extractFigurePaths), and the
-  // typed-arg handlers for openDoc/stopAgent/compactResponse — all
-  // alongside the original settings/main-view routes via the same
+  // showLinterMessages, countLinterMessages, extractFigurePaths), the
+  // typed-arg handlers for openDoc/stopAgent/compactResponse, and the
+  // batch-4 (#3781) follow-ups (removeApiKey, showImportOptions,
+  // toggleView, showProgressView, setApiKey, createAgentWithAI, execute)
+  // — all alongside the original settings/main-view routes via the same
   // dispatch path as the desktop registry. See
   // `extensionCommandSurface.ts` for the handler map.
   //
-  // FOLLOW_UP (#3775): the remaining per-command registrations carry
+  // FOLLOW_UP (#3781): the remaining per-command registrations carry
   // VS Code-specific arguments (TextEditor, Range, Uri, FileLocation,
   // pack/clean configs, agent execution payloads). Migrating those needs
   // either: (a) the `definedHandler` typed-args path in

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -640,18 +640,18 @@ function createAgentCreatorFlow(): Flow<AgentCreatorShared> {
   return new Flow<AgentCreatorShared>(gatherInput);
 }
 
-export function registerAgentCreatorCommands(context: vscode.ExtensionContext) {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      agentCreatorCommands.createAgentWithAI,
-      (category?: AgentCategory) =>
-        handleCreateAgentWithAI(context, category ?? 'workflow'),
-    ),
-  );
+/**
+ * `texra.createAgentWithAI` migrated to the shared command registry in
+ * #3781 batch 4. Kept as a no-op for backward compatibility with the
+ * existing call list in `commands.ts`.
+ */
+export function registerAgentCreatorCommands(
+  _context: vscode.ExtensionContext,
+) {
   return agentCreatorCommands;
 }
 
-async function handleCreateAgentWithAI(
+export async function handleCreateAgentWithAI(
   context: vscode.ExtensionContext,
   category: AgentCategory,
 ) {

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -12,10 +12,15 @@ import type { ExecutionId } from '@shared/schemas';
 
 const CHANNEL = 'ExecuteCommand';
 
-export function registerExecuteCommand(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.execute', runExecuteCommand),
-  );
+/**
+ * `texra.execute` migrated to the shared command registry in #3781 batch
+ * 4 (handler is `runExecuteCommand`). Kept as a no-op for backward
+ * compatibility with the existing call list in `commands.ts`.
+ */
+export function registerExecuteCommand(
+  _context: vscode.ExtensionContext,
+): void {
+  // Intentionally empty: handler moved to the shared registry (#3781 batch 4).
 }
 
 /**

--- a/packages/extension/src/commands/agent/index.ts
+++ b/packages/extension/src/commands/agent/index.ts
@@ -2,6 +2,7 @@
 export { stopAgent, compactResponse } from './agentCommands';
 export {
   agentCreatorCommands,
+  handleCreateAgentWithAI,
   registerAgentCreatorCommands,
 } from './agentCreatorCommands';
 export { runExecuteCommand, registerExecuteCommand } from './executeCommand';

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -80,67 +80,80 @@ async function setApiKeyForProvider(
   }
 }
 
-export function registerApiKeyCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      apiKeyCommands.setApiKey,
-      async (provider?: ApiProvider) => {
-        if (provider) {
-          await setApiKeyForProvider(provider, true);
-          return;
-        }
+/**
+ * Set an API key. Migrated to the shared command registry in
+ * #3781 batch 4. The registry forwards a single typed argument so the
+ * optional `provider` is parsed at the dispatch boundary.
+ */
+export async function setApiKey(provider?: ApiProvider): Promise<void> {
+  if (provider) {
+    await setApiKeyForProvider(provider, true);
+    return;
+  }
 
-        const providerItems =
-          await SecretManager.getApiProviderQuickPickItems();
-        const providerPick = await vscode.window.showQuickPick(providerItems, {
-          placeHolder: 'Select API provider',
-        });
+  const providerItems = await SecretManager.getApiProviderQuickPickItems();
+  const providerPick = await vscode.window.showQuickPick(providerItems, {
+    placeHolder: 'Select API provider',
+  });
 
-        if (providerPick?.provider) {
-          await setApiKeyForProvider(providerPick.provider);
-        }
-      },
-    ),
+  if (providerPick?.provider) {
+    await setApiKeyForProvider(providerPick.provider);
+  }
+}
 
-    vscode.commands.registerCommand(apiKeyCommands.removeApiKey, async () => {
-      const providerItems = await SecretManager.getApiProviderQuickPickItems();
-      const providerPick = await vscode.window.showQuickPick(providerItems, {
-        placeHolder: 'Select API provider to remove key',
-      });
+/**
+ * Remove an API key after a confirmation prompt. Migrated to the shared
+ * command registry in #3781 batch 4.
+ */
+export async function removeApiKey(): Promise<void> {
+  const providerItems = await SecretManager.getApiProviderQuickPickItems();
+  const providerPick = await vscode.window.showQuickPick(providerItems, {
+    placeHolder: 'Select API provider to remove key',
+  });
 
-      const provider = providerPick?.provider;
-      if (!provider) {
-        return;
-      }
+  const provider = providerPick?.provider;
+  if (!provider) {
+    return;
+  }
 
-      const confirm = await vscode.window.showWarningMessage(
-        `Remove the ${provider} API key? This cannot be undone.`,
-        'Remove',
-        'Cancel',
-      );
-      if (confirm !== 'Remove') {
-        return;
-      }
-
-      try {
-        await SecretManager.delete(SecretManager.getApiKeySecretName(provider));
-        vscode.window.showInformationMessage(
-          `${provider} API key has been removed`,
-        );
-        await refreshApiKeyUI();
-        const view = await getMainWebview();
-        view?.webview.postMessage({
-          command: (await SecretManager.anyApiKeyExists())
-            ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER
-            : MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
-        });
-      } catch (err) {
-        await showLoggedErrorMessage(
-          CHANNEL,
-          `Failed to remove ${provider} API key`,
-          err,
-        );
-      }
-    }),
+  const confirm = await vscode.window.showWarningMessage(
+    `Remove the ${provider} API key? This cannot be undone.`,
+    'Remove',
+    'Cancel',
   );
+  if (confirm !== 'Remove') {
+    return;
+  }
+
+  try {
+    await SecretManager.delete(SecretManager.getApiKeySecretName(provider));
+    vscode.window.showInformationMessage(
+      `${provider} API key has been removed`,
+    );
+    await refreshApiKeyUI();
+    const view = await getMainWebview();
+    view?.webview.postMessage({
+      command: (await SecretManager.anyApiKeyExists())
+        ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER
+        : MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+    });
+  } catch (err) {
+    await showLoggedErrorMessage(
+      CHANNEL,
+      `Failed to remove ${provider} API key`,
+      err,
+    );
+  }
+}
+
+/**
+ * Both `texra.setApiKey` and `texra.removeApiKey` are now registered through
+ * the shared command registry in `extensionCommandSurface.ts`. The
+ * registration function is kept as a no-op so existing call sites in
+ * `commands.ts` don't have to be reshuffled — removing the dependency would
+ * require dropping it from the `registerCommands` call list, which is
+ * outside the scope of this batch.
+ */
+export function registerApiKeyCommands(_context: vscode.ExtensionContext): void {
+  // Intentionally empty: handlers moved to the shared registry (#3781 batch 4).
 }

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -11,7 +11,13 @@ import {
 import {
   stopAgent as agentStopAgent,
   compactResponse as agentCompactResponse,
+  handleCreateAgentWithAI as agentHandleCreateAgentWithAI,
+  runExecuteCommand as agentRunExecuteCommand,
 } from '@commands/agent';
+import {
+  setApiKey as apiSetApiKey,
+  removeApiKey as apiRemoveApiKey,
+} from '@commands/api/apiKeyCommands';
 import { downloadArXivSource as latexDownloadArXivSource } from '@commands/latex';
 import { runSetupAssistant as setupRunAssistant } from '@commands/setup';
 import {
@@ -19,6 +25,7 @@ import {
   handleTestConnection as sysHandleTestConnection,
   handleTestAgentLoading as sysHandleTestAgentLoading,
   handleLoadSpecificAgent as sysHandleLoadSpecificAgent,
+  showImportOptions as sysShowImportOptions,
 } from '@commands/system';
 import {
   handleIndentTeX,
@@ -42,14 +49,25 @@ import {
   handleCompileTikzFigures as latexCompileTikzFigures,
 } from '@commands/latex/figCommands';
 import { cloneOverleafProject as gitCloneOverleafProject } from '@commands/git/gitCommands';
-import { openProgressViewInTab as progressOpenInTab } from '@commands/progress/progressViewCommands';
+import {
+  openProgressViewInTab as progressOpenInTab,
+  showProgressView as progressShowProgressView,
+} from '@commands/progress/progressViewCommands';
 import { openDoc as sysOpenDoc } from '@commands/system/helpCommands';
 import { openGettingStarted as sysOpenGettingStarted } from '@commands/system/walkthroughCommands';
 import { handleParseXml as sysParseXml } from '@commands/system/xmlCommands';
 import { handleParseYaml as sysParseYaml } from '@commands/system/yamlCommands';
 import { handleTestTextEditor as sysTestTextEditor } from '@commands/system/textEditorCommands';
-import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import {
+  MAIN_VIEW_COMMANDS,
+  SIDEBAR_VIEWS,
+  getActiveSidebarView,
+} from '@common/webview';
 import { getMainWebview } from '@frontend/system/commandUtils';
+import {
+  type ApiProvider,
+  SecretManager,
+} from '@frontend/secretManager';
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import {
@@ -62,8 +80,37 @@ import {
   SETTINGS_TAB,
   type SettingsTab,
 } from '@shared/schemas/settingsViewMessages';
-import { type AgentCategory } from '@shared/schemas/agent';
+import { AgentCategorySchema, type AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_QUERY } from '@utils/config';
+
+/**
+ * Optional `ApiProvider` argument for `texra.setApiKey`. The schema accepts
+ * `undefined` so the registry's `safeParse` succeeds when the command is
+ * invoked from the palette without arguments — the action then prompts the
+ * user via `showQuickPick`.
+ */
+const SetApiKeyArgSchema = z
+  .enum(SecretManager.API_PROVIDERS)
+  .optional();
+
+/**
+ * Optional `AgentCategory` argument for `texra.createAgentWithAI`. The
+ * registry parses raw `unknown` and the action defaults to `workflow`
+ * when undefined (preserving the legacy `category ?? 'workflow'` shape).
+ */
+const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
+
+/**
+ * Optional `{ inPlace }` argument for `texra.showProgressView`. The
+ * legacy registration accepted any object and only honoured the
+ * `inPlace` boolean — modelling that as an optional schema keeps the
+ * VS Code-side semantics intact when the command is invoked from
+ * keybindings (no args) vs. internal callers (`{ inPlace: true }`).
+ */
+const ShowProgressViewArgSchema = z
+  .object({ inPlace: z.boolean().optional() })
+  .partial()
+  .optional();
 
 import type { CommandId } from './catalog';
 
@@ -132,6 +179,18 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.extractTikzFigures'
   | 'texra.compileTikzFigures'
   | 'texra.cloneOverleafProject'
+  // Batch 4 (#3781) — settings/api/agent surface follow-ups. The
+  // typed handlers carry a Zod schema for their argument so the dispatcher
+  // can parse the optional provider / category / inPlace / config flag
+  // before the handler runs. The remaining no-arg entries (toggleView,
+  // showImportOptions, removeApiKey) drive interactive UI flows internally.
+  | 'texra.removeApiKey'
+  | 'texra.showImportOptions'
+  | 'texra.toggleView'
+  | 'texra.showProgressView'
+  | 'texra.setApiKey'
+  | 'texra.createAgentWithAI'
+  | 'texra.execute'
 >;
 
 /**
@@ -181,6 +240,14 @@ export interface ExtensionCommandActions {
   extractTikzFigures(): Promise<void>;
   compileTikzFigures(): Promise<void>;
   cloneOverleafProject(): Promise<void>;
+  // Batch 4 (#3781).
+  removeApiKey(): Promise<void>;
+  showImportOptions(): Promise<void>;
+  toggleView(): Promise<void>;
+  showProgressView(inPlace: boolean): Promise<void>;
+  setApiKey(provider: ApiProvider | undefined): Promise<void>;
+  createAgentWithAI(category: AgentCategory): Promise<void>;
+  execute(input: unknown): Promise<void>;
 }
 
 export function createExtensionCommandActions(
@@ -244,6 +311,19 @@ export function createExtensionCommandActions(
     extractTikzFigures: latexExtractTikzFigures,
     compileTikzFigures: latexCompileTikzFigures,
     cloneOverleafProject: () => gitCloneOverleafProject(context),
+    removeApiKey: apiRemoveApiKey,
+    showImportOptions: sysShowImportOptions,
+    async toggleView() {
+      const target =
+        getActiveSidebarView() === SIDEBAR_VIEWS.MAIN
+          ? 'texra.showProgressView'
+          : 'texra.showMainView';
+      await vscode.commands.executeCommand(target);
+    },
+    showProgressView: progressShowProgressView,
+    setApiKey: apiSetApiKey,
+    createAgentWithAI: (category) => agentHandleCreateAgentWithAI(context, category),
+    execute: agentRunExecuteCommand,
   };
 }
 
@@ -339,7 +419,7 @@ const EXTENSION_COMMAND_HANDLERS = {
     awaitTrue(actions.countLinterMessages()),
   'texra.extractFigurePaths': (actions) =>
     awaitTrue(actions.extractFigurePaths()),
-  // Batch 3 (#3781).
+  // Batch 3 (#3781) — image / PDF / TikZ / Overleaf entry points.
   'texra.encodeImageToBase64': (actions) =>
     awaitTrue(actions.encodeImageToBase64()),
   'texra.convertPdfToImages': (actions) =>
@@ -350,6 +430,30 @@ const EXTENSION_COMMAND_HANDLERS = {
     awaitTrue(actions.compileTikzFigures()),
   'texra.cloneOverleafProject': (actions) =>
     awaitTrue(actions.cloneOverleafProject()),
+  // Batch 4 (#3781).
+  'texra.removeApiKey': (actions) => awaitTrue(actions.removeApiKey()),
+  'texra.showImportOptions': (actions) =>
+    awaitTrue(actions.showImportOptions()),
+  'texra.toggleView': (actions) => awaitTrue(actions.toggleView()),
+  'texra.showProgressView': definedHandler(
+    ShowProgressViewArgSchema,
+    (actions: ExtensionCommandActions, parsed) =>
+      awaitTrue(actions.showProgressView(parsed?.inPlace === true)),
+  ),
+  'texra.setApiKey': definedHandler(
+    SetApiKeyArgSchema,
+    (actions: ExtensionCommandActions, provider) =>
+      awaitTrue(actions.setApiKey(provider)),
+  ),
+  'texra.createAgentWithAI': definedHandler(
+    CreateAgentWithAIArgSchema,
+    (actions: ExtensionCommandActions, category) =>
+      awaitTrue(actions.createAgentWithAI(category ?? 'workflow')),
+  ),
+  'texra.execute': definedHandler(
+    z.unknown(),
+    (actions: ExtensionCommandActions, input) => awaitTrue(actions.execute(input)),
+  ),
 } as const satisfies Record<
   Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
   // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry

--- a/packages/extension/src/commands/progress/progressViewCommands.ts
+++ b/packages/extension/src/commands/progress/progressViewCommands.ts
@@ -2,30 +2,31 @@ import * as vscode from 'vscode';
 
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
+/**
+ * `texra.showProgressView` migrated to the shared command registry in
+ * #3781 batch 4. Kept as a no-op for backward compatibility with the
+ * existing call list in `commands.ts`.
+ */
 export function registerProgressViewCommands(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'texra.showProgressView',
-      async (options?: unknown) => {
-        const inPlace =
-          typeof options === 'object' &&
-          options !== null &&
-          'inPlace' in options &&
-          (options as { inPlace?: boolean }).inPlace === true;
+  // Intentionally empty: handler moved to the shared registry (#3781 batch 4).
+}
 
-        const provider = ProgressViewProvider.getInstance();
-        if (!provider) {
-          vscode.window.showErrorMessage(
-            'Progress View is not available. Please try again.',
-          );
-          return;
-        }
-        await provider.showProgressView({ inPlace });
-      },
-    ),
-  );
+/**
+ * Show the progress view. Migrated to the shared command registry in
+ * #3781 batch 4. The `inPlace` flag controls whether to keep the
+ * sidebar in its current location vs. focusing it.
+ */
+export async function showProgressView(inPlace: boolean): Promise<void> {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    vscode.window.showErrorMessage(
+      'Progress View is not available. Please try again.',
+    );
+    return;
+  }
+  await provider.showProgressView({ inPlace });
 }
 
 export async function openProgressViewInTab(): Promise<void> {

--- a/packages/extension/src/commands/system/index.ts
+++ b/packages/extension/src/commands/system/index.ts
@@ -1,6 +1,10 @@
 // Barrel export for system commands
 export { helpCommands } from './helpCommands';
-export { mainViewCommands, registerMainViewCommands } from './mainViewCommands';
+export {
+  mainViewCommands,
+  registerMainViewCommands,
+  showImportOptions,
+} from './mainViewCommands';
 export {
   sampleProjectCommands,
   createSampleProject,

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -26,9 +26,10 @@ export const mainViewCommands = {
 /**
  * Registers main view commands for the extension.
  *
- * `texra.mainView.reset` is now registered through the shared command
- * registry in `extensionCommandSurface.ts` (the desktop side already
- * dispatches the same command via `DESKTOP_COMMAND_HANDLERS`).
+ * `texra.mainView.reset` and `texra.showImportOptions` are now
+ * registered through the shared command registry in
+ * `extensionCommandSurface.ts` (the desktop side already dispatches the
+ * same commands via `DESKTOP_COMMAND_HANDLERS`).
  */
 export function registerMainViewCommands(
   context: vscode.ExtensionContext,
@@ -108,44 +109,45 @@ export function registerMainViewCommands(
         }
       },
     ),
-
-    vscode.commands.registerCommand(
-      mainViewCommands.showImportOptions,
-      async () => {
-        const picked = await vscode.window.showQuickPick(
-          [
-            {
-              label: '$(repo-clone) Pull from Overleaf',
-              description: 'Import an existing Overleaf/ShareLaTeX project',
-              command: gitCommands.cloneOverleafProject,
-            },
-            {
-              label: '$(cloud-download) Grab from arXiv',
-              description: "Download a paper's source files",
-              command: arXivCommands.downloadArXivSource,
-            },
-            {
-              label: '$(file-add) Try the sample project',
-              description: 'Create a sample project to play around risk-free',
-              command: sampleProjectCommands.createSampleProject,
-            },
-            {
-              label: '$(rocket) Run the setup assistant agent',
-              description: 'Check tools, credentials, and LaTeX setup',
-              command: 'texra.runSetupAssistant',
-            },
-            {
-              label: '$(book) Walk me through setup',
-              description: 'Open the getting started walkthrough',
-              command: 'texra.openGettingStarted',
-            },
-          ],
-          { placeHolder: 'Import or create a LaTeX project' },
-        );
-        if (picked) {
-          await vscode.commands.executeCommand(picked.command);
-        }
-      },
-    ),
   );
+}
+
+/**
+ * Show the project import quick-pick. Migrated to the shared command
+ * registry in #3781 batch 4.
+ */
+export async function showImportOptions(): Promise<void> {
+  const picked = await vscode.window.showQuickPick(
+    [
+      {
+        label: '$(repo-clone) Pull from Overleaf',
+        description: 'Import an existing Overleaf/ShareLaTeX project',
+        command: gitCommands.cloneOverleafProject,
+      },
+      {
+        label: '$(cloud-download) Grab from arXiv',
+        description: "Download a paper's source files",
+        command: arXivCommands.downloadArXivSource,
+      },
+      {
+        label: '$(file-add) Try the sample project',
+        description: 'Create a sample project to play around risk-free',
+        command: sampleProjectCommands.createSampleProject,
+      },
+      {
+        label: '$(rocket) Run the setup assistant agent',
+        description: 'Check tools, credentials, and LaTeX setup',
+        command: 'texra.runSetupAssistant',
+      },
+      {
+        label: '$(book) Walk me through setup',
+        description: 'Open the getting started walkthrough',
+        command: 'texra.openGettingStarted',
+      },
+    ],
+    { placeHolder: 'Import or create a LaTeX project' },
+  );
+  if (picked) {
+    await vscode.commands.executeCommand(picked.command);
+  }
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -32,11 +32,7 @@ import {
 } from '@auth/config';
 import { getAuthStatus } from '@auth/authCommands';
 import { toErrorMessage } from '@common/errors';
-import {
-  getActiveSidebarView,
-  SIDEBAR_VIEWS,
-  setActiveSidebarView,
-} from '@common/webview';
+import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import {
   globalSM,
   initializeStateManagers,
@@ -605,14 +601,13 @@ export async function activate(context: vscode.ExtensionContext) {
     agentEventDisposable,
     { dispose: disposeStatusListener },
     statusBarItem,
+    // `texra.showMainView` keeps its bespoke registration here because the
+    // handler closes over the `MainViewProvider` and the late-bound sidebar
+    // fallback. `texra.toggleView` migrated to the shared command registry
+    // in #3781 batch 4 — its action only needs module-level state
+    // (`getActiveSidebarView()`) so it doesn't need a closure into
+    // `activate()`.
     vscode.commands.registerCommand('texra.showMainView', showMainView),
-    vscode.commands.registerCommand('texra.toggleView', async () => {
-      const target =
-        getActiveSidebarView() === SIDEBAR_VIEWS.MAIN
-          ? 'texra.showProgressView'
-          : 'texra.showMainView';
-      await vscode.commands.executeCommand(target);
-    }),
     vscode.commands.registerCommand(
       'texra.refreshApiKeyStatus',
       refreshApiKeyStatus,

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -9,6 +9,7 @@ import {
   dispatchCommandFromRegistry,
   type CommandHandler,
 } from '@shared/commands/registry';
+import { AgentCategorySchema } from '@shared/schemas/agent';
 import { StreamTabIdSchema } from '@shared/schemas/identifiers';
 
 // Re-implement the extension's no-arg handler map here in test form. We
@@ -107,6 +108,53 @@ const HANDLERS = {
     awaitTrue(actions.compileTikzFigures()),
   'texra.cloneOverleafProject': (actions: ExtensionCommandActions) =>
     awaitTrue(actions.cloneOverleafProject()),
+  // Batch 4 (#3781) — settings/api/agent surface follow-ups. Mirrors the
+  // real `EXTENSION_COMMAND_HANDLERS` shape so each migrated id is
+  // exercised through the dispatcher without importing the host-coupled
+  // surface. The `ApiProvider` schema is duplicated locally because
+  // `SecretManager` carries a `vscode` import.
+  'texra.removeApiKey': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.removeApiKey()),
+  'texra.showImportOptions': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.showImportOptions()),
+  'texra.toggleView': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.toggleView()),
+  'texra.showProgressView': definedHandler(
+    z
+      .object({ inPlace: z.boolean().optional() })
+      .partial()
+      .optional(),
+    (actions: ExtensionCommandActions, parsed) =>
+      awaitTrue(actions.showProgressView(parsed?.inPlace === true)),
+  ),
+  'texra.setApiKey': definedHandler(
+    z
+      .enum([
+        'openai',
+        'anthropic',
+        'openRouter',
+        'google',
+        'xai',
+        'deepseek',
+        'moonshot',
+        'dashscope',
+        'minimax',
+        'glm',
+      ])
+      .optional(),
+    (actions: ExtensionCommandActions, provider) =>
+      awaitTrue(actions.setApiKey(provider)),
+  ),
+  'texra.createAgentWithAI': definedHandler(
+    AgentCategorySchema.optional(),
+    (actions: ExtensionCommandActions, category) =>
+      awaitTrue(actions.createAgentWithAI(category ?? 'workflow')),
+  ),
+  'texra.execute': definedHandler(
+    z.unknown(),
+    (actions: ExtensionCommandActions, input) =>
+      awaitTrue(actions.execute(input)),
+  ),
   // The typed handlers carry their own argument shapes via
   // `definedHandler`. Matching the registry map's per-entry TArgs widening
   // (`any`) keeps inference per entry without unifying every entry on
@@ -152,6 +200,14 @@ function makeActions(): ExtensionCommandActions {
     extractTikzFigures: vi.fn().mockResolvedValue(undefined),
     compileTikzFigures: vi.fn().mockResolvedValue(undefined),
     cloneOverleafProject: vi.fn().mockResolvedValue(undefined),
+    // Batch 4 (#3781).
+    removeApiKey: vi.fn().mockResolvedValue(undefined),
+    showImportOptions: vi.fn().mockResolvedValue(undefined),
+    toggleView: vi.fn().mockResolvedValue(undefined),
+    showProgressView: vi.fn().mockResolvedValue(undefined),
+    setApiKey: vi.fn().mockResolvedValue(undefined),
+    createAgentWithAI: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -189,6 +245,10 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     ['texra.extractTikzFigures', 'extractTikzFigures'],
     ['texra.compileTikzFigures', 'compileTikzFigures'],
     ['texra.cloneOverleafProject', 'cloneOverleafProject'],
+    // Batch 4 (#3781)
+    ['texra.removeApiKey', 'removeApiKey'],
+    ['texra.showImportOptions', 'showImportOptions'],
+    ['texra.toggleView', 'toggleView'],
   ] as const)('%s dispatches to actions.%s', async (id, actionKey) => {
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
@@ -273,6 +333,111 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
       ),
     ).toBe(false);
     expect(actions.compactResponse).not.toHaveBeenCalled();
+  });
+
+  // Batch 4 (#3781) typed-arg coverage.
+  it('texra.showProgressView with no arg defaults to inPlace=false', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.showProgressView',
+      HANDLERS,
+      actions,
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.showProgressView).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('texra.showProgressView forwards inPlace=true', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.showProgressView',
+      HANDLERS,
+      actions,
+      undefined,
+      { inPlace: true },
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.showProgressView).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it('texra.setApiKey forwards parsed provider', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.setApiKey',
+      HANDLERS,
+      actions,
+      undefined,
+      'anthropic',
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.setApiKey).toHaveBeenCalledExactlyOnceWith('anthropic');
+  });
+
+  it('texra.setApiKey passes undefined when no provider given', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.setApiKey',
+      HANDLERS,
+      actions,
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.setApiKey).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('texra.setApiKey rejects unknown provider', () => {
+    const actions = makeActions();
+    expect(
+      dispatchCommandFromRegistry(
+        'texra.setApiKey',
+        HANDLERS,
+        actions,
+        undefined,
+        'not-a-provider',
+      ),
+    ).toBe(false);
+    expect(actions.setApiKey).not.toHaveBeenCalled();
+  });
+
+  it('texra.createAgentWithAI defaults to workflow when no category given', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.createAgentWithAI',
+      HANDLERS,
+      actions,
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.createAgentWithAI).toHaveBeenCalledExactlyOnceWith(
+      'workflow',
+    );
+  });
+
+  it('texra.createAgentWithAI forwards parsed toolUse category', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.createAgentWithAI',
+      HANDLERS,
+      actions,
+      undefined,
+      'toolUse',
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.createAgentWithAI).toHaveBeenCalledExactlyOnceWith(
+      'toolUse',
+    );
+  });
+
+  it('texra.execute forwards raw input through z.unknown() schema', async () => {
+    const actions = makeActions();
+    const payload = { config: { name: 'test' } };
+    const result = dispatchCommandFromRegistry(
+      'texra.execute',
+      HANDLERS,
+      actions,
+      undefined,
+      payload,
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.execute).toHaveBeenCalledExactlyOnceWith(payload);
   });
 
   // Regression guard for #3782: the migrated handlers must propagate


### PR DESCRIPTION
## Summary

Migrates seven more commands onto the shared typed-args registry (continuing #3781):
- `texra.removeApiKey` — no-arg (interactive provider quick-pick)
- `texra.showImportOptions` — no-arg (interactive import quick-pick)
- `texra.toggleView` — no-arg (was registered late in `extension.ts`; moved into the registry since the action only reads module-level sidebar state)
- `texra.showProgressView` — typed `{ inPlace?: boolean }`
- `texra.setApiKey` — typed `ApiProvider | undefined` (Zod enum derived from `SecretManager.API_PROVIDERS`)
- `texra.createAgentWithAI` — typed `AgentCategory | undefined`, defaults to `'workflow'`
- `texra.execute` — typed `unknown` (the existing internal `AgentConfigSchema.parse` continues to validate the payload)

All async handlers go through `awaitTrue()` so rejections propagate (the regression guard from #3782 still applies). The per-call-site `vscode.commands.registerCommand(...)` entries are removed; the corresponding `register*Commands` functions are kept as no-ops to avoid churn in the `registerCommands(context)` call list.

Adds vitest cases for each new id in `src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts`, including typed-arg coverage (provider parsing, unknown-provider rejection, category default, `inPlace` flag forwarding).

State after this batch: ~50 commands migrated across 5 PRs (#3770: 10, #3774: 6, #3778: 11, #3783: 11, #3784: 5, this PR: 7). ~37 remain — they carry VS Code-specific or multi-positional args (TextEditor / Range / Uri / FileLocation / pack-clean configs).

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing electron / @openrouter/sdk module-resolution errors unchanged)
- [x] `cd packages/desktop && npx vite build --mode development` — clean build
- [x] `npx vitest run src/test-kernel/commands/` — 58 tests pass (3 files)
- [x] `npx vitest run` — 394 tests pass; 2 unrelated failures in `DesktopThemeTokens.vitest.mts` (pre-existing on origin/main)
- [ ] Manual: invoke `texra.setApiKey` from palette → provider quick-pick → set
- [ ] Manual: invoke `texra.removeApiKey` from palette → confirmation → remove
- [ ] Manual: invoke `texra.toggleView` keybinding (Cmd+Alt+T) — flips between launcher and progress
- [ ] Manual: `vscode.commands.executeCommand('texra.showProgressView', { inPlace: true })` works as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how several user-facing VS Code commands are registered/parsed and routed through the shared dispatcher; regressions would surface as missing/broken commands or argument parsing issues, but behavior is largely preserved and covered by new tests.
> 
> **Overview**
> Migrates seven VS Code extension commands to the shared typed-args command registry (`extensionCommandSurface.ts`): `texra.removeApiKey`, `texra.showImportOptions`, `texra.toggleView`, `texra.showProgressView` (optional `{ inPlace?: boolean }`), `texra.setApiKey` (optional `ApiProvider`), `texra.createAgentWithAI` (optional `AgentCategory`, defaults to `workflow`), and `texra.execute` (raw `unknown`).
> 
> Legacy per-command `register*Commands` implementations are converted to *no-ops* for backward compatibility, with the underlying handlers exported and invoked via `createExtensionCommandActions`; `texra.toggleView` is removed from bespoke registration in `extension.ts`. Adds vitest coverage to ensure each migrated command dispatches correctly and that typed-arg parsing/defaulting and rejection propagation behave as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6356d4bc1daa3e94e2be67f6035a3d0c7f0a945e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->