### PR TITLE
fix: reuse external inquiry session links

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -265,17 +265,13 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           ? html`
               <div class="external-inquiry-request__session-links-known">
                 <div class="external-inquiry-request__session-links-label">
-                  Known external session links for this thread:
+                  Known external sessions for follow-ups:
                 </div>
                 <div class="external-inquiry-request__session-links-list">
                   ${repeat(
                     sessionLinks,
                     (link) => link,
-                    (link) => html`
-                      <div class="external-inquiry-request__session-link-item">
-                        ${link}
-                      </div>
-                    `,
+                    (link) => this.renderKnownSessionLink(link),
                   )}
                 </div>
               </div>
@@ -283,7 +279,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           : nothing}
         <div class="external-inquiry-request__session-links-input-group">
           <div class="external-inquiry-request__session-links-label">
-            External chat/thread links (optional):
+            Save external chat link for follow-ups:
           </div>
           <div class="external-inquiry-request__chat-links">
             Open:
@@ -303,17 +299,46 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           </div>
           <textarea
             class="external-inquiry-request__session-links-input"
-            placeholder="Paste one ChatGPT/Claude/Gemini thread link per line..."
+            placeholder="Paste one external thread link per line..."
             .value=${live(this.sessionLinksText)}
             @input=${this.handleSessionLinksInput}
           ></textarea>
           <div class="external-inquiry-request__session-links-hint">
-            Paste back the external chat URLs you used so follow-up inquiries
-            can point you to the same conversations later.
+            Add the chat URL you used after pasting the answer.
           </div>
         </div>
       </div>
     `;
