### PR TITLE
refactor: split process output polling

### DIFF
--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -9,9 +9,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ProcessExecutionHandle } from './ExecutionHandle';
 
 interface ProcessOutputSource {
-  parentStreamId: StreamTabId;
-  stdoutPath: string;
-  stderrPath: string;
+  handle: ProcessExecutionHandle;
   runtimeHost: AgentRuntimeHost;
 }
 
@@ -39,12 +37,8 @@ export function registerProcessOutput(
   handle: ProcessExecutionHandle,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  if (!handle.outputPaths) return;
-
   processOutputs.set(handle.executionId, {
-    parentStreamId: handle.parentStreamId,
-    stdoutPath: handle.outputPaths.stdout,
-    stderrPath: handle.outputPaths.stderr,
+    handle,
     runtimeHost,
   });
   reconcileOutputPoller();
@@ -101,15 +95,17 @@ function schedulePoll(): void {
 
 async function pollProcessOutputs(): Promise<void> {
   await Promise.all(
-    [...processOutputs.entries()].map(([executionId, source]) =>
-      readIncremental(
-        executionId,
-        source.parentStreamId,
-        source.stdoutPath,
-        source.stderrPath,
+    [...processOutputs.values()].map((source) => {
+      const { outputPaths } = source.handle;
+      if (!outputPaths) return Promise.resolve();
+      return readIncremental(
+        source.handle.executionId,
+        source.handle.parentStreamId,
+        outputPaths.stdout,
+        outputPaths.stderr,
         source.runtimeHost,
-      ),
-    ),
+      );
+    }),
   );
 }
 

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -1,0 +1,214 @@
+// Node imports
+import * as fs from 'fs';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - runtime
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type { ProcessExecutionHandle } from './ExecutionHandle';
+
+interface ProcessOutputSource {
+  parentStreamId: StreamTabId;
+  stdoutPath: string;
+  stderrPath: string;
+  runtimeHost: AgentRuntimeHost;
+}
+
+/** Interval at which temp files are read and pushed to the progress UI. */
+const OUTPUT_POLL_INTERVAL_MS = 500;
+
+/** Max bytes to read per file per poll to prevent huge allocations. */
+const MAX_READ_PER_POLL = 128 * 1024;
+
+/** Tracks byte offsets already sent per executionId per stream. */
+const outputOffsets = new Map<string, { stdout: number; stderr: number }>();
+
+const processOutputs = new Map<string, ProcessOutputSource>();
+
+let outputPollTimer: ReturnType<typeof setTimeout> | null = null;
+let pollInFlight = false;
+
+/**
+ * Tracks in-flight reads per executionId so concurrent calls can await
+ * rather than silently skipping final tail output.
+ */
+const readingInProgress = new Map<string, Promise<void>>();
+
+export function registerProcessOutput(
+  handle: ProcessExecutionHandle,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  if (!handle.outputPaths) return;
+
+  processOutputs.set(handle.executionId, {
+    parentStreamId: handle.parentStreamId,
+    stdoutPath: handle.outputPaths.stdout,
+    stderrPath: handle.outputPaths.stderr,
+    runtimeHost,
+  });
+  reconcileOutputPoller();
+}
+
+export function unregisterProcessOutput(executionId: string): void {
+  processOutputs.delete(executionId);
+  outputOffsets.delete(executionId);
+  reconcileOutputPoller();
+}
+
+export async function flushProcessOutput(
+  handle: ProcessExecutionHandle,
+  runtimeHost: AgentRuntimeHost,
+): Promise<void> {
+  if (!handle.outputPaths) return;
+
+  await readIncremental(
+    handle.executionId,
+    handle.parentStreamId,
+    handle.outputPaths.stdout,
+    handle.outputPaths.stderr,
+    runtimeHost,
+  );
+}
+
+function reconcileOutputPoller(): void {
+  const active = processOutputs.size > 0;
+  if (active && !outputPollTimer) {
+    schedulePoll();
+  } else if (!active && outputPollTimer) {
+    clearTimeout(outputPollTimer);
+    outputPollTimer = null;
+  }
+}
+
+/** Schedule the next poll cycle; the next poll waits for the current one. */
+function schedulePoll(): void {
+  outputPollTimer = setTimeout(async () => {
+    outputPollTimer = null;
+    if (pollInFlight) {
+      schedulePoll();
+      return;
+    }
+    pollInFlight = true;
+    try {
+      await pollProcessOutputs();
+    } finally {
+      pollInFlight = false;
+      reconcileOutputPoller();
+    }
+  }, OUTPUT_POLL_INTERVAL_MS);
+}
+
+async function pollProcessOutputs(): Promise<void> {
+  await Promise.all(
+    [...processOutputs.entries()].map(([executionId, source]) =>
+      readIncremental(
+        executionId,
+        source.parentStreamId,
+        source.stdoutPath,
+        source.stderrPath,
+        source.runtimeHost,
+      ),
+    ),
+  );
+}
+
+/**
+ * Find the last byte index that ends a complete UTF-8 character.
+ * If the buffer ends mid-character, those trailing bytes are excluded
+ * so the next read starts at the right boundary.
+ */
+function lastCompleteUtf8(buf: Buffer, bytesRead: number): number {
+  if (bytesRead === 0) return 0;
+  // Walk backward (max 3 bytes: longest UTF-8 lead) looking for
+  // a continuation byte. If we find a lead byte, check whether the
+  // sequence is complete.
+  for (let i = bytesRead - 1; i >= Math.max(0, bytesRead - 3); i--) {
+    const b = buf[i];
+    if (b < 0x80) return bytesRead;
+    if ((b & 0xc0) === 0x80) continue;
+
+    let seqLen: number;
+    if ((b & 0xe0) === 0xc0) seqLen = 2;
+    else if ((b & 0xf0) === 0xe0) seqLen = 3;
+    else if ((b & 0xf8) === 0xf0) seqLen = 4;
+    else return bytesRead;
+
+    return i + seqLen <= bytesRead ? bytesRead : i;
+  }
+  return bytesRead;
+}
+
+async function readTail(
+  path: string,
+  byteOffset: number,
+): Promise<{ text: string; newOffset: number }> {
+  const fh = await fs.promises.open(path, 'r');
+  try {
+    const { size } = await fh.stat();
+    if (size <= byteOffset) return { text: '', newOffset: byteOffset };
+    const toRead = Math.min(size - byteOffset, MAX_READ_PER_POLL);
+    const buf = Buffer.alloc(toRead);
+    const { bytesRead } = await fh.read(buf, 0, toRead, byteOffset);
+    const safeEnd = lastCompleteUtf8(buf, bytesRead);
+    return {
+      text: buf.toString('utf-8', 0, safeEnd),
+      newOffset: byteOffset + safeEnd,
+    };
+  } finally {
+    await fh.close();
+  }
+}
+
+async function readIncremental(
+  executionId: string,
+  parentStreamId: StreamTabId,
+  stdoutPath: string,
+  stderrPath: string,
+  runtimeHost: AgentRuntimeHost,
+): Promise<void> {
+  const inflight = readingInProgress.get(executionId);
+  if (inflight) {
+    await inflight;
+  }
+
+  const work = (async () => {
+    try {
+      const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
+      const [out, err] = await Promise.all([
+        readTail(stdoutPath, prev.stdout).catch(() => ({
+          text: '',
+          newOffset: prev.stdout,
+        })),
+        readTail(stderrPath, prev.stderr).catch(() => ({
+          text: '',
+          newOffset: prev.stderr,
+        })),
+      ]);
+      if (!out.text && !err.text) return;
+
+      outputOffsets.set(executionId, {
+        stdout: out.newOffset,
+        stderr: err.newOffset,
+      });
+
+      runtimeHost.emit('updateProcessOutput', {
+        parentStreamId,
+        executionId,
+        stdout: out.text,
+        stderr: err.text,
+      });
+    } catch {
+      // File may have been deleted between check and read.
+    }
+  })();
+
+  readingInProgress.set(executionId, work);
+  try {
+    await work;
+  } finally {
+    if (readingInProgress.get(executionId) === work) {
+      readingInProgress.delete(executionId);
+    }
+  }
+}

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,8 +5,6 @@
  * change notification, and subagent lineage tracking in a single module.
  */
 
-import * as fs from 'fs';
-
 import {
   getAgentRuntimeHost,
   type AgentRuntimeHost,
@@ -20,6 +18,11 @@ import {
   collectChildSummary,
   interruptActiveChildren as interruptChildren,
 } from './ExecutionHandle';
+import {
+  flushProcessOutput,
+  registerProcessOutput,
+  unregisterProcessOutput,
+} from './ProcessOutputPoller';
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
@@ -82,8 +85,8 @@ export function trackExecution(handle: ExecutionHandle): void {
 
   // Emit process badge update for background bash processes
   if (handle instanceof ProcessExecutionHandle) {
+    registerProcessOutput(handle, runtimeHost);
     emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
-    reconcileOutputPoller();
   }
 }
 
@@ -107,18 +110,11 @@ export function untrackExecution(executionId: string): void {
   // badge handler prunes output entries for processes no longer active.
   if (handle instanceof ProcessExecutionHandle) {
     const finalize = (): void => {
-      outputOffsets.delete(executionId);
+      unregisterProcessOutput(executionId);
       emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
-      reconcileOutputPoller();
     };
     if (handle.outputPaths) {
-      void readIncremental(
-        executionId,
-        handle.parentStreamId,
-        handle.outputPaths.stdout,
-        handle.outputPaths.stderr,
-        runtimeHost,
-      ).finally(finalize);
+      void flushProcessOutput(handle, runtimeHost).finally(finalize);
     } else {
       finalize();
     }
@@ -320,193 +316,6 @@ function emitActiveProcessesUpdate(
     parentStreamId,
     processes,
   });
-}
-
-// ============================================================================
-// Process output polling
-// ============================================================================
-
-/** Interval at which temp files are read and pushed to the progress UI. */
-const OUTPUT_POLL_INTERVAL_MS = 500;
-
-/** Tracks byte offsets already sent per executionId per stream. */
-const outputOffsets = new Map<string, { stdout: number; stderr: number }>();
-
-let outputPollTimer: ReturnType<typeof setTimeout> | null = null;
-let pollInFlight = false;
-
-/** Check whether any tracked execution is a process handle. */
-function hasActiveProcesses(): boolean {
-  for (const h of registry.values()) {
-    if (h instanceof ProcessExecutionHandle) return true;
-  }
-  return false;
-}
-
-/** Start polling if there are active process handles; stop if none remain. */
-function reconcileOutputPoller(): void {
-  const active = hasActiveProcesses();
-  if (active && !outputPollTimer) {
-    schedulePoll();
-  } else if (!active && outputPollTimer) {
-    clearTimeout(outputPollTimer);
-    outputPollTimer = null;
-  }
-}
-
-/** Schedule the next poll cycle (serialized — next poll waits for current to finish). */
-function schedulePoll(): void {
-  outputPollTimer = setTimeout(async () => {
-    // Clear stale timer ID so reconcileOutputPoller sees !outputPollTimer
-    outputPollTimer = null;
-    if (pollInFlight) {
-      schedulePoll();
-      return;
-    }
-    pollInFlight = true;
-    try {
-      await pollProcessOutputs();
-    } finally {
-      pollInFlight = false;
-      reconcileOutputPoller();
-    }
-  }, OUTPUT_POLL_INTERVAL_MS);
-}
-
-/** Read incremental output from temp files and emit to progress UI. */
-async function pollProcessOutputs(): Promise<void> {
-  const reads: Promise<void>[] = [];
-  for (const handle of registry.values()) {
-    if (!(handle instanceof ProcessExecutionHandle)) continue;
-    if (!handle.outputPaths) continue;
-
-    reads.push(
-      readIncremental(
-        handle.executionId,
-        handle.parentStreamId,
-        handle.outputPaths.stdout,
-        handle.outputPaths.stderr,
-        runtimeHostFor(handle),
-      ),
-    );
-  }
-  await Promise.all(reads);
-}
-
-/** Max bytes to read per file per poll — prevents huge allocations from chatty processes. */
-const MAX_READ_PER_POLL = 128 * 1024;
-
-/**
- * Find the last byte index that ends a complete UTF-8 character.
- * If the buffer ends mid-character, those trailing bytes are excluded
- * so the next read starts at the right boundary.
- */
-function lastCompleteUtf8(buf: Buffer, bytesRead: number): number {
-  if (bytesRead === 0) return 0;
-  // Walk backward (max 3 bytes — longest UTF-8 lead) looking for
-  // a continuation byte (10xxxxxx). If we find a lead byte, check
-  // whether the sequence is complete.
-  for (let i = bytesRead - 1; i >= Math.max(0, bytesRead - 3); i--) {
-    const b = buf[i];
-    // ASCII or single-byte — always complete
-    if (b < 0x80) return bytesRead;
-    // Continuation byte (10xxxxxx) — keep scanning for the lead
-    if ((b & 0xc0) === 0x80) continue;
-    // Lead byte — determine expected sequence length
-    let seqLen: number;
-    if ((b & 0xe0) === 0xc0) seqLen = 2;
-    else if ((b & 0xf0) === 0xe0) seqLen = 3;
-    else if ((b & 0xf8) === 0xf0) seqLen = 4;
-    else return bytesRead; // Invalid lead — let toString handle it
-    // Complete if all bytes of the sequence were read
-    return i + seqLen <= bytesRead ? bytesRead : i;
-  }
-  return bytesRead;
-}
-
-/** Read only the new bytes from a file starting at byteOffset (capped per poll). */
-async function readTail(
-  path: string,
-  byteOffset: number,
-): Promise<{ text: string; newOffset: number }> {
-  const fh = await fs.promises.open(path, 'r');
-  try {
-    const { size } = await fh.stat();
-    if (size <= byteOffset) return { text: '', newOffset: byteOffset };
-    const toRead = Math.min(size - byteOffset, MAX_READ_PER_POLL);
-    const buf = Buffer.alloc(toRead);
-    const { bytesRead } = await fh.read(buf, 0, toRead, byteOffset);
-    // Avoid splitting multi-byte UTF-8 characters at the read boundary
-    const safeEnd = lastCompleteUtf8(buf, bytesRead);
-    return {
-      text: buf.toString('utf-8', 0, safeEnd),
-      newOffset: byteOffset + safeEnd,
-    };
-  } finally {
-    await fh.close();
-  }
-}
-
-/**
- * Tracks in-flight reads per executionId so concurrent calls can await
- * rather than silently skipping (which would lose tail output on final flush).
- */
-const readingInProgress = new Map<string, Promise<void>>();
-
-async function readIncremental(
-  executionId: string,
-  parentStreamId: StreamTabId,
-  stdoutPath: string,
-  stderrPath: string,
-  runtimeHost: AgentRuntimeHost,
-): Promise<void> {
-  // If another read is in flight, wait for it then read again —
-  // the final flush must not be skipped or it loses tail output.
-  const inflight = readingInProgress.get(executionId);
-  if (inflight) {
-    await inflight;
-  }
-
-  const work = (async () => {
-    try {
-      const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
-      const [out, err] = await Promise.all([
-        readTail(stdoutPath, prev.stdout).catch(() => ({
-          text: '',
-          newOffset: prev.stdout,
-        })),
-        readTail(stderrPath, prev.stderr).catch(() => ({
-          text: '',
-          newOffset: prev.stderr,
-        })),
-      ]);
-      if (!out.text && !err.text) return;
-
-      outputOffsets.set(executionId, {
-        stdout: out.newOffset,
-        stderr: err.newOffset,
-      });
-
-      runtimeHost.emit('updateProcessOutput', {
-        parentStreamId,
-        executionId,
-        stdout: out.text,
-        stderr: err.text,
-      });
-    } catch {
-      // File may have been deleted between check and read — ignore
-    }
-  })();
-
-  readingInProgress.set(executionId, work);
-  try {
-    await work;
-  } finally {
-    // Only clear if we're still the latest — another call may have replaced us
-    if (readingInProgress.get(executionId) === work) {
-      readingInProgress.delete(executionId);
-    }
-  }
 }
 
 // ============================================================================

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -1,0 +1,98 @@
+// Node imports
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - runtime
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import {
+  flushProcessOutput,
+  unregisterProcessOutput,
+} from '@agent/runtime/ProcessOutputPoller';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+const tmpDirs: string[] = [];
+
+function createRuntimeHost(): {
+  host: AgentRuntimeHost;
+  events: Array<{ event: string; payload: unknown }>;
+} {
+  const events: Array<{ event: string; payload: unknown }> = [];
+  return {
+    events,
+    host: {
+      emit: vi.fn((event: string, payload: unknown) => {
+        events.push({ event, payload });
+      }) as AgentRuntimeHost['emit'],
+    },
+  };
+}
+
+async function makeProcessHandle(runtimeHost: AgentRuntimeHost): Promise<{
+  handle: ProcessExecutionHandle;
+  stdoutPath: string;
+  stderrPath: string;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-poller-'));
+  tmpDirs.push(dir);
+  const stdoutPath = path.join(dir, 'stdout.log');
+  const stderrPath = path.join(dir, 'stderr.log');
+  await fs.writeFile(stdoutPath, 'out-1');
+  await fs.writeFile(stderrPath, 'err-1');
+
+  const handle = new ProcessExecutionHandle(
+    'exec-1',
+    'parent-stream' as StreamTabId,
+    'bash',
+    () => true,
+    runtimeHost,
+  );
+  handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
+  return { handle, stdoutPath, stderrPath };
+}
+
+afterEach(async () => {
+  unregisterProcessOutput('exec-1');
+  await Promise.all(
+    tmpDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true })),
+  );
+});
+
+describe('ProcessOutputPoller', () => {
+  it('flushes only new process output bytes', async () => {
+    const { host, events } = createRuntimeHost();
+    const { handle, stdoutPath, stderrPath } = await makeProcessHandle(host);
+
+    await flushProcessOutput(handle, host);
+    await fs.appendFile(stdoutPath, 'out-2');
+    await fs.appendFile(stderrPath, 'err-2');
+    await flushProcessOutput(handle, host);
+
+    expect(events).toEqual([
+      {
+        event: 'updateProcessOutput',
+        payload: {
+          parentStreamId: 'parent-stream',
+          executionId: 'exec-1',
+          stdout: 'out-1',
+          stderr: 'err-1',
+        },
+      },
+      {
+        event: 'updateProcessOutput',
+        payload: {
+          parentStreamId: 'parent-stream',
+          executionId: 'exec-1',
+          stdout: 'out-2',
+          stderr: 'err-2',
+        },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -11,6 +11,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import {
   flushProcessOutput,
+  registerProcessOutput,
   unregisterProcessOutput,
 } from '@agent/runtime/ProcessOutputPoller';
 
@@ -18,6 +19,10 @@ import {
 import type { StreamTabId } from '@shared/schemas';
 
 const tmpDirs: string[] = [];
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function createRuntimeHost(): {
   host: AgentRuntimeHost;
@@ -34,7 +39,10 @@ function createRuntimeHost(): {
   };
 }
 
-async function makeProcessHandle(runtimeHost: AgentRuntimeHost): Promise<{
+async function makeProcessHandle(
+  runtimeHost: AgentRuntimeHost,
+  options: { assignOutputPaths?: boolean } = {},
+): Promise<{
   handle: ProcessExecutionHandle;
   stdoutPath: string;
   stderrPath: string;
@@ -53,12 +61,15 @@ async function makeProcessHandle(runtimeHost: AgentRuntimeHost): Promise<{
     () => true,
     runtimeHost,
   );
-  handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
+  if (options.assignOutputPaths !== false) {
+    handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
+  }
   return { handle, stdoutPath, stderrPath };
 }
 
 afterEach(async () => {
   unregisterProcessOutput('exec-1');
+  vi.useRealTimers();
   await Promise.all(
     tmpDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true })),
   );
@@ -73,6 +84,42 @@ describe('ProcessOutputPoller', () => {
     await fs.appendFile(stdoutPath, 'out-2');
     await fs.appendFile(stderrPath, 'err-2');
     await flushProcessOutput(handle, host);
+
+    expect(events).toEqual([
+      {
+        event: 'updateProcessOutput',
+        payload: {
+          parentStreamId: 'parent-stream',
+          executionId: 'exec-1',
+          stdout: 'out-1',
+          stderr: 'err-1',
+        },
+      },
+      {
+        event: 'updateProcessOutput',
+        payload: {
+          parentStreamId: 'parent-stream',
+          executionId: 'exec-1',
+          stdout: 'out-2',
+          stderr: 'err-2',
+        },
+      },
+    ]);
+  });
+
+  it('polls handles whose output paths are assigned after registration', async () => {
+    const { host, events } = createRuntimeHost();
+    const { handle, stdoutPath, stderrPath } = await makeProcessHandle(host, {
+      assignOutputPaths: false,
+    });
+
+    registerProcessOutput(handle, host);
+    handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
+
+    await delay(550);
+    await fs.appendFile(stdoutPath, 'out-2');
+    await fs.appendFile(stderrPath, 'err-2');
+    await delay(550);
 
     expect(events).toEqual([
       {


### PR DESCRIPTION
Fixes #3921.

## Summary

This refactor moves process-output polling out of `executionRegistry.ts` into `src/agent/runtime/ProcessOutputPoller.ts`.

`executionRegistry.ts` remains the owner of active execution handles, child lineage, listeners, and UI badge updates. The new poller module owns only process stdout/stderr file tails, byte offsets, polling timer state, in-flight read serialization, and final output flushes before a process badge is removed.

The result keeps the registry narrower without adding a generalized registry abstraction.

## Validation

- `./node_modules/.bin/prettier --write src/agent/runtime/executionRegistry.ts src/agent/runtime/ProcessOutputPoller.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/tsc --noEmit -p packages/extension/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- `./node_modules/eslint/bin/eslint.js src/agent/runtime/executionRegistry.ts src/agent/runtime/ProcessOutputPoller.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `npm run test:kernel -- src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts src/test-kernel/agent/runtime/RunContext.vitest.ts`
- `npm run lint` (0 errors, existing warnings only)
- `npm run compile-tests`

`npm run test:kernel` currently fails locally in unrelated UI suites (`ToolEditRequestPanel.vitest.mts` and `ModelSelectionProviderKeys.vitest.ts`) with `NotSupportedError: This name has already been registered in the registry`; both also fail when run alone. The focused runtime tests for this change pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves and rewires stdout/stderr tail polling and final-flush behavior for background processes; regressions could drop/duplicate output or affect badge updates under concurrency.
> 
> **Overview**
> Refactors background process stdout/stderr tail polling out of `executionRegistry.ts` into a dedicated `ProcessOutputPoller.ts`, which now owns polling timer state, per-execution byte offsets, UTF-8-safe incremental reads, and serialization of concurrent reads.
> 
> `executionRegistry` now registers/unregisters process handles with the poller and uses `flushProcessOutput` during `untrackExecution` to ensure final output is emitted before the active-process badge update. Adds kernel tests covering incremental-only flushing and polling when `outputPaths` are assigned after registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6aecf974b6813a0d89fed6bb30a3269a65642a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->