### PR TITLE
fix: stream Codex in-flight tool calls

### DIFF
--- a/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
@@ -8,7 +8,12 @@ import {
 } from '@agent/runtime/AgentRuntimeHost';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+
 // Local imports - shared
+import { MESSAGE_TYPES } from '@shared/schemas';
 import type {
   ExecutionId,
   StreamTabId,
@@ -17,10 +22,21 @@ import type {
 } from '@shared/schemas';
 
 // Local imports - tools
-import { publishCodexStreamUsage, publishCodexTodos } from '@tools/codex';
+import {
+  publishCodexStreamUsage,
+  publishCodexTodos,
+  runStreamedTurn,
+} from '@tools/codex';
 
 // Local imports - test
 import { createRecordingHost } from '../progressTestUtils';
+
+// Type-only imports
+import type {
+  CommandExecutionItem,
+  Thread,
+  ThreadEvent,
+} from '@openai/codex-sdk';
 
 const streamId = 'stream:codex-child' as StreamTabId;
 const executionId = 'exec:codex-child' as ExecutionId;
@@ -38,6 +54,14 @@ const usage: TokenUsageStats = {
   outputTokens: 5,
   cost: 0,
 };
+
+async function* streamEvents(
+  events: ThreadEvent[],
+): AsyncGenerator<ThreadEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
 
 describe('codex progress events', () => {
   it('publishes todos and usage through the active tool runtime host', async () => {
@@ -108,5 +132,87 @@ describe('codex progress events', () => {
         },
       },
     ]);
+  });
+
+  it('updates in-flight Codex command items in place', async () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+    await store.clear();
+
+    const logger = new AgentLogger(streamId, true);
+    const runtime = createRecordingHost();
+    const startedCommand: CommandExecutionItem = {
+      id: 'cmd-1',
+      type: 'command_execution',
+      command: 'npm run build',
+      aggregated_output: '',
+      status: 'in_progress',
+    };
+    const updatedCommand: CommandExecutionItem = {
+      ...startedCommand,
+      aggregated_output: 'building...',
+    };
+    const completedCommand: CommandExecutionItem = {
+      ...startedCommand,
+      aggregated_output: 'building...\ndone\n',
+      exit_code: 0,
+      status: 'completed',
+    };
+    const thread = {
+      runStreamed: async () => ({
+        events: streamEvents([
+          { type: 'item.started', item: startedCommand },
+          { type: 'item.updated', item: updatedCommand },
+          { type: 'item.completed', item: completedCommand },
+          {
+            type: 'item.completed',
+            item: {
+              id: 'msg-1',
+              type: 'agent_message',
+              text: 'Build succeeded.',
+            },
+          },
+          {
+            type: 'turn.completed',
+            usage: {
+              input_tokens: 12,
+              cached_input_tokens: 0,
+              output_tokens: 4,
+              reasoning_output_tokens: 0,
+            },
+          },
+        ]),
+      }),
+    } as unknown as Thread;
+
+    try {
+      const result = await runStreamedTurn(
+        thread,
+        'Build the project',
+        streamId,
+        logger,
+        runtime.host,
+      );
+
+      expect(result.finalResponse).toBe('Build succeeded.');
+
+      const log = store.get(streamId);
+      const entries = log?.getRange(0, log.head) ?? [];
+      const toolEntries = entries.filter(
+        (entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE,
+      );
+
+      expect(toolEntries).toHaveLength(1);
+      expect(toolEntries[0].data).toMatchObject({
+        toolName: 'bash',
+        summary: 'npm run build',
+        input: { command: 'npm run build' },
+        output: 'building...\ndone',
+        status: 'completed',
+      });
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
   });
 });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -48,6 +48,7 @@ import type {
   StreamStatus,
   TodoItem,
   TokenUsageStats,
+  ToolUseLog,
 } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
@@ -71,6 +72,7 @@ import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
   buildCodexMcpToolLog,
+  buildCodexTodoToolLog,
   buildCodexUsageStats,
 } from './codexShared';
 
@@ -282,6 +284,9 @@ function formatCodexError(
 // Stream tab helpers
 // ============================================================================
 
+type CodexToolLogRef = ReturnType<AgentLogger['emitToolUse']>;
+type ToolUseStatus = NonNullable<ToolUseLog['status']>;
+
 export function publishCodexTodos(
   childStreamId: StreamTabId,
   todos: TodoItem[],
@@ -302,6 +307,14 @@ export function publishCodexStreamUsage(
     executionId,
     usage,
   });
+}
+
+function toProgressTodos(item: TodoListItem): TodoItem[] {
+  return item.items.map((t) => ({
+    content: t.text,
+    status: t.completed ? ('completed' as const) : ('pending' as const),
+    activeForm: t.text,
+  }));
 }
 
 /** Log a completed codex thread item to the child stream's logger. */
@@ -337,18 +350,78 @@ function logCodexItem(
       logger.logWebSearch({ query: (item as WebSearchItem).query });
       break;
     case 'todo_list': {
-      const todos = (item as TodoListItem).items.map((t) => ({
-        content: t.text,
-        status: t.completed ? ('completed' as const) : ('pending' as const),
-        activeForm: t.text,
-      }));
-      publishCodexTodos(childStreamId, todos, runtimeHost);
+      publishCodexTodos(
+        childStreamId,
+        toProgressTodos(item as TodoListItem),
+        runtimeHost,
+      );
       break;
     }
     case 'error':
       logger.error(item.message);
       break;
   }
