### PR TITLE
fix: stop retry loop on OpenAI quota; clarify retryable semantics

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -53,11 +53,11 @@ export class RetryRequestPanel extends BaseRequestPanel {
     const isRelay = data.errorDetails?.isRelayError === true;
     const isCredentialExhausted =
       data.errorDetails?.isCredentialExhausted === true;
-    const retryable = data.errorDetails?.retryable !== false;
+    const userRetryable = data.errorDetails?.userRetryable !== false;
     const metaParts = [
       data.model ? `Model: ${data.model}` : null,
       isRelay ? 'Source: Relay' : null,
-      `Retryable: ${retryable ? 'Yes' : 'No'}`,
+      `Can retry: ${userRetryable ? 'Yes' : 'No'}`,
     ].filter(Boolean);
 
     const detailsText = this.formatRetryDetails(data.errorDetails);

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -81,7 +81,7 @@ const ERROR_DETAIL_FIELDS = [
   'statusCode',
   'statusText',
   'isRelayError',
-  'retryable',
+  'userRetryable',
   'requestId',
   'rawMessage',
   'rawErrorBody',

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -39,7 +39,7 @@ interface ManualRetryPromptResult {
 /** success: model response | failed: retries exhausted | cancelled: user cancelled | skipped: shouldStop was true */
 export type InvocationResult<TSuccess> =
   | ({ kind: 'success' } & TSuccess)
-  | { kind: 'failed'; message: string; retryable?: boolean }
+  | { kind: 'failed'; message: string; userRetryable?: boolean }
   | { kind: 'cancelled' }
   | { kind: 'skipped' };
 
@@ -195,12 +195,13 @@ export abstract class RetryableInvocationNode<
   }
 
   /** Auth/permission errors (401, 403) and credential-exhausted errors
-   *  (relay monthly limit, upstream credit depletion) skip auto-retries —
-   *  they need human attention (switching keys, topping up). */
+   *  (relay monthly limit, upstream credit/quota depletion) skip auto-retries —
+   *  they need human attention (switching keys, topping up). `userRetryable`
+   *  only gates the manual retry UI; auto-retry is a stricter subset. */
   shouldAutoRetry(error: Error): boolean {
     const formatted = formatProviderHttpError(error);
     if (formatted.isCredentialExhausted) return false;
-    if (!formatted.retryable) return false;
+    if (!formatted.userRetryable) return false;
     const code = formatted.statusCode;
     return code !== 401 && code !== 403;
   }
@@ -255,7 +256,7 @@ export abstract class RetryableInvocationNode<
     const operationName = this.getOperationName();
     const formatted = formatProviderHttpError(error);
 
-    if (!formatted.retryable) {
+    if (!formatted.userRetryable) {
       return { shouldRetry: false, userCancelled: false };
     }
 
@@ -291,22 +292,22 @@ export abstract class RetryableInvocationNode<
     error: Error,
   ):
     | { kind: 'cancelled' }
-    | { kind: 'failed'; message: string; retryable?: boolean } {
+    | { kind: 'failed'; message: string; userRetryable?: boolean } {
     if (this._userCancelled) {
       return { kind: 'cancelled' };
     }
 
     const formatted = formatProviderHttpError(error);
-    if (!formatted.retryable) {
+    if (!formatted.userRetryable) {
       this.services.logger.logErrorData(
-        `${this.getOperationName()} failed (not retryable): ${formatted.message}`,
+        `${this.getOperationName()} failed (no retry available): ${formatted.message}`,
         formatted,
       );
     }
     return {
       kind: 'failed',
       message: formatted.message,
-      retryable: formatted.retryable,
+      userRetryable: formatted.userRetryable,
     };
   }
 }
@@ -343,7 +344,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
   if (result.kind === 'failed') {
     retryState.lastError = {
       message: result.message,
-      retryable: result.retryable ?? false,
+      userRetryable: result.userRetryable ?? false,
     };
     state.shouldStop = true;
     state.endTurn = false;
@@ -354,7 +355,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
     logger.warn(EMPTY_RESPONSE_ERROR_MESSAGE);
     retryState.lastError = {
       message: EMPTY_RESPONSE_ERROR_MESSAGE,
-      retryable: false,
+      userRetryable: false,
     };
     state.shouldStop = true;
     state.endTurn = false;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -30,7 +30,7 @@ interface CyclePrepInput {
 type CycleOutcome =
   | { outcome: 'completed'; endTurn: boolean }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; error: Error; retryable?: boolean };
+  | { outcome: 'failed'; error: Error; userRetryable?: boolean };
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
@@ -109,7 +109,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
         return {
           outcome: 'failed',
           error: new Error(cycleShared.lastError.message),
-          retryable: cycleShared.lastError.retryable,
+          userRetryable: cycleShared.lastError.userRetryable,
         };
       }
       if (cycleShared.shouldStop && !cycleShared.endTurn) {
@@ -123,7 +123,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       return {
         outcome: 'failed',
         error: error instanceof Error ? error : new Error(String(error)),
-        retryable: formatted.retryable,
+        userRetryable: formatted.userRetryable,
       };
     }
   }
@@ -133,7 +133,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     error: Error,
   ): Promise<CycleOutcome> {
     const formatted = formatProviderHttpError(error);
-    return { outcome: 'failed', error, retryable: formatted.retryable };
+    return { outcome: 'failed', error, userRetryable: formatted.userRetryable };
   }
 
   async post(
@@ -149,7 +149,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       logger.error(`Response cycle failed: ${execRes.error.message}`);
       shared.lastError = {
         message: execRes.error.message,
-        retryable: execRes.retryable ?? false,
+        userRetryable: execRes.userRetryable ?? false,
       };
       shared.continueRounds = false;
       shared.endTurn = false;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -19,7 +19,7 @@ type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }
   | { outcome: 'skipped' }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; message: string; retryable?: boolean };
