### PR TITLE
feat(desktop): persist + restore stream list across launches (audit item D)

### DIFF
--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -34,7 +34,7 @@ one at a time.
 | 16  | Recent commits banner / Git tab             | Works   | `desktopGitHost.ts` shells out to `git log` (audit item A)                               |
 | 17  | LaTeX preview / build                       | Partial | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab                |
 | 18  | Diff view inside the desktop                | Partial | `desktopDiffHost` opens diff in external editor only                                     |
-| 19  | Cross-launch session restoration            | Partial | Auth session + workspace path restore; in-flight agent runs do not                       |
+| 19  | Cross-launch session restoration            | Works   | Auth + workspace + visual stream rail restore via `desktopStreamSnapshot.ts` (audit item D) |
 | 20  | Crash reporting opt-in flow                 | Works   | `desktopCrashReporting.ts`                                                               |
 
 Legend: **Works** = end-to-end on the standalone build · **Partial** =
@@ -131,13 +131,24 @@ close it:
 - Notes: reuse `<texra-diff-view>` (already imported in `main.ts`); wire
   `desktopDiffHost.openDiff` to set a diff route + payload.
 
-### D. In-flight session restoration (closes #19)
+### D. In-flight session restoration (closes #19) — shipped (visual)
 
-- **Done when:** killing the desktop while an agent is running and
-  re-launching surfaces the in-flight stream on the Progress route with
-  the same `executionId`.
-- Notes: `RunStorageService` already persists run metadata; the missing
-  piece is rehydrating it on cold start.
+- **Status:** Phase 1 (visual rail restoration) shipped. The desktop
+  persists a slim snapshot of the active stream rail to
+  `app.getPath('userData')/streams.json` whenever streams are
+  created/updated/deleted, and hydrates the snapshot on launch as
+  "ghost" entries on the Progress rail so the user can see the runs
+  they had going. See `packages/desktop/src/main/desktopStreamSnapshot.ts`
+  and the snapshot/syncStreams hook in `desktopAgentExecution.ts`.
+  Atomic writes (temp + rename) live in `platform/jsonStore.ts` so a
+  crash mid-flush leaves the previous file intact.
+- **Phase 2 (deferred):** live re-attach to in-flight runtimes is out
+  of scope for this PR. When the user clicks "Resume" on a ghost
+  stream we surface a clear "this run is from a previous session,
+  please start fresh" info dialog rather than silently no-op'ing.
+  Reviving the runtime would require restoring `taskState` + the
+  in-flight conversation from `RunStorageService` and re-attaching
+  PocketFlow handles — substantial work tracked separately.
 
 ### E. Multi-launch settings persistence test
 

--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -14,28 +14,28 @@ one at a time.
 
 ## Status table
 
