### PR TITLE
fix: back off annotation rate limits

### DIFF
--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -1,0 +1,54 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - tools
+import { GitHubRateLimitError } from '@tools/github/githubClient';
+import { PRPollingSource } from '@tools/github/PRPollingSource';
+import type { GhCheckRun } from '@tools/github/prTypes';
+
+interface AnnotationDrainState {
+  pr: { owner: string; repo: string; pullNumber: number };
+  slug: string;
+  listeners: Set<(text: string) => void>;
+  pendingAnnotationRuns: GhCheckRun[];
+}
+
+interface AnnotationDrainSource {
+  drainAnnotationQueue(state: AnnotationDrainState): Promise<void>;
+  fetchAnnotations(
+    owner: string,
+    repo: string,
+    checkRunId: number,
+  ): Promise<unknown[]>;
+}
+
+function createCheckRun(id: number): GhCheckRun {
+  return {
+    id,
+    name: 'lint',
+    status: 'completed',
+    conclusion: 'success',
+    html_url: `https://example.test/checks/${id}`,
+    completed_at: '2026-05-12T00:00:00Z',
+    output: { annotations_count: 1 },
+  };
+}
+
+describe('PRPollingSource annotation drain', () => {
+  it('propagates annotation rate limits to the base poller backoff path', async () => {
+    const source = new PRPollingSource() as unknown as AnnotationDrainSource;
+    const run = createCheckRun(42);
+    const state: AnnotationDrainState = {
+      pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
+      slug: 'owner/repo',
+      listeners: new Set(),
+      pendingAnnotationRuns: [run],
+    };
+    const rateLimit = new GitHubRateLimitError(1_800_000_000);
+    source.fetchAnnotations = vi.fn().mockRejectedValue(rateLimit);
+
+    await expect(source.drainAnnotationQueue(state)).rejects.toBe(rateLimit);
+    expect(source.fetchAnnotations).toHaveBeenCalledWith('owner', 'repo', 42);
+    expect(state.pendingAnnotationRuns).toEqual([run]);
+  });
+});

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -33,9 +33,8 @@ import {
   ghGet,
   GitHubAuthError,
   GitHubPermanentError,
+  GitHubRateLimitError,
 } from './githubClient';
-import type { Disposable } from '@platform/interfaces/disposable';
-
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,
@@ -54,6 +53,7 @@ import {
   type GhReviewComment,
 } from './prTypes';
 import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
+import type { Disposable } from '@platform/interfaces/disposable';
 
 function createInitialState(pr: PRKey): SubscriptionState {
   return {
@@ -863,9 +863,11 @@ export class PRPollingSource extends PollingSourceBase<
    *   scoped token (the main poll's other ghGet calls succeeded, else we
    *   wouldn't be here). If the token is genuinely bad, the main poll path
    *   will detach the subscription via its own ghGet failure.
-   * - Anything else (network, timeout, rate-limit): rotate to the BACK of
-   *   the queue. Without rotation, a persistently-failing head entry would
-   *   starve every other queued run forever.
+   * - `GitHubRateLimitError`: propagate to `PollingSourceBase` so the same
+   *   subscription-level rate-limit backoff governs every GitHub endpoint.
+   * - Anything else (network, timeout): rotate to the BACK of the queue.
+   *   Without rotation, a persistently-failing head entry would starve every
+   *   other queued run forever.
    */
   private async drainAnnotationQueue(state: SubscriptionState): Promise<void> {
     if (state.pendingAnnotationRuns.length === 0) return;
@@ -885,6 +887,13 @@ export class PRPollingSource extends PollingSourceBase<
     // PollingSourceBase.tickInFlight).
     const dropIds = new Set<number>();
     const rotateIds = new Set<number>();
+    const rateLimit = settled.find(
+      (result): result is PromiseRejectedResult =>
+        result.status === 'rejected' &&
+        result.reason instanceof GitHubRateLimitError,
+    );
+    if (rateLimit) throw rateLimit.reason;
+
     for (let i = 0; i < settled.length; i += 1) {
       const run = candidates[i];
       const result = settled[i];


### PR DESCRIPTION
Summary:
- Propagate `GitHubRateLimitError` from PR annotation draining to the shared polling failure path.
- Preserve the annotation queue when rate limits occur, so retries resume after `PollingSourceBase` backoff instead of rotating in-place every tick.
- Add a focused regression test for annotation-drain rate-limit propagation.

Fixes #3332.

Verification:
- `npm run format`
- `npx vitest run src/test-kernel/tools/PRPollingSource.vitest.ts`
- `npm run typecheck`
- `CI=true npm run compile:fast`
- `npm run lint` (0 errors, 76 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR polling error-handling: annotation-drain rate limits now fail the subscription tick to trigger shared backoff, which could change event timeliness and retry behavior across active PR subscriptions.
> 
> **Overview**
> Ensures GitHub annotation-fetch rate limits are handled by the shared `PollingSourceBase` backoff instead of being treated like a transient per-check failure.
> 
> `PRPollingSource.drainAnnotationQueue` now detects `GitHubRateLimitError` from any annotation fetch and rethrows it so polling pauses until the reset time, leaving `pendingAnnotationRuns` intact for a later retry. Adds a focused Vitest regression test asserting the rate-limit error propagates and the annotation queue is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38846200adbdd8a99836131718d9ef1d558ae4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->