### PR TITLE
fix: route desktop tool edit diffs through diff host

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -183,6 +183,7 @@ export class DesktopProgressBridge {
     this.toolEditApprovals = createDesktopToolEditApprovalController({
       openPath: options.openPath,
       openBuildDisplay: options.openBuildDisplay,
+      openDiff: options.openDiff,
       showErrorMessage: (message) => this.showErrorMessage(message),
     });
     this.runtimeHost = {

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { bus } from '@eventBus/ProgressEventBus';
+import type { DiffViewHost } from '@hosts/diffViewHost';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
   previewProposedLatex,
@@ -27,6 +28,7 @@ import { WorkspaceFS } from '@utils/files';
 export interface DesktopToolEditApprovalOptions {
   openPath?: (filePath: string) => Promise<void>;
   openBuildDisplay?: BuildDisplayFn;
+  openDiff?: DiffViewHost['openDiff'];
   showErrorMessage?: (message: string) => Promise<void> | void;
   tempRoot?: string;
 }
@@ -252,6 +254,16 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   private async openDiffPatch(
     entry: DesktopPendingToolEditApproval,
   ): Promise<void> {
+    if (this.options.openDiff) {
+      await this.options.openDiff(
+        { filePath: entry.originalUri.fsPath },
+        { filePath: entry.proposedUri.fsPath },
+        `Tool edit: ${path.basename(entry.request.path)}`,
+        { preserveFocus: true },
+      );
+      return;
+    }
+
     if (!this.options.openPath) {
       await this.report('Desktop diff preview is unavailable.');
       return;

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -5,6 +5,12 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type {
+  DiffOptions,
+  DiffSession,
+  DiffSource,
+  DiffViewHost,
+} from '@hosts/diffViewHost';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
@@ -15,6 +21,7 @@ interface DesktopToolEditApprovalModule {
       location: { absolutePath: string },
       options?: { preserveFocus?: boolean },
     ) => Promise<void>;
+    openDiff?: DiffViewHost['openDiff'];
     showErrorMessage?: (message: string) => Promise<void> | void;
     tempRoot?: string;
   }): {
@@ -241,6 +248,63 @@ describe('desktop tool edit approval', () => {
         await expect(pathExists(opened[0])).resolves.toBe(false);
         await expect(pathExists(opened[1])).resolves.toBe(false);
       });
+    } finally {
+      offShow();
+      controller.dispose();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('routes diff actions through the injected desktop diff host when available', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
+    const { bus, requestToolEditApproval, desktopModule } =
+      await loadApprovalModules();
+    const openPath = vi.fn(async (_filePath: string) => {});
+    const openDiff = vi.fn(
+      async (
+        original: DiffSource,
+        proposed: DiffSource,
+        title: string,
+        _options?: DiffOptions,
+      ): Promise<DiffSession> => ({ original, proposed, title }),
+    );
+    const controller = desktopModule.createDesktopToolEditApprovalController({
+      tempRoot,
+      openPath,
+      openDiff,
+    });
+    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
+    const offShow = bus.on('showToolEditPermission', (payload) =>
+      shown.push(payload),
+    );
+
+    try {
+      const resultPromise = requestToolEditApproval({
+        path: '/workspace/main.tex',
+        originalContent: 'old\n',
+        proposedContent: 'new\n',
+        sourceTool: 'write_file',
+      });
+      await vi.waitFor(() => expect(shown).toHaveLength(1));
+
+      controller.handleAction({
+        requestId: shown[0].requestId,
+        action: 'openDiff',
+      });
+
+      await vi.waitFor(() => expect(openDiff).toHaveBeenCalledOnce());
+      expect(openPath).not.toHaveBeenCalled();
+      const [original, proposed, title, options] = openDiff.mock.calls[0];
+      expect(title).toBe('Tool edit: main.tex');
+      expect(options).toEqual({ preserveFocus: true });
+      await expect(pathExists(original.filePath)).resolves.toBe(true);
+      await expect(pathExists(proposed.filePath)).resolves.toBe(true);
+
+      controller.handleAction({
+        requestId: shown[0].requestId,
+        action: 'reject',
+      });
+      await expect(resultPromise).resolves.toMatchObject({ accepted: false });
     } finally {
       offShow();
       controller.dispose();


### PR DESCRIPTION
## Summary

- Pass the existing desktop diff host into the desktop tool-edit approval controller.
- Route tool-edit `openDiff` actions through `DiffViewHost.openDiff` when available, preserving the existing temporary `.diff` file fallback for headless or unwired hosts.
- Add kernel coverage for the injected diff-host path.

This closes the last remaining part of #3570. Earlier work had already implemented desktop `openFileCompile`, proposed-file preview, and LaTeX diff preview; this PR connects tool-edit diff actions to the Phase 5 diff host.

Fixes #3570.

## Validation

- `npx vitest run src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts`
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npx vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with 75 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to desktop UI wiring for tool-edit diff previews and add test coverage, with the existing temp `.diff` fallback preserved.
> 
> **Overview**
> Tool-edit approval diff previews now use the injected desktop `DiffViewHost.openDiff` when available, instead of always generating and opening a temporary `.diff` file.
> 
> `DesktopProgressBridge` passes `openDiff` into the tool-edit approval controller, and kernel tests add coverage to ensure `openDiff` is called (with `preserveFocus`) and `openPath` is not used when the diff host is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ba51f9cee2e087ba8be890482e55350ed224fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->