### PR TITLE
fix: restore required webview smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,7 @@ jobs:
         run: pnpm run desktop:package:smoke
 
       - name: Smoke extension webviews in Electron
-        # TODO: reduce to required after #3824 — the smoke runner's main-view
-        # fixture currently renders 0 file rows post-FileSelectGroup WA
-        # migration. Tracked separately so unrelated PRs are not blocked by
-        # an issue that needs Electron-runtime debugging on macOS.
         if: runner.os == 'macOS'
-        continue-on-error: true
         run: pnpm run smoke:webviews:run
 
       - name: Upload webview smoke screenshots

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -35,6 +35,11 @@ const views = [
     },
     fixtureMessages: [
       {
+        command: 'setSelectedAgent',
+        sessionType: 'workflow',
+        agentId: 'correct',
+      },
+      {
         command: 'setInputFile',
         files: ['appendix.tex', 'coverLetter.tex', 'main.tex'],
       },


### PR DESCRIPTION
## Summary
- Make the Electron main-view smoke fixture select workflow mode before seeding file rows.
- Restore the webview smoke check as a required CI step by removing the temporary continue-on-error setting.

Closes #3824.

## Verification
- corepack pnpm run smoke:webviews:run
- npm run format
- npm run compile:fast
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables a previously non-blocking macOS Electron webview smoke test in CI, which can increase PR failure rate if the smoke remains flaky. The fixture change is small but could affect smoke coverage/assumptions around workflow-mode initialization.
> 
> **Overview**
> Restores the macOS `smoke:webviews:run` step as a **required** CI check by removing `continue-on-error`.
> 
> Updates the Electron webview smoke fixture (`scripts/smoke-webviews-electron.mjs`) to send a `setSelectedAgent` message (workflow mode) before seeding file-selection messages, so the main-view smoke renders populated file rows again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a81cbc3cf5af24d36a69f78c31ba1f0147d38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->