### PR TITLE
refactor: normalize OpenAI response errors at boundary

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -6,7 +6,7 @@ import { waitForRetry } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getConfig } from '@agent/core/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { formatProviderHttpError, toErrorMessage } from '@common/errors';
+import { normalizeProviderError, toErrorMessage } from '@common/errors';
 import type { AgentLogger } from '@logger/AgentLogger';
 import {
   MESSAGE_TYPES,
@@ -139,7 +139,7 @@ export abstract class RetryableInvocationNode<
       this._hasAttemptedTokenRefresh = false;
       return result;
     } catch (retryErr) {
-      const retryFormatted = formatProviderHttpError(retryErr);
+      const retryFormatted = normalizeProviderError(retryErr);
       if (retryFormatted.isRelayError && retryFormatted.statusCode === 401) {
         services.logger.debug(
           'Still 401 after token refresh, skipping auto-retries',
@@ -180,7 +180,7 @@ export abstract class RetryableInvocationNode<
       return await operation(controller.signal);
     } catch (err) {
       // Reactive 401 recovery: refresh token and retry once
-      const formatted = formatProviderHttpError(err);
+      const formatted = normalizeProviderError(err);
       if (
         formatted.isRelayError &&
         formatted.statusCode === 401 &&
@@ -199,7 +199,7 @@ export abstract class RetryableInvocationNode<
    *  they need human attention (switching keys, topping up). `userRetryable`
    *  only gates the manual retry UI; auto-retry is a stricter subset. */
   shouldAutoRetry(error: Error): boolean {
-    const formatted = formatProviderHttpError(error);
+    const formatted = normalizeProviderError(error);
     if (formatted.isCredentialExhausted) return false;
     if (!formatted.userRetryable) return false;
     const code = formatted.statusCode;
@@ -254,7 +254,7 @@ export abstract class RetryableInvocationNode<
   ): Promise<ManualRetryPromptResult> {
     const { streamId, logger } = this.services;
     const operationName = this.getOperationName();
-    const formatted = formatProviderHttpError(error);
+    const formatted = normalizeProviderError(error);
 
     if (!formatted.userRetryable) {
       return { shouldRetry: false, userCancelled: false };
@@ -297,7 +297,7 @@ export abstract class RetryableInvocationNode<
       return { kind: 'cancelled' };
     }
 
-    const formatted = formatProviderHttpError(error);
+    const formatted = normalizeProviderError(error);
     if (!formatted.userRetryable) {
       this.services.logger.logErrorData(
         `${this.getOperationName()} failed (no retry available): ${formatted.message}`,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -22,11 +22,9 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE } from '@agent/core/constants';
 import { getConfig } from '@agent/core/config';
 import {
-  formatProviderHttpError,
   getSdkErrorMessage,
   isContextWindowError,
   isPreviousResponseIdError,
-  isRetryableStatusCode,
   attachPartialText,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -48,6 +46,12 @@ import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError, withSdkErrorTag } from './support/sdkErrorAdapters';
+import {
+  classifyOpenAIBackgroundResumeError,
+  createOpenAIBackgroundPollingError,
+  createOpenAIBackgroundTerminalError,
+  normalizeOpenAIResponseError,
+} from './openAIResponseErrors';
 
 // Local file imports
 import {
@@ -146,10 +150,6 @@ interface StreamingEventState {
 interface WebSocketExecutionResult {
   response: Response;
   state: StreamingEventState;
-}
-
-interface RequestIdTaggedError extends Error {
-  request_id?: string;
 }
 
 function isResponseFunctionToolCallItem(
@@ -744,27 +744,26 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
         throw err;
       }
-      tagOpenAISdkError(err, this.config.provider);
       // Transient failures (no status / 5xx / 429 / 408) — the background
       // response is likely still alive server-side, so retain the ID and
       // rethrow so the outer retry resumes the same ID. Definitive failures
       // (4xx, notably 404 expired) — clear the ID and create a new request.
       //
-      // Check statusCode directly rather than formatted.userRetryable: the latter
+      // Check statusCode directly rather than providerError.userRetryable: the latter
       // is force-true for relay errors, which would incorrectly retain the ID
       // on a relay-wrapped 404 and loop until retries are exhausted.
-      const formatted = formatProviderHttpError(err);
-      const code = formatted.statusCode;
-      if (code === undefined || isRetryableStatusCode(code)) {
+      const { providerError, shouldRetainPendingResponse } =
+        classifyOpenAIBackgroundResumeError(err, this.config.provider);
+      if (shouldRetainPendingResponse) {
         throw err;
       }
       this.logger.warn(
-        `Couldn't resume the pending OpenAI response; will start a new request. (${formatted.message})`,
+        `Couldn't resume the pending OpenAI response; will start a new request. (${providerError.message})`,
         {
           data: {
             responseId: pendingId,
-            error: formatted.message,
-            statusCode: code,
+            error: providerError.message,
+            statusCode: providerError.statusCode,
           },
         },
       );
@@ -2035,10 +2034,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         updatedMessages: compactedMessages,
       };
     } catch (error) {
-      tagOpenAISdkError(error, this.config.provider);
+      // Attach a capped tail of any streamed text before normalization so the
+      // retry UI receives the same structured error shape downstream.
+      if (streamedText) {
+        attachPartialText(error, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
+      }
 
       // Extract error details for diagnostics (useful for relay errors)
-      const { rawErrorBody } = formatProviderHttpError(error);
+      const providerError = normalizeOpenAIResponseError(
+        error,
+        this.config.provider,
+      );
+      const { rawErrorBody } = providerError;
       if (rawErrorBody) {
         this.logger.debug('Raw error body from provider', {
           data: { rawErrorBody },
@@ -2093,7 +2100,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // Log diagnostic info for other errors when chaining was active
         this.logger.debug(
           `Request failed with previousResponseId=${this.previousResponseId}. ` +
-            `Error: ${getSdkErrorMessage(error)}`,
+            `Error: ${providerError.message}`,
         );
       }
 
@@ -2109,12 +2116,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       // Clear diagnostic state to avoid stale comparison on retry
       this._diagPreFlightTokens = null;
-
-      // Attach a capped tail of any streamed text to the error so the retry
-      // UI can surface progress. No-op when nothing was streamed.
-      if (streamedText) {
-        attachPartialText(error, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
-      }
 
       throw error;
     }
@@ -2367,9 +2368,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // gone server-side. Clear the pending ID so the next retry creates a
         // fresh background request instead of routing through
         // tryResumeBackgroundResponse to rediscover the 404. The wrapping
-        // below strips the 404 status so formatProviderHttpError classifies
-        // the error as retryable (network-like), which keeps the retry loop
-        // engaged rather than bailing out on a non-retryable 4xx.
+        // below strips the 404 status so the provider-error normalizer
+        // classifies the error as retryable (network-like), keeping the retry
+        // loop engaged rather than bailing out on a non-retryable 4xx.
         //
         // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
         // so downstream handlers (relay 401 token refresh, retryability checks,
@@ -2377,17 +2378,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         const statusCode = (err as { status?: number }).status;
         if (statusCode === 404) {
           this.clearPendingBackgroundResponse();
-          const pollingError: RequestIdTaggedError = new Error(
-            `Background response polling failed for ${responseId}: ${getSdkErrorMessage(err)}`,
-            { cause: err },
+          throw createOpenAIBackgroundPollingError(
+            responseId,
+            err,
+            this.config.provider,
           );
-          // Forward request_id so formatProviderHttpError can extract it for
-          // logging diagnostics (detectRequestId doesn't follow the cause chain)
-          const origRequestId = (err as { request_id?: string }).request_id;
-          if (origRequestId) {
-            pollingError.request_id = origRequestId;
-          }
-          throw pollingError;
         }
         throw err;
       }
@@ -2427,10 +2422,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     const fallbackStatus = current.status ?? 'unknown';
-    const errorDetail =
-      current.error?.message ??
-      current.incomplete_details?.reason ??
-      'Background response did not complete successfully.';
     this.logger.error(
       `Background response ${responseId} ended with status ${fallbackStatus}`,
       {
@@ -2444,17 +2435,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
       },
     );
-    const wrapped = new Error(
-      `Background response ${responseId} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${responseId}").`,
-    ) as Error & { error?: unknown; provider?: string };
-    // Keep the synthetic wrapper as a plain response-state error. It often has
-    // no HTTP status; tagging it as a generic SDK APIError would make the
-    // formatter treat unknown provider-side failures as non-retryable.
-    wrapped.provider = this.config.provider;
-    if (current.error) {
-      wrapped.error = current.error;
-    }
-    throw wrapped;
+    throw createOpenAIBackgroundTerminalError(current, this.config.provider);
   }
 
   /** Adds continuation instructions for models without prefill support. */

--- a/src/agent/modelHandlers/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openAIResponseErrors.ts
@@ -1,0 +1,107 @@
+// Local imports - common errors
+import {
+  formatProviderHttpError,
+  isRetryableStatusCode,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
+
+// Type imports
+import type { ProviderError } from '@shared/schemas';
+
+// Local imports - model handlers
+import { tagOpenAISdkError } from './support/sdkErrorAdapters';
+
+export interface OpenAIBackgroundResumeError {
+  providerError: ProviderError;
+  shouldRetainPendingResponse: boolean;
+}
+
+interface RequestIdTaggedError extends Error {
+  request_id?: string;
+  provider?: string;
+}
+
+interface OpenAIBackgroundTerminalState {
+  id: string;
+  status?: string | null;
+  error?: { message?: string | null } | null;
+  incomplete_details?: { reason?: string | null } | null;
+}
+
+function setProviderHint(error: unknown, provider: string): void {
+  if (error && typeof error === 'object' && !('provider' in error)) {
+    (error as { provider?: string }).provider = provider;
+  }
+}
+
+/** Normalize OpenAI Responses errors at the provider boundary. */
+export function normalizeOpenAIResponseError(
+  error: unknown,
+  provider: string,
+): ProviderError {
+  tagOpenAISdkError(error, provider);
+  setProviderHint(error, provider);
+  return normalizeProviderError(error);
+}
+
+/**
+ * Classify a failed background-response resume without spreading retry
+ * decisions across the handler. Unknown/network-like failures keep the
+ * pending response id; definitive HTTP failures clear it.
+ */
+export function classifyOpenAIBackgroundResumeError(
+  error: unknown,
+  provider: string,
+): OpenAIBackgroundResumeError {
+  const providerError = normalizeOpenAIResponseError(error, provider);
+  const code = providerError.statusCode;
+  return {
+    providerError,
+    shouldRetainPendingResponse:
+      code === undefined || isRetryableStatusCode(code),
+  };
+}
+
+/**
+ * A 404 while polling a known background response means the server-side
+ * response is gone. The wrapper intentionally carries no status code so the
+ * retry layer treats this as a recoverable polling failure and offers manual
+ * retry instead of classifying it as a non-retryable 404.
+ */
+export function createOpenAIBackgroundPollingError(
+  responseId: string,
+  cause: unknown,
+  provider: string,
+): Error {
+  tagOpenAISdkError(cause, provider);
+  const causeError = formatProviderHttpError(cause);
+  const pollingError: RequestIdTaggedError = new Error(
+    `Background response polling failed for ${responseId}: ${causeError.message}`,
+    { cause },
+  );
+  pollingError.provider = provider;
+
+  if (causeError.requestId) {
+    pollingError.request_id = causeError.requestId;
+  }
+  return pollingError;
+}
+
+export function createOpenAIBackgroundTerminalError(
+  response: OpenAIBackgroundTerminalState,
+  provider: string,
+): Error {
+  const fallbackStatus = response.status ?? 'unknown';
+  const errorDetail =
+    response.error?.message ??
+    response.incomplete_details?.reason ??
+    'Background response did not complete successfully.';
+  const wrapped = new Error(
+    `Background response ${response.id} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${response.id}").`,
+  ) as Error & { error?: unknown; provider?: string };
+  wrapped.provider = provider;
+  if (response.error) {
+    wrapped.error = response.error;
+  }
+  return wrapped;
+}

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -16,6 +16,10 @@ export {
 
 // These SDK utilities are exposed in the barrel because they have broad usage
 // across the codebase (model handlers, runtime, UI layers).
-export { formatProviderHttpError, getSdkErrorMessage } from './sdkErrorUtils';
+export {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+  normalizeProviderError,
+} from './sdkErrorUtils';
 
 export { AgentError } from './agentErrors';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -540,6 +540,23 @@ export function attachPartialText(err: unknown, text: string): void {
 
 const detectPartialText = partialTextMetadata.detect;
 
+const providerErrorMetadata =
+  createErrorMetadata<ProviderError>('providerError');
+
+/**
+ * Normalize an upstream or SDK error once and attach the structured result to
+ * the thrown value. Retry code should consume this helper so provider-boundary
+ * code can own classification while downstream layers only read the shape.
+ */
+export function normalizeProviderError(err: unknown): ProviderError {
+  const cached = providerErrorMetadata.detect(err);
+  if (cached) return cached;
+
+  const formatted = formatProviderHttpError(err);
+  providerErrorMetadata.attach(err, formatted);
+  return formatted;
+}
+
 /**
  * Maps Anthropic error type strings to their corresponding HTTP status codes.
  * Used to recover the status code when SDK error objects lose it

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -1,0 +1,101 @@
+// Third-party imports
+import { NotFoundError as OpenAINotFoundError } from 'openai';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent model handlers
+import {
+  classifyOpenAIBackgroundResumeError,
+  createOpenAIBackgroundPollingError,
+  createOpenAIBackgroundTerminalError,
+  normalizeOpenAIResponseError,
+} from '@agent/modelHandlers/openAIResponseErrors';
+
+// Local imports - common errors
+import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+
+describe('OpenAI Responses error normalization', () => {
+  it('normalizes provider errors at the OpenAI Responses boundary', () => {
+    const error = new Error('background response failed') as Error & {
+      error: unknown;
+      provider?: string;
+    };
+    error.error = {
+      message: 'You exceeded your current quota.',
+      type: 'insufficient_quota',
+      code: 'insufficient_quota',
+    };
+
+    const providerError = normalizeOpenAIResponseError(error, 'openai');
+
+    expect(providerError.provider).toBe('openai');
+    expect(providerError.isCredentialExhausted).toBe(true);
+    expect(providerError.isUpstreamCreditDepleted).toBe(true);
+    expect(providerError.userRetryable).toBe(true);
+  });
+
+  it('retains pending background responses for transient resume failures', () => {
+    const error = new Error('socket closed');
+
+    const result = classifyOpenAIBackgroundResumeError(error, 'openai');
+
+    expect(result.shouldRetainPendingResponse).toBe(true);
+    expect(result.providerError.statusCode).toBeUndefined();
+    expect(result.providerError.userRetryable).toBe(true);
+  });
+
+  it('clears pending background responses for definitive resume failures', () => {
+    const error = new OpenAINotFoundError(
+      404,
+      { message: 'response not found' },
+      'response not found',
+      new Headers([['x-request-id', 'req_missing']]),
+    );
+
+    const result = classifyOpenAIBackgroundResumeError(error, 'openai');
+
+    expect(result.shouldRetainPendingResponse).toBe(false);
+    expect(result.providerError.statusCode).toBe(404);
+    expect(result.providerError.requestId).toBe('req_missing');
+  });
+
+  it('wraps vanished polling responses as retryable provider failures', () => {
+    const cause = new OpenAINotFoundError(
+      404,
+      { message: 'response not found' },
+      'response not found',
+      new Headers([['x-request-id', 'req_poll']]),
+    );
+    const wrapped = createOpenAIBackgroundPollingError(
+      'resp_123',
+      cause,
+      'openai',
+    );
+
+    const providerError = formatProviderHttpError(wrapped);
+
+    expect(providerError.statusCode).toBeUndefined();
+    expect(providerError.requestId).toBe('req_poll');
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain('resp_123');
+  });
+
+  it('keeps terminal background statuses retryable without HTTP metadata', () => {
+    const wrapped = createOpenAIBackgroundTerminalError(
+      {
+        id: 'resp_failed',
+        status: 'failed',
+        error: {
+          message: 'The background response ended before completion.',
+        },
+      },
+      'openai',
+    );
+
+    const providerError = formatProviderHttpError(wrapped);
+
+    expect(providerError.provider).toBe('openai');
+    expect(providerError.statusCode).toBeUndefined();
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain('resp_failed');
+  });
+});

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -28,6 +28,7 @@ import {
   attachSdkErrorMetadata,
   formatProviderHttpError,
   isUserAbort,
+  normalizeProviderError,
   sdkErrorKindFromStatusCode,
 } from '@common/errors/sdkErrorUtils';
 
@@ -414,6 +415,23 @@ describe('formatProviderHttpError', () => {
     expect(sdkErrorKindFromStatusCode(500)).toBe('internal_server');
     expect(sdkErrorKindFromStatusCode(418)).toBe('api_error');
     expect(sdkErrorKindFromStatusCode(undefined)).toBe('api_error');
+  });
+
+  it('caches normalized provider errors for downstream retry handling', () => {
+    const error = new Error('provider quota');
+    attachSdkErrorMetadata(error, {
+      provider: 'fixture',
+      kind: 'rate_limit',
+      statusCode: 429,
+    });
+
+    const first = normalizeProviderError(error);
+    const second = normalizeProviderError(error);
+
+    expect(second).toBe(first);
+    expect(second.provider).toBe('fixture');
+    expect(second.statusCode).toBe(429);
+    expect(second.userRetryable).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- add an OpenAI Responses error-boundary helper for SDK/upstream/background-polling failures
- cache normalized provider-error shapes so retry handling reads one structured shape instead of reclassifying the same error repeatedly
- keep existing background-response retry semantics: transient resume errors retain the pending response id, definitive resume failures clear it, vanished polling responses remain manually retryable
- cover OpenAI quota exhaustion, background polling wrappers, and normalized retryability with focused tests

Closes #3923.

## Validation

- `prettier --write src/common/errors/sdkErrorUtils.ts src/common/errors/index.ts src/agent/core/flows/RetryState.ts src/agent/modelHandlers/modelHandlerOpenAIResponse.ts src/agent/modelHandlers/openAIResponseErrors.ts src/test-kernel/common/SdkErrorUtils.vitest.mts src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts`
- `vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/common/SdkErrorUtils.vitest.mts src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts`
- `tsc -p tsconfig.json --noEmit`
- `tsc --noEmit -p tsconfig.test-kernel.json`
- `tsc --noEmit` in `packages/extension`
- `tsc --noEmit -p tsconfig.json` in `packages/cli`
- `eslint src/agent/core/flows/RetryState.ts src/agent/modelHandlers/modelHandlerOpenAIResponse.ts src/agent/modelHandlers/openAIResponseErrors.ts src/common/errors/index.ts src/common/errors/sdkErrorUtils.ts src/test-kernel/common/SdkErrorUtils.vitest.mts src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts`
- `eslint src packages/extension/src packages/desktop/src packages/cli/src` (passes with existing warnings)
- direct extension build commands after isolated-worktree package script attempted install: `node ../../scripts/clean-extension-dist.mjs`, `node esbuild.config.mjs`, `node ../../scripts/clean-extension-dist.mjs --webviews-only`, and Vite development builds for `progressView`, `settingsView`, and `webview`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared error formatting/normalization and OpenAI background-response retry paths; mistakes could change retryability decisions or lose HTTP/request-id diagnostics.
> 
> **Overview**
> Centralizes provider-error normalization by introducing cached `normalizeProviderError()` and switching retry logic (`RetryState`) to consume the cached shape instead of re-formatting errors repeatedly.
> 
> Refactors `ModelHandlerOpenAIResponse` error handling to normalize errors at the OpenAI Responses boundary via new helpers (`openAIResponseErrors.ts`), preserving background resume/polling semantics (retain pending IDs on transient failures, clear on definitive failures) while improving diagnostics (request-id propagation, consistent messages, partial streamed text attachment order).
> 
> Exports `normalizeProviderError` from the common errors barrel and adds focused tests covering quota exhaustion normalization, background polling/terminal wrappers, and caching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e7904418942b0b53bb5d5a73da62fa44589016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->