+  | { outcome: 'failed'; message: string; userRetryable?: boolean };
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
@@ -110,7 +110,7 @@ export class ToolUseCycleNode<C> extends Node<
         return {
           outcome: 'failed',
           message: cycleShared.lastError.message,
-          retryable: cycleShared.lastError.retryable,
+          userRetryable: cycleShared.lastError.userRetryable,
         };
       }
       if (cycleShared.shouldStop && !cycleShared.endTurn) {
@@ -134,7 +134,7 @@ export class ToolUseCycleNode<C> extends Node<
     return {
       outcome: 'failed',
       message: error.message,
-      retryable: formatted.retryable,
+      userRetryable: formatted.userRetryable,
     };
   }
 
@@ -179,7 +179,7 @@ export class ToolUseCycleNode<C> extends Node<
       case 'failed':
         shared.lastError = {
           message: execRes.message,
-          retryable: execRes.retryable ?? false,
+          userRetryable: execRes.userRetryable ?? false,
         };
         break;
       case 'cancelled':

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -36,7 +36,7 @@ import {
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { delay, isObject, isString } from '@utils/core';
+import { delay } from '@utils/core';
 import { isNonEmptyString } from '@utils/core';
 import {
   getWebSocketEnabled,
@@ -2446,31 +2446,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const wrapped = new Error(
       `Background response ${responseId} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${responseId}").`,
     ) as Error & { error?: unknown };
-    // Attach the OpenAI error body so formatProviderHttpError can detect
-    // non-retryable conditions (e.g. insufficient_quota) via the
-    // credential-exhausted classifier. Without this, the polling failure
-    // surfaces as a plain Error and the retry layer would loop a fresh
-    // background request immediately.
+    // Attach the OpenAI error body and provider metadata. The body lets
+    // isUpstreamCreditDepletedBody recognize insufficient_quota and route
+    // through the credential-exhausted path (no auto-retry); the provider
+    // tag lets the manual-retry "Use your own API key" picker target the
+    // failing provider. tagOpenAISdkError only handles SDK error classes,
+    // so a plain Error wrapper bypasses it without this explicit tag.
     if (current.error) {
       wrapped.error = current.error;
     }
-    // Tag with provider metadata so downstream UI (manual retry panel /
-    // "Use your own API key" picker) routes to the failing provider's key.
-    // The catch block's tagOpenAISdkError only matches OpenAI SDK error
-    // classes, which a plain Error wrapper does not satisfy. Cast through
-    // unknown because OpenAI's typed error.code enum doesn't include every
-    // value the API actually returns (e.g. insufficient_quota in 429s).
-    const errorRecord = current.error as unknown;
-    const code =
-      isObject(errorRecord) && isString(errorRecord.code)
-        ? errorRecord.code
-        : undefined;
-    const isQuotaLike =
-      code === 'insufficient_quota' || code === 'rate_limit_exceeded';
     attachSdkErrorMetadata(wrapped, {
       provider: this.config.provider,
-      kind: isQuotaLike ? 'rate_limit' : 'api_error',
-      ...(isQuotaLike && { statusCode: 429 }),
+      kind: 'api_error',
     });
     throw wrapped;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -749,7 +749,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // rethrow so the outer retry resumes the same ID. Definitive failures
       // (4xx, notably 404 expired) — clear the ID and create a new request.
       //
-      // Check statusCode directly rather than formatted.retryable: the latter
+      // Check statusCode directly rather than formatted.userRetryable: the latter
       // is force-true for relay errors, which would incorrectly retain the ID
       // on a relay-wrapped 404 and loop until retries are exhausted.
       const formatted = formatProviderHttpError(err);
@@ -2442,9 +2442,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
       },
     );
