### PR TITLE
refactor: require hosts for promise coordinators

### DIFF
--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -11,6 +11,7 @@
  * 3. On resolution → emits 'resolveAgentProposal' to dismiss UI
  */
 
+import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { AgentProposal } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -86,4 +87,6 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const proposalCoordinator = new AgentProposalCoordinator();
+export const proposalCoordinator = new AgentProposalCoordinator(
+  getDefaultAgentRuntimeHost,
+);

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -17,10 +17,7 @@
  * 3. On resolution → emits resolve event to dismiss UI, defers cleanup
  */
 
-import {
-  getDefaultAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // ============================================================================
@@ -31,6 +28,16 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 interface BaseResult {
   action: string;
   feedback?: string;
+}
+
+type RuntimeHostProvider = () => AgentRuntimeHost;
+
+export type CoordinatorRuntimeHost = AgentRuntimeHost | RuntimeHostProvider;
+
+function toRuntimeHostProvider(
+  runtimeHost: CoordinatorRuntimeHost,
+): RuntimeHostProvider {
+  return typeof runtimeHost === 'function' ? runtimeHost : () => runtimeHost;
 }
 
 /** Internal state: pending (waiting for user) or resolved (done) */
@@ -65,14 +72,14 @@ export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
-  /**
-   * Run-owned coordinators pass a concrete host. The default host fallback is
-   * kept only for exported legacy singletons used at host-entry boundaries.
-   */
-  constructor(private readonly configuredRuntimeHost?: AgentRuntimeHost) {}
+  private readonly getRuntimeHost: RuntimeHostProvider;
+
+  constructor(runtimeHost: CoordinatorRuntimeHost) {
+    this.getRuntimeHost = toRuntimeHostProvider(runtimeHost);
+  }
 
   protected get runtimeHost(): AgentRuntimeHost {
-    return this.configuredRuntimeHost ?? getDefaultAgentRuntimeHost();
+    return this.getRuntimeHost();
   }
 
   /** Single source of truth for all pending requests */

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -7,6 +7,7 @@
  * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI
  */
 
+import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { Plan } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -121,4 +122,6 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const planApprovalCoordinator = new PlanApprovalCoordinator();
+export const planApprovalCoordinator = new PlanApprovalCoordinator(
+  getDefaultAgentRuntimeHost,
+);

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -9,6 +9,7 @@
  * 5. On resolution → emits 'resolveRetryRequest' to dismiss UI
  */
 
+import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { ProviderErrorPartial } from '@shared/schemas';
 import {
@@ -147,4 +148,6 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
   }
 }
 
-export const retryCoordinator = new RetryRequestCoordinatorImpl();
+export const retryCoordinator = new RetryRequestCoordinatorImpl(
+  getDefaultAgentRuntimeHost,
+);

--- a/src/test/agent/runtime/PromiseCoordinators.test.ts
+++ b/src/test/agent/runtime/PromiseCoordinators.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'assert';
 
 // Local imports
 import {
+  getDefaultAgentRuntimeHost,
   noopAgentRuntimeHost,
   setDefaultAgentRuntimeHost,
   type AgentRuntimeHost,
@@ -85,10 +86,11 @@ describe('promise coordinators', () => {
     ]);
   });
 
-  it('keeps unconfigured singleton coordinators on the default host boundary', async () => {
-    const coordinator = new PlanApprovalCoordinator();
+  it('keeps legacy singleton coordinators on the default host boundary', async () => {
+    const coordinator = new PlanApprovalCoordinator(getDefaultAgentRuntimeHost);
     const defaultHost = createRecordingHost();
     const ambientHost = createRecordingHost();
+    const replacementHost = createRecordingHost();
     const plan: Plan = {
       summary: 'Use the host boundary',
       steps: [],
@@ -104,10 +106,12 @@ describe('promise coordinators', () => {
         }),
     );
 
+    setDefaultAgentRuntimeHost(replacementHost.host);
     coordinator.resolveRequest('approval:default', { action: 'approve' });
 
     assert.deepEqual(await resultPromise, { action: 'approve' });
     assert.deepEqual(ambientHost.events, []);
+    assert.deepEqual(replacementHost.events, []);
     assert.deepEqual(
       defaultHost.events.map((entry) => entry.event),
       [


### PR DESCRIPTION
## Summary

This change removes the hidden default-host fallback from `BasePromiseCoordinator`.

Every promise coordinator instance now receives an explicit runtime-host source at construction time. Run-owned coordinators already pass their concrete `AgentRuntimeHost` through `AgentLaunchContext`; the exported legacy singleton coordinators now receive `getDefaultAgentRuntimeHost` explicitly as a boundary provider. `BasePromiseCoordinator` snapshots the provider result when a request starts, so show and resolve events stay paired on the same host even if the configured default host changes while the request is pending.

This keeps default-host behavior at the host-entry boundary and makes the shared coordinator base a deeper, simpler module: it owns request state and cleanup, but not runtime-host selection.

Part of #3925 and #3372.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/eslint src/agent/runtime/AgentRuntimeHost.ts src/agent/runtime/BasePromiseCoordinator.ts src/agent/runtime/AgentProposalCoordinator.ts src/agent/runtime/PlanApprovalCoordinator.ts src/agent/runtime/RetryRequestCoordinator.ts src/test/agent/runtime/PromiseCoordinators.test.ts`
- `npm run lint` (passes with the existing 68 warnings)

Note: `src/test/agent/runtime/PromiseCoordinators.test.ts` is an older test file outside the current vitest include pattern (`src/test-kernel/**/*.vitest.ts`), so it was typechecked but not executed by vitest.