### PR TITLE
fix: keep diff approval button compact

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -243,11 +243,13 @@ export const requestPanelStyles: CSSResult = css`
     position: relative;
     display: inline-flex;
     align-items: center;
-    flex: 1 1 12rem;
+    flex: 0 1 auto;
+    max-width: 100%;
   }
 
   .approval-request__actions .diff-dropdown .diff-main-button {
-    flex: 1;
+    flex: 0 1 auto;
+    min-width: 0;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }


### PR DESCRIPTION
## Summary

Fixes the adaptive layout regression where the tool-edit `Open diff` split-button grows across the approval row.

The live expanding element is the `.diff-dropdown` wrapper, so this keeps that wrapper and its main button content-sized while still allowing it to shrink within the row. I checked the adjacent request-panel action styles; the remaining `vscode-toolbar-button` flex selectors do not match the current `wa-button` markup and are better left to a separate cleanup pass rather than folded into this bug fix.

Closes #3919.

## Test plan

- [x] `/Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/prettier --write src/shared/styles/requestPanelStyles.ts`
- [x] `/Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/tsc --noEmit`
- [x] `VITE_WEBVIEW=progressView /Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/vite build --mode development`
- [x] `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only tweak to flex sizing for the diff split-button; could cause minor layout regressions in the approval request action row on edge viewport sizes.
> 
> **Overview**
> Prevents the approval request “Open diff” split-button from stretching across the actions row by changing `.approval-request__actions .diff-dropdown` and its `.diff-main-button` to be content-sized (`flex: 0 1 auto`) while still shrinkable.
> 
> Adds `max-width: 100%` on the wrapper and `min-width: 0` on the main button to avoid overflow and allow proper shrinking within the flex row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c2fddc99a9686389c11745d915cdd823adcb63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->