-| #   | Trajectory                                  | Status  | Backed by                                                                                |
-| --- | ------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| 1   | First launch, no workspace                  | Works   | `desktopOnboarding.ts`, `main.ts` empty-state factory                                    |
-| 2   | First launch, with workspace                | Works   | `--texra-workspace` arg, `DESKTOP_WORKSPACE_PATH_STATE_KEY`                              |
-| 3   | Open Folder via chrome button               | Works   | `dialog.showOpenDialog` → `app.relaunch`                                                 |
-| 4   | Sign In via Researcher Access banner        | Works   | `desktopSupabaseAuth.ts` (full OAuth + protocol cb)                                      |
-| 5   | Manual API key entry (Models tab)           | Works   | `promptInRenderer` + `platform().secrets`                                                |
-| 6   | API key persists across restart             | Works   | `electronSecrets.ts` (safeStorage + keychain)                                            |
-| 7   | Run an agent, stream to Progress            | Works   | `desktopAgentExecution.ts` + `runValidatedExecutionRequest`                              |
-| 8   | Tool-edit / Bash / Plan approval dialog     | Works   | `desktopToolEditApproval.ts`, `progressView` IPC                                         |
-| 9   | Memory tab persistence                      | Works   | `@tools/memory` storage path resolved via platform                                       |
-| 10  | Settings: Multi-Agent / Models / Latex tabs | Works   | `desktopSettingsIpc.ts`                                                                  |
-| 11  | Logs view (Refresh / Copy / Export)         | Works   | `desktopAppLog.ts` + clipboard / save dialog                                             |
-| 12  | Command palette                             | Works   | `desktopCommandPalette.ts`                                                               |
-| 13  | First-run walkthrough                       | Works   | `desktopOnboarding.ts`                                                                   |
-| 14  | Tool install via Settings → Tools           | Partial | Native dialog with copy/run command — no `code --install` automation                     |
-| 15  | Install LaTeX Workshop / VS Code extension  | Partial | Used to silently open MV marketplace; now an honest "this is a VS Code extension" dialog |
-| 16  | Recent commits banner / Git tab             | Works   | `desktopGitHost.ts` shells out to `git log` (audit item A)                               |
-| 17  | LaTeX preview / build                       | Partial | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab                |
-| 18  | Diff view inside the desktop                | Partial | `desktopDiffHost` opens diff in external editor only                                     |
+| #   | Trajectory                                  | Status  | Backed by                                                                                   |
+| --- | ------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
+| 1   | First launch, no workspace                  | Works   | `desktopOnboarding.ts`, `main.ts` empty-state factory                                       |
+| 2   | First launch, with workspace                | Works   | `--texra-workspace` arg, `DESKTOP_WORKSPACE_PATH_STATE_KEY`                                 |
+| 3   | Open Folder via chrome button               | Works   | `dialog.showOpenDialog` → `app.relaunch`                                                    |
+| 4   | Sign In via Researcher Access banner        | Works   | `desktopSupabaseAuth.ts` (full OAuth + protocol cb)                                         |
+| 5   | Manual API key entry (Models tab)           | Works   | `promptInRenderer` + `platform().secrets`                                                   |
+| 6   | API key persists across restart             | Works   | `electronSecrets.ts` (safeStorage + keychain)                                               |
+| 7   | Run an agent, stream to Progress            | Works   | `desktopAgentExecution.ts` + `runValidatedExecutionRequest`                                 |
+| 8   | Tool-edit / Bash / Plan approval dialog     | Works   | `desktopToolEditApproval.ts`, `progressView` IPC                                            |
+| 9   | Memory tab persistence                      | Works   | `@tools/memory` storage path resolved via platform                                          |
+| 10  | Settings: Multi-Agent / Models / Latex tabs | Works   | `desktopSettingsIpc.ts`                                                                     |
+| 11  | Logs view (Refresh / Copy / Export)         | Works   | `desktopAppLog.ts` + clipboard / save dialog                                                |
+| 12  | Command palette                             | Works   | `desktopCommandPalette.ts`                                                                  |
+| 13  | First-run walkthrough                       | Works   | `desktopOnboarding.ts`                                                                      |
+| 14  | Tool install via Settings → Tools           | Partial | Native dialog with copy/run command — no `code --install` automation                        |
+| 15  | Install LaTeX Workshop / VS Code extension  | Partial | Used to silently open MV marketplace; now an honest "this is a VS Code extension" dialog    |
+| 16  | Recent commits banner / Git tab             | Works   | `desktopGitHost.ts` shells out to `git log` (audit item A)                                  |
+| 17  | LaTeX preview / build                       | Partial | `desktopPreviewHost.openBuildDisplay` opens externally; no in-app PDF tab                   |
+| 18  | Diff view inside the desktop                | Partial | `desktopDiffHost` opens diff in external editor only                                        |
 | 19  | Cross-launch session restoration            | Works   | Auth + workspace + visual stream rail restore via `desktopStreamSnapshot.ts` (audit item D) |
