### PR TITLE
feat: add desktop stream commands to palette

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -5,6 +5,7 @@ import {
 } from '@commands/catalog';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import type { StreamTabId } from '@shared/schemas';
 import { type AgentCategory } from '@shared/schemas/agent';
 import {
   SETTINGS_TAB,
@@ -85,6 +86,7 @@ export interface DesktopCommandMenuEntry {
 export interface DesktopCommandActions {
   showRoute(route: DesktopRoute): void;
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
+  showStream?(streamId: StreamTabId): void;
   openDesktopDocs?(): void;
   openLogFolder?(): void;
   openWorkspaceFolder?(): void;

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -1,5 +1,6 @@
 // Desktop wrapper around shared commandPalette — desktop command surface + accelerator formatting.
 
+import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
 import {
   createCommandPalette,
   executeCommandPaletteEntry,
@@ -20,11 +21,15 @@ import {
 export interface DesktopCommandPaletteOptions {
   document: Document;
   actions: DesktopCommandActions;
+  getStreams?: () => readonly StreamTabInfo[];
   platform?: NodeJS.Platform;
   canOpen?: () => boolean;
 }
 
 export type DesktopCommandPaletteController = CommandPaletteController;
+
+export const DESKTOP_SWITCH_STREAM_COMMAND_PREFIX =
+  'texra.desktop.switchStream:';
 
 export function filterDesktopCommandPaletteEntries(
   entries: readonly DesktopCommandMenuEntry[],
@@ -58,20 +63,19 @@ export { isCommandPaletteShortcut };
 export function createDesktopCommandPalette({
   document,
   actions,
+  getStreams,
   platform = getRendererPlatform(document.defaultView),
   canOpen,
 }: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
-  const desktopEntries = getDesktopCommandMenuEntries(undefined, platform);
-  const paletteEntries = desktopEntries
-    .map(toPaletteEntry)
-    .filter((entry): entry is CommandPaletteEntry => entry != null);
-
   return createCommandPalette({
     document,
-    entries: paletteEntries,
+    entries: () =>
+      getDesktopCommandPaletteEntries({
+        streams: actions.showStream == null ? [] : (getStreams?.() ?? []),
+        platform,
+      }),
     canOpen,
-    onExecute: (id) =>
-      dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions),
+    onExecute: (id) => dispatchDesktopPaletteCommand(id, actions),
     classes: {
       dialog: 'desktop-command-palette',
       input: 'desktop-command-palette-input',
@@ -81,6 +85,52 @@ export function createDesktopCommandPalette({
       meta: 'desktop-command-palette-meta',
     },
   });
+}
+
+export function getDesktopCommandPaletteEntries({
+  streams = [],
+  platform = getDefaultPlatform(),
+}: {
+  streams?: readonly StreamTabInfo[];
+  platform?: NodeJS.Platform;
+} = {}): CommandPaletteEntry[] {
+  const desktopEntries = getDesktopCommandMenuEntries(undefined, platform)
+    .map(toPaletteEntry)
+    .filter((entry): entry is CommandPaletteEntry => entry != null);
+  return [...desktopEntries, ...streams.map(toStreamPaletteEntry)];
+}
+
+function dispatchDesktopPaletteCommand(
+  id: string,
+  actions: DesktopCommandActions,
+): boolean | Promise<boolean> {
+  const streamId = parseSwitchStreamCommandId(id);
+  if (streamId != null) {
+    if (!actions.showStream) return false;
+    actions.showStream(streamId);
+    return true;
+  }
+  return dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions);
+}
+
+function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
+  return {
+    id: buildSwitchStreamCommandId(stream.name),
+    label: `Switch to ${stream.label || stream.name}`,
+    meta: stream.description || stream.agent || stream.modelLabel || 'Stream',
+    category: 'Streams',
+    enabled: true,
+  };
+}
+
+function buildSwitchStreamCommandId(streamId: StreamTabId): string {
+  return `${DESKTOP_SWITCH_STREAM_COMMAND_PREFIX}${streamId}`;
+}
+
+function parseSwitchStreamCommandId(id: string): StreamTabId | undefined {
+  if (!id.startsWith(DESKTOP_SWITCH_STREAM_COMMAND_PREFIX)) return undefined;
+  const streamId = id.slice(DESKTOP_SWITCH_STREAM_COMMAND_PREFIX.length);
+  return streamId || undefined;
 }
 
 function toPaletteEntry(
@@ -108,4 +158,8 @@ function getRendererPlatform(view: Window | null): NodeJS.Platform {
   if (platform.includes('mac')) return 'darwin';
   if (platform.includes('win')) return 'win32';
   return 'linux';
+}
+
+function getDefaultPlatform(): NodeJS.Platform {
+  return typeof process === 'undefined' ? 'linux' : process.platform;
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -47,6 +47,7 @@ import {
   setStreamStateForId,
   streamFilter$,
   streamStates$,
+  streams$,
   tabStreams$,
 } from '@progressView/frontend/progressState';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
@@ -67,6 +68,7 @@ import {
   sendFollowupCommand,
   type FrontendEventHandlerContext,
 } from '@progressView/frontend/eventHandlers';
+import type { StreamTabId } from '@shared/schemas';
 
 import {
   DesktopSetRouteMessageSchema,
@@ -881,6 +883,7 @@ const commandPalette = bootstrapFailed
             getWindowTargetOrigin(),
           );
         },
+        showStream: switchToStream,
         openDesktopDocs: () => {
           postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);
         },
@@ -901,6 +904,7 @@ const commandPalette = bootstrapFailed
           );
         },
       },
+      getStreams: () => streams$.get(),
     });
 if (commandPalette) appRoot.append(commandPalette.element);
 
