### PR TITLE
refactor: route flow hosts through run context

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -18,7 +18,10 @@ import {
   clearPlanApprovalForStream,
   clearRetryRequest,
 } from '@agent/runtime/runCoordinators';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  resolveRunRuntimeHost,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
@@ -26,7 +29,6 @@ import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
@@ -117,7 +119,7 @@ export async function runReflectionFlow<C = unknown>(
     onRoundFinalized = async () => {},
     usageMonitor,
   } = input;
-  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
+  const runtimeHost = resolveRunRuntimeHost(input.runtimeHost);
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
   let shared: ReflectionFlowShared | undefined;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -7,7 +7,10 @@ import {
   clearPlanApprovalForStream,
   clearRetryRequest,
 } from '@agent/runtime/runCoordinators';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  resolveRunRuntimeHost,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   PersistedFlow,
   flowKey,
@@ -18,7 +21,6 @@ import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getGlobalState } from '@agent/core/stateStore';
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { GlobalStateKey } from '@common/state/stateKeys';
 import { executionToEndStatus } from '@common/constants/streamStatus';
@@ -145,7 +147,7 @@ export async function runToolUseFlow<C = unknown>(
   onSetup?: ToolUseFlowSetupCallback,
 ): Promise<RunToolUseFlowResult> {
   const { logger, streamId, executionId, setting, onInterrupt } = input;
-  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
+  const runtimeHost = resolveRunRuntimeHost(input.runtimeHost);
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
   const delegationDepth = input.delegationDepth ?? 0;

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,15 +1,15 @@
 // Third-party imports
 import { AsyncLocalStorage } from 'async_hooks';
 
+// Local imports - shared schemas
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
+
 // Local imports - runtime
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentProposalCoordinator } from './AgentProposalCoordinator';
 import type { PlanApprovalCoordinator } from './PlanApprovalCoordinator';
 import type { RetryRequestCoordinatorImpl } from './RetryRequestCoordinator';
-
-// Local imports - shared schemas
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
 export type RunLogData = Record<string, unknown>;
 
