### PR TITLE
fix: restore desktop installer CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,20 @@ jobs:
         run: node scripts/verify-desktop-signing-env.mjs mac
 
       - name: Package macOS desktop installers
-        run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
+        run: |
+          if [ '${{ steps.desktop-signing.outputs.signed }}' != 'true' ]; then
+            unset CSC_LINK
+            unset CSC_KEY_PASSWORD
+            unset APPLE_API_KEY
+            unset APPLE_API_KEY_ID
+            unset APPLE_API_ISSUER
+            unset APPLE_ID
+            unset APPLE_APP_SPECIFIC_PASSWORD
+            unset APPLE_TEAM_ID
+            unset APPLE_KEYCHAIN
+            unset APPLE_KEYCHAIN_PROFILE
+          fi
+          pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
       - name: Check macOS packaged desktop app contents
         run: pnpm run check:desktop-package

--- a/package.json
+++ b/package.json
@@ -104,24 +104,6 @@
     "webpack-cli": "^7.0.2",
     "zod-v3-to-v4": "^1.21.1"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron"
-    ],
-    "supportedArchitectures": {
-      "os": [
-        "current"
-      ],
-      "cpu": [
-        "current",
-        "x64",
-        "arm64"
-      ],
-      "libc": [
-        "current"
-      ]
-    }
-  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.2",
     "@awesome.me/webawesome": "^3.6.0",

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -15,7 +15,7 @@ asar: true
 asarUnpack:
   - '**/node_modules/@openai/codex-*/**'
 npmRebuild: false
-afterPack: ../../scripts/prune-desktop-codex-payload.mjs
+afterPack: ./scripts/prune-desktop-codex-payload.mjs
 directories:
   output: dist-packaged
   buildResources: build

