### PR TITLE
feat(desktop): in-app PDF preview overlay (audit item B)

### DIFF
--- a/packages/desktop/src/desktopPdfMessages.ts
+++ b/packages/desktop/src/desktopPdfMessages.ts
@@ -70,7 +70,14 @@ export function isSafeAbsolutePdfPath(pdfPath: string): boolean {
   // Strip wrapping whitespace — if anything non-trivial was trimmed
   // the path is probably crafted; reject conservatively.
   if (pdfPath.trim() !== pdfPath) return false;
-  // Identify the path shape first. We accept three forms:
+  // Accept exactly three absolute-path shapes; everything else
+  // (relative paths, URL schemes like `http:` / `javascript:` /
+  // `data:` / even `file:`) falls through to `false`. The shape
+  // checks alone reject URL schemes — they don't start with `/`,
+  // `\\`, or a single ASCII drive letter immediately followed by a
+  // path separator — so no separate scheme-rejection branch is
+  // needed.
+  //
   //   - Posix absolute: leading `/`
   //   - Windows drive-letter absolute: `C:\...` or `C:/...`
   //   - Windows UNC absolute: `\\server\share\...`
@@ -78,15 +85,8 @@ export function isSafeAbsolutePdfPath(pdfPath: string): boolean {
   const isWindowsDriveAbs = /^[A-Za-z]:[\\/]/.test(pdfPath);
   const isWindowsUncAbs = pdfPath.startsWith('\\\\');
   if (!(isPosixAbs || isWindowsDriveAbs || isWindowsUncAbs)) return false;
-  // Reject any URL-scheme-looking prefix UNLESS we already matched a
-  // Windows drive-letter path (whose `C:` prefix would otherwise look
-  // like a scheme). `file:` prefixes are rejected too — the renderer
-  // adds `file://` itself, callers must pass a plain filesystem path.
-  if (!isWindowsDriveAbs && /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pdfPath)) {
-    return false;
-  }
-  // Must end in `.pdf` (case-insensitive). The extension check is
-  // belt-and-suspenders — the main process only sends compiled PDFs,
-  // but the renderer shouldn't trust that exclusively.
+  // Must end in `.pdf` (case-insensitive). Belt-and-suspenders — the
+  // main process only sends compiled PDFs today, but the renderer
+  // shouldn't trust that exclusively.
   return /\.pdf$/i.test(pdfPath);
 }

--- a/packages/desktop/src/desktopPdfMessages.ts
+++ b/packages/desktop/src/desktopPdfMessages.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+// IPC plumbing for the in-app PDF preview overlay (audit item B,
+// trajectory #17).
+//
+// `desktopPreviewHost.openBuildDisplay` used to satisfy `BuildDisplayFn`
+// by handing the compiled PDF off to the OS default viewer via
+// `shell.openPath`. With #3801's three-pane shell + #3815's diff
+// overlay landed, we can mount an `<iframe src="file://...">` inside a
+// `wa-dialog` overlay — Electron's bundled Chromium renders PDFs
+// natively, no extra dependency required.
+//
+// This is the second overlay pattern (settings is the first; diff is
+// the prior). Once a third overlay arrives we should extract a shared
+// `createOverlay()` factory; today the duplication is small enough
+// that a shared abstraction would obscure rather than help.
+//
+// `desktop:showPdf` carries:
+//   - `title`: shown in the dialog header (e.g. "paper.pdf")
+//   - `pdfPath`: absolute filesystem path the renderer turns into a
+//     `file://` URL. The renderer rejects payloads whose path doesn't
+//     resolve to an absolute path so a malicious main-process post
+//     can't trick the iframe into loading arbitrary URLs.
+
+export const DESKTOP_PDF_COMMANDS = {
+  SHOW_PDF: 'desktop:showPdf',
+  CLOSE_PDF: 'desktop:closePdf',
+} as const;
+
+export const DesktopShowPdfMessageSchema = z.object({
+  command: z.literal(DESKTOP_PDF_COMMANDS.SHOW_PDF),
+  title: z.string(),
+  // Absolute path to the PDF on disk. The renderer prepends `file://`
+  // and assigns it to an iframe src; see `isSafeAbsolutePdfPath` below
+  // for the sanitization contract.
+  pdfPath: z.string().min(1),
+});
+
+export type DesktopShowPdfMessage = z.infer<typeof DesktopShowPdfMessageSchema>;
+
+export const DesktopClosePdfMessageSchema = z.object({
+  command: z.literal(DESKTOP_PDF_COMMANDS.CLOSE_PDF),
+});
+
+export type DesktopClosePdfMessage = z.infer<
+  typeof DesktopClosePdfMessageSchema
+>;
+
+export function buildDesktopShowPdfMessage(
+  payload: Omit<DesktopShowPdfMessage, 'command'>,
+): DesktopShowPdfMessage {
+  return {
+    command: DESKTOP_PDF_COMMANDS.SHOW_PDF,
+    ...payload,
+  };
+}
+
+// Sanitize the PDF path before rendering it in an iframe. The renderer
+// must only accept absolute filesystem paths — anything that smells
+// like a different URL scheme (`http:`, `javascript:`, `data:`, ...)
+// is rejected to keep the overlay from being abused as a generic
+// browsing surface. Path traversal isn't a concern here because the
+// renderer has no privileged paths it's hiding; the threat model is
+// "main process posts something other than a PDF on disk".
+//
+// VS Code-free zone: pure string predicate, no `node:path` import so
+// the renderer can call this without bundling node polyfills.
+export function isSafeAbsolutePdfPath(pdfPath: string): boolean {
+  if (typeof pdfPath !== 'string' || pdfPath.length === 0) return false;
+  // Strip wrapping whitespace — if anything non-trivial was trimmed
+  // the path is probably crafted; reject conservatively.
+  if (pdfPath.trim() !== pdfPath) return false;
+  // Identify the path shape first. We accept three forms:
+  //   - Posix absolute: leading `/`
+  //   - Windows drive-letter absolute: `C:\...` or `C:/...`
+  //   - Windows UNC absolute: `\\server\share\...`
+  const isPosixAbs = pdfPath.startsWith('/');
+  const isWindowsDriveAbs = /^[A-Za-z]:[\\/]/.test(pdfPath);
+  const isWindowsUncAbs = pdfPath.startsWith('\\\\');
+  if (!(isPosixAbs || isWindowsDriveAbs || isWindowsUncAbs)) return false;
+  // Reject any URL-scheme-looking prefix UNLESS we already matched a
+  // Windows drive-letter path (whose `C:` prefix would otherwise look
+  // like a scheme). `file:` prefixes are rejected too — the renderer
+  // adds `file://` itself, callers must pass a plain filesystem path.
+  if (!isWindowsDriveAbs && /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pdfPath)) {
+    return false;
+  }
+  // Must end in `.pdf` (case-insensitive). The extension check is
+  // belt-and-suspenders — the main process only sends compiled PDFs,
+  // but the renderer shouldn't trust that exclusively.
+  return /\.pdf$/i.test(pdfPath);
+}

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -7,6 +7,8 @@ import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import type { FileLocation } from '@utils/files';
 import { createExternalLocation } from '@utils/files';
 
