### PR TITLE
fix: remove workflow outputExt setting

### DIFF
--- a/docs/blog/launch-blog-post.md
+++ b/docs/blog/launch-blog-post.md
@@ -257,7 +257,6 @@ All agents are defined in YAML. Want a custom agent for your subfield? Create `m
 name: quantum_polish
 settings:
   agentCategory: workflow
-  outputExt: tex
 prompts:
   systemPrompt: |
     You are a quantum information theorist. Ensure all notation

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -59,7 +59,6 @@ settings:
   # Output Handling
   documentTag: document # The main XML tag wrapping the agent's final output (required for CoT).
   endTag: '</document>' # The closing tag that signals the agent has finished its main output.
-  outputExt: tex # Default file extension for the output file (e.g., tex, md, txt).
   prefills:
     - "<document>\n" # List of strings the AI should start its response(s) with.
       # Item [0] is for Round 0, Item [1] is for Round 1 (reflection).

--- a/packages/extension/resources/agents/correct.yaml
+++ b/packages/extension/resources/agents/correct.yaml
@@ -6,7 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   rounds: 1
-  outputExt: tex
   prefills:
     - "Here are the revised \\LaTeX documents. <documents>"
 

--- a/packages/extension/resources/agents/merge.yaml
+++ b/packages/extension/resources/agents/merge.yaml
@@ -6,7 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   rounds: 1
-  outputExt: tex
   prefills:
     - '<documents>'
 

--- a/packages/extension/resources/agents/ocr.yaml
+++ b/packages/extension/resources/agents/ocr.yaml
@@ -5,7 +5,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
   prefills:
     - "Here is the \\LaTeX OCR output. <documents>"
     - ''

--- a/packages/extension/resources/agents/polish.yaml
+++ b/packages/extension/resources/agents/polish.yaml
@@ -5,7 +5,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/transcribe_audio.yaml
+++ b/packages/extension/resources/agents/transcribe_audio.yaml
@@ -5,7 +5,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
   prefills:
     - 'Here is the audio transcript. <documents>'
     - ''

--- a/packages/extension/resources/agents/write/paper2poster.yaml
+++ b/packages/extension/resources/agents/write/paper2poster.yaml
@@ -3,7 +3,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
   isRewrite: False
   prefills:
     - 'Here is the Beamer poster. <documents>'

--- a/packages/extension/resources/agents/write/paper2slide.yaml
+++ b/packages/extension/resources/agents/write/paper2slide.yaml
@@ -3,7 +3,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
   prefills:
     - 'Here is the Beamer presentation. <documents>'
     - ''

--- a/packages/extension/resources/docs/agent-creation/execution_and_testing.md
+++ b/packages/extension/resources/docs/agent-creation/execution_and_testing.md
@@ -13,8 +13,8 @@ flow shapes:
 
 - **Workflow flow** for `agentCategory: workflow`. Fixed rounds, each round
   consumes paired `prefills[i]` / `userRequest[i]`. Operates on a single
-  `inputFile` (or the active editor selection). Emits output files per
-  `outputExt` / `documentTag` / `defaultOutputFiles`.
+  `inputFile` (or the active editor selection). Emits LaTeX output files per
+  `documentTag` / `defaultOutputFiles`.
 - **Tool-use flow** for `agentCategory: toolUse`. Multi-step loop invoking
   declared tools. May WAIT for interim follow-ups, spawn subagents via
   `delegate_workflow` / `delegate_agent`, and resume.
@@ -45,8 +45,8 @@ Use the `delegate_*` tools in the `tools:` list of `creator.yaml`.
    ```
 3. When the follow-up arrives:
    - Inspect the output file(s) the subagent produced.
-   - Confirm the agent honoured `outputExt: tex`, wrapped output correctly,
-     and produced non-empty content.
+   - Confirm the agent wrapped output correctly and produced non-empty LaTeX
+     content.
    - Report pass/fail to the user.
 
 ### Testing a tool-use agent

--- a/packages/extension/resources/docs/agent-creation/workflow_schema.md
+++ b/packages/extension/resources/docs/agent-creation/workflow_schema.md
@@ -16,7 +16,6 @@ settings:
   isRewrite: true # true = editing existing docs, false = creating new
   rounds: 2 # 1 or 2 (default 2)
   temperature: 0.1 # 0.1 for editing, 0.5-0.8 for creative tasks
-  outputExt: tex # MUST be "tex" — TeXRA is a LaTeX tool
   documentTag: documents
   endTag: '</documents>'
   prefills: # MUST have exactly `rounds` entries
@@ -45,7 +44,6 @@ prompts:
 
 ## Critical rules
 
