### PR TITLE
fix: refresh moved custom agent subtrees

### DIFF
--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -226,6 +226,9 @@ export class AgentDirectoryManager {
     directories: Array<{ directory: string; source: AgentSource }>,
   ): Promise<void> {
     // Dispose old watchers
+    const previousExternalWatcherDirectoryPaths = new Set(
+      this.externalWatcherDirectoryPaths,
+    );
     this.watcherDisposables.forEach((watcher) => watcher.dispose());
     this.watcherDisposables = [];
     this.externalWatcherDirectoryPaths.clear();
@@ -249,7 +252,11 @@ export class AgentDirectoryManager {
         continue;
       }
 
-      await this.watchExternalCustomDirectory(entry, directoryUri);
+      await this.watchExternalCustomDirectory(
+        entry,
+        directoryUri,
+        previousExternalWatcherDirectoryPaths,
+      );
       watchedDirectories.push(entry.directory);
     }
 
@@ -297,17 +304,26 @@ export class AgentDirectoryManager {
   private async watchExternalCustomDirectory(
     entry: { directory: string; source: AgentSource },
     directoryUri: vscode.Uri,
+    previousDirectoryPaths: ReadonlySet<string>,
   ): Promise<void> {
     const directories = await this.collectDirectoryUris(directoryUri);
+    const newlyWatchedDirectories: vscode.Uri[] = [];
 
     for (const dirUri of directories) {
-      this.externalWatcherDirectoryPaths.add(
-        this.normalizeFsPath(dirUri.fsPath),
-      );
+      const normalizedDirectoryPath = this.normalizeFsPath(dirUri.fsPath);
+      if (
+        previousDirectoryPaths.size > 0 &&
+        !previousDirectoryPaths.has(normalizedDirectoryPath)
+      ) {
+        newlyWatchedDirectories.push(dirUri);
+      }
+      this.externalWatcherDirectoryPaths.add(normalizedDirectoryPath);
       this.watchDirectoryTree(entry, dirUri, '*', (type, uri) =>
         this.handleExternalDirectoryTreeChange(type, uri),
       );
     }
+
+    await this.dispatchExistingYamlFiles(entry, newlyWatchedDirectories);
   }
 
   private async collectDirectoryUris(root: vscode.Uri): Promise<vscode.Uri[]> {
@@ -368,6 +384,34 @@ export class AgentDirectoryManager {
     this.watcherDirectories = null;
     this.watcherRebuildRequested = true;
     this.scheduleAgentWatcherSetup();
+  }
+
+  private async dispatchExistingYamlFiles(
+    entry: { directory: string; source: AgentSource },
+    directories: readonly vscode.Uri[],
+  ): Promise<void> {
+    for (const directory of directories) {
+      let files: [string, vscode.FileType][];
+      try {
+        files = await vscode.workspace.fs.readDirectory(directory);
+      } catch (error) {
+        logger.debug(
+          CHANNEL,
+          `Unable to scan new agent directory ${directory.fsPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        continue;
+      }
+
+      for (const [name, type] of files) {
+        if ((type & vscode.FileType.File) !== 0 && name.endsWith('.yaml')) {
+          this.dispatchAgentEvent(
+            entry,
+            'create',
+            vscode.Uri.joinPath(directory, name),
+          );
+        }
+      }
+    }
   }
 
   private scheduleAgentWatcherSetup(): void {


### PR DESCRIPTION
## Summary

- Preserve the previous external custom-agent watcher directory set during watcher rebuilds.
- Identify directories that are first discovered by a rebuild and scan only those directories for existing `.yaml` agent files.
- Emit synthetic create events for those existing YAML files so `**/*.yaml` subscribers refresh when a populated subtree is moved into the external custom-agent directory.

Fixes #3408

## Verification

- `npm run format`
- `npm run typecheck`
- `CI=true npm run compile:fast`
- `npm run lint` (0 errors, 75 existing warnings)
- `git diff --check`

Not run: manual VS Code watcher scenario. This environment cannot exercise a live extension host file-system watcher by moving a populated directory into the configured external custom-agent directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VS Code file-watcher rebuild behavior for external custom agent directories by emitting synthetic `create` events for existing files, which could cause missed or duplicate refreshes if the directory-diffing logic is off.
> 
> **Overview**
> Fixes external custom-agent watcher rebuilds so moving an already-populated subtree into the watched directory triggers refreshes.
> 
> During `buildAgentWatchers`, the manager now preserves the prior set of external watched directory paths, detects *newly discovered* directories during `watchExternalCustomDirectory`, and scans only those directories for existing `.yaml` files to emit synthetic `create` events via the normal watcher dispatch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e25114a01ddc93e031f3ec03cf6317df510f5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->