### PR TITLE
refactor: route GitHub subscriptions through runtime host

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -56,6 +56,7 @@ import {
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { selectAgentInMainView } from '@frontend/agents/remoteAgentUtils';
 import {
   applyGitAuthorConfig,
@@ -528,10 +529,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         //   owner/repo/issues/N      → issue
         const k = data.key;
         const removed = k.includes('/pulls/')
-          ? unbindAllForPR(k)
+          ? unbindAllForPR(k, extensionAgentRuntimeHost)
           : k.includes('/issues/')
-            ? unbindAllForIssue(k)
-            : unbindAllForRepo(k);
+            ? unbindAllForIssue(k, extensionAgentRuntimeHost)
+            : unbindAllForRepo(k, extensionAgentRuntimeHost);
         if (removed === 0) {
           void vscode.window.showInformationMessage(
             `No active subscription for ${k}.`,

--- a/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
@@ -1,59 +1,168 @@
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
-// Local imports - agent
-import {
-  getDefaultAgentRuntimeHost,
-  setDefaultAgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
-import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+// Local imports - agent runtime
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
+// Local imports - shared schemas
+import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - tools
-import { emitGitHubSubscriptionChanged } from '@tools/github/subscriptionEventEmitter';
+import {
+  emitGitHubSubscriptionChanged,
+  emitGitHubSubscriptionChangedToHosts,
+} from '@tools/github/subscriptionEventEmitter';
+import { GitHubAuthError } from '@tools/github/githubClient';
+import {
+  PollingSourceBase,
+  type BasePollSubscriptionState,
+} from '@tools/github/PollingSourceBase';
+import { StreamSubscriptionRegistry } from '@tools/github/StreamSubscriptionRegistry';
 
 // Local imports - test
 import { createRecordingHost } from '../progressTestUtils';
 
+class TestPollingSource extends PollingSourceBase<
+  string,
+  BasePollSubscriptionState
+> {
+  private keysChangedEventCount = 0;
+
+  constructor() {
+    super({
+      name: 'TestPollingSource',
+      pollIntervalMs: 10_000,
+      maxConcurrent: 1,
+      backoffBaseMs: 1_000,
+      backoffMaxMs: 1_000,
+      maxFailureDurationMs: 60_000,
+    });
+  }
+
+  protected pollOne(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected formatErrorEvent(): string {
+    return 'subscription error';
+  }
+
+  protected emitKeysChangedEvent(): void {
+    this.keysChangedEventCount += 1;
+  }
+
+  failWithAuthError(state: BasePollSubscriptionState): void {
+    this.handleFailure('owner/repo', state, new GitHubAuthError('bad token'));
+  }
+}
+
+class RegistryTestSource {
+  private readonly keys = new Set<string>();
+  private readonly keyListeners = new Set<(keys: readonly string[]) => void>();
+
+  has(key: string): boolean {
+    return this.keys.has(key);
+  }
+
+  activeKeys(): readonly string[] {
+    return [...this.keys];
+  }
+
+  onKeysChanged(listener: (keys: readonly string[]) => void): {
+    dispose(): void;
+  } {
+    this.keyListeners.add(listener);
+    return { dispose: () => this.keyListeners.delete(listener) };
+  }
+
+  subscribe(
+    input: string,
+    onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
+  ): { dispose(): void } {
+    void onEvent;
+    void runtimeHost;
+    this.keys.add(input);
+    this.emitKeysChanged();
+    return {
+      dispose: () => {
+        this.keys.delete(input);
+        this.emitKeysChanged();
+      },
+    };
+  }
+
+  private emitKeysChanged(): void {
+    const keys = [...this.keys];
+    for (const listener of this.keyListeners) listener(keys);
+  }
+}
+
 describe('GitHub subscription progress events', () => {
-  it('publishes binding changes through the scoped runtime host', () => {
-    const active = createRecordingHost();
-    const fallback = createRecordingHost();
-    const previousDefault = getDefaultAgentRuntimeHost();
-    setDefaultAgentRuntimeHost(fallback.host);
+  it('publishes binding changes through the explicit runtime host', () => {
+    const host = createRecordingHost();
 
-    try {
-      withRunContext(createRunContext({ runtimeHost: active.host }), () => {
-        emitGitHubSubscriptionChanged(
-          'repoSubscriptionBindingsChanged',
-          undefined,
-        );
-      });
-    } finally {
-      setDefaultAgentRuntimeHost(previousDefault);
-    }
+    emitGitHubSubscriptionChanged(
+      host.host,
+      'repoSubscriptionBindingsChanged',
+      undefined,
+    );
 
-    expect(active.events).toEqual([
+    expect(host.events).toEqual([
       { event: 'repoSubscriptionBindingsChanged', payload: undefined },
     ]);
-    expect(fallback.events).toEqual([]);
   });
 
-  it('uses the default runtime host outside a scoped run context', () => {
-    const fallback = createRecordingHost();
-    const previousDefault = getDefaultAgentRuntimeHost();
-    setDefaultAgentRuntimeHost(fallback.host);
+  it('deduplicates multiple bindings that share a runtime host', () => {
+    const host = createRecordingHost();
 
-    try {
-      emitGitHubSubscriptionChanged(
-        'issueSubscriptionBindingsChanged',
-        undefined,
-      );
-    } finally {
-      setDefaultAgentRuntimeHost(previousDefault);
-    }
+    emitGitHubSubscriptionChangedToHosts(
+      [host.host, host.host],
+      'issueSubscriptionBindingsChanged',
+      undefined,
+    );
 
-    expect(fallback.events).toEqual([
+    expect(host.events).toEqual([
       { event: 'issueSubscriptionBindingsChanged', payload: undefined },
+    ]);
+  });
+
+  it('reports token invalid events through the subscription runtime host', () => {
+    const host = createRecordingHost();
+    const listener = () => {};
+    const state: BasePollSubscriptionState = {
+      listeners: new Set([listener]),
+      runtimeHostByListener: new Map([[listener, host.host]]),
+      lastSuccessAt: Date.now(),
+      consecutiveFailures: 0,
+      skipPollUntilMs: 0,
+    };
+
+    new TestPollingSource().failWithAuthError(state);
+
+    expect(host.events).toContainEqual({
+      event: 'githubTokenInvalid',
+      payload: { message: 'bad token' },
+    });
+  });
+
+  it('emits one binding change when unsubscribe disposes synchronously', () => {
+    const host = createRecordingHost();
+    const source = new RegistryTestSource();
+    const registry = new StreamSubscriptionRegistry<string, string>({
+      name: 'test subscriptions',
+      source,
+      keyOf: (input) => input,
+      bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
+    });
+
+    registry.bind('stream-a' as StreamTabId, 'owner/repo', host.host);
+    host.events.length = 0;
+
+    expect(registry.unbind('stream-a' as StreamTabId, 'owner/repo')).toBe(true);
+
+    expect(host.events).toEqual([
+      { event: 'repoSubscriptionBindingsChanged', payload: undefined },
     ]);
   });
 });

--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports - agent
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
 // Local imports - tools
 import {
   DEFAULT_CHECK_ANNOTATION_LEVEL,
@@ -18,6 +21,10 @@ interface AnnotationDrainState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
+  runtimeHostByListener: Map<
+    (text: string) => void,
+    typeof noopAgentRuntimeHost
+  >;
   annotationLevelByListener: Map<
     (text: string) => void,
     GitHubCheckAnnotationLevel
@@ -42,10 +49,12 @@ interface AnnotationDrainSource {
   subscribe(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
+    runtimeHost: typeof noopAgentRuntimeHost,
   ): { dispose(): void };
   updateSubscription(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
+    runtimeHost: typeof noopAgentRuntimeHost,
   ): void;
   getSubscriptionState(key: string): AnnotationDrainState | undefined;
   has(key: string): boolean;
@@ -81,6 +90,7 @@ function createDrainState(runs: GhCheckRun[]): AnnotationDrainState {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set(),
+    runtimeHostByListener: new Map(),
     annotationLevelByListener: new Map(),
     pendingAnnotationRuns: runs,
     lastSuccessAt: Date.now(),
@@ -204,7 +214,7 @@ describe('PRPollingSource annotation drain', () => {
     const source = new PRPollingSource() as unknown as AnnotationDrainSource;
     const pr = { owner: 'owner', repo: 'repo', pullNumber: 7 };
     const listener = vi.fn();
-    const disposable = source.subscribe(pr, listener);
+    const disposable = source.subscribe(pr, listener, noopAgentRuntimeHost);
     const key = prKeyToString(pr);
     const state = source.getSubscriptionState(key);
     expect(state).toBeTruthy();
@@ -221,6 +231,7 @@ describe('PRPollingSource annotation drain', () => {
     source.updateSubscription(
       { ...pr, minAnnotationLevel: 'warning' },
       listener,
+      noopAgentRuntimeHost,
     );
     state.pendingAnnotationRuns = [createCheckRun(14)];
 

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+// Local imports - agent
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
 // Local imports - tools
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
@@ -17,6 +20,10 @@ interface AnnotationDrainState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
+  runtimeHostByListener: Map<
+    (text: string) => void,
+    typeof noopAgentRuntimeHost
+  >;
   annotationLevelByListener: Map<(text: string) => void, 'failure'>;
   pendingAnnotationRuns: GhCheckRun[];
   lastSuccessAt: number;
@@ -107,6 +114,7 @@ function drainState(runs: GhCheckRun[]): AnnotationDrainState {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set(),
+    runtimeHostByListener: new Map(),
     annotationLevelByListener: new Map(),
     pendingAnnotationRuns: runs,
     lastSuccessAt: Date.now(),

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+// Local imports - agent
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
 // Local imports - tools
 import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
 
@@ -8,6 +11,10 @@ interface CiStartedState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
+  runtimeHostByListener: Map<
+    (text: string) => void,
+    typeof noopAgentRuntimeHost
+  >;
   initialized: boolean;
   seenIssueCommentIds: Set<number>;
   seenReviewCommentIds: Set<number>;
@@ -54,10 +61,12 @@ function createState(
   events: string[],
   overrides: Partial<CiStartedState> = {},
 ): CiStartedState {
+  const listener = (text: string) => events.push(text);
   return {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
-    listeners: new Set([(text) => events.push(text)]),
+    listeners: new Set([listener]),
+    runtimeHostByListener: new Map([[listener, noopAgentRuntimeHost]]),
     initialized: true,
     seenIssueCommentIds: new Set(),
     seenReviewCommentIds: new Set(),

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,6 +14,8 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatIssueClosed,
@@ -27,7 +29,7 @@ import {
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from './PollingSourceBase';
-import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
 import type { GhIssue, GhIssueComment } from './prTypes';
 
 import type { Disposable } from '@platform/interfaces/disposable';
@@ -60,6 +62,7 @@ function createInitialState(issue: IssueKey): SubscriptionState {
     issue,
     slug: `${issue.owner}/${issue.repo}`,
     listeners: new Set(),
+    runtimeHostByListener: new Map(),
     initialized: false,
     state: undefined,
     seenCommentIds: new Set(),
@@ -92,13 +95,29 @@ export class IssuePollingSource extends PollingSourceBase<
     });
   }
 
-  subscribe(issue: IssueKey, onEvent: (text: string) => void): Disposable {
+  subscribe(
+    issue: IssueKey,
+    onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
+  ): Disposable {
     const key = issueKeyToString(issue);
-    return this.register(key, () => createInitialState(issue), onEvent);
+    return this.register(
+      key,
+      () => createInitialState(issue),
+      onEvent,
+      runtimeHost,
+    );
   }
 
-  protected emitKeysChangedEvent(keys: readonly string[]): void {
-    emitGitHubSubscriptionChanged('issueSubscriptionsChanged', { keys });
+  protected emitKeysChangedEvent(
+    keys: readonly string[],
+    runtimeHosts: readonly AgentRuntimeHost[],
+  ): void {
+    emitGitHubSubscriptionChangedToHosts(
+      runtimeHosts,
+      'issueSubscriptionsChanged',
+      { keys },
+    );
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,6 +11,7 @@
  * layer above.
  */
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getConfig } from '@utils/config';
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -59,7 +60,7 @@ import {
   type GhReview,
   type GhReviewComment,
 } from './prTypes';
-import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
 import type { Disposable } from '@platform/interfaces/disposable';
 
 export const GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY =
@@ -77,6 +78,7 @@ function createInitialState(pr: PRKey): SubscriptionState {
     pr,
     slug: `${pr.owner}/${pr.repo}`,
     listeners: new Set(),
+    runtimeHostByListener: new Map(),
     initialized: false,
     seenIssueCommentIds: new Set(),
     seenReviewCommentIds: new Set(),
@@ -292,6 +294,7 @@ export class PRPollingSource extends PollingSourceBase<
   subscribe(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
   ): Disposable {
     const key = prKeyToString(input);
     const minAnnotationLevel =
@@ -300,6 +303,7 @@ export class PRPollingSource extends PollingSourceBase<
       key,
       () => createInitialState(input),
       onEvent,
+      runtimeHost,
     );
     this.getSubscriptionState(key)?.annotationLevelByListener.set(
       onEvent,
@@ -318,18 +322,29 @@ export class PRPollingSource extends PollingSourceBase<
   updateSubscription(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
   ): void {
     const key = prKeyToString(input);
     const minAnnotationLevel =
       input.minAnnotationLevel ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
+    this.updateListenerRuntimeHost(key, onEvent, runtimeHost);
     this.getSubscriptionState(key)?.annotationLevelByListener.set(
       onEvent,
       minAnnotationLevel,
     );
   }
 
-  protected emitKeysChangedEvent(keys: readonly string[]): void {
-    emitGitHubSubscriptionChanged('prSubscriptionsChanged', { keys });
+  protected emitKeysChangedEvent(
+    keys: readonly string[],
+    runtimeHosts: readonly AgentRuntimeHost[],
+  ): void {
+    emitGitHubSubscriptionChangedToHosts(
+      runtimeHosts,
+      'prSubscriptionsChanged',
+      {
+        keys,
+      },
+    );
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -11,7 +11,8 @@
  * 24 h detach gate) lives here once.
  */
 
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import {
@@ -24,6 +25,7 @@ import type { Disposable } from '@platform/interfaces/disposable';
 
 export interface BasePollSubscriptionState {
   listeners: Set<(text: string) => void>;
+  runtimeHostByListener: Map<(text: string) => void, AgentRuntimeHost>;
   /** Most recent successful poll. The 24 h detach gate compares against this. */
   lastSuccessAt: number;
   consecutiveFailures: number;
@@ -75,7 +77,10 @@ export abstract class PollingSourceBase<
   protected abstract formatErrorEvent(key: K, state: S, detail: string): string;
 
   /** Subclass: publish the externally visible subscription-changed event. */
-  protected abstract emitKeysChangedEvent(keys: readonly K[]): void;
+  protected abstract emitKeysChangedEvent(
+    keys: readonly K[],
+    runtimeHosts: readonly AgentRuntimeHost[],
+  ): void;
 
   activeKeys(): readonly K[] {
     return [...this.subscriptions.keys()];
@@ -83,6 +88,16 @@ export abstract class PollingSourceBase<
 
   protected getSubscriptionState(key: K): S | undefined {
     return this.subscriptions.get(key);
+  }
+
+  updateListenerRuntimeHost(
+    key: K,
+    onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    this.subscriptions
+      .get(key)
+      ?.runtimeHostByListener.set(onEvent, runtimeHost);
   }
 
   has(key: K): boolean {
@@ -99,9 +114,10 @@ export abstract class PollingSourceBase<
   }
 
   disposeAll(): void {
+    const runtimeHosts = this.activeRuntimeHosts();
     this.subscriptions.clear();
     this.stopTimer();
-    this.notifyKeysChanged();
+    this.notifyKeysChanged(runtimeHosts);
   }
 
   /**
@@ -113,8 +129,10 @@ export abstract class PollingSourceBase<
     key: K,
     initState: () => S,
     onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
   ): Disposable {
     let state = this.subscriptions.get(key);
+    let created = false;
     if (!state) {
       if (this.subscriptions.size >= this.config.maxConcurrent) {
         throw new Error(
@@ -124,9 +142,11 @@ export abstract class PollingSourceBase<
       state = initState();
       this.subscriptions.set(key, state);
       this.logger.info(`Subscribed to ${key}`);
-      this.notifyKeysChanged();
+      created = true;
     }
     state.listeners.add(onEvent);
+    state.runtimeHostByListener.set(onEvent, runtimeHost);
+    if (created) this.notifyKeysChanged([runtimeHost]);
     this.ensureTimer();
     return {
       dispose: () => this.removeListener(key, onEvent),
@@ -150,24 +170,28 @@ export abstract class PollingSourceBase<
    * `pollOne`.
    */
   protected detach(key: K): void {
-    if (!this.subscriptions.has(key)) return;
+    const state = this.subscriptions.get(key);
+    if (!state) return;
+    const runtimeHosts = this.hostsForState(state);
     this.subscriptions.delete(key);
-    this.notifyKeysChanged();
+    this.notifyKeysChanged(runtimeHosts);
   }
 
   private removeListener(key: K, onEvent: (text: string) => void): void {
     const state = this.subscriptions.get(key);
     if (!state) return;
+    const runtimeHost = state.runtimeHostByListener.get(onEvent);
     state.listeners.delete(onEvent);
+    state.runtimeHostByListener.delete(onEvent);
     if (state.listeners.size === 0) {
       this.subscriptions.delete(key);
       this.logger.info(`Unsubscribed from ${key}`);
-      this.notifyKeysChanged();
+      this.notifyKeysChanged(runtimeHost ? [runtimeHost] : []);
     }
     if (this.subscriptions.size === 0) this.stopTimer();
   }
 
-  private notifyKeysChanged(): void {
+  private notifyKeysChanged(runtimeHosts = this.activeRuntimeHosts()): void {
     const keys = [...this.subscriptions.keys()];
     for (const listener of this.keysChangedListeners) {
       try {
@@ -176,7 +200,29 @@ export abstract class PollingSourceBase<
         this.logger.warn(`Keys-changed listener threw: ${String(err)}`);
       }
     }
-    this.emitKeysChangedEvent(keys);
+    this.emitKeysChangedEvent(keys, [...new Set(runtimeHosts)]);
+  }
+
+  private activeRuntimeHosts(): AgentRuntimeHost[] {
+    const runtimeHosts: AgentRuntimeHost[] = [];
+    for (const state of this.subscriptions.values()) {
+      runtimeHosts.push(...this.hostsForState(state));
+    }
+    return [...new Set(runtimeHosts)];
+  }
+
+  private hostsForState(state: S): AgentRuntimeHost[] {
+    return [...new Set(state.runtimeHostByListener.values())];
+  }
+
+  private emitToStateHosts<EventKey extends keyof ProgressEventPayloads>(
+    state: S,
+    event: EventKey,
+    payload: ProgressEventPayloads[EventKey],
+  ): void {
+    for (const runtimeHost of this.hostsForState(state)) {
+      runtimeHost.emit(event, payload);
+    }
   }
 
   private ensureTimer(): void {
@@ -233,10 +279,10 @@ export abstract class PollingSourceBase<
         `Auth error for ${key}; stopping subscription. ${err.message}`,
       );
       this.emit(state, this.formatErrorEvent(key, state, err.message));
-      this.detach(key);
-      getAgentRuntimeHost().emit('githubTokenInvalid', {
+      this.emitToStateHosts(state, 'githubTokenInvalid', {
         message: err.message,
       });
+      this.detach(key);
       return;
     }
     if (err instanceof GitHubPermanentError) {

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,6 +34,8 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatRepoIssueComment,
@@ -57,7 +59,7 @@ import {
   type GhPullsListEntry,
   type GhReviewComment,
 } from './prTypes';
-import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
 
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -172,13 +174,26 @@ export class RepoPollingSource extends PollingSourceBase<
     owner: string,
     repo: string,
     onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
   ): Disposable {
     const key = repoKeyOf(owner, repo);
-    return this.register(key, () => createInitialState(owner, repo), onEvent);
+    return this.register(
+      key,
+      () => createInitialState(owner, repo),
+      onEvent,
+      runtimeHost,
+    );
   }
 
-  protected emitKeysChangedEvent(keys: readonly RepoKey[]): void {
-    emitGitHubSubscriptionChanged('repoSubscriptionsChanged', { keys });
+  protected emitKeysChangedEvent(
+    keys: readonly RepoKey[],
+    runtimeHosts: readonly AgentRuntimeHost[],
+  ): void {
+    emitGitHubSubscriptionChangedToHosts(
+      runtimeHosts,
+      'repoSubscriptionsChanged',
+      { keys },
+    );
   }
 
   protected formatErrorEvent(
@@ -419,6 +434,7 @@ function createInitialState(owner: string, repo: string): SubscriptionState {
     repo,
     slug: repoKeyOf(owner, repo),
     listeners: new Set(),
+    runtimeHostByListener: new Map(),
     initialized: false,
     subscribedAt: new Date(now).toISOString(),
     since: {

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -13,11 +13,11 @@
 
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId } from '@shared/schemas';
 
-import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
 
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -28,8 +28,16 @@ export interface SubscriptionBinding<K extends string> {
 
 interface PollingSourceLike<K extends string, Input> {
   has(key: K): boolean;
-  subscribe(input: Input, onEvent: (text: string) => void): Disposable;
-  updateSubscription?(input: Input, onEvent: (text: string) => void): void;
+  subscribe(
+    input: Input,
+    onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
+  ): Disposable;
+  updateSubscription?(
+    input: Input,
+    onEvent: (text: string) => void,
+    runtimeHost: AgentRuntimeHost,
+  ): void;
   activeKeys(): readonly K[];
   onKeysChanged(listener: (keys: readonly K[]) => void): Disposable;
 }
@@ -51,6 +59,7 @@ export interface StreamSubscriptionRegistryOptions<K extends string, Input> {
 interface BoundSubscription {
   disposable: Disposable;
   onEvent: (text: string) => void;
+  runtimeHost: AgentRuntimeHost;
 }
 
 export class StreamSubscriptionRegistry<K extends string, Input> {
@@ -68,7 +77,11 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   }
 
   /** Returns true if a new subscription was created, false if it already existed. */
-  bind(streamId: StreamTabId, input: Input): boolean {
+  bind(
+    streamId: StreamTabId,
+    input: Input,
+    runtimeHost: AgentRuntimeHost,
+  ): boolean {
     this.ensureHooks();
     const key = this.opts.keyOf(input);
     let bound = this.perStream.get(streamId);
@@ -78,47 +91,64 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
     const existing = bound.get(key);
     if (existing) {
-      this.opts.source.updateSubscription?.(input, existing.onEvent);
+      existing.runtimeHost = runtimeHost;
+      this.opts.source.updateSubscription?.(
+        input,
+        existing.onEvent,
+        runtimeHost,
+      );
       return false;
     }
     // Set a sentinel before subscribe() so list() returns correct owner
     // data if the source's keys-changed hook fires synchronously inside
     // subscribe() before the real disposable is available.
-    const onEvent = (text: string) => {
+    const subscription: BoundSubscription = {
+      disposable: { dispose: () => {} },
+      onEvent: () => {},
+      runtimeHost,
+    };
+    subscription.onEvent = (text: string) => {
       void sendFollowUp(streamId, text).then((result) => {
         if (result.status === 'sent' || result.status === 'queued') {
-          getAgentRuntimeHost().emit('updateQueuedFollowUps', { streamId });
+          subscription.runtimeHost.emit('updateQueuedFollowUps', { streamId });
         }
       });
     };
-    const sentinel = { disposable: { dispose: () => {} }, onEvent };
-    bound.set(key, sentinel);
+    bound.set(key, subscription);
     // The source's keys-changed event fires synchronously during subscribe()
     // for new keys (covering the UI refresh); only emit our registry event
     // for existing keys where that source event won't fire.
     const keyIsNew = !this.opts.source.has(key);
     let disposable: Disposable;
     try {
-      disposable = this.opts.source.subscribe(input, onEvent);
+      disposable = this.opts.source.subscribe(
+        input,
+        subscription.onEvent,
+        runtimeHost,
+      );
     } catch (err) {
       this.removeBoundKey(streamId, bound, key);
       throw err;
     }
-    bound.set(key, { disposable, onEvent });
+    subscription.disposable = disposable;
     this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
-    if (!keyIsNew) this.emitBindingsChanged();
+    if (!keyIsNew) this.emitBindingsChanged([runtimeHost]);
     return true;
   }
 
   /** Returns true if a subscription existed and was removed. */
-  unbind(streamId: StreamTabId, input: Input): boolean {
+  unbind(
+    streamId: StreamTabId,
+    input: Input,
+    runtimeHost?: AgentRuntimeHost,
+  ): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perStream.get(streamId);
     const binding = bound?.get(key);
     if (!bound || !binding) return false;
-    this.disposeSafe(binding.disposable, 'explicit unsubscribe');
     this.removeBoundKey(streamId, bound, key);
-    this.emitBindingsChanged();
+    this.disposeSafe(binding.disposable, 'explicit unsubscribe');
+    this.emitBindingsChanged([runtimeHost ?? binding.runtimeHost]);
     return true;
   }
 
@@ -127,17 +157,24 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
    * bindings removed. Lets the settings UI cancel a subscription globally
    * without needing to know which stream owns it.
    */
-  unbindAll(key: string): number {
-    let removed = 0;
+  unbindAll(key: string, runtimeHost?: AgentRuntimeHost): number {
+    const removedBindings: BoundSubscription[] = [];
+    const runtimeHosts: AgentRuntimeHost[] = [];
     for (const [streamId, bound] of [...this.perStream]) {
       const binding = bound.get(key as K);
       if (!binding) continue;
-      this.disposeSafe(binding.disposable, 'unbindAll');
+      removedBindings.push(binding);
+      runtimeHosts.push(binding.runtimeHost);
       this.removeBoundKey(streamId, bound, key as K);
-      removed += 1;
     }
-    if (removed > 0) this.emitBindingsChanged();
-    return removed;
+    if (removedBindings.length > 0) {
+      for (const binding of removedBindings) {
+        this.disposeSafe(binding.disposable, 'unbindAll');
+      }
+      if (runtimeHost) runtimeHosts.push(runtimeHost);
+      this.emitBindingsChanged(runtimeHosts);
+    }
+    return removedBindings.length;
   }
 
   list(
@@ -165,11 +202,14 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     ToolUseFollowUpQueue.onRelease((streamId) => {
       const bound = this.perStream.get(streamId);
       if (!bound) return;
+      const runtimeHosts = [...bound.values()].map(
+        (binding) => binding.runtimeHost,
+      );
+      this.perStream.delete(streamId);
       for (const binding of bound.values()) {
         this.disposeSafe(binding.disposable, 'release');
       }
-      this.perStream.delete(streamId);
-      this.emitBindingsChanged();
+      this.emitBindingsChanged(runtimeHosts);
     });
     // The polling source can detach subscriptions unilaterally (PR closed,
     // auth failure, 24 h unreachable). Listen to the source directly; the
@@ -182,12 +222,18 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
 
   private pruneMissingSourceKeys(keys: readonly K[]): void {
     const active = new Set<string>(keys);
+    const runtimeHosts: AgentRuntimeHost[] = [];
     for (const [streamId, bound] of [...this.perStream]) {
       for (const key of [...bound.keys()]) {
-        if (!active.has(key)) bound.delete(key);
+        if (!active.has(key)) {
+          const binding = bound.get(key);
+          if (binding) runtimeHosts.push(binding.runtimeHost);
+          bound.delete(key);
+        }
       }
       if (bound.size === 0) this.perStream.delete(streamId);
     }
+    if (runtimeHosts.length > 0) this.emitBindingsChanged(runtimeHosts);
   }
 
   private removeBoundKey(
@@ -207,7 +253,11 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
   }
 
-  private emitBindingsChanged(): void {
-    emitGitHubSubscriptionChanged(this.opts.bindingsChangedEvent, undefined);
+  private emitBindingsChanged(runtimeHosts: Iterable<AgentRuntimeHost>): void {
+    emitGitHubSubscriptionChangedToHosts(
+      runtimeHosts,
+      this.opts.bindingsChangedEvent,
+      undefined,
+    );
   }
 }

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -22,6 +22,7 @@ import { promisify } from 'node:util';
 
 import { z } from 'zod';
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolRunContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { toErrorMessage } from '@common/errors';
 import { ToolError, type ToolResult } from '@tools/result';
@@ -131,14 +132,20 @@ function requireToken(): void {
   }
 }
 
-function requireStreamId(): string {
-  const streamId = getCurrentToolRunContext()?.streamId;
-  if (!streamId) {
+function requireSubscriptionContext(): {
+  streamId: string;
+  runtimeHost: AgentRuntimeHost;
+} {
+  const context = getCurrentToolRunContext();
+  if (!context?.streamId || !context.runtimeHost) {
     throw new ToolError(
       'github_subscription must be called from within an agent stream.',
     );
   }
-  return streamId;
+  return {
+    streamId: context.streamId,
+    runtimeHost: context.runtimeHost,
+  };
 }
 
 function requirePath(input: GitHubSubscriptionInput): ParsedPath {
@@ -171,11 +178,11 @@ async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
   requireToken();
-  const streamId = requireStreamId();
+  const { streamId, runtimeHost } = requireSubscriptionContext();
   const target = requirePath(input);
   const minAnnotationLevel = getMinAnnotationLevel(input);
   if (target.kind === 'repo') {
-    const created = bindRepoSubscription(streamId, target);
+    const created = bindRepoSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}`;
     return {
       summary: created
@@ -187,10 +194,14 @@ async function execSubscribe(
     };
   }
   if (target.kind === 'pr') {
-    const created = bindPRSubscription(streamId, {
-      ...target,
-      minAnnotationLevel,
-    });
+    const created = bindPRSubscription(
+      streamId,
+      {
+        ...target,
+        minAnnotationLevel,
+      },
+      runtimeHost,
+    );
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     const annotationLevelDescription =
       describeAnnotationLevel(minAnnotationLevel);
@@ -223,12 +234,16 @@ async function execSubscribe(
       (await resolveIssueIsPR(target.owner, target.repo, target.issueNumber)));
 
   if (isPR) {
-    const created = bindPRSubscription(streamId, {
-      owner: target.owner,
-      repo: target.repo,
-      pullNumber: target.issueNumber,
-      minAnnotationLevel,
-    });
+    const created = bindPRSubscription(
+      streamId,
+      {
+        owner: target.owner,
+        repo: target.repo,
+        pullNumber: target.issueNumber,
+        minAnnotationLevel,
+      },
+      runtimeHost,
+    );
     const wasIssuePath = !knownPR;
     const annotationLevelDescription =
       describeAnnotationLevel(minAnnotationLevel);
@@ -243,7 +258,7 @@ async function execSubscribe(
         : `Already subscribed to ${prSlug}. Inline check annotation filter is now ${annotationLevelDescription}.`,
     };
   }
-  const created = bindIssueSubscription(streamId, target);
+  const created = bindIssueSubscription(streamId, target, runtimeHost);
   return {
     summary: created
       ? `Subscribed to ${issueSlug}`
@@ -275,10 +290,10 @@ async function resolveIssueIsPR(
 }
 
 function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
-  const streamId = requireStreamId();
+  const { streamId, runtimeHost } = requireSubscriptionContext();
   const target = requirePath(input);
   if (target.kind === 'repo') {
-    const removed = unbindRepoSubscription(streamId, target);
+    const removed = unbindRepoSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}`;
     return {
       summary: removed
@@ -287,7 +302,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
     };
   }
   if (target.kind === 'pr') {
-    const removed = unbindPRSubscription(streamId, target);
+    const removed = unbindPRSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     return {
       summary: removed
@@ -297,12 +312,16 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
   }
   // Symmetric to subscribe: a /issues/N path may have been re-routed to a
   // PR subscription. Try both — whichever owns it wins.
-  const issueRemoved = unbindIssueSubscription(streamId, target);
-  const prRemoved = unbindPRSubscription(streamId, {
-    owner: target.owner,
-    repo: target.repo,
-    pullNumber: target.issueNumber,
-  });
+  const issueRemoved = unbindIssueSubscription(streamId, target, runtimeHost);
+  const prRemoved = unbindPRSubscription(
+    streamId,
+    {
+      owner: target.owner,
+      repo: target.repo,
+      pullNumber: target.issueNumber,
+    },
+    runtimeHost,
+  );
   const slug = `${target.owner}/${target.repo}/issues/${target.issueNumber}`;
   return {
     summary:
@@ -313,7 +332,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
 }
 
 function execList(): ToolResult {
-  const streamId = requireStreamId();
+  const { streamId } = requireSubscriptionContext();
   const prKeys = listPRSubscriptionBindings(prPollingSource.activeKeys())
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -1,3 +1,4 @@
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 import {
@@ -41,19 +42,24 @@ export function listPRSubscriptionBindings(
 export function bindPRSubscription(
   streamId: StreamTabId,
   pr: PRSubscribeInput,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return prSubscriptions.bind(streamId, pr);
+  return prSubscriptions.bind(streamId, pr, runtimeHost);
 }
 
 export function unbindPRSubscription(
   streamId: StreamTabId,
   pr: PRSubscribeInput,
+  runtimeHost?: AgentRuntimeHost,
 ): boolean {
-  return prSubscriptions.unbind(streamId, pr);
+  return prSubscriptions.unbind(streamId, pr, runtimeHost);
 }
 
-export function unbindAllForPR(key: string): number {
-  return prSubscriptions.unbindAll(key);
+export function unbindAllForPR(
+  key: string,
+  runtimeHost?: AgentRuntimeHost,
+): number {
+  return prSubscriptions.unbindAll(key, runtimeHost);
 }
 
 export interface RepoBindInput {
@@ -70,8 +76,19 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
     has: (key) => repoPollingSource.has(key),
     activeKeys: () => repoPollingSource.activeKeys(),
     onKeysChanged: (listener) => repoPollingSource.onKeysChanged(listener),
-    subscribe: (input, listener) =>
-      repoPollingSource.subscribe(input.owner, input.repo, listener),
+    subscribe: (input, listener, runtimeHost) =>
+      repoPollingSource.subscribe(
+        input.owner,
+        input.repo,
+        listener,
+        runtimeHost,
+      ),
+    updateSubscription: (input, listener, runtimeHost) =>
+      repoPollingSource.updateListenerRuntimeHost(
+        repoKeyOf(input.owner, input.repo),
+        listener,
+        runtimeHost,
+      ),
   },
   keyOf: (input) => repoKeyOf(input.owner, input.repo),
   bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
@@ -91,24 +108,41 @@ export function listRepoSubscriptionBindings(
 export function bindRepoSubscription(
   streamId: StreamTabId,
   input: RepoBindInput,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return repoSubscriptions.bind(streamId, input);
+  return repoSubscriptions.bind(streamId, input, runtimeHost);
 }
 
 export function unbindRepoSubscription(
   streamId: StreamTabId,
   input: RepoBindInput,
+  runtimeHost?: AgentRuntimeHost,
 ): boolean {
-  return repoSubscriptions.unbind(streamId, input);
+  return repoSubscriptions.unbind(streamId, input, runtimeHost);
 }
 
-export function unbindAllForRepo(key: string): number {
-  return repoSubscriptions.unbindAll(key);
+export function unbindAllForRepo(
+  key: string,
+  runtimeHost?: AgentRuntimeHost,
+): number {
+  return repoSubscriptions.unbindAll(key, runtimeHost);
 }
 
 const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
   name: 'IssueStreamSubscriptionRegistry',
-  source: issuePollingSource,
+  source: {
+    has: (key) => issuePollingSource.has(key),
+    activeKeys: () => issuePollingSource.activeKeys(),
+    onKeysChanged: (listener) => issuePollingSource.onKeysChanged(listener),
+    subscribe: (input, listener, runtimeHost) =>
+      issuePollingSource.subscribe(input, listener, runtimeHost),
+    updateSubscription: (input, listener, runtimeHost) =>
+      issuePollingSource.updateListenerRuntimeHost(
+        issueKeyToString(input),
+        listener,
+        runtimeHost,
+      ),
+  },
   keyOf: issueKeyToString,
   bindingsChangedEvent: 'issueSubscriptionBindingsChanged',
 });
@@ -127,17 +161,22 @@ export function listIssueSubscriptionBindings(
 export function bindIssueSubscription(
   streamId: StreamTabId,
   issue: IssueKey,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return issueSubscriptions.bind(streamId, issue);
+  return issueSubscriptions.bind(streamId, issue, runtimeHost);
 }
 
 export function unbindIssueSubscription(
   streamId: StreamTabId,
   issue: IssueKey,
+  runtimeHost?: AgentRuntimeHost,
 ): boolean {
-  return issueSubscriptions.unbind(streamId, issue);
+  return issueSubscriptions.unbind(streamId, issue, runtimeHost);
 }
 
-export function unbindAllForIssue(key: string): number {
-  return issueSubscriptions.unbindAll(key);
+export function unbindAllForIssue(
+  key: string,
+  runtimeHost?: AgentRuntimeHost,
+): number {
+  return issueSubscriptions.unbindAll(key, runtimeHost);
 }

--- a/src/tools/github/subscriptionEventEmitter.ts
+++ b/src/tools/github/subscriptionEventEmitter.ts
@@ -1,4 +1,4 @@
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 export type GitHubSubscriptionChangedEvent =
@@ -11,6 +11,22 @@ export type GitHubSubscriptionChangedEvent =
 
 export function emitGitHubSubscriptionChanged<
   K extends GitHubSubscriptionChangedEvent,
->(event: K, payload: ProgressEventPayloads[K]): void {
-  getAgentRuntimeHost().emit(event, payload);
+>(
+  runtimeHost: AgentRuntimeHost,
+  event: K,
+  payload: ProgressEventPayloads[K],
+): void {
+  runtimeHost.emit(event, payload);
+}
+
+export function emitGitHubSubscriptionChangedToHosts<
+  K extends GitHubSubscriptionChangedEvent,
+>(
+  runtimeHosts: Iterable<AgentRuntimeHost>,
+  event: K,
+  payload: ProgressEventPayloads[K],
+): void {
+  for (const runtimeHost of new Set(runtimeHosts)) {
+    emitGitHubSubscriptionChanged(runtimeHost, event, payload);
+  }
 }


### PR DESCRIPTION
Part of #3372.

## Summary
- carry an explicit `AgentRuntimeHost` through GitHub polling subscriptions and stream bindings
- remove the ambient default runtime-host lookup from GitHub subscription progress publication
- publish subscription key changes, binding changes, queued-follow-up updates, and token-invalid notices through the host that owns the subscribing stream
- pass the extension runtime host from Settings when cancelling subscriptions globally

## Design Note
This keeps the polling source as the owner of GitHub state and the stream registry as the owner of `(stream, subscription)` lifetime. The host is not resolved deep in either layer; it is supplied by the tool/settings boundary where the caller is known.

## Validation
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/eslint/bin/eslint.js src/tools/github/subscriptionEventEmitter.ts src/tools/github/PollingSourceBase.ts src/tools/github/PRPollingSource.ts src/tools/github/RepoPollingSource.ts src/tools/github/IssuePollingSource.ts src/tools/github/StreamSubscriptionRegistry.ts src/tools/github/subscriptionBindings.ts src/tools/github/githubSubscriptionTool.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts`
- `npm run lint` (0 errors, existing 68 warnings)
- direct extension build steps passed: `clean-extension-dist`, `node esbuild.config.mjs`, and Vite development builds for `progressView`, `settingsView`, `webview`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how GitHub subscription lifecycle events and auth-failure notifications are routed across runtime hosts; bugs here could cause UI refreshes or token-invalid alerts to go to the wrong stream/host.
> 
> **Overview**
> GitHub subscription plumbing now carries an explicit `AgentRuntimeHost` from the call sites (tool run context and Settings UI) through stream bindings and polling sources, removing ambient/default host lookup.
> 
> `PollingSourceBase` tracks `runtimeHostByListener`, emits subscription-key change events to the relevant hosts, and sends `githubTokenInvalid` to the hosts that own the failing subscription. `StreamSubscriptionRegistry` and `subscriptionBindings` were updated to pass/update runtime hosts on bind/unbind/unbindAll, and Settings now supplies `extensionAgentRuntimeHost` when cancelling subscriptions globally.
> 
> Tests were rewritten/expanded to validate explicit-host emission, deduping across shared hosts, auth-error routing, and synchronous-unsubscribe binding-change behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376f137f9c427529b43f2977289b537c1efb4115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->