-- `outputExt` MUST be `"tex"`. TeXRA is a LaTeX tool — nothing else is valid.
 - `prefills` and `userRequest` MUST both have the same number of entries as
   `rounds`. Round 1 → one entry each; round 2 → two entries each.
 - Always include `{{ INSTRUCTION }}` somewhere so user instructions pass
@@ -136,7 +134,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: '</documents>'
-  outputExt: tex
   prefills:
     - '<scratchpad>'
     - '<scratchpad>'

--- a/packages/extension/resources/templates/agentCreatorWorkflow.yaml
+++ b/packages/extension/resources/templates/agentCreatorWorkflow.yaml
@@ -19,7 +19,6 @@ prompts:
 
     CRITICAL RULES:
     - agentCategory MUST be "workflow" (not "toolUse"). Workflow agents do NOT call tools.
-    - outputExt MUST be "tex" (not "md", "txt", or anything else). TeXRA is a LaTeX tool.
     - documentTag SHOULD be "documents" for new workflow agents.
     - endTag MUST match documentTag as a closing XML tag (e.g. "</documents>").
     - Infer appropriate settings from the agent's description:
@@ -30,8 +29,7 @@ prompts:
     - prefills is OPTIONAL. Omit it unless the agent should skip preamble and force
       the response to start with a specific token (e.g., - "<documents>").
       If you do include prefills, the array length MUST equal the number of rounds.
-    - All fields with defaults can be omitted if the default value is acceptable,
-      BUT outputExt defaults to "txt" so it must always be set explicitly to "tex".
+    - Fields with defaults can be omitted if the default value is acceptable.
     Respond only with the YAML wrapped in <yaml> tags.
 
     TEMPLATE VARIABLES available in prompts (Nunjucks double-brace syntax):
@@ -62,7 +60,6 @@ prompts:
       agentCategory: workflow
       documentTag: documents
       endTag: </documents>
-      outputExt: tex
       isRewrite: <true if editing existing docs, false if creating new>
       temperature: <0.1 for precise editing, 0.5-0.8 for creative>
     prompts:
@@ -91,7 +88,6 @@ prompts:
       agentCategory: workflow
       documentTag: documents
       endTag: </documents>
-      outputExt: tex
     prompts:
       systemPrompt: |
         You are a professional scientist. Your task is to improve a LaTeX research paper
@@ -129,7 +125,6 @@ prompts:
           Output the further enhanced content as <documents><document name="{{ INPUT_FILE }}">...</document></documents>.
 
     IMPORTANT REMINDERS:
-    - outputExt MUST be "tex", never "md" or "txt".
     - The documentTag in prompts must match the settings.documentTag.
     - userRequest must be an array with exactly as many entries as rounds (1 or 2).
     - Omit prefills by default; only add it (with one entry per round) when the agent should

--- a/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
@@ -10,7 +10,6 @@ settings:
   isRewrite: true
   documentTag: documents
   endTag: </documents>
-  outputExt: tex
   # Optional: `prefills` can force the assistant turn to start with a specific
   # token (e.g., - "<documents>") for agents that should skip preamble
   # and jump straight to output. Most workflow agents do not need this --- modern

--- a/packages/extension/resources/tool_use_agents/creator.yaml
+++ b/packages/extension/resources/tool_use_agents/creator.yaml
@@ -128,7 +128,6 @@ prompts:
     - Agent names: lowercase, underscores or dashes only.
     - Keep prompts focused. Write precisely what the agent needs for its
       specific purpose — do not pad with boilerplate.
-    - For workflow agents, `outputExt` must be `tex`. Always.
     - For workflow agents, `prefills` and `userRequest` must have the same
       number of entries as `rounds`.
     - For tool-use agents, `userRequest` must be a single string that

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -36,7 +36,6 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   isRewrite: z.boolean().prefault(true),
   rounds: z.number().prefault(2),
   prefills: z.array(z.string()).prefault([]),
-  outputExt: z.string().prefault('txt'),
 });
 
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
@@ -44,6 +43,15 @@ export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
     .literal(AgentCategory.ToolUse)
     .prefault(AgentCategory.ToolUse),
 });
