### PR TITLE
style(progress-view): strip excessive styling — hovers, shadows, transitions

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -1,10 +1,4 @@
-/**
- * Base class for request panels that support rejection feedback.
- *
- * Adds feedback state, reject/feedback rendering, and common keyboard
- * shortcuts (y/n/escape) on top of BaseRequestPanel.
- * ToolEdit, Bash, and Proposal panels extend this.
- */
+/** Base class for request panels that support rejection feedback. */
 
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -1,12 +1,4 @@
-/**
- * Minimal base class shared by all 4 request panel types.
- *
- * Provides the `permission` property, `emitAction()` helper, and the
- * `handleKeyboardShortcut()` contract that the container delegates to.
- *
- * BaseFeedbackPanel extends this to add reject-feedback support.
- * RetryRequestPanel extends this directly (no feedback).
- */
+/** Base class shared by all request panel types. */
 
 // Third-party imports
 import { LitElement } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -1,11 +1,4 @@
-/**
- * Individual panel component for bash command approval requests.
- *
- * Renders a single bash permission with the command block,
- * approve/reject buttons, and feedback input.
- *
- * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
- */
+/** Bash command approval request panel. */
 
 // Third-party imports
 import { html, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -1,9 +1,4 @@
-/**
- * ContextManagement component for displaying context management events.
- *
- * Displays compaction, clearing, and max_tokens reduction events
- * as collapsible details with statistics.
- */
+/** Displays compaction / clearing / max_tokens reduction events as collapsible details. */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -1,8 +1,4 @@
-/**
- * LatexdiffResults component for displaying latexdiff comparison results.
- *
- * Renders a collapsible details section with file comparison entries.
- */
+/** Collapsible latexdiff comparison results panel. */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
@@ -12,7 +8,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -21,7 +16,8 @@ import type { DiffResultDisplay, DiffStatus } from '@shared/schemas';
 // Local imports - progress view events
 import { ProgressEvents } from '../events';
 
-// Local imports - schemas
+// Local imports - progress view helpers
+import { buildDetailsSummary } from '../formatters/htmlBuilders';
 
 /** Status wa-icon name lookup for latexdiff entries. */
 const LATEXDIFF_STATUS_ICONS: Record<DiffStatus, string> = {
@@ -37,17 +33,21 @@ export class LatexdiffResults extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--wa-space-2xs) 0;
       }
 
-      wa-details {
-        margin: 0;
+      details {
+        margin: var(--wa-space-2xs) 0;
+        content-visibility: auto;
+        contain-intrinsic-size: auto 40px;
       }
 
       .latexdiff-content {
         list-style: none;
         margin: 0;
-        padding: 0;
+        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs) var(--wa-space-s);
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-3xs);
       }
 
       /* .detail-item base styles are in commonViewStyles */
@@ -140,16 +140,13 @@ export class LatexdiffResults extends LitElement {
         : `Latexdiff results (${this.entries.length})`;
 
     return html`
-      <wa-details open>
-        <span slot="summary" class="details-summary">
-          <wa-icon library="texra" name="diff" aria-hidden="true"></wa-icon>
-          <span>${summaryText}</span>
-        </span>
-        <ul
-          class="latexdiff-content"
-          data-log-id=${this.logId}
-          data-run-id=${ifDefined(this.runId || undefined)}
-        >
+      <details
+        open
+        data-log-id=${ifDefined(this.logId || undefined)}
+        data-run-id=${ifDefined(this.runId || undefined)}
+      >
+        ${buildDetailsSummary({ iconName: 'diff', label: summaryText })}
+        <ul class="latexdiff-content">
           ${repeat(
             this.entries,
             (entry, index) =>
@@ -157,7 +154,7 @@ export class LatexdiffResults extends LitElement {
             (entry) => this.renderEntry(entry),
           )}
         </ul>
-      </wa-details>
+      </details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -1,11 +1,4 @@
-/**
- * Individual panel component for plan approval requests.
- *
- * Renders a plan summary, numbered step list with descriptions and
- * file references, approve/reject buttons, and feedback input.
- *
- * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
- */
+/** Plan approval request panel. */
 
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -156,8 +156,6 @@ export class PlanView extends LitElement {
           var(--wa-color-brand-fill-quiet) 65%,
           transparent
         );
-        box-shadow: inset 2px 0 0
-          color-mix(in srgb, var(--wa-color-brand-fill-loud) 50%, transparent);
       }
 
       .plan-step--in-progress .plan-step__icon {

--- a/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
@@ -1,6 +1,4 @@
-/** Container for process-agent streams (e.g. `bash` child tabs). Composes
- * the stream header, command strip, and terminal-styled log list — skipping
- * the LLM workflow/tool-use chrome that doesn't apply to raw stdout/stderr. */
+/** Container for process-agent streams (e.g. `bash` child tabs). */
 
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
@@ -34,14 +32,9 @@ export class ProcessStreamContent extends LitElement {
     const streamState = this.streamContext.streamState;
     if (!streamInfo || !streamState) return nothing;
 
-    // Bash streams register with tool-use kind, so bypass toggles live on the
-    // stream state just like any other tool-use stream — bind them so the
-    // header correctly reflects an active YOLO / Super YOLO toggle.
+    // Bash streams register as tool-use kind; bind bypass toggles so the
+    // header reflects active YOLO / Super YOLO state.
     const toolUse = isToolUseState(streamState) ? streamState : null;
-
-    // Process streams carry the full, untruncated command on `command`
-    // (pulled from the synthetic agent config's `instruction` by
-    // streamInfoUtils). Fall back to `description` for backwards compat.
     const command = streamInfo.command ?? streamInfo.description ?? '';
 
     return html`

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -1,12 +1,4 @@
-/**
- * Individual panel component for agent proposal requests.
- *
- * Renders a single proposal permission with agent/model details,
- * workflow file lists, model selection dropdown, approve/reject/setup
- * buttons, and feedback input.
- *
- * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
- */
+/** Agent proposal request panel. */
 
 // Third-party imports
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -1,11 +1,4 @@
-/**
- * Individual panel component for retry requests.
- *
- * Renders a single retry permission with error details,
- * retry/dismiss buttons, and stream diagnostics.
- *
- * Extends BaseRequestPanel for shared permission/emit/keyboard contract.
- */
+/** Retry request panel for failed model requests. */
 
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -1,20 +1,19 @@
-/**
- * StatisticsPanel component for displaying token usage statistics.
- *
- * Renders a collapsible details section with usage metrics.
- */
+/** Collapsible token-usage stats panel. */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
+
+// Local imports - progress view helpers
+import { buildDetailsSummary } from '../formatters/htmlBuilders';
 
 /** Stat item to display */
 export interface StatItem {
@@ -31,27 +30,19 @@ export class StatisticsPanel extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--wa-space-2xs) 0;
       }
 
-      wa-details {
-        margin: 0;
+      details {
+        margin: var(--wa-space-2xs) 0;
+        content-visibility: auto;
+        contain-intrinsic-size: auto 40px;
       }
 
       .statistics-content {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-2xs) var(--wa-space-s);
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
-        margin-top: var(--wa-space-2xs);
-        background: color-mix(
-          in srgb,
-          var(--wa-color-neutral-fill-quiet) 50%,
-          transparent
-        );
-        border-radius: var(--border-radius-small);
-        border: var(--border-thin) solid
-          color-mix(in srgb, var(--color-border) 70%, transparent);
+        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs) var(--wa-space-s);
       }
 
       .stat-item {
@@ -81,17 +72,9 @@ export class StatisticsPanel extends LitElement {
     }
 
     return html`
-      <wa-details>
-        <span slot="summary" class="details-summary">
-          <wa-icon
-            library="texra"
-            name="graph"
-            class="icon"
-            aria-hidden="true"
-          ></wa-icon>
-          <span>Statistics</span>
-        </span>
-        <div class="statistics-content" data-log-id=${this.logId}>
+      <details data-log-id=${ifDefined(this.logId || undefined)}>
+        ${buildDetailsSummary({ iconName: 'graph', label: 'Statistics' })}
+        <div class="statistics-content">
           ${repeat(
             this.items,
             (item) => item.label,
@@ -107,7 +90,7 @@ export class StatisticsPanel extends LitElement {
             `,
           )}
         </div>