@@ -910,6 +914,17 @@ function openCommandPalette(): void {
 
 function openWorkspaceFolder(): void {
   postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
+}
+
+function switchToStream(streamId: StreamTabId): void {
+  if (!appState.get().streamById.has(streamId)) return;
+  appState.set(
+    mutate(appState.get(), (draft) => {
+      draft.activeStreamId = streamId;
+    }),
+  );
+  postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, { stream: streamId });
+  setRoute('progress');
 }
 
 // Clear the active stream so the center swaps back to <main-app>. PRD § 6:

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -30,9 +30,13 @@ export interface CommandPaletteEntry {
   readonly enabled: boolean;
 }
 
+export type CommandPaletteEntrySource =
+  | readonly CommandPaletteEntry[]
+  | (() => readonly CommandPaletteEntry[]);
+
 export interface CommandPaletteOptions {
   readonly document: Document;
-  readonly entries: readonly CommandPaletteEntry[];
+  readonly entries: CommandPaletteEntrySource;
   readonly onExecute: (id: string) => boolean | Promise<boolean>;
   // Returning false suppresses ALL palette opens — both the global
   // Cmd/Ctrl+K shortcut and any direct `controller.open()` call (e.g. while
@@ -133,6 +137,12 @@ export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
   );
 }
 