+
+/** Drop obsolete settings accepted only for legacy YAML and persisted state. */
+function stripLegacySettingFields(input: unknown): unknown {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return input;
+  }
+  const { outputExt: _outputExt, ...rest } = input as Record<string, unknown>;
+  return rest;
+}
 
 /** Derive endTag from documentTag when endTag is not explicitly set. */
 function deriveEndTag(input: unknown): unknown {
@@ -58,7 +66,7 @@ function deriveEndTag(input: unknown): unknown {
 }
 
 export const AgentSettingSchema = z.preprocess(
-  deriveEndTag,
+  (input) => deriveEndTag(stripLegacySettingFields(input)),
   z.discriminatedUnion('agentCategory', [
     AgentWorkflowSettingSchema,
     AgentToolUseSettingSchema,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -27,6 +27,10 @@ import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  WORKFLOW_DOCUMENT_OUTPUT_EXT,
+  WORKFLOW_RAW_OUTPUT_EXT,
+} from '@agent/output/workflowOutputLayout';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import { LatexMediaManager } from '@latex';
 import type { AgentLogStage } from '@logger/AgentLogger';
@@ -164,7 +168,7 @@ export async function runReflectionFlow<C = unknown>(
         );
       }
       const canonical = fileService.createLocation(
-        getOutputFileName('xml', round),
+        getOutputFileName(WORKFLOW_RAW_OUTPUT_EXT, round),
       ) as AgentFileLocation;
       // Resume-from-pre-refactor compat: if a round was partially written on an
       // older build that used `.tex` for non-scratchpad agents, keep using that
@@ -172,7 +176,7 @@ export async function runReflectionFlow<C = unknown>(
       // instead of starting a fresh round at output.xml.
       if (!AbsoluteFS.existsSync(canonical.absolutePath)) {
         const legacy = fileService.createLocation(
-          getOutputFileName('tex', round),
+          getOutputFileName(WORKFLOW_DOCUMENT_OUTPUT_EXT, round),
         ) as AgentFileLocation;
         if (AbsoluteFS.existsSync(legacy.absolutePath)) {
           return legacy;

--- a/src/agent/output/workflowOutputLayout.ts
+++ b/src/agent/output/workflowOutputLayout.ts
@@ -24,6 +24,12 @@ import { escapeRegExp } from '@utils/core/stringCore';
 /** The fixed basename of every workflow output file (no extension). */
 export const WORKFLOW_OUTPUT_BASENAME = 'output';
 
+/** The fixed extension for TeXRA-named LaTeX workflow outputs. */
+export const WORKFLOW_DOCUMENT_OUTPUT_EXT = 'tex';
+
+/** The fixed extension for raw workflow round output. */
+export const WORKFLOW_RAW_OUTPUT_EXT = 'xml';
+
 /** Parse a directory name of the form `r{round}` into its round index. */
 export function parseWorkflowOutputRoundDir(dirName: string): number | null {
   const match = /^r(\d+)$/.exec(dirName);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -927,10 +927,8 @@ export async function executeMergeAgent(
             onRoundFinalized: (run) =>
               ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
             setting: mergeSetting,
-            getOutputFileLocation: createMergeOutputFileLocationGetter(
-              fileService,
-              mergeSetting.outputExt,
-            ),
+            getOutputFileLocation:
+              createMergeOutputFileLocationGetter(fileService),
             parentStage: ctx.parentStage,
             onRoundCompleted: createRoundProgressCallback(
               ctx.executionId,

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import {
+  WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_OUTPUT_BASENAME,
   workflowMergeOutputPath,
   workflowOutputPath,
@@ -21,8 +22,8 @@ import type { TaskRunFileService, AgentFileLocation } from '@utils/files';
  * would route every round to the same `<workspace>/r{round}/output.{ext}`
  * and clobber outputs across runs.
  */
-export function getOutputFileName(outputExt: string, round: number): string {
-  return workflowOutputPath({ ext: outputExt, round });
+export function getOutputFileName(extension: string, round: number): string {
+  return workflowOutputPath({ ext: extension, round });
 }
 
 /**
@@ -70,27 +71,27 @@ export function getExtractedDocOutputFileName(
  *
  * Merge is a single-output workflow: the round number is not reflected in
  * the filename and the same location is returned for every round. The
- * merge output lives at the runDir root as `_full.{ext}`; per-execution
+ * merge output lives at the runDir root as `_full.tex`; per-execution
  * isolation keeps it from colliding with other runs.
  *
- * The fileService MUST carry an executionId; the fixed `_full.{ext}` path
+ * The fileService MUST carry an executionId; the fixed `_full.tex` path
  * relies on run-storage isolation for uniqueness. Without it, every merge
  * in the workspace would clobber the same file.
  *
- * @param outputExt Extension for the merge output (usually `setting.outputExt`,
- *   which is `tex` for the default merge agent but may differ for a custom
- *   merge agent configured with a non-TeX output format).
+ * Merge is always a LaTeX workflow, so the output extension is fixed rather
+ * than configurable through agent YAML.
  */
 export function createMergeOutputFileLocationGetter(
   fileService: TaskRunFileService,
-  outputExt: string,
 ): (round: number) => AgentFileLocation {
   if (!fileService.hasRunDirectory()) {
     throw new Error(
-      'createMergeOutputFileLocationGetter requires a TaskRunFileService bound to an executionId; the `_full.{ext}` path is only collision-safe inside per-execution run storage.',
+      'createMergeOutputFileLocationGetter requires a TaskRunFileService bound to an executionId; the `_full.tex` path is only collision-safe inside per-execution run storage.',
     );
   }
-  const outputPath = workflowMergeOutputPath({ ext: outputExt });
+  const outputPath = workflowMergeOutputPath({
+    ext: WORKFLOW_DOCUMENT_OUTPUT_EXT,
+  });
   const location = fileService.createLocation(outputPath) as AgentFileLocation;
   return (_round: number): AgentFileLocation => location;
 }

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentCategory, AgentSettingSchema } from '@agent/core/AgentDataclass';
+
+describe('AgentSettingSchema', () => {
+  it('strips legacy workflow outputExt without exposing it in settings', () => {
+    const setting = AgentSettingSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+      outputExt: 'tex',
+    });
+
+    expect(setting.agentCategory).toBe(AgentCategory.Workflow);
+    expect(Object.hasOwn(setting, 'outputExt')).toBe(false);
+  });
+});

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1324,7 +1324,6 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
         agentCategory: AgentCategory.Workflow,
         documentTag: 'latex_document',
         endTag: '</latex_document>',
-        outputExt: 'tex',
       });
       const messages: MessageParam[] = [
         {
@@ -1373,7 +1372,6 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
         agentCategory: AgentCategory.Workflow,
         documentTag: 'latex_document',
         endTag: '</latex_document>',
-        outputExt: 'tex',
       });
       const userMessage: MessageParam = {
         role: 'user',
@@ -1418,7 +1416,6 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
         agentCategory: AgentCategory.Workflow,
         documentTag: 'latex_document',
         endTag: '</latex_document>',
-        outputExt: 'tex',
       });
       const userText = 'revise the document';
       const messages: MessageParam[] = [

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -108,4 +108,36 @@ describe('loadAgentSettingAndPrompts', () => {
       'internal: true should round-trip through AgentSettingSchema',
     );
   });
+
+  it('loads legacy workflow settings that still declare outputExt', async () => {
+    const agentPath = path.join('/', 'tmp', 'agents');
+    const definitionPath = path.join(agentPath, 'legacy.yaml');
+    const resolution: ResolvedAgent = {
+      entry: {
+        source: 'custom',
+        name: 'legacy',
+        path: definitionPath,
+        category: AgentCategory.Workflow,
+      },
+      definitionPath,
+      resolvedName: 'legacy',
+    };
+
+    fileContents.set(
+      normalize(definitionPath),
+      [
+        'name: legacy',
+        'settings:',
+        '  agentCategory: workflow',
+        '  outputExt: tex',
+        'prompts:',
+        '  userRequest: fix it',
+        '',
+      ].join('\n'),
+    );
+
+    const [settings] = await loadAgentSettingAndPrompts(resolution);
+    assert.strictEqual(settings.agentCategory, AgentCategory.Workflow);
+    assert.strictEqual(Object.hasOwn(settings, 'outputExt'), false);
+  });
 });

--- a/src/test/agent/utils/promptBuilder.test.ts
+++ b/src/test/agent/utils/promptBuilder.test.ts
@@ -19,7 +19,6 @@ describe('PromptBuilder', () => {
     isRewrite: true,
     rounds: 2,
     prefills: [],
-    outputExt: 'tex',
     defaultOutputFiles: [],
     requiredFiles: {},
     requiredFilesInternal: {},

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -17,7 +17,6 @@ const baseSetting: AgentSetting = {
   isRewrite: true,
   rounds: 1,
   prefills: [],
-  outputExt: 'tex',
   endTag: '</documents>',
   requiredFiles: {},
   requiredFilesInternal: {},


### PR DESCRIPTION
## Summary

- Remove `outputExt` from workflow agent settings and make merge output use the fixed LaTeX extension internally.
- Strip legacy `outputExt` while parsing agent settings so older custom YAML and persisted settings continue to load.
- Remove `outputExt` from bundled workflow agents, agent templates, and agent-creation documentation.

Fixes #3162.

## Verification

- `npx vitest run src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test-kernel/agent/OutputFilesOrderPrompt.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `CI=true npm run compile:fast`
- `npm run lint` (0 errors, 77 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow agent settings parsing and the on-disk output naming/extension used by workflow and merge runs; regressions could break loading of custom agents or resuming existing executions despite added legacy-compat stripping/tests.
> 
> **Overview**
> **Removes `outputExt` as a supported workflow-agent setting** across bundled agents, templates, and docs, standardizing workflow outputs to fixed extensions instead of YAML-configurable ones.
> 
> **Runtime updates:** `AgentSettingSchema` now strips legacy `outputExt` during preprocess (so older YAML/persisted state still parses), workflow round raw output is treated as `output.xml`, and merge output is always `_full.tex` (no longer parameterized). Adds/updates tests to verify legacy `outputExt` is ignored and call sites no longer depend on it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe6b489b5cce0e57ab45cc8230830284e98173f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->