### PR TITLE
fix: dedupe desktop web component dependencies

### DIFF
--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -15,5 +15,14 @@ export default defineConfig({
       input: resolve(__dirname, 'src/renderer/index.html'),
     },
   },
-  resolve: { alias: aliases },
+  resolve: {
+    alias: aliases,
+    dedupe: [
+      '@awesome.me/webawesome',
+      '@lit/context',
+      '@lit-labs/signals',
+      'lit',
+      'signal-polyfill',
+    ],
+  },
 });


### PR DESCRIPTION
## Summary

- Force the desktop Vite bundle to resolve Web Awesome and Lit packages through one dependency instance.
- Prevent duplicate custom element registration when the desktop shell imports extension webview frontends.

## Verification

- `npm run format`
- `npm run lint` (passes with existing warnings)
- `npm run compile:safe`
- `corepack pnpm --filter @texra/desktop build`
- Electron desktop smoke: launched a temporary workspace, posted a Direct-agent `execute` message through the renderer bridge, and verified `executions/.../r0/paper.polished.tex` was written by the internal validation model handler.

This supports the remaining validation note on #3295 without marking the tracker closed from code inspection alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change that only affects module resolution for the desktop renderer bundle; primary risk is unexpected runtime issues if deduping masks version mismatches.
> 
> **Overview**
> Updates the desktop renderer Vite config to **dedupe Web Awesome and Lit-related packages** (including `lit`, `@lit/context`, `@lit-labs/signals`, and `signal-polyfill`) so they resolve to a single dependency instance.
> 
> This is intended to prevent duplicate custom element registration and other issues when the desktop shell and extension webviews import the same web component libraries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619f73e92bf2f3d3ef45cea09246ac301bdbe663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->