### PR TITLE
fix: make PR annotation warnings opt in

### DIFF
--- a/src/test-kernel/tools/GitHubPREventFormatting.vitest.ts
+++ b/src/test-kernel/tools/GitHubPREventFormatting.vitest.ts
@@ -2,8 +2,11 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - tools
-import { formatCIStarted } from '@tools/github/formatPREvent';
-import type { GhCheckRun } from '@tools/github/prTypes';
+import {
+  formatCheckAnnotations,
+  formatCIStarted,
+} from '@tools/github/formatPREvent';
+import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
 function checkRun(id: number, name: string): GhCheckRun {
   return {
@@ -13,6 +16,19 @@ function checkRun(id: number, name: string): GhCheckRun {
     conclusion: null,
     html_url: `https://example.test/checks/${id}`,
     completed_at: null,
+  };
+}
+
+function annotation(
+  level: GhCheckAnnotation['annotation_level'],
+  index: number,
+): GhCheckAnnotation {
+  return {
+    path: 'blueprint/src/chapter.tex',
+    start_line: index + 1,
+    end_line: index + 1,
+    annotation_level: level,
+    message: `${level} ${index}`,
   };
 }
 
@@ -48,5 +64,24 @@ describe('GitHub PR event formatting', () => {
     const bullets = message.match(/^- /gm) ?? [];
     expect(bullets).toHaveLength(20);
     expect(message).toContain('…and 5 more check names.');
+  });
+
+  it('lists annotation levels from the full filtered set', () => {
+    const run = {
+      ...checkRun(1, 'lint'),
+      status: 'completed',
+      conclusion: 'failure',
+      completed_at: '2026-05-13T00:00:00Z',
+      output: { annotations_count: 21 },
+    } satisfies GhCheckRun;
+    const annotations = [
+      ...Array.from({ length: 20 }, (_, index) => annotation('warning', index)),
+      annotation('failure', 20),
+    ];
+
+    const message = formatCheckAnnotations('owner/repo', 7, run, annotations);
+
+    expect(message).toContain('[FAILURE], [WARNING]');
+    expect(message).toContain('…and 1 more annotation(s).');
   });
 });

--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -2,14 +2,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - tools
+import {
+  DEFAULT_CHECK_ANNOTATION_LEVEL,
+  type GitHubCheckAnnotationLevel,
+} from '@tools/github/checkAnnotationLevels';
 import { GitHubRateLimitError } from '@tools/github/githubClient';
-import { PRPollingSource } from '@tools/github/PRPollingSource';
-import type { GhCheckRun } from '@tools/github/prTypes';
+import {
+  PRPollingSource,
+  prKeyToString,
+  type PRSubscribeInput,
+} from '@tools/github/PRPollingSource';
+import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
 interface AnnotationDrainState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
+  annotationLevelByListener: Map<
+    (text: string) => void,
+    GitHubCheckAnnotationLevel
+  >;
   pendingAnnotationRuns: GhCheckRun[];
   lastSuccessAt: number;
   consecutiveFailures: number;
@@ -25,7 +37,17 @@ interface AnnotationDrainSource {
     owner: string,
     repo: string,
     checkRunId: number,
+    now?: number,
   ): Promise<unknown[]>;
+  subscribe(
+    input: PRSubscribeInput,
+    onEvent: (text: string) => void,
+  ): { dispose(): void };
+  updateSubscription(
+    input: PRSubscribeInput,
+    onEvent: (text: string) => void,
+  ): void;
+  getSubscriptionState(key: string): AnnotationDrainState | undefined;
   has(key: string): boolean;
 }
 
@@ -41,11 +63,25 @@ function createCheckRun(id: number): GhCheckRun {
   };
 }
 
