### PR TITLE
Show desktop shortcut hints

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -352,6 +352,21 @@ function toPlatformAccelerator(
   return accelerator.replaceAll('CommandOrControl', 'Command');
 }
 
+export function formatDesktopAccelerator(
+  accelerator: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (!accelerator) return undefined;
+  const platformAccelerator =
+    platform === 'darwin'
+      ? accelerator.replaceAll('CommandOrControl', 'Command')
+      : accelerator.replaceAll('CommandOrControl', 'Control');
+  const parts = platformAccelerator
+    .split('+')
+    .map((part) => toDisplayAcceleratorPart(part, platform));
+  return platform === 'darwin' ? parts.join('') : parts.join('+');
+}
+
 export function buildDesktopSettingsTabMessage(
   tabIndex: SettingsTab,
   agentSubTab?: AgentCategory,
@@ -447,5 +462,30 @@ function toElectronAcceleratorPart(part: string): string {
     default:
       if (/^f\d{1,2}$/.test(normalized)) return normalized.toUpperCase();
       return normalized.length === 1 ? normalized.toUpperCase() : normalized;
+  }
+}
+
+function toDisplayAcceleratorPart(
+  part: string,
+  platform: NodeJS.Platform,
+): string {
+  const normalized = part.trim().toLowerCase();
+  const isMac = platform === 'darwin';
+  switch (normalized) {
+    case 'cmd':
+    case 'command':
+      return isMac ? '⌘' : 'Cmd';
+    case 'ctrl':
+    case 'control':
+      return isMac ? '⌃' : 'Ctrl';
+    case 'alt':
+    case 'option':
+      return isMac ? '⌥' : 'Alt';
+    case 'shift':
+      return isMac ? '⇧' : 'Shift';
+    default: {
+      const trimmed = part.trim();
+      return trimmed.length === 1 ? trimmed.toUpperCase() : trimmed;
+    }
   }
 }

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -17,6 +17,7 @@ import {
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
+import { getRendererPlatform } from './rendererPlatform';
 
 export interface DesktopCommandPaletteOptions {
   document: Document;
@@ -151,13 +152,6 @@ function toPaletteEntry(
     category: entry.category,
     enabled: entry.enabled,
   };
-}
-
-function getRendererPlatform(view: Window | null): NodeJS.Platform {
-  const platform = view?.navigator.platform.toLowerCase() ?? '';
-  if (platform.includes('mac')) return 'darwin';
-  if (platform.includes('win')) return 'win32';
-  return 'linux';
 }
 
 function getDefaultPlatform(): NodeJS.Platform {

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -17,7 +17,7 @@ import {
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
-import { getRendererPlatform } from './rendererPlatform';
+import { getDefaultPlatform, getRendererPlatform } from './rendererPlatform';
 
 export interface DesktopCommandPaletteOptions {
   document: Document;
@@ -152,8 +152,4 @@ function toPaletteEntry(
     category: entry.category,
     enabled: entry.enabled,
   };
-}
-
-function getDefaultPlatform(): NodeJS.Platform {
-  return typeof process === 'undefined' ? 'linux' : process.platform;
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -110,6 +110,7 @@ import {
 } from '../desktopPdfMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
+import { getRendererPlatform } from './rendererPlatform';
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -160,13 +161,6 @@ function commandTitle(commandId: DesktopCommandId, label: string): string {
 function shortcutTitle(label: string, accelerator: string): string {
   const shortcut = formatDesktopAccelerator(accelerator, rendererPlatform);
   return shortcut ? `${label} - ${shortcut}` : label;
-}
-
-function getRendererPlatform(view: Window | null): NodeJS.Platform {
-  const platform = view?.navigator.platform.toLowerCase() ?? '';
-  if (platform.includes('mac')) return 'darwin';
-  if (platform.includes('win')) return 'win32';
-  return typeof process === 'undefined' ? 'linux' : process.platform;
 }
 
 // `<settings-app>` lives inside the wa-dialog overlay below; `<main-app>` and

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -84,8 +84,11 @@ import {
   buildDesktopMainViewResetMessage,
   buildDesktopSettingsTabMessage,
   DESKTOP_LOCAL_COMMANDS,
+  formatDesktopAccelerator,
+  getDesktopCommandMenuEntries,
   SETTINGS_TAB,
   type DesktopCommandActions,
+  type DesktopCommandId,
 } from '../desktopCommandSurface';
 import {
   DESKTOP_ONBOARDING_COMMANDS,
@@ -137,6 +140,34 @@ const workspacePath = window.texraDesktop?.workspacePath;
 const workspaceFolderName = workspacePath
   ? workspacePath.split(/[\\/]/).pop() || workspacePath
   : undefined;
+const rendererPlatform = getRendererPlatform(document.defaultView);
+const desktopCommandEntriesById = new Map(
+  getDesktopCommandMenuEntries(undefined, rendererPlatform).map((entry) => [
+    entry.id,
+    entry,
+  ]),
+);
+
+function commandTitle(commandId: DesktopCommandId, label: string): string {
+  const entry = desktopCommandEntriesById.get(commandId);
+  const shortcut = formatDesktopAccelerator(
+    entry?.accelerator,
+    rendererPlatform,
+  );
+  return shortcut ? `${label} - ${shortcut}` : label;
+}
+
+function shortcutTitle(label: string, accelerator: string): string {
+  const shortcut = formatDesktopAccelerator(accelerator, rendererPlatform);
+  return shortcut ? `${label} - ${shortcut}` : label;
+}
+
+function getRendererPlatform(view: Window | null): NodeJS.Platform {
+  const platform = view?.navigator.platform.toLowerCase() ?? '';
+  if (platform.includes('mac')) return 'darwin';
+  if (platform.includes('win')) return 'win32';
+  return typeof process === 'undefined' ? 'linux' : process.platform;
+}
 
 // `<settings-app>` lives inside the wa-dialog overlay below; `<main-app>` and
 // `<stream-conversation>` mount directly in the center pane. These are
@@ -335,7 +366,7 @@ function shellTemplate(): TemplateResult {
           appearance="plain"
           size="small"
           ?hidden=${!showConversation}
-          title="Back to launcher"
+          title=${commandTitle('texra.showMainView', 'Back to launcher')}
           aria-label="Back to launcher"
           @click=${returnToLauncher}
         >
@@ -346,6 +377,7 @@ function shellTemplate(): TemplateResult {
           appearance="outlined"
           size="small"
           aria-haspopup="dialog"
+          title=${shortcutTitle('Commands', 'CommandOrControl+K')}
           @click=${openCommandPalette}
         >
           Commands
@@ -354,6 +386,10 @@ function shellTemplate(): TemplateResult {
           class="desktop-folder-button"
           appearance="outlined"
           size="small"
+          title=${commandTitle(
+            DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+            'Open Folder',
+          )}
           @click=${openWorkspaceFolder}
         >
           ${waIcon('folder-open', { slot: 'start' })} Open Folder
@@ -366,7 +402,12 @@ function shellTemplate(): TemplateResult {
               size="small"
               data-route-button=${spec.key}
               aria-label=${spec.label}
-              title=${spec.label}
+              title=${commandTitle(
+                spec.key === 'settings'
+                  ? 'texra.openSettings'
+                  : DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+                spec.label,
+              )}
               @click=${spec.onClick}
             >
               ${waIcon(spec.icon, { label: spec.label })}
@@ -392,7 +433,7 @@ function shellTemplate(): TemplateResult {
               class="desktop-rail-new"
               appearance="outlined"
               size="small"
-              title="New run"
+              title=${commandTitle('texra.mainView.reset', 'New run')}
               aria-label="New run"
               @click=${returnToLauncher}
             >
@@ -405,6 +446,7 @@ function shellTemplate(): TemplateResult {
               class="desktop-rail-settings"
               appearance="plain"
               size="small"
+              title=${commandTitle('texra.openSettings', 'Settings')}
               @click=${openSettingsOverlay}
             >
               ${waIcon('gear', { slot: 'start' })} Settings

--- a/packages/desktop/src/renderer/rendererPlatform.ts
+++ b/packages/desktop/src/renderer/rendererPlatform.ts
@@ -7,6 +7,7 @@ export function getRendererPlatform(view: Window | null): NodeJS.Platform {
   return getDefaultPlatform();
 }
 
-function getDefaultPlatform(): NodeJS.Platform {
+/** Returns the host platform when the browser navigator is inconclusive. */
+export function getDefaultPlatform(): NodeJS.Platform {
   return typeof process === 'undefined' ? 'linux' : process.platform;
 }

--- a/packages/desktop/src/renderer/rendererPlatform.ts
+++ b/packages/desktop/src/renderer/rendererPlatform.ts
@@ -1,0 +1,12 @@
+/** Returns the Electron renderer platform from browser navigator data. */
+export function getRendererPlatform(view: Window | null): NodeJS.Platform {
+  const platform = view?.navigator.platform.toLowerCase() ?? '';
+  if (platform.includes('mac')) return 'darwin';
+  if (platform.includes('win')) return 'win32';
+  if (platform.includes('linux')) return 'linux';
+  return getDefaultPlatform();
+}
+
+function getDefaultPlatform(): NodeJS.Platform {
+  return typeof process === 'undefined' ? 'linux' : process.platform;
+}

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -48,6 +48,10 @@ interface DesktopCommandSurfaceModule {
     keybinding: { key: string; mac?: string },
     platform?: NodeJS.Platform,
   ): string;
+  formatDesktopAccelerator(
+    accelerator: string | undefined,
+    platform?: NodeJS.Platform,
+  ): string | undefined;
   buildDesktopSettingsTabMessage(
     tabIndex: number,
     agentSubTab?: string,
@@ -148,6 +152,20 @@ describe('desktop command surface', () => {
         'linux',
       ),
     ).toBe('Control+Alt+Shift+C');
+  });
+
+  it('formats accelerators for desktop tooltip display', async () => {
+    const { formatDesktopAccelerator } = await loadDesktopCommandSurface();
+
+    expect(formatDesktopAccelerator('Command+Option+M', 'darwin')).toBe('⌘⌥M');
+    expect(formatDesktopAccelerator('CommandOrControl+O', 'darwin')).toBe('⌘O');
+    expect(formatDesktopAccelerator('CommandOrControl+O', 'linux')).toBe(
+      'Ctrl+O',
+    );
+    expect(formatDesktopAccelerator('Control+Alt+Shift+C', 'linux')).toBe(
+      'Ctrl+Alt+Shift+C',
+    );
+    expect(formatDesktopAccelerator(undefined, 'darwin')).toBeUndefined();
   });
 
   it('dispatches supported commands through typed shell actions', async () => {

--- a/src/test-kernel/desktop/DesktopRendererPlatform.vitest.mts
+++ b/src/test-kernel/desktop/DesktopRendererPlatform.vitest.mts
@@ -1,0 +1,29 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopRendererPlatformModule {
+  getRendererPlatform(view: Window | null): NodeJS.Platform;
+}
+
+async function loadDesktopRendererPlatform(): Promise<DesktopRendererPlatformModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('renderer', 'rendererPlatform.ts'))
+  ) as Promise<DesktopRendererPlatformModule>;
+}
+
+function rendererWindow(platform: string): Window {
+  return { navigator: { platform } } as unknown as Window;
+}
+
+describe('desktop renderer platform', () => {
+  it('derives platform values from renderer navigator data', async () => {
+    const { getRendererPlatform } = await loadDesktopRendererPlatform();
+
+    expect(getRendererPlatform(rendererWindow('MacIntel'))).toBe('darwin');
+    expect(getRendererPlatform(rendererWindow('Win32'))).toBe('win32');
+    expect(getRendererPlatform(rendererWindow('Linux x86_64'))).toBe('linux');
+  });
+});

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -111,7 +111,9 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     const styles = readRendererStyles();
 
     expect(rendererMain).toMatch(/class="[^"]*\bdesktop-icon-button\b[^"]*"/);
-    expect(rendererMain).toContain('title="Back to launcher"');
+    expect(rendererMain).toContain(
+      "title=${commandTitle('texra.showMainView', 'Back to launcher')}",
+    );
     expect(rendererMain).toContain('aria-label="Back to launcher"');
     expect(rendererMain).toMatch(
       /waIcon\('arrow-left',\s*\{\s*label:\s*'Back to launcher'\s*\}\)/,
@@ -181,6 +183,20 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toContain('openCommandPalette');
     expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
     expect(rendererMain).toContain('showSettings: openSettingsTab');
+  });
+
+  it('adds platform-formatted shortcut hints to desktop chrome tooltips', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('formatDesktopAccelerator');
+    expect(rendererMain).toContain('getDesktopCommandMenuEntries');
+    expect(rendererMain).toContain(
+      "shortcutTitle('Commands', 'CommandOrControl+K')",
+    );
+    expect(rendererMain).toContain(
+      'DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER',
+    );
+    expect(rendererMain).toContain("commandTitle('texra.openSettings'");
   });
 
   it('mounts desktop-only first-run onboarding controls', () => {

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -190,6 +190,8 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
 
     expect(rendererMain).toContain('formatDesktopAccelerator');
     expect(rendererMain).toContain('getDesktopCommandMenuEntries');
+    expect(rendererMain).toContain("from './rendererPlatform'");
+    expect(rendererMain).not.toContain('function getRendererPlatform');
     expect(rendererMain).toContain(
       "shortcutTitle('Commands', 'CommandOrControl+K')",
     );


### PR DESCRIPTION
Closes #3870

Summary:
- Adds platform-formatted accelerator display for desktop shortcut text.
- Adds shortcut-aware tooltips to desktop chrome controls such as Back to launcher, Commands, and Open Folder.
- Reuses the desktop command catalog so command palette rows and chrome tooltips draw from the same command surface.

Design note:
- The command palette now serves as the searchable shortcut reference; a separate shortcut modal would duplicate that surface.

Validation:
- npm run format
- npm run test:kernel -- src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
- npm run test:kernel -- src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- corepack pnpm --filter @texra/desktop build
- npm run compile:fast
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that formats and displays existing keyboard shortcuts in tooltips; minimal behavioral impact beyond string formatting and platform detection.
> 
> **Overview**
> Adds `formatDesktopAccelerator` to render human-friendly shortcut text (mac symbols vs non-mac labels) and introduces a shared `rendererPlatform` helper for consistent platform detection.
> 
> Updates the desktop renderer chrome (`main.ts`) to append shortcut hints to tooltips by looking up accelerators from the existing desktop command catalog (and a fixed `CommandOrControl+K` for the command palette), keeping chrome + palette aligned. Tests are extended to cover accelerator formatting and renderer platform inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dde02cac829e30627a6939e0540d2895ffb6ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->