### PR TITLE
fix: late bot reviews on #3818 + #3819 — Promise rejection + dispose + macOS reopen

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -353,6 +353,9 @@ export class DesktopProgressBridge {
     this.creationTimestamps.clear();
     this.conversationProgress.clear();
     this.streamBadges.clear();
+    // Bot review (#3819) caught the omission — `deleteAllStreams()`
+    // already clears `restoredStreams`; `dispose()` should match.
+    this.restoredStreams.clear();
     this.workflowFileActions.clearAllBackups();
   }
 

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -71,14 +71,13 @@ export async function openDesktopStreamSnapshotStore(
   const log = options.log ?? console;
   const store = await JsonStore.open(filePath);
   const raw = store.get<unknown>(STREAMS_KEY);
-  const hydrated = parseHydrated(raw, log);
 
-  // Live in-memory list keyed by streamId. We always rewrite the
-  // whole `streams` array on every change — the rail rarely has more
-  // than a dozen entries, so the cost is trivial and the code stays
-  // simple (no merge bugs vs. partial updates).
+  // Live in-memory list keyed by streamId, seeded from the persisted file.
+  // We always rewrite the whole `streams` array on every change — the rail
+  // rarely has more than a dozen entries, so the cost is trivial and the
+  // code stays simple (no merge bugs vs. partial updates).
   const live = new Map<StreamTabId, RestoredStreamSnapshot>(
-    hydrated.map((s) => [s.streamId, s]),
+    parseHydrated(raw, log).map((s) => [s.streamId, s]),
   );
 
   async function persist(): Promise<void> {
@@ -90,7 +89,15 @@ export async function openDesktopStreamSnapshotStore(
   }
 
   return {
-    hydrated,
+    // Bot review (#3819): on macOS the store is created once and shared
+    // across window recreations via `app.on('activate')`. A frozen
+    // `hydrated` array would let previously-deleted streams reappear as
+    // ghosts on window reopen and would miss streams created during the
+    // prior window session. Expose `hydrated` as a getter so each
+    // bridge construction reads the current `live` map.
+    get hydrated() {
+      return [...live.values()];
+    },
     async upsert(snapshot) {
       live.set(snapshot.streamId, snapshot);
       await persist();

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -109,9 +109,19 @@ export function executeCommandPaletteEntry(
   // Sync handlers report their actual result; async handlers (typed-args
   // registry, #3784) return a Promise — treat that as "handled" so the
   // palette closes immediately and the work runs in the background.
-  // Resolution failures surface via the dispatcher's own error logging.
+  //
+  // Bot review (#3818): an async handler that rejects would otherwise
+  // surface as an unhandled rejection at the host. Attach a catch that
+  // logs but doesn't propagate — sync handler errors still throw
+  // synchronously and bubble to the caller.
   const result = onExecute(entry.id);
-  return result === false ? false : true;
+  if (typeof (result as { then?: unknown })?.then === 'function') {
+    (result as Promise<boolean>).catch((error) => {
+      console.error('[command-palette] async dispatch rejected', error);
+    });
+    return true;
+  }
+  return result !== false;
 }
 
 export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {


### PR DESCRIPTION
Addresses late Cursor/Copilot findings on the two prior merges. #3818: attach .catch to async dispatcher Promise so rejections don't bubble as unhandled. #3819: include restoredStreams in dispose(), and turn hydrated into a getter so macOS window-reopen sees current state, not stale store-open snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small lifecycle/persistence and UI-dispatch safety fixes; main impact is preventing ghost stream reappearance on macOS and avoiding unhandled Promise rejections during command execution.
> 
> **Overview**
> Fixes two late-review issues in desktop stream restoration and the shared command palette.
> 
> Desktop stream snapshots are now **kept in sync across window reopens** by exposing `DesktopStreamSnapshotStore.hydrated` as a getter over the live in-memory map (preventing deleted streams from reappearing as ghosts on macOS), and `DesktopProgressBridge.dispose()` now clears `restoredStreams` to match `deleteAllStreams()`.
> 
> Command palette dispatch now **guards async execution** by detecting Promise-returning handlers and attaching a `.catch()` that logs rejections, preventing unhandled rejection noise while still closing the palette immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef234dc8b25e09cde68ce8ca5de6838f9a0db51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->