### PR TITLE
fix: consolidate tool status formatting

### DIFF
--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -1,0 +1,50 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - schemas
+import { STATUS_DISPLAY, TODO_STATUS } from '@shared/schemas';
+
+// Local imports - tools
+import { formatTodoSection } from '@tools/executionFormatters';
+import { formatSubagentProgress } from '@tools/subagentResults';
+
+describe('tool status formatting', () => {
+  it('formats execution todos with the shared status display', () => {
+    expect(
+      formatTodoSection([
+        { content: 'Write proof', status: TODO_STATUS.COMPLETED },
+        { content: 'Check constants', status: TODO_STATUS.IN_PROGRESS },
+        { content: 'Unknown state', status: 'deferred' },
+      ]),
+    ).toEqual([
+      `${STATUS_DISPLAY[TODO_STATUS.COMPLETED].icon} Write proof`,
+      `${STATUS_DISPLAY[TODO_STATUS.IN_PROGRESS].icon} Check constants`,
+      `${STATUS_DISPLAY[TODO_STATUS.PENDING].icon} Unknown state`,
+    ]);
+  });
+
+  it('formats subagent todos with the shared status display', () => {
+    const progress = formatSubagentProgress('exec-1', 'review', {
+      kind: 'todos',
+      todos: [
+        {
+          content: 'Inspect lemma',
+          status: TODO_STATUS.COMPLETED,
+          activeForm: 'Inspecting lemma',
+        },
+        {
+          content: 'Write response',
+          status: TODO_STATUS.PENDING,
+          activeForm: 'Writing response',
+        },
+      ],
+    });
+
+    expect(progress).toContain(
+      `  ${STATUS_DISPLAY[TODO_STATUS.COMPLETED].icon} Inspect lemma`,
+    );
+    expect(progress).toContain(
+      `  ${STATUS_DISPLAY[TODO_STATUS.PENDING].icon} Write response`,
+    );
+  });
+});

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -641,7 +641,7 @@ const WorkflowAgentInputSchema = z.object({
   agent: z.string().describe('Name of the workflow agent to execute'),
   model: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Model short name (e.g., opus47T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
     ),
@@ -860,13 +860,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
 const DelegateAgentInputSchema = z.object({
   agent: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Name of the tool-use agent to delegate to. Required for new delegations, ignored when resuming via execution_id.',
     ),
   model: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Model short name (e.g., opus47T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
     ),
@@ -879,7 +879,7 @@ const DelegateAgentInputSchema = z.object({
   working_directory: workingDirectoryField,
   execution_id: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'If set, sends follow-up instructions to a tool-use subagent instead of starting a new one. Busy subagents queue the follow-up for their next turn. Use the execution ID from the original delegation result or /executions.',
     ),

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -4,7 +4,12 @@ import {
   type ExecutionStatusInfo,
   getHandle,
 } from '@agent/runtime/executionRegistry';
-import { EXECUTION_STATUS } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  STATUS_DISPLAY,
+  TODO_STATUS,
+  type TodoStatus,
+} from '@shared/schemas';
 
 /** Return paths available for a given agent category. */
 export function getAvailablePaths(
@@ -71,16 +76,17 @@ export function formatListingLine(entry: ExecutionListingEntry): string {
   return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
 }
 
-const TODO_ICON: Record<string, string> = {
-  completed: '[x]',
-  in_progress: '[>]',
-  pending: '[ ]',
-};
+function getTodoStatusIcon(status: string | undefined): string {
+  return (
+    STATUS_DISPLAY[status as TodoStatus]?.icon ??
+    STATUS_DISPLAY[TODO_STATUS.PENDING].icon
+  );
+}
 
 /** Format todo items as a checklist. */
 export function formatTodoSection(todos: TodoEntry[]): string[] {
   return todos.map((t) => {
-    const icon = TODO_ICON[t.status ?? ''] ?? '[ ]';
+    const icon = getTodoStatusIcon(t.status);
     return `${icon} ${t.content ?? '(no description)'}`;
   });
 }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -19,8 +19,7 @@ import type {
   TodoItem,
   Plan,
 } from '@shared/schemas';
-import { TODO_STATUS } from '@shared/schemas/todo';
-import { countByStatus } from '@shared/schemas/todoDisplay';
+import { countByStatus, STATUS_DISPLAY } from '@shared/schemas/todoDisplay';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { formatDuration } from '@utils/core';
 import type { DiffFileInfo } from './subagentDiffs';
@@ -201,13 +200,9 @@ export function formatSubagentProgress(
   switch (update.kind) {
     case 'todos': {
       const { completed, inProgress, pending } = countByStatus(update.todos);
-      const TODO_PROGRESS_ICON: Record<string, string> = {
-        [TODO_STATUS.COMPLETED]: '[x]',
-        [TODO_STATUS.IN_PROGRESS]: '[>]',
-      };
       const items = update.todos
         .map((t) => {
-          const icon = TODO_PROGRESS_ICON[t.status ?? ''] ?? '[ ]';
+          const icon = STATUS_DISPLAY[t.status].icon;
           return `  ${icon} ${escapeText(t.content)}`;
         })
         .join('\n');


### PR DESCRIPTION
## Summary

- Consolidate execution todo and subagent progress text formatting on the shared STATUS_DISPLAY table.
- Accept null as well as omission for optional delegate_workflow/delegate_agent model, agent, and execution_id schema fields.
- Add a kernel regression test for shared tool status formatting.

Fixes #3873.

## Verification

- npm run format
- npm run test:kernel -- src/test-kernel/tools/ToolStatusFormatting.vitest.ts
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors, 75 existing warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes user-facing tool output formatting and loosens Zod validation for delegation tool inputs (allowing `null`), which could affect downstream assumptions about required fields.
> 
> **Overview**
> Consolidates execution todo and subagent todo progress rendering to use the shared `STATUS_DISPLAY` icons, including a fallback to *pending* for unknown todo statuses.
> 
> Updates `delegate_workflow`/`delegate_agent` Zod schemas to treat several previously-optional string inputs as `nullish()` (accepting `null` as well as omission).
> 
> Adds a kernel regression test (`ToolStatusFormatting.vitest.ts`) to ensure both execution todo formatting and subagent progress formatting stay aligned with `STATUS_DISPLAY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9fa2da60daa085917ec0f55459707f3f083ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->