### PR TITLE
test: cover desktop memory relaunch persistence

### DIFF
--- a/docs/dev/standalone-trajectory-audit.md
+++ b/docs/dev/standalone-trajectory-audit.md
@@ -150,12 +150,12 @@ close it:
   in-flight conversation from `RunStorageService` and re-attaching
   PocketFlow handles — substantial work tracked separately.
 
-### E. Multi-launch settings persistence test
+### E. Multi-launch settings persistence test — shipped
 
-- **Done when:** a Playwright fixture launches the desktop, writes a
-  Memory entry, closes, relaunches, and verifies the entry survives.
-- Notes: requires sharing the user-data directory between launches by
-  pinning `app.setPath('userData', ...)` for the test run.
+- **Status:** shipped in `packages/desktop/tests/e2e/settingsPersistence.spec.ts`.
+  The fixture launches the desktop, writes a real Memory entry into the
+  workspace storage rooted under a pinned Electron user-data directory, closes,
+  relaunches, and verifies that the Memory tab lists the same entry.
 
 ### F. Native auto-installer for external tools
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -66,6 +66,14 @@ const __dirname = findDesktopMainDir(moduleDirname);
 let mainWindow: BrowserWindow | null = null;
 let reopenMainWindow: (() => void) | undefined;
 
+// Playwright relaunch tests need a deterministic Electron profile so
+// app-scoped stores survive across child processes. Normal desktop launches
+// keep Electron's default userData path.
+const e2eUserDataPath = process.env.TEXRA_DESKTOP_E2E_USER_DATA_PATH;
+if (e2eUserDataPath) {
+  app.setPath('userData', resolvePath(e2eUserDataPath));
+}
+
 function focusOrReopenMainWindow(): void {
   if (!mainWindow) {
     reopenMainWindow?.();

--- a/packages/desktop/src/main/platform/electronStorage.ts
+++ b/packages/desktop/src/main/platform/electronStorage.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import type { StorageProvider } from '@platform/interfaces/storage';
 
-function workspaceStorageId(workspacePath: string | undefined): string {
+export function workspaceStorageId(workspacePath: string | undefined): string {
   const source = workspacePath?.trim() || 'no-workspace';
   return createHash('sha256').update(source).digest('hex').slice(0, 16);
 }

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -17,6 +17,11 @@ export interface LaunchOptions {
    */
   workspacePath?: string;
   /**
+   * Electron user-data directory. Supplying this lets a test relaunch the
+   * desktop app against the same profile so app-scoped stores persist.
+   */
+  userDataPath?: string;
+  /**
    * Extra environment variables to pass to the Electron child process.
    * Useful for stubbing out keychain access.
    */
@@ -68,6 +73,9 @@ export async function launchTexraApp(
       ...process.env,
       // Hint to platform/secrets layer to avoid the macOS keychain prompt.
       TEXRA_DISABLE_KEYCHAIN: '1',
+      ...(options.userDataPath
+        ? { TEXRA_DESKTOP_E2E_USER_DATA_PATH: options.userDataPath }
+        : {}),
       NODE_ENV: 'production',
       ...options.env,
     },
@@ -93,4 +101,32 @@ export async function closeTexraApp(launched: LaunchedApp): Promise<void> {
       // teardown failure that masks the real test outcome.
     }
   }
+}
+
+export async function dismissOnboarding(page: Page): Promise<void> {
+  const hasDismissButton = await page
+    .waitForFunction(
+      () => {
+        const btn = Array.from(document.querySelectorAll('wa-button')).find(
+          (b) => b.textContent?.trim() === 'Got it',
+        );
+        return btn instanceof HTMLElement;
+      },
+      undefined,
+      { timeout: 10_000 },
+    )
+    .then(() => true)
+    .catch(() => false);
+
+  if (!hasDismissButton) return;
+
+  await page.evaluate(() => {
+    const btn = Array.from(document.querySelectorAll('wa-button')).find(
+      (b) => b.textContent?.trim() === 'Got it',
+    );
+    if (btn instanceof HTMLElement) btn.click();
+  });
+  await page
+    .locator('wa-dialog.desktop-onboarding')
+    .waitFor({ state: 'hidden', timeout: 5000 });
 }

--- a/packages/desktop/tests/e2e/settingsPersistence.spec.ts
+++ b/packages/desktop/tests/e2e/settingsPersistence.spec.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { test, expect } from '@playwright/test';
+
+import { workspaceStorageId } from '../../src/main/platform/electronStorage.js';
+import {
+  closeTexraApp,
+  dismissOnboarding,
+  launchTexraApp,
+  type LaunchedApp,
+} from './electronApp.js';
+
+const SETTINGS_TAB_INDEX = {
+  MEMORY: 0,
+} as const;
+
+const MEMORY_FILE_NAME = 'playwright-relaunch-memory.md';
+const MEMORY_DISPLAY_PATH = `/memories/${MEMORY_FILE_NAME}`;
+const MEMORY_PREVIEW_TEXT =
+  'This memory entry is created by the desktop multi-launch Playwright fixture.';
+const MEMORY_FILE_CONTENT = `${MEMORY_PREVIEW_TEXT}
+
+It verifies that the same workspace storage is read after relaunch.
+`;
+
+function writeMemoryEntry(input: {
+  userDataPath: string;
+  workspacePath: string;
+}): void {
+  const memoryDir = join(
+    input.userDataPath,
+    'workspace-storage',
+    workspaceStorageId(input.workspacePath),
+    'memories',
+  );
+  mkdirSync(memoryDir, { recursive: true });
+  writeFileSync(join(memoryDir, MEMORY_FILE_NAME), MEMORY_FILE_CONTENT, 'utf8');
+}
+
+function cleanupDirectory(path: string): void {
+  try {
+    rmSync(path, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup. A stale temp dir is preferable to masking the
+    // assertion that actually failed.
+  }
+}
+
+async function setRoute(
+  launched: LaunchedApp,
+  route: 'main' | 'progress' | 'settings' | 'logs',
+): Promise<void> {
+  await launched.page.evaluate((next) => {
+    window.postMessage({ command: 'desktop:setRoute', route: next }, '*');
+  }, route);
+  await launched.page.waitForFunction(
+    (target) => document.body.dataset.desktopRoute === target,
+    route,
+    { timeout: 5000 },
+  );
+}
+
+async function setSettingsTab(
+  launched: LaunchedApp,
+  tabIndex: number,
+): Promise<void> {
+  await setRoute(launched, 'settings');
+  await launched.page.evaluate((idx) => {
+    window.postMessage({ command: 'setTab', tabIndex: idx }, '*');
+  }, tabIndex);
+  await launched.page.waitForFunction(
+    () => {
+      const settingsApp = document.querySelector('settings-app');
+      return settingsApp?.shadowRoot != null;
+    },
+    undefined,
+    { timeout: 10_000 },
+  );
+}
+
+async function refreshMemoryData(launched: LaunchedApp): Promise<void> {
+  await launched.page.evaluate(() => {
+    window.postMessage({ command: 'getMemoryData' }, '*');
+  });
+}
+
+async function waitForMemoryEntry(launched: LaunchedApp): Promise<void> {
+  await launched.page.waitForFunction(
+    ({ displayPath, previewText }) => {
+      const settingsApp = document.querySelector('settings-app');
+      const root = settingsApp?.shadowRoot;
+      const memoryTab = root?.querySelector('memory-tab') as
+        | (HTMLElement & { shadowRoot: ShadowRoot })
+        | null;
+      const memoryList = memoryTab?.shadowRoot?.querySelector('memory-list') as
+        | (HTMLElement & { shadowRoot: ShadowRoot })
+        | null;
+      const itemElements = Array.from(
+        memoryList?.shadowRoot?.querySelectorAll('memory-item') ?? [],
+      ) as Array<
+        HTMLElement & {
+          item?: { displayPath?: string; preview?: string };
+        }
+      >;
+
+      return itemElements.some((element) => {
+        const item = element.item;
+        return (
+          item?.displayPath === displayPath &&
+          item.preview?.includes(previewText)
+        );
+      });
+    },
+    {
+      displayPath: MEMORY_DISPLAY_PATH,
+      previewText: MEMORY_PREVIEW_TEXT,
+    },
+    { timeout: 10_000 },
+  );
+
+  await expect(launched.page.locator('settings-app')).toHaveCount(1);
+}
+
+async function verifyMemoryEntryIsListed(launched: LaunchedApp): Promise<void> {
+  await setSettingsTab(launched, SETTINGS_TAB_INDEX.MEMORY);
+  await refreshMemoryData(launched);
+  await waitForMemoryEntry(launched);
+}
+
+test('settings memory entries survive relaunch with shared user data', async () => {
+  const workspacePath = mkdtempSync(join(tmpdir(), 'texra-e2e-workspace-'));
+  const userDataPath = mkdtempSync(join(tmpdir(), 'texra-e2e-user-data-'));
+  let currentLaunch: LaunchedApp | undefined;
+
+  try {
+    currentLaunch = await launchTexraApp({ workspacePath, userDataPath });
+    await dismissOnboarding(currentLaunch.page);
+
+    writeMemoryEntry({ userDataPath, workspacePath });
+    await verifyMemoryEntryIsListed(currentLaunch);
+
+    await closeTexraApp(currentLaunch);
+    currentLaunch = undefined;
+
+    currentLaunch = await launchTexraApp({ workspacePath, userDataPath });
+    await dismissOnboarding(currentLaunch.page);
+    await verifyMemoryEntryIsListed(currentLaunch);
+  } finally {
+    if (currentLaunch) {
+      await closeTexraApp(currentLaunch);
+    }
+    cleanupDirectory(workspacePath);
+    cleanupDirectory(userDataPath);
+  }
+});

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -167,12 +167,9 @@ test('settings → models tab mounts and the auth surface is reachable', async (
 });
 
 /**
- * Trajectory 3 — Memory tab is the leftmost settings panel; restart-survival
- * cannot be tested from a single Playwright run (the harness recreates a
- * temp workspace per launch), but we can at least verify the tab mounts.
- *
- * Follow-up: the audit doc lists "memory survives relaunch" as a manual
- * QA scenario. Adding a multi-launch Playwright fixture is tracked there.
+ * Trajectory 3 — Memory tab is the leftmost settings panel. Cross-launch
+ * persistence is covered by `settingsPersistence.spec.ts`, which relaunches
+ * the desktop app on a shared Electron user-data directory.
  */
 test('settings → memory tab mounts', async () => {
   await setSettingsTab(SETTINGS_TAB_INDEX.MEMORY);
@@ -235,11 +232,10 @@ test('settings → tools tab mounts', async () => {
 });
 
 /**
- * Trajectory 6 — settings persistence smoke. Without a multi-launch fixture
- * we cannot fully prove restart-survival, but we can drive the tab a few
- * times and confirm the inner panels do not crash. Failures here would be
- * the kind of "renderer threw mid-tab-switch" regression that breaks the
- * standalone story; covering it cheaply is worth the few hundred ms.
+ * Trajectory 6 — settings tab switching smoke. Drive the tab a few times and
+ * confirm the inner panels do not crash. Failures here would be the kind of
+ * "renderer threw mid-tab-switch" regression that breaks the standalone story;
+ * covering it cheaply is worth the few hundred ms.
  */
 test('rapid settings-tab switching does not crash the renderer', async () => {
   for (const idx of [


### PR DESCRIPTION
## Summary

- Add a Playwright launcher option that pins the Electron user-data directory for relaunch tests.
- Add a desktop e2e spec that writes a real Memory entry into workspace storage, closes the app, relaunches with the same user-data directory, and verifies that the Memory tab still lists the entry.
- Update the standalone trajectory audit notes now that the multi-launch Memory persistence fixture exists.

Fixes #3807.

## Verification

- corepack pnpm --filter @texra/desktop build
- corepack pnpm --filter @texra/desktop test:e2e -- settingsPersistence.spec.ts
- npm run format
- npm run compile:fast
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are mostly Playwright E2E coverage, with a test-only `userData` override gated behind an environment variable.
> 
> **Overview**
> Adds a multi-launch Playwright E2E that pins Electron `userData`, writes a real Memory entry into `workspace-storage`, relaunches the desktop app, and asserts the Memory tab still lists the entry.
> 
> To enable relaunch testing, the desktop main process now honors `TEXRA_DESKTOP_E2E_USER_DATA_PATH` to set a deterministic `app.getPath('userData')`, the test launcher accepts `userDataPath`, and `workspaceStorageId` is exported for the test to compute the on-disk storage location. Docs + existing trajectory comments are updated to reflect the new persistence coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4c7f82987695524802b7b49ca3d93c15e3e55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->