### PR TITLE
fix: bot reviews on #3791/#3793 — state reset + PRD path prefixes

### DIFF
--- a/docs/prd/electron-shell-layout.md
+++ b/docs/prd/electron-shell-layout.md
@@ -109,7 +109,7 @@ Both hosts continue importing from the same packages. No component lives in `pac
 | --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | 1   | State hoist                                             | `progressState.ts` (new), `ProgressApp.ts`, `messageDispatcher.ts`, possibly `slices/*`                                                                             | None — extension and desktop render identically |
 | 2   | Extract `<stream-conversation>` + slim `<progress-app>` | `components/StreamConversation.ts` (new), `ProgressApp.ts`                                                                                                          | None                                            |
-| 3   | Electron shell + workspace-explorer removal             | `desktop/src/renderer/{main.ts,index.html,styles.css}`, `desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `desktopMenu.ts`, `main/index.ts` | Desktop layout flips; extension unchanged       |
+| 3   | Electron shell + workspace-explorer removal             | `packages/desktop/src/renderer/{main.ts,index.html,styles.css}`, `packages/desktop/src/main/desktopWorkspaceExplorer.ts` (deleted) and IPC unwired, `packages/desktop/src/main/desktopMenu.ts`, `packages/desktop/src/main/index.ts` | Desktop layout flips; extension unchanged       |
 
 Each PR independently shippable and revertible. Extension users see no diff until or after all three.
 

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -55,6 +55,7 @@ import {
   pendingApprovalIds$,
   permissions$,
   placement,
+  resetProgressState,
   streamFilter$,
   streamStates$,
   tabStreams$,
@@ -322,7 +323,11 @@ export class ProgressApp extends ProgressAppBase {
 
   constructor() {
     super();
-    // Restore persisted preferences
+    // Module-level state is shared across remounts. Reset everything to
+    // initial values before re-applying persisted preferences so a remount
+    // (tests, hot reload, future multi-instance hosts) doesn't surface
+    // stale placement / approval pulses / narrow-layout state.
+    resetProgressState();
     const prefs = this.prefsManager.getState();
     appState.set({
       ...createInitialState(),

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -142,6 +142,21 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
   return ids;
 });
 
+/**
+ * Reset every writable signal to its initial value. Called from
+ * `ProgressApp`'s constructor so a remount in the same JS context (tests,
+ * hot reload, future multi-instance hosts) gets a clean slate — without
+ * this, `placement` / `narrowLayout` / `permissions$` and the
+ * `_prevApprovalIds` memo Set would carry stale values across mounts.
+ */
+export function resetProgressState(): void {
+  appState.set(createInitialState());
+  placement.set('sidebar');
+  narrowLayout.set(false);
+  permissions$.set([]);
+  _prevApprovalIds = new Set();
+}
+
 // ---------------------------------------------------------------------------
 // Fine-grained active-stream selectors.
 // These return stable Map entry values (via Mutative structural sharing).


### PR DESCRIPTION
Addresses Copilot's real bug on #3793 (`placement` / `narrowLayout` / `permissions$` / `_prevApprovalIds` not reset across remounts) via a new `resetProgressState()` helper, plus the path-prefix nit on #3791's PRD.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only resets in-memory frontend signals on `ProgressApp` construction and updates a documentation path; main risk is unintended state loss if any host relied on cross-remount persistence.
> 
> **Overview**
> Fixes stale Progress View UI state across remounts by adding `resetProgressState()` in `progressState.ts` and invoking it from `ProgressApp`’s constructor before re-applying persisted prefs, ensuring `placement`, `narrowLayout`, `permissions$`, and memoized approval IDs don’t leak between mounts.
> 
> Updates the Electron shell PRD to reference the correct `packages/desktop/...` paths for PR3 artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2bebcdd6f293dca8db332c334ef8cdbd27ca06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->