### PR TITLE
feat: emit CI-started PR polling events

### DIFF
--- a/src/test-kernel/tools/GitHubPREventFormatting.vitest.ts
+++ b/src/test-kernel/tools/GitHubPREventFormatting.vitest.ts
@@ -1,0 +1,52 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - tools
+import { formatCIStarted } from '@tools/github/formatPREvent';
+import type { GhCheckRun } from '@tools/github/prTypes';
+
+function checkRun(id: number, name: string): GhCheckRun {
+  return {
+    id,
+    name,
+    status: 'in_progress',
+    conclusion: null,
+    html_url: `https://example.test/checks/${id}`,
+    completed_at: null,
+  };
+}
+
+describe('GitHub PR event formatting', () => {
+  it('formats CI-started events using check-name wording', () => {
+    const message = formatCIStarted(
+      'owner/repo',
+      7,
+      'abcdef1234567890',
+      [checkRun(1, 'lint'), checkRun(2, 'test')],
+      5,
+    );
+
+    expect(message).toContain(
+      'CI triggered on owner/repo/pulls/7 (head abcdef1): GitHub reports 5 checks registered; this poll observed 2 checks across 2 distinct check names.',
+    );
+    expect(message).toContain('- lint');
+    expect(message).toContain('- test');
+    expect(message).not.toContain('workflow');
+  });
+
+  it('bounds the CI-started check-name list', () => {
+    const message = formatCIStarted(
+      'owner/repo',
+      7,
+      'abcdef1234567890',
+      Array.from({ length: 25 }, (_, i) =>
+        checkRun(i + 1, `check-${String(i + 1).padStart(2, '0')}`),
+      ),
+      25,
+    );
+
+    const bullets = message.match(/^- /gm) ?? [];
+    expect(bullets).toHaveLength(20);
+    expect(message).toContain('…and 5 more check names.');
+  });
+});

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -1,0 +1,236 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+// Local imports - tools
+import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
+
+interface CiStartedState {
+  pr: { owner: string; repo: string; pullNumber: number };
+  slug: string;
+  listeners: Set<(text: string) => void>;
+  initialized: boolean;
+  seenIssueCommentIds: Set<number>;
+  seenReviewCommentIds: Set<number>;
+  seenReviewIds: Set<number>;
+  lastFailedCheckKeys: Set<string>;
+  lastAnnotationKeys: Set<string>;
+  pendingAnnotationRuns: GhCheckRun[];
+  ciStartedSha: string | undefined;
+  ciCompleteSha: string | undefined;
+  ciPassedSha: string | undefined;
+  headSha: string | undefined;
+  state: 'open' | 'closed' | undefined;
+  merged: boolean;
+  mergeableState: string | undefined;
+  etags: {
+    pr?: string;
+    issueComments?: string;
+    reviewComments?: string;
+    reviews?: string;
+  };
+  checkRunsCache?: {
+    etagsByPage: Map<number, string>;
+    pagesByPage: Map<number, GhCheckRun[]>;
+    lastTotalCount: number;
+  };
+  sinceCursors: {
+    issueComments?: string;
+    reviewComments?: string;
+  };
+  lastSuccessAt: number;
+  consecutiveFailures: number;
+  skipPollUntilMs: number;
+}
+
+interface CiStartedSource {
+  pollOne(key: string, state: CiStartedState): Promise<void>;
+}
+
+const SHA = 'abcdef1234567890';
+const OLD_SHA = '1234567890abcdef';
+
+function createState(
+  events: string[],
+  overrides: Partial<CiStartedState> = {},
+): CiStartedState {
+  return {
+    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
+    slug: 'owner/repo',
+    listeners: new Set([(text) => events.push(text)]),
+    initialized: true,
+    seenIssueCommentIds: new Set(),
+    seenReviewCommentIds: new Set(),
+    seenReviewIds: new Set(),
+    lastFailedCheckKeys: new Set(),
+    lastAnnotationKeys: new Set(),
+    pendingAnnotationRuns: [],
+    ciStartedSha: undefined,
+    ciCompleteSha: undefined,
+    ciPassedSha: undefined,
+    headSha: SHA,
+    state: 'open',
+    merged: false,
+    mergeableState: 'clean',
+    etags: {},
+    sinceCursors: {},
+    lastSuccessAt: Date.now(),
+    consecutiveFailures: 0,
+    skipPollUntilMs: 0,
+    ...overrides,
+  };
+}
+
+function prResponse(sha: string): {
+  status: 200;
+  etag: string;
+  data: GhPullRequest;
+} {
+  return {
+    status: 200,
+    etag: `pr-${sha}`,
+    data: {
+      state: 'open',
+      merged: false,
+      mergeable_state: 'clean',
+      head: { sha },
+    },
+  };
+}
+
+function checkRun(id: number, name: string): GhCheckRun {
+  return {
+    id,
+    name,
+    status: 'in_progress',
+    conclusion: null,
+    html_url: `https://example.test/checks/${id}`,
+    completed_at: null,
+  };
+}
+
+function checkRunsResponse(runs: GhCheckRun[]): {
+  status: 200;
+  etag: string;
+  data: { total_count: number; check_runs: GhCheckRun[] };
+} {
+  return {
+    status: 200,
+    etag: `checks-${runs.length}`,
+    data: {
+      total_count: runs.length,
+      check_runs: runs,
+    },
+  };
+}
+
+async function createHarness(): Promise<{
+  ghGet: Mock;
+  source: CiStartedSource;
+}> {
+  vi.resetModules();
+  const ghGet = vi.fn();
+  vi.doMock('@tools/github/githubClient', () => {
+    class GitHubAuthError extends Error {}
+    class GitHubRateLimitError extends Error {
+      constructor(public readonly resetAt: number) {
+        super('GitHub rate limit exceeded');
+      }
+    }
+    class GitHubPermanentError extends Error {
+      constructor(
+        public readonly status: number,
+        message: string,
+      ) {
+        super(message);
+      }
+    }
+    return {
+      ghGet,
+      GitHubAuthError,
+      GitHubRateLimitError,
+      GitHubPermanentError,
+    };
+  });
+  const { PRPollingSource } = await import('@tools/github/PRPollingSource');
+  return {
+    ghGet,
+    source: new PRPollingSource() as unknown as CiStartedSource,
+  };
+}
+
+function queuePollResponses(
+  ghGet: Mock,
+  sha: string,
+  runs: GhCheckRun[],
+): void {
+  ghGet
+    .mockResolvedValueOnce(prResponse(sha))
+    .mockResolvedValueOnce({ status: 304 })
+    .mockResolvedValueOnce({ status: 304 })
+    .mockResolvedValueOnce({ status: 304 })
+    .mockResolvedValueOnce(checkRunsResponse(runs));
+}
+
+describe('PRPollingSource CI-started events', () => {
+  afterEach(() => {
+    vi.doUnmock('@tools/github/githubClient');
+    vi.resetModules();
+  });
+
+  it('seeds existing check runs without replaying a CI-started event', async () => {
+    const { ghGet, source } = await createHarness();
+    const events: string[] = [];
+    const state = createState(events, {
+      initialized: false,
+      headSha: undefined,
+      state: undefined,
+      ciStartedSha: undefined,
+    });
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toEqual([]);
+    expect(state.ciStartedSha).toBe(SHA);
+  });
+
+  it('emits a CI-started event once when check runs first appear', async () => {
+    const { ghGet, source } = await createHarness();
+    const events: string[] = [];
+    const state = createState(events, { ciStartedSha: undefined });
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint'), checkRun(2, 'test')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain('CI triggered');
+    expect(events[0]).toContain('distinct check names');
+    expect(events[0]).not.toContain('workflow');
+    expect(state.ciStartedSha).toBe(SHA);
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint'), checkRun(2, 'test')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toHaveLength(1);
+  });
+
+  it('resets CI-started state on a new head SHA', async () => {
+    const { ghGet, source } = await createHarness();
+    const events: string[] = [];
+    const state = createState(events, {
+      headSha: OLD_SHA,
+      ciStartedSha: OLD_SHA,
+    });
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain('(head abcdef1)');
+    expect(state.ciStartedSha).toBe(SHA);
+  });
+});

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -18,6 +18,7 @@ import {
   formatCheckFailureSummary,
   formatCIComplete,
   formatCIPassed,
+  formatCIStarted,
   formatIssueComment,
   formatMergeConflictDetected,
   formatMergeConflictResolved,
@@ -67,6 +68,7 @@ function createInitialState(pr: PRKey): SubscriptionState {
     lastFailedCheckKeys: new Set(),
     lastAnnotationKeys: new Set(),
     pendingAnnotationRuns: [],
+    ciStartedSha: undefined,
     ciCompleteSha: undefined,
     ciPassedSha: undefined,
     headSha: undefined,
@@ -186,6 +188,8 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * isn't stranded once the check-runs cache stabilizes.
    */
   pendingAnnotationRuns: GhCheckRun[];
+  /** Head SHA for which the one-shot "CI triggered" event has been emitted. */
+  ciStartedSha: string | undefined;
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
   ciCompleteSha: string | undefined;
   /** Head SHA for which the one-shot "CI passed" event has been emitted. */
@@ -303,12 +307,13 @@ export class PRPollingSource extends PollingSourceBase<
       state.state = newState;
       state.merged = newMerged;
       // New push invalidates prior CI terminal state — the next completion
-      // on the new SHA should re-emit both terminal events. Also drop the
+      // on the new SHA should re-emit CI progress events. Also drop the
       // per-page check-runs cache: it's keyed only by page number, and the
       // ETags from the previous SHA can never match the new SHA's responses.
       // Letting it linger would cost one wasted If-None-Match per page on
       // the first post-push tick before the cache naturally refreshes.
       if (state.headSha !== newHead) {
+        state.ciStartedSha = undefined;
         state.ciCompleteSha = undefined;
         state.ciPassedSha = undefined;
         state.checkRunsCache = undefined;
@@ -442,6 +447,9 @@ export class PRPollingSource extends PollingSourceBase<
             state.lastAnnotationKeys.add(this.checkKey(r));
           }
         }
+        if (state.headSha && runs.length > 0) {
+          state.ciStartedSha = state.headSha;
+        }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
         // we only surface transitions that happen after subscribe. Gate on
         // runs.length > 0: an empty array is ambiguous (no CI configured vs.
@@ -525,6 +533,22 @@ export class PRPollingSource extends PollingSourceBase<
       // ETag/page caching is owned by `fetchAllCheckRuns` via
       // `state.checkRunsCache`; nothing to record on `state.etags` here.
       const runs = checksRes.data.check_runs;
+
+      const headSha = state.headSha;
+      if (headSha && runs.length > 0 && state.ciStartedSha !== headSha) {
+        state.ciStartedSha = headSha;
+        this.emit(
+          state,
+          formatCIStarted(
+            state.slug,
+            pr.pullNumber,
+            headSha,
+            runs,
+            checksRes.data.total_count,
+          ),
+        );
+      }
+
       const newFailures: GhCheckRun[] = [];
       const currentFailureKeys = new Set<string>();
       for (const r of runs) {

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -28,6 +28,7 @@ import type {
 const MAX_BODY = 500;
 // A single linter run can emit hundreds; show the first N + overflow hint.
 const MAX_ANNOTATIONS_PER_RUN = 20;
+const MAX_CI_STARTED_CHECK_NAMES = 20;
 const MAX_ANNOTATION_MESSAGE = 300;
 
 const truncate = (s: string | null | undefined): string =>
@@ -196,6 +197,36 @@ export function formatCIPassed(
 ): string {
   return wrap(
     `All ${runs.length} CI checks passed on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}).`,
+  );
+}
+
+export function formatCIStarted(
+  slug: string,
+  prNumber: number,
+  sha: string,
+  runs: GhCheckRun[],
+  totalCount: number,
+): string {
+  const uniqueNames = [...new Set(runs.map((r) => r.name))].sort();
+  const shownNames = uniqueNames.slice(0, MAX_CI_STARTED_CHECK_NAMES);
+  const remainingNames = uniqueNames.length - shownNames.length;
+  const totalCheckLabel = totalCount === 1 ? 'check' : 'checks';
+  const observedCheckLabel = runs.length === 1 ? 'check' : 'checks';
+  const nameLabel = uniqueNames.length === 1 ? 'check name' : 'check names';
+  const body = [
+    ...shownNames.map((name) => `- ${name}`),
+    ...(remainingNames > 0
+      ? [
+          `…and ${remainingNames} more check name${remainingNames === 1 ? '' : 's'}.`,
+        ]
+      : []),
+  ].join('\n');
+
+  return wrap(
+    sections(
+      `CI triggered on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}): GitHub reports ${totalCount} ${totalCheckLabel} registered; this poll observed ${runs.length} ${observedCheckLabel} across ${uniqueNames.length} distinct ${nameLabel}.`,
+      body,
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

- Emit a one-shot `CI triggered` event when GitHub first registers check runs for a watched PR head SHA.
- Seed already-existing check runs on the initial subscription tick, so old CI is not replayed as new activity.
- Format the registered check names with check-name wording and a bounded list with an overflow count.

## Background

This reimplements the useful part of #3328 on current `main`. The previous branch was stale, and review feedback identified two concrete problems: the message called check-run names workflows, and it could emit an unbounded list. This PR keeps the feature small and addresses both points directly.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/GitHubPREventFormatting.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run compile:safe`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new event-emission logic in `PRPollingSource` tied to check-run polling; mistakes could cause noisy duplicate events or missed CI-start notifications across pushes.
> 
> **Overview**
> Emits a new one-shot **“CI triggered”** PR polling event when check runs first appear for a given head SHA, and resets that marker on new pushes so the next SHA can emit again.
> 
> Adds `formatCIStarted` to `formatPREvent` to report total vs observed checks and list *distinct check names* with a hard cap (20) plus an overflow count, and seeds existing check runs on initial subscription to avoid replaying historical CI-started activity. Includes new Vitest coverage for the formatter and for `PRPollingSource` CI-started emission/seed/reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675d3ad5ce4d1ca000d82e7b16dc4b645b620564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->