+function annotation(
+  level: GhCheckAnnotation['annotation_level'],
+  message: string,
+): GhCheckAnnotation {
+  return {
+    path: 'blueprint/src/chapter.tex',
+    start_line: 12,
+    end_line: 12,
+    annotation_level: level,
+    message,
+  };
+}
+
 function createDrainState(runs: GhCheckRun[]): AnnotationDrainState {
   return {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set(),
+    annotationLevelByListener: new Map(),
     pendingAnnotationRuns: runs,
     lastSuccessAt: Date.now(),
     consecutiveFailures: 0,
@@ -72,77 +108,17 @@ describe('PRPollingSource annotation drain', () => {
 
     await source.drainAnnotationQueues([['owner/repo#7', state]]);
 
-    expect(source.fetchAnnotations).toHaveBeenCalledWith('owner', 'repo', 42);
+    expect(source.fetchAnnotations).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      42,
+      expect.any(Number),
+    );
     expect(state.pendingAnnotationRuns).toEqual([run]);
     expect(state.skipPollUntilMs).toBe(1_800_000_000_000);
   });
 
-  it('shares the annotation fetch budget across source instances', async () => {
-    PRPollingSource.resetAnnotationFetchBudgetForTests(4);
-    const firstSource =
-      new PRPollingSource() as unknown as AnnotationDrainSource;
-    const secondSource =
-      new PRPollingSource() as unknown as AnnotationDrainSource;
-    keepTestStatesActive(firstSource);
-    keepTestStatesActive(secondSource);
-    const firstRuns = [createCheckRun(1), createCheckRun(2), createCheckRun(3)];
-    const secondRuns = [
-      createCheckRun(4),
-      createCheckRun(5),
-      createCheckRun(6),
-    ];
-    const firstState = createDrainState(firstRuns);
-    const secondState = createDrainState(secondRuns);
-    firstSource.fetchAnnotations = vi.fn().mockResolvedValue([]);
-    secondSource.fetchAnnotations = vi.fn().mockResolvedValue([]);
-
-    await firstSource.drainAnnotationQueues([['first', firstState]]);
-    await secondSource.drainAnnotationQueues([['second', secondState]]);
-
-    expect(firstSource.fetchAnnotations).toHaveBeenCalledTimes(3);
-    expect(secondSource.fetchAnnotations).toHaveBeenCalledTimes(1);
-    expect(firstState.pendingAnnotationRuns).toEqual([]);
-    expect(secondState.pendingAnnotationRuns).toEqual([
-      secondRuns[1],
-      secondRuns[2],
-    ]);
-  });
-
-  it('keeps queued annotation runs when the process budget is exhausted', async () => {
-    PRPollingSource.resetAnnotationFetchBudgetForTests(0);
-    const source = new PRPollingSource() as unknown as AnnotationDrainSource;
-    keepTestStatesActive(source);
-    const runs = [createCheckRun(7), createCheckRun(8)];
-    const state = createDrainState(runs);
-    source.fetchAnnotations = vi.fn().mockResolvedValue([]);
-
-    await source.drainAnnotationQueues([['owner/repo#7', state]]);
-
-    expect(source.fetchAnnotations).not.toHaveBeenCalled();
-    expect(state.pendingAnnotationRuns).toEqual(runs);
-  });
-
-  it('refills the process budget after the fixed budget window', async () => {
-    const now = 1_800_000_000_000;
-    PRPollingSource.resetAnnotationFetchBudgetForTests(1, now);
-    const source = new PRPollingSource() as unknown as AnnotationDrainSource;
-    keepTestStatesActive(source);
-    const runs = [createCheckRun(10), createCheckRun(11)];
-    const state = createDrainState(runs);
-    source.fetchAnnotations = vi.fn().mockResolvedValue([]);
-
-    await source.drainAnnotationQueues([['owner/repo#7', state]], now);
-    await source.drainAnnotationQueues([['owner/repo#7', state]], now + 29_999);
-    await source.drainAnnotationQueues([['owner/repo#7', state]], now + 30_000);
-
-    expect(
-      vi.mocked(source.fetchAnnotations).mock.calls.map((call) => call[2]),
-    ).toEqual([10, 11]);
-    expect(state.pendingAnnotationRuns).toEqual([]);
-  });
-
   it('drains annotation queues in fair passes across subscriptions', async () => {
-    PRPollingSource.resetAnnotationFetchBudgetForTests(4);
     const source = new PRPollingSource() as unknown as AnnotationDrainSource;
     keepTestStatesActive(source);
     const firstState = createDrainState([
@@ -170,24 +146,88 @@ describe('PRPollingSource annotation drain', () => {
 
     expect(
       vi.mocked(source.fetchAnnotations).mock.calls.map((call) => call[2]),
-    ).toEqual([1, 4, 7, 2]);
-    expect(firstState.pendingAnnotationRuns.map((run) => run.id)).toEqual([3]);
-    expect(secondState.pendingAnnotationRuns.map((run) => run.id)).toEqual([
-      5, 6,
-    ]);
-    expect(thirdState.pendingAnnotationRuns.map((run) => run.id)).toEqual([
-      8, 9,
-    ]);
+    ).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+    expect(firstState.pendingAnnotationRuns.map((run) => run.id)).toEqual([]);
+    expect(secondState.pendingAnnotationRuns.map((run) => run.id)).toEqual([]);
+    expect(thirdState.pendingAnnotationRuns.map((run) => run.id)).toEqual([]);
+  });
 
-    PRPollingSource.resetAnnotationFetchBudgetForTests(4);
-    await source.drainAnnotationQueues([
-      ['first', firstState],
-      ['second', secondState],
-      ['third', thirdState],
-    ]);
+  it('filters check annotations by each listener minimum level', async () => {
+    PRPollingSource.resetAnnotationFetchBudgetForTests();
+    const source = new PRPollingSource() as unknown as AnnotationDrainSource;
+    keepTestStatesActive(source);
+    const run = createCheckRun(12);
+    const state = createDrainState([run]);
+    const defaultListener = vi.fn();
+    const warningListener = vi.fn();
+    const noticeListener = vi.fn();
+    state.listeners.add(defaultListener);
+    state.listeners.add(warningListener);
+    state.listeners.add(noticeListener);
+    state.annotationLevelByListener.set(
+      defaultListener,
+      DEFAULT_CHECK_ANNOTATION_LEVEL,
+    );
+    state.annotationLevelByListener.set(warningListener, 'warning');
+    state.annotationLevelByListener.set(noticeListener, 'notice');
+    source.fetchAnnotations = vi
+      .fn()
+      .mockResolvedValue([
+        annotation('notice', 'advisory note'),
+        annotation('warning', 'format warning'),
+        annotation('failure', 'blocking failure'),
+      ]);
 
-    expect(
-      vi.mocked(source.fetchAnnotations).mock.calls.map((call) => call[2]),
-    ).toEqual([1, 4, 7, 2, 5, 8, 3, 6]);
+    await source.drainAnnotationQueues([['owner/repo#7', state]]);
+
+    expect(defaultListener).toHaveBeenCalledOnce();
+    const defaultMessage = defaultListener.mock.calls[0][0] as string;
+    expect(defaultMessage).toContain('[FAILURE]');
+    expect(defaultMessage).not.toContain('[WARNING]');
+    expect(defaultMessage).not.toContain('[NOTICE]');
+
+    expect(warningListener).toHaveBeenCalledOnce();
+    const warningMessage = warningListener.mock.calls[0][0] as string;
+    expect(warningMessage).toContain('[WARNING]');
+    expect(warningMessage).toContain('[FAILURE]');
+    expect(warningMessage).not.toContain('[NOTICE]');
+
+    expect(noticeListener).toHaveBeenCalledOnce();
+    const noticeMessage = noticeListener.mock.calls[0][0] as string;
+    expect(noticeMessage).toContain('[NOTICE]');
+    expect(noticeMessage).toContain('[WARNING]');
+    expect(noticeMessage).toContain('[FAILURE]');
+  });
+
+  it('updates the annotation level for an existing listener', async () => {
+    PRPollingSource.resetAnnotationFetchBudgetForTests();
+    const source = new PRPollingSource() as unknown as AnnotationDrainSource;
+    const pr = { owner: 'owner', repo: 'repo', pullNumber: 7 };
+    const listener = vi.fn();
+    const disposable = source.subscribe(pr, listener);
+    const key = prKeyToString(pr);
+    const state = source.getSubscriptionState(key);
+    expect(state).toBeTruthy();
+    if (!state) throw new Error('Expected subscription state');
+    source.fetchAnnotations = vi
+      .fn()
+      .mockResolvedValue([annotation('warning', 'format warning')]);
+
+    state.pendingAnnotationRuns = [createCheckRun(13)];
+    await source.drainAnnotationQueues([[key, state]]);
+
+    expect(listener).not.toHaveBeenCalled();
+
+    source.updateSubscription(
+      { ...pr, minAnnotationLevel: 'warning' },
+      listener,
+    );
+    state.pendingAnnotationRuns = [createCheckRun(14)];
+
+    await source.drainAnnotationQueues([[key, state]]);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0]).toContain('[WARNING]');
+    disposable.dispose();
   });
 });

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -1,0 +1,189 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+// Local imports - tools
+import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
+
+interface AnnotationFetchSource {
+  fetchAnnotations(
+    owner: string,
+    repo: string,
+    checkRunId: number,
+    now?: number,
+  ): Promise<GhCheckAnnotation[]>;
+}
+
+interface AnnotationDrainState {
+  pr: { owner: string; repo: string; pullNumber: number };
+  slug: string;
+  listeners: Set<(text: string) => void>;
+  annotationLevelByListener: Map<(text: string) => void, 'failure'>;
+  pendingAnnotationRuns: GhCheckRun[];
+  lastSuccessAt: number;
+  consecutiveFailures: number;
+  skipPollUntilMs: number;
+}
+
+interface AnnotationDrainSource extends AnnotationFetchSource {
+  drainAnnotationQueues(
+    entries: ReadonlyArray<readonly [string, AnnotationDrainState]>,
+    now?: number,
+  ): Promise<void>;
+  has(key: string): boolean;
+}
+
+interface PRPollingSourceClass {
+  new (): AnnotationDrainSource;
+  resetAnnotationFetchBudgetForTests(
+    remainingRequests?: number,
+    nowMs?: number,
+  ): void;
+}
+
+function annotation(
+  level: GhCheckAnnotation['annotation_level'],
+  index: number,
+): GhCheckAnnotation {
+  return {
+    path: 'blueprint/src/chapter.tex',
+    start_line: index + 1,
+    end_line: index + 1,
+    annotation_level: level,
+    message: `${level} ${index}`,
+  };
+}
+
+async function createHarness(): Promise<{
+  ghGet: Mock;
+  source: AnnotationFetchSource;
+  PRPollingSource: PRPollingSourceClass;
+}> {
+  vi.resetModules();
+  const ghGet = vi.fn();
+  vi.doMock('@tools/github/githubClient', () => {
+    class GitHubAuthError extends Error {}
+    class GitHubRateLimitError extends Error {
+      constructor(public readonly resetAt: number) {
+        super('GitHub rate limit exceeded');
+      }
+    }
+    class GitHubPermanentError extends Error {
+      constructor(
+        public readonly status: number,
+        message: string,
+      ) {
+        super(message);
+      }
+    }
+    return {
+      ghGet,
+      GitHubAuthError,
+      GitHubRateLimitError,
+      GitHubPermanentError,
+    };
+  });
+  const { PRPollingSource } = await import('@tools/github/PRPollingSource');
+  return {
+    ghGet,
+    source: new PRPollingSource() as unknown as AnnotationFetchSource,
+    PRPollingSource: PRPollingSource as unknown as PRPollingSourceClass,
+  };
+}
+
+function checkRun(id: number): GhCheckRun {
+  return {
+    id,
+    name: 'lint',
+    status: 'completed',
+    conclusion: 'success',
+    html_url: `https://example.test/checks/${id}`,
+    completed_at: '2026-05-12T00:00:00Z',
+    output: { annotations_count: 1 },
+  };
+}
+
+function drainState(runs: GhCheckRun[]): AnnotationDrainState {
+  return {
+    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
+    slug: 'owner/repo',
+    listeners: new Set(),
+    annotationLevelByListener: new Map(),
+    pendingAnnotationRuns: runs,
+    lastSuccessAt: Date.now(),
+    consecutiveFailures: 0,
+    skipPollUntilMs: 0,
+  };
+}
+
+describe('PRPollingSource annotation pagination', () => {
+  afterEach(() => {
+    vi.doUnmock('@tools/github/githubClient');
+    vi.resetModules();
+  });
+
+  it('fetches later annotation pages before level filtering runs', async () => {
+    const { ghGet, source } = await createHarness();
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      annotation('warning', index),
+    );
+    const secondPage = [annotation('failure', 100)];
+    ghGet
+      .mockResolvedValueOnce({ status: 200, data: firstPage })
+      .mockResolvedValueOnce({ status: 200, data: secondPage });
+
+    const annotations = await source.fetchAnnotations('owner', 'repo', 42);
+
+    expect(annotations).toHaveLength(101);
+    expect(annotations.at(-1)?.annotation_level).toBe('failure');
+    expect(ghGet).toHaveBeenCalledTimes(2);
+    expect(ghGet.mock.calls.map((call) => call[0])).toEqual([
+      '/repos/owner/repo/check-runs/42/annotations?per_page=100&page=1',
+      '/repos/owner/repo/check-runs/42/annotations?per_page=100&page=2',
+    ]);
+  });
+
+  it('caps annotation pagination for malformed full pages', async () => {
+    const { ghGet, source } = await createHarness();
+    const fullPage = Array.from({ length: 100 }, (_, index) =>
+      annotation('warning', index),
+    );
+    ghGet.mockResolvedValue({ status: 200, data: fullPage });
+
+    const annotations = await source.fetchAnnotations('owner', 'repo', 42);
+
+    expect(annotations).toHaveLength(5000);
+    expect(ghGet).toHaveBeenCalledTimes(50);
+    expect(ghGet.mock.calls.at(-1)?.[0]).toBe(
+      '/repos/owner/repo/check-runs/42/annotations?per_page=100&page=50',
+    );
+  });
+
+  it('counts annotation budget by endpoint page', async () => {
+    const { ghGet, source, PRPollingSource } = await createHarness();
+    PRPollingSource.resetAnnotationFetchBudgetForTests(1);
+    const fullPage = Array.from({ length: 100 }, (_, index) =>
+      annotation('warning', index),
+    );
+    ghGet.mockResolvedValue({ status: 200, data: fullPage });
+
+    await expect(source.fetchAnnotations('owner', 'repo', 42)).rejects.toThrow(
+      'Annotation fetch budget exhausted',
+    );
+
+    expect(ghGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves queued annotation runs in place when the page budget is exhausted', async () => {
+    const { ghGet, PRPollingSource } = await createHarness();
+    const source = new PRPollingSource();
+    source.has = vi.fn().mockReturnValue(true);
+    PRPollingSource.resetAnnotationFetchBudgetForTests(0);
+    const runs = [checkRun(7), checkRun(8)];
+    const state = drainState(runs);
+
+    await source.drainAnnotationQueues([['owner/repo#7', state]]);
+
+    expect(ghGet).not.toHaveBeenCalled();
+    expect(state.pendingAnnotationRuns).toEqual(runs);
+  });
+});

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -14,6 +14,11 @@
 import { getConfig } from '@utils/config';
 import { shouldDropBotEvent } from './botFilter';
 import {
+  DEFAULT_CHECK_ANNOTATION_LEVEL,
+  includesCheckAnnotationLevel,
+  type GitHubCheckAnnotationLevel,
+} from './checkAnnotationLevels';
+import {
   formatCheckAnnotations,
   formatCheckFailure,
   formatCheckFailureSummary,
@@ -79,6 +84,7 @@ function createInitialState(pr: PRKey): SubscriptionState {
     lastFailedCheckKeys: new Set(),
     lastAnnotationKeys: new Set(),
     pendingAnnotationRuns: [],
+    annotationLevelByListener: new Map(),
     ciStartedSha: undefined,
     ciCompleteSha: undefined,
     ciPassedSha: undefined,
@@ -106,57 +112,67 @@ const CHECK_RUNS_PAGE_SIZE = 100;
 // Without a cap a malformed/runaway `total_count` could fan out into
 // hundreds of GETs per tick.
 const MAX_CHECK_RUNS_PAGES = 50;
-// Matches the formatter's per-run display cap so we don't pay for annotations
-// we'd only truncate; remaining count is sourced from `annotations_count`.
-const ANNOTATIONS_PAGE_SIZE = 20;
+// Use GitHub's maximum page size so filtering by level does not miss failures
+// that appear after a long run of warnings or notices.
+const ANNOTATIONS_PAGE_SIZE = 100;
+// Same order of magnitude as the check-runs page cap. This is a malformed
+// response guard, not a normal truncation policy.
+const MAX_ANNOTATION_PAGES_PER_RUN = 50;
 // Bound the per-subscription fan-out across runs (e.g. a matrix build
 // lighting up a fleet of checks). Excess candidates stay in
 // `pendingAnnotationRuns` and are drained on subsequent ticks.
-const MAX_ANNOTATION_FETCHES_PER_SUBSCRIPTION_TICK = 3;
+const MAX_ANNOTATION_RUNS_PER_SUBSCRIPTION_TICK = 3;
 // Bound annotation endpoint traffic across all PR subscriptions in this
-// process. This 30s budget window permits at most 1,800 annotation requests
-// per hour, leaving room for the rest of the PR polling endpoints under
-// GitHub's primary 5,000/hour limit. Keep it independent of the poll interval
-// so tuning PR_POLL_INTERVAL_MS does not silently raise the hourly ceiling.
-const MAX_PROCESS_ANNOTATION_FETCHES_PER_WINDOW = 15;
-const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 30_000;
+// process. Pagination claims one unit per annotations page, so this 60s budget
+// window permits at most 3,000 annotation requests per hour, leaving room for
+// the rest of the PR polling endpoints under GitHub's primary 5,000/hour limit.
+// Keep it independent of the poll interval so tuning PR_POLL_INTERVAL_MS does
+// not silently raise the hourly ceiling.
+const MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW = 50;
+const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 60_000;
+
+class AnnotationFetchBudgetExhaustedError extends Error {
+  constructor() {
+    super('Annotation fetch budget exhausted');
+  }
+}
 
 class AnnotationFetchBudget {
   private windowStartMs: number;
-  private remainingFetches: number;
+  private remainingRequests: number;
 
   constructor(
-    private readonly maxFetchesPerWindow: number,
+    private readonly maxRequestsPerWindow: number,
     private readonly windowMs: number,
   ) {
     this.windowStartMs = Date.now();
-    this.remainingFetches = maxFetchesPerWindow;
+    this.remainingRequests = maxRequestsPerWindow;
   }
 
   tryClaim(nowMs = Date.now()): boolean {
     if (nowMs - this.windowStartMs >= this.windowMs) {
       this.windowStartMs = nowMs;
-      this.remainingFetches = this.maxFetchesPerWindow;
+      this.remainingRequests = this.maxRequestsPerWindow;
     }
-    if (this.remainingFetches <= 0) return false;
-    this.remainingFetches -= 1;
+    if (this.remainingRequests <= 0) return false;
+    this.remainingRequests -= 1;
     return true;
   }
 
   resetForTests(
-    remainingFetches = this.maxFetchesPerWindow,
+    remainingRequests = this.maxRequestsPerWindow,
     nowMs = Date.now(),
   ): void {
     this.windowStartMs = nowMs;
-    this.remainingFetches = Math.max(
+    this.remainingRequests = Math.max(
       0,
-      Math.min(this.maxFetchesPerWindow, remainingFetches),
+      Math.min(this.maxRequestsPerWindow, remainingRequests),
     );
   }
 }
 
 const annotationFetchBudget = new AnnotationFetchBudget(
-  MAX_PROCESS_ANNOTATION_FETCHES_PER_WINDOW,
+  MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW,
   ANNOTATION_FETCH_BUDGET_WINDOW_MS,
 );
 
@@ -164,6 +180,10 @@ export interface PRKey {
   owner: string;
   repo: string;
   pullNumber: number;
+}
+
+export interface PRSubscribeInput extends PRKey {
+  minAnnotationLevel?: GitHubCheckAnnotationLevel;
 }
 
 export function prKeyToString(k: PRKey): string {
@@ -199,6 +219,10 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * isn't stranded once the check-runs cache stabilizes.
    */
   pendingAnnotationRuns: GhCheckRun[];
+  annotationLevelByListener: Map<
+    (text: string) => void,
+    GitHubCheckAnnotationLevel
+  >;
   /** Head SHA for which the one-shot "CI triggered" event has been emitted. */
   ciStartedSha: string | undefined;
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
@@ -265,9 +289,43 @@ export class PRPollingSource extends PollingSourceBase<
     annotationFetchBudget.resetForTests(remainingFetches, nowMs);
   }
 
-  subscribe(pr: PRKey, onEvent: (text: string) => void): Disposable {
-    const key = prKeyToString(pr);
-    return this.register(key, () => createInitialState(pr), onEvent);
+  subscribe(
+    input: PRSubscribeInput,
+    onEvent: (text: string) => void,
+  ): Disposable {
+    const key = prKeyToString(input);
+    const minAnnotationLevel =
+      input.minAnnotationLevel ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
+    const disposable = this.register(
+      key,
+      () => createInitialState(input),
+      onEvent,
+    );
+    this.getSubscriptionState(key)?.annotationLevelByListener.set(
+      onEvent,
+      minAnnotationLevel,
+    );
+    return {
+      dispose: () => {
+        this.getSubscriptionState(key)?.annotationLevelByListener.delete(
+          onEvent,
+        );
+        disposable.dispose();
+      },
+    };
+  }
+
+  updateSubscription(
+    input: PRSubscribeInput,
+    onEvent: (text: string) => void,
+  ): void {
+    const key = prKeyToString(input);
+    const minAnnotationLevel =
+      input.minAnnotationLevel ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
+    this.getSubscriptionState(key)?.annotationLevelByListener.set(
+      onEvent,
+      minAnnotationLevel,
+    );
   }
 
   protected emitKeysChangedEvent(keys: readonly string[]): void {
@@ -959,13 +1017,13 @@ export class PRPollingSource extends PollingSourceBase<
         if (!this.has(key)) continue;
         if (state.pendingAnnotationRuns.length === 0) continue;
         const claims = claimsByKey.get(key) ?? 0;
-        if (claims >= MAX_ANNOTATION_FETCHES_PER_SUBSCRIPTION_TICK) continue;
-        if (!annotationFetchBudget.tryClaim(now)) {
-          this.nextAnnotationDrainKey = key;
-          return;
-        }
+        if (claims >= MAX_ANNOTATION_RUNS_PER_SUBSCRIPTION_TICK) continue;
         try {
-          await this.drainNextAnnotationRun(state);
+          const drained = await this.drainNextAnnotationRun(state, now);
+          if (!drained) {
+            this.nextAnnotationDrainKey = key;
+            return;
+          }
         } catch (err) {
           this.handleFailure(key, state, err);
           if (err instanceof GitHubRateLimitError) {
@@ -1026,44 +1084,46 @@ export class PRPollingSource extends PollingSourceBase<
    */
   private async drainNextAnnotationRun(
     state: SubscriptionState,
-  ): Promise<void> {
+    now: number,
+  ): Promise<boolean> {
     const run = state.pendingAnnotationRuns[0];
-    if (!run) return;
+    if (!run) return true;
     const { pr } = state;
     try {
       const annotations = await this.fetchAnnotations(
         pr.owner,
         pr.repo,
         run.id,
+        now,
       );
       this.removePendingAnnotationRun(state, run.id);
       if (annotations.length > 0) {
-        this.emit(
-          state,
-          formatCheckAnnotations(state.slug, pr.pullNumber, run, annotations),
-        );
+        this.emitCheckAnnotations(state, run, annotations);
       }
+      return true;
     } catch (err) {
+      if (err instanceof AnnotationFetchBudgetExhaustedError) return false;
       if (err instanceof GitHubRateLimitError) throw err;
       if (err instanceof GitHubPermanentError) {
         this.logger.warn(
           `Annotations for check ${run.id} unavailable (HTTP ${err.status}); dropping.`,
         );
         this.removePendingAnnotationRun(state, run.id);
-        return;
+        return true;
       }
       if (err instanceof GitHubAuthError) {
         this.logger.warn(
           `Annotations for check ${run.id} forbidden (${err.message}); dropping.`,
         );
         this.removePendingAnnotationRun(state, run.id);
-        return;
+        return true;
       }
       this.removePendingAnnotationRun(state, run.id);
       state.pendingAnnotationRuns.push(run);
       this.logger.warn(
         `Annotation fetch for check ${run.id} failed; rotating to back of queue: ${String(err)}`,
       );
+      return true;
     }
   }
 
@@ -1076,14 +1136,62 @@ export class PRPollingSource extends PollingSourceBase<
     );
   }
 
+  private emitCheckAnnotations(
+    state: SubscriptionState,
+    run: GhCheckRun,
+    annotations: readonly GhCheckAnnotation[],
+  ): void {
+    for (const listener of state.listeners) {
+      const minLevel =
+        state.annotationLevelByListener.get(listener) ??
+        DEFAULT_CHECK_ANNOTATION_LEVEL;
+      const visibleAnnotations = annotations.filter((annotation) =>
+        includesCheckAnnotationLevel(annotation.annotation_level, minLevel),
+      );
+      if (visibleAnnotations.length === 0) continue;
+      const visibleRun: GhCheckRun = {
+        ...run,
+        output: {
+          ...run.output,
+          annotations_count: visibleAnnotations.length,
+        },
+      };
+      try {
+        listener(
+          formatCheckAnnotations(
+            state.slug,
+            state.pr.pullNumber,
+            visibleRun,
+            visibleAnnotations,
+          ),
+        );
+      } catch (err) {
+        this.logger.warn(`Listener threw: ${String(err)}`);
+      }
+    }
+  }
+
   private async fetchAnnotations(
     owner: string,
     repo: string,
     checkRunId: number,
+    now = Date.now(),
   ): Promise<GhCheckAnnotation[]> {
-    const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}`;
-    const res = await ghGet<GhCheckAnnotation[]>(path);
-    return res.status === 200 ? res.data : [];
+    const annotations: GhCheckAnnotation[] = [];
+    for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
+      if (!annotationFetchBudget.tryClaim(now)) {
+        throw new AnnotationFetchBudgetExhaustedError();
+      }
+      const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;
+      const res = await ghGet<GhCheckAnnotation[]>(path);
+      if (res.status !== 200) return annotations;
+      annotations.push(...res.data);
+      if (res.data.length < ANNOTATIONS_PAGE_SIZE) return annotations;
+    }
+    this.logger.warn(
+      `Reached annotation page cap (${MAX_ANNOTATION_PAGES_PER_RUN}) for check ${checkRunId}; emitting fetched annotations only.`,
+    );
+    return annotations;
   }
 }
 

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -81,6 +81,10 @@ export abstract class PollingSourceBase<
     return [...this.subscriptions.keys()];
   }
 
+  protected getSubscriptionState(key: K): S | undefined {
+    return this.subscriptions.get(key);
+  }
+
   has(key: K): boolean {
     return this.subscriptions.has(key);
   }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -29,6 +29,7 @@ export interface SubscriptionBinding<K extends string> {
 interface PollingSourceLike<K extends string, Input> {
   has(key: K): boolean;
   subscribe(input: Input, onEvent: (text: string) => void): Disposable;
+  updateSubscription?(input: Input, onEvent: (text: string) => void): void;
   activeKeys(): readonly K[];
   onKeysChanged(listener: (keys: readonly K[]) => void): Disposable;
 }
@@ -47,9 +48,17 @@ export interface StreamSubscriptionRegistryOptions<K extends string, Input> {
     | 'issueSubscriptionBindingsChanged';
 }
 
+interface BoundSubscription {
+  disposable: Disposable;
+  onEvent: (text: string) => void;
+}
+
 export class StreamSubscriptionRegistry<K extends string, Input> {
   private readonly logger: AgentLogger;
-  private readonly perStream = new Map<StreamTabId, Map<K, Disposable>>();
+  private readonly perStream = new Map<
+    StreamTabId,
+    Map<K, BoundSubscription>
+  >();
   private hooksRegistered = false;
 
   constructor(
@@ -67,11 +76,22 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       bound = new Map();
       this.perStream.set(streamId, bound);
     }
-    if (bound.has(key)) return false;
+    const existing = bound.get(key);
+    if (existing) {
+      this.opts.source.updateSubscription?.(input, existing.onEvent);
+      return false;
+    }
     // Set a sentinel before subscribe() so list() returns correct owner
     // data if the source's keys-changed hook fires synchronously inside
     // subscribe() before the real disposable is available.
-    const sentinel: Disposable = { dispose: () => {} };
+    const onEvent = (text: string) => {
+      void sendFollowUp(streamId, text).then((result) => {
+        if (result.status === 'sent' || result.status === 'queued') {
+          getAgentRuntimeHost().emit('updateQueuedFollowUps', { streamId });
+        }
+      });
+    };
+    const sentinel = { disposable: { dispose: () => {} }, onEvent };
     bound.set(key, sentinel);
     // The source's keys-changed event fires synchronously during subscribe()
     // for new keys (covering the UI refresh); only emit our registry event
@@ -79,18 +99,12 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const keyIsNew = !this.opts.source.has(key);
     let disposable: Disposable;
     try {
-      disposable = this.opts.source.subscribe(input, (text) => {
-        void sendFollowUp(streamId, text).then((result) => {
-          if (result.status === 'sent' || result.status === 'queued') {
-            getAgentRuntimeHost().emit('updateQueuedFollowUps', { streamId });
-          }
-        });
-      });
+      disposable = this.opts.source.subscribe(input, onEvent);
     } catch (err) {
       this.removeBoundKey(streamId, bound, key);
       throw err;
     }
-    bound.set(key, disposable);
+    bound.set(key, { disposable, onEvent });
     this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
     if (!keyIsNew) this.emitBindingsChanged();
     return true;
@@ -100,9 +114,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   unbind(streamId: StreamTabId, input: Input): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perStream.get(streamId);
-    const d = bound?.get(key);
-    if (!bound || !d) return false;
-    this.disposeSafe(d, 'explicit unsubscribe');
+    const binding = bound?.get(key);
+    if (!bound || !binding) return false;
+    this.disposeSafe(binding.disposable, 'explicit unsubscribe');
     this.removeBoundKey(streamId, bound, key);
     this.emitBindingsChanged();
     return true;
@@ -116,9 +130,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   unbindAll(key: string): number {
     let removed = 0;
     for (const [streamId, bound] of [...this.perStream]) {
-      const d = bound.get(key as K);
-      if (!d) continue;
-      this.disposeSafe(d, 'unbindAll');
+      const binding = bound.get(key as K);
+      if (!binding) continue;
+      this.disposeSafe(binding.disposable, 'unbindAll');
       this.removeBoundKey(streamId, bound, key as K);
       removed += 1;
     }
@@ -151,7 +165,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     ToolUseFollowUpQueue.onRelease((streamId) => {
       const bound = this.perStream.get(streamId);
       if (!bound) return;
-      for (const d of bound.values()) this.disposeSafe(d, 'release');
+      for (const binding of bound.values()) {
+        this.disposeSafe(binding.disposable, 'release');
+      }
       this.perStream.delete(streamId);
       this.emitBindingsChanged();
     });
@@ -176,7 +192,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
 
   private removeBoundKey(
     streamId: StreamTabId,
-    bound: Map<K, Disposable>,
+    bound: Map<K, BoundSubscription>,
     key: K,
   ): void {
     bound.delete(key);

--- a/src/tools/github/checkAnnotationLevels.ts
+++ b/src/tools/github/checkAnnotationLevels.ts
@@ -1,0 +1,46 @@
+export type GitHubCheckAnnotationLevel = 'notice' | 'warning' | 'failure';
+
+export const DEFAULT_CHECK_ANNOTATION_LEVEL: GitHubCheckAnnotationLevel =
+  'failure';
+
+const ANNOTATION_LEVEL_ORDER = ['failure', 'warning', 'notice'] as const;
+
+const ANNOTATION_LEVEL_RANK: Readonly<
+  Record<GitHubCheckAnnotationLevel, number>
+> = {
+  notice: 0,
+  warning: 1,
+  failure: 2,
+};
+
+export function normalizeCheckAnnotationLevel(
+  level: string | null | undefined,
+): GitHubCheckAnnotationLevel {
+  if (level === 'warning' || level === 'failure') {
+    return level;
+  }
+  return 'notice';
+}
+
+export function includesCheckAnnotationLevel(
+  annotationLevel: string | null | undefined,
+  minLevel: GitHubCheckAnnotationLevel,
+): boolean {
+  return (
+    ANNOTATION_LEVEL_RANK[normalizeCheckAnnotationLevel(annotationLevel)] >=
+    ANNOTATION_LEVEL_RANK[minLevel]
+  );
+}
+
+export function formatCheckAnnotationLevelList(
+  annotations: ReadonlyArray<{ annotation_level?: string | null }>,
+): string {
+  const levels = new Set(
+    annotations.map((annotation) =>
+      normalizeCheckAnnotationLevel(annotation.annotation_level),
+    ),
+  );
+  return ANNOTATION_LEVEL_ORDER.filter((level) => levels.has(level))
+    .map((level) => `[${level.toUpperCase()}]`)
+    .join(', ');
+}

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -17,6 +17,7 @@ import {
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
+import { formatCheckAnnotationLevelList } from './checkAnnotationLevels';
 import type {
   GhCheckAnnotation,
   GhCheckRun,
@@ -182,7 +183,7 @@ export function formatCheckAnnotations(
       : run.html_url;
   return wrap(
     sections(
-      `Check "${run.name}" reported ${total} inline annotation(s) on ${prRef(slug, prNumber)}. Each annotation is tagged with its level ([NOTICE], [WARNING], or [FAILURE]); investigate and determine what action (if any) is needed.`,
+      `Check "${run.name}" reported ${total} matching inline annotation(s) on ${prRef(slug, prNumber)}. Each annotation is tagged with its level (${formatCheckAnnotationLevelList(annotations)}); investigate and determine what action (if any) is needed.`,
       shown.map(annotationBlock).join('\n\n'),
       overflow,
     ),

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -28,14 +28,18 @@ import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 
 import { defineTool } from '../core/define';
+import {
+  DEFAULT_CHECK_ANNOTATION_LEVEL,
+  type GitHubCheckAnnotationLevel,
+} from './checkAnnotationLevels';
 import { getGitHubToken } from './githubAuth';
 import { ghGet } from './githubClient';
 import {
   bindIssueSubscription,
-  listIssueSubscriptionBindings,
   bindPRSubscription,
-  listPRSubscriptionBindings,
   bindRepoSubscription,
+  listIssueSubscriptionBindings,
+  listPRSubscriptionBindings,
   listRepoSubscriptionBindings,
   unbindIssueSubscription,
   unbindPRSubscription,
@@ -59,6 +63,12 @@ const GitHubSubscriptionInputSchema = z.strictObject({
    * - `owner/repo/issues/N`      — per-issue subscription.
    */
   path: z.string().nullish(),
+  /**
+   * Lowest inline check-annotation level to send for PR subscriptions.
+   * Defaults to failures only; use "warning" to include warnings, or
+   * "notice" to include every annotation GitHub reports.
+   */
+  min_annotation_level: z.enum(['failure', 'warning', 'notice']).nullish(),
   /**
    * Working directory for `find_current` to resolve the current branch's PR.
    * Defaults to the agent's working directory.
@@ -140,12 +150,30 @@ function requirePath(input: GitHubSubscriptionInput): ParsedPath {
   return parsePath(input.path);
 }
 
+function getMinAnnotationLevel(
+  input: GitHubSubscriptionInput,
+): GitHubCheckAnnotationLevel {
+  return input.min_annotation_level ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
+}
+
+function describeAnnotationLevel(level: GitHubCheckAnnotationLevel): string {
+  switch (level) {
+    case 'failure':
+      return 'failures only';
+    case 'warning':
+      return 'warnings and failures';
+    case 'notice':
+      return 'notices, warnings, and failures';
+  }
+}
+
 async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
   requireToken();
   const streamId = requireStreamId();
   const target = requirePath(input);
+  const minAnnotationLevel = getMinAnnotationLevel(input);
   if (target.kind === 'repo') {
     const created = bindRepoSubscription(streamId, target);
     const slug = `${target.owner}/${target.repo}`;
@@ -159,15 +187,20 @@ async function execSubscribe(
     };
   }
   if (target.kind === 'pr') {
-    const created = bindPRSubscription(streamId, target);
+    const created = bindPRSubscription(streamId, {
+      ...target,
+      minAnnotationLevel,
+    });
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
+    const annotationLevelDescription =
+      describeAnnotationLevel(minAnnotationLevel);
     return {
       summary: created
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
-        : `Already subscribed to ${slug}. Activity continues until command="unsubscribe" or the PR closes.`,
+        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
+        : `Already subscribed to ${slug}. Inline check annotation filter is now ${annotationLevelDescription}. Activity continues until command="unsubscribe" or the PR closes.`,
     };
   }
   // The path "owner/repo/issues/N" is ambiguous: the /issues/comments
@@ -194,8 +227,11 @@ async function execSubscribe(
       owner: target.owner,
       repo: target.repo,
       pullNumber: target.issueNumber,
+      minAnnotationLevel,
     });
     const wasIssuePath = !knownPR;
+    const annotationLevelDescription =
+      describeAnnotationLevel(minAnnotationLevel);
     return {
       summary: created
         ? wasIssuePath
@@ -203,8 +239,8 @@ async function execSubscribe(
           : `Subscribed to ${prSlug}`
         : `Already subscribed to ${prSlug}`,
       output: created
-        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
-        : `Already subscribed to ${prSlug}.`,
+        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
+        : `Already subscribed to ${prSlug}. Inline check annotation filter is now ${annotationLevelDescription}.`,
     };
   }
   const created = bindIssueSubscription(streamId, target);
@@ -469,6 +505,7 @@ export class GitHubSubscriptionTool extends defineTool({
     'Path mirrors GitHub\'s REST URL shape and encodes the hierarchy: "owner/repo" addresses the whole repo (coarse, orchestrator-friendly); "owner/repo/pulls/N" addresses a specific pull request and "owner/repo/issues/N" addresses a specific issue (nuanced, worker-friendly).',
     'Commands:',
     '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
+    'For PR subscriptions, min_annotation_level controls inline check annotations: "failure" (default) sends failures only, "warning" includes warnings, and "notice" includes every annotation.',
     '- unsubscribe: stop watching the path.',
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -5,7 +5,11 @@ import {
   issuePollingSource,
   type IssueKey,
 } from './IssuePollingSource';
-import { prKeyToString, prPollingSource, type PRKey } from './PRPollingSource';
+import {
+  prKeyToString,
+  prPollingSource,
+  type PRSubscribeInput,
+} from './PRPollingSource';
 import {
   repoKeyOf,
   repoPollingSource,
@@ -13,7 +17,10 @@ import {
 } from './RepoPollingSource';
 import { StreamSubscriptionRegistry } from './StreamSubscriptionRegistry';
 
-const prSubscriptions = new StreamSubscriptionRegistry<string, PRKey>({
+const prSubscriptions = new StreamSubscriptionRegistry<
+  string,
+  PRSubscribeInput
+>({
   name: 'PRStreamSubscriptionRegistry',
   source: prPollingSource,
   keyOf: prKeyToString,
@@ -31,13 +38,16 @@ export function listPRSubscriptionBindings(
   return prSubscriptions.list(keys);
 }
 
-export function bindPRSubscription(streamId: StreamTabId, pr: PRKey): boolean {
+export function bindPRSubscription(
+  streamId: StreamTabId,
+  pr: PRSubscribeInput,
+): boolean {
   return prSubscriptions.bind(streamId, pr);
 }
 
 export function unbindPRSubscription(
   streamId: StreamTabId,
-  pr: PRKey,
+  pr: PRSubscribeInput,
 ): boolean {
   return prSubscriptions.unbind(streamId, pr);
 }


### PR DESCRIPTION
Closes #3917.

## Summary
- add a PR subscription `min_annotation_level` option, defaulting inline check annotations to failures only
- keep PR polling as the single source of GitHub check data and filter annotations per listener
- update existing PR subscriptions when a stream changes its annotation level
- page through check annotations before filtering, with a malformed-response cap
- charge the annotation fetch budget per endpoint page so pagination remains bounded under the GitHub request limit
- centralize annotation-level normalization and formatting

## Validation
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts src/test-kernel/tools/GitHubPREventFormatting.vitest.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/eslint/bin/eslint.js src/tools/github/checkAnnotationLevels.ts src/tools/github/PollingSourceBase.ts src/tools/github/PRPollingSource.ts src/tools/github/StreamSubscriptionRegistry.ts src/tools/github/subscriptionBindings.ts src/tools/github/githubSubscriptionTool.ts src/tools/github/formatPREvent.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/GitHubPREventFormatting.vitest.ts`
- `npm run lint` (0 errors, existing 68 warnings)
- `npm run compile:fast` (blocked by pnpm `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` before build)
- direct extension build steps passed: `clean-extension-dist`, `node esbuild.config.mjs`, and Vite development builds for `progressView`, `settingsView`, `webview`
