### PR TITLE
fix(zod): preserve best-effort showProgressView arg semantics + cleanup

### DIFF
--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -2,6 +2,8 @@
 import * as vscode from 'vscode';
 import { z } from 'zod';
 
+import type { CommandId } from './catalog';
+
 // Local imports
 import {
   signIn as authSignIn,
@@ -102,17 +104,13 @@ const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
 
 /**
  * Optional `{ inPlace }` argument for `texra.showProgressView`. The
- * legacy registration accepted any object and only honoured the
- * `inPlace` boolean — modelling that as an optional schema keeps the
- * VS Code-side semantics intact when the command is invoked from
- * keybindings (no args) vs. internal callers (`{ inPlace: true }`).
+ * legacy registration accepted any argument shape and only honoured the
+ * `inPlace` boolean — `z.unknown()` here preserves that best-effort
+ * semantics so callers passing `null`, booleans, or stringified flags
+ * still open the progress view (just without the in-place flag) instead
+ * of being rejected by the dispatcher as unhandled.
  */
-const ShowProgressViewArgSchema = z
-  .object({ inPlace: z.boolean().optional() })
-  .partial()
-  .optional();
-
-import type { CommandId } from './catalog';
+const ShowProgressViewArgSchema = z.unknown();
 
 const RESET_CHANNEL = 'mainViewCommands';
 
@@ -440,8 +438,13 @@ const EXTENSION_COMMAND_HANDLERS = {
   'texra.toggleView': (actions) => awaitTrue(actions.toggleView()),
   'texra.showProgressView': definedHandler(
     ShowProgressViewArgSchema,
-    (actions: ExtensionCommandActions, parsed) =>
-      awaitTrue(actions.showProgressView(parsed?.inPlace === true)),
+    (actions: ExtensionCommandActions, parsed) => {
+      const inPlace =
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        (parsed as { inPlace?: unknown }).inPlace === true;
+      return awaitTrue(actions.showProgressView(inPlace));
+    },
   ),
   'texra.setApiKey': definedHandler(
     SetApiKeyArgSchema,


### PR DESCRIPTION
Three bot review findings on #3785 addressed: best-effort arg semantics restored via z.unknown() + runtime guard, redundant .partial() removed, import ordering fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to VS Code command argument parsing/validation for a single command, restoring permissive behavior; main risk is slight behavior change for callers relying on strict schema rejection.
> 
> **Overview**
> Restores legacy *best-effort* argument handling for `texra.showProgressView` by switching its Zod arg schema from an optional object to `z.unknown()` and adding a runtime guard that only treats `inPlace` as true when a non-null object contains `inPlace: true`.
> 
> Also cleans up minor command-surface hygiene by removing redundant schema modifiers and fixing the `CommandId` type import ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46403c3a3afa714c907dec197c8c13f424b78272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->