### PR TITLE
refactor: pass host to execution subscriptions

### DIFF
--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -16,10 +16,7 @@ import {
   getHandle,
   type ExecutionHandle,
 } from '@agent/runtime/executionRegistry';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -193,6 +190,7 @@ class ExecutionSubscription implements Disposable {
 export function bindExecutionSubscription(
   streamId: StreamTabId,
   executionId: string,
+  runtimeHost: AgentRuntimeHost,
 ): void {
   ensureReleaseHook();
 
@@ -210,11 +208,7 @@ export function bindExecutionSubscription(
   }
   if (bound.has(executionId)) return;
 
-  const subscription = new ExecutionSubscription(
-    streamId,
-    handle,
-    getAgentRuntimeHost(),
-  );
+  const subscription = new ExecutionSubscription(streamId, handle, runtimeHost);
   bound.set(executionId, subscription);
   if (subscription.bind()) {
     logger.info(

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -632,7 +632,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
   private handleSubscribe(executionId: ExecutionId): ToolResult {
     const ctx = getCurrentToolRunContext();
     const streamId = ctx?.streamId;
-    if (!streamId) {
+    if (!streamId || !ctx.runtimeHost) {
       throw new ToolError(
         'subscribe must be called from within an agent stream.',
       );
@@ -646,7 +646,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       );
     }
     try {
-      bindExecutionSubscription(streamId, executionId);
+      bindExecutionSubscription(streamId, executionId, ctx.runtimeHost);
     } catch (err) {
       throw new ToolError(err instanceof Error ? err.message : String(err));
     }


### PR DESCRIPTION
## Summary

This change removes ambient runtime-host resolution from execution subscription binding.

`ExecutionSubscriptionBinder` now requires the caller to pass the `AgentRuntimeHost` that owns the subscriber stream. The only caller, the executions tool, already has the current tool-run context, so it passes `ctx.runtimeHost` directly when subscribing. The binder continues to own subscription state, listener disposal, and follow-up delivery, but no longer decides which host should receive queued-follow-up update events.

Part of #3925 and #3372.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/eslint src/agent/runtime/ExecutionSubscriptionBinder.ts src/tools/ExecutionsTool.ts`
- `npm run lint` (passes with the existing 68 warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how execution follow-up updates are routed by requiring callers to provide an `AgentRuntimeHost`; missing/incorrect host could prevent queued follow-up update events from reaching the right stream.
> 
> **Overview**
> Removes ambient runtime-host resolution from execution subscriptions by making `bindExecutionSubscription` require an explicit `AgentRuntimeHost`.
> 
> Updates the `executions` tool subscribe flow to require `ctx.runtimeHost` and pass it through, ensuring follow-up queue update events are emitted on the owning host rather than a globally resolved one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924d22220cc45aa5488546c74d33badec2ca9bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->