+}
+
+function buildCodexLiveToolLog(
+  item: ThreadItem,
+  status: ToolUseStatus,
+): ToolUseLog | null {
+  switch (item.type) {
+    case 'command_execution':
+      return buildCodexCommandToolLog(item);
+    case 'file_change': {
+      const fileLog = buildCodexFileChangeToolLog(item);
+      return fileLog ? { ...fileLog, status } : null;
+    }
+    case 'mcp_tool_call':
+      return buildCodexMcpToolLog(item as McpToolCallItem);
+    case 'todo_list':
+      return buildCodexTodoToolLog(item as TodoListItem, status);
+    default:
+      return null;
+  }
+}
+
+function updateCodexLiveToolLog(
+  logger: AgentLogger,
+  refs: Map<string, CodexToolLogRef>,
+  item: ThreadItem,
+  toolLog: ToolUseLog,
+): void {
+  const existing = refs.get(item.id);
+  if (!existing) {
+    refs.set(item.id, logger.emitToolUse(toolLog));
+    return;
+  }
+
+  const { status = 'completed', ...rest } = toolLog;
+  logger.updateToolUse(existing.logId, rest, existing.groupId, status);
+}
+
+function publishCodexItemProgress(params: {
+  item: ThreadItem;
+  status: ToolUseStatus;
+  childStreamId: StreamTabId;
+  logger: AgentLogger;
+  refs: Map<string, CodexToolLogRef>;
+  runtimeHost: AgentRuntimeHost;
+}): boolean {
+  const { item, status, childStreamId, logger, refs, runtimeHost } = params;
+
+  if (item.type === 'todo_list') {
+    publishCodexTodos(
+      childStreamId,
+      toProgressTodos(item as TodoListItem),
+      runtimeHost,
+    );
+  }
+
+  const toolLog = buildCodexLiveToolLog(item, status);
+  if (!toolLog) return false;
+
+  updateCodexLiveToolLog(logger, refs, item, toolLog);
+  return true;
 }
 
 /** Log a turn summary to the child stream. */
@@ -370,7 +443,7 @@ function logTurnSummary(
 // ============================================================================
 
 /** Run a single streamed turn, logging events to the child stream. */
-async function runStreamedTurn(
+export async function runStreamedTurn(
   thread: Thread,
   prompt: string,
   childStreamId: StreamTabId,
@@ -382,12 +455,34 @@ async function runStreamedTurn(
   const { events } = await thread.runStreamed(prompt, { signal });
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;
+  const itemLogRefs = new Map<string, CodexToolLogRef>();
 
   for await (const event of events) {
     switch (event.type) {
+      case 'item.started':
+      case 'item.updated':
+        publishCodexItemProgress({
+          item: event.item,
+          status: 'in_progress',
+          childStreamId,
+          logger,
+          refs: itemLogRefs,
+          runtimeHost,
+        });
+        break;
       case 'item.completed': {
         const { item } = event;
-        logCodexItem(item, childStreamId, logger, runtimeHost);
+        const wasRenderedAsProgress = publishCodexItemProgress({
+          item,
+          status: 'completed',
+          childStreamId,
+          logger,
+          refs: itemLogRefs,
+          runtimeHost,
+        });
+        if (!wasRenderedAsProgress) {
+          logCodexItem(item, childStreamId, logger, runtimeHost);
+        }
         if (item.type === 'agent_message') {
           responseParts.push(item.text);
         }


### PR DESCRIPTION
## Summary

Codex child stream tabs now render live progress for in-flight tool items. The stream loop handles `item.started` and `item.updated` events, keeps one log entry per Codex item id, and updates that entry when the completed event arrives. This covers command execution, MCP calls, file-change items, and the Codex todo list without adding a new progress event shape.

## Design

The implementation reuses the existing `AgentLogger.emitToolUse` / `updateToolUse` path and the existing progress-view tool-use rendering. The only new state is a per-turn map from Codex item id to the log entry created for that item, so partial updates replace the same row instead of producing duplicate completed rows.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the repository's existing warnings)
- `npm run compile:safe`
- `git diff --check`

Fixes #2983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex streaming event handling to emit and update live tool-use log entries based on `item.started`/`item.updated`, which can affect child-stream UI/log rendering and ordering. Moderate risk due to new per-turn state and update-in-place behavior across multiple item types.
> 
> **Overview**
> Codex child streams now render **live progress for in-flight items** by handling `item.started` and `item.updated` events and updating a single tool-use log entry per Codex item id instead of only logging on completion.
> 
> `runStreamedTurn` is exported and now tracks per-item log refs, emitting/updating tool logs for command executions, MCP calls, file changes, and todo lists; todos are also published to the runtime host during progress updates. Tests add coverage to ensure command execution items update in place (no duplicate rows) and that runtime-host routing for todos/usage remains intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d1fc8b09f657783ff6f4ada8d40074f47eb100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->