### PR TITLE
feat(desktop): in-app diff view overlay (audit item C, redo on three-pane shell)

### DIFF
--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -14,28 +14,28 @@ one at a time.
 
 ## Status table
 
-| # | Trajectory                                  | Status      | Backed by                                              |
-| - | ------------------------------------------- | ----------- | ------------------------------------------------------ |
-| 1 | First launch, no workspace                  | Works       | `desktopOnboarding.ts`, `main.ts` empty-state factory  |
-| 2 | First launch, with workspace                | Works       | `--texra-workspace` arg, `DESKTOP_WORKSPACE_PATH_STATE_KEY` |
-| 3 | Open Folder via chrome button               | Works       | `dialog.showOpenDialog` → `app.relaunch`               |
-| 4 | Sign In via Researcher Access banner        | Works       | `desktopSupabaseAuth.ts` (full OAuth + protocol cb)    |
-| 5 | Manual API key entry (Models tab)           | Works       | `promptInRenderer` + `platform().secrets`              |
-| 6 | API key persists across restart             | Works       | `electronSecrets.ts` (safeStorage + keychain)          |
-| 7 | Run an agent, stream to Progress            | Works       | `desktopAgentExecution.ts` + `runValidatedExecutionRequest` |
-| 8 | Tool-edit / Bash / Plan approval dialog     | Works       | `desktopToolEditApproval.ts`, `progressView` IPC       |
-| 9 | Memory tab persistence                      | Works       | `@tools/memory` storage path resolved via platform     |
-| 10| Settings: Multi-Agent / Models / Latex tabs | Works       | `desktopSettingsIpc.ts`                                |
-| 11| Logs view (Refresh / Copy / Export)         | Works       | `desktopAppLog.ts` + clipboard / save dialog           |
-| 12| Command palette                             | Works       | `desktopCommandPalette.ts`                             |
-| 13| First-run walkthrough                       | Works       | `desktopOnboarding.ts`                                 |
-| 14| Tool install via Settings → Tools           | Partial     | Native dialog with copy/run command — no `code --install` automation |
-| 15| Install LaTeX Workshop / VS Code extension  | Partial     | Used to silently open MV marketplace; now an honest "this is a VS Code extension" dialog |
-| 16| Recent commits banner / Git tab             | Stub        | Always reports `commits: []`; `isGitRepo` now probes `.git` but no log access |
-| 17| LaTeX preview / build                       | Partial     | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab |
-| 18| Diff view inside the desktop                | Partial     | `desktopDiffHost` opens diff in external editor only   |
-| 19| Cross-launch session restoration            | Partial     | Auth session + workspace path restore; in-flight agent runs do not |
-| 20| Crash reporting opt-in flow                 | Works       | `desktopCrashReporting.ts`                             |
+| #   | Trajectory                                  | Status  | Backed by                                                                                |
+| --- | ------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| 1   | First launch, no workspace                  | Works   | `desktopOnboarding.ts`, `main.ts` empty-state factory                                    |
+| 2   | First launch, with workspace                | Works   | `--texra-workspace` arg, `DESKTOP_WORKSPACE_PATH_STATE_KEY`                              |
+| 3   | Open Folder via chrome button               | Works   | `dialog.showOpenDialog` → `app.relaunch`                                                 |
+| 4   | Sign In via Researcher Access banner        | Works   | `desktopSupabaseAuth.ts` (full OAuth + protocol cb)                                      |
+| 5   | Manual API key entry (Models tab)           | Works   | `promptInRenderer` + `platform().secrets`                                                |
+| 6   | API key persists across restart             | Works   | `electronSecrets.ts` (safeStorage + keychain)                                            |
+| 7   | Run an agent, stream to Progress            | Works   | `desktopAgentExecution.ts` + `runValidatedExecutionRequest`                              |
+| 8   | Tool-edit / Bash / Plan approval dialog     | Works   | `desktopToolEditApproval.ts`, `progressView` IPC                                         |
+| 9   | Memory tab persistence                      | Works   | `@tools/memory` storage path resolved via platform                                       |
+| 10  | Settings: Multi-Agent / Models / Latex tabs | Works   | `desktopSettingsIpc.ts`                                                                  |
+| 11  | Logs view (Refresh / Copy / Export)         | Works   | `desktopAppLog.ts` + clipboard / save dialog                                             |
+| 12  | Command palette                             | Works   | `desktopCommandPalette.ts`                                                               |
+| 13  | First-run walkthrough                       | Works   | `desktopOnboarding.ts`                                                                   |
+| 14  | Tool install via Settings → Tools           | Partial | Native dialog with copy/run command — no `code --install` automation                     |
+| 15  | Install LaTeX Workshop / VS Code extension  | Partial | Used to silently open MV marketplace; now an honest "this is a VS Code extension" dialog |
+| 16  | Recent commits banner / Git tab             | Stub    | Always reports `commits: []`; `isGitRepo` now probes `.git` but no log access            |
+| 17  | LaTeX preview / build                       | Partial | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab                |
+| 18  | Diff view inside the desktop                | Partial | `desktopDiffHost` opens diff in external editor only                                     |
+| 19  | Cross-launch session restoration            | Partial | Auth session + workspace path restore; in-flight agent runs do not                       |
+| 20  | Crash reporting opt-in flow                 | Works   | `desktopCrashReporting.ts`                                                               |
 
 Legend: **Works** = end-to-end on the standalone build · **Partial** =
 shell exists, but the UX has a friction point or relies on a sibling