-| 20  | Crash reporting opt-in flow                 | Works   | `desktopCrashReporting.ts`                                                               |
+| 20  | Crash reporting opt-in flow                 | Works   | `desktopCrashReporting.ts`                                                                  |
 
 Legend: **Works** = end-to-end on the standalone build · **Partial** =
 shell exists, but the UX has a friction point or relies on a sibling

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -72,6 +72,8 @@ import {
 import { getConfig } from '@utils/config/configUtils';
 
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
+import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
+import type { RestoredStreamSnapshot } from '@shared/schemas';
 import {
   createDesktopToolEditApprovalController,
   type DesktopToolEditApprovalController,
@@ -86,6 +88,13 @@ export interface DesktopAgentExecutionOptions {
   confirmAcceptFile?: (message: string) => Promise<boolean>;
   showErrorMessage?: (message: string) => Promise<void> | void;
   showInfoMessage?: (message: string) => Promise<void> | void;
+  /**
+   * Optional snapshot store wired by the desktop entrypoint. When
+   * provided, the bridge persists a slim snapshot of the rail on each
+   * stream change (audit item D / trajectory #19) and surfaces
+   * previously-persisted "ghost" streams in the rail at launch.
+   */
+  streamSnapshotStore?: DesktopStreamSnapshotStore;
 }
 
 export interface DesktopAgentExecution {
@@ -112,6 +121,7 @@ export interface DesktopProgressBridgeOptions {
   confirmAcceptFile?: (message: string) => Promise<boolean>;
   showInfoMessage?: (message: string) => Promise<void>;
   showErrorMessage?: (message: string) => Promise<void>;
+  streamSnapshotStore?: DesktopStreamSnapshotStore;
 }
 
 function toFileLocation(filePath: string): FileLocation {
@@ -144,6 +154,16 @@ export class DesktopProgressBridge {
   private agentFilter: AgentCategoryFilter = 'all';
   private readonly unsubscribe: () => void;
   private readonly toolEditApprovals: DesktopToolEditApprovalController;
+  /**
+   * Restored "ghost" streams hydrated from the cross-launch snapshot.
+   * Keyed by streamId. An entry is removed once a live progress event
+   * with the same id arrives (the live entry takes over and the
+   * ghost is no longer needed). Audit item D / trajectory #19.
+   */
+  private readonly restoredStreams = new Map<
+    StreamTabId,
+    RestoredStreamSnapshot
+  >();
 
   readonly runtimeHost: AgentRuntimeHost;
 
@@ -236,6 +256,86 @@ export class DesktopProgressBridge {
           },
         );
       },
+    });
+
+    // Hydrate previously-persisted "ghost" streams so the rail shows
+    // the user's prior runs at launch (audit item D / trajectory #19).
+    // We seed creation timestamps, statuses, descriptions, executionIds,
+    // and categories from the snapshot — but NOT taskState, since we
+    // can't resurrect runtime state. The renderer will show these as
+    // stopped/orphaned entries; "Resume run" funnels back through the
+    // existing storage-backed resume path when an executionId is
+    // available, otherwise falls back to "start fresh".
+    const hydrated = options.streamSnapshotStore?.hydrated ?? [];
+    for (const snapshot of hydrated) {
+      this.restoredStreams.set(snapshot.streamId, snapshot);
+      this.creationTimestamps.set(
+        snapshot.streamId,
+        snapshot.creationTimestamp,
+      );
+      this.categories.set(snapshot.streamId, snapshot.agentCategory);
+      this.statuses.set(snapshot.streamId, snapshot.lastKnownStatus);
+      if (snapshot.description) {
+        this.descriptions.set(snapshot.streamId, snapshot.description);
+      }
+      if (snapshot.executionId) {
+        this.executionIds.set(snapshot.streamId, snapshot.executionId);
+      }
+    }
+  }
+
+  /**
+   * Build a RestoredStreamSnapshot for `streamId` from current bridge
+   * state and forward it to the persistence store. Best-effort: any
+   * write error is logged but never thrown — persistence problems
+   * must not break agent execution.
+   */
+  private persistStreamSnapshot(streamId: StreamTabId): void {
+    const store = this.options.streamSnapshotStore;
+    if (!store) return;
+
+    const taskState = this.taskStates.get(streamId);
+    const restored = this.restoredStreams.get(streamId);
+    const category =
+      taskState?.agentConfig.agentCategory ??
+      this.categories.get(streamId) ??
+      restored?.agentCategory ??
+      AGENT_CATEGORY.WORKFLOW;
+    const info = this.buildStreamInfo(streamId);
+    const snapshot: RestoredStreamSnapshot = {
+      streamId,
+      label: info.label,
+      agent: info.agent ?? restored?.agent,
+      agentCategory: category,
+      inputFile: info.inputFile || restored?.inputFile,
+      instruction:
+        taskState?.agentConfig.instruction || restored?.instruction,
+      lastKnownStatus:
+        this.statuses.get(streamId) ??
+        restored?.lastKnownStatus ??
+        STREAM_STATUS.STOPPED,
+      description: this.descriptions.get(streamId) ?? restored?.description,
+      executionId: this.executionIds.get(streamId) ?? restored?.executionId,
+      creationTimestamp: this.getCreationTimestamp(streamId),
+      lastTimestamp:
+        this.streamLogs.getLastTimestamp(streamId) ?? restored?.lastTimestamp,
+      persistedAt: Date.now(),
+    };
+    void store.upsert(snapshot).catch((error: unknown) => {
+      this.logger.warn('Failed to persist stream snapshot', {
+        data: error instanceof Error ? error : { error },
+      });
+    });
+  }
+
+  private removePersistedStream(streamId: StreamTabId): void {
+    this.restoredStreams.delete(streamId);
+    const store = this.options.streamSnapshotStore;
+    if (!store) return;
+    void store.remove(streamId).catch((error: unknown) => {
+      this.logger.warn('Failed to remove persisted stream snapshot', {
+        data: error instanceof Error ? error : { error },
+      });
     });
   }
 
