### PR TITLE
[codex] Add CLI ask approval prompts

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -19,7 +19,10 @@ import {
   RUN_FLAGS_WITH_VALUE,
   type CliContext,
 } from '../runtime/cliContext';
-import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
+import {
+  hasCliApprovalDenied,
+  installCliApprovalHandlers,
+} from '../runtime/approvalAdapter';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { createCliRuntimeHost } from '../runtime/runtimeHost';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -212,7 +215,11 @@ async function runWorkflowAgent(
 
   return {
     exitCode:
-      result.status === 'error' ? CliExitCode.AgentError : CliExitCode.Success,
+      result.status === 'error' && hasCliApprovalDenied(runContext)
+        ? CliExitCode.ApprovalDenied
+        : result.status === 'error'
+          ? CliExitCode.AgentError
+          : CliExitCode.Success,
   };
 }
 

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -17,11 +17,11 @@ import {
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 // Local imports - CLI runtime
-import type { CliContext } from './cliContext';
+import { askCliQuestion, type CliContext } from './cliContext';
 
 function denyMessage(policy: CliContext['approvalPolicy']): string {
   return policy === 'ask'
-    ? 'Interactive approval prompts are not implemented in this CLI path yet.'
+    ? 'Interactive approval requires a TTY; this CLI run is headless.'
     : 'Denied by CLI approval policy.';
 }
 
@@ -32,18 +32,177 @@ function externalInquiryMessage(policy: CliContext['approvalPolicy']): string {
   return denyMessage(policy);
 }
 
+const deniedApprovalContexts = new WeakSet<CliContext>();
+
+function markApprovalDenied(context: CliContext): void {
+  deniedApprovalContexts.add(context);
+}
+
+export function hasCliApprovalDenied(context: CliContext): boolean {
+  return deniedApprovalContexts.has(context);
+}
+
+function approvalPromptAllowed(context: CliContext): boolean {
+  return context.approvalPolicy === 'ask' && context.mode === 'interactive';
+}
+
+function parseApprovalAnswer(answer: string): boolean {
+  const normalized = answer.trim().toLowerCase();
+  return normalized === 'y' || normalized === 'yes';
+}
+
+async function askApproval(
+  context: CliContext,
+  summary: string,
+): Promise<{
+  accepted: boolean;
+  userMessage?: string;
+}> {
+  if (context.approvalPolicy === 'yolo') return { accepted: true };
+  if (!approvalPromptAllowed(context)) {
+    markApprovalDenied(context);
+    return {
+      accepted: false,
+      userMessage: denyMessage(context.approvalPolicy),
+    };
+  }
+
+  let answer: string;
+  try {
+    answer = await askCliQuestion(`${summary}\nApprove? [y/N] `);
+  } catch {
+    markApprovalDenied(context);
+    return { accepted: false, userMessage: 'CLI approval prompt failed.' };
+  }
+
+  const accepted = parseApprovalAnswer(answer);
+  if (!accepted) markApprovalDenied(context);
+  return {
+    accepted,
+    userMessage: accepted ? undefined : 'Rejected from CLI approval prompt.',
+  };
+}
+
+async function askExternalInquiry(
+  context: CliContext,
+  question: string,
+): Promise<{ submitted: true; answer: string } | { submitted: false }> {
+  if (context.approvalPolicy === 'yolo') {
+    return { submitted: false };
+  }
+  if (!approvalPromptAllowed(context)) {
+    markApprovalDenied(context);
+    return { submitted: false };
+  }
+
+  let answer: string;
+  try {
+    answer = await askCliQuestion(
+      `External inquiry requested:\n${question}\nAnswer (blank to skip): `,
+    );
+  } catch {
+    markApprovalDenied(context);
+    return { submitted: false };
+  }
+
+  if (answer.trim().length === 0) {
+    markApprovalDenied(context);
+    return { submitted: false };
+  }
+  return { submitted: true, answer };
+}
+
 async function decideToolEdit(
   request: ToolEditApprovalRequest,
   context: CliContext,
 ): Promise<ToolEditApprovalResult> {
-  if (context.approvalPolicy === 'yolo') {
-    return { accepted: true, appliedContent: request.proposedContent };
-  }
-  return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
+  const decision = await askApproval(
+    context,
+    `Tool edit requested by ${request.sourceTool}: ${request.path}`,
+  );
+  return decision.accepted
+    ? { accepted: true, appliedContent: request.proposedContent }
+    : { accepted: false, userMessage: decision.userMessage };
 }
 
 export function installCliApprovalHandlers(context: CliContext): void {
   setToolEditApprovalHandler((request) => decideToolEdit(request, context));
+}
+
+async function handleCliApprovalEventAsync<
+  K extends keyof ProgressEventPayloads,
+>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+  context: CliContext,
+): Promise<void> {
+  switch (event) {
+    case 'showBashPermission': {
+      const data = payload as ProgressEventPayloads['showBashPermission'];
+      const decision = await askApproval(
+        context,
+        `Bash command requested:\n${data.command}`,
+      );
+      await handleProgressViewBashApprovalAction({
+        requestId: data.requestId,
+        action: decision.accepted ? 'approve' : 'reject',
+        feedback: decision.userMessage,
+      });
+      return;
+    }
+    case 'showPlanApproval': {
+      const data = payload as ProgressEventPayloads['showPlanApproval'];
+      const decision = await askApproval(
+        context,
+        `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`,
+      );
+      resolvePlanApproval(data.approvalId, {
+        action: decision.accepted ? 'approve' : 'reject',
+        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+      });
+      return;
+    }
+    case 'showAgentProposal': {
+      const data = payload as ProgressEventPayloads['showAgentProposal'];
+      const decision = await askApproval(
+        context,
+        `Agent proposal requested:\n${JSON.stringify(data, null, 2)}`,
+      );
+      resolveProposal(data.proposalId, {
+        action: decision.accepted ? 'approve' : 'reject',
+        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+      });
+      return;
+    }
+    case 'showRetryRequest': {
+      const data = payload as ProgressEventPayloads['showRetryRequest'];
+      const decision = await askApproval(
+        context,
+        `Retry requested for ${data.operation}: ${data.errorMessage ?? 'unknown error'}`,
+      );
+      if (decision.accepted) {
+        triggerRetry(data.streamId);
+      } else {
+        cancelRetry(data.streamId);
+      }
+      return;
+    }
+    case 'showExternalInquiry': {
+      const data = payload as ProgressEventPayloads['showExternalInquiry'];
+      const answer = await askExternalInquiry(context, data.question);
+      await handleExternalInquiryAction({
+        requestId: data.requestId,
+        action: answer.submitted ? 'submit' : 'skip',
+        answer: answer.submitted ? answer.answer : undefined,
+        feedback: answer.submitted
+          ? undefined
+          : externalInquiryMessage(context.approvalPolicy),
+      });
+      return;
+    }
+    default:
+      return;
+  }
 }
 
 export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