+  }
+
+  private renderKnownSessionLink(link: string): TemplateResult {
+    const href = ExternalInquiryPanel.safeHttpUrl(link);
+    if (!href) {
+      return html`
+        <div class="external-inquiry-request__session-link-item">${link}</div>
+      `;
+    }
+
+    return html`
+      <a
+        class="external-inquiry-request__session-link-item"
+        href=${href}
+        target="_blank"
+        rel="noopener noreferrer"
+        >${link}</a
+      >
+    `;
+  }
+
+  private static safeHttpUrl(link: string): string | undefined {
+    try {
+      const url = new URL(link);
+      return url.protocol === 'http:' || url.protocol === 'https:'
+        ? url.href
+        : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private renderActions(): TemplateResult {

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -50,6 +50,17 @@ function getRequestId(permission: { data: unknown }): string {
   return (permission.data as ExternalInquiryPermission).requestId;
 }
 
+function safeHttpUrl(link: string): string | undefined {
+  try {
+    const url = new URL(link);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.href
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Clear draft for a resolved inquiry. Called from eventHandlers on submit/reject. */
 export function clearInquiryDraft(requestId: string): void {
   draftCache.delete(requestId);
@@ -265,7 +276,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           ? html`
               <div class="external-inquiry-request__session-links-known">
                 <div class="external-inquiry-request__session-links-label">
-                  Known external sessions for follow-ups:
+                  Known external session links:
                 </div>
                 <div class="external-inquiry-request__session-links-list">
                   ${repeat(
@@ -279,7 +290,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           : nothing}
         <div class="external-inquiry-request__session-links-input-group">
           <div class="external-inquiry-request__session-links-label">
-            Save external chat link for follow-ups:
+            Save external session link for follow-ups:
           </div>
           <div class="external-inquiry-request__chat-links">
             Open:
@@ -299,7 +310,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           </div>
           <textarea
             class="external-inquiry-request__session-links-input"
-            placeholder="Paste one external thread link per line..."
+            placeholder="Paste one external session link per line..."
             .value=${live(this.sessionLinksText)}
             @input=${this.handleSessionLinksInput}
           ></textarea>
@@ -312,7 +323,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   }
 
   private renderKnownSessionLink(link: string): TemplateResult {
-    const href = ExternalInquiryPanel.safeHttpUrl(link);
+    const href = safeHttpUrl(link);
     if (!href) {
       return html`
         <div class="external-inquiry-request__session-link-item">${link}</div>
@@ -328,17 +339,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
         >${link}</a
       >
     `;
-  }
-
-  private static safeHttpUrl(link: string): string | undefined {
-    try {
-      const url = new URL(link);
-      return url.protocol === 'http:' || url.protocol === 'https:'
-        ? url.href
-        : undefined;
-    } catch {
-      return undefined;
-    }
   }
 
   private renderActions(): TemplateResult {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -713,21 +713,27 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__session-link-item {
+    display: block;
     font-size: var(--font-size-sm);
     font-family: var(--wa-font-family-mono);
     color: var(--wa-color-text-link);
+    text-decoration: none;
     word-break: break-word;
+  }
+
+  a.external-inquiry-request__session-link-item:hover {
+    text-decoration: underline;
   }
 
   .external-inquiry-request__session-links-input {
     width: 100%;
-    min-height: 72px;
-    max-height: min(18vh, 8rem);
+    min-height: 2.75rem;
+    max-height: min(12vh, 5rem);
     resize: vertical;
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
-    padding: ${sp.medium};
+    padding: ${sp.small} ${sp.medium};
     background: var(--wa-form-control-background-color);
     color: var(--wa-form-control-text-color);
     border: var(--border-thin) solid var(--wa-form-control-border-color);
@@ -814,8 +820,8 @@ export const requestPanelStyles: CSSResult = css`
     }
 
     .external-inquiry-request__session-links-input {
-      min-height: 64px;
-      max-height: min(16vh, 7rem);
+      min-height: 2.5rem;
+      max-height: min(10vh, 4.5rem);
     }
   }
 

--- a/src/test-kernel/agent/toolUse/ExternalInquirySessionLinks.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ExternalInquirySessionLinks.vitest.ts
@@ -1,0 +1,123 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - schemas
+import type { ExternalInquiryThreadId } from '@shared/schemas';
+
+// Local imports - external inquiry
+import type {
+  ExternalInquiryThreadManifest,
+  ExternalInquiryTurnRecord,
+  PersistedExternalInquiryTurn,
+} from '@tools/inquiry/externalInquiryStorage';
+import {
+  buildExternalInquiryResult,
+  collectKnownSessionLinks,
+} from '@tools/inquiry/externalInquiryResultFormatter';
+
+const THREAD_ID = 'ei_012345abcdef' as ExternalInquiryThreadId;
+const TIMESTAMP = '2026-05-13T00:00:00.000Z';
+
+function makeTurn(
+  turnIndex: number,
+  sessionLinks?: string[],
+): ExternalInquiryTurnRecord {
+  return {
+    turnIndex,
+    timestamp: TIMESTAMP,
+    question: `Question ${turnIndex}`,
+    context: undefined,
+    questionRelativePath: `t${turnIndex}/question.txt`,
+    contextRelativePath: undefined,
+    answerRelativePath: `t${turnIndex}/answer.txt`,
+    sessionLinks,
+  };
+}
+
+function makeManifest(
+  turns: ExternalInquiryTurnRecord[],
+): ExternalInquiryThreadManifest {
+  return {
+    threadId: THREAD_ID,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+    turns,
+  };
+}
+
+function makePersistedTurn(
+  sessionLinks?: string[],
+): PersistedExternalInquiryTurn {
+  const turn = makeTurn(1, sessionLinks);
+  return {
+    threadId: THREAD_ID,
+    manifest: makeManifest([turn]),
+    turn,
+  };
+}
+
+function makeFollowUpPersistedTurn(): PersistedExternalInquiryTurn {
+  const firstTurn = makeTurn(1, ['https://chatgpt.com/c/original']);
+  const followUpTurn = makeTurn(2);
+  return {
+    threadId: THREAD_ID,
+    manifest: makeManifest([firstTurn, followUpTurn]),
+    turn: followUpTurn,
+  };
+}
+
+describe('external inquiry session links', () => {
+  it('collects known session links from newest to oldest without duplicates', () => {
+    expect(
+      collectKnownSessionLinks(
+        makeManifest([
+          makeTurn(1, [
+            'https://chatgpt.com/c/old',
+            'https://claude.ai/chat/a',
+          ]),
+          makeTurn(2, [
+            'https://chatgpt.com/c/new',
+            'https://chatgpt.com/c/old',
+          ]),
+        ]),
+      ),
+    ).toEqual([
+      'https://chatgpt.com/c/new',
+      'https://chatgpt.com/c/old',
+      'https://claude.ai/chat/a',
+    ]);
+  });
+
+  it('tells the agent to reuse the thread id when session links exist', () => {
+    const result = buildExternalInquiryResult({
+      persisted: makePersistedTurn(['https://chatgpt.com/c/thread']),
+      answer: 'The calculation is consistent.',
+      includeLongAnswerRedirect: false,
+    });
+
+    expect(result.output).toContain(`Use thread_id=${THREAD_ID}`);
+    expect(result.output).toContain('known external session links');
+    expect(result.output).toContain('- https://chatgpt.com/c/thread');
+  });
+
+  it('asks for external chat URLs when no session link was captured', () => {
+    const result = buildExternalInquiryResult({
+      persisted: makePersistedTurn(),
+      answer: 'The calculation is consistent.',
+      includeLongAnswerRedirect: false,
+    });
+
+    expect(result.output).toContain('paste the external chat URL');
+  });
+
+  it('uses older manifest links when a follow-up turn adds no new link', () => {
+    const result = buildExternalInquiryResult({
+      persisted: makeFollowUpPersistedTurn(),
+      answer: 'The follow-up answer is consistent.',
+      includeLongAnswerRedirect: false,
+    });
+
+    expect(result.output).toContain('known external session links');
+    expect(result.output).toContain('- https://chatgpt.com/c/original');
+  });
+});

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -53,7 +53,8 @@ const ExternalInquiryInputSchema = z.strictObject({
     ),
   thread_id: ExternalInquiryThreadIdSchema.nullish().describe(
     'Durable external inquiry thread ID from a previous external_inquiry result. ' +
-      'Omit to start a new external-inquiry thread. Pass it to continue an existing thread.',
+      'Omit to start a new external-inquiry thread. Pass it to continue an existing thread; ' +
+      'known external session links from that thread will be shown to the user.',
   ),
   context: z
     .string()
@@ -234,6 +235,8 @@ Tips for effective questions:
 - If continuing an existing external thread, summarize what was established before
 
 Every successful call returns a durable thread_id. Omit thread_id to start a new external-inquiry thread. Pass thread_id to continue the same thread in later calls, even from a future run.
+
+If a result lists external session links, keep using the returned thread_id for follow-up questions. The inquiry panel will show those links to the user so they can continue the same outside conversation.
 
 Set suggestSearch=true when the question could benefit from the external model using web search (e.g., looking up recent papers, checking specific results).
 

--- a/src/tools/inquiry/externalInquiryResultFormatter.ts
+++ b/src/tools/inquiry/externalInquiryResultFormatter.ts
@@ -47,6 +47,30 @@ function appendSessionLinks(
   lines.push('', heading, ...sessionLinks.map((link) => `- ${link}`));
 }
 
+function appendContinuationGuidance(
+  lines: string[],
+  persisted: PersistedExternalInquiryTurn,
+): void {
+  const { threadId } = persisted;
+  const hasSessionLinks = (getKnownSessionLinks(persisted)?.length ?? 0) > 0;
+
+  lines.push(
+    '',
+    `Use thread_id=${threadId} to continue this external inquiry thread.`,
+  );
+
+  if (hasSessionLinks) {
+    lines.push(
+      'For follow-up inquiries, pass that thread_id so the user is shown the known external session links and can continue the same external conversation.',
+    );
+    return;
+  }
+
+  lines.push(
+    'Ask the user to paste the external chat URL when they submit an answer so later follow-ups can return to the same external conversation.',
+  );
+}
+
 export function collectKnownSessionLinks(
   manifest: ExternalInquiryThreadManifest | null | undefined,
 ): string[] | undefined {
@@ -64,6 +88,12 @@ export function collectKnownSessionLinks(
   }
 
   return known.length ? known : undefined;
+}
+
+function getKnownSessionLinks(
+  persisted: PersistedExternalInquiryTurn,
+): string[] | undefined {
+  return collectKnownSessionLinks(persisted.manifest);
 }
 
 export function buildRejectedExternalInquiryResult(
@@ -90,11 +120,10 @@ function buildExternalInquiryOutput(
     'Answer from external model:',
     '',
     answer,
-    '',
-    `Use thread_id=${persisted.threadId} to continue this external conversation.`,
   ];
 
-  appendSessionLinks(lines, persisted.turn.sessionLinks ?? undefined);
+  appendContinuationGuidance(lines, persisted);
+  appendSessionLinks(lines, getKnownSessionLinks(persisted));
   appendManifestHint(lines, currentManifestPath(persisted));
 
   return lines.join('\n');
@@ -184,10 +213,10 @@ export function buildExternalInquiryResult(params: {
       `Thread ID: ${params.persisted.threadId}`,
       'The full answer has been saved to /executions/current/report.',
       'Use the executions tool with path=/executions/current/report to inspect it.',
-      `Use thread_id=${params.persisted.threadId} to continue this external conversation.`,
     ];
 
-    appendSessionLinks(lines, params.persisted.turn.sessionLinks ?? undefined);
+    appendContinuationGuidance(lines, params.persisted);
+    appendSessionLinks(lines, getKnownSessionLinks(params.persisted));
     appendManifestHint(lines, currentManifestPath(params.persisted));
 
     if (preview) {

--- a/src/tools/inquiry/externalInquiryResultFormatter.ts
+++ b/src/tools/inquiry/externalInquiryResultFormatter.ts
@@ -50,9 +50,10 @@ function appendSessionLinks(
 function appendContinuationGuidance(
   lines: string[],
   persisted: PersistedExternalInquiryTurn,
+  knownSessionLinks: string[] | undefined,
 ): void {
   const { threadId } = persisted;
-  const hasSessionLinks = (getKnownSessionLinks(persisted)?.length ?? 0) > 0;
+  const hasSessionLinks = (knownSessionLinks?.length ?? 0) > 0;
 
   lines.push(
     '',
@@ -122,8 +123,9 @@ function buildExternalInquiryOutput(
     answer,
   ];
 
-  appendContinuationGuidance(lines, persisted);
-  appendSessionLinks(lines, getKnownSessionLinks(persisted));
+  const knownSessionLinks = getKnownSessionLinks(persisted);
+  appendContinuationGuidance(lines, persisted, knownSessionLinks);
+  appendSessionLinks(lines, knownSessionLinks);
   appendManifestHint(lines, currentManifestPath(persisted));
 
   return lines.join('\n');
@@ -215,8 +217,9 @@ export function buildExternalInquiryResult(params: {
       'Use the executions tool with path=/executions/current/report to inspect it.',
     ];
 
-    appendContinuationGuidance(lines, params.persisted);
-    appendSessionLinks(lines, getKnownSessionLinks(params.persisted));
+    const knownSessionLinks = getKnownSessionLinks(params.persisted);
+    appendContinuationGuidance(lines, params.persisted, knownSessionLinks);
+    appendSessionLinks(lines, knownSessionLinks);
     appendManifestHint(lines, currentManifestPath(params.persisted));
 
     if (preview) {


### PR DESCRIPTION
## Summary

This PR completes the external inquiry session-link follow-up flow from #2980. External inquiry results now tell the agent to keep using the durable `thread_id` so stored external chat URLs remain available on later follow-ups. The result formatter also treats the thread manifest as the source of truth for known session links, so a follow-up turn can reuse links captured on earlier turns even when the current answer does not add a new URL.

The progress panel now renders known external session links as safe HTTP(S) links and reduces the optional link-entry field to a compact control. The user is still prompted to save the external chat URL after pasting an answer, but the control no longer occupies the same space as the answer field.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/ExternalInquirySessionLinks.vitest.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:safe`
- `git diff --check`

Fixes #2980

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `external_inquiry` results are formatted and how session links are collected from thread manifests, which can affect agent follow-up behavior and user guidance. Also updates the extension UI to render stored links as clickable URLs with new input sizing/styling.
> 
> **Overview**
> External inquiry follow-ups now treat the thread manifest as the source of truth for *known external session links* (newest-first, de-duped) and include explicit continuation guidance in formatted tool outputs, so later turns can reuse links captured earlier.
> 
> The progress view panel now renders known session links as **safe HTTP(S) clickable links** (non-HTTP(S) remain plain text) and makes the optional link-entry control more compact with updated copy and styles. A new Vitest suite validates link collection, reuse guidance, and fallback prompting when no link is captured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297b8dbeaf41ae0939bdea3c5c724b4b1051d8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->