@@ -368,9 +468,21 @@ export class DesktopProgressBridge {
   }
 
   private syncStreams(): void {
-    const streams = this.streamLogs
-      .keys()
-      .map((id) => this.buildStreamInfo(id));
+    const liveIds = new Set(this.streamLogs.keys());
+    const liveStreams = [...liveIds].map((id) => this.buildStreamInfo(id));
+
+    // Restored "ghost" entries that haven't been replaced by live
+    // events yet. We surface them on the rail so the user can see the
+    // runs they had going (audit item D / trajectory #19). Skipping
+    // ghosts whose id is already in `liveIds` prevents duplicates when
+    // a previous run resumed in the same launch.
+    const ghostStreams: StreamTabInfo[] = [];
+    for (const [id, snapshot] of this.restoredStreams) {
+      if (liveIds.has(id)) continue;
+      ghostStreams.push(this.buildGhostStreamInfo(snapshot));
+    }
+
+    const streams = [...liveStreams, ...ghostStreams];
     const streamStates = Object.fromEntries(
       streams.map((stream) => [
         stream.name,
@@ -384,6 +496,21 @@ export class DesktopProgressBridge {
       agentFilter: this.agentFilter,
       streamStates,
     });
+  }
+
+  private buildGhostStreamInfo(
+    snapshot: RestoredStreamSnapshot,
+  ): StreamTabInfo {
+    return {
+      name: snapshot.streamId,
+      label: snapshot.label,
+      agent: snapshot.agent,
+      agentCategory: snapshot.agentCategory,
+      inputFile: snapshot.inputFile ?? '',
+      creationTimestamp: snapshot.creationTimestamp,
+      executionId: snapshot.executionId,
+      description: snapshot.description,
+    };
   }
 
   private flushLogs(streamId: StreamTabId): void {
@@ -444,6 +571,10 @@ export class DesktopProgressBridge {
         this.taskStates.set(data.streamId, data.taskState);
         if (data.executionId)
           this.executionIds.set(data.streamId, data.executionId);
+        // Live event arrived for what may have been a ghost. Drop the
+        // ghost entry — the live stream owns the rail row now.
+        this.restoredStreams.delete(data.streamId);
+        this.persistStreamSnapshot(data.streamId);
         this.syncStreams();
         break;
       }
@@ -452,6 +583,8 @@ export class DesktopProgressBridge {
         const wasKnownStream = this.streamLogs.has(data.streamId);
         this.ensureStream(data.streamId);
         this.statuses.set(data.streamId, data.status);
+        this.restoredStreams.delete(data.streamId);
+        this.persistStreamSnapshot(data.streamId);
         if (!wasKnownStream) {
           this.syncStreams();
         }
@@ -539,6 +672,7 @@ export class DesktopProgressBridge {
         const data =
           payload as ProgressEventPayloads['updateStreamDescription'];
         this.descriptions.set(data.streamId, data.description);
+        this.persistStreamSnapshot(data.streamId);
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION,
           stream: data.streamId,
@@ -748,7 +882,11 @@ export class DesktopProgressBridge {
   }
 
   setActiveStream(streamId: StreamTabId): void {
-    if (!this.streamLogs.has(streamId) && !this.taskStates.has(streamId)) {
+    if (
+      !this.streamLogs.has(streamId) &&
+      !this.taskStates.has(streamId) &&
+      !this.restoredStreams.has(streamId)
+    ) {
       return;
     }
     this.activeStream = streamId;
@@ -767,8 +905,11 @@ export class DesktopProgressBridge {
 
   async deleteStream(streamId: StreamTabId): Promise<void> {
     const hadStream =
-      this.streamLogs.has(streamId) || this.taskStates.has(streamId);
+      this.streamLogs.has(streamId) ||
+      this.taskStates.has(streamId) ||
+      this.restoredStreams.has(streamId);
     if (!hadStream) return;
+    this.removePersistedStream(streamId);
 
     cleanupApprovalsForStream(streamId);
     retryCoordinator.clearRequest(streamId);
@@ -813,6 +954,19 @@ export class DesktopProgressBridge {
       retryCoordinator.clearRequest(streamId);
       ToolUseFollowUpQueue.release(streamId);
     }
+    // Drop persisted ghosts too: a "delete all" should leave nothing
+    // for the next launch to hydrate, otherwise users would see the
+    // ghosts come back zombie-style after relaunch.
+    this.restoredStreams.clear();
+    if (this.options.streamSnapshotStore) {
+      void this.options.streamSnapshotStore
+        .replaceAll([])
+        .catch((error: unknown) => {
+          this.logger.warn('Failed to clear stream snapshot store', {
+            data: error instanceof Error ? error : { error },
+          });
+        });
+    }
 
     await this.streamLogs.clear();
     this.cursors.clear();
@@ -848,7 +1002,17 @@ export class DesktopProgressBridge {
 
   async resumeStream(streamId: StreamTabId): Promise<void> {
     const taskState = this.taskStates.get(streamId);
-    if (!taskState) return;
+    if (!taskState) {
+      // Ghost stream from a prior launch: we don't have taskState in
+      // memory and reviving the runtime is out of scope (audit item
+      // D Phase 2). Surface a clear message rather than silently no-op.
+      if (this.restoredStreams.has(streamId)) {
+        await this.showInfoMessage(
+          'This run is from a previous session. Live resume is not yet supported — please start a fresh run.',
+        );
+      }
+      return;
+    }
 
     const executionId = this.executionIds.get(streamId);
     await this.runExecution({
@@ -1149,6 +1313,7 @@ export function createDesktopAgentExecution(
     confirmAcceptFile: options.confirmAcceptFile,
     showInfoMessage: async (message) => options.showInfoMessage?.(message),
     showErrorMessage: async (message) => options.showErrorMessage?.(message),
+    streamSnapshotStore: options.streamSnapshotStore,
   });
 
   return {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -308,8 +308,7 @@ export class DesktopProgressBridge {
       agent: info.agent ?? restored?.agent,
       agentCategory: category,
       inputFile: info.inputFile || restored?.inputFile,
-      instruction:
-        taskState?.agentConfig.instruction || restored?.instruction,
+      instruction: taskState?.agentConfig.instruction || restored?.instruction,
       lastKnownStatus:
         this.statuses.get(streamId) ??
         restored?.lastKnownStatus ??

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -1,0 +1,140 @@
+/**
+ * Cross-launch stream snapshot persistence (audit item D / trajectory #19).
+ *
+ * The desktop app already restores auth + the workspace path on relaunch
+ * but the rail of in-flight agent runs evaporated when the app exited,
+ * so users had no way to find their previous work. This module
+ * persists a slim, on-disk snapshot of the active stream rail and
+ * hydrates it on launch as visual "ghost" entries — the user can see
+ * the runs they had going and click through to a "Resume run" path
+ * that either reuses the existing storage-backed resume IPC (when
+ * taskState is recoverable) or surfaces a clear "start fresh" prompt.
+ *
+ * Live re-establishment of agent runtimes is intentionally out of
+ * scope here — that's tracked as a Phase 2 follow-up. Just shipping
+ * the visual rail closes the user-visible "where did my run go?" gap.
+ *
+ * Persistence layout: a single `streams.json` under
+ * `app.getPath('userData')`. Atomic writes (temp + rename) are
+ * provided by the underlying `JsonStore`, so a crash mid-flush leaves
+ * the previous file intact rather than corrupting the snapshot.
+ */
+
+import {
+  emptyRestoredStreamsFile,
+  RestoredStreamsFileSchema,
+  STREAM_STATUS,
+  type RestoredStreamSnapshot,
+  type RestoredStreamsFile,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { JsonStore } from './platform/jsonStore.js';
+
+const STREAMS_KEY = 'restoredStreams';
+
+export interface DesktopStreamSnapshotStore {
+  /**
+   * All previously-persisted snapshots, with `lastKnownStatus`
+   * normalised to `stopped` because we cannot tell from cold start
+   * whether the agent actually finished — the renderer should treat
+   * them as inactive ghosts.
+   */
+  readonly hydrated: readonly RestoredStreamSnapshot[];
+  /**
+   * Persist (insert or update) a single stream snapshot.
+   * Idempotent: subsequent calls with the same `streamId` overwrite.
+   */
+  upsert(snapshot: RestoredStreamSnapshot): Promise<void>;
+  /** Remove a snapshot. Safe to call when the stream isn't tracked. */
+  remove(streamId: StreamTabId): Promise<void>;
+  /** Replace the entire snapshot list. */
+  replaceAll(snapshots: RestoredStreamSnapshot[]): Promise<void>;
+  /** Current in-memory snapshot list (post-hydrate). */
+  getAll(): RestoredStreamSnapshot[];
+}
+
+interface OpenOptions {
+  /** Optional logger override (defaults to `console`). */
+  log?: Pick<Console, 'warn'>;
+}
+
+/**
+ * Open the persisted snapshot file and return a write-through store.
+ * The file is created on first write — opening a non-existent file
+ * yields an empty in-memory state.
+ */
+export async function openDesktopStreamSnapshotStore(
+  filePath: string,
+  options: OpenOptions = {},
+): Promise<DesktopStreamSnapshotStore> {
+  const log = options.log ?? console;
+  const store = await JsonStore.open(filePath);
+  const raw = store.get<unknown>(STREAMS_KEY);
+  const hydrated = parseHydrated(raw, log);
+
+  // Live in-memory list keyed by streamId. We always rewrite the
+  // whole `streams` array on every change — the rail rarely has more
+  // than a dozen entries, so the cost is trivial and the code stays
+  // simple (no merge bugs vs. partial updates).
+  const live = new Map<StreamTabId, RestoredStreamSnapshot>(
+    hydrated.map((s) => [s.streamId, s]),
+  );
+
+  async function persist(): Promise<void> {
+    const file: RestoredStreamsFile = {
+      version: 1,
+      streams: [...live.values()],
+    };
+    await store.set(STREAMS_KEY, file);
+  }
+
+  return {
+    hydrated,
+    async upsert(snapshot) {
+      live.set(snapshot.streamId, snapshot);
+      await persist();
+    },
+    async remove(streamId) {
+      if (!live.delete(streamId)) return;
+      await persist();
+    },
+    async replaceAll(snapshots) {
+      live.clear();
+      for (const snapshot of snapshots) {
+        live.set(snapshot.streamId, snapshot);
+      }
+      await persist();
+    },
+    getAll() {
+      return [...live.values()];
+    },
+  };
+}
+
+/**
+ * Parse the persisted blob, returning a normalized list. A malformed
+ * or missing file yields an empty list — never throw at startup; a
+ * corrupt snapshot must not block the user from launching the app.
+ */
+function parseHydrated(
+  raw: unknown,
+  log: Pick<Console, 'warn'>,
+): RestoredStreamSnapshot[] {
+  if (raw == null) return [];
+  const parsed = RestoredStreamsFileSchema.safeParse(raw);
+  if (!parsed.success) {
+    log.warn(
+      '[texra-desktop] Discarding malformed stream snapshot file',
+      parsed.error.issues.slice(0, 3),
+    );
+    return emptyRestoredStreamsFile().streams;
+  }
+  // Normalise status to "stopped" — we don't know if the agent
+  // actually finished, and we explicitly never want the rail to claim
+  // a run is still running just because it was running last time.
+  return parsed.data.streams.map((s) => ({
+    ...s,
+    lastKnownStatus: STREAM_STATUS.STOPPED,
+  }));
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -20,6 +20,10 @@ import { interruptAllCodexSessions } from '@tools/codex';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
+import {
+  openDesktopStreamSnapshotStore,
+  type DesktopStreamSnapshotStore,
+} from './desktopStreamSnapshot.js';
 import { createDesktopDiffHost } from './desktopDiffHost.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
 import { createDesktopPreviewHost } from './desktopPreviewHost.js';
@@ -133,6 +137,7 @@ function createWindow(options: {
   authCoordinator: DesktopAuthCoordinator;
   authCallbackState: DesktopAuthCallbackState;
   initializeCrashReporting: () => Promise<void>;
+  streamSnapshotStore?: DesktopStreamSnapshotStore;
 }): void {
   const window = new BrowserWindow({
     width: 960,
@@ -277,6 +282,7 @@ function createWindow(options: {
       await dialog.showMessageBox(window, { type: 'info', message });
     },
     showErrorMessage,
+    streamSnapshotStore: options.streamSnapshotStore,
   });
   const fileSelection = createDesktopFileSelection({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
@@ -540,12 +546,24 @@ if (protocolLifecycle.shouldContinue) {
       );
       initializeDesktopServerSideKeyAccess(console);
       installContentSecurityPolicy();
+      // Cross-launch stream rail persistence — audit item D /
+      // trajectory #19. A failed open shouldn't block app startup,
+      // so we treat it as "no snapshot available" and continue.
+      let streamSnapshotStore: DesktopStreamSnapshotStore | undefined;
+      try {
+        streamSnapshotStore = await openDesktopStreamSnapshotStore(
+          join(app.getPath('userData'), 'streams.json'),
+        );
+      } catch (error) {
+        console.warn('Failed to open desktop stream snapshot store', error);
+      }
       reopenMainWindow = () =>
         createWindow({
           workspacePath: platformInit.workspacePath,
           authCoordinator,
           authCallbackState,
           initializeCrashReporting,
+          streamSnapshotStore,
         });
       reopenMainWindow();
 

--- a/packages/desktop/src/main/platform/jsonStore.ts
+++ b/packages/desktop/src/main/platform/jsonStore.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 type JsonRecord = Record<string, unknown>;
@@ -60,6 +60,25 @@ export class JsonStore {
 
   private async flush(snapshot: JsonRecord): Promise<void> {
     await mkdir(dirname(this.filePath), { recursive: true });
-    await writeFile(this.filePath, `${JSON.stringify(snapshot, null, 2)}\n`);
+    // Atomic write: stage to a sibling temp path, then rename. A crash
+    // mid-write leaves the previous file intact; without this we could
+    // corrupt the snapshot if the app is force-quit during persistence.
+    // The temp suffix is process-unique so concurrent JsonStore writers
+    // (different files in the same dir) don't collide.
+    const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      await writeFile(tempPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+      await rename(tempPath, this.filePath);
+    } catch (error) {
+      // Best-effort cleanup of stale temp file. Swallow ENOENT (rename
+      // already consumed it) and similar — the original error is what
+      // matters.
+      try {
+        await unlink(tempPath);
+      } catch {
+        // ignore
+      }
+      throw error;
+    }
   }
 }

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -43,3 +43,4 @@ export * from './settingsViewMessages';
 
 // Layer 7: Composite schemas (depend on multiple layers)
 export * from './streamState';
+export * from './streamRestoration';

--- a/src/shared/schemas/streamRestoration.ts
+++ b/src/shared/schemas/streamRestoration.ts
@@ -1,0 +1,76 @@
+/**
+ * Schemas for cross-launch stream restoration on the desktop app.
+ *
+ * Audit item D / trajectory #19. The desktop persists a slim snapshot
+ * of the active stream rail when streams are created/updated and on
+ * shutdown. On the next launch the snapshot is hydrated as
+ * "ghost" entries on the rail so users can find their previous runs
+ * — even though the live agent runtimes were killed when the app
+ * exited. We deliberately do NOT try to re-attach to in-flight
+ * agents; that requires reviving the runtime and is tracked
+ * separately. A "Resume run" button surfaces in-rail and either
+ * defers to existing storage-backed resume (when taskState exists)
+ * or falls back to a clear "start fresh" prompt.
+ */
+
+import { z } from 'zod';
+
+import { AgentCategorySchema } from './agent';
+import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
+import { StreamStatusSchema } from './stream';
+
+export const RESTORED_STREAM_FILE_VERSION = 1;
+
+/**
+ * Slim subset of `StreamTabInfo` + `StreamMetadata` that's safe to
+ * persist to disk. We intentionally omit log entries, output files,
+ * todos, badges, etc. — those would balloon the snapshot and we have
+ * no way to faithfully resurrect them without the full runtime.
+ */
+export const RestoredStreamSnapshotSchema = z.object({
+  /** Stream tab id (e.g. "agent@123"). Stable across relaunches. */
+  streamId: StreamTabIdSchema,
+  /** Display label used by the rail. */
+  label: z.string(),
+  /** Agent name that launched the stream (best-effort). */
+  agent: z.string().optional(),
+  agentCategory: AgentCategorySchema,
+  /** Original input file (for workflow agents). */
+  inputFile: z.string().optional(),
+  /** Original instruction text — useful for "start fresh" fallback. */
+  instruction: z.string().optional(),
+  /** Last known status before shutdown. We mark it explicitly stopped
+   * on hydrate so the UI doesn't claim the run is still running. */
+  lastKnownStatus: StreamStatusSchema,
+  /** AI-generated description, if any. */
+  description: z.string().optional(),
+  /** Execution id for storage lookup (powers resume / transcript view). */
+  executionId: ExecutionIdSchema.optional(),
+  /** Original creation timestamp (ms since epoch). */
+  creationTimestamp: z.number(),
+  /** Last activity timestamp (ms since epoch) — used to sort the rail. */
+  lastTimestamp: z.number().optional(),
+  /** When the snapshot row itself was last persisted (ms since epoch). */
+  persistedAt: z.number(),
+});
+
+export type RestoredStreamSnapshot = z.infer<
+  typeof RestoredStreamSnapshotSchema
+>;
+
+/**
+ * Versioned envelope persisted to `streams.json`. The version field
+ * lets future schema changes detect older formats and migrate or
+ * discard them gracefully — we treat a malformed/older file as
+ * "no snapshot" and start over rather than crashing on launch.
+ */
+export const RestoredStreamsFileSchema = z.object({
+  version: z.literal(RESTORED_STREAM_FILE_VERSION),
+  streams: z.array(RestoredStreamSnapshotSchema),
+});
+
+export type RestoredStreamsFile = z.infer<typeof RestoredStreamsFileSchema>;
+
+export function emptyRestoredStreamsFile(): RestoredStreamsFile {
+  return { version: RESTORED_STREAM_FILE_VERSION, streams: [] };
+}

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -1,0 +1,192 @@
+// Node imports
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - shared schemas
+import { STREAM_STATUS } from '@shared/schemas';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+type Snapshot = {
+  streamId: string;
+  label: string;
+  agent?: string;
+  agentCategory: 'workflow' | 'toolUse';
+  inputFile?: string;
+  instruction?: string;
+  lastKnownStatus: string;
+  description?: string;
+  executionId?: string;
+  creationTimestamp: number;
+  lastTimestamp?: number;
+  persistedAt: number;
+};
+
+type Store = {
+  hydrated: readonly Snapshot[];
+  upsert(snapshot: Snapshot): Promise<void>;
+  remove(id: string): Promise<void>;
+  replaceAll(snapshots: Snapshot[]): Promise<void>;
+  getAll(): Snapshot[];
+};
+
+interface Module {
+  openDesktopStreamSnapshotStore(
+    filePath: string,
+    options?: { log?: { warn(...args: unknown[]): void } },
+  ): Promise<Store>;
+}
+
+async function loadModule(): Promise<Module> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopStreamSnapshot.ts'))
+  ) as Promise<Module>;
+}
+
+function makeSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    streamId: 'workflowAgent@1',
+    label: 'workflowAgent: paper.tex',
+    agent: 'workflowAgent',
+    agentCategory: 'workflow',
+    inputFile: 'paper.tex',
+    instruction: 'Polish the abstract',
+    lastKnownStatus: STREAM_STATUS.RUNNING,
+    description: 'Polish the abstract section',
+    executionId: 'abc-123',
+    creationTimestamp: 1_700_000_000_000,
+    lastTimestamp: 1_700_000_500_000,
+    persistedAt: 1_700_000_500_500,
+    ...overrides,
+  };
+}
+
+describe('DesktopStreamSnapshot', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function tempFilePath(): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-stream-snapshot-'));
+    return join(tempDir, 'streams.json');
+  }
+
+  it('starts empty when the file does not exist', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const store = await openDesktopStreamSnapshotStore(await tempFilePath());
+
+    expect(store.hydrated).toEqual([]);
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('persists snapshots and reloads them on a fresh open', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const initial = await openDesktopStreamSnapshotStore(filePath);
+    await initial.upsert(makeSnapshot());
+    await initial.upsert(
+      makeSnapshot({ streamId: 'toolUseAgent@2', agentCategory: 'toolUse' }),
+    );
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated).toHaveLength(2);
+    const ids = reopened.hydrated.map((s) => s.streamId).sort();
+    expect(ids).toEqual(['toolUseAgent@2', 'workflowAgent@1']);
+  });
+
+  it('normalises status to STOPPED on hydrate', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const writer = await openDesktopStreamSnapshotStore(filePath);
+    await writer.upsert(
+      makeSnapshot({ lastKnownStatus: STREAM_STATUS.RUNNING }),
+    );
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated.every((s) => s.lastKnownStatus === 'stopped')).toBe(
+      true,
+    );
+  });
+
+  it('upsert overwrites an existing snapshot with the same id', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    await store.upsert(makeSnapshot({ description: 'first' }));
+    await store.upsert(makeSnapshot({ description: 'second' }));
+
+    expect(store.getAll()).toHaveLength(1);
+    expect(store.getAll()[0]?.description).toBe('second');
+  });
+
+  it('remove drops a snapshot and persists the removal', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    await store.upsert(makeSnapshot());
+    await store.remove('workflowAgent@1');
+
+    expect(store.getAll()).toEqual([]);
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated).toEqual([]);
+  });
+
+  it('remove is a no-op when the id is unknown', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const store = await openDesktopStreamSnapshotStore(await tempFilePath());
+    await expect(store.remove('does-not-exist')).resolves.toBeUndefined();
+  });
+
+  it('replaceAll wipes the snapshot list', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    await store.upsert(makeSnapshot());
+    await store.replaceAll([]);
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated).toEqual([]);
+  });
+
+  it('discards a malformed snapshot file without throwing', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-stream-snapshot-'));
+    const filePath = join(tempDir, 'streams.json');
+    await writeFile(filePath, '{ not json');
+
+    const warn = (..._args: unknown[]): void => {};
+    const store = await openDesktopStreamSnapshotStore(filePath, {
+      log: { warn },
+    });
+    expect(store.hydrated).toEqual([]);
+  });
+
+  it('writes a versioned envelope under the restoredStreams key', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    await store.upsert(makeSnapshot());
+
+    const raw = JSON.parse(await readFile(filePath, 'utf8')) as {
+      restoredStreams: { version: number; streams: Snapshot[] };
+    };
+    expect(raw.restoredStreams.version).toBe(1);
+    expect(raw.restoredStreams.streams).toHaveLength(1);
+  });
+});

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -114,9 +114,9 @@ describe('DesktopStreamSnapshot', () => {
     );
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(reopened.hydrated.every((s) => s.lastKnownStatus === 'stopped')).toBe(
-      true,
-    );
+    expect(
+      reopened.hydrated.every((s) => s.lastKnownStatus === 'stopped'),
+    ).toBe(true);
   });
 
   it('upsert overwrites an existing snapshot with the same id', async () => {


### PR DESCRIPTION
## Summary

Closes audit item D / trajectory #19 in `docs/dev/standalone-trajectory-audit.md` — visual cross-launch restoration of the active stream rail. The desktop already restored auth + workspace path at launch, but the in-flight stream rail evaporated when the app exited, leaving users with no way to find their previous runs.

This PR delivers Phase 1 (visual rail restoration). Phase 2 (live re-attach to in-flight agent runtimes) is deferred — clicking "Resume" on a ghost stream surfaces a clear "this run is from a previous session, please start fresh" info dialog rather than silently no-op'ing. Reviving the runtime would require restoring `taskState` + the in-flight conversation from `RunStorageService` and re-attaching PocketFlow handles, which is substantial enough to track separately.

### What's persisted
A slim per-stream snapshot — id, label, agent, category, instruction, last-known status, description, executionId, creationTimestamp, lastTimestamp — to `app.getPath('userData')/streams.json`. We deliberately omit log entries, output files, todos, and badges; those would balloon the snapshot and we have no way to faithfully resurrect them anyway.

### What's added
- `packages/desktop/src/main/desktopStreamSnapshot.ts` — JsonStore-backed write-through snapshot store with graceful fallback to empty on malformed input.
- `src/shared/schemas/streamRestoration.ts` — versioned Zod schema for the persisted envelope.
- Atomic writes (temp + rename) added to `platform/jsonStore.ts` so a crash mid-flush leaves the previous file intact rather than corrupting the snapshot.
- `DesktopProgressBridge` hydrates ghosts on construction, persists snapshots on `setTaskState` / `updateStreamStatus` / `updateStreamDescription`, removes them on `deleteStream` / `deleteAllStreams`, merges them into `syncStreams()` output, and surfaces a clear info dialog when `resumeStream` is called against a ghost.

## Test plan
- [x] `npx tsc --noEmit` clean (only pre-existing OpenRouter SDK + electron-types errors that also exist on `origin/main`).
- [x] `cd packages/desktop && npx vite build --mode development` clean.
- [x] `npx vitest run` — 431 passed, 5 pre-existing failures on main unchanged. New `DesktopStreamSnapshot.vitest.mts` adds 9 passing tests covering persist/reload, status normalisation, upsert/remove/replaceAll idempotence, malformed-file recovery, and the on-disk envelope shape.
- [ ] Playwright unavailable in this worktree (no `node_modules`); manual smoke recommended on a built desktop bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new on-disk persistence and hydration logic for Progress streams, which can affect startup behavior and file I/O reliability. Risk is mitigated via schema validation, best-effort error handling, and atomic writes but still touches core desktop execution flow.
> 
> **Overview**
> Enables **cross-launch restoration of the Progress stream rail** by persisting a slim per-stream snapshot to `app.getPath('userData')/streams.json` and hydrating it on startup as stopped “ghost” streams.
> 
> Adds a new `desktopStreamSnapshot` store (JsonStore-backed) plus shared Zod schemas (`streamRestoration`) for the versioned snapshot format; `DesktopProgressBridge` now merges ghosts into `syncStreams()`, persists updates on key stream events, clears snapshots on delete actions, and shows an explicit info dialog when users attempt to resume a ghost stream.
> 
> Updates `JsonStore` to use **atomic temp-file + rename writes** to avoid corrupting JSON files on crash/force-quit, and wires snapshot store initialization into the desktop main entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61307ccb43cc6255cc5dd0bbda49e88f5e2410b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->