### PR TITLE
refactor: require hosts for agent entry helpers

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1162,7 +1162,12 @@ export class DesktopProgressBridge {
       import('@agent/runtime/executeAgent'),
       import('@agent/runtime/helperModel'),
     ]);
-    await executeMergeAgent(getHelperModelName(), baseFile, editedFile);
+    await executeMergeAgent(
+      getHelperModelName(),
+      baseFile,
+      editedFile,
+      this.runtimeHost,
+    );
   }
 
   private async acceptEditedFile(

--- a/packages/extension/src/commands/agent/mergeCommands.ts
+++ b/packages/extension/src/commands/agent/mergeCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
 import { getHelperModelName } from '@agent/runtime/helperModel';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 
 const CHANNEL = 'MergeCommands';
@@ -34,5 +35,6 @@ async function handleMerge(
     model ?? getHelperModelName(),
     baseFile ?? inputFile,
     editedFile,
+    extensionAgentRuntimeHost,
   );
 }

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -53,20 +53,16 @@ async function resumeFromSnapshot(
       streamId,
     });
 
-    await resumeToolUseFromSnapshot(
-      snapshot,
-      (session) => {
-        const allFollowUps =
-          followUp !== undefined
-            ? [followUp, ...queuedFollowUps]
-            : queuedFollowUps;
+    await resumeToolUseFromSnapshot(snapshot, runtimeHost, (session) => {
+      const allFollowUps =
+        followUp !== undefined
+          ? [followUp, ...queuedFollowUps]
+          : queuedFollowUps;
 
-        for (const text of allFollowUps) {
-          session.appendFollowUp(text);
-        }
-      },
-      runtimeHost,
-    );
+      for (const text of allFollowUps) {
+        session.appendFollowUp(text);
+      }
+    });
 
     return { success: true };
   } catch (error) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -465,9 +465,8 @@ export async function executeMergeAgent(
   model: string,
   inputFile: string,
   editedFile: string,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<void> {
-  const host = runtimeHost ?? getAgentRuntimeHost();
   const configPayload: AgentConfigPayload = {
     agent: 'merge',
     model,
@@ -476,7 +475,7 @@ export async function executeMergeAgent(
   };
   const ctx = await buildAgentLaunchContext({
     configPayload,
-    runtimeHost: host,
+    runtimeHost,
     taskType: 'Merge task',
   });
   const { streamId, executionId } = ctx;
@@ -523,14 +522,13 @@ export async function executeMergeAgent(
 
 export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
+  runtimeHost: AgentRuntimeHost,
   setupSession?: (session: IToolUseSession) => void,
-  runtimeHost?: AgentRuntimeHost,
 ): Promise<void> {
-  const host = runtimeHost ?? getAgentRuntimeHost();
   const ctx = await buildAgentLaunchContext({
     configPayload: snapshot.agentConfig,
     executionId: snapshot.executionId,
-    runtimeHost: host,
+    runtimeHost,
     streamTabIdOverride: snapshot.streamId,
     // resumeCommand surfaces its own warning toast on failure; skip the
     // bus-level error to avoid double-notifying.


### PR DESCRIPTION
## Summary

This PR removes ambient runtime-host fallback from the specialized agent entry helpers:

- `executeMergeAgent` now requires the caller's `AgentRuntimeHost`.
- `resumeToolUseFromSnapshot` now takes the required host before the optional session setup callback.
- VS Code and desktop merge callers pass their existing host boundary explicitly.
- The existing resume command already had the host; it now passes it through the required argument position.

This intentionally leaves the main `executeAgent` options shape unchanged. The goal is another bounded #3925/#3372 cleanup, not a broad public API migration.

Refs #3925.
Refs #3372.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit` from `packages/extension`
- `../../node_modules/.bin/tsc --noEmit` from `packages/desktop`
- `./node_modules/eslint/bin/eslint.js src/agent/runtime/executeAgent.ts packages/extension/src/commands/agent/mergeCommands.ts packages/extension/src/commands/agent/resumeCommand.ts packages/desktop/src/main/desktopAgentExecution.ts` (0 errors; existing desktop import-order warnings)
- `npm run lint` (0 errors; existing warning set)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes exported helper signatures (`executeMergeAgent`, `resumeToolUseFromSnapshot`) and relies on all call sites passing the correct `AgentRuntimeHost`, which could cause runtime failures if any integration is missed.
> 
> **Overview**
> Removes the implicit fallback to a global runtime host for the specialized entry helpers by making `executeMergeAgent` and `resumeToolUseFromSnapshot` require an explicit `AgentRuntimeHost` (and reorders `resumeToolUseFromSnapshot` args to take the host before the optional session setup callback).
> 
> Updates the desktop merge flow and VS Code extension commands to pass their host boundary explicitly (desktop uses `this.runtimeHost`; extension uses `extensionAgentRuntimeHost` / `getAgentRuntimeHost()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df0e135e0b71953efa77cd1444f4b0515ef6515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->