### PR TITLE
fix: preserve find_current default branch fallback

### DIFF
--- a/src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts
+++ b/src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOriginHeadDefaultBranch } from '@tools/github/githubSubscriptionTool';
+
+describe('parseOriginHeadDefaultBranch', () => {
+  it('extracts the branch name from origin HEAD symbolic refs', () => {
+    expect(parseOriginHeadDefaultBranch('origin/main')).toBe('main');
+    expect(parseOriginHeadDefaultBranch('refs/remotes/origin/trunk')).toBe(
+      'trunk',
+    );
+  });
+
+  it('ignores non-origin symbolic refs', () => {
+    expect(parseOriginHeadDefaultBranch('upstream/main')).toBeUndefined();
+    expect(
+      parseOriginHeadDefaultBranch('refs/remotes/upstream/main'),
+    ).toBeUndefined();
+  });
+});

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -344,6 +344,26 @@ async function getDefaultBranch(owner: string, repo: string): Promise<string> {
   return res.data.default_branch ?? 'main';
 }
 
+export function parseOriginHeadDefaultBranch(ref: string): string | undefined {
+  const branch = ref.trim().replace(/^refs\/remotes\//, '');
+  if (!branch.startsWith('origin/')) return undefined;
+  return branch.slice('origin/'.length) || undefined;
+}
+
+async function getLocalDefaultBranchHint(
+  cwd: string,
+): Promise<string | undefined> {
+  try {
+    const ref = await gitInDir(
+      ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+      cwd,
+    );
+    return parseOriginHeadDefaultBranch(ref);
+  } catch {
+    return undefined;
+  }
+}
+
 async function listOpenPullSuggestions(
   owner: string,
   repo: string,
@@ -365,9 +385,10 @@ async function listOpenPullSuggestions(
 async function getFindCurrentFallbackInfo(
   owner: string,
   repo: string,
+  cwd: string,
 ): Promise<{ defaultBranch?: string; suggestions: string }> {
   const [defaultBranchResult, suggestionsResult] = await Promise.allSettled([
-    getDefaultBranch(owner, repo),
+    getDefaultBranch(owner, repo).catch(() => getLocalDefaultBranchHint(cwd)),
     listOpenPullSuggestions(owner, repo),
   ]);
   return {
@@ -422,6 +443,7 @@ async function execFindCurrent(
     const { defaultBranch, suggestions } = await getFindCurrentFallbackInfo(
       remote.owner,
       remote.repo,
+      cwd,
     );
     if (branch === defaultBranch) {
       throw new ToolError(


### PR DESCRIPTION
## Summary

- Recover a default-branch hint for `find_current` from local `origin/HEAD` when the GitHub default-branch API call fails.
- Preserve the existing “default branch unknown” behavior when neither the API nor the local symbolic ref can identify the default branch.
- Add a kernel test for parsing local `origin/HEAD` symbolic refs.

Fixes #3262.

## Verification

- `npx vitest run src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts`
- `npm run format`
- `npm run typecheck`
- `CI=true npm run compile:fast`
- `npm run lint` (0 errors, 77 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a local-git fallback when the GitHub default-branch API call fails, plus unit coverage; behavior is otherwise unchanged and failure still results in the existing "default branch unknown" errors.
> 
> **Overview**
> Improves `github_subscription` `find_current` fallback behavior by recovering the repo default-branch hint from the local `refs/remotes/origin/HEAD` symbolic ref when the GitHub `/repos/{owner}/{repo}` default-branch lookup fails.
> 
> Adds `parseOriginHeadDefaultBranch()` and a `vitest` kernel test to ensure only `origin/*` refs are parsed and non-`origin` refs are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c255154f112dfb9aba79745195e23230e57f293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->