+import { buildDesktopShowPdfMessage } from '../desktopPdfMessages.js';
+
 export interface DesktopShellAdapter {
   openExternal(url: string): Promise<void>;
   openPath(filePath: string): Promise<string>;
@@ -19,6 +21,27 @@ export interface DesktopPreviewHost extends ExternalOpener {
 export interface DesktopPreviewHostOptions {
   shell: DesktopShellAdapter;
   showErrorMessage?: (message: string) => Promise<void> | void;
+  /**
+   * Posts a `desktop:showPdf` IPC message to the renderer so it can
+   * mount an `<iframe>` (Electron's built-in Chromium PDF viewer)
+   * inside the wa-dialog overlay. Return `false` (or throw) when the
+   * renderer is not reachable — e.g. the IPC bridge isn't wired yet
+   * at startup, or the BrowserWindow has been destroyed. The host
+   * then transparently falls back to `shell.openPath` so the user
+   * never gets a silent failure (mirrors the diff host's contract,
+   * caught by Copilot review on PR #3815).
+   *
+   * When undefined, `openBuildDisplay` skips the overlay entirely and
+   * uses the external-viewer flow — keeps tests and unattended
+   * invocations working.
+   */
+  postToRenderer?(message: unknown): boolean | void;
+  /**
+   * Force the legacy external-viewer flow (`shell.openPath`). Useful
+   * for headless tests and as an opt-out if the in-app overlay
+   * misbehaves. Defaults to `false` (prefer the in-app overlay).
+   */
+  forceExternal?: boolean;
 }
 
 function toErrorMessage(error: unknown): string {
@@ -73,6 +96,30 @@ export function createDesktopPreviewHost(
     }
   }
 
+  // Try to render the PDF inside the desktop via the wa-dialog overlay.
+  // Returns `true` when the renderer accepted the IPC, `false` when we
+  // should fall back to the external viewer. Mirrors the diff host's
+  // contract: a `false` return value or a thrown error opts into
+  // `shell.openPath`. Bot review on #3815 explicitly required not
+  // silently swallowing IPC failures.
+  function tryShowPdfInRenderer(pdfPath: string, title: string): boolean {
+    if (!options.postToRenderer || options.forceExternal) return false;
+    try {
+      const result = options.postToRenderer(
+        buildDesktopShowPdfMessage({ title, pdfPath }),
+      );
+      // `void` (the common case) is treated as success; explicit
+      // `false` opts into the external-viewer fallback.
+      return result !== false;
+    } catch (error) {
+      console.error(
+        '[desktop] desktopPreviewHost: postToRenderer failed; falling back to external viewer',
+        error,
+      );
+      return false;
+    }
+  }
+
   async function openBuildDisplay(fileLocation: FileLocation): Promise<void> {
     const sourcePath = fileLocation.absolutePath;
     await ensurePathExists(sourcePath);
@@ -103,6 +150,15 @@ export function createDesktopPreviewHost(
         `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.`,
       );
     }
+
+    // Confirm the PDF is on disk before rendering it (the iframe will
+    // happily load nothing and present a blank surface otherwise).
+    await ensurePathExists(pdfPath);
+
+    // Prefer the in-app overlay (audit item B / trajectory #17).
+    // External-viewer fallback covers headless tests and the
+    // `forceExternal` escape hatch.
+    if (tryShowPdfInRenderer(pdfPath, path.basename(pdfPath))) return;
 
     await openPath(pdfPath);
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -185,7 +185,13 @@ function createWindow(options: {
     postToRenderer: (message) => {
       const ipc = ipcRef.current;
       if (!ipc) return false;
-      if (window.isDestroyed()) return false;
+      // `installDesktopHostBridge.postToRenderer` is itself a no-op when
+      // `webContents.isDestroyed()`. Without checking that here too, this
+      // wrapper would falsely report success and the preview host would
+      // skip the external-viewer fallback. Bot review (#3816) caught it.
+      if (window.isDestroyed() || window.webContents.isDestroyed()) {
+        return false;
+      }
       ipc.postToRenderer(message);
       return true;
     },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -171,6 +171,24 @@ function createWindow(options: {
   const previewHost = createDesktopPreviewHost({
     shell,
     showErrorMessage,
+    // Audit item B / trajectory #17: prefer the in-app PDF overlay
+    // (<iframe> mounted inside a wa-dialog so Electron's bundled
+    // Chromium PDF viewer renders the build output). The external
+    // viewer (`shell.openPath`) is preserved as a fallback when
+    // `postToRenderer` is unavailable or the renderer rejects the
+    // post — mirrors the diff-host wiring just above.
+    //
+    // Return `false` when the IPC bridge is not yet wired (startup
+    // race) or the BrowserWindow has been destroyed; the host then
+    // falls back to the external viewer so previews never silently
+    // disappear.
+    postToRenderer: (message) => {
+      const ipc = ipcRef.current;
+      if (!ipc) return false;
+      if (window.isDestroyed()) return false;
+      ipc.postToRenderer(message);
+      return true;
+    },
   });
   const refreshDesktopAuthSurfaces = async () => {
     const profile = await desktopAuth.getProfileData();

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -94,6 +94,13 @@ import {
   type DesktopShowDiffMessage,
   type DesktopCloseDiffMessage,
 } from '../desktopDiffMessages';
+import {
+  DesktopShowPdfMessageSchema,
+  DesktopClosePdfMessageSchema,
+  isSafeAbsolutePdfPath,
+  type DesktopShowPdfMessage,
+  type DesktopClosePdfMessage,
+} from '../desktopPdfMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
 
@@ -676,6 +683,125 @@ function closeDiffOverlay(): void {
 }
 
 // =============================================================================
+// PDF preview overlay (audit item B, trajectory #17)
+// =============================================================================
+//
+// Replaces `desktopPreviewHost.openBuildDisplay`'s old "open the PDF in
+// the OS viewer" flow with an in-app `<iframe src="file://...">` mounted
+// inside a wa-dialog overlay — Electron's bundled Chromium renders PDFs
+// natively, so no extra dependency is required. Mirrors the diff
+// overlay shape so the two surfaces share UX + keyboard handling
+// (Esc dismisses; clicking the close button hides the dialog without
+// unmounting it).
+//
+// Note: this is the second overlay (settings was first via the
+// drawer/dialog refactor; diff via #3815). If a third overlay arrives
+// we should extract a shared `createOverlay()` factory; today the
+// duplication is small enough that an abstraction would be premature.
+
+let pdfDialog: WaDialog | null = null;
+let pdfFrameElement: HTMLIFrameElement | null = null;
+let pdfTitleElement: HTMLElement | null = null;
+let pdfSubtitleElement: HTMLElement | null = null;
+
+function ensurePdfDialog(): WaDialog {
+  if (pdfDialog) return pdfDialog;
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  dialog.classList.add('desktop-pdf-overlay');
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = false;
+  dialog.setAttribute('aria-label', 'PDF preview');
+
+  const body = document.createElement('section');
+  body.classList.add('desktop-pdf-body');
+
+  const header = document.createElement('header');
+  header.classList.add('desktop-pdf-header');
+  const titleEl = document.createElement('h2');
+  titleEl.classList.add('desktop-pdf-title');
+  titleEl.textContent = 'Preview';
+  pdfTitleElement = titleEl;
+  const subtitleEl = document.createElement('p');
+  subtitleEl.classList.add('desktop-pdf-subtitle');
+  pdfSubtitleElement = subtitleEl;
+  header.append(titleEl, subtitleEl);
+
+  // Use an `<iframe>` (not `<webview>`) — `<webview>` requires
+  // `webviewTag: true` in webPreferences which we don't enable.
+  // Electron's main BrowserWindow renders PDFs in iframes via the
+  // bundled Chromium PDF plugin, no flag needed. The src is set
+  // when the overlay is opened (we keep it empty initially so
+  // dormant dialogs don't load anything).
+  const frame = document.createElement('iframe');
+  frame.classList.add('desktop-pdf-frame');
+  frame.setAttribute('title', 'PDF preview');
+  // sandbox: allow same-origin so the PDF viewer's controls (toolbar,
+  // page nav) work; deny scripts so a malformed PDF can't run JS into
+  // our renderer. The Chromium PDF viewer itself runs in a separate
+  // origin so this restriction is benign.
+  frame.setAttribute('sandbox', 'allow-same-origin');
+  pdfFrameElement = frame;
+
+  body.append(header, frame);
+  dialog.append(body);
+
+  // Explicit close button — wa-dialog handles Esc natively, but the
+  // visible affordance matches the settings + diff overlays.
+  const close = document.createElement('wa-button');
+  close.classList.add('desktop-pdf-close');
+  close.setAttribute('appearance', 'plain');
+  close.setAttribute('size', 'small');
+  close.setAttribute('aria-label', 'Close PDF preview');
+  close.setAttribute('title', 'Close PDF preview');
+  render(waIcon('xmark'), close);
+  close.addEventListener('click', () => {
+    dialog.open = false;
+  });
+  dialog.append(close);
+
+  // Clear the iframe src when the dialog hides so we don't keep the
+  // PDF resident in memory across closes. Re-opening reassigns the
+  // src in `openPdfOverlay`.
+  dialog.addEventListener('wa-after-hide', () => {
+    if (pdfFrameElement) pdfFrameElement.removeAttribute('src');
+  });
+
+  appRoot.append(dialog);
+  pdfDialog = dialog;
+  return dialog;
+}
+
+function openPdfOverlay(payload: DesktopShowPdfMessage): void {
+  // Extra defense in depth: even though the schema parsed `pdfPath`
+  // as a non-empty string, the renderer enforces an absolute-fs-path
+  // contract before assigning to `iframe.src`. Anything that smells
+  // like a non-`file:` URL is rejected (logged + ignored). The main
+  // process is the only producer today, but the renderer should not
+  // trust messages it didn't originate (Cursor Bugbot guidance).
+  if (!isSafeAbsolutePdfPath(payload.pdfPath)) {
+    console.error(
+      '[desktop] desktopPdfOverlay: rejected unsafe PDF path',
+      payload.pdfPath,
+    );
+    return;
+  }
+  const dialog = ensurePdfDialog();
+  if (pdfTitleElement) pdfTitleElement.textContent = payload.title;
+  if (pdfSubtitleElement) pdfSubtitleElement.textContent = payload.pdfPath;
+  if (pdfFrameElement) {
+    // `encodeURI` keeps `/`, `:`, and the drive-letter colon intact
+    // while escaping spaces and other path characters that would
+    // otherwise produce a malformed URL.
+    pdfFrameElement.src = `file://${encodeURI(payload.pdfPath)}`;
+  }
+  dialog.open = true;
+}
+
+function closePdfOverlay(): void {
+  if (pdfDialog) pdfDialog.open = false;
+}
+
+// =============================================================================
 // Onboarding + command palette
 // =============================================================================
 
@@ -781,6 +907,18 @@ function isDesktopCloseDiffMessage(
   return DesktopCloseDiffMessageSchema.safeParse(message).success;
 }
 
+function isDesktopShowPdfMessage(
+  message: unknown,
+): message is DesktopShowPdfMessage {
+  return DesktopShowPdfMessageSchema.safeParse(message).success;
+}
+
+function isDesktopClosePdfMessage(
+  message: unknown,
+): message is DesktopClosePdfMessage {
+  return DesktopClosePdfMessageSchema.safeParse(message).success;
+}
+
 // Bridge for legacy `desktop:setRoute` IPC. The shell no longer has four
 // routes, so map the old route names onto the new surfaces:
 //   - 'main' / 'progress' → center pane (clear active stream for 'main')
@@ -840,6 +978,15 @@ window.addEventListener('message', (event) => {
   }
   if (isDesktopCloseDiffMessage(event.data)) {
     closeDiffOverlay();
+    return;
+  }
+  if (isDesktopShowPdfMessage(event.data)) {
+    const parsed = DesktopShowPdfMessageSchema.safeParse(event.data);
+    if (parsed.success) openPdfOverlay(parsed.data);
+    return;
+  }
+  if (isDesktopClosePdfMessage(event.data)) {
+    closePdfOverlay();
     return;
   }
   // Progress view messages: dispatch directly into the shared messageDispatcher
@@ -1039,4 +1186,6 @@ export {
   openLogsDrawer,
   openDiffOverlay,
   closeDiffOverlay,
+  openPdfOverlay,
+  closePdfOverlay,
 };

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -789,12 +789,53 @@ function openPdfOverlay(payload: DesktopShowPdfMessage): void {
   if (pdfTitleElement) pdfTitleElement.textContent = payload.title;
   if (pdfSubtitleElement) pdfSubtitleElement.textContent = payload.pdfPath;
   if (pdfFrameElement) {
-    // `encodeURI` keeps `/`, `:`, and the drive-letter colon intact
-    // while escaping spaces and other path characters that would
-    // otherwise produce a malformed URL.
-    pdfFrameElement.src = `file://${encodeURI(payload.pdfPath)}`;
+    pdfFrameElement.src = pdfPathToFileUrl(payload.pdfPath);
   }
   dialog.open = true;
+}
+
+/**
+ * Convert an absolute filesystem path (already shape-validated by
+ * `isSafeAbsolutePdfPath`) into a `file:` URL safe for an iframe `src`.
+ *
+ * - posix `/abs/path.pdf` → `file:///abs/path.pdf`
+ * - Windows drive `C:\path\file.pdf` → `file:///C:/path/file.pdf`
+ * - Windows UNC `\\server\share\file.pdf` → `file://server/share/file.pdf`
+ *
+ * Per-segment `encodeURIComponent` percent-encodes `#`, `?`, spaces, and
+ * other URL-unsafe characters that `encodeURI` leaves intact, so the
+ * iframe doesn't truncate or alter the loaded path. Bot review (#3816)
+ * caught the prior `file://${encodeURI(path)}` form which produced
+ * invalid URLs for Windows drive-letter and UNC paths.
+ */
+function pdfPathToFileUrl(absolutePath: string): string {
+  const normalised = absolutePath.replace(/\\/g, '/');
+  // Windows UNC: //server/share/file → file://server/share/file
+  if (normalised.startsWith('//')) {
+    const segments = normalised.slice(2).split('/').map(encodeURIComponent);
+    return `file://${segments.join('/')}`;
+  }
+  // posix absolute: /abs/file → file:///abs/file
+  if (normalised.startsWith('/')) {
+    const segments = normalised.slice(1).split('/').map(encodeURIComponent);
+    return `file:///${segments.join('/')}`;
+  }
+  // Windows drive: C:/path/file → file:///C:/path/file
+  // Drive letter colon stays unescaped; only the rest of the segments are
+  // percent-encoded.
+  const driveMatch = normalised.match(/^([A-Za-z]):\/(.*)$/);
+  if (driveMatch) {
+    const drive = driveMatch[1];
+    const rest = driveMatch[2]
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/');
+    return `file:///${drive}:/${rest}`;
+  }
+  // Defensive fallback — shouldn't happen because `isSafeAbsolutePdfPath`
+  // already accepted only the three shapes above. Encode the whole string
+  // so we still produce a parseable URL.
+  return `file:///${encodeURIComponent(normalised)}`;
 }
 
 function closePdfOverlay(): void {

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -378,6 +378,87 @@ wa-button.desktop-diff-close::part(base) {
 }
 
 /* =====================================================================
+   PDF preview overlay (wa-dialog) — audit item B, trajectory #17
+   --------------------------------------------------------------------- */
+
+wa-dialog.desktop-pdf-overlay {
+  --width: 100vw;
+  --height: 100vh;
+}
+
+wa-dialog.desktop-pdf-overlay::part(dialog) {
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  margin: 0;
+  border-radius: 0;
+}
+
+wa-dialog.desktop-pdf-overlay::part(body) {
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+wa-dialog.desktop-pdf-overlay .desktop-pdf-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background: var(--wa-color-surface-default);
+}
+
+wa-dialog.desktop-pdf-overlay .desktop-pdf-header {
+  padding: var(--wa-space-m) var(--wa-space-l);
+  border-bottom: var(--wa-border-style-default, solid)
+    var(--wa-border-width-default, 1px) var(--wa-color-neutral-fill-quiet);
+  background: var(--wa-color-surface-raised);
+}
+
+wa-dialog.desktop-pdf-overlay .desktop-pdf-title {
+  margin: 0;
+  font-size: var(--wa-font-size-l);
+  font-weight: var(--wa-font-weight-semibold);
+  color: var(--wa-color-text-normal);
+}
+
+wa-dialog.desktop-pdf-overlay .desktop-pdf-subtitle {
+  margin: var(--wa-space-2xs) 0 0;
+  font-size: var(--wa-font-size-s);
+  color: var(--wa-color-text-quiet);
+  font-family: var(--wa-font-family-code, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+wa-dialog.desktop-pdf-overlay .desktop-pdf-frame {
+  flex: 1;
+  min-height: 0;
+  display: block;
+  width: 100%;
+  border: 0;
+  background: var(--wa-color-surface-default);
+}
+
+wa-button.desktop-pdf-close {
+  position: absolute;
+  top: var(--wa-space-s);
+  right: var(--wa-space-s);
+  z-index: 10;
+}
+
+wa-button.desktop-pdf-close::part(base) {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: var(--wa-border-radius-m, 3px);
+  background: var(--wa-color-surface-raised);
+  color: var(--wa-color-text-normal);
+}
+
+/* =====================================================================
    Logs drawer (wa-drawer)
    --------------------------------------------------------------------- */
 

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -352,3 +352,142 @@ test('desktop:showDiff opens the in-app diff overlay', async () => {
     { timeout: 5000 },
   );
 });
+
+/**
+ * Trajectory 17 — in-app PDF preview overlay (audit item B).
+ *
+ * `desktopPreviewHost.openBuildDisplay` posts `desktop:showPdf` to the
+ * renderer; the renderer lazy-creates a wa-dialog overlay containing
+ * an `<iframe>` pointed at `file://${pdfPath}` (Electron's bundled
+ * Chromium PDF viewer). We simulate the IPC by `window.postMessage`-ing
+ * the same payload and assert the dialog opens with an iframe whose
+ * `src` resolves to the supplied PDF path.
+ *
+ * We don't wait for the iframe to load the PDF (Chromium's PDF plugin
+ * is heavy + the test PDF doesn't exist on disk); verifying the
+ * contract — dialog open, title populated, iframe src matches — is
+ * enough to catch wiring regressions.
+ */
+test('desktop:showPdf opens the in-app PDF overlay', async () => {
+  // Reset chrome — previous tests may have left dialogs open.
+  await launched.page.evaluate(() => {
+    const dialogs = document.querySelectorAll('wa-dialog');
+    dialogs.forEach((d) => {
+      (d as unknown as { open: boolean }).open = false;
+    });
+  });
+
+  const pdfPath = '/tmp/texra-trajectory/output.pdf';
+  const payload = {
+    command: 'desktop:showPdf',
+    title: 'output.pdf',
+    pdfPath,
+  };
+
+  await launched.page.evaluate((message) => {
+    window.postMessage(message, '*');
+  }, payload);
+
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+      if (!dialog) return false;
+      const open = (dialog as unknown as { open: boolean }).open === true;
+      return open || dialog.hasAttribute('open');
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+
+  const dialog = launched.page.locator('wa-dialog.desktop-pdf-overlay');
+  await expect(dialog).toHaveCount(1);
+  await expect(dialog.locator('.desktop-pdf-title')).toHaveText('output.pdf');
+  await expect(dialog.locator('.desktop-pdf-subtitle')).toHaveText(pdfPath);
+
+  const iframeProps = await launched.page.evaluate(() => {
+    const el = document.querySelector(
+      'wa-dialog.desktop-pdf-overlay iframe.desktop-pdf-frame',
+    ) as HTMLIFrameElement | null;
+    if (!el) return null;
+    return {
+      src: el.getAttribute('src'),
+      sandbox: el.getAttribute('sandbox'),
+    };
+  });
+  expect(iframeProps).not.toBeNull();
+  expect(iframeProps?.src).toBe(`file://${pdfPath}`);
+  expect(iframeProps?.sandbox).toBe('allow-same-origin');
+
+  // Unsafe paths must be rejected — the renderer logs + ignores them
+  // rather than assigning to iframe.src. Reset the dialog first so
+  // we can prove no state change.
+  await launched.page.evaluate(() => {
+    const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+    if (dialog) (dialog as unknown as { open: boolean }).open = false;
+  });
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+      return (
+        dialog == null || (dialog as unknown as { open: boolean }).open === false
+      );
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+  await launched.page.evaluate(() => {
+    window.postMessage(
+      {
+        command: 'desktop:showPdf',
+        title: 'malicious',
+        pdfPath: 'http://evil.com/x.pdf',
+      },
+      '*',
+    );
+  });
+  // Give the message handler a chance to run; the dialog must NOT
+  // open because the path was rejected.
+  await launched.page.waitForTimeout(200);
+  const stillClosed = await launched.page.evaluate(() => {
+    const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+    return (
+      dialog == null || (dialog as unknown as { open: boolean }).open === false
+    );
+  });
+  expect(stillClosed).toBe(true);
+
+  // Re-open with a valid path to verify the close pathway.
+  await launched.page.evaluate((path) => {
+    window.postMessage(
+      {
+        command: 'desktop:showPdf',
+        title: 'output.pdf',
+        pdfPath: path,
+      },
+      '*',
+    );
+  }, pdfPath);
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+      if (!dialog) return false;
+      return (dialog as unknown as { open: boolean }).open === true;
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+
+  // Close via desktop:closePdf — the dialog should close.
+  await launched.page.evaluate(() => {
+    window.postMessage({ command: 'desktop:closePdf' }, '*');
+  });
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
+      if (!dialog) return true;
+      return (dialog as unknown as { open: boolean }).open === false;
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+});

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -429,7 +429,8 @@ test('desktop:showPdf opens the in-app PDF overlay', async () => {
     () => {
       const dialog = document.querySelector('wa-dialog.desktop-pdf-overlay');
       return (
-        dialog == null || (dialog as unknown as { open: boolean }).open === false
+        dialog == null ||
+        (dialog as unknown as { open: boolean }).open === false
       );
     },
     undefined,

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
@@ -63,7 +63,10 @@ describe('createDesktopDiffHost', () => {
     const { createDesktopDiffHost } = await loadDesktopDiffHost();
     const host = createDesktopDiffHost({
       openPath,
-      postToRenderer: (message) => posted.push(message),
+      postToRenderer: (message) => {
+        posted.push(message);
+        return true;
+      },
     });
 
     await host.openDiff(
@@ -169,7 +172,10 @@ describe('createDesktopDiffHost', () => {
       openPath: vi.fn(async (filePath: string) => {
         openedPaths.push(filePath);
       }),
-      postToRenderer: (message) => posted.push(message),
+      postToRenderer: (message) => {
+        posted.push(message);
+        return true;
+      },
       forceExternal: true,
     });
 

--- a/src/test-kernel/desktop/DesktopPdfMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPdfMessages.vitest.mts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+async function loadPdfMessages(): Promise<
+  typeof import('../../../packages/desktop/src/desktopPdfMessages')
+> {
+  return (await import(
+    moduleFileUrl(desktopSourcePath('desktopPdfMessages.ts'))
+  )) as typeof import('../../../packages/desktop/src/desktopPdfMessages');
+}
+
+describe('DesktopShowPdfMessageSchema', () => {
+  it('round-trips a complete payload', async () => {
+    const { DesktopShowPdfMessageSchema, buildDesktopShowPdfMessage } =
+      await loadPdfMessages();
+    const message = buildDesktopShowPdfMessage({
+      title: 'paper.pdf',
+      pdfPath: '/abs/path/to/paper.pdf',
+    });
+    const parsed = DesktopShowPdfMessageSchema.parse(message);
+    expect(parsed.command).toBe('desktop:showPdf');
+    expect(parsed.pdfPath).toBe('/abs/path/to/paper.pdf');
+  });
+
+  it('rejects empty pdfPath', async () => {
+    const { DesktopShowPdfMessageSchema } = await loadPdfMessages();
+    const result = DesktopShowPdfMessageSchema.safeParse({
+      command: 'desktop:showPdf',
+      title: 'paper',
+      pdfPath: '',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('isSafeAbsolutePdfPath', () => {
+  it('accepts posix absolute PDF paths', async () => {
+    const { isSafeAbsolutePdfPath } = await loadPdfMessages();
+    expect(isSafeAbsolutePdfPath('/Users/me/paper.pdf')).toBe(true);
+    expect(isSafeAbsolutePdfPath('/tmp/build/output.PDF')).toBe(true);
+  });
+
+  it('accepts Windows drive-letter and UNC absolute PDF paths', async () => {
+    const { isSafeAbsolutePdfPath } = await loadPdfMessages();
+    expect(isSafeAbsolutePdfPath('C:\\Users\\me\\paper.pdf')).toBe(true);
+    expect(isSafeAbsolutePdfPath('C:/Users/me/paper.pdf')).toBe(true);
+    expect(isSafeAbsolutePdfPath('\\\\server\\share\\paper.pdf')).toBe(true);
+  });
+
+  it('rejects URL-scheme prefixes', async () => {
+    const { isSafeAbsolutePdfPath } = await loadPdfMessages();
+    expect(isSafeAbsolutePdfPath('http://evil.com/x.pdf')).toBe(false);
+    expect(isSafeAbsolutePdfPath('https://evil.com/x.pdf')).toBe(false);
+    expect(isSafeAbsolutePdfPath('javascript:alert(1)')).toBe(false);
+    expect(isSafeAbsolutePdfPath('data:application/pdf,abc')).toBe(false);
+    // Even `file:` is rejected — the renderer prepends `file://` itself.
+    expect(isSafeAbsolutePdfPath('file:///tmp/x.pdf')).toBe(false);
+  });
+
+  it('rejects relative paths and non-PDF extensions', async () => {
+    const { isSafeAbsolutePdfPath } = await loadPdfMessages();
+    expect(isSafeAbsolutePdfPath('relative/path.pdf')).toBe(false);
+    expect(isSafeAbsolutePdfPath('./paper.pdf')).toBe(false);
+    expect(isSafeAbsolutePdfPath('/tmp/script.js')).toBe(false);
+    expect(isSafeAbsolutePdfPath('/tmp/no-extension')).toBe(false);
+  });
+
+  it('rejects empty / whitespace-padded strings', async () => {
+    const { isSafeAbsolutePdfPath } = await loadPdfMessages();
+    expect(isSafeAbsolutePdfPath('')).toBe(false);
+    expect(isSafeAbsolutePdfPath('  /tmp/x.pdf  ')).toBe(false);
+  });
+});

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
@@ -13,6 +13,8 @@ interface DesktopPreviewHostModule {
       openPath(filePath: string): Promise<string>;
     };
     showErrorMessage?: (message: string) => Promise<void> | void;
+    postToRenderer?: (message: unknown) => boolean | void;
+    forceExternal?: boolean;
   }): {
     openBuildDisplay(location: { absolutePath: string }): Promise<void>;
     openExternal(url: string): Promise<void>;
@@ -267,5 +269,106 @@ describe('desktop preview host', () => {
 
     await host.openExternal('https://texra.ai');
     expect(shell.openExternal).toHaveBeenCalledWith('https://texra.ai');
+  });
+
+  // --- Audit item B / trajectory #17: in-app PDF overlay ----------------
+
+  it('prefers the in-app PDF overlay when postToRenderer accepts the post', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const texPath = path.join(dir, 'paper.tex');
+    const pdfPath = path.join(dir, 'paper.pdf');
+    await writeFile(texPath, '\\documentclass{article}');
+    await writeFile(pdfPath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+    const postToRenderer = vi.fn((_message: unknown) => true);
+
+    const host = createDesktopPreviewHost({ shell, postToRenderer });
+
+    await host.openBuildDisplay({ absolutePath: texPath });
+    // The overlay path is taken; shell.openPath is NOT called.
+    expect(postToRenderer).toHaveBeenCalledTimes(1);
+    expect(postToRenderer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'desktop:showPdf',
+        title: 'paper.pdf',
+        pdfPath,
+      }),
+    );
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it('falls back to external viewer when postToRenderer returns false', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const texPath = path.join(dir, 'paper.tex');
+    const pdfPath = path.join(dir, 'paper.pdf');
+    await writeFile(texPath, '\\documentclass{article}');
+    await writeFile(pdfPath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+    const postToRenderer = vi.fn((_message: unknown) => false);
+
+    const host = createDesktopPreviewHost({ shell, postToRenderer });
+
+    await host.openBuildDisplay({ absolutePath: texPath });
+    expect(postToRenderer).toHaveBeenCalledTimes(1);
+    expect(shell.openPath).toHaveBeenCalledWith(pdfPath);
+  });
+
+  it('falls back to external viewer when postToRenderer throws', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const texPath = path.join(dir, 'paper.tex');
+    const pdfPath = path.join(dir, 'paper.pdf');
+    await writeFile(texPath, '\\documentclass{article}');
+    await writeFile(pdfPath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+    const postToRenderer = vi.fn((_message: unknown) => {
+      throw new Error('IPC bridge not ready');
+    });
+    // Silence the expected console.error so the test output is clean.
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const host = createDesktopPreviewHost({ shell, postToRenderer });
+
+    await host.openBuildDisplay({ absolutePath: texPath });
+    expect(postToRenderer).toHaveBeenCalledTimes(1);
+    expect(shell.openPath).toHaveBeenCalledWith(pdfPath);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('forceExternal=true skips the overlay path entirely', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const texPath = path.join(dir, 'paper.tex');
+    const pdfPath = path.join(dir, 'paper.pdf');
+    await writeFile(texPath, '\\documentclass{article}');
+    await writeFile(pdfPath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+    const postToRenderer = vi.fn((_message: unknown) => true);
+
+    const host = createDesktopPreviewHost({
+      shell,
+      postToRenderer,
+      forceExternal: true,
+    });
+
+    await host.openBuildDisplay({ absolutePath: texPath });
+    expect(postToRenderer).not.toHaveBeenCalled();
+    expect(shell.openPath).toHaveBeenCalledWith(pdfPath);
   });
 });


### PR DESCRIPTION
## Summary

Closes audit item **B** / trajectory **#17** from `docs/dev/standalone-trajectory-audit.md` ("LaTeX preview / build" was Partial — `desktopPreviewHost.openBuildDisplay` opened the PDF externally; no in-app PDF tab).

Mirrors the diff overlay pattern shipped in #3815: a lazily-mounted `wa-dialog.desktop-pdf-overlay` containing an `<iframe src="file://...">` so Electron's bundled Chromium PDF viewer renders the build output without leaving the desktop. No new runtime dependency.

- New IPC schema `packages/desktop/src/desktopPdfMessages.ts` (Zod-validated, VS Code-free zone) with `desktop:showPdf` / `desktop:closePdf` and an `isSafeAbsolutePdfPath` predicate that accepts only posix absolute, Windows drive-letter absolute, and Windows UNC absolute paths ending in `.pdf`. URL schemes (`http:`, `javascript:`, `data:`, even `file:`), relative paths, whitespace-padded paths, and non-PDF extensions are rejected before the renderer touches `iframe.src`.
- `desktopPreviewHost.openBuildDisplay` gains `postToRenderer` + `forceExternal` options; returns `false` from the wired callback when the IPC bridge isn't reachable yet (startup race) or the BrowserWindow has been destroyed, so the host transparently falls back to `shell.openPath`. Same fall-back contract as the diff host (PR #3815 review).
- Renderer wires `ensurePdfDialog` / `openPdfOverlay` / `closePdfOverlay` mirroring the diff overlay shape (full-window dialog, header w/ title + path subtitle, explicit close button, `Esc` handled natively). On `wa-after-hide` the iframe `src` is cleared so PDFs don't stay resident across closes.
- Iframe is sandboxed `allow-same-origin` so the Chromium PDF viewer can wire its own toolbar; scripts denied so a malformed PDF can't run JS in the renderer.
- Vitest coverage: `DesktopPreviewHost.vitest.mts` adds 4 cases (overlay preferred, IPC `false` fallback, IPC throws fallback, `forceExternal=true` skip); new `DesktopPdfMessages.vitest.mts` locks the schema + sanitizer contract.
- Playwright trajectory: `desktop:showPdf opens the in-app PDF overlay` validates dialog open, title/subtitle population, `iframe.src === "file://${pdfPath}"`, sandbox attribute, unsafe-path rejection, and `desktop:closePdf` close.

This is the **second overlay** (settings was first; diff is the prior). When a third overlay arrives we should extract a shared `createOverlay()` factory; today the duplication is small enough that an abstraction would obscure rather than help — the duplicated structure makes review easier.

## Verify

- [x] `npm run typecheck` — only pre-existing electron / openrouter errors (verified by stashing changes and re-running on `main`)
- [x] `cd packages/desktop && npx vite build --mode development` — clean
- [x] `npx vitest run` at threshold — 5 pre-existing failures on `main` (theme-tokens, composition-root, renderer-shell string-match) carry over unchanged; new pdf-overlay specs pass
- [x] `cd packages/desktop && pnpm test:e2e trajectories.spec.ts` — diff + new pdf overlay both pass; 6 pre-existing failures (legacy `.desktop-route[data-route=...]` selectors retired by #3801) carry over from `main` unchanged

## Bot reviews

Waited ~10 min for Cursor Bugbot, Copilot, and Codex.

- **Codex**: posted "Codex usage limits have been reached for code reviews" — repo credits exhausted; review skipped server-side.
- **Cursor Bugbot / Copilot**: no review request appeared on this PR (`reviewRequests: []`, `latestReviews: []`); they don't seem to be wired for this branch.

In the absence of bot findings I did one self-review pass and dropped a dead URL-scheme reject branch in the path sanitizer (the shape-check already covers every URL-scheme prefix; tests pass before and after). Commit `refactor(desktop): drop dead URL-scheme reject in PDF path sanitizer` documents the simplification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the desktop LaTeX preview flow to load local PDFs inside a renderer `iframe` via new IPC, which could impact preview reliability and file/URL handling if sanitization or IPC wiring is wrong. Fallbacks and new tests reduce risk but this touches the Electron main↔renderer boundary.
> 
> **Overview**
> Enables **in-app PDF preview** for LaTeX build output by introducing new `desktop:showPdf` / `desktop:closePdf` IPC messages and wiring `desktopPreviewHost.openBuildDisplay` to prefer posting to the renderer instead of always calling `shell.openPath`.
> 
> Adds a renderer-side full-screen `wa-dialog` overlay that lazy-mounts a sandboxed `<iframe>` for `file://` PDF rendering, plus path-to-URL encoding and a strict `isSafeAbsolutePdfPath` validator to reject non-absolute paths and URL schemes before assigning `iframe.src`.
> 
> Updates desktop startup wiring to provide `postToRenderer` (with destroyed-window detection) and adds Vitest + Playwright coverage for overlay open/close behavior and for fallback to the external viewer when IPC is unavailable/forced off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c55fcf9e9362ac8e1ebd90eca5724c43cf30efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->