-      </wa-details>
+      </details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -1,17 +1,4 @@
-/**
- * `<stream-conversation>` — the body of the Progress view's active stream.
- *
- * Hoisted out of `ProgressApp.renderStreamContent()` (PRD:
- * docs/prd/electron-shell-layout.md § 7.B). Subscribes to module-level signals
- * from `../progressState.ts` so the conversation body can mount independently
- * of `<progress-app>` — required for the Electron three-pane shell (PR 3) where
- * `<stream-conversation>` and `<stream-tabs>` live in different DOM trees.
- *
- * Behavior preservation: the rendered tree, child events, and Lit context
- * provider values match the previous `ProgressApp` body exactly. The page-
- * level "no runs yet" empty-state remains owned by `<progress-app>` for now —
- * see the PR description for why we deferred that part of the PRD wording.
- */
+/** `<stream-conversation>` — body of the Progress view's active stream. */
 
 // Third-party imports
 import { LitElement, css, html, type TemplateResult } from 'lit';
@@ -65,19 +52,12 @@ export class StreamConversation extends SignalWatcher(LitElement) {
       overflow: hidden;
     }
 
-    /* Stream content containers - pass-through for layout, mirrors
-       the equivalent block previously in ProgressApp.styles. */
     tool-use-stream-content,
     workflow-stream-content,
     process-stream-content {
       display: contents;
     }
   `;
-
-  // ---- Lit context providers --------------------------------------------
-  // Identical shape and update timing to the providers that previously lived
-  // on `<progress-app>`. Descendants (`workflow-stream-content`, `log-list`,
-  // `background-tasks-panel`, …) are unchanged.
 
   @provide({ context: streamStateContext })
   @state()
@@ -99,12 +79,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   @state()
   private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
-  /**
-   * Sync signal-computed values into @provide/@state context properties.
-   * SignalWatcher triggers requestUpdate() when any read signal changes,
-   * so this runs only when computed values actually propagate. Mirrors the
-   * willUpdate() previously in ProgressApp.
-   */
+  /** Sync signal-computed values into @provide/@state context properties. */
   protected override willUpdate(): void {
     this.streamContextValue = streamContext$.get();
     this.streamLogContextValue = logContext$.get();
@@ -116,8 +91,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   override render(): TemplateResult {
     const { streamInfo, streamState, isToolUse } = this.streamContextValue;
 
-    // No active stream — show empty log-list. Identical to the prior
-    // `renderStreamContent` early return.
+    // No active stream — show empty log-list.
     if (!streamInfo || !streamState) {
       return html`<log-list></log-list>`;
     }

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -141,11 +141,6 @@ export class StreamHeader extends LitElement {
         gap: var(--wa-space-2xs);
         color: var(--color-text-secondary);
         border-bottom: var(--border-thin) solid var(--color-border);
-        background: linear-gradient(
-          to bottom,
-          color-mix(in srgb, var(--wa-color-surface-default) 80%, transparent),
-          transparent
-        );
       }
 
       .log-header__primary {
@@ -251,10 +246,6 @@ export class StreamHeader extends LitElement {
       .yolo-toggle-button,
       .super-yolo-toggle-button {
         flex-shrink: 0;
-        transition:
-          color var(--transition-normal),
-          background-color var(--transition-normal),
-          box-shadow var(--transition-normal);
       }
 
       .yolo-toggle-button.is-active,
@@ -271,7 +262,7 @@ export class StreamHeader extends LitElement {
         --_toggle-color: var(--color-warning);
       }
 
-      /* Shared active toggle styles */
+      /* Active toggle: color + tinted background. */
       :is(.yolo-toggle-button, .super-yolo-toggle-button).is-active {
         color: var(--_toggle-color);
         background-color: color-mix(
@@ -279,18 +270,6 @@ export class StreamHeader extends LitElement {
           var(--_toggle-color) 15%,
           transparent
         );
-        box-shadow: 0 0 8px
-          color-mix(in srgb, var(--_toggle-color) 40%, transparent);
-      }
-
-      :is(.yolo-toggle-button, .super-yolo-toggle-button).is-active:hover {
-        background-color: color-mix(
-          in srgb,
-          var(--_toggle-color) 25%,
-          transparent
-        );
-        box-shadow: 0 0 12px
-          color-mix(in srgb, var(--_toggle-color) 60%, transparent);
       }
 
       .parent-link {
@@ -302,18 +281,11 @@ export class StreamHeader extends LitElement {
         color: var(--color-text-secondary);
         cursor: pointer;
         white-space: nowrap;
-        opacity: var(--opacity-subtle);
         border-radius: var(--border-radius-small);
-        transition:
-          opacity var(--transition-fast),
-          background-color var(--transition-fast),
-          color var(--transition-fast);
       }
 
       .parent-link:hover {
-        opacity: var(--opacity-full);
         color: var(--color-text-link);
-        background-color: var(--wa-color-neutral-fill-quiet);
       }
 
       .parent-link:focus-visible {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -110,10 +110,6 @@ export class StreamTab extends LitElement {
         width: 100%;
         gap: var(--wa-space-3xs);
         border-left: var(--border-thick) solid transparent;
-        transition:
-          border-left-color var(--transition-normal),
-          background-color var(--transition-fast),
-          box-shadow var(--transition-fast);
       }
 
       /*
@@ -159,19 +155,9 @@ export class StreamTab extends LitElement {
         border-left-color: var(--color-warning);
       }
 
-      /* Pending approval — pulsing orange, visually distinct from all status colors */
-      @keyframes pulse-border {
-        0%,
-        100% {
-          border-left-color: var(--wa-color-chart-orange, #d18616);
-        }
-        50% {
-          border-left-color: transparent;
-        }
-      }
-
+      /* Pending approval — solid orange left rail. */
       .tab-container.has-pending-approval {
-        animation: pulse-border 2s ease-in-out infinite;
+        border-left-color: var(--wa-color-chart-orange, #d18616);
       }
 
       .tab {
@@ -249,10 +235,6 @@ export class StreamTab extends LitElement {
         margin: 0;
         color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
         opacity: 0;
-        transition:
-          opacity var(--transition-fast),
-          color var(--transition-fast),
-          background-color var(--transition-fast);
       }
 
       /* Reveal the delete affordance only when the row is hovered,
@@ -267,14 +249,13 @@ export class StreamTab extends LitElement {
       .tab-container:hover {
         background-color: color-mix(
           in srgb,
-          var(--wa-color-neutral-fill-quiet) 70%,
+          var(--wa-color-neutral-fill-quiet) 25%,
           transparent
         );
       }
 
       /*
-       * Match VS Code's list-item selection: flip background + foreground
-       * together. The descendant-wildcard selector below forces nested spans
+       * The descendant wildcard rule below forces nested spans
        * (.last-active, .model) and codicon glyphs to inherit the selection
        * color even when intermediate elements define their own.
        */
@@ -285,8 +266,6 @@ export class StreamTab extends LitElement {
           transparent
         );
         color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
-        box-shadow: inset 0 0 0 1px
-          color-mix(in srgb, var(--wa-color-brand-fill-loud) 18%, transparent);
       }
 
       /*
@@ -347,11 +326,6 @@ export class StreamTab extends LitElement {
         );
       }
 
-      .tab-delete:hover::part(base),
-      .tab-delete:focus-within::part(base) {
-        background-color: var(--wa-color-surface-raised);
-      }
-
       .tab-delete:hover,
       .tab-delete:focus-within {
         color: var(--wa-color-danger-on-quiet);
@@ -375,12 +349,10 @@ export class StreamTab extends LitElement {
 
       .tab-expand:hover {
         opacity: 1;
-        background-color: var(--wa-color-surface-raised);
       }
 
       .tab-expand wa-icon {
         font-size: var(--font-size-xs);
-        transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
       }
 
       .tab-expand[aria-expanded='true'] wa-icon {

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -1,10 +1,4 @@
-/**
- * Fully declarative task group list component.
- * Data flows in, DOM flows out. No imperative manipulation.
- *
- * Renders groups, headers, and log entries inline — no intermediate
- * Shadow DOM components. Uses guard() to skip unchanged templates.
- */
+/** Declarative task group list — renders groups, headers, and log entries inline. */
 
 // Third-party imports
 import { LitElement, html, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -1,5 +1,4 @@
-/** Renders a `$ <command>` strip in VS Code terminal styling. Used above
- * process-agent stream output to show the command that spawned the session. */
+/** Renders a `$ <command>` strip above process-agent stream output. */
 
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -1,11 +1,4 @@
-/**
- * Individual panel component for tool edit approval requests.
- *
- * Renders a single tool edit permission with diff metadata, diff actions
- * (including LaTeX dropdown), approve/reject buttons, and feedback input.
- *
- * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
- */
+/** Tool edit approval request panel. */
 
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/ToolTimer.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolTimer.ts
@@ -1,11 +1,4 @@
-/**
- * Live elapsed-time timer for in-progress tool calls.
- *
- * Renders a ticking counter (e.g. "3s", "1min 12s") that updates every second.
- * When a timeout limit is provided, displays "elapsed / limit" so the user
- * can see how close the command is to being killed.
- * Automatically starts on connect and stops on disconnect.
- */
+/** Live elapsed-time timer for in-progress tool calls. */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -14,6 +14,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
 import { CopyButtonController } from '@shared/controllers';
+import { compactIconActionButtonStyles } from '@shared/styles';
 import { designTokens } from '@shared/styles/litStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
@@ -68,6 +69,7 @@ function decodeXmlEntitiesForDisplay(text: string): string {
 export class UserMessage extends LitElement {
   static override styles = [
     designTokens,
+    compactIconActionButtonStyles,
     css`
       :host {
         display: block;
@@ -76,11 +78,11 @@ export class UserMessage extends LitElement {
       .user-message-container {
         display: flex;
         justify-content: flex-end;
-        margin: var(--wa-space-2xs) 0;
+        margin: var(--wa-space-3xs) 0;
       }
 
       .user-message {
-        padding: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
         max-width: 85%;
         background-color: var(--wa-color-editor-selection);
         border: var(--border-thin) solid var(--wa-color-surface-border);
@@ -91,7 +93,6 @@ export class UserMessage extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-3xs);
-        margin-bottom: var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         color: var(--wa-color-text-quiet);
       }
@@ -124,7 +125,7 @@ export class UserMessage extends LitElement {
         color: var(--wa-color-text-normal);
         white-space: pre-wrap;
         word-wrap: break-word;
-        line-height: var(--line-height-relaxed);
+        line-height: var(--line-height-normal);
         font-size: var(--font-size-sm);
       }
 

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -10,6 +10,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
@@ -38,35 +39,10 @@ export class WorkflowToolUseFollowupSection extends LitElement {
         display: block;
       }
 
-      .followup {
-        border-top: var(--border-thin) solid var(--color-border);
-        padding: var(--wa-space-2xs) 0;
-        color: var(--color-text-secondary);
-      }
-
-      .followup__header {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        width: 100%;
-        padding: 0;
-        border: none;
-        background: transparent;
-        color: var(--color-text);
-        cursor: pointer;
-      }
-
-      .followup__title {
-        flex: 1;
-        text-align: left;
-        font-weight: var(--font-weight-medium);
-      }
-
       .followup__body {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-2xs);
-        margin-top: var(--wa-space-2xs);
       }
 
       .followup__description {
@@ -118,7 +94,6 @@ export class WorkflowToolUseFollowupSection extends LitElement {
   @property({ attribute: false }) options: FollowupOptionsState | null = null;
   @property({ attribute: false }) streamModel: string | null = null;
 
-  @state() private expanded = false;
   @state() private selectedAgent = '';
   @state() private selectedModel = '';
   @state() private initialQuestion = '';
@@ -140,108 +115,86 @@ export class WorkflowToolUseFollowupSection extends LitElement {
     const ready = agents.length > 0 && models.some((model) => !model.disabled);
 
     return html`
-      <div
-        class="followup"
+      <wa-details
+        class="panel-collapsible"
+        summary="Tool-use follow-up"
+        @wa-show=${this.handleShow}
         role="region"
         aria-label="Workflow tool-use follow-up"
       >
-        <button
-          class="followup__header"
-          type="button"
-          aria-expanded=${this.expanded ? 'true' : 'false'}
-          @click=${this.toggleExpanded}
-        >
-          <wa-icon
-            library="texra"
-            name=${this.expanded ? 'chevron-down' : 'chevron-right'}
-            aria-hidden="true"
-          ></wa-icon>
-          <span class="followup__title">Tool-use follow-up</span>
-          <wa-icon
-            library="texra"
-            name="comment-discussion"
-            aria-hidden="true"
-          ></wa-icon>
-        </button>
-
-        ${this.expanded
-          ? html`
-              <div class="followup__body">
-                <div class="followup__description">
-                  Start an interactive tool-use chat from this workflow result.
-                  The new chat gets the workflow output locations and your note
-                  as context.
-                </div>
-                <div class="followup__controls">
-                  <label class="followup__field">
-                    <span class="followup__label">Agent</span>
-                    <wa-select
-                      placement="top"
-                      aria-label="Follow-up tool-use agent"
-                      .value=${this.selectedAgent}
-                      ?disabled=${agents.length === 0}
-                      @change=${this.handleAgentChange}
-                    >
-                      ${renderAgentOptions(agents, this.selectedAgent)}
-                    </wa-select>
-                  </label>
-                  <label class="followup__field">
-                    <span class="followup__label">Model</span>
-                    <wa-select
-                      placement="top"
-                      aria-label="Follow-up model"
-                      .value=${this.selectedModel}
-                      ?disabled=${models.length === 0}
-                      @change=${this.handleModelChange}
-                    >
-                      ${renderModelOptions(models, this.selectedModel)}
-                    </wa-select>
-                  </label>
-                </div>
-                <wa-textarea
-                  aria-label="Follow-up note"
-                  placeholder="Ask what the tool-use agent should do with these results."
-                  rows="3"
-                  resize="vertical"
-                  .value=${this.initialQuestion}
-                  @input=${this.handleQuestionInput}
-                ></wa-textarea>
-                <div class="followup__actions">
-                  <wa-button
-                    appearance="outlined"
-                    variant="neutral"
-                    size="small"
-                    ?disabled=${!ready}
-                    @click=${this.setupFollowup}
-                  >
-                    <wa-icon
-                      slot="start"
-                      library="texra"
-                      name="reply"
-                      aria-hidden="true"
-                    ></wa-icon>
-                    Setup
-                  </wa-button>
-                  <wa-button
-                    appearance="filled"
-                    variant="brand"
-                    size="small"
-                    ?disabled=${!ready}
-                    @click=${this.runFollowup}
-                  >
-                    <wa-icon
-                      slot="start"
-                      library="texra"
-                      name="play"
-                      aria-hidden="true"
-                    ></wa-icon>
-                    Run
-                  </wa-button>
-                </div>
-              </div>
-            `
-          : nothing}
-      </div>
+        <div class="followup__body">
+          <div class="followup__description">
+            Start an interactive tool-use chat from this workflow result. The
+            new chat gets the workflow output locations and your note as
+            context.
+          </div>
+          <div class="followup__controls">
+            <label class="followup__field">
+              <span class="followup__label">Agent</span>
+              <wa-select
+                placement="top"
+                aria-label="Follow-up tool-use agent"
+                .value=${this.selectedAgent}
+                ?disabled=${agents.length === 0}
+                @change=${this.handleAgentChange}
+              >
+                ${renderAgentOptions(agents, this.selectedAgent)}
+              </wa-select>
+            </label>
+            <label class="followup__field">
+              <span class="followup__label">Model</span>
+              <wa-select
+                placement="top"
+                aria-label="Follow-up model"
+                .value=${this.selectedModel}
+                ?disabled=${models.length === 0}
+                @change=${this.handleModelChange}
+              >
+                ${renderModelOptions(models, this.selectedModel)}
+              </wa-select>
+            </label>
+          </div>
+          <wa-textarea
+            aria-label="Follow-up note"
+            placeholder="Ask what the tool-use agent should do with these results."
+            rows="3"
+            resize="vertical"
+            .value=${this.initialQuestion}
+            @input=${this.handleQuestionInput}
+          ></wa-textarea>
+          <div class="followup__actions">
+            <wa-button
+              appearance="plain"
+              size="small"
+              ?disabled=${!ready}
+              @click=${this.setupFollowup}
+            >
+              <wa-icon
+                slot="start"
+                library="texra"
+                name="reply"
+                aria-hidden="true"
+              ></wa-icon>
+              Setup
+            </wa-button>
+            <wa-button
+              appearance="filled"
+              variant="brand"
+              size="small"
+              ?disabled=${!ready}
+              @click=${this.runFollowup}
+            >
+              <wa-icon
+                slot="start"
+                library="texra"
+                name="play"
+                aria-hidden="true"
+              ></wa-icon>
+              Run
+            </wa-button>
+          </div>
+        </div>
+      </wa-details>
     `;
   }
 
@@ -276,11 +229,10 @@ export class WorkflowToolUseFollowupSection extends LitElement {
     }
   }
 
-  private toggleExpanded = (): void => {
-    this.expanded = !this.expanded;
-    if (this.expanded) {
-      this.dispatchEvent(ProgressEvents.followupRequestOptions());
-    }
+  private handleShow = (event: Event): void => {
+    // wa-show bubbles from nested wa-select; only react to our own.
+    if (event.target !== event.currentTarget) return;
+    this.dispatchEvent(ProgressEvents.followupRequestOptions());
   };
 
   private handleAgentChange = (event: Event): void => {

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -52,21 +52,9 @@ export const codeBlockStyles = css`
     color: var(--wa-color-text-quiet, #888);
     cursor: pointer;
     border-radius: var(--border-radius-small);
-    transition:
-      background-color var(--transition-fast),
-      color var(--transition-fast),
-      transform var(--transition-fast);
 
     &:hover {
-      background-color: var(--wa-color-toolbar-hover, rgba(90, 93, 94, 0.31));
       color: var(--wa-color-text-normal);
-    }
-
-    &:active {
-      background-color: var(
-        --wa-color-toolbar-active,
-        rgba(99, 102, 103, 0.31)
-      );
     }
 
     &.copied {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -14,7 +14,6 @@ export const groupStyles = css`
     align-items: center;
     background-color: transparent;
     border-left: var(--border-medium) solid var(--color-border);
-    transition: border-left-color var(--transition-normal);
   }
 
   .log-group-header {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -14,31 +14,12 @@ export const groupStyles = css`
     align-items: center;
     background-color: transparent;
     border-left: var(--border-medium) solid var(--color-border);
-    transition:
-      border-left-color var(--transition-normal),
-      background-color var(--transition-fast),
-      box-shadow var(--transition-fast);
-  }
-
-  /*
-   * Subtle inset highlight on hover gives each group row a tactile "lift"
-   * without pulling focus from running-state colour cues.
-   */
-  .log-group-header:hover {
-    background-color: color-mix(
-      in srgb,
-      var(--wa-color-neutral-fill-quiet) 70%,
-      transparent
-    );
-    box-shadow: inset 1px 0 0
-      color-mix(in srgb, var(--wa-color-text-normal) 8%, transparent);
+    transition: border-left-color var(--transition-normal);
   }
 
   .log-group-header {
     &.is-running {
       border-left-color: var(--wa-color-status-warning-bg);
-      box-shadow: inset 2px 0 0
-        color-mix(in srgb, var(--wa-color-status-warning-bg) 35%, transparent);
     }
 
     &.is-error {
@@ -94,8 +75,16 @@ export const groupStyles = css`
     border-left: var(--border-medium) solid transparent;
   }
 
+  /* Align custom-element panels with native banner-details indent. */
   .log-group-content
-    > :is(.log-group-header, .log-group-content, .log-line, .banner-details) {
+    > :is(
+      .log-group-header,
+      .log-group-content,
+      .log-line,
+      .banner-details,
+      statistics-panel,
+      latexdiff-results
+    ) {
     margin-left: var(--wa-space-2xs);
   }
 
@@ -103,7 +92,9 @@ export const groupStyles = css`
     border-left-width: var(--border-thin);
   }
 
-  .log-group-content .log-group-content :is(.log-line, .banner-details) {
+  .log-group-content
+    .log-group-content
+    :is(.log-line, .banner-details, statistics-panel, latexdiff-results) {
     margin-left: 0;
   }
 `;

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -123,7 +123,6 @@ export const logEntryStyles = css`
   :is(.file-link, .web-search-link) {
     color: var(--color-text-link);
     cursor: pointer;
-    transition: color var(--transition-fast);
   }
 
   :is(.file-link, .web-search-link):hover {
@@ -181,9 +180,6 @@ export const logEntryStyles = css`
     padding: 0 var(--wa-space-3xs);
     opacity: 0;
     margin-left: auto;
-    transition:
-      opacity var(--transition-normal),
-      color var(--transition-normal);
     cursor: pointer;
   }
 

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -72,17 +72,9 @@ export const toolUseStyles = css`
   }
 
   .banner-details--relay-error {
-    position: relative;
-  }
-
-  .banner-details--relay-error::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    inset-block: 0;
-    width: var(--border-thick);
-    background: var(--wa-color-warning-on-quiet, #ff8c00);
-    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+    border-left: var(--border-medium) solid
+      var(--wa-color-warning-on-quiet, #ff8c00);
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
   }
 
   .banner-details--relay-error > .details-summary .label {
@@ -110,7 +102,7 @@ export const toolUseStyles = css`
   :is(.tool-user-feedback, .tool-error-content) {
     padding: var(--wa-space-2xs);
     border-radius: var(--border-radius-small);
-    border-left: var(--border-thick) solid;
+    border-left: var(--border-medium) solid;
   }
 
   .tool-user-feedback {
@@ -149,9 +141,6 @@ export const toolUseStyles = css`
     display: inline-flex;
     align-items: center;
     gap: var(--wa-space-3xs);
-    transition:
-      color var(--transition-fast),
-      background-color var(--transition-fast);
   }
 
   .proposal-restore-link:focus-visible {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -156,8 +156,6 @@ export class AgentSelectionPanel extends LitElement {
         background: var(--wa-color-brand-fill-quiet);
         color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
         border-left-color: var(--wa-color-brand-fill-loud);
-        box-shadow: inset 0 0 0 1px
-          color-mix(in srgb, var(--wa-color-brand-fill-loud) 12%, transparent);
       }
 
       .agent-list-item.selected .agent-list-item-name,

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -155,7 +155,6 @@ export const profileViewStyles: CSSResult = css`
     background: var(--wa-form-control-background-color);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
-    transition: border-color var(--transition-normal);
   }
 
   wa-radio.api-access-option:hover {

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -158,7 +158,6 @@ export class AgentsTab extends LitElement {
         border: none;
         border-radius: var(--border-radius);
         cursor: pointer;
-        transition: color var(--transition-fast);
       }
 
       .agents-dir-icon-btn:hover {

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -91,17 +91,10 @@ export class MultiAgentTab extends LitElement {
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         cursor: pointer;
-        transition:
-          border-color var(--transition-fast),
-          background-color var(--transition-fast);
       }
 
       .preset-card:hover {
         border-color: var(--wa-color-focus);
-        background-color: var(
-          --texra-list-hoverBackground,
-          rgba(128, 128, 128, 0.1)
-        );
       }
 
       .preset-card:focus-visible {

--- a/packages/extension/src/webview/frontend/components/BannerGroup.ts
+++ b/packages/extension/src/webview/frontend/components/BannerGroup.ts
@@ -1,10 +1,4 @@
-/**
- * Lightweight container for MainView banners.
- *
- * Renders individual banner components (API key, agent config,
- * dependency, getting started, login) by passing through state
- * properties. Each banner handles its own rendering and events.
- */
+/** Container for MainView banners — passes state through to each banner component. */
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -99,12 +99,12 @@ export class InstructionPanel extends LitElement {
     css`
       :host {
         display: block;
-        /* Bumped from 6rem so the "Agent…" placeholder is readable on a
-           cold-start launcher (no agent selected yet) without clipping. */
+        /* Symmetric ranges for agent + model selects so the two boxes are
+           identical-width at every viewport. */
         --agent-select-min-width: 7rem;
-        --agent-select-max-width: min(11rem, calc(100vw - 9rem));
-        --model-select-min-width: 6rem;
-        --model-select-max-width: min(13rem, calc(100vw - 9rem));
+        --agent-select-max-width: min(12rem, calc((100vw - 12rem) / 2));
+        --model-select-min-width: 7rem;
+        --model-select-max-width: min(12rem, calc((100vw - 12rem) / 2));
         --agent-model-listbox-min-width: 12rem;
         --agent-model-listbox-max-width: min(
           20rem,
@@ -314,33 +314,8 @@ export class InstructionPanel extends LitElement {
         color: var(--wa-color-brand-on-loud);
         border: var(--border-thin) solid
           color-mix(in srgb, black 8%, var(--wa-color-brand-fill-loud));
-        box-shadow:
-          0 1px 1px rgb(0 0 0 / 8%),
-          inset 0 1px 0 rgb(255 255 255 / 12%);
         font-weight: var(--font-weight-semibold, 600);
         letter-spacing: 0.01em;
-        transition:
-          transform var(--transition-fast),
-          box-shadow var(--transition-fast),
-          background-color var(--transition-fast),
-          filter var(--transition-fast);
-      }
-
-      wa-button.execute-button::part(base):hover {
-        transform: translateY(-0.5px);
-        filter: brightness(1.06);
-        box-shadow:
-          0 3px 8px
-            color-mix(in srgb, var(--wa-color-brand-fill-loud) 28%, transparent),
-          inset 0 1px 0 rgb(255 255 255 / 18%);
-      }
-
-      wa-button.execute-button::part(base):active {
-        transform: translateY(0.5px);
-        filter: brightness(0.97);
-        box-shadow:
-          0 0 0 transparent,
-          inset 0 1px 0 rgb(0 0 0 / 8%);
       }
 
       wa-button.execute-button:focus-visible::part(base) {
@@ -360,8 +335,8 @@ export class InstructionPanel extends LitElement {
 
       /*
        * Hairline separator + compact monospace badge — distinctive but
-       * disciplined. Uses inset shadow instead of a fill so the chip
-       * remains legible against the brand-fill background in both
+       * disciplined. Uses a translucent border outline (no fill) so the
+       * chip remains legible against the brand-fill background in both
        * light and dark themes.
        */
       .execute-button__kbd {
@@ -378,7 +353,7 @@ export class InstructionPanel extends LitElement {
         font-weight: 500;
         letter-spacing: 0.04em;
         opacity: 0.75;
-        box-shadow: inset 0 0 0 var(--border-thin) rgb(255 255 255 / 28%);
+        border: var(--border-thin) solid rgb(255 255 255 / 28%);
         position: relative;
       }
 

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -1,9 +1,4 @@
-/**
- * LatexDiffsSection component for MainView LaTeXDiff controls.
- *
- * Renders the LaTeXDiff section with base/edited file selectors,
- * commit selector, and diff action buttons.
- */
+/** LaTeXDiff section with base/edited file selectors, commit selector, and diff actions. */
 
 // Side-effect imports - register WA select & option components
 import '@awesome.me/webawesome/dist/components/select/select.js';

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -43,38 +43,11 @@ export class LoginBanner extends LitElement {
         line-height: var(--line-height-relaxed, 1.5);
       }
 
-      /*
-       * The Sign In CTA is the primary banner action across the whole UI —
-       * polish it with a quiet brand glow on hover and a tighter chrome
-       * than the surrounding plain dismiss button.
-       */
       #loginBannerButton::part(base) {
         min-height: 26px;
         padding-inline: var(--wa-space-s);
-        border-radius: var(--wa-border-radius-m, 6px);
         font-weight: var(--font-weight-semibold, 600);
         letter-spacing: 0.01em;
-        box-shadow:
-          0 1px 1px rgb(0 0 0 / 6%),
-          inset 0 1px 0 rgb(255 255 255 / 12%);
-        transition:
-          filter var(--transition-fast),
-          box-shadow var(--transition-fast),
-          transform var(--transition-fast);
-      }
-
-      #loginBannerButton::part(base):hover {
-        filter: brightness(1.06);
-        transform: translateY(-0.5px);
-        box-shadow:
-          0 3px 8px
-            color-mix(in srgb, var(--wa-color-brand-fill-loud) 28%, transparent),
-          inset 0 1px 0 rgb(255 255 255 / 18%);
-      }
-
-      #loginBannerButton::part(base):active {
-        transform: translateY(0.5px);
-        filter: brightness(0.97);
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
+++ b/packages/extension/src/webview/frontend/components/OutputFilesSection.ts
@@ -1,8 +1,4 @@
-/**
- * OutputFilesSection component for MainView multiple outputs.
- *
- * Renders the collapsible output files list with toggle and action buttons.
- */
+/** Collapsible output files list with toggle and action buttons. */
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
@@ -41,33 +37,13 @@ export class OutputFilesSection extends LitElement {
         display: block;
       }
 
-      /*
-       * OutputFilesSection feed treatment — tighter row chrome, soft inset
-       * highlight on hover, brand-tinted remove affordance. Sits on top of
-       * the shared multiFilesStyles so other consumers (latexdiffs) keep
-       * their leaner row chrome.
-       */
       .multiple-files-list {
-        background: color-mix(
-          in srgb,
-          var(--wa-color-neutral-fill-quiet) 25%,
-          transparent
-        );
         padding: var(--wa-space-3xs);
       }
 
       .file-item {
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-radius: var(--border-radius-small);
-        transition:
-          background-color var(--transition-fast),
-          box-shadow var(--transition-fast);
-      }
-
-      .file-item:hover {
-        background-color: var(--wa-color-neutral-fill-quiet);
-        box-shadow: inset 1px 0 0
-          color-mix(in srgb, var(--wa-color-brand-fill-loud) 40%, transparent);
       }
 
       .file-item .file-name {
@@ -83,10 +59,6 @@ export class OutputFilesSection extends LitElement {
       .file-item:hover .remove-button,
       .file-item:focus-within .remove-button {
         opacity: 1;
-      }
-
-      .file-item .remove-button:hover::part(base) {
-        color: var(--wa-color-danger-fill-loud);
       }
 
       .file-list-placeholder {

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -1,24 +1,10 @@
 // Shared layout for inline wa-callout banners. wa-callout owns the variant
-// color, border, and padding; this stylesheet handles host display, the
-// bottom margin, and the row layout for the message + action buttons inside
-// the callout's default slot.
-//
-// Banners always render their wa-callout into the DOM and use the
-// `data-visible` attribute on the host (driven by the `visible` property /
-// equivalent state) to drive a CSS-only fade + height-collapse transition.
-// This avoids the abrupt mount/unmount jump from `if (!visible) return
-// nothing` while keeping JS out of the animation path.
+// color, border, and padding; this stylesheet handles host display and the
+// row layout for the message + action buttons inside the callout's default slot.
 
 import { css, type CSSResult } from 'lit';
 
-/**
- * Drive the CSS-only fade + height-collapse transition on a banner host.
- *
- * The shared `bannerStyles` selectors key off `[data-visible='true']` and the
- * accompanying `aria-hidden` attribute provides the matching a11y signal.
- * Centralising the writes keeps the five banner components from each carrying
- * their own copy of the visibility-derivation logic.
- */
+/** Reflect banner visibility onto the host for CSS targeting and a11y. */
 export function applyBannerVisibility(
   host: HTMLElement,
   visible: boolean,
@@ -29,74 +15,30 @@ export function applyBannerVisibility(
 
 export const bannerStyles: CSSResult = css`
   :host {
-    /*
-     * 1fr/0fr grid trick collapses the banner's height as part of the
-     * fade-out so surrounding content slides up smoothly. The transition
-     * runs in both directions (open and dismiss) with no JS timers.
-     */
-    display: grid;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows var(--transition-normal);
+    display: block;
   }
 
-  :host([data-visible='true']) {
-    grid-template-rows: 1fr;
+  :host(:not([data-visible='true'])) {
+    display: none;
   }
 
   .banner-frame {
-    overflow: hidden;
     min-height: 0;
   }
 
   wa-callout {
     margin-bottom: var(--wa-space-s);
-    opacity: 0;
-    transform: translateY(calc(-1 * var(--wa-space-2xs)));
-    transition:
-      opacity 180ms ease,
-      transform 180ms ease,
-      visibility 0s linear 180ms;
-    pointer-events: none;
-    /* Compact callout chrome — stricter minimalism, tight banner padding. */
     --padding: var(--wa-space-2xs) var(--wa-space-xs);
-    /* Subtle hairline above the variant border for refined density. */
-    border-radius: var(--wa-border-radius-m, 6px);
-  }
-
-  :host([data-visible='true']) wa-callout {
-    opacity: 1;
-    transform: translateY(0);
-    visibility: visible;
-    transition:
-      opacity 180ms ease,
-      transform 180ms ease,
-      visibility 0s linear 0s;
-    pointer-events: auto;
-  }
-
-  /*
-   * When the banner is hidden, drop its bottom margin so the layout fully
-   * collapses. The margin transition runs alongside the grid-row collapse.
-   */
-  :host(:not([data-visible='true'])) wa-callout {
-    margin-bottom: 0;
   }
 
   wa-callout::part(message) {
     padding-block: var(--wa-space-2xs);
-    line-height: var(--line-height-relaxed, 1.5);
+    line-height: var(--line-height-normal);
   }
 
-  /*
-   * Cohesive icon treatment across all banners — quiet circular tile
-   * tinted by the variant colour. Establishes a consistent visual rhythm:
-   * apiKey (warning), login (brand), dependency (warning), gettingStarted
-   * (brand), agentConfig (warning) all share the same icon framing.
-   */
   wa-callout::part(icon) {
     padding-inline-end: var(--wa-space-2xs);
     font-size: 0.95em;
-    opacity: 0.92;
   }
 
   .banner-row {
@@ -114,12 +56,6 @@ export const bannerStyles: CSSResult = css`
     line-height: var(--line-height-relaxed, 1.5);
   }
 
-  /*
-   * Bold cue for inline names — used by ApiKeyBanner ("<provider> API key
-   * missing") and GettingStartedBanner ("Welcome to TeXRA!"). A touch
-   * tighter letter-spacing distinguishes the lede from the body without
-   * a font weight clash.
-   */
   .banner-row strong {
     font-weight: var(--font-weight-semibold, 600);
     letter-spacing: -0.005em;
@@ -132,22 +68,10 @@ export const bannerStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
-  /*
-   * Banner action buttons share the same compact, refined silhouette —
-   * tighter padding than the WA default plain button, with a subtle
-   * hover tint that uses the callout's surrounding tone.
-   */
   .actions wa-button::part(base) {
     min-height: 24px;
     padding-inline: var(--wa-space-xs);
     border-radius: var(--wa-border-radius-s, 4px);
     font-size: var(--font-size-sm);
-    transition:
-      background-color var(--transition-fast),
-      color var(--transition-fast);
-  }
-
-  .actions wa-button[appearance='plain']::part(base):hover {
-    background: color-mix(in srgb, currentColor 8%, transparent);
   }
 `;

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -262,8 +262,7 @@ export const dropdownStyles = css`
   }
 
   wa-button.has-options::part(base) {
-    box-shadow: inset 0 0 0 1px
-      var(--wa-color-brand-border-quiet, var(--wa-color-focus));
+    border-color: var(--wa-color-brand-border-quiet, var(--wa-color-focus));
   }
 
   .dropdown-container .dropdown-menu {

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -296,11 +296,14 @@ export const dropdownStyles = css`
     height: 20px;
     padding: var(--wa-space-3xs);
     font-size: var(--font-size-sm);
-    transition: background-color var(--transition-fast);
   }
 
   .dropdown-container .dropdown-menu wa-checkbox:hover {
-    background: var(--wa-color-neutral-fill-quiet);
+    background: color-mix(
+      in srgb,
+      var(--wa-color-neutral-fill-quiet) 30%,
+      transparent
+    );
   }
 `;
 

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -106,7 +106,6 @@ export const commonViewStyles: CSSResult = css`
   .collapsible::part(body) {
     max-height: var(--height-medium);
     overflow: hidden;
-    transition: max-height var(--transition-slow);
   }
 
   .collapsible[open]::part(body) {
@@ -116,7 +115,6 @@ export const commonViewStyles: CSSResult = css`
   .collapsible::part(content) {
     display: grid;
     grid-template-rows: 1fr;
-    transition: grid-template-rows var(--transition-normal);
   }
 
   .collapsible:not([open])::part(content) {

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -75,7 +75,11 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .list-item:hover {
-    background-color: var(--wa-color-neutral-fill-quiet);
+    background-color: color-mix(
+      in srgb,
+      var(--wa-color-neutral-fill-quiet) 30%,
+      transparent
+    );
   }
 
   .list-item:focus-within {
@@ -141,17 +145,13 @@ export const commonViewStyles: CSSResult = css`
     padding: 0 var(--wa-space-2xs) var(--wa-space-2xs);
   }
 
-  /*
-   * Smooth open/close for the wa-details version of the panel using the
-   * grid 1fr/0fr trick so long content scales without a fixed max-height
-   * cap. wa-details exposes the body via the 'content' part. The direct
-   * child wrapper carries 'overflow: hidden' and 'min-height: 0' so the
-   * grid row can clamp it without truncation jumps.
-   */
+  /* wa-details exposes the body via the 'content' part. The grid 1fr/0fr
+     trick lets long content scale without a fixed max-height cap. The
+     direct child wrapper carries 'overflow: hidden' and 'min-height: 0'
+     so the grid row can clamp it without truncation jumps. */
   .panel-collapsible::part(content) {
     display: grid;
     grid-template-rows: 1fr;
-    transition: grid-template-rows var(--transition-normal);
   }
 
   .panel-collapsible:not([open])::part(content) {
@@ -266,12 +266,6 @@ export const commonViewStyles: CSSResult = css`
     cursor: pointer;
     list-style: none;
     user-select: none;
-    opacity: var(--opacity-normal);
-    transition: opacity var(--transition-fast);
-  }
-
-  .details-summary:hover {
-    opacity: var(--opacity-full);
   }
 
   .details-summary:focus-visible {
@@ -285,7 +279,6 @@ export const commonViewStyles: CSSResult = css`
     opacity: var(--opacity-subtle);
     font-size: var(--font-size-sm);
     display: inline-block;
-    transition: transform var(--transition-fast);
   }
 
   details[open] > summary .toggle-icon {
@@ -325,7 +318,6 @@ export const commonViewStyles: CSSResult = css`
 
   .btn-secondary {
     opacity: var(--opacity-normal);
-    transition: opacity var(--transition-fast);
   }
 
   .btn-secondary:hover {
@@ -475,34 +467,6 @@ export const commonViewStyles: CSSResult = css`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  /* Utility: minimal icon button reset (no background, no border) */
-  .icon-btn-reset {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    color: inherit;
-    opacity: var(--opacity-subtle);
-    transition: opacity var(--transition-fast);
-  }
-
-  .icon-btn-reset:hover {
-    opacity: var(--opacity-full);
-  }
-
-  .icon-btn-reset:active {
-    transform: scale(0.95);
-  }
-
-  .icon-btn-reset:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: 1px;
-    border-radius: var(--border-radius-small);
-  }
 `;
 
 /**
@@ -579,9 +543,5 @@ export const filledButtonStyles: CSSResult = css`
   .filled-button--secondary {
     color: var(--wa-color-neutral-on-quiet, inherit);
     background: var(--wa-color-neutral-fill-quiet, transparent);
-  }
-
-  .filled-button--secondary:hover {
-    background: var(--wa-color-neutral-fill-loud, transparent);
   }
 `;

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -92,18 +92,6 @@ export const designTokens: CSSResult = css`
 `;
 
 export const animationStyles: CSSResult = css`
-  @keyframes pulse-scale {
-    0%,
-    100% {
-      transform: scale(1);
-      opacity: 1;
-    }
-    50% {
-      transform: scale(1.15);
-      opacity: 0.8;
-    }
-  }
-
   @keyframes spin {
     from {
       transform: rotate(0deg);

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -58,13 +58,10 @@ export const markdownStyles = css`
   }
 
   .markdown-content h2 {
-    padding-left: var(--wa-space-xs);
     margin-top: var(--wa-space-s);
     margin-bottom: var(--wa-space-2xs);
-    border-left: var(--border-thick) solid var(--wa-color-activity-badge-bg);
     border-bottom: var(--border-thin) solid var(--color-border);
     padding-bottom: var(--wa-space-3xs);
-    border-radius: var(--border-radius) 0 0 var(--border-radius);
     color: var(--color-text-link);
   }
 
@@ -103,7 +100,6 @@ export const markdownStyles = css`
     margin: 0.5em 0;
     border-radius: var(--border-radius);
     background-color: var(--wa-color-surface-lowered);
-    border-left: var(--wa-space-3xs) solid var(--wa-color-activity-badge-bg);
     overflow-x: auto;
   }
 
@@ -129,7 +125,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content blockquote {
-    border-left: var(--border-thick) solid var(--wa-color-activity-badge-bg);
+    border-left: var(--border-medium) solid var(--wa-color-activity-badge-bg);
     margin: var(--wa-space-xs) 0;
     padding-left: var(--wa-space-l);
     color: var(--color-text-secondary);
@@ -175,11 +171,6 @@ export const markdownStyles = css`
   .markdown-content em strong,
   .markdown-content strong em {
     color: var(--wa-color-brand-on-quiet);
-  }
-
-  .banner-content--scratchpad p:has(strong:first-child) {
-    border-left: calc(var(--wa-space-2xs) - 1px) solid var(--wa-color-icon-info);
-    padding-left: var(--wa-space-xs);
   }
 
   .markdown-content :is(h2 + p, p + p, h1 + h1, h2 + h2, h3 + h3, h4 + h4) {

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -138,7 +138,6 @@ export const permissionCardStyles: CSSResult = css`
     color: var(--wa-color-text-link);
     cursor: pointer;
     text-decoration: none;
-    transition: color var(--transition-fast);
   }
 
   .file-link:hover {

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -28,7 +28,6 @@ export const permissionCardStyles: CSSResult = css`
     width: min(92vw, 600px);
     max-height: min(80vh, 44rem);
     overflow: hidden;
-    box-shadow: 0 2px 8px var(--wa-color-surface-shadow, rgba(0, 0, 0, 0.24));
   }
 
   .permission-header {
@@ -41,7 +40,7 @@ export const permissionCardStyles: CSSResult = css`
 
   .permission-body {
     font-size: var(--font-size);
-    line-height: var(--line-height-relaxed);
+    line-height: var(--line-height-normal);
     max-height: min(38vh, 24rem);
     overflow-y: auto;
     scrollbar-gutter: stable;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -175,22 +175,22 @@ export const requestPanelStyles: CSSResult = css`
 
   /* Type-specific item accent */
   .approval-request {
-    border-left: var(--border-thick) solid var(--wa-color-text-normal);
+    border-left: var(--border-medium) solid var(--wa-color-text-normal);
   }
   .bash-approval-request {
-    border-left: var(--border-thick) solid var(--wa-color-terminal-ansi-yellow);
+    border-left: var(--border-medium) solid var(--wa-color-terminal-ansi-yellow);
   }
   .retry-request {
-    border-left: var(--border-thick) solid var(--color-warning);
+    border-left: var(--border-medium) solid var(--color-warning);
   }
   .workflow-proposal {
-    border-left: var(--border-thick) solid var(--wa-color-text-link);
+    border-left: var(--border-medium) solid var(--wa-color-text-link);
   }
   .plan-approval-request {
-    border-left: var(--border-thick) solid var(--wa-color-text-link);
+    border-left: var(--border-medium) solid var(--wa-color-text-link);
   }
   .external-inquiry-request {
-    border-left: var(--border-thick) solid var(--wa-color-focus);
+    border-left: var(--border-medium) solid var(--wa-color-focus);
   }
 
   /* Shared action button width — approval and bash use the same flex-basis */
@@ -292,7 +292,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .bash-approval-request__command .code-block {
-    border-left: var(--border-thick) solid var(--wa-color-terminal-ansi-yellow);
+    border-left: var(--border-medium) solid var(--wa-color-terminal-ansi-yellow);
   }
 
   .bash-approval-request__command .code-block pre {
@@ -606,8 +606,6 @@ export const requestPanelStyles: CSSResult = css`
     padding: ${sp.small} ${sp.medium};
     background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
-    border-left: var(--border-thick) solid
-      var(--wa-color-blockquote-border, var(--wa-color-focus));
     line-height: var(--line-height-normal);
   }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -65,12 +65,11 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   :is(${CONTAINERS}) {
-    margin: ${sp.large} 0;
-    padding: ${sp.large};
+    margin: ${sp.medium} 0;
+    padding: ${sp.medium};
     border: var(--border-thin) solid var(--wa-form-control-border-color);
     border-radius: var(--border-radius-large);
     background: var(--wa-color-surface-default);
-    box-shadow: 0 2px 8px var(--wa-color-surface-shadow, rgba(0, 0, 0, 0.12));
     display: flex;
     flex-direction: column;
     gap: ${sp.medium};

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -10,17 +10,12 @@ export const statusIndicatorStyles: CSSResult = css`
     flex-shrink: 0;
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-subtle, 0.7);
-    transition:
-      background-color var(--transition-slow),
-      box-shadow var(--transition-slow),
-      opacity var(--transition-slow);
   }
 
   .status-indicator.is-running,
   .tab-status.is-running {
     background-color: var(--color-success, #4caf50);
     opacity: var(--opacity-full);
-    animation: pulse-scale 2s infinite;
   }
 
   .status-indicator.is-stopped,
@@ -39,21 +34,18 @@ export const statusIndicatorStyles: CSSResult = css`
   .tab-status.is-waiting {
     background-color: var(--wa-color-text-link);
     opacity: var(--opacity-full);
-    animation: pulse-scale 3s infinite;
   }
 
   .status-indicator.is-resuming,
   .tab-status.is-resuming {
     background-color: var(--wa-color-text-link);
     opacity: var(--opacity-full);
-    animation: pulse-scale 1.5s infinite;
   }
 
   .status-indicator.is-initializing,
   .tab-status.is-initializing {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-full);
-    animation: pulse-scale 2.5s infinite;
   }
 
   .status-indicator.is-ready,

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -28,20 +28,8 @@ export const viewTabStyles: CSSResult = css`
     padding-block: 5px;
     padding-inline: var(--wa-space-s);
     color: color-mix(in srgb, var(--wa-color-text-normal) 70%, transparent);
-    transition:
-      color var(--transition-fast),
-      background-color var(--transition-fast);
     border-radius: var(--wa-border-radius-s, 4px) var(--wa-border-radius-s, 4px)
       0 0;
-  }
-
-  wa-tab::part(base):hover {
-    color: var(--wa-color-text-normal);
-    background-color: color-mix(
-      in srgb,
-      var(--wa-color-neutral-fill-quiet) 60%,
-      transparent
-    );
   }
 
   /*


### PR DESCRIPTION
## Summary

Sweeping cleanup of progress-view + shared webview styles to remove visually heavy decorative styling. Driven by user feedback during a single design pass: *"too non-compact"*, *"cannot be visually heavy"*, *"i hate hovering, too much distractions"*, *"i dont like shadow"*, *"i hate transitions and most of the animations"*, *"do a comprehensive audit … not to put more band aids"*.

Net diff: **159 insertions, 405 deletions** across 17 files.

## What was removed / reduced

**Drop shadows** (decorative)
- Request-panel containers (\`requestPanelStyles.ts\`)
- Permission card, plan-step in-progress ring
- YOLO/super-YOLO toggle glow + hover glow
- Execute button rest/hover/active shadows + transform
- Execute button kbd chip → real \`border\`
- File-select \`.has-options\` ring → real \`border-color\`
- Stream tab \`.is-active\` inset ring

**Hover background swaps**
- \`wa-tab\` (Launcher / Progress tabs)
- \`.tab-container\` reduced 70% mix → 25%; removed for \`.tab-delete\`, \`.tab-expand\`
- \`.list-item\` solid fill → 30% mix
- \`.filled-button--secondary\`, \`.btn-secondary\` opacity transition
- \`.parent-link\` background swap
- Code-block copy button background swap
- Group banner \`.log-group-header\` hover (Init / r0 / r1 rows)

**Transitions**
- Color/background/box-shadow transitions across StreamHeader, StreamTabs, code-block copy, status indicators, panel-collapsible content grid, details-summary opacity, toggle-icon rotate

**Animations**
- \`pulse-scale\` keyframe + all references on status indicator dots
- \`pulse-border\` keyframe on pending-approval tab rail
- linear-gradient on \`StreamHeader.log-header\`

## Layout / consistency fixes

- **Statistics + Latexdiff** converted from \`<wa-details>\` (heavy bordered card) to native \`<details>\` using the shared \`buildDetailsSummary\` helper, matching the compact \`banner-details\` style of Thinking / Scratchpad / Files
- **Tool-use follow-up** converted from a hand-rolled \`<button>\` toggle (chevron on left + custom expand state) to \`<wa-details class="panel-collapsible">\`, matching Generated Files exactly
  - \`@state() expanded\` removed (\`wa-details\` owns its open state)
  - \`handleHide\` removed; \`handleShow\` reduced to dispatching \`followupRequestOptions\` once
  - Setup button changed from \`appearance="outlined" variant="neutral"\` (heavy hover fill) to \`appearance="plain"\` so we don't fight WA defaults with \`::part\` overrides
- **Custom-element panels** (\`statistics-panel\`, \`latexdiff-results\`) added to the \`.log-group-content > :is(...)\` margin selector so their summary chevrons align with the native banner-details ones
- **Agent + model selects in launcher footer**: previously asymmetric (agent capped at 11rem, model at 13rem with different viewport math); now identical \`7rem\` min and \`min(12rem, (100vw - 12rem) / 2)\` max so the two boxes are always the same size and split remaining viewport evenly — eliminates the narrow-width collision where the boxes touched and shifted relative position
- **User message bubble** vertical padding/margin tightened (\`2xs\` → \`3xs\` container margin, \`2xs\` → \`3xs\` vertical padding) and dropped \`line-height-relaxed\`

## Test plan

- [ ] Reload the extension; verify Init / r0 / r1 group banners no longer change background on hover
- [ ] Verify Launcher / Progress tabs do not change background on hover
- [ ] Verify Statistics and Latexdiff result panels render as compact inline details (no bordered card) and their chevrons align with Thinking / Scratchpad
- [ ] Verify Tool-use follow-up panel renders with the same chevron-on-right header style as Generated Files
- [ ] In the launcher footer, narrow the panel and verify the agent and model select boxes stay the same width as each other with a visible gap
- [ ] Verify status indicator dots (running / waiting / resuming / initializing) are static (no pulse)
- [ ] Verify pending-approval stream tab has a static orange left rail (no pulse)
- [ ] Verify Setup / Run buttons in the follow-up panel — hover state should not aggressively flip Setup to a dark fill
- [ ] Verify execute button in launcher — no hover lift / no glow shadow
- [ ] Verify request-panel containers (approval / bash / retry / plan / external inquiry) render flat without drop shadow
- [ ] Verify permission card modal renders without drop shadow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CSS/UI refactors, but it changes collapsible implementations (`wa-details` vs native `details`) and follow-up panel event handling, which could subtly affect rendering, spacing, and interaction behavior across the Progress and Main webviews.
> 
> **Overview**
> **Visual simplification pass across Progress/Main webviews.** Removes many decorative **shadows, hover background swaps, transitions, and pulsing animations**, tightening spacing/line-height and flattening request panels, tabs, headers, and buttons.
> 
> **Collapsible UI alignment changes.** Converts `statistics-panel` and `latexdiff-results` from `wa-details` to native `details` using the shared `buildDetailsSummary`, and refactors `WorkflowToolUseFollowupSection` to use `wa-details` (dropping custom expanded state) with updated `wa-show` handling. Banner visibility styling is also simplified to `display: none` when hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5369630c9cac5d434a41b5c8780837f1fccbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->