### PR TITLE
[codex] Route legacy logs through structured logger

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -1,23 +1,26 @@
-import { AsyncLocalStorage } from 'async_hooks';
-
 import { type LogLevel } from '@shared/schemas';
 import { getConfig } from '@utils/config';
 import { serializeError } from '@utils/core';
 
+import {
+  createStructuredLogger,
+  type Logger,
+  type LogRecord,
+  type LogSink as StructuredLogSink,
+} from './structuredLogger';
 import { getColorForLevel } from './utils';
 import type { LogUtilsOptions } from './logOptions';
 
-const contextStorage = new AsyncLocalStorage<Map<string, string[]>>();
-
-interface LogSink {
+interface OutputSink {
   appendLine(message: string): void;
   dispose?(): void;
 }
 
-type OutputChannelFactory = (name: string) => LogSink;
+type OutputChannelFactory = (name: string) => OutputSink;
 
-const channels = new Map<string, LogSink>();
-let mainOutputChannel: LogSink | null = null;
+const channels = new Map<string, OutputSink>();
+const legacyLoggers = new Map<string, Logger>();
+let mainOutputChannel: OutputSink | null = null;
 let outputChannelFactory: OutputChannelFactory | null = null;
 
 function getKey(channel: string, isAgent: boolean): string {
@@ -31,7 +34,7 @@ function getTimestamp(): string {
   return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}.${pad(now.getMilliseconds(), 3)}`;
 }
 
-function createConsoleSink(channel: string): LogSink {
+function createConsoleSink(channel: string): OutputSink {
   return {
     appendLine(message: string) {
       console.info(`[${channel}] ${message}`);
@@ -39,12 +42,12 @@ function createConsoleSink(channel: string): LogSink {
   };
 }
 
-function createOutputChannel(channel: string, isAgent: boolean): LogSink {
+function createOutputChannel(channel: string, isAgent: boolean): OutputSink {
   const name = isAgent ? `TeXRA ${channel}` : 'TeXRA';
   return outputChannelFactory?.(name) ?? createConsoleSink(name);
 }
 
-function ensureChannel(channel: string, isAgent: boolean): LogSink {
+function ensureChannel(channel: string, isAgent: boolean): OutputSink {
   const key = getKey(channel, isAgent);
   const existing = channels.get(key);
   if (existing) return existing;
@@ -56,35 +59,52 @@ function ensureChannel(channel: string, isAgent: boolean): LogSink {
   return output;
 }
 
-function getActiveGroupStack(
-  channel: string,
-  isAgent: boolean,
-): string[] | undefined {
-  return contextStorage.getStore()?.get(getKey(channel, isAgent));
+class LegacyOutputChannelSink implements StructuredLogSink {
+  constructor(
+    private readonly output: OutputSink,
+    private readonly channel: string,
+    private readonly isAgent: boolean,
+  ) {}
+
+  write(record: LogRecord): void {
+    writeLine(this.output, this.channel, this.isAgent, record);
+  }
 }
 
 function writeLine(
-  channel: LogSink,
+  output: OutputSink,
   streamId: string,
-  level: LogLevel,
-  message: string,
   isAgent: boolean,
-  data: unknown,
+  record: LogRecord,
 ): void {
   const prefix = isAgent ? '' : `[${streamId}] `;
-  channel.appendLine(
-    `${getColorForLevel(level)} [${getTimestamp()}] ${prefix}${message}`,
+  output.appendLine(
+    `${getColorForLevel(record.level)} [${getTimestamp()}] ${prefix}${record.message}`,
   );
 
   const includeStructuredData = getConfig<boolean>(
     'texra.logger.debugMode',
     false,
   );
+  const data = record.fields.data;
   if (!includeStructuredData || data === null || data === undefined) return;
 
   const payload =
     typeof data === 'string' ? data : JSON.stringify(data, null, 2);
-  channel.appendLine(payload);
+  output.appendLine(payload);
+}
+
+function ensureLegacyLogger(channel: string, isAgent: boolean): Logger {
+  const key = getKey(channel, isAgent);
+  const existing = legacyLoggers.get(key);
+  if (existing) return existing;
+
+  const output = ensureChannel(channel, isAgent);
+  const logger = createStructuredLogger(
+    new LegacyOutputChannelSink(output, channel, isAgent),
+  ).child({ streamId: channel, isAgent });
+  legacyLoggers.set(key, logger);
+  return logger;
 }
 
 function logWithGroup(
@@ -94,21 +114,35 @@ function logWithGroup(
   options: LogUtilsOptions = {},
 ): void {
   const isAgent = options.isAgent ?? false;
-  const output = ensureChannel(channel, isAgent);
   const resolvedData =
     options.data instanceof Error ? serializeError(options.data) : options.data;
+  const legacyLogger = ensureLegacyLogger(channel, isAgent);
+  const activeGroupId = legacyLogger.activeGroupId();
+  const shouldEnterExplicitGroup =
+    options.groupId !== undefined && options.groupId !== activeGroupId;
+  const leaveGroup = shouldEnterExplicitGroup
+    ? legacyLogger.group(options.groupId)
+    : undefined;
 
-  writeLine(output, channel, level, message, isAgent, resolvedData);
+  try {
+    legacyLogger[level](message, {
+      ...options,
+      groupId: options.groupId ?? activeGroupId,
+      data: resolvedData,
+    });
+  } finally {
+    leaveGroup?.();
+  }
 }
 
 export function initialize(channel: string, isAgent = false): void {
-  ensureChannel(channel, isAgent);
+  ensureLegacyLogger(channel, isAgent);
 }
 
 export function setOutputChannelFactory(
   factory: OutputChannelFactory | null,
 ): void {
-  const sinks = new Set<LogSink>(channels.values());
+  const sinks = new Set<OutputSink>(channels.values());
   if (mainOutputChannel) {
     sinks.add(mainOutputChannel);
   }
@@ -117,6 +151,7 @@ export function setOutputChannelFactory(
   }
   outputChannelFactory = factory;
   channels.clear();
+  legacyLoggers.clear();
   mainOutputChannel = null;
 }
 
@@ -124,7 +159,7 @@ export function getActiveGroupId(
   channel: string,
   isAgent = false,
 ): string | undefined {
-  return getActiveGroupStack(channel, isAgent)?.at(-1);
+  return ensureLegacyLogger(channel, isAgent).activeGroupId();
 }
 
 export function runWithGroupContext<T>(
@@ -133,12 +168,7 @@ export function runWithGroupContext<T>(
   isAgent: boolean,
   fn: () => Promise<T> | T,
 ): Promise<T> {
-  const parentStore = contextStorage.getStore() ?? new Map<string, string[]>();
-  const childStore = new Map(parentStore);
-  const key = getKey(channel, isAgent);
-  const stack = childStore.get(key) ?? [];
-  childStore.set(key, [...stack, groupId]);
-  return contextStorage.run(childStore, () => Promise.resolve().then(fn));
+  return ensureLegacyLogger(channel, isAgent).withGroup(groupId, fn);
 }
 
 export function debug(

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -118,10 +118,11 @@ function logWithGroup(
     options.data instanceof Error ? serializeError(options.data) : options.data;
   const legacyLogger = ensureLegacyLogger(channel, isAgent);
   const activeGroupId = legacyLogger.activeGroupId();
+  const explicitGroupId = options.groupId;
   const shouldEnterExplicitGroup =
-    options.groupId !== undefined && options.groupId !== activeGroupId;
+    explicitGroupId !== undefined && explicitGroupId !== activeGroupId;
   const leaveGroup = shouldEnterExplicitGroup
-    ? legacyLogger.group(options.groupId)
+    ? legacyLogger.group(explicitGroupId)
     : undefined;
 
   try {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -118,22 +118,11 @@ function logWithGroup(
     options.data instanceof Error ? serializeError(options.data) : options.data;
   const legacyLogger = ensureLegacyLogger(channel, isAgent);
   const activeGroupId = legacyLogger.activeGroupId();
-  const explicitGroupId = options.groupId;
-  const shouldEnterExplicitGroup =
-    explicitGroupId !== undefined && explicitGroupId !== activeGroupId;
-  const leaveGroup = shouldEnterExplicitGroup
-    ? legacyLogger.group(explicitGroupId)
-    : undefined;
-
-  try {
-    legacyLogger[level](message, {
-      ...options,
-      groupId: options.groupId ?? activeGroupId,
-      data: resolvedData,
-    });
-  } finally {
-    leaveGroup?.();
-  }
+  legacyLogger[level](message, {
+    ...options,
+    groupId: options.groupId ?? activeGroupId,
+    data: resolvedData,
+  });
 }
 
 export function initialize(channel: string, isAgent = false): void {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -119,7 +119,6 @@ function logWithGroup(
   const legacyLogger = ensureLegacyLogger(channel, isAgent);
   const activeGroupId = legacyLogger.activeGroupId();
   legacyLogger[level](message, {
-    ...options,
     groupId: options.groupId ?? activeGroupId,
     data: resolvedData,
   });

--- a/src/logger/structuredLogger.ts
+++ b/src/logger/structuredLogger.ts
@@ -41,11 +41,7 @@ interface SinkRef {
   current: LogSink;
 }
 
-interface GroupQueue {
-  tail: Promise<void>;
-}
-
-const activeGroupQueue = new AsyncLocalStorage<GroupQueue>();
+const activeGroupStack = new AsyncLocalStorage<readonly string[]>();
 
 export function createStructuredLogger(sink: LogSink): Logger {
   return new StructuredLogger({ current: sink });
@@ -62,7 +58,6 @@ class StructuredLogger implements Logger {
     private readonly sinkRef: SinkRef,
     private readonly fields: LogFields = {},
     groupStack: string[] = [],
-    private readonly groupQueue: GroupQueue = { tail: Promise.resolve() },
   ) {
     this.groupStack = groupStack;
   }
@@ -84,7 +79,7 @@ class StructuredLogger implements Logger {
   }
 
   activeGroupId(): string | undefined {
-    return this.groupStack.at(-1);
+    return this.currentGroups().at(-1);
   }
 
   group(label: string): () => void {
@@ -92,38 +87,10 @@ class StructuredLogger implements Logger {
   }
 
   async withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T> {
-    if (activeGroupQueue.getStore() === this.groupQueue) {
-      return this.runGroup(label, fn);
-    }
-
-    const previousGroup = this.groupQueue.tail.catch(() => undefined);
-    let releaseGroup: () => void = () => undefined;
-    this.groupQueue.tail = previousGroup.then(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseGroup = resolve;
-        }),
-    );
-    await previousGroup;
-
+    const parentGroups = this.currentGroups();
     try {
-      return await activeGroupQueue.run(this.groupQueue, () =>
-        this.runGroup(label, fn),
-      );
+      return await activeGroupStack.run([...parentGroups, label], fn);
     } finally {
-      releaseGroup();
-    }
-  }
-
-  private async runGroup<T>(
-    label: string,
-    fn: () => Promise<T> | T,
-  ): Promise<T> {
-    const pop = this.enterGroup(label, false);
-    try {
-      return await fn();
-    } finally {
-      pop();
       await this.sinkRef.current.flush?.();
     }
   }
@@ -153,7 +120,6 @@ class StructuredLogger implements Logger {
       this.sinkRef,
       mergeFields(this.fields, fields),
       this.groupStack,
-      this.groupQueue,
     );
   }
 
@@ -170,8 +136,12 @@ class StructuredLogger implements Logger {
       level,
       message,
       fields: mergeFields(this.fields, fields),
-      groups: [...this.groupStack],
+      groups: [...this.currentGroups()],
     });
+  }
+
+  private currentGroups(): readonly string[] {
+    return activeGroupStack.getStore() ?? this.groupStack;
   }
 }
 

--- a/src/logger/structuredLogger.ts
+++ b/src/logger/structuredLogger.ts
@@ -58,6 +58,14 @@ function mergeFields(left: LogFields, right: LogFields | undefined): LogFields {
   return right ? { ...left, ...right } : left;
 }
 
+function cloneGroupStacks(
+  stacks: Map<GroupContextKey, string[]> | undefined,
+): Map<GroupContextKey, string[]> {
+  return new Map(
+    [...(stacks?.entries() ?? [])].map(([key, groups]) => [key, [...groups]]),
+  );
+}
+
 class StructuredLogger implements Logger {
   private readonly groupStack: string[];
 
@@ -99,7 +107,7 @@ class StructuredLogger implements Logger {
   async withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T> {
     const parentGroups = this.currentGroups();
     const parentStacks = activeGroupStacks.getStore();
-    const nextStacks = new Map(parentStacks);
+    const nextStacks = cloneGroupStacks(parentStacks);
     nextStacks.set(this.context.groupContextKey, [...parentGroups, label]);
     try {
       return await activeGroupStacks.run(nextStacks, fn);

--- a/src/logger/structuredLogger.ts
+++ b/src/logger/structuredLogger.ts
@@ -44,7 +44,7 @@ interface SinkRef {
 type GroupContextKey = symbol;
 
 const activeGroupStacks = new AsyncLocalStorage<
-  ReadonlyMap<GroupContextKey, readonly string[]>
+  Map<GroupContextKey, string[]>
 >();
 
 export function createStructuredLogger(sink: LogSink): Logger {
@@ -109,17 +109,21 @@ class StructuredLogger implements Logger {
   }
 
   private enterGroup(label: string, flushOnPop: boolean): () => void {
-    const index = this.groupStack.length;
-    this.groupStack.push(label);
+    const activeStack = activeGroupStacks
+      .getStore()
+      ?.get(this.context.groupContextKey);
+    const groups = activeStack ?? this.groupStack;
+    const index = groups.length;
+    groups.push(label);
     let popped = false;
     return () => {
       if (popped) return;
       popped = true;
-      if (this.groupStack[index] === label) {
-        this.groupStack.splice(index, 1);
+      if (groups[index] === label) {
+        groups.splice(index, 1);
       } else {
-        const currentIndex = this.groupStack.lastIndexOf(label);
-        if (currentIndex >= 0) this.groupStack.splice(currentIndex, 1);
+        const currentIndex = groups.lastIndexOf(label);
+        if (currentIndex >= 0) groups.splice(currentIndex, 1);
       }
       if (flushOnPop) {
         const flush = this.context.sinkRef.current.flush?.();

--- a/src/logger/structuredLogger.ts
+++ b/src/logger/structuredLogger.ts
@@ -30,6 +30,7 @@ export interface Logger {
   info(message: string, fields?: LogFields): void;
   warn(message: string, fields?: LogFields): void;
   error(message: string, fields?: LogFields): void;
+  activeGroupId(): string | undefined;
   group(label: string): () => void;
   withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T>;
   child(fields: LogFields): Logger;
@@ -80,6 +81,10 @@ class StructuredLogger implements Logger {
 
   error(message: string, fields?: LogFields): void {
     this.write('error', message, fields);
+  }
+
+  activeGroupId(): string | undefined {
+    return this.groupStack.at(-1);
   }
 
   group(label: string): () => void {

--- a/src/logger/structuredLogger.ts
+++ b/src/logger/structuredLogger.ts
@@ -41,10 +41,17 @@ interface SinkRef {
   current: LogSink;
 }
 
-const activeGroupStack = new AsyncLocalStorage<readonly string[]>();
+type GroupContextKey = symbol;
+
+const activeGroupStacks = new AsyncLocalStorage<
+  ReadonlyMap<GroupContextKey, readonly string[]>
+>();
 
 export function createStructuredLogger(sink: LogSink): Logger {
-  return new StructuredLogger({ current: sink });
+  return new StructuredLogger({
+    sinkRef: { current: sink },
+    groupContextKey: Symbol('structuredLoggerGroupContext'),
+  });
 }
 
 function mergeFields(left: LogFields, right: LogFields | undefined): LogFields {
@@ -55,7 +62,10 @@ class StructuredLogger implements Logger {
   private readonly groupStack: string[];
 
   constructor(
-    private readonly sinkRef: SinkRef,
+    private readonly context: {
+      readonly sinkRef: SinkRef;
+      readonly groupContextKey: GroupContextKey;
+    },
     private readonly fields: LogFields = {},
     groupStack: string[] = [],
   ) {
@@ -88,10 +98,13 @@ class StructuredLogger implements Logger {
 
   async withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T> {
     const parentGroups = this.currentGroups();
+    const parentStacks = activeGroupStacks.getStore();
+    const nextStacks = new Map(parentStacks);
+    nextStacks.set(this.context.groupContextKey, [...parentGroups, label]);
     try {
-      return await activeGroupStack.run([...parentGroups, label], fn);
+      return await activeGroupStacks.run(nextStacks, fn);
     } finally {
-      await this.sinkRef.current.flush?.();
+      await this.context.sinkRef.current.flush?.();
     }
   }
 
@@ -109,7 +122,7 @@ class StructuredLogger implements Logger {
         if (currentIndex >= 0) this.groupStack.splice(currentIndex, 1);
       }
       if (flushOnPop) {
-        const flush = this.sinkRef.current.flush?.();
+        const flush = this.context.sinkRef.current.flush?.();
         if (flush) void flush.catch(() => undefined);
       }
     };
@@ -117,21 +130,21 @@ class StructuredLogger implements Logger {
 
   child(fields: LogFields): Logger {
     return new StructuredLogger(
-      this.sinkRef,
+      this.context,
       mergeFields(this.fields, fields),
       this.groupStack,
     );
   }
 
   async swapSink(next: LogSink): Promise<void> {
-    const previous = this.sinkRef.current;
+    const previous = this.context.sinkRef.current;
     await previous.flush?.();
     await previous.close?.();
-    this.sinkRef.current = next;
+    this.context.sinkRef.current = next;
   }
 
   private write(level: LogLevel, message: string, fields?: LogFields): void {
-    this.sinkRef.current.write({
+    this.context.sinkRef.current.write({
       ts: new Date().toISOString(),
       level,
       message,
@@ -141,7 +154,10 @@ class StructuredLogger implements Logger {
   }
 
   private currentGroups(): readonly string[] {
-    return activeGroupStack.getStore() ?? this.groupStack;
+    return (
+      activeGroupStacks.getStore()?.get(this.context.groupContextKey) ??
+      this.groupStack
+    );
   }
 }
 

--- a/src/test/logger/structuredLogger.test.ts
+++ b/src/test/logger/structuredLogger.test.ts
@@ -114,6 +114,24 @@ describe('structuredLogger', () => {
     );
   });
 
+  it('nests manual groups inside async group scopes', async () => {
+    const sink = new MemorySink();
+    const logger = createStructuredLogger(sink);
+
+    await logger.withGroup('async', async () => {
+      const leaveManual = logger.group('manual');
+      logger.info('inside manual group');
+      leaveManual();
+      logger.info('after manual group');
+    });
+    logger.info('after async group');
+
+    assert.deepEqual(
+      sink.records.map((record) => record.groups),
+      [['async', 'manual'], ['async'], []],
+    );
+  });
+
   it('flushes and closes the old sink when swapping sinks', async () => {
     const first = new FlushCountingSink();
     const second = new FlushCountingSink();

--- a/src/test/logger/structuredLogger.test.ts
+++ b/src/test/logger/structuredLogger.test.ts
@@ -91,6 +91,29 @@ describe('structuredLogger', () => {
     );
   });
 
+  it('isolates async group scopes across logger instances', async () => {
+    const firstSink = new MemorySink();
+    const secondSink = new MemorySink();
+    const first = createStructuredLogger(firstSink);
+    const second = createStructuredLogger(secondSink);
+
+    await first.withGroup('first', async () => {
+      first.info('first message');
+      second.info('second message');
+      assert.equal(first.activeGroupId(), 'first');
+      assert.equal(second.activeGroupId(), undefined);
+    });
+
+    assert.deepEqual(
+      firstSink.records.map((record) => record.groups),
+      [['first']],
+    );
+    assert.deepEqual(
+      secondSink.records.map((record) => record.groups),
+      [[]],
+    );
+  });
+
   it('flushes and closes the old sink when swapping sinks', async () => {
     const first = new FlushCountingSink();
     const second = new FlushCountingSink();

--- a/src/test/logger/structuredLogger.test.ts
+++ b/src/test/logger/structuredLogger.test.ts
@@ -66,6 +66,31 @@ describe('structuredLogger', () => {
     );
   });
 
+  it('isolates overlapping async group scopes on the same logger', async () => {
+    const sink = new MemorySink();
+    const logger = createStructuredLogger(sink);
+    let releaseOuter: () => void = () => undefined;
+
+    const outer = logger.withGroup('outer', async () => {
+      logger.info('outer start');
+      await new Promise<void>((resolve) => {
+        releaseOuter = resolve;
+      });
+      logger.info('outer end');
+    });
+
+    await logger.withGroup('other', async () => {
+      logger.info('other message');
+    });
+    releaseOuter();
+    await outer;
+
+    assert.deepEqual(
+      sink.records.map((record) => record.groups),
+      [['outer'], ['other'], ['outer']],
+    );
+  });
+
   it('flushes and closes the old sink when swapping sinks', async () => {
     const first = new FlushCountingSink();
     const second = new FlushCountingSink();

--- a/src/test/logger/structuredLogger.test.ts
+++ b/src/test/logger/structuredLogger.test.ts
@@ -1,0 +1,83 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - logger
+import {
+  createStructuredLogger,
+  type LogRecord,
+  type LogSink,
+  MemorySink,
+} from '@logger/structuredLogger';
+
+class FlushCountingSink implements LogSink {
+  readonly records: LogRecord[] = [];
+  flushCount = 0;
+  closed = false;
+
+  write(record: LogRecord): void {
+    this.records.push(record);
+  }
+
+  async flush(): Promise<void> {
+    this.flushCount += 1;
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+describe('structuredLogger', () => {
+  it('records nested groups and exposes the active group id', async () => {
+    const sink = new MemorySink();
+    const logger = createStructuredLogger(sink);
+
+    await logger.withGroup('outer', async () => {
+      assert.equal(logger.activeGroupId(), 'outer');
+      logger.info('outer message');
+      await logger.withGroup('inner', async () => {
+        assert.equal(logger.activeGroupId(), 'inner');
+        logger.warn('inner message');
+      });
+      assert.equal(logger.activeGroupId(), 'outer');
+    });
+
+    assert.equal(logger.activeGroupId(), undefined);
+    assert.deepEqual(
+      sink.records.map((record) => record.groups),
+      [['outer'], ['outer', 'inner']],
+    );
+  });
+
+  it('handles out-of-order group closers without leaking later groups', () => {
+    const sink = new MemorySink();
+    const logger = createStructuredLogger(sink);
+    const leaveOuter = logger.group('outer');
+    const leaveInner = logger.group('inner');
+
+    leaveOuter();
+    logger.info('after outer close');
+    leaveInner();
+    logger.info('after all close');
+
+    assert.deepEqual(
+      sink.records.map((record) => record.groups),
+      [['inner'], []],
+    );
+  });
+
+  it('flushes and closes the old sink when swapping sinks', async () => {
+    const first = new FlushCountingSink();
+    const second = new FlushCountingSink();
+    const logger = createStructuredLogger(first);
+
+    logger.info('before swap');
+    await logger.swapSink(second);
+    logger.info('after swap');
+
+    assert.equal(first.flushCount, 1);
+    assert.equal(first.closed, true);
+    assert.equal(first.records.length, 1);
+    assert.equal(second.records.length, 1);
+  });
+});

--- a/src/test/logger/structuredLogger.test.ts
+++ b/src/test/logger/structuredLogger.test.ts
@@ -132,6 +132,26 @@ describe('structuredLogger', () => {
     );
   });
 
+  it('does not alias group arrays across nested logger scopes', async () => {
+    const firstSink = new MemorySink();
+    const secondSink = new MemorySink();
+    const first = createStructuredLogger(firstSink);
+    const second = createStructuredLogger(secondSink);
+
+    await first.withGroup('first', async () => {
+      await second.withGroup('second', async () => {
+        first.group('manual');
+        first.info('inside nested logger scope');
+      });
+      first.info('after nested logger scope');
+    });
+
+    assert.deepEqual(
+      firstSink.records.map((record) => record.groups),
+      [['first', 'manual'], ['first']],
+    );
+  });
+
   it('flushes and closes the old sink when swapping sinks', async () => {
     const first = new FlushCountingSink();
     const second = new FlushCountingSink();


### PR DESCRIPTION
## Summary

This stacked PR takes the next Logger v2 migration step by making the legacy `logUtils` output-channel surface delegate record construction to `structuredLogger` while preserving async-local group context.

This is intentionally a compatibility boundary, not a new logging framework. Existing extension and desktop call sites can continue importing `@logger/logUtils`, while `LogRecord`, structured sinks, and grouped logging semantics become the source of truth below that surface.

## What changed

- Adds `Logger.activeGroupId()` to expose the current structured group.
- Moves `structuredLogger.withGroup()` to an async-local group stack, so concurrent async callers on the same channel keep independent group context.
- Deep-clones inherited async group stacks so nested logger scopes do not alias mutable group arrays across logger families.
- Keeps manual `group()` closers for explicit stack scopes, but no longer uses `group()` merely to attach a single-message `groupId`.
- Adds a legacy output-channel sink that renders `LogRecord` values to the existing VS Code/console output-channel abstraction.
- Preserves `setOutputChannelFactory()`, channel caching, main `TeXRA` output behavior, agent-channel naming, and debug-mode data rendering.
- Adds focused structured logger tests for nested groups, out-of-order group closers, overlapping async groups, cross-logger isolation, manual groups inside async groups, aliasing protection, and `swapSink()` flush/close delivery.

## Source of truth

- `src/logger/structuredLogger.ts` owns `LogRecord`, async-local grouping, sink swapping, and in-memory test sinks.
- `src/logger/logUtils.ts` is now a compatibility shim over structured logging for existing host call sites.
- Progress-view `StreamLogEntry` behavior remains in `AgentLogger` / `StreamLogStore` and is not collapsed into `LogRecord`.

## Temporary compatibility facts

These remain temporary until the rest of #3833 is migrated:

- output-channel factory and channel cache in `logUtils`
- debug-mode structured data rendering in the legacy output channel
- legacy agent/shared channel naming
- `AgentLogger` dual role as progress-view writer and legacy log facade

## Host impact

- Extension: existing output-channel behavior is preserved through the legacy sink.
- Desktop: existing `AgentLogger` and `logUtils` call sites continue to work through the compatibility shim.
- CLI: no behavior change; CLI already uses structured logger sinks directly.

## Validation

- Commit hooks ran `npm run format` successfully for the commits on this PR.
- GitHub Actions are passing for the latest head commit, including format, validation, and review jobs.
- I added focused tests in `src/test/logger/structuredLogger.test.ts`, but did not run them manually in this turn because validation runs were not requested.

## Issue linkage

- Advances #3833 by routing the legacy host logging surface through structured records and host sinks.
- Addresses the follow-up logger host sink issue #3842.
