### PR TITLE
fix(ci): stop format-pr from rejecting on workflow-file changes

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -48,6 +48,16 @@ jobs:
 
       - name: Commit formatting changes
         run: |
+          # Defensive: drop any workflow-file modifications before staging.
+          # `.prettierignore` already excludes `.github/workflows/`, but if a
+          # future prettier config or another tool ever touches workflow YAML,
+          # the GITHUB_TOKEN lacks `workflows: write` and the push will be
+          # rejected. Keeping this guard means format-pr always succeeds.
+          if ! git diff --quiet -- .github/workflows/; then
+            echo "Reverting accidental workflow-file changes (GITHUB_TOKEN cannot push these)."
+            git checkout -- .github/workflows/
+          fi
+
           if git diff --quiet; then
             echo "No formatting changes needed."
             exit 0

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,9 @@ packages/extension/resources/templates/
 
 # Claude Code agent scratch space (worktrees contain unstaged template files)
 .claude/
+
+# GitHub Actions workflows — the format-pr workflow's GITHUB_TOKEN lacks
+# `workflows: write` permission, so any auto-formatting of workflow YAML
+# triggers a "refusing to update workflow" push rejection. Skip them
+# entirely from format runs.
+.github/workflows/


### PR DESCRIPTION
Fixes the `refusing to allow a GitHub App to create or update workflow ... without workflows permission` push rejection seen on `claude/plan-cli-version-FkvLg` and other branches. Two layers: `.prettierignore` excludes `.github/workflows/` and the format-pr commit step reverts any accidental workflow-file modifications before staging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts formatting automation to avoid committing `.github/workflows` updates; no runtime code or data paths are affected.
> 
> **Overview**
> Prevents the `format-pr` workflow from being blocked by GitHub’s restriction on updating workflow files without `workflows: write`.
> 
> Formatting runs now *skip* `.github/workflows/` via `.prettierignore`, and the workflow defensively reverts any detected changes under `.github/workflows/` before staging/committing so the auto-format commit/push can still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2606dfef529a46e5c08931f0f30541aa4fc63524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->