### PR TITLE
fix(progress): address bot reviews on #3796 — order + dedupe state init

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -323,14 +323,14 @@ export class ProgressApp extends ProgressAppBase {
 
   constructor() {
     super();
-    // Module-level state is shared across remounts. Reset everything to
-    // initial values before re-applying persisted preferences so a remount
-    // (tests, hot reload, future multi-instance hosts) doesn't surface
-    // stale placement / approval pulses / narrow-layout state.
+    // Module-level state is shared across remounts in the same JS context
+    // (tests, hot reload). Reset writable signals + the approval-id memo,
+    // then layer the persisted streamFilter pref on top of the post-reset
+    // appState — keeps the constructor to one `appState.set` instead of two.
     resetProgressState();
     const prefs = this.prefsManager.getState();
     appState.set({
-      ...createInitialState(),
+      ...appState.get(),
       streamFilter: prefs.streamFilter,
     });
   }

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -144,17 +144,22 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
 
 /**
  * Reset every writable signal to its initial value. Called from
- * `ProgressApp`'s constructor so a remount in the same JS context (tests,
- * hot reload, future multi-instance hosts) gets a clean slate — without
- * this, `placement` / `narrowLayout` / `permissions$` and the
- * `_prevApprovalIds` memo Set would carry stale values across mounts.
+ * `ProgressApp`'s constructor on remount in the same JS context (tests,
+ * hot reload). Progress state is singleton-scoped per the file header, so
+ * the reset is a per-mount slate, not multi-instance coordination.
+ *
+ * Order matters: `_prevApprovalIds` must be cleared BEFORE
+ * `permissions$.set([])` because that setter triggers `pendingApprovalIds$`
+ * recomputation, which reads `_prevApprovalIds` for the stable-Set memo —
+ * if we clear the cache after, the next read sees a stale prior Set and
+ * returns it instead of the empty post-reset value.
  */
 export function resetProgressState(): void {
+  _prevApprovalIds = new Set();
   appState.set(createInitialState());
   placement.set('sidebar');
   narrowLayout.set(false);
   permissions$.set([]);
-  _prevApprovalIds = new Set();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two real bot findings on #3796: real ordering bug in resetProgressState() (permissions$.set([]) recomputed pendingApprovalIds$ before _prevApprovalIds was cleared, breaking memoization), and a redundant double-set of appState in ProgressApp's constructor. Both fixed; comment clarified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small frontend state-initialization changes, but they affect remount/reset behavior and approval-id memoization which could impact UI updates if incorrect.
> 
> **Overview**
> Fixes Progress view remount initialization by **clearing the pending-approval memo cache before resetting permissions**, preventing `pendingApprovalIds$` from reusing a stale Set during `resetProgressState()`.
> 
> Also simplifies `ProgressApp` construction to avoid a redundant `appState.set` by resetting state first and then applying the persisted `streamFilter` on top of the post-reset state, with updated comments clarifying the singleton/remount semantics and ordering dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d30fe949190290c6e8a90a0586bd684d792f64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->