### PR TITLE
refactor: require hosts on execution handles

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -7,10 +7,7 @@
  */
 
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_STATUS,
@@ -54,7 +51,7 @@ export interface ExecutionHandle {
   readonly category: 'workflow' | 'toolUse' | 'process';
   readonly agentName: string;
   readonly startedAt: number;
-  readonly runtimeHost?: AgentRuntimeHost;
+  readonly runtimeHost: AgentRuntimeHost;
 
   /** Get current status without probing multiple registries. */
   getStatus(): ExecutionStatusInfo;
@@ -94,7 +91,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly childStreamId: StreamTabId,
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
-    readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
+    readonly runtimeHost: AgentRuntimeHost,
   ) {
     this._parentStreamId = parentStreamId;
   }
@@ -165,7 +162,7 @@ export class ProcessExecutionHandle implements ExecutionHandle {
     readonly parentStreamId: StreamTabId,
     readonly agentName: string,
     private readonly killFn: () => boolean,
-    readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
+    readonly runtimeHost: AgentRuntimeHost,
   ) {}
 
   getStatus(): ExecutionStatusInfo {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -50,7 +50,7 @@ StreamStatusService.onDidChange(({ streamId }) => {
       handle instanceof AgentExecutionHandle &&
       handle.childStreamId === streamId
     ) {
-      const runtimeHost = runtimeHostFor(handle);
+      const runtimeHost = handle.runtimeHost;
       notifyWaiters(executionId);
       // Re-emit badge update so the parent's background tasks panel
       // reflects the new status (e.g. running → waiting).
@@ -69,7 +69,7 @@ StreamStatusService.onDidChange(({ streamId }) => {
 /** Register an execution handle. */
 export function trackExecution(handle: ExecutionHandle): void {
   registry.set(handle.executionId, handle);
-  const runtimeHost = runtimeHostFor(handle);
+  const runtimeHost = handle.runtimeHost;
 
   // Emit subagent UI update and parent linkage only for actual subagents
   // (where parentStreamId differs from childStreamId)
@@ -95,7 +95,7 @@ export function untrackExecution(executionId: string): void {
   const handle = registry.get(executionId);
   registry.delete(executionId);
   notifyWaiters(executionId);
-  const runtimeHost = runtimeHostFor(handle);
+  const runtimeHost = handle?.runtimeHost ?? getAgentRuntimeHost();
 
   // Emit subagent UI update on removal (only for actual subagents)
   if (
@@ -322,20 +322,16 @@ function emitActiveProcessesUpdate(
 // Internal helpers
 // ============================================================================
 
-function runtimeHostFor(handle: ExecutionHandle | undefined): AgentRuntimeHost {
-  return handle?.runtimeHost ?? getAgentRuntimeHost();
-}
-
 function runtimeHostForParent(parentStreamId: StreamTabId): AgentRuntimeHost {
   for (const handle of registry.values()) {
     if (handle.parentStreamId === parentStreamId) {
-      return runtimeHostFor(handle);
+      return handle.runtimeHost;
     }
     if (
       handle instanceof AgentExecutionHandle &&
       handle.childStreamId === parentStreamId
     ) {
-      return runtimeHostFor(handle);
+      return handle.runtimeHost;
     }
   }
   return getAgentRuntimeHost();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1,0 +1,67 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import {
+  AgentExecutionHandle,
+  trackExecution,
+  untrackExecution,
+} from '@agent/runtime/executionRegistry';
+import type { StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('executionRegistry', () => {
+  it('publishes handle updates through the handle runtime host', () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const executionId = 'exec-handle-runtime-host-test';
+    const parentStreamId = 'parent-handle-runtime-host-test' as StreamTabId;
+    const childStreamId = 'child-handle-runtime-host-test' as StreamTabId;
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+
+      trackExecution(handle);
+      untrackExecution(executionId);
+
+      expect(explicit.events.map((entry) => entry.event)).toEqual([
+        'updateActiveSubagents',
+        'setParentStream',
+        'updateActiveSubagents',
+      ]);
+      expect(explicit.events[0].payload).toMatchObject({
+        parentStreamId,
+        children: [
+          {
+            executionId,
+            agentName: 'test-subagent',
+            childStreamId,
+          },
+        ],
+      });
+      expect(explicit.events[2].payload).toEqual({
+        parentStreamId,
+        children: [],
+      });
+      expect(fallback.events).toEqual([]);
+    } finally {
+      untrackExecution(executionId);
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+});

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -5,6 +5,7 @@ import { strict as assert } from 'assert';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { createRunState } from '@agent/core/AgentState';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
   trackExecution,
@@ -79,6 +80,7 @@ describe('ToolUseFollowUp', () => {
       childStreamId,
       'test-subagent',
       'toolUse',
+      noopAgentRuntimeHost,
     );
     trackExecution(handle);
 
@@ -113,6 +115,7 @@ describe('ToolUseFollowUp', () => {
       childStreamId,
       'test-subagent',
       'toolUse',
+      noopAgentRuntimeHost,
     );
     trackExecution(handle);
     ToolUseFollowUpQueue.release(parentStreamId);


### PR DESCRIPTION
## Summary

This PR makes execution handles carry an explicit `AgentRuntimeHost` instead of allowing the handle constructors to fall back to the ambient runtime host.

The production construction sites already pass the owning host. The registry now uses `handle.runtimeHost` directly when publishing child/process updates for a known handle, and the remaining ambient lookup is limited to the no-handle boundary case.

Refs #3925.
Refs #3372.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit` from `packages/extension`
- `./node_modules/eslint/bin/eslint.js src/agent/runtime/ExecutionHandle.ts src/agent/runtime/executionRegistry.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test/agent/toolUse/ToolUseFollowUp.test.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how execution updates are routed by requiring an explicit `runtimeHost` on all execution handles; mistakes in handle construction could cause progress/status events to emit to the wrong host or not at all. Limited behavior change otherwise, with added tests covering host selection.
> 
> **Overview**
> Execution handles (`AgentExecutionHandle`/`ProcessExecutionHandle`) now require a non-optional `runtimeHost` and no longer default to `getAgentRuntimeHost()` at construction.
> 
> `executionRegistry` is updated to emit subagent/process UI updates using `handle.runtimeHost` for tracked executions, with ambient host lookup only as a fallback when untracking a missing handle. Adds a kernel test asserting events are emitted on the explicit host and updates existing tests to pass `noopAgentRuntimeHost` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bba8d449fc023c10aeee227838a4d0f4f32177b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->