### PR TITLE
fix: gate CI-started PR polling event

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -576,6 +576,13 @@
             "maximum": 100,
             "description": "Number of recent commits to show in the commit selection dropdown",
             "order": 1
+          },
+          "texra.git.emitPrCiStartedEvents": {
+            "type": "boolean",
+            "default": false,
+            "description": "Emit a PR subscription event when GitHub check runs first appear for a new head commit.",
+            "scope": "resource",
+            "order": 2
           }
         }
       },

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -863,6 +863,13 @@
         },
         {
           "properties": {
+            "texra.git.emitPrCiStartedEvents": {
+              "default": false,
+              "description": "Emit a PR subscription event when GitHub check runs first appear for a new head commit.",
+              "order": 2,
+              "scope": "resource",
+              "type": "boolean"
+            },
             "texra.git.numberOfCommitsToShow": {
               "default": 20,
               "description": "Number of recent commits to show in the commit selection dropdown",

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -43,6 +43,9 @@ export const DEFAULT_TEXRA_SETTINGS = {
   agentOutputs: {
     autoOpenFinal: true,
   },
+  inlineCriticism: {
+    enabled: false,
+  },
   ui: {
     showApiKeyReminders: true,
     showLoginBanner: true,
@@ -215,6 +218,7 @@ export const DEFAULT_TEXRA_SETTINGS = {
   },
   git: {
     numberOfCommitsToShow: 20,
+    emitPrCiStartedEvents: false,
   },
   audio: {
     soxPath: '',
@@ -255,6 +259,13 @@ export const TexraSettingsSchema = z
           .prefault(DEFAULT_TEXRA_SETTINGS.agentOutputs.autoOpenFinal),
       })
       .prefault(DEFAULT_TEXRA_SETTINGS.agentOutputs),
+    inlineCriticism: z
+      .strictObject({
+        enabled: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.inlineCriticism.enabled),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.inlineCriticism),
     ui: z
       .strictObject({
         showApiKeyReminders: z
@@ -436,6 +447,9 @@ export const TexraSettingsSchema = z
           .min(1)
           .max(100)
           .prefault(DEFAULT_TEXRA_SETTINGS.git.numberOfCommitsToShow),
+        emitPrCiStartedEvents: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.git.emitPrCiStartedEvents),
       })
       .prefault(DEFAULT_TEXRA_SETTINGS.git),
     audio: z
@@ -494,6 +508,7 @@ export type TexraSettings = z.infer<typeof TexraSettingsSchema>;
 
 export const TEXRA_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',
+  'inlineCriticism.enabled',
   'ui.showApiKeyReminders',
   'ui.showLoginBanner',
   'ui.showGettingStartedBanner',
@@ -535,6 +550,7 @@ export const TEXRA_SETTING_PATHS = [
   'latexdiff.pictureEnvironments',
   'latexdiff.tempFileLocation',
   'git.numberOfCommitsToShow',
+  'git.emitPrCiStartedEvents',
   'audio.soxPath',
   'apiKeys.set',
   'apiKeys.remove',

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -48,6 +48,7 @@ interface CiStartedSource {
 
 const SHA = 'abcdef1234567890';
 const OLD_SHA = '1234567890abcdef';
+let emitCiStartedEvents = false;
 
 function createState(
   events: string[],
@@ -123,12 +124,22 @@ function checkRunsResponse(runs: GhCheckRun[]): {
   };
 }
 
-async function createHarness(): Promise<{
+async function createHarness(
+  options: {
+    emitCiStartedEvents?: boolean;
+  } = {},
+): Promise<{
   ghGet: Mock;
   source: CiStartedSource;
 }> {
   vi.resetModules();
+  emitCiStartedEvents = options.emitCiStartedEvents ?? false;
   const ghGet = vi.fn();
+  vi.doMock('@utils/config', () => ({
+    getConfig: vi.fn((_key: string, defaultValue: unknown) =>
+      emitCiStartedEvents ? true : defaultValue,
+    ),
+  }));
   vi.doMock('@tools/github/githubClient', () => {
     class GitHubAuthError extends Error {}
     class GitHubRateLimitError extends Error {
@@ -174,10 +185,25 @@ function queuePollResponses(
 describe('PRPollingSource CI-started events', () => {
   afterEach(() => {
     vi.doUnmock('@tools/github/githubClient');
+    vi.doUnmock('@utils/config');
+    emitCiStartedEvents = false;
     vi.resetModules();
   });
 
-  it('seeds existing check runs without replaying a CI-started event', async () => {
+  it('keeps CI-started events disabled by default while recording observed runs', async () => {
+    const { ghGet, source } = await createHarness();
+    const events: string[] = [];
+    const state = createState(events, { ciStartedSha: undefined });
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toEqual([]);
+    expect(state.ciStartedSha).toBe(SHA);
+  });
+
+  it('seeds existing check runs while disabled without emitting', async () => {
     const { ghGet, source } = await createHarness();
     const events: string[] = [];
     const state = createState(events, {
@@ -195,8 +221,30 @@ describe('PRPollingSource CI-started events', () => {
     expect(state.ciStartedSha).toBe(SHA);
   });
 
+  it('seeds existing check runs without replaying a CI-started event when enabled', async () => {
+    const { ghGet, source } = await createHarness({
+      emitCiStartedEvents: true,
+    });
+    const events: string[] = [];
+    const state = createState(events, {
+      initialized: false,
+      headSha: undefined,
+      state: undefined,
+      ciStartedSha: undefined,
+    });
+
+    queuePollResponses(ghGet, SHA, [checkRun(1, 'lint')]);
+
+    await source.pollOne('owner/repo/pulls/7', state);
+
+    expect(events).toEqual([]);
+    expect(state.ciStartedSha).toBe(SHA);
+  });
+
   it('emits a CI-started event once when check runs first appear', async () => {
-    const { ghGet, source } = await createHarness();
+    const { ghGet, source } = await createHarness({
+      emitCiStartedEvents: true,
+    });
     const events: string[] = [];
     const state = createState(events, { ciStartedSha: undefined });
 
@@ -218,7 +266,9 @@ describe('PRPollingSource CI-started events', () => {
   });
 
   it('resets CI-started state on a new head SHA', async () => {
-    const { ghGet, source } = await createHarness();
+    const { ghGet, source } = await createHarness({
+      emitCiStartedEvents: true,
+    });
     const events: string[] = [];
     const state = createState(events, {
       headSha: OLD_SHA,

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,6 +11,7 @@
  * layer above.
  */
 
+import { getConfig } from '@utils/config';
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatCheckAnnotations,
@@ -55,6 +56,16 @@ import {
 } from './prTypes';
 import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import type { Disposable } from '@platform/interfaces/disposable';
+
+export const GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY =
+  'texra.git.emitPrCiStartedEvents';
+
+function shouldEmitCIStartedEvents(): boolean {
+  return getConfig<boolean>(
+    GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY,
+    false,
+  );
+}
 
 function createInitialState(pr: PRKey): SubscriptionState {
   return {
@@ -537,16 +548,18 @@ export class PRPollingSource extends PollingSourceBase<
       const headSha = state.headSha;
       if (headSha && runs.length > 0 && state.ciStartedSha !== headSha) {
         state.ciStartedSha = headSha;
-        this.emit(
-          state,
-          formatCIStarted(
-            state.slug,
-            pr.pullNumber,
-            headSha,
-            runs,
-            checksRes.data.total_count,
-          ),
-        );
+        if (shouldEmitCIStartedEvents()) {
+          this.emit(
+            state,
+            formatCIStarted(
+              state.slug,
+              pr.pullNumber,
+              headSha,
+              runs,
+              checksRes.data.total_count,
+            ),
+          );
+        }
       }
 
       const newFailures: GhCheckRun[] = [];


### PR DESCRIPTION
## Summary

- Add `texra.git.emitPrCiStartedEvents`, defaulting to `false`, so CI-started PR subscription messages are opt-in.
- Skip both CI-started seeding and CI-started emission while the setting is disabled.
- Extend the CI-started polling tests for the default-off and enabled paths.
- Add the existing `texra.inlineCriticism.enabled` package setting to the settings schema so the package-configuration check remains consistent.

Closes #3906.

## Validation

- `npm run format`
- `npm run test:kernel -- src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts src/test-kernel/tools/GitHubPREventFormatting.vitest.ts`
- `npm run check:settings-configuration`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run compile:safe`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is narrowly scoped to PR polling event emission and is default-off behind a new setting, with updated tests to cover both enabled/disabled paths.
> 
> **Overview**
> Makes the PR-polling **"CI triggered"** subscription message opt-in by adding `texra.git.emitPrCiStartedEvents` (default `false`) and gating `formatCIStarted` emission in `PRPollingSource` behind this config.
> 
> Updates kernel tests to mock config and assert default-off behavior while still recording `ciStartedSha`, and extends the settings schema (and extension manifest snapshot) to include `git.emitPrCiStartedEvents` plus the existing `inlineCriticism.enabled` key to keep settings/package invariants consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f147be005a229b37a2f2dacce2d289e6f8c6c0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->