### PR TITLE
refactor: route approval bypass updates through explicit host

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -30,6 +30,7 @@ import {
 import { RecordingManager } from '@common/managers/RecordingManager';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
@@ -225,22 +226,36 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: async (
         data,
       ) => {
-        const isNowEnabled = toggleToolEditApprovalSessionBypass(data.stream);
+        const isNowEnabled = toggleToolEditApprovalSessionBypass(
+          data.stream,
+          extensionAgentRuntimeHost,
+        );
         const msg = isNowEnabled
           ? 'YOLO mode enabled: Tool actions will be auto-approved for this stream.'
           : 'YOLO mode disabled: Tool actions will prompt for approval.';
         await vscode.window.showInformationMessage(msg);
       },
       [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: async (data) => {
-        const isNowEnabled = toggleProposalBypass(data.stream);
+        const isNowEnabled = toggleProposalBypass(
+          data.stream,
+          extensionAgentRuntimeHost,
+        );
         if (isNowEnabled) {
           // Delegation auto-approval also accepts tool edits in this stream.
           if (!isApprovalBypassedForStream(data.stream)) {
-            setToolEditApprovalSessionBypass(data.stream, true);
+            setToolEditApprovalSessionBypass(
+              data.stream,
+              true,
+              extensionAgentRuntimeHost,
+            );
           }
         } else {
           // Returning to manual task approval also restores edit prompts.
-          setToolEditApprovalSessionBypass(data.stream, false);
+          setToolEditApprovalSessionBypass(
+            data.stream,
+            false,
+            extensionAgentRuntimeHost,
+          );
         }
         const msg = isNowEnabled
           ? 'Delegated task auto-approval enabled for this stream.'

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -1,9 +1,18 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type { StreamTabId } from '@shared/schemas';
+import {
+  cleanupAllApprovals,
+  toggleProposalBypass,
+  toggleToolEditApprovalSessionBypass,
+} from '@tools/approval';
 import {
   handleProgressViewBashApprovalAction,
   requestBashApproval,
@@ -27,6 +36,10 @@ async function waitForRecordedEvent<TEvent extends string>(
 }
 
 describe('human prompt progress events', () => {
+  afterEach(() => {
+    cleanupAllApprovals();
+  });
+
   it('publishes bash approval events through the tool runtime host', async () => {
     const { events, host } = createRecordingHost();
     const streamId = 'stream:bash-approval' as StreamTabId;
@@ -120,5 +133,56 @@ describe('human prompt progress events', () => {
         payload: { requestId: show.payload.requestId },
       },
     ]);
+  });
+
+  it('publishes tool-edit bypass changes through the explicit runtime host', () => {
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const streamId = 'stream:tool-edit-bypass' as StreamTabId;
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const enabled = toggleToolEditApprovalSessionBypass(
+        streamId,
+        explicit.host,
+      );
+
+      expect(enabled).toBe(true);
+      expect(explicit.events).toEqual([
+        {
+          event: 'updateToolEditApprovalBypassState',
+          payload: { streamId, bypassActive: true },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('publishes proposal bypass changes through the explicit runtime host', () => {
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const streamId = 'stream:proposal-bypass' as StreamTabId;
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const enabled = toggleProposalBypass(streamId, explicit.host);
+
+      expect(enabled).toBe(true);
+      expect(explicit.events).toEqual([
+        {
+          event: 'updateSuperYoloBypassState',
+          payload: { streamId, bypassActive: true },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
   });
 });

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -2,6 +2,7 @@
 import * as assert from 'assert';
 
 // Local imports - agent types
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 // Local imports - tools
 import type { StreamTabId } from '@shared/schemas';
@@ -150,7 +151,12 @@ describe('Tool edit approval gating', () => {
       return { accepted: true };
     });
 
-    setToolEditApprovalSessionBypass(TEST_STREAM_ID, true);
+    setToolEditApprovalSessionBypass(
+      TEST_STREAM_ID,
+      true,
+      noopAgentRuntimeHost,
+      { silent: true },
+    );
 
     // Note: bypass check requires streamId on the request, which isn't set in unit tests
     // This test verifies the bypass is set correctly; integration tests verify full flow
@@ -166,11 +172,17 @@ describe('Tool edit approval gating', () => {
     // Initially bypass is off (cleared in beforeEach)
 
     // Toggle on - should return true
-    const enabledState = toggleToolEditApprovalSessionBypass(TEST_STREAM_ID);
+    const enabledState = toggleToolEditApprovalSessionBypass(
+      TEST_STREAM_ID,
+      noopAgentRuntimeHost,
+    );
     assert.strictEqual(enabledState, true, 'Toggle returns true when enabling');
 
     // Toggle off - should return false
-    const disabledState = toggleToolEditApprovalSessionBypass(TEST_STREAM_ID);
+    const disabledState = toggleToolEditApprovalSessionBypass(
+      TEST_STREAM_ID,
+      noopAgentRuntimeHost,
+    );
     assert.strictEqual(
       disabledState,
       false,
@@ -178,7 +190,10 @@ describe('Tool edit approval gating', () => {
     );
 
     // Toggle on again
-    const reenabledState = toggleToolEditApprovalSessionBypass(TEST_STREAM_ID);
+    const reenabledState = toggleToolEditApprovalSessionBypass(
+      TEST_STREAM_ID,
+      noopAgentRuntimeHost,
+    );
     assert.strictEqual(
       reenabledState,
       true,

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -1,21 +1,27 @@
 /** Per-stream bypass state for agent delegation proposals. */
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 const bypassedByStream = new Map<StreamTabId, boolean>();
 
-function notifyBypassState(streamId: StreamTabId): void {
-  getAgentRuntimeHost().emit('updateSuperYoloBypassState', {
+function notifyBypassState(
+  streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  runtimeHost.emit('updateSuperYoloBypassState', {
     streamId,
     bypassActive: bypassedByStream.get(streamId) ?? false,
   });
 }
 
 /** Toggle per-stream proposal bypass. Returns new state. */
-export function toggleProposalBypass(streamId: StreamTabId): boolean {
+export function toggleProposalBypass(
+  streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): boolean {
   const newState = !(bypassedByStream.get(streamId) ?? false);
   bypassedByStream.set(streamId, newState);
-  notifyBypassState(streamId);
+  notifyBypassState(streamId, runtimeHost);
   return newState;
 }
 

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -24,12 +24,7 @@ export interface StreamApprovalController<R extends { accepted: boolean }> {
   unregisterPending(id: string): void;
   getPending(id: string): PendingApproval<R> | undefined;
   isBypassed(streamId: StreamTabId): boolean;
-  setBypass(
-    streamId: StreamTabId,
-    enabled: boolean,
-    options?: { silent?: boolean },
-  ): void;
-  toggleBypass(streamId: StreamTabId): boolean;
+  setBypass(streamId: StreamTabId, enabled: boolean): void;
   enqueue<T>(run: () => Promise<T>): Promise<T>;
   rejectPendingForStream(streamId: StreamTabId): void;
   rejectAllPending(): void;
@@ -41,7 +36,6 @@ export interface StreamApprovalControllerOptions<
   R extends { accepted: boolean },
 > {
   rejectionResult: () => R;
-  notifyBypassChange?: (streamId: StreamTabId, bypassActive: boolean) => void;
 }
 
 export function createStreamApprovalController<R extends { accepted: boolean }>(
@@ -50,13 +44,6 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
   const pending = new Map<string, PendingApproval<R>>();
   const bypassedByStream = new Map<StreamTabId, boolean>();
   let queue: Promise<void> = Promise.resolve();
-
-  function notify(streamId: StreamTabId): void {
-    options.notifyBypassChange?.(
-      streamId,
-      bypassedByStream.get(streamId) ?? false,
-    );
-  }
 
   function rejectMatching(streamId?: StreamTabId): void {
     for (const entry of pending.values()) {
@@ -80,15 +67,8 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     isBypassed(streamId) {
       return bypassedByStream.get(streamId) ?? false;
     },
-    setBypass(streamId, enabled, opts) {
+    setBypass(streamId, enabled) {
       bypassedByStream.set(streamId, enabled);
-      if (!opts?.silent) notify(streamId);
-    },
-    toggleBypass(streamId) {
-      const next = !(bypassedByStream.get(streamId) ?? false);
-      bypassedByStream.set(streamId, next);
-      notify(streamId);
-      return next;
     },
     enqueue(run) {
       const operation = queue.then(run);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -6,7 +6,7 @@ import {
 } from 'diff-match-patch';
 import { z } from 'zod';
 
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolRunContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
@@ -63,12 +63,6 @@ export type ToolEditApprovalAction =
 export const toolEditApprovalController =
   createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
-    notifyBypassChange: (streamId, bypassActive) => {
-      getAgentRuntimeHost().emit('updateToolEditApprovalBypassState', {
-        streamId,
-        bypassActive,
-      });
-    },
   });
 
 let customHandler:
@@ -95,15 +89,25 @@ export function unregisterPendingApproval(id: string): void {
 export function setToolEditApprovalSessionBypass(
   streamId: StreamTabId,
   enabled: boolean,
+  runtimeHost: AgentRuntimeHost,
   options?: { silent?: boolean },
 ): void {
-  toolEditApprovalController.setBypass(streamId, enabled, options);
+  toolEditApprovalController.setBypass(streamId, enabled);
+  if (!options?.silent) {
+    runtimeHost.emit('updateToolEditApprovalBypassState', {
+      streamId,
+      bypassActive: enabled,
+    });
+  }
 }
 
 export function toggleToolEditApprovalSessionBypass(
   streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return toolEditApprovalController.toggleBypass(streamId);
+  const next = !toolEditApprovalController.isBypassed(streamId);
+  setToolEditApprovalSessionBypass(streamId, next, runtimeHost);
+  return next;
 }
 
 export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
@@ -368,5 +372,5 @@ export function buildApprovalRejectedResult(
  * activated; the subsequent SYNC_STREAM_CONTENT carries the bypass state.
  */
 export function enableYoloOnChildStream(childStreamId: StreamTabId): void {
-  toolEditApprovalController.setBypass(childStreamId, true, { silent: true });
+  toolEditApprovalController.setBypass(childStreamId, true);
 }


### PR DESCRIPTION
## Summary
- Route tool-edit and proposal bypass progress updates through the explicit runtime host owned by the progress-view action caller.
- Remove the progress-notification hook from the generic stream approval queue so it only owns queueing, pending approvals, and bypass state.
- Add focused regression coverage that verifies bypass updates do not fall back to the process-level default host.

## Validation
- ./node_modules/.bin/vitest run --configLoader runner --config vitest.config.mjs src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ../../node_modules/.bin/tsc --noEmit (packages/extension)
- npm run lint (0 errors; existing warnings remain)

Refs #3925
Refs #3372