### PR TITLE
feat(desktop): real Git host — git log parsing for recent commits (audit item A)

### DIFF
--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -109,7 +109,7 @@ close it:
 
 ### A. Real desktop Git host (closes trajectory #16) — DONE
 
-- Shipped in `desktop/git-host`. `packages/desktop/src/main/desktopGitHost.ts`
+- Implemented in `packages/desktop/src/main/desktopGitHost.ts` (PR #3817).
   spawns `git log -n 20 --pretty=format:'%h\t%s\t%cr'` via
   `child_process.execFile` inside the workspace, parses tab-separated
   fields, and rebuilds the `<short>: <subject> (<relative>)` label

--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -31,7 +31,7 @@ one at a time.
 | 13  | First-run walkthrough                       | Works   | `desktopOnboarding.ts`                                                                   |
 | 14  | Tool install via Settings → Tools           | Partial | Native dialog with copy/run command — no `code --install` automation                     |
 | 15  | Install LaTeX Workshop / VS Code extension  | Partial | Used to silently open MV marketplace; now an honest "this is a VS Code extension" dialog |
-| 16  | Recent commits banner / Git tab             | Stub    | Always reports `commits: []`; `isGitRepo` now probes `.git` but no log access            |
+| 16  | Recent commits banner / Git tab             | Works   | `desktopGitHost.ts` shells out to `git log` (audit item A)                               |
 | 17  | LaTeX preview / build                       | Partial | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab                |
 | 18  | Diff view inside the desktop                | Partial | `desktopDiffHost` opens diff in external editor only                                     |
 | 19  | Cross-launch session restoration            | Partial | Auth session + workspace path restore; in-flight agent runs do not                       |
@@ -107,16 +107,15 @@ Marketplace` / `Copy ID` / `Close`) instead of silently opening the
 Each of the following has concrete acceptance criteria so a single PR can
 close it:
 
-### A. Real desktop Git host (closes trajectory #16)
+### A. Real desktop Git host (closes trajectory #16) — DONE
 
-- **Done when:** opening a workspace that is a git repo populates the
-  recent-commits picker on the launcher with the last 20 commits.
-- Notes: spawn `git log` via `child_process.execFile` inside the
-  workspace; stream stdout, parse with `--pretty=format`, cache for the
-  session.
-- Affected files: `packages/desktop/src/main/index.ts`,
-  `packages/desktop/src/main/desktopShellIpc.ts`, new
-  `packages/desktop/src/main/desktopGitHost.ts`.
+- Shipped in `desktop/git-host`. `packages/desktop/src/main/desktopGitHost.ts`
+  spawns `git log -n 20 --pretty=format:'%h\t%s\t%cr'` via
+  `child_process.execFile` inside the workspace, parses tab-separated
+  fields, and rebuilds the `<short>: <subject> (<relative>)` label
+  shape the renderer already consumes. `desktopShellIpc.ts` accepts an
+  injected `getRecentCommits` host; `index.ts` wires it. `git`-missing
+  / not-a-repo / timeout failures fall back to an empty list.
 
 ### B. In-app PDF preview (closes #17)
 

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -1,0 +1,186 @@
+/**
+ * Desktop git host — closes audit item A from
+ * `docs/dev/standalone-trajectory-audit.md` (trajectory #16).
+ *
+ * The VS Code extension surfaces "recent commits" via `texra.getRecentCommits`,
+ * which shells out to `git log` with `--pretty=format:'%h: %s (%cr)'` and
+ * returns the lines verbatim. The desktop shell historically replied to
+ * `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS` with an empty list because no
+ * `vscode.git`-equivalent host port existed. This module fills that gap by
+ * spawning `git log` directly via Node's `child_process.execFile` (no shell,
+ * no string interpolation — the workspace path travels via `cwd`).
+ *
+ * The renderer's `SetRecentCommitsMessageSchema` consumes a `string[]` of
+ * pre-formatted labels, so we parse a richer tab-separated `--pretty=format`
+ * payload (`%h%x09%s%x09%cr`) and rebuild the same `<short>: <subject>
+ * (<relative>)` shape the extension produces. Splitting the format keeps the
+ * parser robust against subjects that contain `: ` literally — those would
+ * have been ambiguous if we'd echoed the human-readable label directly.
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Maximum number of commits the renderer will display in the launcher banner.
+ * Mirrors the extension's `texra.git.numberOfCommitsToShow` default (20). The
+ * desktop currently has no per-user override; if/when one is wired the cap
+ * stays here as a defence-in-depth bound.
+ */
+const DEFAULT_COMMIT_LIMIT = 20;
+const MAX_COMMIT_LIMIT = 1000;
+
+/** Field separator used inside `git log --pretty=format` (literal TAB). */
+const FIELD_SEPARATOR = '\t';
+
+/**
+ * `%h` short hash, `%s` subject, `%cr` committer date relative. Tabs separate
+ * fields so subjects with literal `: ` survive the round-trip.
+ */
+const COMMIT_PRETTY_FORMAT = `%h${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%cr`;
+
+/**
+ * Hard upper bound on git output bytes (8 MiB). 20 commits with subjects
+ * comfortably fits inside the default 1 MiB; this is purely a guard against
+ * pathological repos that could otherwise OOM the main process.
+ */
+const MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+
+const GIT_TIMEOUT_MS = 10_000;
+
+export interface DesktopGitHost {
+  /**
+   * Returns the most recent commits in the workspace, formatted as
+   * `<shortHash>: <subject> (<relativeDate>)`. The boolean reports whether
+   * the workspace looked like a git repo at probe time. Both the array and
+   * the boolean are answered conservatively when probing fails.
+   */
+  getRecentCommits(): Promise<DesktopGitCommitsResult>;
+}
+
+export interface DesktopGitCommitsResult {
+  commits: string[];
+  isGitRepo: boolean;
+}
+
+export interface CreateDesktopGitHostOptions {
+  /**
+   * Resolves the workspace path at call time. Pulled lazily so the host
+   * picks up workspace switches without needing to be re-instantiated.
+   */
+  getWorkspacePath: () => string | undefined;
+  /**
+   * Hard cap on the number of commits returned. Defaults to 20 to match
+   * `texra.git.numberOfCommitsToShow`.
+   */
+  commitLimit?: number;
+  /** Hook for surfacing unexpected errors (logging, telemetry). */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Build a desktop git host backed by `git log` via `child_process.execFile`.
+ *
+ * The host is intentionally stateless — each call re-probes the workspace so
+ * callers don't have to invalidate caches when the user switches folders.
+ * The launcher banner only fires on `REQUEST_RECENT_COMMITS`, so the cost of
+ * a fresh `git log` per request is negligible compared with caching
+ * complexity.
+ */
+export function createDesktopGitHost(
+  options: CreateDesktopGitHostOptions,
+): DesktopGitHost {
+  const limit = clampCommitLimit(options.commitLimit ?? DEFAULT_COMMIT_LIMIT);
+
+  return {
+    async getRecentCommits(): Promise<DesktopGitCommitsResult> {
+      const workspace = options.getWorkspacePath();
+      if (!workspace) {
+        return { commits: [], isGitRepo: false };
+      }
+      // Cheap synchronous probe before paying for `git log`. Same heuristic
+      // the existing `isWorkspaceGitRepo` shim used — it deliberately accepts
+      // sub-worktrees that have a `.git` file pointer, not just directories.
+      let isGitRepo = false;
+      try {
+        isGitRepo = existsSync(join(workspace, '.git'));
+      } catch (error) {
+        options.onError?.(error);
+        return { commits: [], isGitRepo: false };
+      }
+      if (!isGitRepo) {
+        return { commits: [], isGitRepo: false };
+      }
+
+      try {
+        const { stdout } = await execFileAsync(
+          'git',
+          [
+            'log',
+            '-n',
+            String(limit),
+            `--pretty=format:${COMMIT_PRETTY_FORMAT}`,
+          ],
+          {
+            cwd: workspace,
+            timeout: GIT_TIMEOUT_MS,
+            maxBuffer: MAX_BUFFER_BYTES,
+            // Disable any pager git would otherwise spin up — it would never
+            // close on a non-tty parent and we'd hit the timeout instead.
+            env: { ...process.env, GIT_PAGER: 'cat', PAGER: 'cat' },
+          },
+        );
+        return { commits: parseCommitLog(stdout), isGitRepo: true };
+      } catch (error) {
+        // `git` missing from PATH, not a repo, or any other failure -> empty
+        // list. We still report `isGitRepo: true` because the `.git` probe
+        // already passed; surfacing "no commits yet" is more accurate than
+        // pretending the user is outside a repo and would otherwise mask
+        // legitimate empty-repo states.
+        options.onError?.(error);
+        return { commits: [], isGitRepo: true };
+      }
+    },
+  };
+}
+
+/**
+ * Convert tab-separated `git log` output into the `<hash>: <subject>
+ * (<relative>)` label shape the renderer expects.
+ *
+ * Exported for unit tests so we can pin the behaviour against fixtures that
+ * include awkward subjects (literal `: `, embedded tabs, blank lines).
+ */
+export function parseCommitLog(stdout: string): string[] {
+  if (!stdout) return [];
+  const lines = stdout.split('\n');
+  const commits: string[] = [];
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line) continue;
+    // Split on the first two TABs only so subjects containing tabs
+    // (rare but legal) round-trip correctly.
+    const firstTab = line.indexOf(FIELD_SEPARATOR);
+    if (firstTab < 0) continue;
+    const lastTab = line.lastIndexOf(FIELD_SEPARATOR);
+    if (lastTab <= firstTab) continue;
+    const hash = line.slice(0, firstTab);
+    const subject = line.slice(firstTab + 1, lastTab);
+    const relative = line.slice(lastTab + 1);
+    if (!hash || !subject || !relative) continue;
+    commits.push(`${hash}: ${subject} (${relative})`);
+  }
+  return commits;
+}
+
+function clampCommitLimit(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_COMMIT_LIMIT;
+  const rounded = Math.floor(value);
+  if (rounded <= 0) return DEFAULT_COMMIT_LIMIT;
+  if (rounded > MAX_COMMIT_LIMIT) return MAX_COMMIT_LIMIT;
+  return rounded;
+}

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -19,8 +19,6 @@
  */
 
 import { execFile } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -102,14 +100,26 @@ export function createDesktopGitHost(
       if (!workspace) {
         return { commits: [], isGitRepo: false };
       }
-      // Cheap synchronous probe before paying for `git log`. Same heuristic
-      // the existing `isWorkspaceGitRepo` shim used — it deliberately accepts
-      // sub-worktrees that have a `.git` file pointer, not just directories.
+      // Bot review (#3817) flagged that the prior `existsSync('.git')` probe
+      // wrongly reports `false` when the user opens a subdirectory inside a
+      // repo (`.git` only exists at the repo root). Use `git rev-parse
+      // --is-inside-work-tree` instead — that's also what handles the
+      // `.git`-as-pointer-file case for worktrees and submodules. The cost
+      // is one extra `git` invocation up front but the call is fast (<10ms
+      // typical) so we eat it for correctness.
       let isGitRepo = false;
       try {
-        isGitRepo = existsSync(join(workspace, '.git'));
-      } catch (error) {
-        options.onError?.(error);
+        const { stdout } = await execFileAsync(
+          'git',
+          ['rev-parse', '--is-inside-work-tree'],
+          { cwd: workspace, timeout: GIT_TIMEOUT_MS },
+        );
+        isGitRepo = stdout.trim() === 'true';
+      } catch {
+        // `git` missing from PATH, not a repo, or rev-parse failed for any
+        // other reason — treat as "not a repo". Avoid surfacing this via
+        // `onError` because it's the steady-state for any non-git workspace
+        // and would spam logs.
         return { commits: [], isGitRepo: false };
       }
       if (!isGitRepo) {
@@ -120,6 +130,11 @@ export function createDesktopGitHost(
         const { stdout } = await execFileAsync(
           'git',
           [
+            // `--no-pager` is portable across platforms (no dependency on
+            // `cat` being on PATH, which broke on Windows per #3817).
+            // `execFile` already runs git non-tty so a pager wouldn't
+            // normally engage, but we pin it explicitly anyway.
+            '--no-pager',
             'log',
             '-n',
             String(limit),
@@ -129,18 +144,15 @@ export function createDesktopGitHost(
             cwd: workspace,
             timeout: GIT_TIMEOUT_MS,
             maxBuffer: MAX_BUFFER_BYTES,
-            // Disable any pager git would otherwise spin up — it would never
-            // close on a non-tty parent and we'd hit the timeout instead.
-            env: { ...process.env, GIT_PAGER: 'cat', PAGER: 'cat' },
           },
         );
         return { commits: parseCommitLog(stdout), isGitRepo: true };
       } catch (error) {
         // `git` missing from PATH, not a repo, or any other failure -> empty
-        // list. We still report `isGitRepo: true` because the `.git` probe
-        // already passed; surfacing "no commits yet" is more accurate than
-        // pretending the user is outside a repo and would otherwise mask
-        // legitimate empty-repo states.
+        // list. We still report `isGitRepo: true` because the rev-parse
+        // probe already passed; surfacing "no commits yet" is more accurate
+        // than pretending the user is outside a repo and would otherwise
+        // mask legitimate empty-repo states.
         options.onError?.(error);
         return { commits: [], isGitRepo: true };
       }

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -42,15 +42,25 @@ export interface DesktopShellActionFactoryOptions {
   openWorkspaceFolder?: () => Promise<void>;
   signIn?: () => Promise<void>;
   /**
-   * Synchronous probe for "is the active workspace a git repo". Used by
-   * `setRecentCommitsUnavailable` so the desktop reports the correct
-   * `isGitRepo` state to the renderer banner — previously this always
-   * reported `false`, which made the launcher claim the user is outside
-   * a repo even when they're inside one. The desktop never wires recent
-   * commits (no vscode.git API in standalone), but the boolean still
-   * drives banner copy.
+   * Synchronous probe for "is the active workspace a git repo". Used as a
+   * fallback when `getRecentCommits` is not supplied so the desktop still
+   * reports the correct `isGitRepo` state to the renderer banner. When
+   * `getRecentCommits` is wired (production path in `index.ts`), this probe
+   * is unused — the git host's own result is authoritative.
    */
   isWorkspaceGitRepo?: () => boolean;
+  /**
+   * Async git log host — closes audit item A from
+   * `docs/dev/standalone-trajectory-audit.md` (trajectory #16). When
+   * provided, the shell forwards the workspace's most recent commits to
+   * the renderer instead of replying with an empty list. Errors are
+   * swallowed by the host itself; failures surface as `commits: []` plus
+   * the best-effort `isGitRepo` boolean.
+   */
+  getRecentCommits?: () => Promise<{
+    commits: string[];
+    isGitRepo: boolean;
+  }>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -64,7 +74,14 @@ export interface DesktopShellActionInstanceOptions {
 export interface DesktopShellActions extends DesktopCommandActions {
   signIn(): void;
   openAgentDirectory(customDirSet?: boolean): void;
-  setRecentCommitsUnavailable(): void;
+  /**
+   * Posts the most recent git commits to the renderer in response to
+   * `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS`. When the host has a real
+   * git port wired (`getRecentCommits`), the response includes the actual
+   * `git log` output; otherwise it falls back to an empty list with a
+   * best-effort `isGitRepo` flag derived from `isWorkspaceGitRepo`.
+   */
+  sendRecentCommits(): void;
 }
 
 const SWITCH_VIEW_ROUTES = {
@@ -146,11 +163,36 @@ export function createDesktopShellActions(
     openLogFolder,
     openWorkspaceFolder,
     resetMainView,
-    setRecentCommitsUnavailable: () => {
-      // Defaults to `false` so consumers without a workspace probe behave
-      // like the original code. When `isWorkspaceGitRepo` is supplied
-      // (production wiring in `index.ts`), the renderer learns the real
-      // repo state even though the commit list itself is unavailable.
+    sendRecentCommits: () => {
+      // Prefer the real git host when wired (closes audit item A from
+      // `docs/dev/standalone-trajectory-audit.md`). Falls back to the
+      // synchronous `.git` probe so the boolean stays honest even when no
+      // git host is supplied (e.g. in tests, or before the host is wired).
+      const getRecentCommits = options.getRecentCommits;
+      if (getRecentCommits) {
+        void getRecentCommits()
+          .then(({ commits, isGitRepo }) => {
+            renderer.postToRenderer({
+              command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+              commits,
+              isGitRepo,
+            });
+          })
+          .catch((error) => {
+            // The git host already swallows expected errors; reaching this
+            // catch implies a programmer bug. Surface the error so it gets
+            // logged, but still send a conservative reply so the launcher
+            // banner doesn't hang waiting for a response.
+            reportAsyncError(error);
+            renderer.postToRenderer({
+              command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+              commits: [],
+              isGitRepo: false,
+            });
+          });
+        return;
+      }
+      // No git host: best-effort `isGitRepo` boolean, empty commit list.
       let isGitRepo = false;
       try {
         isGitRepo = options.isWorkspaceGitRepo?.() ?? false;
@@ -219,7 +261,7 @@ function dispatchMainViewInboundOnShell(
       actions.openAgentDirectory(message.customDirSet === true);
       return true;
     case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
-      actions.setRecentCommitsUnavailable();
+      actions.sendRecentCommits();
       return true;
     default:
       return false;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -36,6 +36,7 @@ import { refreshDesktopModelListStateIfNeeded } from './desktopModelListRefresh.
 import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
+import { createDesktopGitHost } from './desktopGitHost.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
 import {
   createDesktopAuthCallbackState,
@@ -398,6 +399,15 @@ function createWindow(options: {
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     { onAsyncError: reportAsyncError },
   );
+  // Real desktop git host — closes audit item A from
+  // `docs/dev/standalone-trajectory-audit.md` (trajectory #16). Spawns
+  // `git log` under the active workspace to populate the launcher banner's
+  // recent-commits picker. The host is stateless and re-probes per request,
+  // so workspace switches don't need cache invalidation.
+  const gitHost = createDesktopGitHost({
+    getWorkspacePath: () => options.workspacePath,
+    onError: reportAsyncError,
+  });
   const shellActions = createDesktopShellActions(
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     {
@@ -407,21 +417,7 @@ function createWindow(options: {
       openPath: previewHost.openPath,
       openWorkspaceFolder,
       signIn: () => desktopAuth.signIn(),
-      isWorkspaceGitRepo: () => {
-        // `recentCommits` is currently unavailable on desktop (no vscode.git
-        // host port yet — tracked in docs/dev/standalone-trajectory-audit.md
-        // as the "Git tab on desktop" follow-up). Until that lands, surface
-        // an honest `isGitRepo` boolean by probing `.git` directly so the
-        // renderer banner copy reflects the actual repo state instead of
-        // always claiming the user is outside a repo.
-        const workspace = options.workspacePath;
-        if (!workspace) return false;
-        try {
-          return existsSync(join(workspace, '.git'));
-        } catch {
-          return false;
-        }
-      },
+      getRecentCommits: () => gitHost.getRecentCommits(),
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -826,10 +826,7 @@ function pdfPathToFileUrl(absolutePath: string): string {
   const driveMatch = normalised.match(/^([A-Za-z]):\/(.*)$/);
   if (driveMatch) {
     const drive = driveMatch[1];
-    const rest = driveMatch[2]
-      .split('/')
-      .map(encodeURIComponent)
-      .join('/');
+    const rest = driveMatch[2].split('/').map(encodeURIComponent).join('/');
     return `file:///${drive}:/${rest}`;
   }
   // Defensive fallback — shouldn't happen because `isSafeAbsolutePdfPath`

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -22,6 +22,11 @@ interface DesktopShellIpcModule {
       getCustomAgentDirectory?: () => Promise<string>;
       openPath?: (filePath: string) => Promise<void>;
       signIn?: () => Promise<void>;
+      isWorkspaceGitRepo?: () => boolean;
+      getRecentCommits?: () => Promise<{
+        commits: string[];
+        isGitRepo: boolean;
+      }>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -247,6 +252,82 @@ describe('desktop IPC adapters', () => {
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.AGENTS,
     });
+  });
+
+  it('forwards real recent commits when a git host is wired', async () => {
+    // Closes audit item A: `getRecentCommits` is now a first-class shell
+    // option, so the launcher banner sees the actual `git log` output
+    // instead of the legacy empty stub.
+    const { createDesktopShellIpc } = await loadDesktopShellIpc();
+    const postToRenderer = vi.fn();
+    const getRecentCommits = vi.fn(async () => ({
+      commits: ['abc1234: Add feature (2 days ago)'],
+      isGitRepo: true,
+    }));
+    const shellIpc = createDesktopShellIpc(
+      { postToRenderer },
+      { getRecentCommits },
+    );
+
+    expect(
+      shellIpc.handleMessage({
+        command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
+      }),
+    ).toBe(true);
+    // Resolve the inner promise then the .then() chain.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getRecentCommits).toHaveBeenCalledOnce();
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+      commits: ['abc1234: Add feature (2 days ago)'],
+      isGitRepo: true,
+    });
+  });
+
+  it('falls back to empty list + isWorkspaceGitRepo when no git host is wired', async () => {
+    const { createDesktopShellIpc } = await loadDesktopShellIpc();
+    const postToRenderer = vi.fn();
+    const isWorkspaceGitRepo = vi.fn(() => true);
+    const shellIpc = createDesktopShellIpc(
+      { postToRenderer },
+      { isWorkspaceGitRepo },
+    );
+
+    shellIpc.handleMessage({
+      command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
+    });
+
+    expect(isWorkspaceGitRepo).toHaveBeenCalledOnce();
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+      commits: [],
+      isGitRepo: true,
+    });
+  });
+
+  it('parses tab-separated git log output into renderer-shaped labels', async () => {
+    // The git host parser shapes lines into `<hash>: <subject>
+    // (<relative>)` so the renderer can keep its existing string[] schema.
+    const { parseCommitLog } = (await import(
+      moduleFileUrl(desktopSourcePath('main', 'desktopGitHost.ts'))
+    )) as { parseCommitLog: (stdout: string) => string[] };
+
+    const stdout = [
+      'abc1234\tAdd feature\t2 days ago',
+      'def5678\tFix: handle edge case\t3 days ago',
+      // Blank lines are silently skipped.
+      '',
+      // Lines missing a relative date are skipped (defensive — should not
+      // happen with our format but proves the parser doesn't crash).
+      'badrow',
+    ].join('\n');
+
+    expect(parseCommitLog(stdout)).toEqual([
+      'abc1234: Add feature (2 days ago)',
+      'def5678: Fix: handle edge case (3 days ago)',
+    ]);
+    expect(parseCommitLog('')).toEqual([]);
   });
 
   it('wires the main login banner to desktop sign-in', async () => {


### PR DESCRIPTION
## Summary

Closes **audit item A** / **trajectory #16** in [`docs/dev/standalone-trajectory-audit.md`](../tree/main/docs/dev/standalone-trajectory-audit.md). The desktop shell previously answered `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS` with `commits: []` because no `vscode.git`-equivalent host port existed in the standalone build. This PR adds a real `git log`-backed host so the launcher's recent-commits banner actually works on desktop.

- New `packages/desktop/src/main/desktopGitHost.ts` spawns `git log -n 20 --pretty=format:'%h\t%s\t%cr'` via Node's `child_process.execFile` (no shell, workspace path travels through `cwd`), parses tab-separated fields, and rebuilds the `<short>: <subject> (<relative>)` label shape the renderer already consumes — no schema change.
- `desktopShellIpc.ts` accepts an injected async `getRecentCommits` host; falls back to the synchronous `.git` probe when the host is absent (kept for tests / future hosts).
- `index.ts` wires the host to the active workspace path. Stateless — re-probes per request so workspace switches need no cache invalidation.
- Vitest covers the wired-host path, the unwired-host fallback, and the parser's handling of `: ` in subjects, blank lines, and malformed rows.

Failure modes (`git` missing, zero-commit repo, timeout, non-repo path, pager hang) all fall through to an empty list; subjects with literal `: ` survive thanks to TAB-separated parsing.

## Test plan

- [x] `npx vitest run src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts` — 10 passed (was 7; added 3 covering wired host, unwired fallback, parser fixtures).
- [x] Full vitest suite — same 5 pre-existing failures as `origin/main` (theme tokens, composition root PATH fixer, renderer shell mount); none related to this PR.
- [x] `npm run typecheck` — same pre-existing OpenRouter SDK module-resolution errors as baseline; no new errors introduced.
- [x] `cd packages/desktop && npx vite build --mode development` clean.
- [x] `pnpm --filter @texra/desktop build:main / build:preload / build:renderer` clean (`build` script's typecheck gate trips on a pre-existing `desktopCommandPalette.ts` boolean issue identical to baseline).
- [x] `pnpm run test:e2e` — same 6 pre-existing trajectories failures as `origin/main`; the 6 passing tests still pass. Recent-commits trajectory not yet covered by e2e screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new main-process integration that shells out to `git`, which can fail in varied user environments (missing git, large repos, timeouts) and could impact launcher responsiveness if misbehaving despite the added guards.
> 
> **Overview**
> Enables the desktop launcher’s *Recent commits* banner/Git tab by adding a real `git` host that shells out to `git rev-parse` + `git log` and returns the last 20 commits in the renderer’s existing label format.
> 
> `desktopShellIpc` now supports an injected async `getRecentCommits` path (with a fallback `isWorkspaceGitRepo` probe), and `index.ts` wires the new `createDesktopGitHost` into production. Tests add coverage for the wired-host path, fallback behavior, and `git log` parsing; docs update trajectory #16 to **Works**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21494d45332f2fb589d3f88f5e8a7e17a734fcd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->