### PR TITLE
refactor(progress): PRD PR 2 — extract <stream-conversation>, slim <progress-app>

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -2,8 +2,7 @@ import { create } from 'mutative';
 
 // Third-party imports
 import { html, css, type TemplateResult } from 'lit';
-import { provide } from '@lit/context';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import { z } from 'zod';
@@ -34,7 +33,6 @@ import {
   TEXRA_ICON_LIBRARY,
 } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
-import { isProcessAgent } from '@shared/streams/agentKind';
 import '@shared/wa/tabs';
 import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 
@@ -49,18 +47,14 @@ import {
   type StreamState,
 } from './store';
 import {
-  activeProcessOutputs$,
   activeStreamId$,
   appState,
   childStreamsByParent$,
   hasAnyStreams$,
-  logContext$,
   narrowLayout,
   pendingApprovalIds$,
   permissions$,
   placement,
-  streamById$,
-  streamContext$,
   streamFilter$,
   streamStates$,
   tabStreams$,
@@ -93,35 +87,14 @@ import {
   type MessageHandlerContext,
 } from './messageDispatcher';
 
-// Local imports - progress view contexts
-import {
-  EMPTY_LOG_CONTEXT,
-  EMPTY_PROCESS_OUTPUTS,
-  EMPTY_STREAM_BY_ID,
-  EMPTY_STREAM_CONTEXT,
-  permissionsContext,
-  processOutputContext,
-  streamByIdContext,
-  streamLogContext,
-  streamStateContext,
-  type ProcessOutputMap,
-  type StreamByIdMap,
-  type StreamContextValue,
-  type StreamLogContextValue,
-} from './contexts/streamContexts';
 import type { FrontendEventHandlerContext } from './eventHandlers';
 // Local imports - progress view components
 import './components/StreamTabs';
-import './components/ToolUseStreamContent';
-import './components/WorkflowStreamContent';
-import './components/ProcessStreamContent';
+import './components/StreamConversation';
 import './components/UserMessage';
 import './components/StatisticsPanel';
 import './components/LatexdiffResults';
 import './components/ContextManagement';
-
-// Local imports - progress view component types
-import type { PermissionState } from './components/PermissionCard';
 
 registerTeXRAWebAwesomeIcons();
 
@@ -272,21 +245,10 @@ export class ProgressApp extends ProgressAppBase {
         max-width: 360px;
       }
 
-      .content-area {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        min-width: 0;
-        min-height: 0;
-        overflow: hidden;
-      }
-
-      /* Stream content containers - pass-through for layout */
-      tool-use-stream-content,
-      workflow-stream-content,
-      process-stream-content {
-        display: contents;
-      }
+      /* .content-area and stream-content layout rules moved to
+         components/StreamConversation.ts (the :host block + its shadow
+         scope). The <stream-conversation> element is now the slot=start
+         element directly. */
 
       .desktop-empty-progress {
         display: grid;
@@ -352,26 +314,6 @@ export class ProgressApp extends ProgressAppBase {
     narrowLayout.set(width < 500);
   });
 
-  @provide({ context: streamStateContext })
-  @state()
-  private streamContextValue: StreamContextValue = EMPTY_STREAM_CONTEXT;
-
-  @provide({ context: streamLogContext })
-  @state()
-  private streamLogContextValue: StreamLogContextValue = EMPTY_LOG_CONTEXT;
-
-  @provide({ context: permissionsContext })
-  @state()
-  private permissionsContextValue: PermissionState[] = [];
-
-  @provide({ context: processOutputContext })
-  @state()
-  private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
-
-  @provide({ context: streamByIdContext })
-  @state()
-  private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
-
   private prefsManager = new PersistedState(
     webviewStorage,
     'progressViewPrefs',
@@ -400,19 +342,6 @@ export class ProgressApp extends ProgressAppBase {
 
   protected get readyCommand(): string | null {
     return PROGRESS_VIEW_COMMANDS.WEBVIEW_READY;
-  }
-
-  /**
-   * Sync signal-computed values into @provide/@state context properties.
-   * SignalWatcher triggers requestUpdate() when any read signal changes,
-   * so this runs only when computed values actually propagate.
-   */
-  protected override willUpdate(): void {
-    this.streamContextValue = streamContext$.get();
-    this.streamLogContextValue = logContext$.get();
-    this.permissionsContextValue = permissions$.get();
-    this.processOutputContextValue = activeProcessOutputs$.get();
-    this.streamByIdContextValue = streamById$.get();
   }
 
   render(): TemplateResult {
@@ -497,13 +426,22 @@ export class ProgressApp extends ProgressAppBase {
           ? html`
               <div class="split-container">
                 <wa-split-panel .position=${splitPosition}>
-                  <div
+                  <stream-conversation
                     slot="start"
-                    class="content-area"
                     @stream-switch=${this.onStreamSwitch}
-                  >
-                    ${this.renderStreamContent()}
-                  </div>
+                    @toolbar-command=${this.onToolbarCommand}
+                    @permission-action=${this.onPermissionAction}
+                    @file-action=${this.onFileAction}
+                    @compile-fixer-run=${this.onCompileFixerRun}
+                    @followup-request-options=${this.onFollowupRequestOptions}
+                    @followup-setup=${this.onFollowupSetup}
+                    @followup-run=${this.onFollowupRun}
+                    @followup-change=${this.onFollowUpChange}
+                    @followup-send=${this.onFollowUpSend}
+                    @followup-polish=${this.onFollowUpPolish}
+                    @followup-clear=${this.onFollowUpClear}
+                    @followup-focus-complete=${this.onFollowUpFocusComplete}
+                  ></stream-conversation>
 
                   <stream-tabs
                     slot="end"
@@ -555,56 +493,6 @@ export class ProgressApp extends ProgressAppBase {
           })}
         </div>
       </section>
-    `;
-  }
-
-  /**
-   * Render stream content based on stream type.
-   * Single branch point - delegates to typed container components.
-   */
-  private renderStreamContent(): TemplateResult {
-    const { streamInfo, streamState, isToolUse } = this.streamContextValue;
-    if (!streamInfo || !streamState) {
-      // No active stream - show empty log-list
-      return html`<log-list></log-list>`;
-    }
-
-    // Process agents (e.g. bash) proxy raw stdout/stderr — render them with a
-    // dedicated terminal-style container, not the LLM workflow/tool-use chrome.
-    if (isProcessAgent(streamInfo.agent)) {
-      return html`
-        <process-stream-content
-          @toolbar-command=${this.onToolbarCommand}
-        ></process-stream-content>
-      `;
-    }
-
-    // Single branch point: delegate to typed container component
-    if (isToolUse) {
-      return html`
-        <tool-use-stream-content
-          @toolbar-command=${this.onToolbarCommand}
-          @permission-action=${this.onPermissionAction}
-          @followup-change=${this.onFollowUpChange}
-          @followup-send=${this.onFollowUpSend}
-          @followup-polish=${this.onFollowUpPolish}
-          @followup-clear=${this.onFollowUpClear}
-          @followup-focus-complete=${this.onFollowUpFocusComplete}
-        ></tool-use-stream-content>
-      `;
-    }
-
-    // Workflow stream (default for non-tool-use)
-    return html`
-      <workflow-stream-content
-        @toolbar-command=${this.onToolbarCommand}
-        @permission-action=${this.onPermissionAction}
-        @file-action=${this.onFileAction}
-        @compile-fixer-run=${this.onCompileFixerRun}
-        @followup-request-options=${this.onFollowupRequestOptions}
-        @followup-setup=${this.onFollowupSetup}
-        @followup-run=${this.onFollowupRun}
-      ></workflow-stream-content>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -1,0 +1,145 @@
+/**
+ * `<stream-conversation>` — the body of the Progress view's active stream.
+ *
+ * Hoisted out of `ProgressApp.renderStreamContent()` (PRD:
+ * docs/prd/electron-shell-layout.md § 7.B). Subscribes to module-level signals
+ * from `../progressState.ts` so the conversation body can mount independently
+ * of `<progress-app>` — required for the Electron three-pane shell (PR 3) where
+ * `<stream-conversation>` and `<stream-tabs>` live in different DOM trees.
+ *
+ * Behavior preservation: the rendered tree, child events, and Lit context
+ * provider values match the previous `ProgressApp` body exactly. The page-
+ * level "no runs yet" empty-state remains owned by `<progress-app>` for now —
+ * see the PR description for why we deferred that part of the PRD wording.
+ */
+
+// Third-party imports
+import { LitElement, css, html, type TemplateResult } from 'lit';
+import { provide } from '@lit/context';
+import { customElement, state } from 'lit/decorators.js';
+
+// Local imports - shared
+import { isProcessAgent } from '@shared/streams/agentKind';
+import { SignalWatcher } from '@shared/signals';
+
+// Local imports - progress view
+import {
+  activeProcessOutputs$,
+  logContext$,
+  permissions$,
+  streamById$,
+  streamContext$,
+} from '../progressState';
+import {
+  EMPTY_LOG_CONTEXT,
+  EMPTY_PROCESS_OUTPUTS,
+  EMPTY_STREAM_BY_ID,
+  EMPTY_STREAM_CONTEXT,
+  permissionsContext,
+  processOutputContext,
+  streamByIdContext,
+  streamLogContext,
+  streamStateContext,
+  type ProcessOutputMap,
+  type StreamByIdMap,
+  type StreamContextValue,
+  type StreamLogContextValue,
+} from '../contexts/streamContexts';
+import type { PermissionState } from './PermissionCard';
+
+// Side-effect imports - body components rendered below.
+import './ToolUseStreamContent';
+import './WorkflowStreamContent';
+import './ProcessStreamContent';
+import './LogList';
+
+@customElement('stream-conversation')
+export class StreamConversation extends SignalWatcher(LitElement) {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    /* Stream content containers - pass-through for layout, mirrors
+       the equivalent block previously in ProgressApp.styles. */
+    tool-use-stream-content,
+    workflow-stream-content,
+    process-stream-content {
+      display: contents;
+    }
+  `;
+
+  // ---- Lit context providers --------------------------------------------
+  // Identical shape and update timing to the providers that previously lived
+  // on `<progress-app>`. Descendants (`workflow-stream-content`, `log-list`,
+  // `background-tasks-panel`, …) are unchanged.
+
+  @provide({ context: streamStateContext })
+  @state()
+  private streamContextValue: StreamContextValue = EMPTY_STREAM_CONTEXT;
+
+  @provide({ context: streamLogContext })
+  @state()
+  private streamLogContextValue: StreamLogContextValue = EMPTY_LOG_CONTEXT;
+
+  @provide({ context: permissionsContext })
+  @state()
+  private permissionsContextValue: PermissionState[] = [];
+
+  @provide({ context: processOutputContext })
+  @state()
+  private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
+
+  @provide({ context: streamByIdContext })
+  @state()
+  private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
+
+  /**
+   * Sync signal-computed values into @provide/@state context properties.
+   * SignalWatcher triggers requestUpdate() when any read signal changes,
+   * so this runs only when computed values actually propagate. Mirrors the
+   * willUpdate() previously in ProgressApp.
+   */
+  protected override willUpdate(): void {
+    this.streamContextValue = streamContext$.get();
+    this.streamLogContextValue = logContext$.get();
+    this.permissionsContextValue = permissions$.get();
+    this.processOutputContextValue = activeProcessOutputs$.get();
+    this.streamByIdContextValue = streamById$.get();
+  }
+
+  override render(): TemplateResult {
+    const { streamInfo, streamState, isToolUse } = this.streamContextValue;
+
+    // No active stream — show empty log-list. Identical to the prior
+    // `renderStreamContent` early return.
+    if (!streamInfo || !streamState) {
+      return html`<log-list></log-list>`;
+    }
+
+    // Process agents (e.g. bash) proxy raw stdout/stderr — render them with
+    // a dedicated terminal-style container, not the LLM workflow/tool-use
+    // chrome.
+    if (isProcessAgent(streamInfo.agent)) {
+      return html`<process-stream-content></process-stream-content>`;
+    }
+
+    if (isToolUse) {
+      return html`<tool-use-stream-content></tool-use-stream-content>`;
+    }
+
+    // Workflow stream (default for non-tool-use).
+    return html`<workflow-stream-content></workflow-stream-content>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'stream-conversation': StreamConversation;
+  }
+}

--- a/src/test-kernel/progressView/StreamConversation.vitest.mts
+++ b/src/test-kernel/progressView/StreamConversation.vitest.mts
@@ -1,0 +1,104 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('<stream-conversation>', () => {
+  it('is registered as a custom element with the expected tag name', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
+    );
+
+    expect(source).toContain("@customElement('stream-conversation')");
+    expect(source).toContain('export class StreamConversation');
+  });
+
+  it('subscribes to module-level progressState signals (no per-instance state hoist)', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
+    );
+
+    // Reads must come from progressState.ts so the conversation can mount
+    // independently of <progress-app> in the desktop three-pane shell.
+    expect(source).toMatch(/from '\.\.\/progressState'/);
+    expect(source).toContain('streamContext$.get()');
+    expect(source).toContain('logContext$.get()');
+    expect(source).toContain('permissions$.get()');
+    expect(source).toContain('activeProcessOutputs$.get()');
+    expect(source).toContain('streamById$.get()');
+  });
+
+  it('provides the same Lit contexts that <progress-app> previously provided', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
+    );
+
+    // Descendant components consume these contexts; the providers must move
+    // with the renderer body so the contexts are still available.
+    expect(source).toContain('@provide({ context: streamStateContext })');
+    expect(source).toContain('@provide({ context: streamLogContext })');
+    expect(source).toContain('@provide({ context: permissionsContext })');
+    expect(source).toContain('@provide({ context: processOutputContext })');
+    expect(source).toContain('@provide({ context: streamByIdContext })');
+  });
+
+  it('renders the same body branches that ProgressApp.renderStreamContent() used to', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
+    );
+
+    // Empty (no active stream) → log-list. Process / tool-use / workflow
+    // branches preserved verbatim from the prior renderStreamContent().
+    expect(source).toContain('<log-list>');
+    expect(source).toContain('<process-stream-content>');
+    expect(source).toContain('<tool-use-stream-content>');
+    expect(source).toContain('<workflow-stream-content>');
+    expect(source).toContain('isProcessAgent(streamInfo.agent)');
+  });
+
+  it('uses SignalWatcher so module-level signal writes trigger re-render', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
+    );
+
+    // SignalWatcher(LitElement) is the canonical way for the conversation
+    // body to react to progressState changes without owning the state.
+    expect(source).toContain('SignalWatcher(LitElement)');
+  });
+
+  it('is mounted by ProgressApp via the side-effect import', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/ProgressApp.ts',
+    );
+
+    expect(source).toContain("import './components/StreamConversation';");
+    expect(source).toContain('<stream-conversation');
+  });
+
+  it('removes the @provide context state from <progress-app> (now thin shell)', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/ProgressApp.ts',
+    );
+
+    // PRD § 7.C: <progress-app> becomes view-header + <wa-split-panel>.
+    // The provider responsibility now lives on <stream-conversation>.
+    expect(source).not.toContain('streamStateContext');
+    expect(source).not.toContain('streamLogContext');
+    expect(source).not.toContain('processOutputContext');
+    expect(source).not.toContain('streamByIdContext');
+    // No bespoke renderStreamContent() anymore — the body is one element.
+    expect(source).not.toContain('renderStreamContent');
+  });
+});


### PR DESCRIPTION
## Summary

PRD PR 2 of 3 (PRD: [docs/prd/electron-shell-layout.md](docs/prd/electron-shell-layout.md) § 7.B + § 8). Extracts `<stream-conversation>` and slims `<progress-app>`. Sets up independent mounting so PR 3 can build the Electron three-pane shell.

**Zero visual or behavioral diff** on the VS Code extension and current desktop progress view.

### What moved

- New `packages/extension/src/progressView/frontend/components/StreamConversation.ts` — Lit element `<stream-conversation>` (`SignalWatcher(LitElement)`).
  - Subscribes to module-level signals exposed by PR 1: `streamContext$`, `logContext$`, `permissions$`, `activeProcessOutputs$`, `streamById$`.
  - Provides the five Lit contexts that descendants consume: `streamStateContext`, `streamLogContext`, `permissionsContext`, `processOutputContext`, `streamByIdContext`. Identical shape and update timing to the prior providers in `<progress-app>`.
  - Renders the same four body branches (no active stream → `<log-list>`; process agent → `<process-stream-content>`; tool-use → `<tool-use-stream-content>`; default → `<workflow-stream-content>`).
- `packages/extension/src/progressView/frontend/ProgressApp.ts` slimmed: −132 / +20 lines.
  - Removed: five `@provide`/`@state` context bindings, `willUpdate()`, `renderStreamContent()`, four child component registration imports, six no-longer-used signal/context/type imports, the `.content-area` and `tool-use-stream-content / workflow-stream-content / process-stream-content` CSS rules.
  - Added: one `import './components/StreamConversation';` and the `<stream-conversation slot="start">` element wired with the union of all child events (`@toolbar-command`, `@permission-action`, `@file-action`, `@compile-fixer-run`, `@followup-*`, `@stream-switch`).

### Deliberate deviation from PRD § 7.B

PRD § 7.B says `<stream-conversation>` should render "the body … plus the empty-state." This PR keeps the page-level "no runs yet" empty-state in `<progress-app>`. Reason: today's render gates the entire `<wa-split-panel>` on `hasAnyStreams`. Moving the empty-state into `<stream-conversation>` while preserving zero visual diff would have required either (a) always mounting the split-panel (changes layout — `<stream-tabs>` sidebar would appear with its own placeholder when empty), or (b) adding a `hasAnyStreams` branch inside `<stream-conversation>`. Both are observable changes on the VS Code extension. The task description explicitly says: "If anything would change observable behavior … STOP and document the conflict in the PR body rather than ship a regression." PR 3 can move the empty-state once only `<stream-conversation>` mounts in the Electron three-pane shell. The component doc-comment flags this for reviewers.

### Why events still work

`createEvent` (`src/shared/utils/events.ts:7`) sets `bubbles: true, composed: true`, so events fired from inside `<stream-conversation>`'s shadow DOM cross both shadow boundaries (stream-conversation → split-panel → progress-app) and reach ProgressApp's existing listeners unchanged. The five Lit context providers move with the body, so descendant `@consume` calls in `WorkflowStreamContent`, `ToolUseStreamContent`, `LogList`, `BackgroundTasksPanel`, and `ProcessStreamContent` continue to discover the closer provider.

## Test plan

- [x] `npm run typecheck` — only pre-existing electron/openrouter errors (verified against origin/main).
- [x] `cd packages/desktop && npx vite build --mode development` — clean.
- [x] `npm run compile:fast` — clean.
- [x] `npx vitest run` — 65 of 67 files pass; 7 new tests added in `src/test-kernel/progressView/StreamConversation.vitest.mts`; same 4 pre-existing failures (`fix-path` package missing + `--desktop-color` token tests, both unrelated and confirmed present on origin/main via `git stash`).
- [x] `npm run lint` — 0 errors, only pre-existing warnings unrelated to this diff.
- [ ] `cd packages/desktop && pnpm exec playwright test` — could not run in this worktree (`packages/desktop/node_modules` not installed; pnpm warning confirmed). Reviewer with desktop deps installed should verify `progress.png` is visually identical.

## Lines diff

- `packages/extension/src/progressView/frontend/ProgressApp.ts`: +20 / −132
- `packages/extension/src/progressView/frontend/components/StreamConversation.ts`: +145 (new)
- `src/test-kernel/progressView/StreamConversation.vitest.mts`: +104 (new)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a UI/refactor, but it moves Lit context providers and signal subscriptions into a new component, which could break descendant rendering or event wiring if any context/event propagation assumptions change.
> 
> **Overview**
> Extracts the Progress view’s active-stream body into a new `<stream-conversation>` component that subscribes directly to module-level `progressState` signals and re-homes the five Lit context providers (`streamState`, logs, permissions, process outputs, `streamById`).
> 
> `<progress-app>` is slimmed into a shell that renders the header + split panel, mounts `<stream-conversation slot="start">`, and forwards the union of stream/toolbar/permission/file/follow-up events to existing handlers; the prior `renderStreamContent()` branching and related CSS/imports are removed.
> 
> Adds a Vitest “test-kernel” suite that asserts the new element registration, signal reads, context providers, and mounting/removal expectations to guard the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66315a32c89227b3e29890d71591dbae414234b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->