@@ -93,7 +93,7 @@ do useful work standalone.
 ## Tactical fixes shipped in this PR
 
 1. `installToolExtension` now uses a clear info dialog (`Open in
-   Marketplace` / `Copy ID` / `Close`) instead of silently opening the
+Marketplace` / `Copy ID` / `Close`) instead of silently opening the
    VS Code Marketplace.
 2. `runToolCommand` and `runInstallCommand` now expose a `Copy` button so
    users can paste the suggested command directly into a terminal.

--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -52,9 +52,14 @@ export function buildDesktopShowDiffMessage(
   };
 }
 
-export function buildDesktopCloseDiffMessage(): DesktopCloseDiffMessage {
-  return { command: DESKTOP_DIFF_COMMANDS.CLOSE_DIFF };
-}
+// `desktop:closeDiff` is consumed by the renderer's window-message
+// handler; producers (today: the Playwright trajectory test) construct
+// the literal `{ command: 'desktop:closeDiff' }` inline via
+// `window.postMessage`, since that test runs in the browser context
+// where importing this module isn't worth the bundle hit. The schema
+// (`DesktopCloseDiffMessageSchema`) remains the source of truth. No
+// `buildDesktopCloseDiffMessage` helper is defined to avoid dead code
+// (Cursor Bugbot review on PR #3815).
 
 // Map a file extension to a Monaco language id. Kept narrow on purpose —
 // Monaco's full registry is large and we only need the languages a TeXRA

--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+// IPC plumbing for the in-app diff overlay (audit item C, trajectory #18).
+//
+// The desktop main process used to satisfy `DiffViewHost.openDiff` by
+// generating a `.diff` patch file and opening it in the OS default editor
+// (`desktopDiffHost.ts`). With #3801's three-pane shell landed, the
+// renderer can now mount `<texra-diff-view>` (Monaco-backed) inside a
+// `wa-dialog` overlay — the same pattern as the settings overlay.
+//
+// `desktop:showDiff` carries the original/proposed text + a hint language
+// for Monaco's tokenizer, so the renderer never has to read disk. The
+// main process keeps the file paths around for its own logging.
+
+export const DESKTOP_DIFF_COMMANDS = {
+  SHOW_DIFF: 'desktop:showDiff',
+  CLOSE_DIFF: 'desktop:closeDiff',
+} as const;
+
+export const DesktopShowDiffMessageSchema = z.object({
+  command: z.literal(DESKTOP_DIFF_COMMANDS.SHOW_DIFF),
+  title: z.string(),
+  originalText: z.string(),
+  proposedText: z.string(),
+  // Monaco language id (e.g. 'plaintext', 'typescript', 'latex'). The
+  // renderer falls back to 'plaintext' on unknown values.
+  language: z.string().default('plaintext'),
+  // File hints purely for the dialog header / a11y label. Not used to
+  // re-read content — the text is already in the payload.
+  originalPath: z.string().optional(),
+  proposedPath: z.string().optional(),
+});
+
+export type DesktopShowDiffMessage = z.infer<
+  typeof DesktopShowDiffMessageSchema
+>;
+
+export const DesktopCloseDiffMessageSchema = z.object({
+  command: z.literal(DESKTOP_DIFF_COMMANDS.CLOSE_DIFF),
+});
+
+export type DesktopCloseDiffMessage = z.infer<
+  typeof DesktopCloseDiffMessageSchema
+>;
+
+export function buildDesktopShowDiffMessage(
+  payload: Omit<DesktopShowDiffMessage, 'command'>,
+): DesktopShowDiffMessage {
+  return {
+    command: DESKTOP_DIFF_COMMANDS.SHOW_DIFF,
+    ...payload,
+  };
+}
+
+export function buildDesktopCloseDiffMessage(): DesktopCloseDiffMessage {
+  return { command: DESKTOP_DIFF_COMMANDS.CLOSE_DIFF };
+}
+
+// Map a file extension to a Monaco language id. Kept narrow on purpose —
+// Monaco's full registry is large and we only need the languages a TeXRA
+// workflow actually emits diffs for. Falls back to 'plaintext'.
+//
+// VS Code-free zone: pure string mapping, no `vscode.languages` lookup.
+const EXTENSION_TO_MONACO_LANGUAGE: Record<string, string> = {
+  '.tex': 'latex',
+  '.bib': 'bibtex',
+  '.cls': 'latex',
+  '.sty': 'latex',
+  '.md': 'markdown',
+  '.markdown': 'markdown',
+  '.json': 'json',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.js': 'javascript',
+  '.jsx': 'javascript',
+  '.html': 'html',
+  '.htm': 'html',
+  '.css': 'css',
+  '.scss': 'scss',
+  '.less': 'less',
+  '.py': 'python',
+  '.sh': 'shell',
+  '.bash': 'shell',
+  '.zsh': 'shell',
+};
+
+export function monacoLanguageForFilePath(
+  filePath: string | undefined,
+): string {
+  if (!filePath) return 'plaintext';
+  // Use `lastIndexOf` rather than path.extname so this works in the
+  // renderer (no node:path) too. We accept any segment after the last
+  // dot in the basename.
+  const slashIndex = Math.max(
+    filePath.lastIndexOf('/'),
+    filePath.lastIndexOf('\\'),
+  );
+  const basename = slashIndex >= 0 ? filePath.slice(slashIndex + 1) : filePath;
+  const dotIndex = basename.lastIndexOf('.');
+  if (dotIndex < 0) return 'plaintext';
+  const ext = basename.slice(dotIndex).toLowerCase();
+  return EXTENSION_TO_MONACO_LANGUAGE[ext] ?? 'plaintext';
+}

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -24,11 +24,18 @@ export interface DesktopDiffHostOptions {
   openPath(filePath: string): Promise<void>;
   /**
    * Posts a `desktop:showDiff` IPC message to the renderer so it can
-   * mount `<texra-diff-view>` inside the wa-dialog overlay. When
-   * undefined the host falls back to the external-editor flow — keeps
-   * tests and unattended invocations working.
+   * mount `<texra-diff-view>` inside the wa-dialog overlay. Return
+   * `false` (or throw) when the renderer is not reachable — e.g. the
+   * IPC bridge isn't wired yet at startup, or the BrowserWindow has
+   * been destroyed. The host then transparently falls back to the
+   * external-editor flow so the user never gets a silent failure
+   * (caught by Copilot review on PR #3815).
+   *
+   * When undefined, `openDiff` skips the overlay entirely and uses
+   * the external-editor flow — keeps tests and unattended invocations
+   * working.
    */
-  postToRenderer?(message: unknown): void;
+  postToRenderer?(message: unknown): boolean | void;
   /**
    * Force the legacy external-editor flow (writes a `.diff` patch file).
    * Useful for headless tests and as an opt-out if the in-app overlay
@@ -52,23 +59,41 @@ export function createDesktopDiffHost(
 
     // Prefer the in-app overlay when wired. Falling back to the external
     // editor is intentional for headless tests + the audit-item-C escape
-    // hatch (`forceExternal`).
+    // hatch (`forceExternal`). Wrap the post in try/catch and respect a
+    // `false` return value from `postToRenderer` so we transparently
+    // fall back when the IPC bridge isn't reachable yet (startup race)
+    // or the BrowserWindow has been destroyed (Copilot/Cursor review
+    // on #3815 — silent overlay failure was the only previous failure
+    // mode).
     if (options.postToRenderer && !options.forceExternal) {
       // Pick a language hint from the proposed file extension; the
       // proposed path is the one the user is reviewing for acceptance,
       // so its extension wins over the (possibly stale) original.
       const language = monacoLanguageForFilePath(proposed.filePath);
-      options.postToRenderer(
-        buildDesktopShowDiffMessage({
-          title,
-          originalText: originalContent,
-          proposedText: proposedContent,
-          language,
-          originalPath: original.filePath,
-          proposedPath: proposed.filePath,
-        }),
-      );
-      return { original, proposed, title };
+      let posted = false;
+      try {
+        const result = options.postToRenderer(
+          buildDesktopShowDiffMessage({
+            title,
+            originalText: originalContent,
+            proposedText: proposedContent,
+            language,
+            originalPath: original.filePath,
+            proposedPath: proposed.filePath,
+          }),
+        );
+        // `void` (the common case) is treated as success; explicit
+        // `false` opts into the external-editor fallback.
+        posted = result !== false;
+      } catch (error) {
+        console.error(
+          '[desktop] desktopDiffHost: postToRenderer failed; falling back to external editor',
+          error,
+        );
+        posted = false;
+      }
+      if (posted) return { original, proposed, title };
+      // fall through to the external-editor flow below.
     }
 
     // External-editor fallback: keep the previous behaviour — write a

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -10,8 +10,31 @@ import {
 } from '@hosts/diffViewHost';
 import { computeUserPatch } from '@tools/approval/toolEditApproval';
 
+import {
+  buildDesktopShowDiffMessage,
+  monacoLanguageForFilePath,
+} from '../desktopDiffMessages.js';
+
 export interface DesktopDiffHostOptions {
+  /**
+   * Falls back to the OS default editor (writes a `.diff` patch file and
+   * calls `openPath`). Used when the renderer overlay is unavailable or
+   * `forceExternal === true`.
+   */
   openPath(filePath: string): Promise<void>;
+  /**
+   * Posts a `desktop:showDiff` IPC message to the renderer so it can
+   * mount `<texra-diff-view>` inside the wa-dialog overlay. When
+   * undefined the host falls back to the external-editor flow — keeps
+   * tests and unattended invocations working.
+   */
+  postToRenderer?(message: unknown): void;
+  /**
+   * Force the legacy external-editor flow (writes a `.diff` patch file).
+   * Useful for headless tests and as an opt-out if the in-app overlay
+   * misbehaves. Defaults to `false` (prefer the in-app overlay).
+   */
+  forceExternal?: boolean;
 }
 
 export function createDesktopDiffHost(
@@ -26,6 +49,30 @@ export function createDesktopDiffHost(
       readFile(original.filePath, 'utf8'),
       readFile(proposed.filePath, 'utf8'),
     ]);
+
+    // Prefer the in-app overlay when wired. Falling back to the external
+    // editor is intentional for headless tests + the audit-item-C escape
+    // hatch (`forceExternal`).
+    if (options.postToRenderer && !options.forceExternal) {
+      // Pick a language hint from the proposed file extension; the
+      // proposed path is the one the user is reviewing for acceptance,
+      // so its extension wins over the (possibly stale) original.
+      const language = monacoLanguageForFilePath(proposed.filePath);
+      options.postToRenderer(
+        buildDesktopShowDiffMessage({
+          title,
+          originalText: originalContent,
+          proposedText: proposedContent,
+          language,
+          originalPath: original.filePath,
+          proposedPath: proposed.filePath,
+        }),
+      );
+      return { original, proposed, title };
+    }
+
+    // External-editor fallback: keep the previous behaviour — write a
+    // unified patch file to a tmp dir and hand off via `openPath`.
     const patch =
       computeUserPatch(originalContent, proposedContent) ??
       `No textual changes for ${path.basename(proposed.filePath)}.\n`;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -224,7 +224,19 @@ function createWindow(options: {
       // (<texra-diff-view> inside a wa-dialog). The external-editor
       // path is preserved as a fallback when `postToRenderer` is
       // unavailable or `forceExternal` is set.
-      postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+      //
+      // Return `false` when the IPC bridge is not yet wired (startup
+      // race) or the BrowserWindow has been destroyed — the host then
+      // falls back to the external-editor flow so diffs never silently
+      // disappear. Bot review (#3815): the previous arrow form
+      // silently no-op'd on `ipcRef.current === undefined`.
+      postToRenderer: (message) => {
+        const ipc = ipcRef.current;
+        if (!ipc) return false;
+        if (window.isDestroyed()) return false;
+        ipc.postToRenderer(message);
+        return true;
+      },
     }),
     confirmAcceptFile: async (message) => {
       const result = await dialog.showMessageBox(window, {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -220,6 +220,11 @@ function createWindow(options: {
     opener: previewHost,
     diff: createDesktopDiffHost({
       openPath: previewHost.openPath,
+      // Audit item C / trajectory #18: prefer the in-app overlay
+      // (<texra-diff-view> inside a wa-dialog). The external-editor
+      // path is preserved as a fallback when `postToRenderer` is
+      // unavailable or `forceExternal` is set.
+      postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     }),
     confirmAcceptFile: async (message) => {
       const result = await dialog.showMessageBox(window, {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -88,6 +88,12 @@ import {
   DesktopOnboardingSetStateMessageSchema,
   type DesktopOnboardingSetStateMessage,
 } from '../desktopOnboardingMessages';
+import {
+  DesktopShowDiffMessageSchema,
+  DesktopCloseDiffMessageSchema,
+  type DesktopShowDiffMessage,
+  type DesktopCloseDiffMessage,
+} from '../desktopDiffMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
 
@@ -576,6 +582,100 @@ function openSettingsOverlay(): void {
 }
 
 // =============================================================================
+// Diff overlay (audit item C, trajectory #18)
+// =============================================================================
+//
+// Replaces `desktopDiffHost`'s old "open the patch in the OS editor" flow
+// with an in-app `<texra-diff-view>` mounted inside a wa-dialog overlay.
+// Mirrors the settings-overlay pattern so the two surfaces share UX +
+// keyboard handling (Esc dismisses; clicking the close button hides the
+// dialog without unmounting it).
+
+interface DiffViewElement extends HTMLElement {
+  originalText: string;
+  proposedText: string;
+  language: string;
+}
+
+let diffDialog: WaDialog | null = null;
+let diffViewElement: DiffViewElement | null = null;
+let diffTitleElement: HTMLElement | null = null;
+let diffSubtitleElement: HTMLElement | null = null;
+
+function ensureDiffDialog(): WaDialog {
+  if (diffDialog) return diffDialog;
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  dialog.classList.add('desktop-diff-overlay');
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = false;
+  dialog.setAttribute('aria-label', 'Compare files');
+
+  const body = document.createElement('section');
+  body.classList.add('desktop-diff-body');
+
+  const header = document.createElement('header');
+  header.classList.add('desktop-diff-header');
+  const titleEl = document.createElement('h2');
+  titleEl.classList.add('desktop-diff-title');
+  titleEl.textContent = 'Compare';
+  diffTitleElement = titleEl;
+  const subtitleEl = document.createElement('p');
+  subtitleEl.classList.add('desktop-diff-subtitle');
+  diffSubtitleElement = subtitleEl;
+  header.append(titleEl, subtitleEl);
+
+  // Lazily create the <texra-diff-view> on first show (Monaco is heavy
+  // to import; defer until actually needed). The element is reused
+  // across re-opens — Lit's @property setter handles content swaps.
+  const view = document.createElement('texra-diff-view') as DiffViewElement;
+  view.classList.add('desktop-diff-view');
+  diffViewElement = view;
+
+  body.append(header, view);
+  dialog.append(body);
+
+  // Explicit close button — wa-dialog handles Esc natively but we want a
+  // visible affordance to match the settings overlay.
+  const close = document.createElement('wa-button');
+  close.classList.add('desktop-diff-close');
+  close.setAttribute('appearance', 'plain');
+  close.setAttribute('size', 'small');
+  close.setAttribute('aria-label', 'Close diff');
+  close.setAttribute('title', 'Close diff');
+  render(waIcon('xmark'), close);
+  close.addEventListener('click', () => {
+    dialog.open = false;
+  });
+  dialog.append(close);
+
+  appRoot.append(dialog);
+  diffDialog = dialog;
+  return dialog;
+}
+
+function openDiffOverlay(payload: DesktopShowDiffMessage): void {
+  const dialog = ensureDiffDialog();
+  if (diffTitleElement) diffTitleElement.textContent = payload.title;
+  if (diffSubtitleElement) {
+    // Show the proposed path (the file the user is reviewing) — fall
+    // back to the original or empty string. This is purely informative;
+    // payload contains the full text already.
+    diffSubtitleElement.textContent =
+      payload.proposedPath ?? payload.originalPath ?? '';
+  }
+  if (diffViewElement) {
+    diffViewElement.originalText = payload.originalText;
+    diffViewElement.proposedText = payload.proposedText;
+    diffViewElement.language = payload.language;
+  }
+  dialog.open = true;
+}
+
+function closeDiffOverlay(): void {
+  if (diffDialog) diffDialog.open = false;
+}
+
+// =============================================================================
 // Onboarding + command palette
 // =============================================================================
 
@@ -669,6 +769,18 @@ function isThemeMessage(message: unknown): message is SetThemeMessage {
   return SetThemeMessageSchema.safeParse(message).success;
 }
 
+function isDesktopShowDiffMessage(
+  message: unknown,
+): message is DesktopShowDiffMessage {
+  return DesktopShowDiffMessageSchema.safeParse(message).success;
+}
+
+function isDesktopCloseDiffMessage(
+  message: unknown,
+): message is DesktopCloseDiffMessage {
+  return DesktopCloseDiffMessageSchema.safeParse(message).success;
+}
+
 // Bridge for legacy `desktop:setRoute` IPC. The shell no longer has four
 // routes, so map the old route names onto the new surfaces:
 //   - 'main' / 'progress' → center pane (clear active stream for 'main')
@@ -716,6 +828,18 @@ window.addEventListener('message', (event) => {
   }
   if (isDesktopSetLogMessage(event.data)) {
     renderLogSnapshot(event.data);
+    return;
+  }
+  if (isDesktopShowDiffMessage(event.data)) {
+    // Parse again to pick up the schema's `.default('plaintext')` for
+    // language — the type guard accepts it either way, but we want the
+    // runtime fallback so a missing language doesn't break Monaco.
+    const parsed = DesktopShowDiffMessageSchema.safeParse(event.data);
+    if (parsed.success) openDiffOverlay(parsed.data);
+    return;
+  }
+  if (isDesktopCloseDiffMessage(event.data)) {
+    closeDiffOverlay();
     return;
   }
   // Progress view messages: dispatch directly into the shared messageDispatcher
@@ -909,4 +1033,10 @@ function renderLogSnapshot(message: DesktopSetLogMessage): void {
 // Re-export references that downstream modules (or future hooks) may want to
 // drive imperatively. Keeps the API surface explicit even though the desktop
 // shell currently consumes them directly.
-export { setRoute, openSettingsOverlay, openLogsDrawer };
+export {
+  setRoute,
+  openSettingsOverlay,
+  openLogsDrawer,
+  openDiffOverlay,
+  closeDiffOverlay,
+};

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -299,6 +299,85 @@ wa-button.desktop-settings-close::part(base) {
 }
 
 /* =====================================================================
+   Diff overlay (wa-dialog) — audit item C, trajectory #18
+   --------------------------------------------------------------------- */
+
+wa-dialog.desktop-diff-overlay {
+  --width: 100vw;
+  --height: 100vh;
+}
+
+wa-dialog.desktop-diff-overlay::part(dialog) {
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  margin: 0;
+  border-radius: 0;
+}
+
+wa-dialog.desktop-diff-overlay::part(body) {
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+wa-dialog.desktop-diff-overlay .desktop-diff-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background: var(--wa-color-surface-default);
+}
+
+wa-dialog.desktop-diff-overlay .desktop-diff-header {
+  padding: var(--wa-space-m) var(--wa-space-l);
+  border-bottom: var(--wa-border-style-default, solid)
+    var(--wa-border-width-default, 1px) var(--wa-color-neutral-fill-quiet);
+  background: var(--wa-color-surface-raised);
+}
+
+wa-dialog.desktop-diff-overlay .desktop-diff-title {
+  margin: 0;
+  font-size: var(--wa-font-size-l);
+  font-weight: var(--wa-font-weight-semibold);
+  color: var(--wa-color-text-normal);
+}
+
+wa-dialog.desktop-diff-overlay .desktop-diff-subtitle {
+  margin: var(--wa-space-2xs) 0 0;
+  font-size: var(--wa-font-size-s);
+  color: var(--wa-color-text-quiet);
+  font-family: var(--wa-font-family-code, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+wa-dialog.desktop-diff-overlay .desktop-diff-view {
+  flex: 1;
+  min-height: 0;
+  display: block;
+  width: 100%;
+}
+
+wa-button.desktop-diff-close {
+  position: absolute;
+  top: var(--wa-space-s);
+  right: var(--wa-space-s);
+  z-index: 10;
+}
+
+wa-button.desktop-diff-close::part(base) {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: var(--wa-border-radius-m, 3px);
+  background: var(--wa-color-surface-raised);
+  color: var(--wa-color-text-normal);
+}
+
+/* =====================================================================
    Logs drawer (wa-drawer)
    --------------------------------------------------------------------- */
 

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -250,3 +250,101 @@ test('rapid settings-tab switching does not crash the renderer', async () => {
   // The chrome must still be alive after the burst.
   await expect(launched.page.locator('.desktop-brand')).toBeVisible();
 });
+
+/**
+ * Trajectory 18 — in-app diff overlay (audit item C).
+ *
+ * `desktopDiffHost` posts `desktop:showDiff` to the renderer; the renderer
+ * lazy-creates a wa-dialog overlay containing `<texra-diff-view>`. We
+ * simulate the IPC by `window.postMessage`-ing the same payload and assert
+ * the dialog opens and carries the supplied title + content.
+ *
+ * Monaco is heavy (workers + WASM) so we don't wait for the editor to
+ * finish loading — only that the dialog and the `<texra-diff-view>`
+ * element exist with the right props.
+ */
+test('desktop:showDiff opens the in-app diff overlay', async () => {
+  // Reset chrome to a known state — the previous test may have left
+  // settings open.
+  await launched.page.evaluate(() => {
+    const dialogs = document.querySelectorAll('wa-dialog');
+    dialogs.forEach((d) => {
+      (d as unknown as { open: boolean }).open = false;
+    });
+  });
+
+  const payload = {
+    command: 'desktop:showDiff',
+    title: 'Compare paper.tex',
+    originalText: '\\documentclass{article}\nold body\n',
+    proposedText: '\\documentclass{article}\nnew body\n',
+    language: 'latex',
+    originalPath: '/tmp/original/paper.tex',
+    proposedPath: '/tmp/proposed/paper.tex',
+  };
+
+  await launched.page.evaluate((message) => {
+    window.postMessage(message, '*');
+  }, payload);
+
+  // Wait for the dialog to appear and open. wa-dialog reflects `open` as
+  // an attribute when set; check both since timing of wa internals
+  // varies.
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-diff-overlay');
+      if (!dialog) return false;
+      const open = (dialog as unknown as { open: boolean }).open === true;
+      return open || dialog.hasAttribute('open');
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+
+  const dialog = launched.page.locator('wa-dialog.desktop-diff-overlay');
+  await expect(dialog).toHaveCount(1);
+  // Title + subtitle are populated from the payload.
+  await expect(dialog.locator('.desktop-diff-title')).toHaveText(
+    'Compare paper.tex',
+  );
+  await expect(dialog.locator('.desktop-diff-subtitle')).toHaveText(
+    '/tmp/proposed/paper.tex',
+  );
+  // The diff component element exists with the right props (we don't
+  // wait for Monaco to finish loading — verifying the contract is enough).
+  const diffViewProps = await launched.page.evaluate(() => {
+    const el = document.querySelector(
+      'wa-dialog.desktop-diff-overlay texra-diff-view',
+    ) as
+      | (HTMLElement & {
+          originalText: string;
+          proposedText: string;
+          language: string;
+        })
+      | null;
+    if (!el) return null;
+    return {
+      originalText: el.originalText,
+      proposedText: el.proposedText,
+      language: el.language,
+    };
+  });
+  expect(diffViewProps).not.toBeNull();
+  expect(diffViewProps?.originalText).toContain('old body');
+  expect(diffViewProps?.proposedText).toContain('new body');
+  expect(diffViewProps?.language).toBe('latex');
+
+  // Close via desktop:closeDiff — the dialog should close.
+  await launched.page.evaluate(() => {
+    window.postMessage({ command: 'desktop:closeDiff' }, '*');
+  });
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-diff-overlay');
+      if (!dialog) return true;
+      return (dialog as unknown as { open: boolean }).open === false;
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+});

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -119,7 +119,9 @@ test('first launch shows a usable launcher chrome', async () => {
   // The main view itself either renders <main-app> or the no-workspace empty
   // state — both are valid first-launch outcomes. The audit doc tracks which
   // one each user actually hits.
-  const mainSection = launched.page.locator('.desktop-route[data-route="main"]');
+  const mainSection = launched.page.locator(
+    '.desktop-route[data-route="main"]',
+  );
   await expect(mainSection).toBeVisible();
 });
 
@@ -201,7 +203,9 @@ test('logs route renders the desktop log viewer', async () => {
   const header = launched.page.locator('.desktop-log-viewer-header');
   await expect(header).toBeVisible();
   // Header has Refresh / Copy / Export / Open Folder buttons.
-  const actions = launched.page.locator('.desktop-log-viewer-actions wa-button');
+  const actions = launched.page.locator(
+    '.desktop-log-viewer-actions wa-button',
+  );
   await expect(actions).toHaveCount(4);
 });
 

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
@@ -9,8 +9,16 @@ import { describe, expect, it, vi } from 'vitest';
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
+async function loadDesktopDiffHost(): Promise<
+  typeof import('../../../packages/desktop/src/main/desktopDiffHost')
+> {
+  return (await import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopDiffHost.ts'))
+  )) as typeof import('../../../packages/desktop/src/main/desktopDiffHost');
+}
+
 describe('createDesktopDiffHost', () => {
-  it('opens a generated patch file for compared files', async () => {
+  it('falls back to a generated patch file when no renderer is wired', async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
     const originalPath = path.join(tempDir, 'original.txt');
     const proposedPath = path.join(tempDir, 'proposed.txt');
@@ -19,9 +27,7 @@ describe('createDesktopDiffHost', () => {
       writeFile(proposedPath, 'hello\nnew\n', 'utf8'),
     ]);
     const openedPaths: string[] = [];
-    const { createDesktopDiffHost } = (await import(
-      moduleFileUrl(desktopSourcePath('main', 'desktopDiffHost.ts'))
-    )) as typeof import('../../../packages/desktop/src/main/desktopDiffHost');
+    const { createDesktopDiffHost } = await loadDesktopDiffHost();
 
     const host = createDesktopDiffHost({
       openPath: vi.fn(async (filePath: string) => {
@@ -39,5 +45,74 @@ describe('createDesktopDiffHost', () => {
     expect(path.extname(openedPaths[0])).toBe('.diff');
     await expect(readFile(openedPaths[0], 'utf8')).resolves.toContain('-old');
     await expect(readFile(openedPaths[0], 'utf8')).resolves.toContain('+new');
+  });
+
+  it('posts desktop:showDiff to the renderer when wired', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+    const originalPath = path.join(tempDir, 'doc.tex');
+    const proposedPath = path.join(tempDir, 'doc.proposed.tex');
+    await Promise.all([
+      writeFile(originalPath, 'hello\nold\n', 'utf8'),
+      writeFile(proposedPath, 'hello\nnew\n', 'utf8'),
+    ]);
+    const posted: unknown[] = [];
+    const openPath = vi.fn(async () => {
+      // External fallback should not be invoked when postToRenderer is set.
+    });
+
+    const { createDesktopDiffHost } = await loadDesktopDiffHost();
+    const host = createDesktopDiffHost({
+      openPath,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    await host.openDiff(
+      { filePath: originalPath },
+      { filePath: proposedPath },
+      'Compare doc.tex',
+    );
+
+    expect(openPath).not.toHaveBeenCalled();
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      command: 'desktop:showDiff',
+      title: 'Compare doc.tex',
+      originalText: 'hello\nold\n',
+      proposedText: 'hello\nnew\n',
+      language: 'latex',
+      proposedPath,
+      originalPath,
+    });
+  });
+
+  it('honors forceExternal even when postToRenderer is wired', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+    const originalPath = path.join(tempDir, 'a.txt');
+    const proposedPath = path.join(tempDir, 'b.txt');
+    await Promise.all([
+      writeFile(originalPath, 'a\n', 'utf8'),
+      writeFile(proposedPath, 'b\n', 'utf8'),
+    ]);
+    const posted: unknown[] = [];
+    const openedPaths: string[] = [];
+    const { createDesktopDiffHost } = await loadDesktopDiffHost();
+
+    const host = createDesktopDiffHost({
+      openPath: vi.fn(async (filePath: string) => {
+        openedPaths.push(filePath);
+      }),
+      postToRenderer: (message) => posted.push(message),
+      forceExternal: true,
+    });
+
+    await host.openDiff(
+      { filePath: originalPath },
+      { filePath: proposedPath },
+      'Compare',
+    );
+
+    expect(posted).toHaveLength(0);
+    expect(openedPaths).toHaveLength(1);
+    expect(path.extname(openedPaths[0])).toBe('.diff');
   });
 });

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
@@ -85,6 +85,74 @@ describe('createDesktopDiffHost', () => {
     });
   });
 
+  it('falls back to the external editor when postToRenderer returns false', async () => {
+    // Simulates the renderer not being reachable — IPC bridge not yet
+    // wired at startup or BrowserWindow already destroyed. Bot review
+    // (#3815, Copilot + Cursor): the host previously silently dropped
+    // the diff in this case.
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+    const originalPath = path.join(tempDir, 'a.tex');
+    const proposedPath = path.join(tempDir, 'b.tex');
+    await Promise.all([
+      writeFile(originalPath, 'a\n', 'utf8'),
+      writeFile(proposedPath, 'b\n', 'utf8'),
+    ]);
+    const openedPaths: string[] = [];
+    const { createDesktopDiffHost } = await loadDesktopDiffHost();
+    const host = createDesktopDiffHost({
+      openPath: vi.fn(async (filePath: string) => {
+        openedPaths.push(filePath);
+      }),
+      postToRenderer: () => false,
+    });
+
+    await host.openDiff(
+      { filePath: originalPath },
+      { filePath: proposedPath },
+      'Compare',
+    );
+
+    expect(openedPaths).toHaveLength(1);
+    expect(path.extname(openedPaths[0])).toBe('.diff');
+  });
+
+  it('falls back to the external editor when postToRenderer throws', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+    const originalPath = path.join(tempDir, 'a.tex');
+    const proposedPath = path.join(tempDir, 'b.tex');
+    await Promise.all([
+      writeFile(originalPath, 'a\n', 'utf8'),
+      writeFile(proposedPath, 'b\n', 'utf8'),
+    ]);
+    const openedPaths: string[] = [];
+    const { createDesktopDiffHost } = await loadDesktopDiffHost();
+    // Suppress the deliberate console.error from the host so the test
+    // output stays clean.
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const host = createDesktopDiffHost({
+      openPath: vi.fn(async (filePath: string) => {
+        openedPaths.push(filePath);
+      }),
+      postToRenderer: () => {
+        throw new Error('renderer destroyed');
+      },
+    });
+
+    await host.openDiff(
+      { filePath: originalPath },
+      { filePath: proposedPath },
+      'Compare',
+    );
+
+    expect(openedPaths).toHaveLength(1);
+    expect(path.extname(openedPaths[0])).toBe('.diff');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   it('honors forceExternal even when postToRenderer is wired', async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
     const originalPath = path.join(tempDir, 'a.txt');

--- a/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+async function loadDiffMessages(): Promise<
+  typeof import('../../../packages/desktop/src/desktopDiffMessages')
+> {
+  return (await import(
+    moduleFileUrl(desktopSourcePath('desktopDiffMessages.ts'))
+  )) as typeof import('../../../packages/desktop/src/desktopDiffMessages');
+}
+
+describe('monacoLanguageForFilePath', () => {
+  it('maps known LaTeX extensions', async () => {
+    const { monacoLanguageForFilePath } = await loadDiffMessages();
+    expect(monacoLanguageForFilePath('foo.tex')).toBe('latex');
+    expect(monacoLanguageForFilePath('/abs/path/foo.bib')).toBe('bibtex');
+    expect(monacoLanguageForFilePath('windows\\path\\foo.sty')).toBe('latex');
+  });
+
+  it('falls back to plaintext on unknown / missing extensions', async () => {
+    const { monacoLanguageForFilePath } = await loadDiffMessages();
+    expect(monacoLanguageForFilePath(undefined)).toBe('plaintext');
+    expect(monacoLanguageForFilePath('Makefile')).toBe('plaintext');
+    expect(monacoLanguageForFilePath('foo.unknownext')).toBe('plaintext');
+  });
+
+  it('is case-insensitive', async () => {
+    const { monacoLanguageForFilePath } = await loadDiffMessages();
+    expect(monacoLanguageForFilePath('FOO.TEX')).toBe('latex');
+    expect(monacoLanguageForFilePath('Foo.MD')).toBe('markdown');
+  });
+});
+
+describe('DesktopShowDiffMessageSchema', () => {
+  it('round-trips a complete payload', async () => {
+    const { DesktopShowDiffMessageSchema, buildDesktopShowDiffMessage } =
+      await loadDiffMessages();
+    const message = buildDesktopShowDiffMessage({
+      title: 'Compare',
+      originalText: 'a',
+      proposedText: 'b',
+      language: 'latex',
+      originalPath: '/a',
+      proposedPath: '/b',
+    });
+    const parsed = DesktopShowDiffMessageSchema.parse(message);
+    expect(parsed.command).toBe('desktop:showDiff');
+    expect(parsed.language).toBe('latex');
+  });
+
+  it('defaults missing language to plaintext', async () => {
+    const { DesktopShowDiffMessageSchema } = await loadDiffMessages();
+    const parsed = DesktopShowDiffMessageSchema.parse({
+      command: 'desktop:showDiff',
+      title: 'Compare',
+      originalText: 'a',
+      proposedText: 'b',
+    });
+    expect(parsed.language).toBe('plaintext');
+  });
+});


### PR DESCRIPTION
## Summary

Wires the desktop's `desktopDiffHost` onto the new three-pane shell so "Compare" actions render side-by-side Monaco diffs inside the app, not in the OS default editor. Closes audit item **C** / trajectory **#18** in `docs/dev/standalone-trajectory-audit.md`.

This **supersedes #3810**, which was closed because its diff predated #3801's three-pane shell rewrite of `packages/desktop/src/renderer/main.ts` and could not be auto-resolved.

### Implementation

- **IPC**: new `desktopDiffMessages.ts` schema with `desktop:showDiff` / `desktop:closeDiff`. The show payload carries `originalText`, `proposedText`, a Monaco `language` hint, and the file paths (informational only — text is in the payload). Schema lives in a VS Code-free zone.
- **Main**: `desktopDiffHost.openDiff` now posts `desktop:showDiff` when a `postToRenderer` is wired (default path). Legacy external-editor flow is preserved as a fallback when `postToRenderer` is missing or `forceExternal: true` is set — keeps headless tests working.
- **Renderer**: added `ensureDiffDialog()` / `openDiffOverlay()` / `closeDiffOverlay()` factories that mirror `ensureSettingsDialog()`. A full-window `wa-dialog.desktop-diff-overlay` lazily mounts `<texra-diff-view>` and reuses the element across re-opens. The window-message handler routes both diff messages.
- **Tests**: Playwright trajectory posts `desktop:showDiff`, asserts the dialog opens, and verifies `<texra-diff-view>`'s props. Vitests cover the IPC schema, language map (`.tex` → `latex`, etc.), and the three host paths (renderer wired, fallback, force-external).

### Bot review handling

Cursor Bugbot, Copilot, and Codex reviews will be addressed in a follow-up commit on this branch before merge — only must-fix findings (real bugs, regressions, broken types). Stylistic suggestions deferred.

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing `@openrouter/sdk` + `desktopCommandPalette.ts` errors unchanged on origin/main).
- [x] `cd packages/desktop && npx vite build --mode development` — clean build.
- [x] `npx vitest run src/test-kernel/desktop/DesktopDiffHost.vitest.mts src/test-kernel/desktop/DesktopDiffMessages.vitest.mts` — 8/8 pass.
- [x] Full `npx vitest run` — 408/411 pass; 3 failures are pre-existing on origin/main (DesktopThemeTokens form-control color, ElectronRendererShell multi-line createElement match).
- [ ] `pnpm exec playwright test` for `trajectories.spec.ts` — to be run by reviewer in CI (local harness needs prebuilt main+preload+renderer artifacts).

## References

- `docs/dev/standalone-trajectory-audit.md` § C ("In-app diff view")
- Trajectory #18 in the same doc
- Closed #3810 (rebase-of-PR-3810 — could not auto-resolve against #3801)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes diff-opening behavior and adds new IPC/UI overlay paths, with potential for renderer IPC timing issues; mitigated by explicit external-editor fallback and added tests.
> 
> **Overview**
> **Adds an in-app diff viewer for TeXRA Desktop.** `desktopDiffHost.openDiff` now prefers posting a new `desktop:showDiff` message (carrying original/proposed text + language hint) so the renderer can display a side-by-side Monaco diff, while keeping the legacy “write a `.diff` file and `openPath`” flow as a fallback (and via `forceExternal`).
> 
> The renderer adds a full-screen `wa-dialog` diff overlay that mounts `<texra-diff-view>`, handles `desktop:showDiff`/`desktop:closeDiff`, and includes new styling. Tests are expanded with a Playwright trajectory for the overlay plus Vitest coverage for the IPC schema, language mapping, and fallback behavior; the audit doc status table is reformatted/updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91dc717945abf688d403006e13f068549d8ff0e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->