-    throw new Error(
+    const wrapped = new Error(
       `Background response ${responseId} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${responseId}").`,
-    );
+    ) as Error & { error?: unknown };
+    // Attach the OpenAI error body so formatProviderHttpError can detect
+    // non-retryable conditions (e.g. insufficient_quota) via the
+    // credential-exhausted classifier. Without this, the polling failure
+    // surfaces as a plain Error and the retry layer would loop a fresh
+    // background request immediately.
+    if (current.error) {
+      wrapped.error = current.error;
+    }
+    throw wrapped;
   }
 
   /** Adds continuation instructions for models without prefill support. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -36,7 +36,7 @@ import {
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { delay } from '@utils/core';
+import { delay, isObject, isString } from '@utils/core';
 import { isNonEmptyString } from '@utils/core';
 import {
   getWebSocketEnabled,
@@ -48,6 +48,7 @@ import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError } from './support/sdkErrorAdapters';
+import { attachSdkErrorMetadata } from '@common/errors/sdkErrorUtils';
 
 // Local file imports
 import {
@@ -2453,6 +2454,24 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (current.error) {
       wrapped.error = current.error;
     }
+    // Tag with provider metadata so downstream UI (manual retry panel /
+    // "Use your own API key" picker) routes to the failing provider's key.
+    // The catch block's tagOpenAISdkError only matches OpenAI SDK error
+    // classes, which a plain Error wrapper does not satisfy. Cast through
+    // unknown because OpenAI's typed error.code enum doesn't include every
+    // value the API actually returns (e.g. insufficient_quota in 429s).
+    const errorRecord = current.error as unknown;
+    const code =
+      isObject(errorRecord) && isString(errorRecord.code)
+        ? errorRecord.code
+        : undefined;
+    const isQuotaLike =
+      code === 'insufficient_quota' || code === 'rate_limit_exceeded';
+    attachSdkErrorMetadata(wrapped, {
+      provider: this.config.provider,
+      kind: isQuotaLike ? 'rate_limit' : 'api_error',
+      ...(isQuotaLike && { statusCode: 429 }),
+    });
     throw wrapped;
   }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -614,54 +614,33 @@ function isRelayMonthlyLimitBody(rawErrorBody: unknown): boolean {
  *  balance-depleted 400. Match on the message prefix because Anthropic's
  *  type is generic `invalid_request_error` — the message is the reliable
  *  signal. Covers both the direct format and the enveloped format. */
+function pickStringField(v: unknown, key: string): string | undefined {
+  if (!isObject(v)) return undefined;
+  const value = (v as Record<string, unknown>)[key];
+  return isString(value) ? value : undefined;
+}
+
 function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
   if (!isObject(rawErrorBody)) return false;
-  const body = rawErrorBody as {
-    type?: unknown;
-    code?: unknown;
-    message?: unknown;
-    error?: unknown;
-  };
-  const pick = (
-    v: unknown,
-  ): { type?: string; code?: string; message?: string } | undefined =>
-    isObject(v)
-      ? {
-          type: isString((v as { type?: unknown }).type)
-            ? (v as { type: string }).type
-            : undefined,
-          code: isString((v as { code?: unknown }).code)
-            ? (v as { code: string }).code
-            : undefined,
-          message: isString((v as { message?: unknown }).message)
-            ? (v as { message: string }).message
-            : undefined,
-        }
-      : undefined;
-  const candidates = [pick(body), pick(body.error)];
+  const candidates = [
+    rawErrorBody,
+    (rawErrorBody as { error?: unknown }).error,
+  ];
   return candidates.some((c) => {
-    if (!c) return false;
-    // Anthropic upstream: 400 invalid_request_error with credit-balance message.
-    if (
-      c.type === 'invalid_request_error' &&
-      typeof c.message === 'string' &&
-      c.message.toLowerCase().includes('credit balance is too low')
-    ) {
-      return true;
-    }
-    // OpenAI upstream: insufficient_quota (HTTP 429 or background response.error).
-    // Match by code/type to handle both shapes, plus a message fallback for
-    // background responses where the SDK only exposes { code, message }.
-    if (c.code === 'insufficient_quota' || c.type === 'insufficient_quota') {
+    if (!isObject(c)) return false;
+    const type = pickStringField(c, 'type');
+    const code = pickStringField(c, 'code');
+    const message = pickStringField(c, 'message')?.toLowerCase();
+    if (code === 'insufficient_quota' || type === 'insufficient_quota') {
       return true;
     }
     if (
-      typeof c.message === 'string' &&
-      c.message.toLowerCase().includes('exceeded your current quota')
+      type === 'invalid_request_error' &&
+      message?.includes('credit balance is too low')
     ) {
       return true;
     }
-    return false;
+    return message?.includes('exceeded your current quota') ?? false;
   });
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -610,16 +610,16 @@ function isRelayMonthlyLimitBody(rawErrorBody: unknown): boolean {
   );
 }
 
