### PR TITLE
refactor: require host for agent path resolution

### DIFF
--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -9,12 +9,13 @@ import * as yaml from 'yaml';
 import { resolveAgent, getWorkflowAgents } from '@agent/index';
 import { loadYaml, loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { getAgentPath } from '@agent/runtime/executeAgent';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import {
   getActiveEditorWithGuards,
   logGuardFailure,
 } from '@frontend/editor/activeFileGuards';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'TestCommands';
@@ -93,7 +94,7 @@ export async function handleLoadSpecificAgent(): Promise<void> {
     logger.info(CHANNEL, `Testing loading of agent: ${agentName}`);
 
     // Use getAgentPath to resolve the agent
-    const agentPath = await getAgentPath(agentName);
+    const agentPath = await getAgentPath(agentName, extensionAgentRuntimeHost);
     logger.info(
       CHANNEL,
       `Loading from path: ${path.dirname(agentPath.definitionPath)}`,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -36,7 +36,6 @@ import {
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { AgentProposalCoordinator } from './AgentProposalCoordinator';
-import { getAgentRuntimeHost, type AgentRuntimeHost } from './AgentRuntimeHost';
 import { PlanApprovalCoordinator } from './PlanApprovalCoordinator';
 import { RetryRequestCoordinatorImpl } from './RetryRequestCoordinator';
 import {
@@ -47,6 +46,7 @@ import {
 } from './RunContext';
 import { retainRunCoordinatorsForStream } from './runCoordinators';
 import { StreamStatusService } from './StreamStatusService';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface AgentLaunchContext extends AgentCore {
   usageMonitor: UsageMonitor;
@@ -114,15 +114,12 @@ export async function withExecutionRunContext<T>(
 
 export async function getAgentPath(
   agentIdentifier: string,
-  options?: { runtimeHost?: AgentRuntimeHost },
+  runtimeHost: AgentRuntimeHost,
 ): Promise<ResolvedAgent> {
   const result = resolveAgent(agentIdentifier);
   if (result) return result;
 
-  (options?.runtimeHost ?? getAgentRuntimeHost()).emit(
-    'showAgentConfigBanner',
-    { agentName: agentIdentifier },
-  );
+  runtimeHost.emit('showAgentConfigBanner', { agentName: agentIdentifier });
   throw new AgentError(`Could not find agent: ${agentIdentifier}`);
 }
 
@@ -175,7 +172,7 @@ async function assembleAgentLaunchContext(
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
   const fullConfig = AgentConfigSchema.parse(configPayload);
-  const resolution = await getAgentPath(fullConfig.agent, { runtimeHost });
+  const resolution = await getAgentPath(fullConfig.agent, runtimeHost);
   const [loadedSettings, prompt] = await loadAgentSettingAndPrompts(
     resolution,
     { outputFiles: fullConfig.outputFiles },

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -1,0 +1,42 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { getAgentPath } from '@agent/runtime/AgentLaunchContext';
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('AgentLaunchContext', () => {
+  it('publishes missing-agent banners through the explicit runtime host', async () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      await expect(
+        getAgentPath(
+          '__missing_agent_for_launch_context_test__',
+          explicit.host,
+        ),
+      ).rejects.toThrow('Could not find agent');
+
+      expect(explicit.events).toEqual([
+        {
+          event: 'showAgentConfigBanner',
+          payload: {
+            agentName: '__missing_agent_for_launch_context_test__',
+          },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR removes the ambient runtime-host fallback from missing-agent resolution. `getAgentPath` now requires the caller to provide the `AgentRuntimeHost` that owns the user-facing missing-agent banner.

The launch path already has this host in `AgentLaunchInput`; the extension-only YAML test command now passes the extension runtime host explicitly. This keeps banner publication on the same ownership boundary as the caller instead of reaching through the default runtime host.

Refs #3925.
Refs #3372.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit` from `packages/extension`
- `./node_modules/eslint/bin/eslint.js src/agent/runtime/AgentLaunchContext.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts packages/extension/src/commands/system/yamlCommands.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `getAgentPath` API to require an explicit `AgentRuntimeHost`, which can break callers and alter where user-facing banner events are emitted if any call sites weren’t updated.
> 
> **Overview**
> Removes the ambient/default runtime-host fallback when resolving missing agents: `getAgentPath` now requires an explicit `AgentRuntimeHost` and emits `showAgentConfigBanner` only on that host.
> 
> Updates the agent launch path and the extension YAML test command to pass their owning runtime host explicitly, and adds a vitest asserting missing-agent banners do not leak to the default host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661cf051f618926c4bd933ef59fe3090b352e377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->