@@ -52,56 +211,13 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
   context: CliContext,
 ): boolean {
   switch (event) {
-    case 'showBashPermission': {
-      const data = payload as ProgressEventPayloads['showBashPermission'];
-      void handleProgressViewBashApprovalAction({
-        requestId: data.requestId,
-        action: context.approvalPolicy === 'yolo' ? 'approve' : 'reject',
-        feedback:
-          context.approvalPolicy === 'yolo'
-            ? undefined
-            : denyMessage(context.approvalPolicy),
-      });
+    case 'showBashPermission':
+    case 'showPlanApproval':
+    case 'showAgentProposal':
+    case 'showRetryRequest':
+    case 'showExternalInquiry':
+      void handleCliApprovalEventAsync(event, payload, context);
       return true;
-    }
-    case 'showPlanApproval': {
-      const data = payload as ProgressEventPayloads['showPlanApproval'];
-      resolvePlanApproval(data.approvalId, {
-        action: context.approvalPolicy === 'yolo' ? 'approve' : 'reject',
-        ...(context.approvalPolicy === 'yolo'
-          ? {}
-          : { feedback: denyMessage(context.approvalPolicy) }),
-      });
-      return true;
-    }
-    case 'showAgentProposal': {
-      const data = payload as ProgressEventPayloads['showAgentProposal'];
-      resolveProposal(data.proposalId, {
-        action: context.approvalPolicy === 'yolo' ? 'approve' : 'reject',
-        ...(context.approvalPolicy === 'yolo'
-          ? {}
-          : { feedback: denyMessage(context.approvalPolicy) }),
-      });
-      return true;
-    }
-    case 'showRetryRequest': {
-      const data = payload as ProgressEventPayloads['showRetryRequest'];
-      if (context.approvalPolicy === 'yolo') {
-        triggerRetry(data.streamId);
-      } else {
-        cancelRetry(data.streamId);
-      }
-      return true;
-    }
-    case 'showExternalInquiry': {
-      const data = payload as ProgressEventPayloads['showExternalInquiry'];
-      void handleExternalInquiryAction({
-        requestId: data.requestId,
-        action: 'skip',
-        feedback: externalInquiryMessage(context.approvalPolicy),
-      });
-      return true;
-    }
     default:
       return false;
   }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -33,6 +33,7 @@ function externalInquiryMessage(policy: CliContext['approvalPolicy']): string {
 }
 
 const deniedApprovalContexts = new WeakSet<CliContext>();
+const cliPromptQueues = new WeakMap<CliContext, Promise<unknown>>();
 
 function markApprovalDenied(context: CliContext): void {
   deniedApprovalContexts.add(context);
@@ -49,6 +50,19 @@ function approvalPromptAllowed(context: CliContext): boolean {
 function parseApprovalAnswer(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === 'y' || normalized === 'yes';
+}
+
+function enqueueCliPrompt<T>(
+  context: CliContext,
+  prompt: () => Promise<T>,
+): Promise<T> {
+  const previous = cliPromptQueues.get(context) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(prompt);
+  cliPromptQueues.set(
+    context,
+    next.catch(() => undefined),
+  );
+  return next;
 }
 
 async function askApproval(
@@ -69,7 +83,9 @@ async function askApproval(
 
   let answer: string;
   try {
-    answer = await askCliQuestion(`${summary}\nApprove? [y/N] `);
+    answer = await enqueueCliPrompt(context, () =>
+      askCliQuestion(`${summary}\nApprove? [y/N] `),
+    );
   } catch {
     markApprovalDenied(context);
     return { accepted: false, userMessage: 'CLI approval prompt failed.' };
@@ -86,28 +102,37 @@ async function askApproval(
 async function askExternalInquiry(
   context: CliContext,
   question: string,
-): Promise<{ submitted: true; answer: string } | { submitted: false }> {
+): Promise<
+  { submitted: true; answer: string } | { submitted: false; feedback: string }
+> {
   if (context.approvalPolicy === 'yolo') {
-    return { submitted: false };
+    return { submitted: false, feedback: externalInquiryMessage('yolo') };
   }
   if (!approvalPromptAllowed(context)) {
     markApprovalDenied(context);
-    return { submitted: false };
+    return {
+      submitted: false,
+      feedback: denyMessage(context.approvalPolicy),
+    };
   }
 
   let answer: string;
   try {
-    answer = await askCliQuestion(
-      `External inquiry requested:\n${question}\nAnswer (blank to skip): `,
+    answer = await enqueueCliPrompt(context, () =>
+      askCliQuestion(
+        `External inquiry requested:\n${question}\nAnswer (blank to skip): `,
+      ),
     );
   } catch {
     markApprovalDenied(context);
-    return { submitted: false };
+    return {
+      submitted: false,
+      feedback: 'CLI external inquiry prompt failed.',
+    };
   }
 
   if (answer.trim().length === 0) {
-    markApprovalDenied(context);
-    return { submitted: false };
+    return { submitted: false, feedback: 'External inquiry skipped by user.' };
   }
   return { submitted: true, answer };
 }
@@ -194,14 +219,88 @@ async function handleCliApprovalEventAsync<
         requestId: data.requestId,
         action: answer.submitted ? 'submit' : 'skip',
         answer: answer.submitted ? answer.answer : undefined,
-        feedback: answer.submitted
-          ? undefined
-          : externalInquiryMessage(context.approvalPolicy),
+        feedback: answer.submitted ? undefined : answer.feedback,
       });
       return;
     }
     default:
       return;
+  }
+}
+
+function immediateApprovalDecision(context: CliContext):
+  | {
+      accepted: boolean;
+      userMessage?: string;
+    }
+  | undefined {
+  if (context.approvalPolicy === 'yolo') return { accepted: true };
+  if (approvalPromptAllowed(context)) return undefined;
+  markApprovalDenied(context);
+  return {
+    accepted: false,
+    userMessage: denyMessage(context.approvalPolicy),
+  };
+}
+
+function handleImmediateCliApprovalEvent<K extends keyof ProgressEventPayloads>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+  context: CliContext,
+): boolean {
+  if (event === 'showExternalInquiry') {
+    if (approvalPromptAllowed(context)) return false;
+    const data = payload as ProgressEventPayloads['showExternalInquiry'];
+    const feedback = externalInquiryMessage(context.approvalPolicy);
+    if (context.approvalPolicy !== 'yolo') markApprovalDenied(context);
+    void handleExternalInquiryAction({
+      requestId: data.requestId,
+      action: 'skip',
+      feedback,
+    });
+    return true;
+  }
+
+  const decision = immediateApprovalDecision(context);
+  if (!decision) return false;
+
+  switch (event) {
+    case 'showBashPermission': {
+      const data = payload as ProgressEventPayloads['showBashPermission'];
+      void handleProgressViewBashApprovalAction({
+        requestId: data.requestId,
+        action: decision.accepted ? 'approve' : 'reject',
+        feedback: decision.userMessage,
+      });
+      return true;
+    }
+    case 'showPlanApproval': {
+      const data = payload as ProgressEventPayloads['showPlanApproval'];
+      resolvePlanApproval(data.approvalId, {
+        action: decision.accepted ? 'approve' : 'reject',
+        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+      });
+      return true;
+    }
+    case 'showAgentProposal': {
+      const data = payload as ProgressEventPayloads['showAgentProposal'];
+      resolveProposal(data.proposalId, {
+        action: decision.accepted ? 'approve' : 'reject',
+        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+      });
+      return true;
+    }
+    case 'showRetryRequest': {
+      const data = payload as ProgressEventPayloads['showRetryRequest'];
+      if (decision.accepted) {
+        triggerRetry(data.streamId);
+      } else {
+        cancelRetry(data.streamId);
+      }
+      return true;
+    }
+    default:
+      return false;
   }
 }
 
@@ -216,6 +315,9 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
     case 'showAgentProposal':
     case 'showRetryRequest':
     case 'showExternalInquiry':
+      if (handleImmediateCliApprovalEvent(event, payload, context)) {
+        return true;
+      }
       void handleCliApprovalEventAsync(event, payload, context);
       return true;
     default:

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -2,6 +2,7 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 
 // Local imports - CLI runtime
@@ -60,14 +61,30 @@ export const CLI_BOOLEAN_FLAGS = new Set([
 
 interface CliAmbientState {
   readonly isCi: boolean;
+  readonly stdinIsTty: boolean;
   readonly stdoutIsTty: boolean;
+  readonly stderrIsTty: boolean;
 }
 
 function readCliAmbientState(): CliAmbientState {
   return {
     isCi: Boolean(process.env.CI),
+    stdinIsTty: process.stdin.isTTY === true,
     stdoutIsTty: process.stdout.isTTY === true,
+    stderrIsTty: process.stderr.isTTY === true,
   };
+}
+
+export async function askCliQuestion(question: string): Promise<string> {
+  const prompt = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    return await prompt.question(question);
+  } finally {
+    prompt.close();
+  }
 }
 
 export function cliFlagName(arg: string): string {
@@ -190,7 +207,9 @@ export function applyCliGlobalArgs(
 function cliMode(args: readonly string[], ambient: CliAmbientState): CliMode {
   if (hasBooleanFlag(args, '--print', '-p')) return 'headless';
   if (ambient.isCi) return 'headless';
+  if (!ambient.stdinIsTty) return 'headless';
   if (!ambient.stdoutIsTty) return 'headless';
+  if (!ambient.stderrIsTty) return 'headless';
   return 'interactive';
 }
 


### PR DESCRIPTION
## Summary

This stacked PR implements the first interactive `ask` approval path for the TeXRA CLI without moving request lifecycle out of the shared coordinators.

The CLI still has one local owner for policy interpretation: `packages/cli/src/runtime/approvalAdapter.ts`. The shared bash, plan, proposal, retry, external-inquiry, and tool-edit coordinators keep their existing request identities and settlement paths.

## What changed

- Adds terminal prompting for `--approval-policy ask`.
- Serializes CLI approval prompts per `CliContext`, so simultaneous approval events cannot create competing readline consumers on stdin.
- Fails closed in headless/non-TTY mode with a clear denial message.
- Keeps `--approval-policy yolo` as automatic approval where safe.
- Preserves synchronous yolo settlement for plan, proposal, and retry coordinator events.
- Keeps external inquiry in yolo mode as a no-human-input skip, not a fabricated answer.
- Treats a blank external-inquiry answer in interactive ask mode as a user skip, not as a headless failure or an approval denial.
- Reports user-skipped and prompt-failed external inquiries distinctly to the agent.
- Maps runs that fail after a real CLI approval denial to `CliExitCode.ApprovalDenied`.
- Sources terminal/headless facts from `CliContext` and keeps prompts on stderr so stdout can remain machine-readable.

## Approval matrix covered in code

- Tool edit: approve/reject through `setToolEditApprovalHandler`.
- Bash: settles `handleProgressViewBashApprovalAction`.
- Plan: settles `resolvePlanApproval`.
- Proposal: settles `resolveProposal`.
- Retry: settles `triggerRetry` / `cancelRetry`.
- External inquiry: submits a typed answer in ask mode, skips in yolo/headless/denied cases, and reports user skips distinctly from prompt failures.

## Source of truth

- CLI terminal facts and prompt primitive: `packages/cli/src/runtime/cliContext.ts`.
- CLI policy-to-decision mapping: `packages/cli/src/runtime/approvalAdapter.ts`.
- CLI process exit-code mapping: `packages/cli/src/commands/root.ts`.

Tool handlers do not parse CLI flags and do not own policy interpretation.

## Host impact

- Extension: no behavior change.
- Desktop: no behavior change.
- CLI: `ask` now prompts in interactive terminals and fails closed otherwise.

## Validation

- Commit hooks ran `npm run format` successfully for the commits on this PR.
- GitHub Actions are passing for the latest head commit, including format, validation, and review jobs.
- I did not run focused CLI/typecheck validation manually in this turn because validation runs were not requested.

## Issue linkage

- Advances #3835 by implementing the CLI approval policy adapter and terminal handlers.
- Addresses the follow-up approval matrix issue #3841.
