### PR TITLE
refactor: bind run coordinators to runtime host

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -303,9 +303,9 @@ async function assembleAgentLaunchContext(
     runtimeHost,
     workingDirectory: configPayload.workingDirectory?.trim() || undefined,
     coordinators: {
-      plan: new PlanApprovalCoordinator(),
-      proposal: new AgentProposalCoordinator(),
-      retry: new RetryRequestCoordinatorImpl(),
+      plan: new PlanApprovalCoordinator(runtimeHost),
+      proposal: new AgentProposalCoordinator(runtimeHost),
+      retry: new RetryRequestCoordinatorImpl(runtimeHost),
     },
   };
 }

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -18,7 +18,7 @@
  */
 
 import {
-  getAgentRuntimeHost,
+  getDefaultAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -65,10 +65,14 @@ export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
+  /**
+   * Run-owned coordinators pass a concrete host. The default host fallback is
+   * kept only for exported legacy singletons used at host-entry boundaries.
+   */
   constructor(private readonly configuredRuntimeHost?: AgentRuntimeHost) {}
 
   protected get runtimeHost(): AgentRuntimeHost {
-    return this.configuredRuntimeHost ?? getAgentRuntimeHost();
+    return this.configuredRuntimeHost ?? getDefaultAgentRuntimeHost();
   }
 
   /** Single source of truth for all pending requests */

--- a/src/test/agent/runtime/PromiseCoordinators.test.ts
+++ b/src/test/agent/runtime/PromiseCoordinators.test.ts
@@ -2,7 +2,11 @@
 import { strict as assert } from 'assert';
 
 // Local imports
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  noopAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -27,9 +31,15 @@ function createRecordingHost(): {
 }
 
 describe('promise coordinators', () => {
-  it('captures the run-context runtime host for approval show and resolve events', async () => {
-    const coordinator = new PlanApprovalCoordinator();
+  afterEach(() => {
+    setDefaultAgentRuntimeHost(noopAgentRuntimeHost);
+  });
+
+  it('uses the configured runtime host for approval show and resolve events', async () => {
     const { events, host } = createRecordingHost();
+    const defaultHost = createRecordingHost();
+    const ambientHost = createRecordingHost();
+    const coordinator = new PlanApprovalCoordinator(host);
     const plan: Plan = {
       summary: 'Refactor runtime event plumbing',
       steps: [
@@ -42,8 +52,9 @@ describe('promise coordinators', () => {
       ],
     };
 
+    setDefaultAgentRuntimeHost(defaultHost.host);
     const resultPromise = withRunContext(
-      createRunContext({ runtimeHost: host }),
+      createRunContext({ runtimeHost: ambientHost.host }),
       () =>
         coordinator.waitForApproval('stream:runtime', {
           approvalId: 'approval:runtime',
@@ -54,6 +65,8 @@ describe('promise coordinators', () => {
     coordinator.resolveRequest('approval:runtime', { action: 'approve' });
 
     assert.deepEqual(await resultPromise, { action: 'approve' });
+    assert.deepEqual(defaultHost.events, []);
+    assert.deepEqual(ambientHost.events, []);
     assert.deepEqual(events, [
       { event: 'requestEnsureProgressView', payload: {} },
       { event: 'setActiveStream', payload: { streamId: 'stream:runtime' } },
@@ -72,42 +85,72 @@ describe('promise coordinators', () => {
     ]);
   });
 
-  it('dismisses the previous run-context host when a request is replaced', async () => {
+  it('keeps unconfigured singleton coordinators on the default host boundary', async () => {
     const coordinator = new PlanApprovalCoordinator();
-    const first = createRecordingHost();
-    const second = createRecordingHost();
+    const defaultHost = createRecordingHost();
+    const ambientHost = createRecordingHost();
+    const plan: Plan = {
+      summary: 'Use the host boundary',
+      steps: [],
+    };
+
+    setDefaultAgentRuntimeHost(defaultHost.host);
+    const resultPromise = withRunContext(
+      createRunContext({ runtimeHost: ambientHost.host }),
+      () =>
+        coordinator.waitForApproval('stream:default', {
+          approvalId: 'approval:default',
+          plan,
+        }),
+    );
+
+    coordinator.resolveRequest('approval:default', { action: 'approve' });
+
+    assert.deepEqual(await resultPromise, { action: 'approve' });
+    assert.deepEqual(ambientHost.events, []);
+    assert.deepEqual(
+      defaultHost.events.map((entry) => entry.event),
+      [
+        'requestEnsureProgressView',
+        'setActiveStream',
+        'showPlanApproval',
+        'resolvePlanApproval',
+      ],
+    );
+  });
+
+  it('dismisses a replaced request through the coordinator host', async () => {
+    const { events, host } = createRecordingHost();
+    const coordinator = new PlanApprovalCoordinator(host);
     const plan: Plan = {
       summary: 'Replace pending approval',
       steps: [],
     };
 
-    const firstResult = withRunContext(
-      createRunContext({ runtimeHost: first.host }),
-      () =>
-        coordinator.waitForApproval('stream:first', {
-          approvalId: 'approval:replace',
-          plan,
-        }),
-    );
-    const secondResult = withRunContext(
-      createRunContext({ runtimeHost: second.host }),
-      () =>
-        coordinator.waitForApproval('stream:second', {
-          approvalId: 'approval:replace',
-          plan,
-        }),
-    );
+    const firstResult = coordinator.waitForApproval('stream:first', {
+      approvalId: 'approval:replace',
+      plan,
+    });
+    const secondResult = coordinator.waitForApproval('stream:second', {
+      approvalId: 'approval:replace',
+      plan,
+    });
 
     assert.deepEqual(await firstResult, { action: 'reject' });
     assert.equal(
-      first.events.at(-1)?.event,
-      'resolvePlanApproval',
-      'the first host should receive the dismissal event',
+      events.at(-1)?.event,
+      'showPlanApproval',
+      'the replacement request should be the active prompt',
     );
 
     coordinator.resolveRequest('approval:replace', { action: 'approve' });
 
     assert.deepEqual(await secondResult, { action: 'approve' });
-    assert.equal(second.events.at(-1)?.event, 'resolvePlanApproval');
+    assert.deepEqual(
+      events
+        .filter((entry) => entry.event === 'resolvePlanApproval')
+        .map((entry) => entry.payload),
+      [{ approvalId: 'approval:replace' }, { approvalId: 'approval:replace' }],
+    );
   });
 });


### PR DESCRIPTION
## Summary

- bind run-owned plan, proposal, and retry coordinators to the `AgentLaunchContext` runtime host
- make `BasePromiseCoordinator` fall back only to the default host boundary, not the ambient run context
- update coordinator tests to cover configured-host ownership and the remaining legacy singleton boundary

Closes #3922.

## Validation

- `prettier --write src/agent/runtime/BasePromiseCoordinator.ts src/agent/runtime/AgentLaunchContext.ts src/test/agent/runtime/PromiseCoordinators.test.ts`
- `tsc -p tsconfig.json --noEmit`
- `tsc --noEmit -p tsconfig.test-kernel.json`
- `tsc --noEmit` in `packages/extension`
- `tsc --noEmit -p tsconfig.json` in `packages/cli`
- `vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `eslint src packages/extension/src packages/desktop/src packages/cli/src` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which `AgentRuntimeHost` receives coordinator show/resolve events; mis-binding could cause prompts/toasts to appear on the wrong UI host or not dismiss correctly.
> 
> **Overview**
> Binds run-owned coordinators (`plan`, `proposal`, `retry`) created in `AgentLaunchContext` to the run’s `runtimeHost`, instead of relying on ambient host lookup.
> 
> Updates `BasePromiseCoordinator` to fall back only to `getDefaultAgentRuntimeHost()` (not the run-context host), keeping legacy singleton coordinators on a stable host boundary.
> 
> Reworks promise coordinator tests to validate configured-host ownership, default-host singleton behavior, and correct dismissal behavior when requests are replaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6163b8ff2e14d595f10b9225caef926d303cef3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->