### PR TITLE
fix: enforce GPT-5 reasoning caps in relay

### DIFF
--- a/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
+++ b/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
@@ -6,6 +6,16 @@ import { describe, it } from 'vitest';
 
 // Local imports - Supabase relay
 import { capOpenAIReasoningEffortForTier } from '../../../supabase/functions/relay/reasoning';
+import {
+  FREE_TIER,
+  MAX_TIER,
+  ULTRA_TIER,
+} from '../../../supabase/functions/relay/tierConstants';
+
+const TIER_CAPS = {
+  [FREE_TIER]: 'medium',
+  [MAX_TIER]: 'high',
+} as const;
 
 describe('relay GPT-5 reasoning effort caps', () => {
   it('caps chat-completions xhigh to medium for free tier GPT-5 requests', () => {
@@ -17,8 +27,9 @@ describe('relay GPT-5 reasoning effort caps', () => {
     assert.deepEqual(
       capOpenAIReasoningEffortForTier(body, {
         provider: 'openai',
-        tier: 'free',
+        tier: FREE_TIER,
         modelName: body.model,
+        tierCaps: TIER_CAPS,
       }),
       {
         model: 'gpt-5-mini-2025-08-15',
@@ -36,8 +47,9 @@ describe('relay GPT-5 reasoning effort caps', () => {
     assert.deepEqual(
       capOpenAIReasoningEffortForTier(body, {
         provider: 'openai',
-        tier: 'Max',
+        tier: MAX_TIER,
         modelName: body.model,
+        tierCaps: TIER_CAPS,
       }),
       {
         model: 'openai/gpt5-mini',
@@ -55,8 +67,9 @@ describe('relay GPT-5 reasoning effort caps', () => {
     assert.equal(
       capOpenAIReasoningEffortForTier(body, {
         provider: 'openai',
-        tier: 'Ultra',
+        tier: ULTRA_TIER,
         modelName: body.model,
+        tierCaps: TIER_CAPS,
       }),
       body,
     );
@@ -75,16 +88,18 @@ describe('relay GPT-5 reasoning effort caps', () => {
     assert.equal(
       capOpenAIReasoningEffortForTier(nonGpt5Body, {
         provider: 'openai',
-        tier: 'free',
+        tier: FREE_TIER,
         modelName: nonGpt5Body.model,
+        tierCaps: TIER_CAPS,
       }),
       nonGpt5Body,
     );
     assert.equal(
       capOpenAIReasoningEffortForTier(nonOpenAIBody, {
         provider: 'deepseek',
-        tier: 'free',
+        tier: FREE_TIER,
         modelName: nonOpenAIBody.model,
+        tierCaps: TIER_CAPS,
       }),
       nonOpenAIBody,
     );

--- a/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
+++ b/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
@@ -1,0 +1,92 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - Supabase relay
+import { capOpenAIReasoningEffortForTier } from '../../../supabase/functions/relay/reasoning';
+
+describe('relay GPT-5 reasoning effort caps', () => {
+  it('caps chat-completions xhigh to medium for free tier GPT-5 requests', () => {
+    const body = {
+      model: 'gpt-5-mini-2025-08-15',
+      reasoning_effort: 'xhigh',
+    };
+
+    assert.deepEqual(
+      capOpenAIReasoningEffortForTier(body, {
+        provider: 'openai',
+        tier: 'free',
+        modelName: body.model,
+      }),
+      {
+        model: 'gpt-5-mini-2025-08-15',
+        reasoning_effort: 'medium',
+      },
+    );
+  });
+
+  it('caps responses xhigh to high for Max tier GPT-5 requests', () => {
+    const body = {
+      model: 'openai/gpt5-mini',
+      reasoning: { effort: 'xhigh', summary: 'auto' },
+    };
+
+    assert.deepEqual(
+      capOpenAIReasoningEffortForTier(body, {
+        provider: 'openai',
+        tier: 'Max',
+        modelName: body.model,
+      }),
+      {
+        model: 'openai/gpt5-mini',
+        reasoning: { effort: 'high', summary: 'auto' },
+      },
+    );
+  });
+
+  it('does not cap Ultra tier GPT-5 requests', () => {
+    const body = {
+      model: 'gpt-5-mini-2025-08-15',
+      reasoning_effort: 'xhigh',
+    };
+
+    assert.equal(
+      capOpenAIReasoningEffortForTier(body, {
+        provider: 'openai',
+        tier: 'Ultra',
+        modelName: body.model,
+      }),
+      body,
+    );
+  });
+
+  it('does not cap non-GPT-5 or non-OpenAI requests', () => {
+    const nonGpt5Body = {
+      model: 'gpt-4.1',
+      reasoning_effort: 'xhigh',
+    };
+    const nonOpenAIBody = {
+      model: 'gpt-5-mini-2025-08-15',
+      reasoning_effort: 'xhigh',
+    };
+
+    assert.equal(
+      capOpenAIReasoningEffortForTier(nonGpt5Body, {
+        provider: 'openai',
+        tier: 'free',
+        modelName: nonGpt5Body.model,
+      }),
+      nonGpt5Body,
+    );
+    assert.equal(
+      capOpenAIReasoningEffortForTier(nonOpenAIBody, {
+        provider: 'deepseek',
+        tier: 'free',
+        modelName: nonOpenAIBody.model,
+      }),
+      nonOpenAIBody,
+    );
+  });
+});

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -70,6 +70,7 @@ import {
   ULTRA_TIER,
   FREE_TIER,
 } from './models.ts';
+import { capOpenAIReasoningEffortForTier } from './reasoning.ts';
 
 // =============================================================================
 // Constants
@@ -107,6 +108,8 @@ type ProviderKey =
   | 'dashscope'
   | 'minimax'
   | 'glm';
+
+type JsonRecord = Record<string, unknown>;
 
 // =============================================================================
 // Provider Configuration
@@ -166,6 +169,10 @@ const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
 
 function getProviderConfig(provider: string): ProviderConfig | null {
   return PROVIDER_CONFIGS[provider as ProviderKey] || null;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getEnabledProviders(): string[] {
@@ -570,14 +577,19 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   );
 
   let requestBody: string | null = null;
+  let requestBodyJson: unknown = null;
   let modelName: string | null = null;
 
   if (userTier !== ULTRA_TIER && c.req.method !== 'GET' && !isModelFreePath) {
     requestBody = await c.req.text();
 
     try {
-      const bodyJson = JSON.parse(requestBody);
-      modelName = bodyJson.model || null;
+      requestBodyJson = JSON.parse(requestBody);
+      modelName =
+        isJsonRecord(requestBodyJson) &&
+        typeof requestBodyJson.model === 'string'
+          ? requestBodyJson.model
+          : null;
     } catch {
       // Not JSON, try extracting from path
     }
@@ -596,6 +608,15 @@ app.all('/:provider{[^/]+}/*', async (c) => {
           : `Could not determine model from request. ${tierName} tier requires explicit model specification.`,
         403,
       );
+    }
+
+    const cappedBody = capOpenAIReasoningEffortForTier(requestBodyJson, {
+      provider,
+      tier: userTier,
+      modelName,
+    });
+    if (cappedBody !== requestBodyJson) {
+      requestBody = JSON.stringify(cappedBody);
     }
   }
 

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -69,8 +69,13 @@ import {
   getSpendingLimit,
   ULTRA_TIER,
   FREE_TIER,
+  MAX_TIER,
 } from './models.ts';
-import { capOpenAIReasoningEffortForTier } from './reasoning.ts';
+import {
+  capOpenAIReasoningEffortForTier,
+  isJsonRecord,
+  type ReasoningEffortCap,
+} from './reasoning.ts';
 
 // =============================================================================
 // Constants
@@ -85,6 +90,11 @@ const RELAY_VERSION = '1.9.0';
 
 // Upstream request timeout (390s to fit within Supabase's 400s wall clock limit)
 const UPSTREAM_TIMEOUT_MS = 390000;
+
+const OPENAI_GPT5_REASONING_EFFORT_CAPS: Record<string, ReasoningEffortCap> = {
+  [FREE_TIER]: 'medium',
+  [MAX_TIER]: 'high',
+};
 
 // =============================================================================
 // Types
@@ -108,8 +118,6 @@ type ProviderKey =
   | 'dashscope'
   | 'minimax'
   | 'glm';
-
-type JsonRecord = Record<string, unknown>;
 
 // =============================================================================
 // Provider Configuration
@@ -169,10 +177,6 @@ const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
 
 function getProviderConfig(provider: string): ProviderConfig | null {
   return PROVIDER_CONFIGS[provider as ProviderKey] || null;
-}
-
-function isJsonRecord(value: unknown): value is JsonRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getEnabledProviders(): string[] {
@@ -614,6 +618,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
       provider,
       tier: userTier,
       modelName,
+      tierCaps: OPENAI_GPT5_REASONING_EFFORT_CAPS,
     });
     if (cappedBody !== requestBodyJson) {
       requestBody = JSON.stringify(cappedBody);
@@ -644,6 +649,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     'proxy-authorization',
     'proxy-connection',
     'authorization',
+    'content-length',
     'x-api-key',
     'x-goog-api-key',
     'x-texra-auth',

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -9,6 +9,9 @@
  */
 
 import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.6.1';
+import { FREE_TIER, MAX_TIER, ULTRA_TIER } from './tierConstants.ts';
+
+export { FREE_TIER, MAX_TIER, ULTRA_TIER };
 
 // =============================================================================
 // Types
@@ -129,11 +132,6 @@ export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
 // =============================================================================
 // Tier Constants
 // =============================================================================
-
-/** Tier value constants - exported for use in relay index.ts */
-export const ULTRA_TIER = 'Ultra';
-export const MAX_TIER = 'Max';
-export const FREE_TIER = 'free';
 
 /**
  * Get the monthly spending limit for a tier.

--- a/supabase/functions/relay/reasoning.ts
+++ b/supabase/functions/relay/reasoning.ts
@@ -1,0 +1,72 @@
+export interface ReasoningEffortCapContext {
+  provider: string;
+  tier: string;
+  modelName: string | null;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isGpt5Model(modelName: string | null): boolean {
+  if (!modelName) return false;
+
+  const normalized = modelName.toLowerCase().trim();
+  const modelPart = normalized.includes('/')
+    ? normalized.slice(normalized.indexOf('/') + 1)
+    : normalized;
+
+  return modelPart.startsWith('gpt-5') || modelPart.startsWith('gpt5');
+}
+
+function capForTier(tier: string): 'high' | 'medium' | null {
+  if (tier === 'Max') return 'high';
+  if (tier === 'free') return 'medium';
+  return null;
+}
+
+/**
+ * Apply the relay-side GPT-5 reasoning cap for included-access requests.
+ *
+ * The extension applies the same cap before it calls the relay. This helper
+ * enforces the policy at the server boundary as well, so direct relay callers
+ * cannot bypass it by sending `xhigh` manually.
+ */
+export function capOpenAIReasoningEffortForTier(
+  requestBody: unknown,
+  context: ReasoningEffortCapContext,
+): unknown {
+  const cappedEffort = capForTier(context.tier);
+  if (
+    context.provider !== 'openai' ||
+    !cappedEffort ||
+    !isGpt5Model(context.modelName) ||
+    !isRecord(requestBody)
+  ) {
+    return requestBody;
+  }
+
+  let cappedBody: JsonRecord | null = null;
+  const nextBody = () => {
+    cappedBody ??= { ...requestBody };
+    return cappedBody;
+  };
+
+  if (requestBody.reasoning_effort === 'xhigh') {
+    nextBody().reasoning_effort = cappedEffort;
+  }
+
+  if (
+    isRecord(requestBody.reasoning) &&
+    requestBody.reasoning.effort === 'xhigh'
+  ) {
+    nextBody().reasoning = {
+      ...requestBody.reasoning,
+      effort: cappedEffort,
+    };
+  }
+
+  return cappedBody ?? requestBody;
+}

--- a/supabase/functions/relay/reasoning.ts
+++ b/supabase/functions/relay/reasoning.ts
@@ -2,11 +2,13 @@ export interface ReasoningEffortCapContext {
   provider: string;
   tier: string;
   modelName: string | null;
+  tierCaps: Record<string, ReasoningEffortCap>;
 }
 
-type JsonRecord = Record<string, unknown>;
+export type ReasoningEffortCap = 'high' | 'medium';
+export type JsonRecord = Record<string, unknown>;
 
-function isRecord(value: unknown): value is JsonRecord {
+export function isJsonRecord(value: unknown): value is JsonRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
@@ -21,10 +23,11 @@ function isGpt5Model(modelName: string | null): boolean {
   return modelPart.startsWith('gpt-5') || modelPart.startsWith('gpt5');
 }
 
-function capForTier(tier: string): 'high' | 'medium' | null {
-  if (tier === 'Max') return 'high';
-  if (tier === 'free') return 'medium';
-  return null;
+function capForTier(
+  tier: string,
+  tierCaps: Record<string, ReasoningEffortCap>,
+): ReasoningEffortCap | null {
+  return tierCaps[tier] ?? null;
 }
 
 /**
@@ -38,12 +41,12 @@ export function capOpenAIReasoningEffortForTier(
   requestBody: unknown,
   context: ReasoningEffortCapContext,
 ): unknown {
-  const cappedEffort = capForTier(context.tier);
+  const cappedEffort = capForTier(context.tier, context.tierCaps);
   if (
     context.provider !== 'openai' ||
     !cappedEffort ||
     !isGpt5Model(context.modelName) ||
-    !isRecord(requestBody)
+    !isJsonRecord(requestBody)
   ) {
     return requestBody;
   }
@@ -59,7 +62,7 @@ export function capOpenAIReasoningEffortForTier(
   }
 
   if (
-    isRecord(requestBody.reasoning) &&
+    isJsonRecord(requestBody.reasoning) &&
     requestBody.reasoning.effort === 'xhigh'
   ) {
     nextBody().reasoning = {

--- a/supabase/functions/relay/tierConstants.ts
+++ b/supabase/functions/relay/tierConstants.ts
@@ -1,0 +1,4 @@
+/** Tier value constants shared by relay modules. */
+export const ULTRA_TIER = 'Ultra';
+export const MAX_TIER = 'Max';
+export const FREE_TIER = 'free';


### PR DESCRIPTION
## Summary
- Add a relay-side GPT-5 reasoning-effort cap so direct OpenAI relay callers cannot bypass the included-access policy by sending `xhigh` manually.
- Apply the same silent downgrade used by the client: `free` tier goes to `medium`, `Max` tier goes to `high`, and other tiers are unchanged.
- Cover both OpenAI chat-completions style `reasoning_effort` and responses-style `reasoning.effort` payloads with a focused regression test.

## Test plan
- [x] `npm run format`
- [x] `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/supabase/RelayReasoningCaps.vitest.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` (existing warnings only)
- [x] `npm run compile:fast`
- [x] `deno check supabase/functions/relay/reasoning.ts`
- [x] `deno check --node-modules-dir=auto supabase/functions/relay/index.ts`

Fixes #3257

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relay request parsing and mutation for OpenAI GPT-5 requests, which can affect upstream payloads and header forwarding; mistakes could inadvertently alter or reject valid requests.
> 
> **Overview**
> Adds relay-side enforcement to **silently cap OpenAI GPT-5 reasoning effort** based on user tier (e.g., `free` → `medium`, `Max` → `high`) for both chat-completions `reasoning_effort` and responses `reasoning.effort` payload shapes.
> 
> Refactors tier string constants into shared `tierConstants.ts`, introduces `reasoning.ts` helpers (`isJsonRecord`, `capOpenAIReasoningEffortForTier`), updates the relay proxy to parse JSON bodies more safely, rewrite the request body when capped, and skip forwarding `content-length`.
> 
> Adds a focused Vitest regression test covering capping behavior, non-capping for `Ultra`, and no-ops for non-GPT-5 or non-OpenAI requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848f206732dde1b9ac5d04da6be618b3988b1fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->