### PR TITLE
fix(ci): widen command-palette onExecute to accept Promise<boolean>

### DIFF
--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -33,7 +33,7 @@ export interface CommandPaletteEntry {
 export interface CommandPaletteOptions {
   readonly document: Document;
   readonly entries: readonly CommandPaletteEntry[];
-  readonly onExecute: (id: string) => boolean;
+  readonly onExecute: (id: string) => boolean | Promise<boolean>;
   // Returning false suppresses ALL palette opens — both the global
   // Cmd/Ctrl+K shortcut and any direct `controller.open()` call (e.g. while
   // a first-run walkthrough is visible). The guard runs at the entry of
@@ -103,10 +103,15 @@ export function getNextCommandPaletteIndex(
 
 export function executeCommandPaletteEntry(
   entry: CommandPaletteEntry | undefined,
-  onExecute: (id: string) => boolean,
+  onExecute: (id: string) => boolean | Promise<boolean>,
 ): boolean {
   if (!entry?.enabled) return false;
-  return onExecute(entry.id);
+  // Sync handlers report their actual result; async handlers (typed-args
+  // registry, #3784) return a Promise — treat that as "handled" so the
+  // palette closes immediately and the work runs in the background.
+  // Resolution failures surface via the dispatcher's own error logging.
+  const result = onExecute(entry.id);
+  return result === false ? false : true;
 }
 
 export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {


### PR DESCRIPTION
Unblocks the desktop validate matrix on main. After #3784 widened registry dispatcher to async, desktopCommandPalette's call site started failing strict typecheck against the boolean-only `onExecute`. Widen the shared signature to accept `boolean | Promise<boolean>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens the shared `onExecute` contract to accept promises and changes dispatch to treat any async execution as handled, which could subtly change palette-close behavior for commands that previously relied on returning `false` to keep the palette open.
> 
> **Overview**
> Updates the shared command palette API to allow `onExecute` to return `boolean | Promise<boolean>`.
> 
> Adjusts `executeCommandPaletteEntry` so promise-returning handlers are treated as **handled** (palette closes immediately) while only an explicit synchronous `false` keeps the palette open; async errors are expected to be surfaced by the dispatcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ff4677169c21631877f6219e92ed1c396a1494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->