-/** True when the upstream provider (Anthropic today) returned a credit-
- *  balance-depleted 400. Match on the message prefix because Anthropic's
- *  type is generic `invalid_request_error` — the message is the reliable
- *  signal. Covers both the direct format and the enveloped format. */
 function pickStringField(v: unknown, key: string): string | undefined {
   if (!isObject(v)) return undefined;
   const value = (v as Record<string, unknown>)[key];
   return isString(value) ? value : undefined;
 }
 
+/** True when the upstream provider returned a credit/quota exhaustion body.
+ *  Anthropic uses a generic `invalid_request_error`, so its message remains
+ *  part of the signal; OpenAI may report `insufficient_quota` directly.
+ *  Covers both the direct format and the enveloped format. */
 function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
   if (!isObject(rawErrorBody)) return false;
   const candidates = [

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -114,29 +114,29 @@ interface SdkErrorEntry {
   classNames: readonly string[];
   message?: string;
   fallbackStatusCode?: number;
-  retryable?: boolean;
+  userRetryable?: boolean;
 }
 
 const SDK_ERRORS: SdkErrorEntry[] = [
-  // Connection errors (retryable)
+  // Connection errors (transient — show retry button)
   {
     kind: 'connection_timeout',
     classNames: ['APIConnectionTimeoutError'],
     message: 'Connection timed out',
-    retryable: true,
+    userRetryable: true,
   },
   {
     kind: 'connection',
     classNames: ['APIConnectionError'],
     message: 'Connection error',
-    retryable: true,
+    userRetryable: true,
   },
-  // Abort errors (not retryable)
+  // Abort errors (user cancelled — no retry button)
   {
     kind: 'user_abort',
     classNames: ['APIUserAbortError'],
     message: 'Request aborted',
-    retryable: false,
+    userRetryable: false,
   },
   // HTTP errors (retryable derived from status code)
   {
@@ -241,7 +241,7 @@ function matchSdkError(
     return {
       message: entry.message,
       provider,
-      retryable: entry.retryable ?? false,
+      userRetryable: entry.userRetryable ?? false,
       requestId,
     };
   }
@@ -266,11 +266,11 @@ function matchSdkError(
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
-    // SDK errors without status codes are unusual - be conservative and don't retry
+    // SDK errors without status codes are unusual - be conservative and don't offer retry
     return {
       message: finalMessage,
       provider,
-      retryable: false,
+      userRetryable: false,
       requestId,
     };
   }
@@ -283,7 +283,7 @@ function matchSdkError(
     statusCode,
     statusText,
     provider,
-    retryable: isRetryableStatusCode(statusCode),
+    userRetryable: isRetryableStatusCode(statusCode),
     requestId,
   };
 }
@@ -618,14 +618,20 @@ function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
   if (!isObject(rawErrorBody)) return false;
   const body = rawErrorBody as {
     type?: unknown;
+    code?: unknown;
     message?: unknown;
     error?: unknown;
   };
-  const pick = (v: unknown): { type?: string; message?: string } | undefined =>
+  const pick = (
+    v: unknown,
+  ): { type?: string; code?: string; message?: string } | undefined =>
     isObject(v)
       ? {
           type: isString((v as { type?: unknown }).type)
             ? (v as { type: string }).type
+            : undefined,
+          code: isString((v as { code?: unknown }).code)
+            ? (v as { code: string }).code
             : undefined,
           message: isString((v as { message?: unknown }).message)
             ? (v as { message: string }).message
@@ -633,12 +639,30 @@ function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
         }
       : undefined;
   const candidates = [pick(body), pick(body.error)];
-  return candidates.some(
-    (c) =>
-      c?.type === 'invalid_request_error' &&
+  return candidates.some((c) => {
+    if (!c) return false;
+    // Anthropic upstream: 400 invalid_request_error with credit-balance message.
+    if (
+      c.type === 'invalid_request_error' &&
       typeof c.message === 'string' &&
-      c.message.toLowerCase().includes('credit balance is too low'),
-  );
+      c.message.toLowerCase().includes('credit balance is too low')
+    ) {
+      return true;
+    }
+    // OpenAI upstream: insufficient_quota (HTTP 429 or background response.error).
+    // Match by code/type to handle both shapes, plus a message fallback for
+    // background responses where the SDK only exposes { code, message }.
+    if (c.code === 'insufficient_quota' || c.type === 'insufficient_quota') {
+      return true;
+    }
+    if (
+      typeof c.message === 'string' &&
+      c.message.toLowerCase().includes('exceeded your current quota')
+    ) {
+      return true;
+    }
+    return false;
+  });
 }
 
 export function formatProviderHttpError(err: unknown): ProviderError {
@@ -657,7 +681,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (err instanceof DOMException && err.name === 'AbortError') {
     return {
       message: 'Request aborted',
-      retryable: false,
+      userRetryable: false,
       isRelayError: false,
       rawErrorBody,
       streamDiagnostics,
@@ -665,11 +689,11 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     };
   }
 
-  // Disk full — local I/O error, never retryable
+  // Disk full — local I/O error, no retry will help
   if (isDiskFullError(err)) {
     return {
       message: 'No space left on device. Free up disk space and try again.',
-      retryable: false,
+      userRetryable: false,
       isRelayError: false,
       rawErrorBody,
       streamDiagnostics,
@@ -682,11 +706,11 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (sdkMatch) {
     return {
       ...sdkMatch,
-      // Credential-exhausted errors are not auto-retried (see
-      // RetryableInvocationNode.shouldAutoRetry) but the retry panel
-      // still surfaces with the "Use your own API key" button, so the
-      // `retryable` flag stays true here.
-      retryable: isRelay || sdkMatch.retryable || isCredentialExhausted,
+      // Credential-exhausted errors keep userRetryable=true so the retry
+      // panel surfaces with the "Use your own API key" affordance, but
+      // shouldAutoRetry separately suppresses auto-retry for them — a
+      // fresh attempt with the same depleted credential would just fail.
+      userRetryable: isRelay || sdkMatch.userRetryable || isCredentialExhausted,
       isRelayError: isRelay,
       isCredentialExhausted: isCredentialExhausted || undefined,
       isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
@@ -708,8 +732,8 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const finalMessage =
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
   // No status code on an unrecognized error likely means a network-level failure
-  // (DNS, proxy, TLS, etc.) — treat as retryable for safety.
-  const retryable =
+  // (DNS, proxy, TLS, etc.) — show retry button for safety.
+  const userRetryable =
     isRelay ||
     isCredentialExhausted ||
     (statusCode ? isRetryableStatusCode(statusCode) : true);
@@ -727,7 +751,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     statusCode,
     statusText,
     provider,
-    retryable,
+    userRetryable,
     isRelayError: isRelay,
     isCredentialExhausted: isCredentialExhausted || undefined,
     isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -23,8 +23,22 @@ export const StreamDiagnosticsSchema = z.object({
 
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;
 
+function normalizeProviderErrorRetryFlag(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const data = value as Record<string, unknown>;
+  if ('userRetryable' in data || typeof data.retryable !== 'boolean') {
+    return value;
+  }
+  return {
+    ...data,
+    userRetryable: data.retryable,
+  };
+}
+
 /** Core error details from a provider/SDK */
-const ProviderErrorSchema = z.object({
+const ProviderErrorObjectSchema = z.object({
   message: z.string(),
   statusCode: z.int().optional(),
   statusText: z.string().optional(),
@@ -58,6 +72,10 @@ const ProviderErrorSchema = z.object({
    *  at runtime, so size enforcement is the producer's responsibility. */
   partialText: z.string().optional(),
 });
+const ProviderErrorSchema = z.preprocess(
+  normalizeProviderErrorRetryFlag,
+  ProviderErrorObjectSchema,
+);
 export type ProviderError = z.infer<typeof ProviderErrorSchema>;
 
 /** Context about where/when the error occurred */
@@ -68,20 +86,27 @@ export const ErrorContextSchema = z.object({
 export type ErrorContext = z.infer<typeof ErrorContextSchema>;
 
 /** Complete error log data - combines provider error with context */
-export const ErrorLogDataSchema = ProviderErrorSchema.extend(
-  ErrorContextSchema.shape,
-).extend({
-  rawMessage: z.string().optional(),
-});
+export const ErrorLogDataSchema = z.preprocess(
+  normalizeProviderErrorRetryFlag,
+  ProviderErrorObjectSchema.extend(ErrorContextSchema.shape).extend({
+    rawMessage: z.string().optional(),
+  }),
+);
 export type ErrorLogData = z.infer<typeof ErrorLogDataSchema>;
 
 /** Provider error with all fields optional for event transport */
-export const ProviderErrorPartialSchema = ProviderErrorSchema.partial();
+export const ProviderErrorPartialSchema = z.preprocess(
+  normalizeProviderErrorRetryFlag,
+  ProviderErrorObjectSchema.partial(),
+);
 export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
 
 /** Minimal error info for retry state tracking */
-export const RetryErrorInfoSchema = ProviderErrorSchema.pick({
-  message: true,
-  userRetryable: true,
-});
+export const RetryErrorInfoSchema = z.preprocess(
+  normalizeProviderErrorRetryFlag,
+  ProviderErrorObjectSchema.pick({
+    message: true,
+    userRetryable: true,
+  }),
+);
 export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -29,7 +29,13 @@ const ProviderErrorSchema = z.object({
   statusCode: z.int().optional(),
   statusText: z.string().optional(),
   provider: z.string().optional(),
-  retryable: z.boolean(),
+  /** True when the user should be offered a retry button. This gates the
+   *  manual retry UI — it does NOT mean the retry loop will auto-retry. The
+   *  auto-retry decision is made separately by `shouldAutoRetry`, which
+   *  excludes credentialExhausted/auth errors even when `userRetryable` is
+   *  true (because they need user action — a key swap or new API key —
+   *  before any retry makes sense). */
+  userRetryable: z.boolean(),
   isRelayError: z.boolean(),
   /** True when the credential (relay monthly limit OR upstream provider
    *  account) has been exhausted. Auto-retry is skipped for these errors
@@ -76,6 +82,6 @@ export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
 /** Minimal error info for retry state tracking */
 export const RetryErrorInfoSchema = ProviderErrorSchema.pick({
   message: true,
-  retryable: true,
+  userRetryable: true,
 });
 export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -31,6 +31,12 @@ import {
   sdkErrorKindFromStatusCode,
 } from '@common/errors/sdkErrorUtils';
 
+// Local imports - shared schemas
+import {
+  ErrorLogDataSchema,
+  RetryErrorInfoSchema,
+} from '@shared/schemas/errors';
+
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
@@ -288,6 +294,47 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(false);
   });
 
+  it('classifies OpenAI insufficient_quota bodies as credential exhaustion', () => {
+    const error = new Error('quota exhausted') as Error & { error: unknown };
+    error.error = {
+      message: 'You exceeded your current quota.',
+      type: 'insufficient_quota',
+      code: 'insufficient_quota',
+    };
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'rate_limit',
+      statusCode: 429,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.isCredentialExhausted).toBe(true);
+    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
+  });
+
+  it('classifies OpenAI quota messages without code as credential exhaustion', () => {
+    const error = new Error('quota exhausted') as Error & { error: unknown };
+    error.error = {
+      message:
+        'You exceeded your current quota, please check your plan and billing details.',
+    };
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'rate_limit',
+      statusCode: 429,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.isCredentialExhausted).toBe(true);
+    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
+  });
+
   it('formats tagged Anthropic user abort errors', () => {
     const error = new AnthropicAPIUserAbortError();
     tagAnthropicSdkError(error, 'anthropic');
@@ -327,5 +374,23 @@ describe('formatProviderHttpError', () => {
     expect(sdkErrorKindFromStatusCode(500)).toBe('internal_server');
     expect(sdkErrorKindFromStatusCode(418)).toBe('api_error');
     expect(sdkErrorKindFromStatusCode(undefined)).toBe('api_error');
+  });
+});
+
+describe('provider error schemas', () => {
+  it('normalizes legacy retryable fields from persisted error logs', () => {
+    const errorLog = ErrorLogDataSchema.parse({
+      message: 'old persisted error',
+      retryable: false,
+      isRelayError: false,
+    });
+    const retryInfo = RetryErrorInfoSchema.parse({
+      message: 'old retry state',
+      retryable: true,
+    });
+
+    expect(errorLog.userRetryable).toBe(false);
+    expect('retryable' in errorLog).toBe(false);
+    expect(retryInfo.userRetryable).toBe(true);
   });
 });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -48,7 +48,7 @@ describe('formatProviderHttpError', () => {
     );
 
     expect(formatted.message).toBe('new provider error shape');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('detects OpenAI provider errors without importing SDK classes at runtime', () => {
@@ -58,7 +58,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('openai');
     expect(formatted.statusCode).toBe(429);
-    expect(formatted.retryable).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
   });
 
   it('detects Anthropic provider errors without importing SDK classes at runtime', () => {
@@ -68,7 +68,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('anthropic');
     expect(formatted.statusCode).toBe(401);
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('matches SDK abort errors through the prototype chain', () => {
@@ -111,9 +111,9 @@ describe('formatProviderHttpError', () => {
     );
 
     expect(connectionError.provider).toBe('openai');
-    expect(connectionError.retryable).toBe(true);
+    expect(connectionError.userRetryable).toBe(true);
     expect(timeoutError.provider).toBe('openai');
-    expect(timeoutError.retryable).toBe(true);
+    expect(timeoutError.userRetryable).toBe(true);
   });
 
   it('preserves provider context for native Anthropic HTTP errors', () => {
@@ -146,9 +146,9 @@ describe('formatProviderHttpError', () => {
     );
 
     expect(connectionError.provider).toBe('anthropic');
-    expect(connectionError.retryable).toBe(true);
+    expect(connectionError.userRetryable).toBe(true);
     expect(timeoutError.provider).toBe('anthropic');
-    expect(timeoutError.retryable).toBe(true);
+    expect(timeoutError.userRetryable).toBe(true);
   });
 
   it('prefers Anthropic request-id when response headers include both request id styles', () => {
@@ -201,7 +201,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('openai');
     expect(formatted.statusCode).toBe(400);
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('detects Anthropic provider from Windows pnpm stack paths', () => {
@@ -212,7 +212,7 @@ describe('formatProviderHttpError', () => {
     const formatted = formatProviderHttpError(err);
 
     expect(formatted.provider).toBe('anthropic');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('detects Google provider from Windows pnpm stack paths', () => {
@@ -223,7 +223,7 @@ describe('formatProviderHttpError', () => {
     const formatted = formatProviderHttpError(err);
 
     expect(formatted.provider).toBe('google');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('keeps SDK user aborts non-retryable while preserving provider attribution', () => {
@@ -235,7 +235,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('Request aborted');
     expect(formatted.provider).toBe('openai');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('formats symbol-tagged SDK errors without SDK prototype matching', () => {
@@ -253,7 +253,7 @@ describe('formatProviderHttpError', () => {
     expect(formatted.message).toBe(
       'HTTP 429 Too Many Requests – provider quota',
     );
-    expect(formatted.retryable).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
   });
 
   it('formats tagged OpenAI connection errors with existing retry behavior', () => {
@@ -265,7 +265,7 @@ describe('formatProviderHttpError', () => {
     expect(formatted.provider).toBe('openai');
     expect(formatted.statusCode).toBeUndefined();
     expect(formatted.message).toBe('Connection timed out');
-    expect(formatted.retryable).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
   });
 
   it('formats tagged OpenAI HTTP errors with status metadata', () => {
@@ -285,7 +285,7 @@ describe('formatProviderHttpError', () => {
     expect(formatted.message).toContain('HTTP 400 Bad Request');
     expect(formatted.message).toContain('bad payload');
     expect(formatted.requestId).toBe('req_123');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('formats tagged Anthropic user abort errors', () => {
@@ -296,7 +296,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('anthropic');
     expect(formatted.message).toBe('Request aborted');
-    expect(formatted.retryable).toBe(false);
+    expect(formatted.userRetryable).toBe(false);
   });
 
   it('formats tagged Google API errors with inferred kind from status', () => {
@@ -313,7 +313,7 @@ describe('formatProviderHttpError', () => {
     expect(formatted.message).toBe(
       'HTTP 429 Too Many Requests – quota exceeded',
     );
-    expect(formatted.retryable).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
   });
 
   it('derives SDK error kinds from the shared status mapping', () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -8,6 +8,7 @@
 
 // Third-party imports
 import { randomUUID } from 'crypto';
+import { statSync } from 'fs';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -143,6 +144,19 @@ const memoriesField = z
 const WORKTREE_DISABLED_MESSAGE =
   "git worktree support is disabled in this workspace. Omit working_directory, or enable 'Allow agents to work in git worktrees' on the Multi-Agent settings tab.";
 
+function ensureWorkingDirectoryExists(dir: string): void {
+  try {
+    const stat = statSync(dir);
+    if (stat.isDirectory()) return;
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `working_directory must be an existing directory: ${reason}`,
+    );
+  }
+  throw new Error(`working_directory must be a directory: ${dir}`);
+}
+
 /**
  * Shared Zod field for the `working_directory` parameter on delegation tools.
  * Validates and normalizes in one step so downstream code always receives the
@@ -171,6 +185,15 @@ const workingDirectoryField = z
       ctx.addIssue({
         code: 'custom',
         message: WORKTREE_DISABLED_MESSAGE,
+      });
+      return z.NEVER;
+    }
+    try {
+      ensureWorkingDirectoryExists(trimmed);
+    } catch (e) {
+      ctx.addIssue({
+        code: 'custom',
+        message: e instanceof Error ? e.message : String(e),
       });
       return z.NEVER;
     }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -72,7 +72,10 @@ import {
   formatFollowUpInstruction,
 } from '@tools/subagentResults';
 import { isWorktreeSupportEnabled } from '@tools/worktreeConfig';
-import { parseWorkingDirectory } from '@tools/pathResolution';
+import {
+  ensureDirectoryExists,
+  parseWorkingDirectory,
+} from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - memory
@@ -166,10 +169,20 @@ const workingDirectoryField = z
       });
       return z.NEVER;
     }
-    if (trimmed && !isWorktreeSupportEnabled()) {
+    if (!trimmed) return trimmed;
+    if (!isWorktreeSupportEnabled()) {
       ctx.addIssue({
         code: 'custom',
         message: WORKTREE_DISABLED_MESSAGE,
+      });
+      return z.NEVER;
+    }
+    try {
+      ensureDirectoryExists(trimmed);
+    } catch (e) {
+      ctx.addIssue({
+        code: 'custom',
+        message: e instanceof Error ? e.message : String(e),
       });
       return z.NEVER;
     }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -72,10 +72,7 @@ import {
   formatFollowUpInstruction,
 } from '@tools/subagentResults';
 import { isWorktreeSupportEnabled } from '@tools/worktreeConfig';
-import {
-  ensureDirectoryExists,
-  parseWorkingDirectory,
-} from '@tools/pathResolution';
+import { parseWorkingDirectory } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - memory
@@ -174,15 +171,6 @@ const workingDirectoryField = z
       ctx.addIssue({
         code: 'custom',
         message: WORKTREE_DISABLED_MESSAGE,
-      });
-      return z.NEVER;
-    }
-    try {
-      ensureDirectoryExists(trimmed);
-    } catch (e) {
-      ctx.addIssue({
-        code: 'custom',
-        message: e instanceof Error ? e.message : String(e),
       });
       return z.NEVER;
     }

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import { statSync } from 'fs';
 import * as path from 'path';
 
 // Local imports - tools
@@ -38,6 +39,36 @@ export function parseWorkingDirectory(
     );
   }
   return trimmed;
+}
+
+/**
+ * Verify `dir` exists on disk and is a directory. Throws ToolError otherwise.
+ * Called at delegation dispatch time so subagents never start with a bogus cwd
+ * that would silently break every downstream filesystem tool.
+ */
+export function ensureDirectoryExists(dir: string): void {
+  let stat;
+  try {
+    stat = statSync(dir);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') {
+      throw new ToolError(`working_directory does not exist: ${dir}`);
+    }
+    if (code === 'EACCES' || code === 'EPERM') {
+      throw new ToolError(`working_directory is not accessible: ${dir}`);
+    }
+    throw new ToolError(
+      `working_directory could not be opened: ${dir} (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+  }
+  if (!stat.isDirectory()) {
+    throw new ToolError(
+      `working_directory exists but is not a directory: ${dir}`,
+    );
+  }
 }
 
 /**

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import { statSync } from 'fs';
 import * as path from 'path';
 
 // Local imports - tools
@@ -39,36 +38,6 @@ export function parseWorkingDirectory(
     );
   }
   return trimmed;
-}
-
-/**
- * Verify `dir` exists on disk and is a directory. Throws ToolError otherwise.
- * Called at delegation dispatch time so subagents never start with a bogus cwd
- * that would silently break every downstream filesystem tool.
- */
-export function ensureDirectoryExists(dir: string): void {
-  let stat;
-  try {
-    stat = statSync(dir);
-  } catch (e) {
-    const code = (e as NodeJS.ErrnoException | undefined)?.code;
-    if (code === 'ENOENT') {
-      throw new ToolError(`working_directory does not exist: ${dir}`);
-    }
-    if (code === 'EACCES' || code === 'EPERM') {
-      throw new ToolError(`working_directory is not accessible: ${dir}`);
-    }
-    throw new ToolError(
-      `working_directory could not be opened: ${dir} (${
-        e instanceof Error ? e.message : String(e)
-      })`,
-    );
-  }
-  if (!stat.isDirectory()) {
-    throw new ToolError(
-      `working_directory exists but is not a directory: ${dir}`,
-    );
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stops the immediate retry loop on OpenAI quota errors (#3851, #3828). Background-mode polling threw a plain `Error` with no body, so the classifier fell through to the default `retryable=true` branch. The handler now wraps the thrown error with the upstream `response.error` payload and provider metadata, and `isUpstreamCreditDepletedBody` detects `insufficient_quota` so `isCredentialExhausted` suppresses auto-retry.
- Renames `ProviderError.retryable` to `userRetryable` to make it clear the flag gates the manual retry UI button, not the auto-retry loop. Auto-retry is gated separately by `isCredentialExhausted` / `shouldAutoRetry`. Historical persisted `retryable` payloads are normalized when parsed so older progress logs keep their structured error details.
- Validates `working_directory` at delegation dispatch time so a subagent never starts with a nonexistent or non-directory cwd.

## Test plan
- [x] `npm run format`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/test-kernel/common/SdkErrorUtils.vitest.mts` — 26/26 pass
- [x] `CI=true npm run compile:fast`
- [x] `npm run lint` — 0 errors; existing import-order warnings remain
- [ ] Reproduce quota-exhausted account: confirm agent stops cleanly with credential-exhausted notice instead of retry-looping
- [ ] Trigger a non-credit transient (e.g. 502): confirm manual-retry UI still appears with "Can retry: Yes"
- [ ] Delegate with bogus `working_directory`: confirm Zod validation error surfaces before subagent dispatch

Fixes #3851, #3828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/error classification across agent flows and OpenAI background polling, which could alter when executions stop vs. offer manual retry. Risk is moderate due to behavior changes in failure handling and user-facing retry UI.
> 
> **Overview**
> Prevents runaway retry loops on OpenAI background-mode failures by wrapping background polling terminal errors with attached provider metadata (including the upstream error body) so quota/credit exhaustion is detected and auto-retry is suppressed.
> 
> Renames the provider error flag from `retryable` to `userRetryable` across schemas, logging, and flow outcomes to clarify it only gates the *manual retry UI* (UI label updated to “Can retry”), while auto-retry remains separately constrained by auth/credential-exhaustion checks.
> 
> Broadens upstream credit/quota exhaustion detection (e.g., `insufficient_quota` / quota-exceeded messages) and tightens delegation tool validation to reject invalid `working_directory` values early when worktree support is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4eb5fed9be3548c5095e7bac423c3ad01c07979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->