### PR TITLE
fix(zod): bot reviews on #3788/#3789

### DIFF
--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -2,8 +2,6 @@
 import * as vscode from 'vscode';
 import { z } from 'zod';
 
-import type { CommandId } from './catalog';
-
 // Local imports
 import {
   signIn as authSignIn,
@@ -84,6 +82,7 @@ import {
 } from '@shared/schemas/settingsViewMessages';
 import { AgentCategorySchema, type AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_QUERY } from '@utils/config';
+import type { CommandId } from './catalog';
 
 /**
  * Optional `ApiProvider` argument for `texra.setApiKey`. The schema accepts
@@ -191,17 +190,16 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.execute'
 >;
 
-/**
- * DUPLICATE REGISTRATION AUDIT (#3787 follow-up):
- * All 50 command IDs in `EXTENSION_COMMAND_HANDLERS` +
- * `EXTENSION_PARAMETERIZED_HANDLERS` have been verified to have no stale
- * `vscode.commands.registerCommand(...)` calls elsewhere in the codebase.
- *
- * The remaining 46 `registerCommand` call sites (as of the last audit) all
- * register command ids NOT present in the registry — they are legitimate
- * VS Code-only handlers (file ops, git, latex tools, pack/clean variants,
- * etc.) and have no duplicates. Registry handlers are the single source of
- * truth for the commands listed here.
+/*
+ * Duplicate-registration audit (#3787 follow-up):
+ * Every command id in `EXTENSION_COMMAND_HANDLERS` +
+ * `EXTENSION_PARAMETERIZED_HANDLERS` has been verified to have no stale
+ * `vscode.commands.registerCommand(...)` call elsewhere. The remaining
+ * legacy `registerCommand` call sites all register ids NOT present in
+ * the registry — they're legitimate VS Code-only handlers (file ops, git,
+ * latex tools, pack/clean variants). The shared `commandCatalog` remains
+ * the authoritative list of registry entries; this map is the
+ * authoritative registration mechanism for those entries.
  */
 
 /**


### PR DESCRIPTION
Audit comment converted to plain block + counts dropped; CommandId import moved into Local imports per eslint import-order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/lint-only change; no functional code paths or command registration behavior are modified.
> 
> **Overview**
> Adjusts `extensionCommandSurface.ts` import ordering by moving the `CommandId` type into the local-import section to satisfy eslint `import-order`.
> 
> Replaces the verbose JSDoc-style duplicate-registration audit note (including specific counts) with a shorter plain block comment while keeping the same intent and references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019069bdf5f3b41a6e7bed4fd5f2084c6fe78110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->