@@ -128,6 +128,12 @@ export function withRunContext<T>(
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   return runContextScope.run(context, fn);
+}
+
+export function resolveRunRuntimeHost(
+  explicitHost?: AgentRuntimeHost,
+): AgentRuntimeHost {
+  return explicitHost ?? useRunContext().runtimeHost;
 }
 
 /** Return the active run context, or throw if none is installed. */

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -68,11 +68,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 import { StreamStatusService } from './StreamStatusService';
-import {
-  getAgentRuntimeHost,
-  runWithAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from './AgentRuntimeHost';
+import { getAgentRuntimeHost, type AgentRuntimeHost } from './AgentRuntimeHost';
 import { createInterruptCallbacks } from './InterruptManager';
 import {
   trackExecution,
@@ -205,7 +201,7 @@ async function beginRunStage(
 interface AgentLaunchInput {
   configPayload: AgentConfigPayload;
   executionId?: ExecutionId;
-  runtimeHost?: AgentRuntimeHost;
+  runtimeHost: AgentRuntimeHost;
   streamTabIdOverride?: StreamTabId;
   taskType?: string;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
@@ -661,7 +657,7 @@ async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
-  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
+  const { runtimeHost } = input;
   const executionId = input.executionId ?? generateExecutionId();
   if (
     !input.streamTabIdOverride &&
@@ -750,191 +746,121 @@ export async function executeAgent(
   executionId?: ExecutionId,
   options?: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
-  return runWithAgentRuntimeHost(options?.runtimeHost, async () => {
-    const ctx = await buildAgentLaunchContext({
-      configPayload,
-      executionId,
-      onBeforeActivation: options?.onStreamResolved,
-      enforceCategory: options?.enforceCategory,
-      suppressErrorNotification: options?.isSubagent,
-    });
-    ctx.delegationDepth = options?.delegationDepth ?? 0;
-    return withExecutionRunContext(ctx, async () => {
-      const { setting, streamId, config } = ctx;
-      const { agent: agentName } = config;
-      const { isSubagent } = options ?? {};
-
-      // Fire-and-forget: generate AI session description from the user's instruction.
-      // Triggered at the start so cancelled/errored sessions still get descriptions.
-      // Applies to all agents including subagents so their progress tabs show
-      // meaningful descriptions in multi-agent pipelines.
-      generateSessionDescription(
-        ctx.executionId,
-        streamId,
-        config,
-        ctx.runtimeHost,
-      ).catch(() => {});
-      return runFlowWithLifecycle(
-        ctx,
-        streamId,
-        agentName,
-        async () => {
-          // Pre-execution UI setup
-          if (executionId) await ensureRunDir(executionId);
-          StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
-            runtimeHost: ctx.runtimeHost,
-          });
-          logger.info(`Starting task execution (streamId: ${streamId})`);
-          logger.info(`Input file: ${config.inputFile}`);
-          logger.debug(
-            `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,
-          );
-          logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
-          // Subagents don't need to force-open the progress board or show notifications —
-          // the orchestrator's stream is already visible.
-          if (!isSubagent && !getRunStorageService().isViewVisible()) {
-            ctx.runtimeHost.emit('requestEnsureProgressView', {
-              fallbackNotification: buildFallbackNotification(config),
-            });
-          }
-          ctx.runtimeHost.emit('setTaskState', {
-            streamId,
-            executionId,
-            taskState: agentConfigToTaskState(config),
-          });
-
-          const taskStage = await logger.stage(
-            `Task: ${agentName}@${config.model}`,
-          );
-          return taskStage.run(async () => {
-            logger.info(`Executing ${agentName} with model ${config.model}`);
-            const interrupts = createInterruptCallbacks();
-
-            if (setting.agentCategory === AgentCategory.ToolUse) {
-              let toolUseTurns = 0;
-              const result = await runToolUseFlow({
-                ...ctx,
-                ...interrupts,
-                onRoundFinalized: (run) =>
-                  ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-                setting: ctx.setting as AgentToolUseSetting,
-                isSubagent,
-                onBeforeWaiting: options?.onBeforeWaiting,
-                onProgress: (update) => {
-                  if (update.kind === 'overview') {
-                    toolUseTurns++;
-                    ctx.runtimeHost.emit('updateConversationProgress', {
-                      streamId,
-                      progress: {
-                        conversationTurns: toolUseTurns,
-                        toolCallCount: update.toolCallCount,
-                      },
-                    });
-                  }
-                  options?.onProgress?.(update);
-                },
-                onFollowUpConsumed: () => {
-                  ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                    streamId: ctx.streamId,
-                  });
-                  options?.onFollowUpConsumed?.();
-                },
-              });
-              return {
-                category: 'toolUse' as const,
-                status: result.status,
-                lastResponse: result.lastResponse,
-                touchedFiles: result.touchedFiles,
-                executionId: ctx.executionId,
-                streamId,
-              };
-            }
-
-            const onRoundCompleted = createRoundProgressCallback(
-              ctx.executionId,
-              streamId,
-              ctx.runtimeHost,
-              options?.onProgress,
-            );
-            const result = await runReflectionFlow({
-              ...ctx,
-              ...interrupts,
-              onRoundFinalized: (run) =>
-                ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-              setting: ctx.setting as AgentWorkflowSetting,
-              parentStage: ctx.parentStage,
-              onRoundCompleted,
-            });
-            return {
-              category: 'workflow' as const,
-              status: result.status,
-              outputs: toOutputSummaries(result.roundOutputs),
-              compileFailures: toCompileFailureSummaries(result.roundOutputs),
-              executionId: ctx.executionId,
-              streamId,
-            };
-          });
-        },
-        {
-          isSubagent,
-          category:
-            setting.agentCategory === AgentCategory.ToolUse
-              ? 'toolUse'
-              : 'workflow',
-          parentStreamId: options?.parentStreamId,
-          onCompleted: options?.onCompleted,
-        },
-      );
-    });
+  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
+  const ctx = await buildAgentLaunchContext({
+    configPayload,
+    executionId,
+    runtimeHost,
+    onBeforeActivation: options?.onStreamResolved,
+    enforceCategory: options?.enforceCategory,
+    suppressErrorNotification: options?.isSubagent,
   });
-}
+  ctx.delegationDepth = options?.delegationDepth ?? 0;
+  return withExecutionRunContext(ctx, async () => {
+    const { setting, streamId, config } = ctx;
+    const { agent: agentName } = config;
+    const { isSubagent } = options ?? {};
 
-export async function executeMergeAgent(
-  model: string,
-  inputFile: string,
-  editedFile: string,
-  runtimeHost?: AgentRuntimeHost,
-): Promise<void> {
-  const host = runtimeHost ?? getAgentRuntimeHost();
-  return runWithAgentRuntimeHost(host, async () => {
-    const configPayload: AgentConfigPayload = {
-      agent: 'merge',
-      model,
-      inputFile,
-      editedFile,
-    };
-    const ctx = await buildAgentLaunchContext({
-      configPayload,
-      taskType: 'Merge task',
-    });
-    const { streamId, executionId } = ctx;
-
-    await withExecutionRunContext(ctx, () =>
-      runFlowWithLifecycle(ctx, streamId, 'merge', async () => {
+    // Fire-and-forget: generate AI session description from the user's instruction.
+    // Triggered at the start so cancelled/errored sessions still get descriptions.
+    // Applies to all agents including subagents so their progress tabs show
+    // meaningful descriptions in multi-agent pipelines.
+    generateSessionDescription(
+      ctx.executionId,
+      streamId,
+      config,
+      ctx.runtimeHost,
+    ).catch(() => {});
+    return runFlowWithLifecycle(
+      ctx,
+      streamId,
+      agentName,
+      async () => {
+        // Pre-execution UI setup
+        if (executionId) await ensureRunDir(executionId);
         StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
           runtimeHost: ctx.runtimeHost,
         });
+        logger.info(`Starting task execution (streamId: ${streamId})`);
+        logger.info(`Input file: ${config.inputFile}`);
+        logger.debug(
+          `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,
+        );
+        logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
+        // Subagents don't need to force-open the progress board or show notifications —
+        // the orchestrator's stream is already visible.
+        if (!isSubagent && !getRunStorageService().isViewVisible()) {
+          ctx.runtimeHost.emit('requestEnsureProgressView', {
+            fallbackNotification: buildFallbackNotification(config),
+          });
+        }
+        ctx.runtimeHost.emit('setTaskState', {
+          streamId,
+          executionId,
+          taskState: agentConfigToTaskState(config),
+        });
 
-        const taskStage = await logger.stage(`Task: merge@${model}`);
+        const taskStage = await logger.stage(
+          `Task: ${agentName}@${config.model}`,
+        );
         return taskStage.run(async () => {
-          logger.info(`Executing merge with model ${model}`);
+          logger.info(`Executing ${agentName} with model ${config.model}`);
+          const interrupts = createInterruptCallbacks();
 
-          const fileService = new TaskRunFileService(executionId);
-          const mergeSetting = ctx.setting as AgentWorkflowSetting;
+          if (setting.agentCategory === AgentCategory.ToolUse) {
+            let toolUseTurns = 0;
+            const result = await runToolUseFlow({
+              ...ctx,
+              ...interrupts,
+              onRoundFinalized: (run) =>
+                ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+              setting: ctx.setting as AgentToolUseSetting,
+              isSubagent,
+              onBeforeWaiting: options?.onBeforeWaiting,
+              onProgress: (update) => {
+                if (update.kind === 'overview') {
+                  toolUseTurns++;
+                  ctx.runtimeHost.emit('updateConversationProgress', {
+                    streamId,
+                    progress: {
+                      conversationTurns: toolUseTurns,
+                      toolCallCount: update.toolCallCount,
+                    },
+                  });
+                }
+                options?.onProgress?.(update);
+              },
+              onFollowUpConsumed: () => {
+                ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                  streamId: ctx.streamId,
+                });
+                options?.onFollowUpConsumed?.();
+              },
+            });
+            return {
+              category: 'toolUse' as const,
+              status: result.status,
+              lastResponse: result.lastResponse,
+              touchedFiles: result.touchedFiles,
+              executionId: ctx.executionId,
+              streamId,
+            };
+          }
+
+          const onRoundCompleted = createRoundProgressCallback(
+            ctx.executionId,
+            streamId,
+            ctx.runtimeHost,
+            options?.onProgress,
+          );
           const result = await runReflectionFlow({
             ...ctx,
-            ...createInterruptCallbacks(),
+            ...interrupts,
             onRoundFinalized: (run) =>
               ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-            setting: mergeSetting,
-            getOutputFileLocation:
-              createMergeOutputFileLocationGetter(fileService),
+            setting: ctx.setting as AgentWorkflowSetting,
             parentStage: ctx.parentStage,
-            onRoundCompleted: createRoundProgressCallback(
-              ctx.executionId,
-              streamId,
-              ctx.runtimeHost,
-            ),
+            onRoundCompleted,
           });
           return {
             category: 'workflow' as const,
@@ -945,9 +871,78 @@ export async function executeMergeAgent(
             streamId,
           };
         });
-      }),
+      },
+      {
+        isSubagent,
+        category:
+          setting.agentCategory === AgentCategory.ToolUse
+            ? 'toolUse'
+            : 'workflow',
+        parentStreamId: options?.parentStreamId,
+        onCompleted: options?.onCompleted,
+      },
     );
   });
+}
+
+export async function executeMergeAgent(
+  model: string,
+  inputFile: string,
+  editedFile: string,
+  runtimeHost?: AgentRuntimeHost,
+): Promise<void> {
+  const host = runtimeHost ?? getAgentRuntimeHost();
+  const configPayload: AgentConfigPayload = {
+    agent: 'merge',
+    model,
+    inputFile,
+    editedFile,
+  };
+  const ctx = await buildAgentLaunchContext({
+    configPayload,
+    runtimeHost: host,
+    taskType: 'Merge task',
+  });
+  const { streamId, executionId } = ctx;
+
+  await withExecutionRunContext(ctx, () =>
+    runFlowWithLifecycle(ctx, streamId, 'merge', async () => {
+      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+        runtimeHost: ctx.runtimeHost,
+      });
+
+      const taskStage = await logger.stage(`Task: merge@${model}`);
+      return taskStage.run(async () => {
+        logger.info(`Executing merge with model ${model}`);
+
+        const fileService = new TaskRunFileService(executionId);
+        const mergeSetting = ctx.setting as AgentWorkflowSetting;
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...createInterruptCallbacks(),
+          onRoundFinalized: (run) =>
+            ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+          setting: mergeSetting,
+          getOutputFileLocation:
+            createMergeOutputFileLocationGetter(fileService),
+          parentStage: ctx.parentStage,
+          onRoundCompleted: createRoundProgressCallback(
+            ctx.executionId,
+            streamId,
+            ctx.runtimeHost,
+          ),
+        });
+        return {
+          category: 'workflow' as const,
+          status: result.status,
+          outputs: toOutputSummaries(result.roundOutputs),
+          compileFailures: toCompileFailureSummaries(result.roundOutputs),
+          executionId: ctx.executionId,
+          streamId,
+        };
+      });
+    }),
+  );
 }
 
 export async function resumeToolUseFromSnapshot(
@@ -956,73 +951,70 @@ export async function resumeToolUseFromSnapshot(
   runtimeHost?: AgentRuntimeHost,
 ): Promise<void> {
   const host = runtimeHost ?? getAgentRuntimeHost();
-  return runWithAgentRuntimeHost(host, async () => {
-    const ctx = await buildAgentLaunchContext({
-      configPayload: snapshot.agentConfig,
-      executionId: snapshot.executionId,
-      streamTabIdOverride: snapshot.streamId,
-      // resumeCommand surfaces its own warning toast on failure; skip the
-      // bus-level error to avoid double-notifying.
-      suppressErrorNotification: true,
-    });
-    // Recover delegation depth from the persisted parent-execution chain
-    // so resumed subagents remain gated by the nested-delegation policy
-    // instead of silently promoting to root.
-    ctx.delegationDepth = await computeDelegationDepthFromStorage(
-      snapshot.executionId,
-    );
-    const { setting, streamId } = ctx;
+  const ctx = await buildAgentLaunchContext({
+    configPayload: snapshot.agentConfig,
+    executionId: snapshot.executionId,
+    runtimeHost: host,
+    streamTabIdOverride: snapshot.streamId,
+    // resumeCommand surfaces its own warning toast on failure; skip the
+    // bus-level error to avoid double-notifying.
+    suppressErrorNotification: true,
+  });
+  // Recover delegation depth from the persisted parent-execution chain
+  // so resumed subagents remain gated by the nested-delegation policy
+  // instead of silently promoting to root.
+  ctx.delegationDepth = await computeDelegationDepthFromStorage(
+    snapshot.executionId,
+  );
+  const { setting, streamId } = ctx;
 
-    await withExecutionRunContext(ctx, async () => {
-      if (setting.agentCategory !== AgentCategory.ToolUse) {
-        throw new AgentError(
-          'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
-        );
-      }
-
-      await runFlowWithLifecycle(
-        ctx,
-        streamId,
-        snapshot.agentConfig.agent,
-        async () => {
-          StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
-            runtimeHost: ctx.runtimeHost,
-          });
-
-          const result = await runToolUseFlow(
-            {
-              ...ctx,
-              ...createInterruptCallbacks(),
-              onRoundFinalized: (run) =>
-                ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-              setting: setting as AgentToolUseSetting,
-              resumeSnapshot: snapshot,
-              // Derive from the recovered parent chain: any execution with a
-              // parent is a subagent. Without this, the rebuilt system prompt
-              // would drop subagent-specific instructions (e.g. the shared
-              // /memories protocol) that the fresh run had included.
-              isSubagent: (ctx.delegationDepth ?? 0) > 0,
-              onFollowUpConsumed: () =>
-                ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                  streamId: ctx.streamId,
-                }),
-            },
-            undefined,
-            setupSession
-              ? (context) => setupSession(context.session)
-              : undefined,
-          );
-          return {
-            category: 'toolUse' as const,
-            status: result.status,
-            lastResponse: result.lastResponse,
-            touchedFiles: result.touchedFiles,
-            executionId: ctx.executionId,
-            streamId,
-          };
-        },
-        { category: 'toolUse' },
+  await withExecutionRunContext(ctx, async () => {
+    if (setting.agentCategory !== AgentCategory.ToolUse) {
+      throw new AgentError(
+        'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
       );
-    });
+    }
+
+    await runFlowWithLifecycle(
+      ctx,
+      streamId,
+      snapshot.agentConfig.agent,
+      async () => {
+        StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+          runtimeHost: ctx.runtimeHost,
+        });
+
+        const result = await runToolUseFlow(
+          {
+            ...ctx,
+            ...createInterruptCallbacks(),
+            onRoundFinalized: (run) =>
+              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+            setting: setting as AgentToolUseSetting,
+            resumeSnapshot: snapshot,
+            // Derive from the recovered parent chain: any execution with a
+            // parent is a subagent. Without this, the rebuilt system prompt
+            // would drop subagent-specific instructions (e.g. the shared
+            // /memories protocol) that the fresh run had included.
+            isSubagent: (ctx.delegationDepth ?? 0) > 0,
+            onFollowUpConsumed: () =>
+              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                streamId: ctx.streamId,
+              }),
+          },
+          undefined,
+          setupSession ? (context) => setupSession(context.session) : undefined,
+        );
+        return {
+          category: 'toolUse' as const,
+          status: result.status,
+          lastResponse: result.lastResponse,
+          touchedFiles: result.touchedFiles,
+          executionId: ctx.executionId,
+          streamId,
+        };
+      },
+      { category: 'toolUse' },
+    );
   });
 }

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -2,7 +2,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { createRunContext } from '@agent/runtime/RunContext';
+import {
+  createRunContext,
+  resolveRunRuntimeHost,
+  withRunContext,
+} from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 function createRuntimeHost(): AgentRuntimeHost {
@@ -39,5 +43,30 @@ describe('RunContext', () => {
     expect(first).not.toBe(second);
     expect(first.logger).not.toBe(second.logger);
     expect(first.approvals).not.toBe(second.approvals);
+  });
+
+  it('resolves runtime host from the active run context', () => {
+    const runtimeHost = createRuntimeHost();
+    const context = createRunContext({ runtimeHost });
+
+    const resolved = withRunContext(context, () => resolveRunRuntimeHost());
+
+    expect(resolved).toBe(runtimeHost);
+  });
+
+  it('prefers an explicit runtime host over the active run context', () => {
+    const scoped = createRuntimeHost();
+    const explicit = createRuntimeHost();
+    const context = createRunContext({ runtimeHost: scoped });
+
+    const resolved = withRunContext(context, () =>
+      resolveRunRuntimeHost(explicit),
+    );
+
+    expect(resolved).toBe(explicit);
+  });
+
+  it('requires an active context when no runtime host is explicit', () => {
+    expect(() => resolveRunRuntimeHost()).toThrow(/outside withRunContext/);
   });
 });


