### PR TITLE
fix(desktop): simplify launcher back button

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -280,7 +280,7 @@ function shellTemplate(): TemplateResult {
       <nav class="desktop-nav" aria-label="Desktop chrome">
         <span class="desktop-brand">TeXRA</span>
         <wa-button
-          class="desktop-back-button"
+          class="desktop-icon-button"
           appearance="plain"
           size="small"
           ?hidden=${!showConversation}
@@ -288,7 +288,7 @@ function shellTemplate(): TemplateResult {
           aria-label="Back to launcher"
           @click=${returnToLauncher}
         >
-          ${waIcon('arrow-left', { slot: 'start' })} Launcher
+          ${waIcon('arrow-left', { label: 'Back to launcher' })}
         </wa-button>
         <wa-button
           class="desktop-command-button"
@@ -318,7 +318,7 @@ function shellTemplate(): TemplateResult {
               title=${spec.label}
               @click=${spec.onClick}
             >
-              ${waIcon(spec.icon)}
+              ${waIcon(spec.icon, { label: spec.label })}
             </wa-button>
           `,
         )}

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -49,15 +49,6 @@ wa-button[hidden] {
   display: none !important;
 }
 
-wa-button.desktop-back-button::part(base) {
-  height: 28px;
-  padding: 0 10px;
-  border-color: transparent;
-  border-radius: var(--wa-border-radius-m);
-  background: transparent;
-  color: var(--wa-color-text-normal);
-}
-
 wa-button.desktop-icon-button::part(base) {
   width: 28px;
   height: 28px;

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -373,10 +373,11 @@ interface WaIconOptions {
   readonly slot?: 'start' | 'end' | 'icon';
   readonly className?: string;
   readonly variant?: 'solid' | 'regular';
+  readonly label?: string;
 }
 
-// Lit template for <wa-icon>. Centralizes library + variant + aria-hidden so
-// callers don't repeat them.
+// Lit template for <wa-icon>. Decorative icons stay hidden from assistive
+// technology; icon-only controls pass a label as required by Web Awesome.
 export function waIcon(
   name: TeXRAIconName,
   options: WaIconOptions = {},
@@ -387,6 +388,7 @@ export function waIcon(
     variant=${options.variant ?? 'solid'}
     slot=${ifDefined(options.slot)}
     class=${ifDefined(options.className)}
-    aria-hidden="true"
+    label=${ifDefined(options.label)}
+    aria-hidden=${ifDefined(options.label == null ? 'true' : undefined)}
   ></wa-icon>`;
 }

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -89,6 +89,25 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     );
   });
 
+  it('renders the launcher back action as an icon-only chrome button', () => {
+    const rendererMain = readRendererMain();
+    const styles = readRendererStyles();
+
+    expect(rendererMain).toMatch(/class="[^"]*\bdesktop-icon-button\b[^"]*"/);
+    expect(rendererMain).toContain('title="Back to launcher"');
+    expect(rendererMain).toContain('aria-label="Back to launcher"');
+    expect(rendererMain).toMatch(
+      /waIcon\('arrow-left',\s*\{\s*label:\s*'Back to launcher'\s*\}\)/,
+    );
+    expect(rendererMain).toContain('waIcon(spec.icon, { label: spec.label })');
+    expect(rendererMain).not.toContain('TEXRA_ICON_LIBRARY');
+    expect(rendererMain).not.toContain('desktop-back-button');
+    expect(rendererMain).not.toContain(
+      "${waIcon('arrow-left', { slot: 'start' })} Launcher",
+    );
+    expect(styles).not.toContain('wa-button.desktop-back-button::part(base)');
+  });
+
   it('mounts settings as a wa-dialog overlay (not a route)', () => {
     const rendererMain = readRendererMain();
     const styles = readRendererStyles();


### PR DESCRIPTION
## Summary
- Simplifies the Desktop conversation back control to an icon-only chrome button.
- Uses the shared `waIcon` helper with an explicit icon label, so this Web Awesome icon-only button remains accessible while decorative icons stay hidden.
- Removes the obsolete back-button-specific styling and adds a renderer-shell regression test so the inline `Launcher` label does not return accidentally.

## Test plan
- [x] `npx vitest run src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- [x] `npx tsc --noEmit`
- [x] `npm run format`
- [x] `CI=true npm run compile:fast`
- [x] `npm run lint` (0 errors; existing import-order warnings remain)

Fixes #3863

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility tweak limited to desktop renderer chrome, with a small shared `waIcon` helper change that could affect icon ARIA behavior if misused.
> 
> **Overview**
> Simplifies the desktop renderer “Back to launcher” control into an **icon-only** chrome button and removes the dedicated back-button styling.
> 
> Extends the shared `waIcon` helper to optionally accept an accessible `label`, keeping decorative icons `aria-hidden` while allowing icon-only buttons to provide the required label. Adds a regression test to ensure the icon-only back button and labeling don’t revert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bed0ccc6526f437a0efc3adb439c8a7c06b1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->