### PR TITLE
fix: keep OpenAI background failures retryable

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -48,7 +48,6 @@ import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError } from './support/sdkErrorAdapters';
-import { attachSdkErrorMetadata } from '@common/errors/sdkErrorUtils';
 
 // Local file imports
 import {
@@ -2445,20 +2444,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     );
     const wrapped = new Error(
       `Background response ${responseId} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${responseId}").`,
-    ) as Error & { error?: unknown };
-    // Attach the OpenAI error body and provider metadata. The body lets
-    // isUpstreamCreditDepletedBody recognize insufficient_quota and route
-    // through the credential-exhausted path (no auto-retry); the provider
-    // tag lets the manual-retry "Use your own API key" picker target the
-    // failing provider. tagOpenAISdkError only handles SDK error classes,
-    // so a plain Error wrapper bypasses it without this explicit tag.
+    ) as Error & { error?: unknown; provider?: string };
+    // Keep the synthetic wrapper as a plain response-state error. It often has
+    // no HTTP status; tagging it as a generic SDK APIError would make the
+    // formatter treat unknown provider-side failures as non-retryable.
+    wrapped.provider = this.config.provider;
     if (current.error) {
       wrapped.error = current.error;
     }
-    attachSdkErrorMetadata(wrapped, {
-      provider: this.config.provider,
-      kind: 'api_error',
-    });
     throw wrapped;
   }
 

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -335,6 +335,46 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(true);
   });
 
+  it('classifies provider-attributed OpenAI quota bodies without SDK metadata', () => {
+    const error = new Error('background response failed') as Error & {
+      error: unknown;
+      provider: string;
+    };
+    error.provider = 'openai';
+    error.error = {
+      message: 'You exceeded your current quota.',
+      type: 'insufficient_quota',
+      code: 'insufficient_quota',
+    };
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBeUndefined();
+    expect(formatted.isCredentialExhausted).toBe(true);
+    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.userRetryable).toBe(true);
+  });
+
+  it('keeps provider-attributed background failures retryable without a status code', () => {
+    const error = new Error('background response failed') as Error & {
+      error: unknown;
+      provider: string;
+    };
+    error.provider = 'openai';
+    error.error = {
+      message: 'The background response ended before completion.',
+      type: 'server_error',
+    };
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBeUndefined();
+    expect(formatted.isCredentialExhausted).toBeUndefined();
+    expect(formatted.userRetryable).toBe(true);
+  });
+
   it('formats tagged Anthropic user abort errors', () => {
     const error = new AnthropicAPIUserAbortError();
     tagAnthropicSdkError(error, 'anthropic');


### PR DESCRIPTION
## Summary

This is a follow-up to #3879. It keeps synthetic OpenAI background-response failures on the plain-error path while preserving the provider and raw OpenAI error body.

The previous wrapper attached generic SDK API-error metadata even when OpenAI did not provide an HTTP status. The common formatter treats statusless generic API errors as non-retryable, which meant a background response that failed without a quota body could lose both automatic and manual retry paths. The wrapper now records the provider directly on the plain error instead. Quota bodies still classify as credential exhaustion, and generic statusless background failures remain retryable.

## Validation

- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/common/SdkErrorUtils.vitest.mts
- npm run lint
- npm run compile:safe
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4bbf0fe203462cba543c78d4ca62dde225554b46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->