+function resolveCommandPaletteEntries(
+  entries: CommandPaletteEntrySource,
+): CommandPaletteEntry[] {
+  return [...(typeof entries === 'function' ? entries() : entries)];
+}
+
 export function createCommandPalette({
   document,
   entries,
@@ -147,8 +157,9 @@ export function createCommandPalette({
   // Reactive state — every mutation calls renderTemplate() to keep the DOM
   // in sync. wa-dialog handles modal backdrop, focus trap, escape key, and
   // focus restoration natively, so we no longer manage those by hand.
-  let visibleEntries: CommandPaletteEntry[] = [...entries];
-  let activeIndex = entries.length > 0 ? 0 : -1;
+  let allEntries: CommandPaletteEntry[] = [];
+  let visibleEntries: CommandPaletteEntry[] = [];
+  let activeIndex = -1;
   let query = '';
 
   const dialog = document.createElement('wa-dialog') as WaDialog;
@@ -165,7 +176,7 @@ export function createCommandPalette({
   const handleFilterInput = (event: Event): void => {
     const target = event.target as WaInput | null;
     query = target?.value ?? '';
-    visibleEntries = filterCommandPaletteEntries(entries, query);
+    visibleEntries = filterCommandPaletteEntries(allEntries, query);
     activeIndex = visibleEntries.length > 0 ? 0 : -1;
     renderTemplate();
   };
@@ -268,8 +279,9 @@ export function createCommandPalette({
   const open = (): void => {
     if (canOpen?.() === false) return;
     if (dialog.open) return;
+    allEntries = resolveCommandPaletteEntries(entries);
     query = '';
-    visibleEntries = [...entries];
+    visibleEntries = [...allEntries];
     activeIndex = visibleEntries.length > 0 ? 0 : -1;
     renderTemplate();
     dialog.open = true;

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -20,10 +21,16 @@ interface DesktopCommandPaletteModule {
     actions: {
       showRoute(route: string): void;
       showSettings(tabIndex?: number): void;
+      showStream?(streamId: string): void;
     };
+    getStreams?: () => DesktopPaletteStream[];
     platform?: NodeJS.Platform;
     canOpen?: () => boolean;
   }): DesktopCommandPaletteController;
+  getDesktopCommandPaletteEntries(options?: {
+    streams?: DesktopPaletteStream[];
+    platform?: NodeJS.Platform;
+  }): DesktopPaletteEntry[];
   filterDesktopCommandPaletteEntries(
     entries: DesktopPaletteEntry[],
     query: string,
@@ -50,6 +57,16 @@ interface DesktopPaletteEntry {
   accelerator?: string;
   enabled: boolean;
   unavailableReason?: string;
+}
+
+interface DesktopPaletteStream {
+  name: string;
+  label: string;
+  agentCategory: string;
+  creationTimestamp: number;
+  description?: string;
+  agent?: string;
+  modelLabel?: string;
 }
 
 async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule> {
@@ -244,6 +261,59 @@ describe('desktop command palette', () => {
     await flushDialogTicks();
 
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+    expect(controller.element.open).toBe(false);
+  });
+
+  it('adds current streams as switch commands when opened', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const actions = {
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+      showStream: vi.fn(),
+    };
+    let streams: DesktopPaletteStream[] = [];
+    const controller = createDesktopCommandPalette({
+      document,
+      actions,
+      getStreams: () => streams,
+      platform: 'darwin',
+    });
+
+    document.body.append(controller.element);
+    await flushDialogTicks();
+
+    streams = [
+      {
+        name: 'stream-proof',
+        label: 'Spectral proof run',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        creationTimestamp: 1,
+        description: 'Checking the main lemma',
+      },
+    ];
+    controller.open();
+    await flushDialogTicks();
+
+    setWaInputValue(controller.element, 'spectral lemma');
+    await flushDialogTicks();
+
+    const filteredItems =
+      controller.element.querySelectorAll<HTMLButtonElement>(
+        '.desktop-command-palette-item',
+      );
+    expect([...filteredItems].map((item) => item.dataset.commandId)).toEqual([
+      'texra.desktop.switchStream:stream-proof',
+    ]);
+
+    const waInput = controller.element.querySelector(
+      'wa-input.desktop-command-palette-input',
+    )!;
+    waInput.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    await flushDialogTicks();
+
+    expect(actions.showStream).toHaveBeenCalledWith('stream-proof');
     expect(controller.element.open).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Make the shared command palette resolve entries when it opens, so host entries can reflect current state.
- Add Desktop stream-switch entries to the Cmd/Ctrl+K palette and dispatch them through the progress stream state.
- Preserve the existing desktop command catalog entries and add kernel coverage for dynamically added streams.

This closes the practical command-palette gap: the keyboard palette and catalog-backed quick actions were already present, and stream switching is now searchable by current stream labels and metadata. Desktop commands whose underlying surfaces do not yet exist, such as new-window or auth commands, remain outside this small change.

## Validation

- npm run format
- npm run test:kernel -- src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
- corepack pnpm --filter @texra/desktop build
- npm run compile:fast
- npm run lint (0 errors, 75 existing warnings)
- git diff --check

Closes #3866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared command palette API to support lazy entry resolution on open, which could affect any consumers expecting a static entry list. Adds new stream-switch dispatch logic that mutates active stream state and sends a progress-view switch message, so regressions would show up as incorrect navigation/selection.
> 
> **Overview**
> The command palette now supports *dynamic entry sources* by allowing `entries` to be a function and resolving the list when the palette opens (instead of capturing a static array).
> 
> Desktop uses this to append per-stream “Switch to …” entries (with a `texra.desktop.switchStream:` prefix) and routes execution through a new `actions.showStream` hook that updates the active stream, posts `PROGRESS_VIEW_COMMANDS.SWITCH_STREAM`, and navigates to `progress`.
> 
> Kernel tests are extended to cover dynamically injected stream entries and their dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53cbc438de6aa46409080b2ba4d99d94e7f902b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->