### PR TITLE
Improve desktop empty states

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -18,6 +18,8 @@ import {
 import type { MenuItemConstructorOptions } from 'electron';
 import type { DesktopRoute } from './desktopShellMessages.js';
 
+export { SETTINGS_TAB };
+
 export const DESKTOP_LOCAL_COMMANDS = {
   SHOW_LOGS: 'texra.desktop.showLogs',
   OPEN_LOG_FOLDER: 'texra.desktop.openLogFolder',

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -84,6 +84,8 @@ import {
   buildDesktopMainViewResetMessage,
   buildDesktopSettingsTabMessage,
   DESKTOP_LOCAL_COMMANDS,
+  SETTINGS_TAB,
+  type DesktopCommandActions,
 } from '../desktopCommandSurface';
 import {
   DESKTOP_ONBOARDING_COMMANDS,
@@ -186,6 +188,11 @@ function emptyWorkspaceTemplate(): TemplateResult {
         TeXRA desktop needs a workspace before it can discover files, run
         agents, and place outputs.
       </p>
+      <ul class="desktop-empty-workspace-capabilities">
+        <li>Select TeX, Markdown, or text files from the opened folder.</li>
+        <li>Run workflow or tool-use agents with the chosen model.</li>
+        <li>Review progress, logs, and generated outputs in one window.</li>
+      </ul>
       <div class="desktop-empty-workspace-actions">
         <wa-button
           appearance="filled"
@@ -194,14 +201,54 @@ function emptyWorkspaceTemplate(): TemplateResult {
           @click=${() =>
             postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER)}
         >
-          Open Folder
+          ${waIcon('folder-open', { slot: 'start' })} Open Folder
         </wa-button>
         <wa-button
           appearance="outlined"
           class="desktop-secondary-button"
           @click=${openLogsDrawer}
         >
-          Logs
+          ${waIcon('file-lines', { slot: 'start' })} Logs
+        </wa-button>
+      </div>
+    </section>
+  `;
+}
+
+function emptyStreamsTemplate(): TemplateResult {
+  return html`
+    <section class="desktop-empty-streams" aria-label="First run suggestions">
+      <div class="desktop-empty-streams-copy">
+        <h2>Start from the launcher</h2>
+        <p>
+          Choose files and an agent above, or check model access before the
+          first run.
+        </p>
+        <p class="desktop-empty-streams-example">
+          Try: <q>polish the abstract</q>
+        </p>
+      </div>
+      <div class="desktop-empty-streams-actions">
+        <wa-button
+          appearance="outlined"
+          size="small"
+          @click=${() => openSettingsTab(SETTINGS_TAB.MODELS)}
+        >
+          ${waIcon('key', { slot: 'start' })} Models
+        </wa-button>
+        <wa-button
+          appearance="outlined"
+          size="small"
+          @click=${() => openSettingsTab(SETTINGS_TAB.AGENTS)}
+        >
+          ${waIcon('robot', { slot: 'start' })} Agents
+        </wa-button>
+        <wa-button
+          appearance="outlined"
+          size="small"
+          @click=${openCommandPalette}
+        >
+          ${waIcon('terminal', { slot: 'start' })} Commands
         </wa-button>
       </div>
     </section>
@@ -276,7 +323,9 @@ const CHROME_ICON_BUTTONS: ReadonlyArray<ChromeIconButtonSpec> = [
 
 function shellTemplate(): TemplateResult {
   const activeId = activeStreamId$.get();
-  const showConversation = activeId != null && hasAnyStreams$.get();
+  const hasStreams = hasAnyStreams$.get();
+  const showConversation = activeId != null && hasStreams;
+  const showLauncherEmptyState = hasWorkspace && !hasStreams;
   return html`
     <section class="desktop-shell">
       <nav class="desktop-nav" aria-label="Desktop chrome">
@@ -368,7 +417,18 @@ function shellTemplate(): TemplateResult {
             data-pane="launcher"
             ?hidden=${showConversation}
           >
-            ${hasWorkspace ? mainView : noWorkspacePlaceholder}
+            ${hasWorkspace
+              ? html`
+                  <section
+                    class=${showLauncherEmptyState
+                      ? 'desktop-launcher-surface desktop-launcher-surface--empty'
+                      : 'desktop-launcher-surface'}
+                  >
+                    ${mainView}
+                    ${showLauncherEmptyState ? emptyStreamsTemplate() : nothing}
+                  </section>
+                `
+              : noWorkspacePlaceholder}
           </section>
           <section
             class="desktop-pane"
@@ -602,6 +662,20 @@ function openSettingsOverlay(): void {
   currentRoute = 'settings';
   document.body.dataset.desktopRoute = 'settings';
   dialog.open = true;
+}
+
+type ShowSettingsArgs = Parameters<DesktopCommandActions['showSettings']>;
+
+function openSettingsTab(
+  tabIndex?: ShowSettingsArgs[0],
+  agentSubTab?: ShowSettingsArgs[1],
+): void {
+  openSettingsOverlay();
+  if (tabIndex == null) return;
+  window.postMessage(
+    buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
+    getWindowTargetOrigin(),
+  );
 }
 
 // =============================================================================
@@ -875,14 +949,7 @@ const commandPalette = bootstrapFailed
       canOpen: () => !firstRunWalkthrough?.isVisible(),
       actions: {
         showRoute: setRoute,
-        showSettings: (tabIndex, agentSubTab) => {
-          openSettingsOverlay();
-          if (tabIndex == null) return;
-          window.postMessage(
-            buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
-            getWindowTargetOrigin(),
-          );
-        },
+        showSettings: openSettingsTab,
         showStream: switchToStream,
         openDesktopDocs: () => {
           postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -219,6 +219,24 @@ wa-button.desktop-rail-settings::part(base) {
   height: 100%;
 }
 
+.desktop-launcher-surface {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+}
+
+.desktop-launcher-surface--empty {
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.desktop-launcher-surface > main-app {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+}
+
 .desktop-right {
   /* Reserved column. Hidden today; will host the diff/approve UX later. */
   display: none;
@@ -552,16 +570,85 @@ wa-input.desktop-command-palette-input::part(base) {
 }
 
 .desktop-empty-workspace-panel p {
-  margin: 0 0 var(--wa-space-l);
+  margin: 0 0 var(--wa-space-m);
   color: var(--wa-color-text-quiet);
   font-size: 15px;
   line-height: 1.5;
 }
 
+.desktop-empty-workspace-capabilities {
+  display: grid;
+  gap: var(--wa-space-xs);
+  max-width: 440px;
+  margin: 0 auto var(--wa-space-l);
+  padding: 0;
+  color: var(--wa-color-text-quiet);
+  font-size: 13px;
+  line-height: 1.45;
+  list-style-position: inside;
+  text-align: left;
+}
+
 .desktop-empty-workspace-actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   gap: var(--wa-space-s);
+}
+
+.desktop-empty-streams {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--wa-space-m);
+  align-items: center;
+  padding: var(--wa-space-s) var(--wa-space-l);
+  border-top: 1px solid var(--wa-color-surface-border);
+  background: var(--wa-color-surface-lowered);
+}
+
+.desktop-empty-streams-copy {
+  min-width: 0;
+}
+
+.desktop-empty-streams-copy h2 {
+  margin: 0 0 var(--wa-space-2xs);
+  color: var(--wa-color-text-normal);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.desktop-empty-streams-copy p {
+  margin: 0;
+  color: var(--wa-color-text-quiet);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.desktop-empty-streams-copy .desktop-empty-streams-example {
+  margin-top: var(--wa-space-2xs);
+  color: var(--wa-color-text-normal);
+}
+
+.desktop-empty-streams-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--wa-space-xs);
+}
+
+.desktop-empty-streams-actions wa-button::part(base) {
+  border-radius: var(--wa-border-radius-m, 3px);
+}
+
+@media (max-width: 720px) {
+  .desktop-empty-streams {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .desktop-empty-streams-actions {
+    justify-content: flex-start;
+  }
 }
 
 .desktop-bootstrap-fallback {

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -89,6 +89,23 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     );
   });
 
+  it('renders concise empty-state guidance for first launch and no sessions', () => {
+    const rendererMain = readRendererMain();
+    const styles = readRendererStyles();
+
+    expect(rendererMain).toContain('desktop-empty-workspace-capabilities');
+    expect(rendererMain).toContain(
+      'Run workflow or tool-use agents with the chosen model.',
+    );
+    expect(rendererMain).toContain('desktop-empty-streams');
+    expect(rendererMain).toContain('Try: <q>polish the abstract</q>');
+    expect(rendererMain).toContain('SETTINGS_TAB.MODELS');
+    expect(rendererMain).toContain('SETTINGS_TAB.AGENTS');
+    expect(rendererMain).toContain('openCommandPalette');
+    expect(styles).toContain('.desktop-launcher-surface--empty');
+    expect(styles).toContain('.desktop-empty-streams-actions');
+  });
+
   it('renders the launcher back action as an icon-only chrome button', () => {
     const rendererMain = readRendererMain();
     const styles = readRendererStyles();
@@ -163,7 +180,7 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toContain('createDesktopCommandPalette');
     expect(rendererMain).toContain('openCommandPalette');
     expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
-    expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
+    expect(rendererMain).toContain('showSettings: openSettingsTab');
   });
 
   it('mounts desktop-only first-run onboarding controls', () => {


### PR DESCRIPTION
Closes #3868

Summary:
- Adds a short capability list to the no-workspace desktop prompt.
- Adds a compact no-session launcher band with links to Models, Agents, and Commands.
- Reuses the existing desktop settings-tab message path for these entry points.

Validation:
- npm run format
- npm run test:kernel -- src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- corepack pnpm --filter @texra/desktop build
- npm run compile:fast
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX and styling changes in the Electron renderer, plus minor refactoring of the settings-open action; low risk aside from potential regressions in empty-state rendering and settings tab navigation.
> 
> **Overview**
> Improves TeXRA Desktop’s launcher *empty states* by adding a short capability list to the no-workspace prompt and a new “first run / no sessions” guidance band with quick actions to open `Models`, `Agents`, or the command palette.
> 
> Refactors settings navigation by exporting `SETTINGS_TAB` from `desktopCommandSurface` and centralizing the “open settings + optionally select tab” behavior in `openSettingsTab`, which is reused by both the new empty-state buttons and the command palette.
> 
> Updates CSS to support the new launcher layout (`desktop-launcher-surface` + empty-state band styling) and extends the desktop renderer shell kernel test to assert the new guidance text, actions, and class names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629d18c7ca80d76b81efc480644e5e44bea61138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->