### PR DESCRIPTION
## Summary

This is a focused slice of #3397 and #3372. It removes one duplicated ambient runtime-host path from the agent runtime without changing user-facing behavior.

- make agent launch-context assembly receive an explicit `AgentRuntimeHost`
- stop wrapping `executeAgent`, `executeMergeAgent`, and `resumeToolUseFromSnapshot` in the older `runWithAgentRuntimeHost()` scope
- make reflection and tool-use flows resolve their host from an explicit argument or the active `RunContext`, not from the global runtime-host fallback
- add focused tests for `RunContext` host resolution

This does not close #3397 or #3372. The default host, approval singletons, logger imports, and several tool/runtime fallback sites remain for later slices.

## Validation

- `npm run format`
- `npm run test:kernel -- src/test-kernel/agent/runtime/RunContext.vitest.ts`
- `npm run compile:safe`
- `npm run desktop:build`
- `corepack pnpm --filter @texra/cli build`
- `npm run lint` (0 errors; existing warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent execution/flow wiring by removing the legacy `runWithAgentRuntimeHost` scoping and changing how `runtimeHost` is resolved, which could surface as missing UI/progress events if any call path lacks an active `RunContext` or explicit host.
> 
> **Overview**
> Routes `runtimeHost` resolution for `runReflectionFlow` and `runToolUseFlow` through the active `RunContext` via new `resolveRunRuntimeHost()` (or an explicitly passed host), removing direct fallback to `getAgentRuntimeHost()` inside the flows.
> 
> Refactors `executeAgent`, `executeMergeAgent`, and `resumeToolUseFromSnapshot` to stop wrapping execution in `runWithAgentRuntimeHost()` and instead pass an explicit `runtimeHost` into launch-context construction, making host ownership come from the per-run context rather than an ambient ALS scope.
> 
> Adds kernel tests covering `resolveRunRuntimeHost()` behavior (context-derived, explicit override, and error when no context).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce4672356e4bee9662a90600985feab9eb0d3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->