### PR TITLE
refactor: use filesystem helper for delegation cwd checks

### DIFF
--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -8,7 +8,6 @@
 
 // Third-party imports
 import { randomUUID } from 'crypto';
-import { statSync } from 'fs';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -82,7 +81,7 @@ import { displayToStoragePath } from '@tools/memory/memoryUtils';
 // Local imports - worktree config
 
 // Local imports - utils
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { generateExecutionId } from '@utils/core/executionId';
 
 // ============================================================================
@@ -146,7 +145,7 @@ const WORKTREE_DISABLED_MESSAGE =
 
 function ensureWorkingDirectoryExists(dir: string): void {
   try {
-    const stat = statSync(dir);
+    const stat = AbsoluteFS.statSync(dir);
     if (stat.isDirectory()) return;
   } catch (e) {
     const reason = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary
- Replace direct fs.statSync usage in delegation working-directory validation with AbsoluteFS.statSync.
- Keep the validation behavior unchanged while following the repository filesystem abstraction.
- Follow up on the #3879 automated review suggestion about raw fs usage in src/tools.

## Test plan
- npm run format
- npm run typecheck
- npm run compile:fast
- npm run lint
- git diff --check

Note: attempted npx vitest run src/test/tools/DelegationTools.test.ts, but the current Vitest config only includes src/test-kernel/**/*.vitest.{ts,mts}, so no test file was selected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that swaps direct `fs.statSync` usage for the existing filesystem abstraction while keeping the same working-directory validation behavior.
> 
> **Overview**
> Updates delegation working-directory validation to use the repo’s filesystem helper instead of Node’s raw `fs`.
> 
> `ensureWorkingDirectoryExists` now calls `AbsoluteFS.statSync` (and `DelegationTools` imports `AbsoluteFS`), removing the direct `fs.statSync` dependency while preserving the existing directory/existence checks and error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89982fcddb0537d716655e3f822160096e1bb721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->