### PR TITLE
fix: clear interrupted Codex stream status

### DIFF
--- a/src/test-kernel/tools/CodexLoopStatus.vitest.ts
+++ b/src/test-kernel/tools/CodexLoopStatus.vitest.ts
@@ -1,0 +1,56 @@
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - agent runtime
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+
+// Local imports - schemas
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+// Local imports - tools
+import { finalizeCodexLoopStatus } from '@tools/codex';
+
+const streamIds = [
+  'stream:codex-loop-running',
+  'stream:codex-loop-waiting',
+  'stream:codex-loop-stopped',
+] as const satisfies readonly StreamTabId[];
+
+function effectiveStatus(streamId: StreamTabId): string {
+  return StreamStatusService.get(streamId) ?? STREAM_STATUS.READY;
+}
+
+describe('finalizeCodexLoopStatus', () => {
+  afterEach(() => {
+    for (const streamId of streamIds) {
+      StreamStatusService.clear(streamId, { emit: false });
+    }
+  });
+
+  it('clears RUNNING when the Codex loop exits during an interrupted turn', () => {
+    const streamId = streamIds[0];
+    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+
+    finalizeCodexLoopStatus(streamId);
+
+    expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
+  });
+
+  it('clears WAITING when the Codex loop exits between turns', () => {
+    const streamId = streamIds[1];
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { emit: false });
+
+    finalizeCodexLoopStatus(streamId);
+
+    expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
+  });
+
+  it('preserves terminal statuses set by other runtime paths', () => {
+    const streamId = streamIds[2];
+    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
+
+    finalizeCodexLoopStatus(streamId);
+
+    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+  });
+});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -45,13 +45,14 @@ import type {
   StreamTabId,
   ExecutionId,
   StorageKey,
+  StreamStatus,
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
-import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
@@ -217,6 +218,21 @@ function isCleanCodexInterruption(
   session: CodexFollowUpSession,
 ): boolean {
   return signal.aborted || session.isInterrupted() || isAbortError(err);
+}
+
+function isCodexLoopOwnedStatus(status: StreamStatus | undefined): boolean {
+  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
+}
+
+/**
+ * Clear the transient status owned by a Codex loop after the loop exits.
+ * Explicit terminal statuses set by other runtime paths, such as STOPPED or
+ * ERROR, are left intact.
+ */
+export function finalizeCodexLoopStatus(childStreamId: StreamTabId): void {
+  if (isCodexLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
+    StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+  }
 }
 
 // ============================================================================
@@ -533,9 +549,7 @@ function startCodexLoop(params: {
       await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
 
-      if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
-        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
-      }
+      finalizeCodexLoopStatus(childStreamId);
     }
   })();
 }


### PR DESCRIPTION
## Summary

- Clear Codex loop-owned `RUNNING` and `WAITING` statuses when the Codex loop exits.
- Preserve explicit terminal statuses, such as `STOPPED`, that may have been set by another runtime path.
- Add a kernel regression test for interrupted-turn, between-turn, and terminal-status cleanup.

Fixes #3290

## Verification

- `npm run format`
- `npx vitest run src/test-kernel/tools/CodexLoopStatus.vitest.ts`
- `npm run typecheck`
- `CI=true npm run compile:fast`
- `npm run lint` (0 errors, 75 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Codex child stream status cleanup plus a regression test; potential impact is limited to stream status/UX around interrupted or completed Codex loops.
> 
> **Overview**
> Codex loop shutdown now normalizes the child stream status by clearing Codex-owned transient states (`RUNNING`/`WAITING`) back to `READY` via a new `finalizeCodexLoopStatus`, instead of only resetting `WAITING`.
> 
> It explicitly preserves terminal statuses (e.g. `STOPPED`/`ERROR`) that may be set by other runtime paths, and adds `CodexLoopStatus.vitest.ts` to prevent regressions for interrupted turns, between-turn exits, and terminal-status preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0f5dd29a461ea46b784f22eb652b0d69e3fa62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->