### PR TITLE
feat: show model availability status

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -9,6 +9,7 @@ export interface CliModelAccess {
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
+  if (model.availabilityLabel) return model.availabilityLabel.toLowerCase();
   if (!model.disabled && !model.requiresKey) return 'available';
   if (model.requiresKey) {
     const provider = model.provider ? `${model.provider} ` : '';

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -1565,12 +1565,25 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       });
     }
 
+    const affectsModelAvailability =
+      def?.globalStateKey === GlobalStateKey.USE_OPENROUTER;
+    if (affectsModelAvailability) {
+      invalidateModelOptionsCache();
+    }
+
     await this.withActiveWebview(async (w) => {
       await Promise.all([
         this.sendProfileData(w),
         this.sendSuperYoloEnabled(w),
+        affectsModelAvailability
+          ? this.sendModelSelectionData(w)
+          : Promise.resolve(),
       ]);
     });
+
+    if (affectsModelAvailability) {
+      await vscode.commands.executeCommand('texra.refreshAllOptions');
+    }
   }
 
   // ============================================================

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,6 +1,7 @@
 import { ModelProvider } from 'llm-zoo';
 import { getConfig } from '@agent/core/config';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import {
   getProviderEndpoint,
   getDashScopeUseChina,
@@ -67,10 +68,7 @@ export function shouldUseOpenRouter(config: {
   requiresResponsesAPI?: boolean;
   openRouterOnly: boolean;
 }): boolean {
-  // Models requiring direct API access bypass OpenRouter
-  if (config.requiresResponsesAPI) return false;
-
-  return config.openRouterOnly || getUseOpenRouter();
+  return shouldRouteModelThroughOpenRouter(config, getUseOpenRouter());
 }
 
 /**

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -14,6 +14,9 @@ import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 // Local imports - shared constants
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 
+// Local imports - config
+import { getUseOpenRouter } from '@utils/config/providerConfig';
+
 // Local imports - sibling
 import { API_PROVIDERS, apiKeyExists, type ApiProvider } from './apiProviders';
 import {
@@ -36,8 +39,11 @@ interface ModelAvailabilityStatus {
 async function getPersonalAccessKindForModel(
   config: ModelConfig,
   hasOpenRouter: boolean,
+  useOpenRouter: boolean,
 ): Promise<PersonalModelAccessKind | null> {
-  if (config.openRouterOnly) return hasOpenRouter ? 'openrouter-key' : null;
+  if (shouldRouteThroughOpenRouter(config, useOpenRouter)) {
+    return hasOpenRouter ? 'openrouter-key' : null;
+  }
 
   const provider = config.provider as ApiProvider;
   if (!(API_PROVIDERS as readonly string[]).includes(provider)) {
@@ -59,8 +65,17 @@ async function getPersonalAccessKindForModel(
 interface ModelAvailabilityContext {
   hasOpenRouter: boolean;
   hasServerAccess: boolean;
+  useOpenRouter: boolean;
   useIncludedAccess: boolean;
   serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
+}
+
+function shouldRouteThroughOpenRouter(
+  config: ModelConfig,
+  useOpenRouter: boolean,
+): boolean {
+  if (config.requiresResponsesAPI) return false;
+  return config.openRouterOnly || useOpenRouter;
 }
 
 function canUseIncludedAccessForModel(
@@ -81,12 +96,13 @@ async function resolveModelAvailability(
   config: ModelConfig,
   ctx: ModelAvailabilityContext,
 ): Promise<ModelAvailabilityStatus> {
-  // OpenRouter-only models are intentionally outside included access; a
-  // configured OpenRouter key is the only ready state for them.
-  if (config.openRouterOnly) {
+  // OpenRouter routing is intentionally outside included access; a configured
+  // OpenRouter key is the only ready state for these calls.
+  if (shouldRouteThroughOpenRouter(config, ctx.useOpenRouter)) {
     const personalAccess = await getPersonalAccessKindForModel(
       config,
       ctx.hasOpenRouter,
+      ctx.useOpenRouter,
     );
     if (personalAccess === 'openrouter-key') {
       return {
@@ -121,6 +137,7 @@ async function resolveModelAvailability(
     const personalAccess = await getPersonalAccessKindForModel(
       config,
       ctx.hasOpenRouter,
+      ctx.useOpenRouter,
     );
     if (personalAccess === 'provider-key') {
       return {
@@ -150,7 +167,7 @@ async function resolveModelAvailability(
     kind: 'not-included',
     label: 'Not included',
     available: false,
-    requiresKey: true,
+    requiresKey: false,
   };
 }
 
@@ -163,6 +180,7 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
   return {
     hasOpenRouter,
     hasServerAccess,
+    useOpenRouter: getUseOpenRouter(),
     useIncludedAccess: serverSideKeyService.getUseIncludedModelAccess(),
     serverSideKeyService,
   };
@@ -180,7 +198,7 @@ export async function getModelUnavailableReason(
   if (availability.available) return null;
 
   // Determine the specific reason
-  if (config.openRouterOnly) {
+  if (shouldRouteThroughOpenRouter(config, ctx.useOpenRouter)) {
     return `Model "${model}" requires an OpenRouter API key. Set your OpenRouter key in the extension settings.`;
   }
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -92,12 +92,7 @@ async function resolveModelAvailability(
   // OpenRouter routing is intentionally outside included access; a configured
   // OpenRouter key is the only ready state for these calls.
   if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
-    const personalAccess = await getPersonalAccessKindForModel(
-      config,
-      ctx.hasOpenRouter,
-      ctx.useOpenRouter,
-    );
-    if (personalAccess === 'openrouter-key') {
+    if (ctx.hasOpenRouter) {
       return {
         kind: 'openrouter-key',
         label: 'OpenRouter key',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -9,7 +9,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - state
 // Local imports - shared schemas
-import type { ModelOptionData } from '@shared/schemas';
+import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 
 // Local imports - shared constants
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
@@ -23,24 +23,37 @@ import {
   getVisibleModels,
 } from './modelOptionsBasic';
 
-/** Check if a model is available via personal API keys. */
-async function hasPersonalKeyForModel(
+type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
+
+interface ModelAvailabilityStatus {
+  kind: ModelAvailabilityKind;
+  label: string;
+  available: boolean;
+  requiresKey: boolean;
+}
+
+/** Check whether a model is available through a personal provider or OpenRouter key. */
+async function getPersonalAccessKindForModel(
   config: ModelConfig,
   hasOpenRouter: boolean,
-): Promise<boolean> {
-  if (config.openRouterOnly) return hasOpenRouter;
+): Promise<PersonalModelAccessKind | null> {
+  if (config.openRouterOnly) return hasOpenRouter ? 'openrouter-key' : null;
 
   const provider = config.provider as ApiProvider;
-  if (!(API_PROVIDERS as readonly string[]).includes(provider)) return true;
+  if (!(API_PROVIDERS as readonly string[]).includes(provider)) {
+    return 'provider-key';
+  }
 
   try {
-    return (
-      (await apiKeyExists(platform().secrets, provider)) ||
-      !!(config.openrouterFullName && hasOpenRouter)
-    );
+    if (await apiKeyExists(platform().secrets, provider)) {
+      return 'provider-key';
+    }
   } catch {
-    return false;
+    // Treat unreadable provider keys as absent, but still allow OpenRouter
+    // fallback below when this model has an OpenRouter route.
   }
+
+  return config.openrouterFullName && hasOpenRouter ? 'openrouter-key' : null;
 }
 
 interface ModelAvailabilityContext {
@@ -50,22 +63,54 @@ interface ModelAvailabilityContext {
   serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
 }
 
-/** Determine if a model is available based on access mode and keys. */
-async function isModelAvailable(
+function canUseIncludedAccessForModel(
   model: string,
   config: ModelConfig,
   ctx: ModelAvailabilityContext,
-): Promise<boolean> {
-  // openRouterOnly models always need OpenRouter key
-  if (config.openRouterOnly) return ctx.hasOpenRouter;
-
-  // Check server-side relay availability
-  if (
+) {
+  return (
     ctx.hasServerAccess &&
     ctx.serverSideKeyService.isProviderOnServer(config.provider) &&
     ctx.serverSideKeyService.canUseModelSync(model)
-  ) {
-    return true;
+  );
+}
+
+/** Determine how a model can be used in the current access mode. */
+async function resolveModelAvailability(
+  model: string,
+  config: ModelConfig,
+  ctx: ModelAvailabilityContext,
+): Promise<ModelAvailabilityStatus> {
+  // OpenRouter-only models are intentionally outside included access; a
+  // configured OpenRouter key is the only ready state for them.
+  if (config.openRouterOnly) {
+    const personalAccess = await getPersonalAccessKindForModel(
+      config,
+      ctx.hasOpenRouter,
+    );
+    if (personalAccess === 'openrouter-key') {
+      return {
+        kind: 'openrouter-key',
+        label: 'OpenRouter key',
+        available: true,
+        requiresKey: false,
+      };
+    }
+    return {
+      kind: 'missing-key',
+      label: 'Missing API key',
+      available: false,
+      requiresKey: true,
+    };
+  }
+
+  if (canUseIncludedAccessForModel(model, config, ctx)) {
+    return {
+      kind: 'included-access',
+      label: 'Included access',
+      available: true,
+      requiresKey: false,
+    };
   }
 
   // Fall back to personal API keys when:
@@ -73,10 +118,40 @@ async function isModelAvailable(
   // - User has default "Use Included Access" but isn't actually authenticated with server access
   //   (avoids showing all models as disabled for unauthenticated users)
   if (!ctx.useIncludedAccess || !ctx.hasServerAccess) {
-    return hasPersonalKeyForModel(config, ctx.hasOpenRouter);
+    const personalAccess = await getPersonalAccessKindForModel(
+      config,
+      ctx.hasOpenRouter,
+    );
+    if (personalAccess === 'provider-key') {
+      return {
+        kind: 'provider-key',
+        label: 'API key set',
+        available: true,
+        requiresKey: false,
+      };
+    }
+    if (personalAccess === 'openrouter-key') {
+      return {
+        kind: 'openrouter-key',
+        label: 'OpenRouter key',
+        available: true,
+        requiresKey: false,
+      };
+    }
+    return {
+      kind: 'missing-key',
+      label: 'Missing API key',
+      available: false,
+      requiresKey: true,
+    };
   }
 
-  return false;
+  return {
+    kind: 'not-included',
+    label: 'Not included',
+    available: false,
+    requiresKey: true,
+  };
 }
 
 async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
@@ -101,15 +176,15 @@ export async function getModelUnavailableReason(
   if (!config) return `Model "${model}" is not recognized.`;
 
   const ctx = await buildAvailabilityContext();
-  const available = await isModelAvailable(model, config, ctx);
-  if (available) return null;
+  const availability = await resolveModelAvailability(model, config, ctx);
+  if (availability.available) return null;
 
   // Determine the specific reason
   if (config.openRouterOnly) {
     return `Model "${model}" requires an OpenRouter API key. Set your OpenRouter key in the extension settings.`;
   }
 
-  if (ctx.useIncludedAccess && ctx.hasServerAccess) {
+  if (availability.kind === 'not-included') {
     // User has server access but model isn't available on their tier
     return `Model "${model}" is not available with your current subscription tier. Upgrade your plan or switch to a different model.`;
   }
@@ -130,7 +205,7 @@ async function buildModelOptionData(
     return { value: model, label: model };
   }
 
-  const available = await isModelAvailable(model, config, ctx);
+  const availability = await resolveModelAvailability(model, config, ctx);
   return {
     value: model,
     label: config.label,
@@ -138,8 +213,10 @@ async function buildModelOptionData(
     context: formatContext(config.contextWindow),
     cost: formatCost(config.inputPrice, config.outputPrice),
     hint: buildModelHint(config),
-    requiresKey: !available,
-    disabled: !available,
+    availability: availability.kind,
+    availabilityLabel: availability.label,
+    requiresKey: availability.requiresKey,
+    disabled: !availability.available,
   };
 }
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -25,6 +25,7 @@ import {
   formatCost,
   getVisibleModels,
 } from './modelOptionsBasic';
+import { shouldRouteModelThroughOpenRouter } from './openRouterRouting';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
 
@@ -41,7 +42,7 @@ async function getPersonalAccessKindForModel(
   hasOpenRouter: boolean,
   useOpenRouter: boolean,
 ): Promise<PersonalModelAccessKind | null> {
-  if (shouldRouteThroughOpenRouter(config, useOpenRouter)) {
+  if (shouldRouteModelThroughOpenRouter(config, useOpenRouter)) {
     return hasOpenRouter ? 'openrouter-key' : null;
   }
 
@@ -70,14 +71,6 @@ interface ModelAvailabilityContext {
   serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
 }
 
-function shouldRouteThroughOpenRouter(
-  config: ModelConfig,
-  useOpenRouter: boolean,
-): boolean {
-  if (config.requiresResponsesAPI) return false;
-  return config.openRouterOnly || useOpenRouter;
-}
-
 function canUseIncludedAccessForModel(
   model: string,
   config: ModelConfig,
@@ -98,7 +91,7 @@ async function resolveModelAvailability(
 ): Promise<ModelAvailabilityStatus> {
   // OpenRouter routing is intentionally outside included access; a configured
   // OpenRouter key is the only ready state for these calls.
-  if (shouldRouteThroughOpenRouter(config, ctx.useOpenRouter)) {
+  if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
     const personalAccess = await getPersonalAccessKindForModel(
       config,
       ctx.hasOpenRouter,
@@ -198,7 +191,7 @@ export async function getModelUnavailableReason(
   if (availability.available) return null;
 
   // Determine the specific reason
-  if (shouldRouteThroughOpenRouter(config, ctx.useOpenRouter)) {
+  if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
     return `Model "${model}" requires an OpenRouter API key. Set your OpenRouter key in the extension settings.`;
   }
 

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -1,0 +1,13 @@
+export interface OpenRouterRoutingConfig {
+  requiresResponsesAPI?: boolean;
+  openRouterOnly: boolean;
+}
+
+/** Return whether this model request should be routed through OpenRouter. */
+export function shouldRouteModelThroughOpenRouter(
+  config: OpenRouterRoutingConfig,
+  useOpenRouter: boolean,
+): boolean {
+  if (config.requiresResponsesAPI) return false;
+  return config.openRouterOnly || useOpenRouter;
+}

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -77,11 +77,22 @@ export const PickerOptionBaseSchema = z.object({
 });
 export type PickerOptionBase = z.infer<typeof PickerOptionBaseSchema>;
 
+export const ModelAvailabilityKindSchema = z.enum([
+  'included-access',
+  'provider-key',
+  'openrouter-key',
+  'missing-key',
+  'not-included',
+]);
+export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
+
 export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),
   hint: z.string().optional(),
+  availability: ModelAvailabilityKindSchema.optional(),
+  availabilityLabel: z.string().optional(),
   requiresKey: z.boolean().optional(),
   disabled: z.boolean().optional(),
 });

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -125,7 +125,7 @@ export const selectStyles: CSSResult = css`
    * Border uses subtle surface-border, not heavier panel border. */
   ${compactFormControlStyles}
 
-  .api-key-missing {
+  .model-option-status {
     color: var(--wa-color-danger-on-quiet);
     opacity: var(--opacity-full);
     font-style: normal;

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -74,11 +74,7 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
     (opt.requiresKey ? 'missing-key' : opt.disabled ? 'not-included' : '');
   const availabilityLabel =
     opt.availabilityLabel ??
-    (opt.requiresKey
-      ? 'Missing API key'
-      : opt.disabled
-        ? 'Unavailable'
-        : 'Ready');
+    (opt.requiresKey ? 'Missing API key' : opt.disabled ? 'Unavailable' : '');
 
   const hints: string[] = [];
   if (decorator.label) hints.push(decorator.label);
@@ -96,7 +92,9 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
       data-cost=${opt.cost || nothing}
       data-availability=${availability || nothing}
       data-requires-key=${opt.requiresKey ? 'true' : nothing}
-      aria-label=${`${opt.label} (${availabilityLabel})`}
+      aria-label=${availabilityLabel
+        ? `${opt.label} (${availabilityLabel})`
+        : opt.label}
     >
       ${display}
       ${opt.disabled

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -74,7 +74,7 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
     (opt.requiresKey ? 'missing-key' : opt.disabled ? 'not-included' : '');
   const availabilityLabel =
     opt.availabilityLabel ??
-    (opt.requiresKey ? 'Missing API key' : opt.disabled ? 'Unavailable' : '');
+    (opt.requiresKey ? 'Missing API key' : opt.disabled ? 'Not included' : '');
 
   const hints: string[] = [];
   if (decorator.label) hints.push(decorator.label);

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -69,11 +69,21 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
   const display = decorator.unicode
     ? `${decorator.unicode} ${opt.label}`
     : opt.label;
+  const availability =
+    opt.availability ??
+    (opt.requiresKey ? 'missing-key' : opt.disabled ? 'not-included' : '');
+  const availabilityLabel =
+    opt.availabilityLabel ??
+    (opt.requiresKey
+      ? 'Missing API key'
+      : opt.disabled
+        ? 'Unavailable'
+        : 'Ready');
 
   const hints: string[] = [];
   if (decorator.label) hints.push(decorator.label);
   if (opt.hint) hints.push(opt.hint);
-  if (opt.requiresKey) hints.push('⚠ API key not configured');
+  if (availabilityLabel) hints.push(availabilityLabel);
   const tooltip = hints.join(' | ');
 
   return html`
@@ -84,11 +94,13 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
       data-provider=${opt.provider || nothing}
       data-context=${opt.context || nothing}
       data-cost=${opt.cost || nothing}
+      data-availability=${availability || nothing}
       data-requires-key=${opt.requiresKey ? 'true' : nothing}
+      aria-label=${`${opt.label} (${availabilityLabel})`}
     >
       ${display}
-      ${opt.requiresKey
-        ? html`<span class="api-key-missing"> ✗</span>`
+      ${opt.disabled
+        ? html`<span class="model-option-status"> ${availabilityLabel} </span>`
         : nothing}
     </wa-option>
   `;

--- a/src/test-kernel/model/OpenRouterRouting.vitest.ts
+++ b/src/test-kernel/model/OpenRouterRouting.vitest.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+
+describe('shouldRouteModelThroughOpenRouter', () => {
+  it('routes OpenRouter-only models through OpenRouter', () => {
+    expect(
+      shouldRouteModelThroughOpenRouter(
+        { openRouterOnly: true, requiresResponsesAPI: false },
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('routes ordinary models through OpenRouter when the global mode is enabled', () => {
+    expect(
+      shouldRouteModelThroughOpenRouter(
+        { openRouterOnly: false, requiresResponsesAPI: false },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not route Responses API models through OpenRouter', () => {
+    expect(
+      shouldRouteModelThroughOpenRouter(
+        { openRouterOnly: true, requiresResponsesAPI: true },
+        true,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit model availability kind and label to model option data
- distinguish Included Access, provider API keys, OpenRouter keys, missing keys, and models outside the current included tier
- show the status in shared model picker tooltips, accessibility labels, disabled option text, and CLI model access output

## Design Notes
This keeps the existing picker structure and avoids live provider probing. The model option computation remains the single place that decides whether a model is ready for the current access mode.

## Validation
- npm run format
- npm run typecheck
- npm run test:kernel -- src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts src/test-kernel/settings/ProviderKeyRows.vitest.mts
- npm run compile:fast
- npm run lint
- git diff --check

Closes #3867

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how model availability is computed and displayed across the extension/CLI, including OpenRouter routing decisions and cache invalidation on settings changes. Risk is moderate because incorrect availability classification could disable models or route requests through the wrong backend.
> 
> **Overview**
> Adds explicit model availability metadata (`availability` + `availabilityLabel`) to `ModelOptionData` and computes it in `computeModelOptionsData`, distinguishing **included access**, **provider key**, **OpenRouter key**, **missing key**, and **not included** states.
> 
> Updates the shared model picker rendering to show these statuses in tooltips/ARIA labels and as inline text for disabled options, and updates the CLI to prefer `availabilityLabel` for its model status output.
> 
> Centralizes OpenRouter routing logic in new `shouldRouteModelThroughOpenRouter` (used by both proxy/base-URL resolution and model availability checks), adds kernel tests for it, and ensures toggling the OpenRouter global setting invalidates model option caches and refreshes model options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c86f481932ed2b354c7925a6b9faa39d119c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->