### PR TITLE
test(progress): bot reviews on #3795

### DIFF
--- a/src/test-kernel/progressView/StreamConversation.vitest.mts
+++ b/src/test-kernel/progressView/StreamConversation.vitest.mts
@@ -16,7 +16,7 @@ function readSource(relativePath: string): string {
 }
 
 describe('<stream-conversation>', () => {
-  it('is registered as a custom element with the expected tag name', () => {
+  it('declares the @customElement decorator with the expected tag name (static source check)', () => {
     const source = readSource(
       'packages/extension/src/progressView/frontend/components/StreamConversation.ts',
     );
@@ -96,6 +96,7 @@ describe('<stream-conversation>', () => {
     // The provider responsibility now lives on <stream-conversation>.
     expect(source).not.toContain('streamStateContext');
     expect(source).not.toContain('streamLogContext');
+    expect(source).not.toContain('permissionsContext');
     expect(source).not.toContain('processOutputContext');
     expect(source).not.toContain('streamByIdContext');
     // No bespoke renderStreamContent() anymore — the body is one element.


### PR DESCRIPTION
Two test fixes from bot reviews on #3795: rename test to reflect static-source check, add permissionsContext assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a vitest spec by renaming a test case and adding one additional source-string assertion; no production code changes.
> 
> **Overview**
> Updates the `StreamConversation.vitest.mts` spec to better reflect that the custom element registration is verified via a *static source check* (renames the test description).
> 
> Strengthens the regression coverage around the Progress view refactor by additionally asserting that `permissionsContext` is no longer provided from `ProgressApp.ts` (matching the expectation that context providers moved off the thin shell).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cb4fa73b5c60a3554da1e8e6a337be19737c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->