### PR TITLE
fix(workflow): correct diff stats, surface subagent output paths, render markdown

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -8,6 +8,7 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -16,9 +17,11 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { CopyButtonController } from '@shared/controllers';
 import { compactIconActionButtonStyles } from '@shared/styles';
 import { designTokens } from '@shared/styles/litStyles';
+import { markdownStyles } from '@shared/styles/markdownStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers
+import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { formatTimestamp } from '../formatters/timestampUtils';
 
 const STRUCTURED_DELIVERY_TAGS = [
@@ -70,6 +73,7 @@ export class UserMessage extends LitElement {
   static override styles = [
     designTokens,
     compactIconActionButtonStyles,
+    markdownStyles,
     css`
       :host {
         display: block;
@@ -137,15 +141,9 @@ export class UserMessage extends LitElement {
           var(--wa-color-surface-default)
         );
         border-radius: var(--border-radius-small);
-        font-family: var(
-          --wa-font-family-mono,
-          ui-monospace,
-          SFMono-Regular,
-          Consolas,
-          monospace
-        );
-        font-size: var(--wa-editor-font-size, var(--font-size-sm));
+        font-size: var(--font-size-sm);
         line-height: 1.35;
+        white-space: normal;
       }
 
       .user-message-timestamp {
@@ -249,11 +247,18 @@ export class UserMessage extends LitElement {
                 })
               : nothing}
           </div>
-          <div
-            class="user-message-content"
-            data-log-id=${this.logId}
-            .textContent=${displayText}
-          ></div>
+          ${isStructuredDelivery
+            ? html`<div
+                class="user-message-content markdown-content"
+                data-log-id=${this.logId}
+              >
+                ${unsafeHTML(processMarkdownContent(displayText))}
+              </div>`
+            : html`<div
+                class="user-message-content"
+                data-log-id=${this.logId}
+                .textContent=${displayText}
+              ></div>`}
         </div>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -209,6 +209,12 @@ export class UserMessage extends LitElement {
     const rawMessageCopyState = this.rawMessageCopyController.state;
     const { isStructuredDelivery, hasRawMessage, displayText } =
       this.getDisplayState();
+    // processMarkdownContent uses MarkdownIt with html:false and escapes
+    // restored LaTeX reference labels before the renderer output reaches
+    // unsafeHTML.
+    const structuredMarkdownHtml = isStructuredDelivery
+      ? processMarkdownContent(displayText)
+      : '';
 
     return html`
       <div class="user-message-container">
@@ -252,7 +258,7 @@ export class UserMessage extends LitElement {
                 class="user-message-content markdown-content"
                 data-log-id=${this.logId}
               >
-                ${unsafeHTML(processMarkdownContent(displayText))}
+                ${unsafeHTML(structuredMarkdownHtml)}
               </div>`
             : html`<div
                 class="user-message-content"

--- a/packages/extension/src/progressView/frontend/formatters/markdownRenderer.ts
+++ b/packages/extension/src/progressView/frontend/formatters/markdownRenderer.ts
@@ -9,6 +9,7 @@ import katex from 'katex';
 
 // Local imports - shared highlighting
 import { highlightCode } from '@shared/highlighting/highlightCode';
+import { escapeAttr } from '@shared/utils/xmlEscape';
 
 // Local imports - progress view helpers
 import { katexMacros } from '../katexMacros';
@@ -55,9 +56,12 @@ export const getMarkdownRenderer = (): MarkdownIt => {
   return markdownRenderer;
 };
 
-/** Create LaTeX reference HTML element. */
+/** Create LaTeX reference HTML element. Labels arrive from model output and
+ *  may carry crafted characters; escape via the shared util so a label
+ *  cannot break out of the `data-label` attribute or the inner text. */
 const createLatexReferenceHtml = (refType: string, label: string): string => {
-  return `<span class="latex-ref clickable-link" data-label="${label}">\\${refType}{${label}}</span>`;
+  const safeLabel = escapeAttr(label);
+  return `<span class="latex-ref clickable-link" data-label="${safeLabel}">\\${refType}{${safeLabel}}</span>`;
 };
 
 /** Protect LaTeX references from markdown parsing. */

--- a/packages/extension/src/progressView/frontend/formatters/markdownRenderer.ts
+++ b/packages/extension/src/progressView/frontend/formatters/markdownRenderer.ts
@@ -9,7 +9,7 @@ import katex from 'katex';
 
 // Local imports - shared highlighting
 import { highlightCode } from '@shared/highlighting/highlightCode';
-import { escapeAttr } from '@shared/utils/xmlEscape';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
 // Local imports - progress view helpers
 import { katexMacros } from '../katexMacros';
@@ -60,30 +60,41 @@ export const getMarkdownRenderer = (): MarkdownIt => {
  *  may carry crafted characters; escape via the shared util so a label
  *  cannot break out of the `data-label` attribute or the inner text. */
 const createLatexReferenceHtml = (refType: string, label: string): string => {
-  const safeLabel = escapeAttr(label);
-  return `<span class="latex-ref clickable-link" data-label="${safeLabel}">\\${refType}{${safeLabel}}</span>`;
+  const safeAttrLabel = escapeAttr(label);
+  const safeTextLabel = escapeText(label);
+  return `<span class="latex-ref clickable-link" data-label="${safeAttrLabel}">\\${refType}{${safeTextLabel}}</span>`;
 };
 
+interface ProtectedLatexReference {
+  refType: string;
+  label: string;
+}
+
 /** Protect LaTeX references from markdown parsing. */
-const protectLatexReferences = (content: string): string => {
-  content = content.replaceAll(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
-  content = content.replaceAll(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
-  content = content.replaceAll(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
-  return content;
+const protectLatexReferences = (
+  content: string,
+): { content: string; refs: ProtectedLatexReference[] } => {
+  const refs: ProtectedLatexReference[] = [];
+  const protectedContent = content.replaceAll(
+    /\\(ref|cref|eqref)\{([^}]+)\}/g,
+    (_match, refType: string, label: string) => {
+      const index = refs.push({ refType, label }) - 1;
+      return `@@LATEX-REF-${index}@@`;
+    },
+  );
+  return { content: protectedContent, refs };
 };
 
 /** Restore LaTeX references from placeholders to clickable elements. */
-const restoreLatexReferences = (content: string): string => {
-  return content
-    .replaceAll(/@@LATEX-REF:([^@]+)@@/g, (_, label) =>
-      createLatexReferenceHtml('ref', label),
-    )
-    .replaceAll(/@@LATEX-CREF:([^@]+)@@/g, (_, label) =>
-      createLatexReferenceHtml('cref', label),
-    )
-    .replaceAll(/@@LATEX-EQREF:([^@]+)@@/g, (_, label) =>
-      createLatexReferenceHtml('eqref', label),
-    );
+const restoreLatexReferences = (
+  content: string,
+  refs: ProtectedLatexReference[],
+): string => {
+  return content.replaceAll(/@@LATEX-REF-(\d+)@@/g, (match, rawIndex) => {
+    const index = Number(rawIndex);
+    const ref = refs[index];
+    return ref ? createLatexReferenceHtml(ref.refType, ref.label) : match;
+  });
 };
 
 /** Simple hash function for cache keys (FNV-1a variant). */
@@ -118,7 +129,7 @@ export const processMarkdownContent = (
 
   // Pre-process LaTeX references to protect them from markdown parsing
   // Note: Pandoc reference formats are normalized to LaTeX at the source (xmlUtils.ts)
-  const protectedContent = protectLatexReferences(content);
+  const { content: protectedContent, refs } = protectLatexReferences(content);
 
   // Add line break before bold text starting a new sentence (capital letter after period)
   // This fixes OpenAI reasoning summary output which omits line breaks before bold headers
@@ -133,7 +144,7 @@ export const processMarkdownContent = (
   const parsedMarkdown = md.render(formattedContent);
 
   // Post-process to restore and style LaTeX references
-  const result = restoreLatexReferences(parsedMarkdown);
+  const result = restoreLatexReferences(parsedMarkdown, refs);
 
   // Store in cache with LRU eviction
   if (useCache && cacheKey) {

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -45,12 +45,22 @@ export class MemoryItem extends LitElement {
 
       .memory-preview {
         font-size: var(--font-size-sm);
-        line-height: var(--line-height-normal);
-        padding: var(--wa-space-xs);
+        line-height: var(--line-height-tight, 1.3);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
         border-radius: var(--border-radius);
         margin: 0;
-        max-height: 200px;
+        max-height: 140px;
         overflow-y: auto;
+      }
+
+      .memory-preview .markdown-content > :first-child {
+        margin-top: 0;
+      }
+      .memory-preview .markdown-content > :last-child {
+        margin-bottom: 0;
+      }
+      .memory-preview .markdown-content p {
+        margin: var(--wa-space-3xs) 0;
       }
 
       .memory-item.pinned {

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -158,7 +158,7 @@ export class OutputNode<C = unknown> extends Node<
       outputState,
       baseFiles,
       currentRound,
-      { isRewrite: setting.isRewrite },
+      { isRewrite: setting.isRewrite, executionId: this.services.executionId },
     );
 
     return { roundOutput, summary, compileFailures, emitCompileFailures };

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -10,6 +10,7 @@ import {
 import { runCompileCheck } from '@agent/output/compileCheck';
 import { extractFilesFromXml } from '@agent/output/xmlExtraction';
 import { traceFileLineage } from '@agent/output/lineageMapping';
+import { resolveBaseFilesForDiff } from '@agent/output/snapshotResolution';
 import { checkExpectedOutputs } from '@agent/output/outputValidation';
 import {
   summarizeRound,
@@ -78,6 +79,17 @@ export class OutputNode<C = unknown> extends Node<
       this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
 
+    // Substitute workspace base files with their pre-run snapshot when
+    // captured by prepareRunWorkspace. In-place workflows overwrite the
+    // live workspace file before output processing runs, so diffing
+    // against it would collapse to 0/0. This resolution is done once
+    // here so the mapping, latexdiff, and diff stats all see consistent
+    // base locations.
+    const diffBaseFiles = await resolveBaseFilesForDiff(
+      baseFiles,
+      this.services.executionId,
+    );
+
     let mapping: RoundFileMapping | undefined;
     let compileFailures: CompileFailure[] = [];
     let emitCompileFailures = false;
@@ -110,14 +122,14 @@ export class OutputNode<C = unknown> extends Node<
       );
 
       if (hasRoundOutputs(outputState, currentRound)) {
-        mapping = traceFileLineage(outputState, baseFiles, currentRound);
+        mapping = traceFileLineage(outputState, diffBaseFiles, currentRound);
 
         await tryOperation(
           'Latexdiff',
           () =>
             this.handleLatexdiff(
               currentRound,
-              baseFiles,
+              diffBaseFiles,
               mapping!,
               diffManager,
             ),
@@ -150,15 +162,20 @@ export class OutputNode<C = unknown> extends Node<
       this.services,
       outputLocation,
       currentRound,
-      { endTurn, mapping, isRewrite: setting.isRewrite },
+      {
+        endTurn,
+        mapping,
+        isRewrite: setting.isRewrite,
+        baseFiles: diffBaseFiles,
+      },
     );
 
     // Get round output — critical, throw if it fails
     const roundOutput = await getRoundOutput(
       outputState,
-      baseFiles,
+      diffBaseFiles,
       currentRound,
-      { isRewrite: setting.isRewrite, executionId: this.services.executionId },
+      { isRewrite: setting.isRewrite },
     );
 
     return { roundOutput, summary, compileFailures, emitCompileFailures };

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -79,12 +79,8 @@ export class OutputNode<C = unknown> extends Node<
       this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
 
-    // Substitute workspace base files with their pre-run snapshot when
-    // captured by prepareRunWorkspace. In-place workflows overwrite the
-    // live workspace file before output processing runs, so diffing
-    // against it would collapse to 0/0. This resolution is done once
-    // here so the mapping, latexdiff, and diff stats all see consistent
-    // base locations.
+    // Resolve to pre-run snapshots once so mapping, latexdiff, and diff
+    // stats all see the same base locations (see snapshotResolution).
     const diffBaseFiles = await resolveBaseFilesForDiff(
       baseFiles,
       this.services.executionId,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -65,7 +65,11 @@ export interface RunReflectionFlowInput<
   parentStage: AgentLogStage;
   getOutputFileLocation?: (round: number) => AgentFileLocation;
   usageMonitor?: UsageMonitor;
-  onRoundCompleted?: (roundIndex: number, totalRounds: number) => void;
+  onRoundCompleted?: (
+    roundIndex: number,
+    totalRounds: number,
+    outputPaths: readonly string[],
+  ) => void;
 }
 
 export interface RunReflectionFlowResult {
@@ -268,7 +272,13 @@ export async function runReflectionFlow<C = unknown>(
         },
         checkInterruption,
         onRoundCompleted: (roundIndex, s) => {
-          input.onRoundCompleted?.(roundIndex, s.totalRounds);
+          const outputs = outputState.rounds.get(roundIndex)?.outputs ?? [];
+          const outputPaths = outputs.map((o) =>
+            'relativePath' in o.location
+              ? o.location.relativePath
+              : o.location.absolutePath,
+          );
+          input.onRoundCompleted?.(roundIndex, s.totalRounds, outputPaths);
         },
       },
     });

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -9,15 +9,10 @@ import { diff_match_patch } from 'diff-match-patch';
 
 import * as logger from '@agent/core/logger';
 import type { DiffStats } from '@agent/types/DiffTypes';
-import type {
-  ExecutionId,
-  OutputFileInfo,
-  FileLocation,
-} from '@shared/schemas';
+import type { OutputFileInfo, FileLocation } from '@shared/schemas';
 import { flexibleFS, getComparablePath } from '@utils/files';
 import { countLines } from '@utils/text/stringUtils';
 
-import { resolveBaseFilesForDiff } from './snapshotResolution';
 import { traceFileLineage } from './lineageMapping';
 import { ensureRound, type OutputState } from './outputState';
 import type { RoundFileMapping } from './types';
@@ -69,24 +64,24 @@ async function computeDiffStats(
 // Public API
 // ============================================================================
 
-/** Computes diff stats for all output files in a round. */
+/** Computes diff stats for all output files in a round.
+ *
+ *  Callers in workflows must pass snapshot-resolved baseFiles (via
+ *  resolveBaseFilesForDiff) when an executionId is available; passing
+ *  the live workspace path would collapse in-place diffs to 0/0. The
+ *  precomputedMapping, if provided, must have been built against the
+ *  same snapshot-resolved baseFiles — otherwise the mapping's base
+ *  locations still point at the overwritten files. */
 export async function computeOutputDiffStats(
   state: OutputState,
   baseFiles: FileLocation[],
   currRound: number,
   precomputedMapping?: RoundFileMapping,
-  options?: { isRewrite?: boolean; executionId?: ExecutionId },
+  options?: { isRewrite?: boolean },
 ): Promise<OutputFileInfo[]> {
   const roundOutputs = ensureRound(state, currRound);
-  // Substitute workspace base files with their pre-run snapshot when one
-  // exists. In-place workflows overwrite the live workspace file before
-  // we get here; reading it as the diff base would collapse to 0/0.
-  const diffBaseFiles = await resolveBaseFilesForDiff(
-    baseFiles,
-    options?.executionId,
-  );
   const mapping =
-    precomputedMapping ?? traceFileLineage(state, diffBaseFiles, currRound);
+    precomputedMapping ?? traceFileLineage(state, baseFiles, currRound);
   const suppressLineage = options?.isRewrite === false;
 
   return Promise.all(
@@ -111,12 +106,8 @@ export async function computeOutputDiffStats(
       // "methods") don't match the base filename via basename strategies.
       // If no diff base was found but there is exactly one base file, use it
       // so the diff stats reflect real changes against the original.
-      if (
-        !diffBaseLocation &&
-        !originalLocation &&
-        diffBaseFiles.length === 1
-      ) {
-        const candidate = diffBaseFiles[0];
+      if (!diffBaseLocation && !originalLocation && baseFiles.length === 1) {
+        const candidate = baseFiles[0];
         if (getComparablePath(candidate) !== locationPath) {
           diffBaseLocation = candidate;
         }

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -9,10 +9,15 @@ import { diff_match_patch } from 'diff-match-patch';
 
 import * as logger from '@agent/core/logger';
 import type { DiffStats } from '@agent/types/DiffTypes';
-import type { OutputFileInfo, FileLocation } from '@shared/schemas';
+import type {
+  ExecutionId,
+  OutputFileInfo,
+  FileLocation,
+} from '@shared/schemas';
 import { flexibleFS, getComparablePath } from '@utils/files';
 import { countLines } from '@utils/text/stringUtils';
 
+import { resolveBaseFilesForDiff } from './snapshotResolution';
 import { traceFileLineage } from './lineageMapping';
 import { ensureRound, type OutputState } from './outputState';
 import type { RoundFileMapping } from './types';
@@ -70,11 +75,18 @@ export async function computeOutputDiffStats(
   baseFiles: FileLocation[],
   currRound: number,
   precomputedMapping?: RoundFileMapping,
-  options?: { isRewrite?: boolean },
+  options?: { isRewrite?: boolean; executionId?: ExecutionId },
 ): Promise<OutputFileInfo[]> {
   const roundOutputs = ensureRound(state, currRound);
+  // Substitute workspace base files with their pre-run snapshot when one
+  // exists. In-place workflows overwrite the live workspace file before
+  // we get here; reading it as the diff base would collapse to 0/0.
+  const diffBaseFiles = await resolveBaseFilesForDiff(
+    baseFiles,
+    options?.executionId,
+  );
   const mapping =
-    precomputedMapping ?? traceFileLineage(state, baseFiles, currRound);
+    precomputedMapping ?? traceFileLineage(state, diffBaseFiles, currRound);
   const suppressLineage = options?.isRewrite === false;
 
   return Promise.all(
@@ -99,8 +111,12 @@ export async function computeOutputDiffStats(
       // "methods") don't match the base filename via basename strategies.
       // If no diff base was found but there is exactly one base file, use it
       // so the diff stats reflect real changes against the original.
-      if (!diffBaseLocation && !originalLocation && baseFiles.length === 1) {
-        const candidate = baseFiles[0];
+      if (
+        !diffBaseLocation &&
+        !originalLocation &&
+        diffBaseFiles.length === 1
+      ) {
+        const candidate = diffBaseFiles[0];
         if (getComparablePath(candidate) !== locationPath) {
           diffBaseLocation = candidate;
         }

--- a/src/agent/output/roundSummary.ts
+++ b/src/agent/output/roundSummary.ts
@@ -59,7 +59,7 @@ export async function summarizeRound(
         deps.baseFiles,
         currRound,
         options.mapping,
-        { isRewrite: options.isRewrite },
+        { isRewrite: options.isRewrite, executionId: deps.executionId },
       );
       data.outputs = fileInfos;
       const storageKey = getStorageKey(state);
@@ -96,7 +96,7 @@ export async function getRoundOutput(
   state: OutputState,
   baseFiles: FileLocation[],
   round: number,
-  options?: { isRewrite?: boolean },
+  options?: { isRewrite?: boolean; executionId?: string },
 ): Promise<RoundOutput> {
   const data = ensureRoundData(state, round);
 

--- a/src/agent/output/roundSummary.ts
+++ b/src/agent/output/roundSummary.ts
@@ -44,6 +44,11 @@ export async function summarizeRound(
     stage?: AgentLogStage;
     mapping?: RoundFileMapping;
     isRewrite?: boolean;
+    /** Snapshot-resolved base files. Required for in-place workflows so
+     *  diff stats are computed against the pre-run snapshot rather than
+     *  the overwritten workspace file. When omitted, falls back to
+     *  deps.baseFiles (live workspace paths). */
+    baseFiles?: FileLocation[];
   },
 ): Promise<RoundSummary> {
   return withOutputStage(
@@ -56,10 +61,10 @@ export async function summarizeRound(
 
       const fileInfos = await computeOutputDiffStats(
         state,
-        deps.baseFiles,
+        options.baseFiles ?? deps.baseFiles,
         currRound,
         options.mapping,
-        { isRewrite: options.isRewrite, executionId: deps.executionId },
+        { isRewrite: options.isRewrite },
       );
       data.outputs = fileInfos;
       const storageKey = getStorageKey(state);
@@ -96,7 +101,7 @@ export async function getRoundOutput(
   state: OutputState,
   baseFiles: FileLocation[],
   round: number,
-  options?: { isRewrite?: boolean; executionId?: string },
+  options?: { isRewrite?: boolean },
 ): Promise<RoundOutput> {
   const data = ensureRoundData(state, round);
 

--- a/src/agent/output/snapshotResolution.ts
+++ b/src/agent/output/snapshotResolution.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolves base files to their pre-run snapshot for diff computation.
+ *
+ * `prepareRunWorkspace` copies each workspace base file into
+ * `executions/<id>/original/<relativePath>` before any agent edits run.
+ * In-place workflows overwrite the live workspace file, so diffing
+ * against the live path yields 0/0; the snapshot preserves the
+ * canonical "before" content for accurate stats.
+ */
+
+import { promises as fs } from 'fs';
+
+import type { ExecutionId, FileLocation } from '@shared/schemas';
+import {
+  createRunStorageLocation,
+  getOriginalSnapshotPath,
+} from '@utils/files/taskRunStorage';
+
+/** Map each workspace base file to its snapshot location when one exists.
+ *  Non-workspace files and missing snapshots pass through unchanged. */
+export async function resolveBaseFilesForDiff(
+  baseFiles: FileLocation[],
+  executionId: ExecutionId | undefined,
+): Promise<FileLocation[]> {
+  if (executionId === undefined) return baseFiles;
+  return Promise.all(
+    baseFiles.map(async (loc) => {
+      if (loc.kind !== 'workspace') return loc;
+      const snapshotAbsolute = getOriginalSnapshotPath(
+        executionId,
+        loc.relativePath,
+      );
+      try {
+        const stats = await fs.stat(snapshotAbsolute);
+        if (!stats.isFile()) return loc;
+      } catch {
+        return loc;
+      }
+      return createRunStorageLocation(
+        snapshotAbsolute,
+        loc.relativePath,
+        executionId,
+      );
+    }),
+  );
+}

--- a/src/agent/output/snapshotResolution.ts
+++ b/src/agent/output/snapshotResolution.ts
@@ -8,9 +8,8 @@
  * canonical "before" content for accurate stats.
  */
 
-import { promises as fs } from 'fs';
-
 import type { ExecutionId, FileLocation } from '@shared/schemas';
+import { AbsoluteFS } from '@utils/files';
 import {
   createRunStorageLocation,
   getOriginalSnapshotPath,
@@ -30,12 +29,7 @@ export async function resolveBaseFilesForDiff(
         executionId,
         loc.relativePath,
       );
-      try {
-        const stats = await fs.stat(snapshotAbsolute);
-        if (!stats.isFile()) return loc;
-      } catch {
-        return loc;
-      }
+      if (!(await AbsoluteFS.isFile(snapshotAbsolute))) return loc;
       return createRunStorageLocation(
         snapshotAbsolute,
         loc.relativePath,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -427,8 +427,12 @@ function createRoundProgressCallback(
   streamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
   onProgress?: (update: SubagentProgressUpdate) => void,
-): (roundIndex: number, totalRounds: number) => void {
-  return (roundIndex, totalRounds) => {
+): (
+  roundIndex: number,
+  totalRounds: number,
+  outputPaths?: readonly string[],
+) => void {
+  return (roundIndex, totalRounds, outputPaths) => {
     updateExecutionProgress(executionId, {
       currentRound: roundIndex,
       totalRounds,
@@ -437,6 +441,7 @@ function createRoundProgressCallback(
       kind: 'round',
       currentRound: roundIndex,
       totalRounds,
+      outputPaths: outputPaths ?? [],
     });
     runtimeHost.emit('updateConversationProgress', {
       streamId,

--- a/src/shared/schemas/subagentProgress.ts
+++ b/src/shared/schemas/subagentProgress.ts
@@ -21,6 +21,11 @@ export interface RoundProgressUpdate {
   readonly kind: 'round';
   readonly currentRound: number;
   readonly totalRounds: number;
+  /** Workspace-relative (or external absolute) paths of files produced by
+   *  this round. Empty when the round produced no output files. The
+   *  orchestrator can read these on demand without waiting for the final
+   *  delivery. */
+  readonly outputPaths: readonly string[];
 }
 
 /** Periodic overview of tool-use subagent activity. */

--- a/src/shared/utils/xmlEscape.ts
+++ b/src/shared/utils/xmlEscape.ts
@@ -1,0 +1,17 @@
+/** XML/HTML escaping helpers. Single source of truth for both agent-core
+ *  XML emission (e.g. <subagent-result> wrappers) and frontend HTML
+ *  interpolation (e.g. processMarkdownContent's LaTeX reference labels).
+ *  Co-located in @shared/utils so both sides import the same function. */
+
+/** Escape for use inside a double-quoted HTML/XML attribute value. */
+export function escapeAttr(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;');
+}
+
+/** Escape XML/HTML text content (element bodies). */
+export function escapeText(s: string): string {
+  return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;');
+}

--- a/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
+++ b/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
@@ -1,0 +1,31 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - progress view
+import { processMarkdownContent } from '@progressView/frontend/formatters/markdownRenderer';
+
+describe('processMarkdownContent security', () => {
+  it('escapes raw HTML before rendering markdown output', () => {
+    const rendered = processMarkdownContent('<script>alert(1)</script>');
+    const dom = new JSDOM(`<main>${rendered}</main>`);
+
+    expect(dom.window.document.querySelector('script')).toBeNull();
+    expect(dom.window.document.body.textContent).toContain(
+      '<script>alert(1)</script>',
+    );
+  });
+
+  it('escapes restored LaTeX reference labels before HTML insertion', () => {
+    const label = 'bad" onclick="alert(1)<img src=x>';
+    const rendered = processMarkdownContent(`See \\ref{${label}}.`);
+    const dom = new JSDOM(`<main>${rendered}</main>`);
+    const ref = dom.window.document.querySelector('.latex-ref');
+
+    expect(ref).not.toBeNull();
+    expect(ref?.getAttribute('onclick')).toBeNull();
+    expect(ref?.getAttribute('data-label')).toBe(label);
+    expect(ref?.textContent).toBe(`\\ref{${label}}`);
+    expect(dom.window.document.querySelector('img')).toBeNull();
+  });
+});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -51,7 +51,7 @@ import type {
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
-import { escapeAttr, escapeText } from '@tools/subagentResults';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -445,5 +445,3 @@ function lastNLines(text: string, n: number): string {
   const lines = text.split('\n');
   return lines.length <= n ? text : lines.slice(-n).join('\n');
 }
-
-export { escapeAttr, escapeText } from '@shared/utils/xmlEscape';

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -21,6 +21,7 @@ import type {
 } from '@shared/schemas';
 import { TODO_STATUS } from '@shared/schemas/todo';
 import { countByStatus } from '@shared/schemas/todoDisplay';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { formatDuration } from '@utils/core';
 import type { DiffFileInfo } from './subagentDiffs';
 
@@ -445,14 +446,4 @@ function lastNLines(text: string, n: number): string {
   return lines.length <= n ? text : lines.slice(-n).join('\n');
 }
 
-export function escapeAttr(s: string): string {
-  return s
-    .replaceAll('&', '&amp;')
-    .replaceAll('"', '&quot;')
-    .replaceAll('<', '&lt;');
-}
-
-/** Escape XML text content (element bodies). */
-export function escapeText(s: string): string {
-  return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;');
-}
+export { escapeAttr, escapeText } from '@shared/utils/xmlEscape';

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -217,8 +217,16 @@ export function formatSubagentProgress(
       ].join('\n');
     }
 
-    case 'round':
-      return `<subagent-progress ${idAttr} ${agentAttr} type="round" current="${update.currentRound + 1}" total="${update.totalRounds}" />`;
+    case 'round': {
+      const head = `<subagent-progress ${idAttr} ${agentAttr} type="round" current="${update.currentRound + 1}" total="${update.totalRounds}"`;
+      if (update.outputPaths.length === 0) {
+        return `${head} />`;
+      }
+      const fileLines = update.outputPaths.map(
+        (p) => `<file path="${escapeAttr(p)}" />`,
+      );
+      return [`${head}>`, ...fileLines, '</subagent-progress>'].join('\n');
+    }
 
     case 'overview': {
       const fileList =

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -97,6 +97,26 @@ export function getRunDir(id: ExecutionId): string {
 }
 
 /**
+ * Absolute path of the immutable pre-run snapshot for a base file. The
+ * snapshot is captured by {@link TaskRunFileService.prepareRunWorkspace}
+ * before any agent modifications, so diffs against it remain accurate
+ * even for in-place workflows where the live workspace file has since
+ * been overwritten by the agent.
+ *
+ * Returns the candidate path unconditionally; callers should `stat` it
+ * before reading because `prepareRunWorkspace` skips files that were
+ * absent or non-regular at snapshot time.
+ */
+export function getOriginalSnapshotPath(
+  executionId: ExecutionId,
+  workspaceRelativePath: string,
+): string {
+  return StorageFS.fullPath(
+    path.join(TASK_RUNS_DIR, executionId, 'original', workspaceRelativePath),
+  );
+}
+
+/**
  * Resolve a storage-relative path, checking `executions/` first then
  * legacy `taskRuns/`. Returns the storage-relative path that exists,
  * or `undefined` if neither location has the target.


### PR DESCRIPTION
## Summary
- **#3853** — Workflow agents that overwrite the input file in-place produced +0/-0 diff stats because `computeDiffStats` read the same path twice. New `snapshotResolution.ts` substitutes workspace base files with their pre-run snapshot (captured by `prepareRunWorkspace` under `executions/<id>/original/<relativePath>`). `computeDiffStats` itself is unchanged; it receives the right `FileLocation`.
- **#3852** — `RoundProgressUpdate` now carries `outputPaths` so the orchestrator can see what a sub-workflow produced before the final delivery. `formatSubagentProgress` emits these as `<file path="..."/>` children of `<subagent-progress type="round">`.
- **#3850** — `UserMessage` renders structured-delivery messages (subagent / codex / background results) through the existing markdown renderer so lists and code fences render naturally. The renderer keeps raw HTML disabled and restores LaTeX references only after escaping label text and attributes. `MemoryItem` also keeps note previews compact and scrollable.

## Test plan
- [x] `npx vitest run src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts`
- [x] `npx tsc --noEmit`
- [x] `npm run format`
- [x] `CI=true npm run compile:fast`
- [x] `npm run lint` (0 errors; existing import-order warnings remain)
- [ ] Run a workflow agent that rewrites its input file: confirm progress shows non-zero +/- counts on r1 instead of +0/-0
- [ ] Delegate to a workflow subagent producing files: confirm orchestrator sees `<file path="..."/>` entries inside `<subagent-progress type="round">` between rounds
- [ ] Trigger a subagent delivery containing markdown (lists, code fences): confirm the UserMessage bubble renders formatted markdown
- [ ] Open Memory tab with several long notes: confirm preview panes are compact (≤140 px) and scrollable

Fixes #3853, #3852, #3850

🤖 Generated with [Claude Code](https://claude.com/claude-code)