### PR TITLE
fix: preserve bibliography search paths for latexdiff

### DIFF
--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -32,6 +32,27 @@ const ERROR_MESSAGES = {
   FAILED_GENERAL: (commandType: string) => `Failed to run ${commandType}`,
 } as const;
 
+export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = [
+  'cite\\*?',
+  'citep\\*?',
+  'citet\\*?',
+  'citealp\\*?',
+  'citealt\\*?',
+  'citeauthor\\*?',
+  'citeyear\\*?',
+  'citeyearpar\\*?',
+  'parencite\\*?',
+  'textcite\\*?',
+  'autocite\\*?',
+  'footcite\\*?',
+  'supercite\\*?',
+  'smartcite\\*?',
+] as const;
+
+export function buildLatexdiffTextCommandExclusionFlag(): string {
+  return `--exclude-textcmd=${LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS.join(',')}`;
+}
+
 /**
  * Options for diff execution.
  * @property mathMarkup - Math markup mode ('off' | 'whole' | 'coarse' | 'fine').
@@ -112,6 +133,7 @@ export class DiffCommandExecutor {
       '--encoding=utf8',
       '-c',
       `PICTUREENV=${pictureEnvs}`,
+      buildLatexdiffTextCommandExclusionFlag(),
       `--math-markup=${mathMarkup}`,
       ...(subtype ? [`--subtype=${subtype}`] : []),
       inputFile,
@@ -135,6 +157,7 @@ export class DiffCommandExecutor {
       `PICTUREENV=${pictureEnvs}`,
       '--force',
       '--git',
+      buildLatexdiffTextCommandExclusionFlag(),
       `--math-markup=${mathMarkup}`,
       ...(subtype ? [`--subtype=${subtype}`] : []),
       '-r',

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -22,6 +22,23 @@ logger.initialize(CHANNEL);
 
 // Tool configurations have been moved to utils/toolUtils.ts for centralized management
 
+export function buildKpathseaSearchPath(
+  prependPaths: readonly string[],
+  existingValue: string | undefined = undefined,
+  delimiter: string = path.delimiter,
+): string | undefined {
+  const prefix = prependPaths
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(delimiter);
+  if (!prefix) return undefined;
+
+  const value = existingValue
+    ? `${prefix}${delimiter}${existingValue}`
+    : prefix;
+  return value.endsWith(delimiter) ? value : `${value}${delimiter}`;
+}
+
 /**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
@@ -65,15 +82,30 @@ export async function compileLatex2Pdf(
     // Use path.delimiter for cross-platform compatibility (`:` on Unix, `;` on Windows)
     const needsTexInputs = texInputParts.length > 1 || process.env.TEXINPUTS;
     const texInputs = needsTexInputs
-      ? texInputParts.join(path.delimiter) +
-        path.delimiter +
-        (process.env.TEXINPUTS ?? '')
+      ? buildKpathseaSearchPath(texInputParts, process.env.TEXINPUTS)
       : undefined;
+    const bibSearchParts = workspacePath ? [workspacePath] : [];
+    const bibInputs = buildKpathseaSearchPath(
+      bibSearchParts,
+      process.env.BIBINPUTS,
+    );
+    const bstInputs = buildKpathseaSearchPath(
+      bibSearchParts,
+      process.env.BSTINPUTS,
+    );
     const env: Record<string, string> = {
       ...(texInputs && { TEXINPUTS: texInputs }),
+      ...(bibInputs && { BIBINPUTS: bibInputs }),
+      ...(bstInputs && { BSTINPUTS: bstInputs }),
     };
     if (texInputs) {
       logger.debug(channel, `Setting TEXINPUTS to: ${texInputs}`);
+    }
+    if (bibInputs) {
+      logger.debug(channel, `Setting BIBINPUTS to: ${bibInputs}`);
+    }
+    if (bstInputs) {
+      logger.debug(channel, `Setting BSTINPUTS to: ${bstInputs}`);
     }
 
     const latexmkArgs = [

--- a/src/test-kernel/latex/LatexdiffBibQuality.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffBibQuality.vitest.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildKpathseaSearchPath } from '@latex/texTools';
+import {
+  buildLatexdiffTextCommandExclusionFlag,
+  LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS,
+} from '@latex/latexdiff/diffCommandExecutor';
+
+describe('latexdiff bibliography quality helpers', () => {
+  it('excludes common citation commands from latexdiff text-command wrapping', () => {
+    expect(buildLatexdiffTextCommandExclusionFlag()).toBe(
+      `--exclude-textcmd=${LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS.join(',')}`,
+    );
+    expect(LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS).toContain('citep\\*?');
+    expect(LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS).toContain('citet\\*?');
+    expect(LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS).toContain(
+      'parencite\\*?',
+    );
+  });
+
+  it('prepends BIBINPUTS and BSTINPUTS paths while preserving kpathsea defaults', () => {
+    expect(buildKpathseaSearchPath(['/workspace'], undefined, ':')).toBe(
+      '/workspace:',
+    );
+    expect(buildKpathseaSearchPath(['/workspace'], '/custom', ':')).toBe(
+      '/workspace:/custom:',
+    );
+  });
+
+  it('uses the platform delimiter for TeX search paths', () => {
+    expect(
+      buildKpathseaSearchPath(['C:\\work', 'D:\\shared'], 'E:\\texmf', ';'),
+    ).toBe('C:\\work;D:\\shared;E:\\texmf;');
+  });
+
+  it('omits empty TeX search paths', () => {
+    expect(buildKpathseaSearchPath(['', '  '], undefined, ':')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- exclude common citation commands from latexdiff text-command wrapping so citations remain BibTeX-visible
- prepend workspace bibliography/style search paths through BIBINPUTS and BSTINPUTS while preserving kpathsea defaults with the trailing-separator convention
- add focused tests for the latexdiff citation flag and TeX search-path construction

Refs #3234 (Phase 8).

## Validation
- npm run test:kernel -- src/test-kernel/latex/LatexdiffBibQuality.vitest.ts
- npm run compile:safe
- npm run desktop:build
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts LaTeX diff/compile command-line flags and environment search paths, which can change bibliography resolution behavior across platforms and user setups. Scope is contained and covered by new targeted tests.
> 
> **Overview**
> Improves bibliography stability when generating diffs by passing `latexdiff`/`latexdiff-vc` an `--exclude-textcmd=` flag that prevents common citation commands from being wrapped as text (keeping them BibTeX-visible).
> 
> Refactors TeX search-path construction into `buildKpathseaSearchPath()` and uses it to prepend workspace paths while preserving kpathsea’s trailing-delimiter convention; additionally sets `BIBINPUTS` and `BSTINPUTS` (alongside `TEXINPUTS`) during PDF compilation.
> 
> Adds a focused Vitest suite verifying the latexdiff exclusion flag and kpathsea path formatting (including Windows delimiter behavior and empty-path omission).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c068c83e491884cd449589709426c0f2cc6e3369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->