### PR TITLE
docs(prd): refresh electron-shell-layout reference (vscode-split-layout → wa-split-panel)

### DIFF
--- a/docs/prd/electron-shell-layout.md
+++ b/docs/prd/electron-shell-layout.md
@@ -96,7 +96,7 @@ New `packages/extension/src/progressView/frontend/progressState.ts` exports toda
 The body currently rendered by `ProgressApp.renderStreamContent()` (plus the empty-state) moves into a new Lit element that subscribes to `progressState`. Internal children unchanged: `<stream-header>`, `<context-management>`, `<todo-list>`, `<background-tasks-panel>`, `<log-list>` / `<task-group-list>`, request panels, `<usage-panel>`, `<follow-up-input>`.
 
 **C. `<progress-app>` becomes a thin shell.**
-For VS Code: renders `view-header` plus `<vscode-split-layout>` containing `<stream-conversation>` and `<stream-tabs>` — identical UX to today. For Electron: not mounted at all; the children mount directly in window panes.
+For VS Code: renders `view-header` plus `<wa-split-panel>` containing `<stream-conversation>` and `<stream-tabs>` — identical UX to today. For Electron: not mounted at all; the children mount directly in window panes. (The PRD originally referenced `<vscode-split-layout>`; that component was retired during the Web Awesome migration session, so `wa-split-panel` is now the project's canonical split control.)
 
 **D. Electron renderer shell.**
 Replaces the four-route tab router. Three panes. Center swaps between `<main-app>` and `<stream-conversation>` driven by `activeStreamId$`. Settings overlay on gear. Workspace explorer deleted.


### PR DESCRIPTION
PRD #3791 was authored before this session retired `vscode-split-layout`. Refresh §7.C to reference `wa-split-panel` so the PRD matches the actual component the project uses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a PRD component reference; no runtime or build impact.
> 
> **Overview**
> Updates the Electron shell layout PRD (`docs/prd/electron-shell-layout.md`) to reference `wa-split-panel` instead of the retired `vscode-split-layout` for the VS Code split layout description, aligning the document with the current Web Awesome component choice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a798a8b1392755647fd2e2aaf64ea211fccd6fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->