### PR TITLE
fix(zod): bot-review findings on #3780/#3784 + remove stale registerCommand duplicates

### DIFF
--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -25,12 +25,16 @@ test.beforeAll(async () => {
   launched = await launchTexraApp();
   // Wait for IPC bootstrap (which sets walkthrough state from disk) by checking
   // for the "Got it" button, then click to dismiss persistently.
-  await launched.page.waitForFunction(() => {
-    const btn = Array.from(document.querySelectorAll('wa-button')).find(
-      (b) => b.textContent?.trim() === 'Got it',
-    );
-    return btn instanceof HTMLElement;
-  });
+  await launched.page.waitForFunction(
+    () => {
+      const btn = Array.from(document.querySelectorAll('wa-button')).find(
+        (b) => b.textContent?.trim() === 'Got it',
+      );
+      return btn instanceof HTMLElement;
+    },
+    undefined,
+    { timeout: 10000 },
+  );
   const dismissed = await launched.page.evaluate(() => {
     const btn = Array.from(document.querySelectorAll('wa-button')).find(
       (b) => b.textContent?.trim() === 'Got it',
@@ -42,8 +46,14 @@ test.beforeAll(async () => {
     return false;
   });
   if (dismissed) {
-    // Wait for the walkthrough dialog to be hidden after dismissing.
-    await launched.page.locator('wa-dialog[walkthrough-dialog]').waitFor({ state: 'hidden', timeout: 5000 });
+    // Wait for the onboarding walkthrough dialog to detach after dismissing.
+    // The dialog is rendered as `<wa-dialog class="desktop-onboarding">` (see
+    // `packages/desktop/src/renderer/desktopOnboarding.ts`), so target that
+    // class — the previous `wa-dialog[walkthrough-dialog]` selector matched
+    // nothing and made the wait a no-op.
+    await launched.page
+      .locator('wa-dialog.desktop-onboarding')
+      .waitFor({ state: 'hidden', timeout: 5000 });
   }
 });
 
@@ -105,16 +115,32 @@ test('settings screenshot', async () => {
   await launched.page.evaluate((tabIndex) => {
     window.postMessage({ command: 'setTab', tabIndex }, '*');
   }, multiAgentTabIndex);
-  // Wait for the webview/iframe to signal tab content is ready.
-  // The settings webview processes the message and renders the tab asynchronously.
-  // Check for a known element that appears when the Multi-Agent tab is active.
-  await launched.page.waitForFunction(() => {
-    // Settings webview loads asynchronously; wait for it to have rendered content.
-    const settingsSection = document.querySelector('.desktop-route[data-route="settings"]');
-    if (!settingsSection) return false;
-    // Check if the webview has any child content (iframe or custom elements).
-    return settingsSection.querySelector('*') != null;
-  }, { timeout: 10000 });
+  // Wait for the Multi-Agent tab to actually be active. The settings webview
+  // loads `<settings-app>` asynchronously, then the tab-group activates the
+  // requested panel. We probe the shadow DOM to confirm the multi-agent panel
+  // is rendered and visible — a generic `querySelector('*')` check passed
+  // immediately and made the wait a no-op.
+  await launched.page.waitForFunction(
+    () => {
+      const settingsSection = document.querySelector(
+        '.desktop-route[data-route="settings"]',
+      );
+      if (!settingsSection) return false;
+      const settingsApp = settingsSection.querySelector('settings-app');
+      const root = settingsApp?.shadowRoot;
+      if (!root) return false;
+      const activeTab = root.querySelector(
+        'wa-tab[panel="multi-agent"][active]',
+      );
+      const activePanel = root.querySelector(
+        'wa-tab-panel[name="multi-agent"][active]',
+      );
+      // Either signal indicates the multi-agent tab has been activated.
+      return activeTab != null || activePanel != null;
+    },
+    undefined,
+    { timeout: 10000 },
+  );
   await launched.page.screenshot({
     path: join(SCREENSHOTS_DIR, 'settings.png'),
     fullPage: false,
@@ -141,18 +167,25 @@ test('command palette opens and dismisses', async () => {
   });
   expect(opened).toBe(true);
   // Wait for the command palette dialog to appear and contain entries.
-  await launched.page.waitForFunction(() => {
-    const dialog = document.querySelector<HTMLElement>(
-      '.desktop-command-palette',
-    );
-    if (!dialog) return false;
-    // Entries are rendered as buttons inside the palette body; falling back
-    // to any clickable item lets the test survive class-name churn.
-    const entries = dialog.querySelectorAll(
-      'button, [role="option"], .desktop-command-palette-entry',
-    );
-    return entries.length > 0;
-  }, { timeout: 5000 });
+  // NOTE: `waitForFunction(pageFn, arg, options)` — pass timeout in the 3rd
+  // parameter, not as the predicate's arg, otherwise Playwright falls back
+  // to its default timeout.
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector<HTMLElement>(
+        '.desktop-command-palette',
+      );
+      if (!dialog) return false;
+      // Entries are rendered as buttons inside the palette body; falling back
+      // to any clickable item lets the test survive class-name churn.
+      const entries = dialog.querySelectorAll(
+        'button, [role="option"], .desktop-command-palette-entry',
+      );
+      return entries.length > 0;
+    },
+    undefined,
+    { timeout: 5000 },
+  );
   const entryCount = await launched.page.evaluate(() => {
     const dialog = document.querySelector<HTMLElement>(
       '.desktop-command-palette',
@@ -167,13 +200,18 @@ test('command palette opens and dismisses', async () => {
   // Dismiss with Escape and verify the dialog closes.
   await launched.page.keyboard.press('Escape');
   // Wait for the dialog to close by checking for the `open` attribute removal.
-  await launched.page.waitForFunction(() => {
-    const dialog = document.querySelector<HTMLElement>(
-      '.desktop-command-palette',
-    );
-    if (!dialog) return true;
-    return dialog.getAttribute('open') == null;
-  }, { timeout: 5000 });
+  // Pass timeout via options (3rd param), not as the predicate arg.
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector<HTMLElement>(
+        '.desktop-command-palette',
+      );
+      if (!dialog) return true;
+      return dialog.getAttribute('open') == null;
+    },
+    undefined,
+    { timeout: 5000 },
+  );
   const closed = await launched.page.evaluate(() => {
     const dialog = document.querySelector<HTMLElement>(
       '.desktop-command-palette',

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -230,11 +230,14 @@ export interface ExtensionCommandActions {
   showLinterMessages(): Promise<void>;
   countLinterMessages(): Promise<void>;
   extractFigurePaths(): Promise<void>;
-  // Batch 3 (#3781). The image/PDF handlers return data to
-  // `executeCommand` callers (palette invocations don't consume the
-  // value, but the existing return-type surface is preserved). The
-  // registry's typed return is `Promise<boolean>`, so handlers below
-  // discard the data values after awaiting.
+  // Batch 3 (#3781). The action functions return data (the underlying
+  // `string | string[] | undefined`) for direct callers, but the
+  // registry's typed return is `Promise<boolean>`, so the dispatcher
+  // wraps them with `awaitTrue(...)` and the resolved data is
+  // intentionally dropped. Palette / `executeCommand` callers don't
+  // consume the value today; if a future caller needs the original
+  // payload it must call the action helper directly instead of going
+  // through `vscode.commands.executeCommand`.
   encodeImageToBase64(): Promise<string | undefined>;
   convertPdfToImages(): Promise<string[] | string | undefined>;
   extractTikzFigures(): Promise<void>;

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -21,7 +21,9 @@ export function registerImageCommands(_context: vscode.ExtensionContext) {
   // `texra.convertPdfToImages` are now registered through
   // `extensionCommandSurface` (see #3775 / #3781 batch 3). This stub
   // remains so `commands.ts` can keep its existing call site; the
-  // exported handlers above are referenced by the registry's actions.
+  // exported handlers (`handleCountPdfPages`,
+  // `handleEncodeImageToBase64`, `handleConvertPdfToImages`) defined
+  // below are referenced by the registry's actions.
 }
 
 export async function handleCountPdfPages(): Promise<void> {

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -449,7 +449,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
   describe('async rejection propagation (regression guard for #3782)', () => {
     it.each([
       ['texra.cleanOutput', 'cleanOutput'],
-      ['texra.signIn'.replace('signIn', 'auth.signIn'), 'signIn'],
+      ['texra.auth.signIn', 'signIn'],
       ['texra.encodeImageToBase64', 'encodeImageToBase64'],
       ['texra.cloneOverleafProject', 'cloneOverleafProject'],
     ] as const)('%s rejection bubbles up', async (id, actionKey) => {


### PR DESCRIPTION
## Summary

Address bot-review findings on the recent Playwright (#3780) and async-semantics + image/figure migration (#3784) PRs, and audit the remaining `vscode.commands.registerCommand` call sites in `packages/extension/src/commands/` for stale duplicates.

### #3780 — Playwright deterministic waits (Copilot + Cursor)

- **Walkthrough dialog selector**: `wa-dialog[walkthrough-dialog]` matches no element (renderer uses `<wa-dialog class=\"desktop-onboarding\">`). With `state: 'hidden'`, Playwright treated the no-match locator as already detached, making the wait a no-op. Switched to `wa-dialog.desktop-onboarding`.
- **Initial \"Got it\" wait**: missing explicit timeout. Pass `{ timeout: 10000 }` via the options parameter.
- **Multi-Agent settings tab wait**: predicate returned true the moment any descendant existed under the settings route — effectively a no-op. Probe the `<settings-app>` shadow root for an active `wa-tab[panel=\"multi-agent\"][active]` / `wa-tab-panel[name=\"multi-agent\"][active]` instead.
- **Two `waitForFunction` calls in the command-palette test**: `{ timeout: 5000 }` was passed as the predicate's *arg* instead of Playwright options (options are the 3rd parameter). Moved timeouts to the correct slot.

### #3784 — async semantics + image/figure migration (Copilot)

- `extensionCommandSurface.ts`: comment at the image/PDF action declarations claimed \"return-type surface is preserved\", but the registry wraps them with `awaitTrue(...)` and always resolves to `true`, discarding the underlying `string | string[] | undefined`. Updated comment to describe what actually happens.
- `latex/imageCommands.ts`: stub comment said \"exported handlers above\" — the handlers are actually defined *below*. Reworded to name the handlers explicitly.
- `ExtensionCommandRegistry.vitest.ts`: replaced the indirect `'texra.signIn'.replace('signIn', 'auth.signIn')` with the literal `'texra.auth.signIn'`.

### `registerCommand` audit

After running `grep -rn vscode.commands.registerCommand`, the count is **46**, not the ~92 mentioned in the task brief — prior batches already cleaned up the duplicates. Each remaining call site registers a command id that is **not** present in `EXTENSION_COMMAND_HANDLERS` / `EXTENSION_PARAMETERIZED_HANDLERS`:

- `texra.clean*`, `texra.pack*`, `texra.latexdiff*`, `texra.compare`, `texra.acceptEdited`, `texra.merge`, `texra.sendFollowUp`, `texra.resumeAgent`, `texra.refresh{Model,Agent,All}Options`, `texra.openFile{,Compile}`, `texra.openLabel`, `texra.{isGitRepository,getRecentCommits,findCommitInHistory}`, `texra.restoreState`, 12 `texra.select*` file-selection ids, `texra.showGitSettings`.

All are legitimate VS Code-only call sites; nothing to remove. The two `registerCommand` calls inside `extensionCommandSurface.ts` itself are the registry's own loop — also legitimate.

## Test plan

- [x] `npm run typecheck` — clean against repo's set of pre-existing errors (electron / @openrouter/sdk module-resolution noise on origin/main, unchanged by this PR).
- [x] `cd packages/desktop && npx vite build --mode development` — clean, builds renderer in 1.45s.
- [x] `npx vitest run` — 392 passing (4 pre-existing failures in `DesktopThemeTokens` and `ElectronCompositionRoot` unrelated to this PR; verified identical on origin/main).
- [x] `npx vitest run src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` — 52/52 passing (covers the touched literal-id assertion).
- [ ] `pnpm exec playwright test` in `packages/desktop/` — cannot run locally because `fix-path` is missing from the workspace (also fails on origin/main; pre-existing env limitation, not regression). The screenshot.spec.ts edits pass typecheck and follow Playwright's documented `(pageFn, arg, options)` signature, so CI should validate them where the dependency is installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test synchronization logic and comment/test-string cleanups, with no runtime behavior changes beyond improving test determinism.
> 
> **Overview**
> Improves desktop Playwright E2E stability by fixing `waitForFunction` timeout usage, waiting on the correct onboarding dialog selector (`wa-dialog.desktop-onboarding`), and making the settings screenshot wait specifically for the Multi-Agent tab to become active via `settings-app` shadow DOM checks.
> 
> Cleans up extension command-surface documentation around image/PDF commands (clarifying that return payloads are intentionally dropped via `awaitTrue`) and updates related comments/tests, including using the literal `texra.auth.signIn` command id in the async-rejection regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e1cb1c33d2d9801b27df54a80f7bdb7f440f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->