--- a/packages/desktop/scripts/prune-desktop-codex-payload.mjs
+++ b/packages/desktop/scripts/prune-desktop-codex-payload.mjs
@@ -1,0 +1,1 @@
+export { default } from '../../../scripts/prune-desktop-codex-payload.mjs';

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,14 @@
 packages:
   - packages/*
+supportedArchitectures:
+  os:
+    - current
+  cpu:
+    - current
+    - x64
+    - arm64
+  libc:
+    - current
 allowBuilds:
   '@google/genai': true
   '@openrouter/sdk': true

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -297,20 +297,31 @@ function hasSegmentToken(segment, ...tokens) {
 function archFromPathToken(normalizedPath) {
   const segments = normalizedPath.split('/').reverse();
   for (const segment of segments) {
-    if (hasSegmentToken(segment, 'universal')) return 'universal';
+    if (isUniversalDarwinSegment(segment)) return 'universal';
     if (hasSegmentToken(segment, 'arm64', 'aarch64')) return 'arm64';
     if (hasSegmentToken(segment, 'x64', 'x86_64', 'amd64')) return 'x64';
   }
   return null;
 }
 
+function isUniversalDarwinSegment(segment) {
+  return (
+    (segment === 'universal' || hasSegmentToken(segment, 'mac', 'darwin')) &&
+    hasSegmentToken(segment, 'universal')
+  );
+}
+
 function normalizeArch(arch, normalizedPath, normalizedPlatform) {
+  const pathArch = archFromPathToken(normalizedPath);
+  if (normalizedPlatform === 'darwin' && pathArch === 'universal') {
+    return 'universal';
+  }
+
   const archName = archNameByElectronBuilderArch[arch] ?? arch;
   if (archName === 'universal') return 'universal';
   if (archName === 'arm64') return 'arm64';
   if (archName === 'x64') return 'x64';
 
-  const pathArch = archFromPathToken(normalizedPath);
   if (pathArch != null) return pathArch;
 
   if (

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -24,6 +24,9 @@ const payloadUrl = pathToFileURL(
 const pruneHookUrl = pathToFileURL(
   repoPath('scripts/prune-desktop-codex-payload.mjs'),
 ).href;
+const desktopPruneHookUrl = pathToFileURL(
+  repoPath('packages/desktop/scripts/prune-desktop-codex-payload.mjs'),
+).href;
 const extensionPackageUtilsUrl = pathToFileURL(
   repoPath('scripts/extension-package-utils.mjs'),
 ).href;
@@ -108,7 +111,11 @@ describe('desktop Codex package payload', () => {
 
   it('infers architecture from path tokens nearest the app bundle', async () => {
     const { inferCodexPlatformKeys } = (await import(payloadUrl)) as {
-      inferCodexPlatformKeys: (input: { appPath: string }) => string[];
+      inferCodexPlatformKeys: (input: {
+        appPath: string;
+        arch?: number;
+        platform?: string;
+      }) => string[];
     };
 
     expect(
@@ -121,6 +128,13 @@ describe('desktop Codex package payload', () => {
         appPath: '/tmp/universal-cache/dist/mac-arm64/TeXRA.app',
       }),
     ).toEqual(['darwin-arm64']);
+    expect(
+      inferCodexPlatformKeys({
+        platform: 'darwin',
+        arch: 1,
+        appPath: '/tmp/universal-cache/dist/TeXRA.app',
+      }),
+    ).toEqual(['darwin-x64']);
   });
 
   it('defaults Linux and Windows package paths without architecture tokens to x64', async () => {
@@ -159,6 +173,45 @@ describe('desktop Codex package payload', () => {
     );
 
     expect(universalBudget).toBeGreaterThan(singlePlatformBudget);
+  });
+
+  it('keeps both Darwin Codex packages during universal temp packaging', async () => {
+    const { inferCodexPlatformKeys } = (await import(payloadUrl)) as {
+      inferCodexPlatformKeys: (input: {
+        arch: number;
+        appPath: string;
+        platform: string;
+      }) => string[];
+    };
+
+    expect(
+      inferCodexPlatformKeys({
+        platform: 'darwin',
+        arch: 1,
+        appPath:
+          '/tmp/dist-packaged/mac-universal-x64-temp/TeXRA.app/Contents/Resources',
+      }),
+    ).toEqual(['darwin-x64', 'darwin-arm64']);
+  });
+
+  it('loads the desktop-local electron-builder pruning hook', async () => {
+    const rootHook = await import(pruneHookUrl);
+    const desktopHook = await import(desktopPruneHookUrl);
+
+    expect(desktopHook.default).toBe(rootHook.default);
+  });
+
+  it('keeps pnpm platform settings in the workspace manifest', () => {
+    const rootPackageJson = JSON.parse(
+      readFileSync(repoPath('package.json'), 'utf8'),
+    ) as { pnpm?: unknown };
+    const workspaceYaml = readFileSync(repoPath('pnpm-workspace.yaml'), 'utf8');
+
+    expect(rootPackageJson.pnpm).toBeUndefined();
+    expect(workspaceYaml).toContain('supportedArchitectures:');
+    expect(workspaceYaml).toContain('  cpu:');
+    expect(workspaceYaml).toContain('    - x64');
+    expect(workspaceYaml).toContain('    - arm64');
   });
 
   it('resolves relative metafile imports from the importing output directory', () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -206,6 +206,28 @@ function createDeferred(): {
   return { promise, resolve };
 }
 
+function inactiveLatexSettingsStatus(): unknown {
+  return {
+    outDir: true,
+    autoRevealExclude: true,
+    texDistributionInstalled: false,
+    latexWorkshopInstalled: false,
+    latexdiffInstalled: false,
+    latexindentInstalled: false,
+    texcountInstalled: false,
+    imageProcessingInstalled: false,
+    platform: 'linux',
+    pdflatexPath: null,
+    latexmkPath: null,
+    latexdiffPath: null,
+    latexindentPath: null,
+    texcountPath: null,
+    ghostscriptPath: null,
+    graphicsmagickPath: null,
+    packageManager: null,
+  };
+}
+
 describe('desktop settings IPC', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -834,25 +856,8 @@ describe('desktop settings IPC', () => {
           requiresSetup: false,
         },
       ],
-      detectLatexSettingsStatus: async () => ({
-        outDir: true,
-        autoRevealExclude: true,
-        texDistributionInstalled: false,
-        latexWorkshopInstalled: false,
-        latexdiffInstalled: false,
-        latexindentInstalled: false,
-        texcountInstalled: false,
-        imageProcessingInstalled: false,
-        platform: 'linux',
-        pdflatexPath: null,
-        latexmkPath: null,
-        latexdiffPath: null,
-        latexindentPath: null,
-        texcountPath: null,
-        ghostscriptPath: null,
-        graphicsmagickPath: null,
-        packageManager: null,
-      }),
+      detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
+      onError: () => undefined,
       postToRenderer: (message) => posted.push(message),
     });
 
@@ -898,6 +903,11 @@ describe('desktop settings IPC', () => {
       config: new MemoryConfigStore(),
       sendStartupCatalogData: true,
       modelListRefresh: modelListRefresh.promise,
+      loadAgents: async () => undefined,
+      getCustomAgentDirectory: async () => '',
+      buildToolDashboardItems: async () => [],
+      detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
+      onError: () => undefined,
       postToRenderer: (message) => posted.push(message),
     });
 


### PR DESCRIPTION
## Summary

- move pnpm platform settings from the deprecated package.json pnpm block into pnpm-workspace.yaml so pnpm 11 installs the cross-architecture Codex optional packages needed by macOS universal packaging
- route the electron-builder afterPack hook through a desktop-local wrapper so Windows packaging no longer resolves a hook outside its detected workspace root
- keep Codex payload pruning from reducing macOS universal temporary apps to different package sets before electron-builder merges them

Fixes #3898.

## Verification

- npm run format
- npm run typecheck
- npm run compile:fast
- npm run lint (passes with the existing warning baseline)
- npx vitest run src/test-kernel/desktop/DesktopCodexPayload.vitest.mts src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes desktop packaging/CI behavior (signing env handling, electron-builder hooks, and pnpm architecture settings), which could break installer generation across platforms if misconfigured.
> 
> **Overview**
> Restores reliable desktop installer builds by preventing macOS packaging from accidentally running with partial signing/notarization env vars, and by routing the `electron-builder` `afterPack` pruning hook through a desktop-local wrapper path.
> 
> Moves pnpm cross-architecture installation settings out of the deprecated root `package.json` `pnpm` block into `pnpm-workspace.yaml`, and adjusts Codex payload platform/arch inference to avoid pruning one half of macOS *universal* temp builds. Updates/extends vitest coverage to lock in these behaviors and fixes desktop settings IPC tests by centralizing the default LaTeX tooling status stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1141f46c76da6857ede97fb4b7459536e55b21b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->