### PR TITLE
fix: avoid duplicate Anthropic stream failure logs

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -861,9 +861,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const diagnostics = streamHandler.getDiagnostics();
         if (!diagnostics.messageStopReceived) {
           // The catch block below will read current diagnostics, attach them
-          // to the enriched error, and log at warn — no inner attach/log
-          // here, otherwise one truncation event produces two warns and
-          // two diagnostics snapshots (with drifting elapsedSecs).
+          // to the enriched error, and keep one diagnostics snapshot. The
+          // retry node owns the visible failure row.
           throw new Error(
             `Stream ended without message_stop after ${diagnostics.elapsedSecs}s ` +
               `(${diagnostics.eventsProcessed} events, ` +

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -922,13 +922,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
             partialTextLength: partialText.length,
           },
         };
-        // Aborts are control flow, not failures. Everything else is a warn
-        // so silent proxy drops surface without debug logging enabled.
-        if (isAbort) {
-          this.logger.debug(logMessage, logData);
-        } else {
-          this.logger.warn(logMessage, logData);
-        }
+        // The retry node owns user-facing failure reporting. Keep stream
+        // diagnostics available without showing a second visible failure row.
+        this.logger.debug(logMessage, logData);
 
         attachStreamDiagnostics(enrichedError, diagnostics);
         attachPartialText(enrichedError, partialText);

--- a/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
@@ -1,0 +1,120 @@
+// Third-party imports
+import { BadRequestError as AnthropicBadRequestError } from '@anthropic-ai/sdk';
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent model handlers
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+// Type imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
+
+function createHandler(): ModelHandlerAnthropic {
+  const handler = new ModelHandlerAnthropic({
+    name: 'test-anthropic',
+    label: 'Test Anthropic',
+    fullName: 'claude-test',
+    shortName: 'claude-test',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    },
+    // Keeps the unit test independent from the server-side key service.
+    openRouterOnly: true,
+  });
+
+  (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
+    true;
+  return handler;
+}
+
+function createLoggerStub() {
+  return {
+    streamId: 'test',
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fileList: vi.fn(),
+    withCurrentGroup: vi.fn(() => undefined),
+    runWithinCurrentGroup: vi.fn(async (fn: () => unknown) => fn()),
+    runWithGroup: vi.fn(
+      async (_groupId: string | undefined, fn: () => unknown) => fn(),
+    ),
+  };
+}
+
+function createStreamStub(error: unknown): unknown {
+  return {
+    on: vi.fn(),
+    controller: { abort: vi.fn() },
+    finalMessage: vi.fn(async () => {
+      throw error;
+    }),
+    currentMessage: undefined,
+    request_id: 'req_low_credit',
+  };
+}
+
+describe('Anthropic stream failure logging', () => {
+  it('keeps raw stream failures out of visible warning logs', async () => {
+    const handler = createHandler();
+    const logger = createLoggerStub();
+    handler.setLogger(logger as unknown as AgentLogger);
+
+    const providerError = new AnthropicBadRequestError(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message:
+            'Your credit balance is too low to access the Anthropic API.',
+        },
+        request_id: 'req_low_credit',
+      },
+      undefined,
+      new Headers([['request-id', 'req_low_credit']]),
+    );
+    const stream = createStreamStub(providerError);
+    const client = {
+      beta: {
+        messages: {
+          stream: vi.fn(() => stream),
+        },
+      },
+    };
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+
+    await expect(
+      handler.createResponse({
+        client: client as unknown as Anthropic,
+        messages,
+        temperature: 0,
+      }),
+    ).rejects.toBe(providerError);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Stream failed:'),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          partialTextLength: 0,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #3916

## Summary
- lowers Anthropic raw stream-failure diagnostics from warn to debug
- leaves retry state as the single user-visible owner of model-call failure reporting
- adds a kernel regression test for the low-credit Anthropic stream error shape

## Validation
- vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
- tsc -p tsconfig.json --noEmit
- tsc --noEmit -p tsconfig.test-kernel.json
- eslint src/agent/modelHandlers/modelHandlerAnthropic.ts src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
- eslint src packages/extension/src packages/desktop/src packages/cli/src (68 existing warnings, 0 errors)
- prettier --check src/agent/modelHandlers/modelHandlerAnthropic.ts src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
- node packages/extension/esbuild.config.mjs

Note: corepack pnpm --filter texra compile:fast still hits pnpm non-interactive module purge in this isolated worktree before building, so the underlying extension esbuild step was run directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust log level/wording for Anthropic streaming failures and add a regression test, without altering request/response behavior.
> 
> **Overview**
> Prevents duplicate, user-visible failure rows by logging Anthropic streaming failures (including truncation cases) at `debug` instead of `warn`, while still attaching stream diagnostics/partial text to the thrown error.
> 
> Adds a kernel Vitest regression test (`AnthropicStreamFailureLogging.vitest.ts`) that simulates an Anthropic low-credit `BadRequestError` during streaming and asserts no `warn` logs are emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9650c320d3586d811dd54e8fa02ee75f67e0ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->