### PR TITLE
refactor: use explicit extension runtime host in commands

### DIFF
--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -12,6 +12,7 @@ import {
   interruptActiveChildren,
 } from '@agent/runtime/executionRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { STREAM_STATUS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -24,7 +25,9 @@ export function stopAgent(streamId: StreamTabId): void {
     interruptActiveChildren(streamId);
   }
   getInterruptible(streamId)?.interrupt();
-  StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);
+  StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+    runtimeHost: extensionAgentRuntimeHost,
+  });
 }
 
 export async function compactResponse(streamId: StreamTabId): Promise<void> {

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   sendFollowUp,
@@ -11,6 +10,7 @@ import {
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { STREAM_STATUS } from '@shared/schemas';
@@ -42,7 +42,9 @@ async function lazyDetectWaitingStatus(
   try {
     const hasFlow = await hasPersistedFlowRecord(executionId);
     if (hasFlow) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+        runtimeHost: extensionAgentRuntimeHost,
+      });
       logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
     }
     return hasFlow;
@@ -113,14 +115,12 @@ async function handleFollowUpResult(
   result: SendFollowUpResult,
   streamId: StreamTabId,
 ): Promise<void> {
-  const runtimeHost = getAgentRuntimeHost();
-
   switch (result.status) {
     case 'sent':
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      extensionAgentRuntimeHost.emit('updateQueuedFollowUps', { streamId });
       break;
     case 'queued':
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      extensionAgentRuntimeHost.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
         // tryAutoResume also returns false when the stream is already
@@ -133,7 +133,9 @@ async function handleFollowUpResult(
             // too, but that's the lesser evil — leaving the queue open would
             // leak late child deliveries into the next run on this stream.
             ToolUseFollowUpQueue.release(streamId);
-            runtimeHost.emit('updateQueuedFollowUps', { streamId });
+            extensionAgentRuntimeHost.emit('updateQueuedFollowUps', {
+              streamId,
+            });
             await vscode.window.showWarningMessage(
               'Message dropped — no session available to receive it. Start a new agent task to continue.',
             );

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { STREAM_STATUS } from '@shared/schemas';
 import { getToolUsePersistenceEnabled } from '@utils/config';
@@ -41,7 +41,7 @@ async function resumeFromSnapshot(
   }
 
   ToolUseFollowUpQueue.acquire(streamId);
-  const runtimeHost = getAgentRuntimeHost();
+  const runtimeHost = extensionAgentRuntimeHost;
   StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
     runtimeHost,
   });


### PR DESCRIPTION
## Summary

This change removes ambient runtime-host resolution from the extension agent command layer.

The extension commands now use `extensionAgentRuntimeHost` directly when they emit progress events or update `StreamStatusService`:

- `stopAgent` passes the extension host when it marks a stream stopped.
- `texra.sendFollowUp` emits queued-follow-up updates through the extension host and passes it during lazy waiting-state detection.
- `texra.resumeAgent` resumes tool-use sessions with the extension host instead of resolving a host at runtime.

This keeps host ownership at the extension boundary and reduces the remaining non-boundary fallback paths tracked in #3925 and #3372.

## Validation

- `../../node_modules/.bin/tsc --noEmit` from `packages/extension/`
- `./node_modules/.bin/eslint packages/extension/src/commands/agent/agentCommands.ts packages/extension/src/commands/agent/followUpCommand.ts packages/extension/src/commands/agent/resumeCommand.ts`
- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts`
- `npm run lint` (passes with the existing 68 warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extension agent command paths that drive stream status transitions and queued follow-up UI updates; incorrect host wiring could cause missed events or stale status in the extension UI.
> 
> **Overview**
> Removes ambient runtime-host resolution from the extension’s agent command layer by switching to the explicit `extensionAgentRuntimeHost`.
> 
> `stopAgent`, lazy waiting-state detection in `texra.sendFollowUp`, and `texra.resumeAgent` now pass/emit through the extension host when calling `StreamStatusService.set(...)` and when emitting `updateQueuedFollowUps`, ensuring status and progress events are attributed to the extension runtime host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e95484737741df3212d0655511cbff7391b173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->