### PR TITLE
fix(ci): unblock typecheck on main (.mts generic + dispatchDesktopCommand return)

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -315,7 +315,7 @@ const DESKTOP_COMMAND_HANDLERS = {
 export function dispatchDesktopCommand(
   id: DesktopCommandId,
   actions: DesktopCommandActions,
-): boolean {
+): boolean | Promise<boolean> {
   return dispatchCommandFromRegistry(
     id,
     DESKTOP_COMMAND_HANDLERS,

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -70,7 +70,7 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     const { ElectronSecrets } = await loadElectronSecrets();
     const warnings: string[] = [];
     const fakeStore = {
-      get: <T>(_key: string): T | undefined =>
+      get: <T,>(_key: string): T | undefined =>
         ({
           encrypted: true,
           value: Buffer.from('encrypted:value').toString('base64'),
@@ -100,7 +100,7 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     const { ElectronSecrets } = await loadElectronSecrets();
     const warnings: string[] = [];
     const fakeStore = {
-      get: <T>(_key: string): T | undefined =>
+      get: <T,>(_key: string): T | undefined =>
         ({
           encrypted: true,
           value: Buffer.from('encrypted:value').toString('base64'),


### PR DESCRIPTION
Fixes two CI-blocking typecheck errors on main: `<T>` → `<T,>` in .mts file (parser ambiguity), and `dispatchDesktopCommand` return widened to `boolean | Promise<boolean>` to match upstream signature widening from #3784.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: type-only signature adjustments to satisfy TypeScript/CI, with no behavioral changes beyond allowing `dispatchDesktopCommand` callers to handle async handlers.
> 
> **Overview**
> Unblocks CI TypeScript checks by widening `dispatchDesktopCommand`’s return type to `boolean | Promise<boolean>` to match an upstream async-capable command dispatcher.
> 
> Fixes a `.mts` parsing/typecheck issue in `ElectronSecretsBootstrap.vitest.mts` by changing `get: <T>` to `get: <T,>` for an unambiguous generic arrow function signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434112fa00387b56919b3e0e1ad917f3e6086818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->