### PR TITLE
refactor: require tool host for human prompts

### DIFF
--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -41,98 +41,122 @@ describe('human prompt progress events', () => {
   });
 
   it('publishes bash approval events through the tool runtime host', async () => {
-    const { events, host } = createRecordingHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
     const streamId = 'stream:bash-approval' as StreamTabId;
 
-    const approval = withToolFileInteractionContext(
-      {
-        streamId,
-        runtimeHost: host,
-        tracker: {} as never,
-      },
-      () => requestBashApproval({ command: 'echo hello' }),
-    );
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
 
-    const show = await waitForRecordedEvent(events, 'showBashPermission');
-    await handleProgressViewBashApprovalAction({
-      requestId: show.payload.requestId,
-      action: 'approve',
-    });
-
-    await expect(approval).resolves.toMatchObject({ accepted: true });
-
-    expect(events).toEqual([
-      { event: 'requestEnsureProgressView', payload: {} },
-      { event: 'setActiveStream', payload: { streamId } },
-      {
-        event: 'showBashPermission',
-        payload: {
-          requestId: show.payload.requestId,
-          command: 'echo hello',
-          allowBypass: true,
+      const approval = withToolFileInteractionContext(
+        {
           streamId,
+          runtimeHost: explicit.host,
+          tracker: {} as never,
         },
-      },
-      {
-        event: 'resolveBashPermission',
-        payload: { requestId: show.payload.requestId },
-      },
-    ]);
+        () => requestBashApproval({ command: 'echo hello' }),
+      );
+
+      const show = await waitForRecordedEvent(
+        explicit.events,
+        'showBashPermission',
+      );
+      await handleProgressViewBashApprovalAction({
+        requestId: show.payload.requestId,
+        action: 'approve',
+      });
+
+      await expect(approval).resolves.toMatchObject({ accepted: true });
+
+      expect(explicit.events).toEqual([
+        { event: 'requestEnsureProgressView', payload: {} },
+        { event: 'setActiveStream', payload: { streamId } },
+        {
+          event: 'showBashPermission',
+          payload: {
+            requestId: show.payload.requestId,
+            command: 'echo hello',
+            allowBypass: true,
+            streamId,
+          },
+        },
+        {
+          event: 'resolveBashPermission',
+          payload: { requestId: show.payload.requestId },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
   });
 
   it('publishes external inquiry events through the tool runtime host', async () => {
-    const { events, host } = createRecordingHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
     const streamId = 'stream:external-inquiry' as StreamTabId;
     const tool = new ExternalInquiryTool();
 
-    const result = withToolFileInteractionContext(
-      {
-        streamId,
-        runtimeHost: host,
-        tracker: {} as never,
-      },
-      () =>
-        tool.call({
-          question: 'What should the agent check next?',
-          context: 'Runtime host boundary test',
-          suggestSearch: true,
-          attachFiles: ['notes.tex'],
-        }),
-    );
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
 
-    const show = await waitForRecordedEvent(events, 'showExternalInquiry');
-    await handleExternalInquiryAction({
-      requestId: show.payload.requestId,
-      action: 'skip',
-      feedback: 'Use local evidence instead.',
-    });
-
-    await expect(result).resolves.toMatchObject({
-      summary: 'User rejected external inquiry with feedback',
-    });
-
-    expect(events).toEqual([
-      { event: 'requestEnsureProgressView', payload: {} },
-      { event: 'setActiveStream', payload: { streamId } },
-      {
-        event: 'showExternalInquiry',
-        payload: {
-          requestId: show.payload.requestId,
-          question: 'What should the agent check next?',
-          threadId: undefined,
-          context: 'Runtime host boundary test',
-          suggestSearch: true,
-          attachFiles: ['notes.tex'],
-          sessionLinks: undefined,
-          allowBypass: false,
+      const result = withToolFileInteractionContext(
+        {
           streamId,
+          runtimeHost: explicit.host,
+          tracker: {} as never,
         },
-      },
-      {
-        event: 'resolveExternalInquiry',
-        payload: { requestId: show.payload.requestId },
-      },
-    ]);
+        () =>
+          tool.call({
+            question: 'What should the agent check next?',
+            context: 'Runtime host boundary test',
+            suggestSearch: true,
+            attachFiles: ['notes.tex'],
+          }),
+      );
+
+      const show = await waitForRecordedEvent(
+        explicit.events,
+        'showExternalInquiry',
+      );
+      await handleExternalInquiryAction({
+        requestId: show.payload.requestId,
+        action: 'skip',
+        feedback: 'Use local evidence instead.',
+      });
+
+      await expect(result).resolves.toMatchObject({
+        summary: 'User rejected external inquiry with feedback',
+      });
+
+      expect(explicit.events).toEqual([
+        { event: 'requestEnsureProgressView', payload: {} },
+        { event: 'setActiveStream', payload: { streamId } },
+        {
+          event: 'showExternalInquiry',
+          payload: {
+            requestId: show.payload.requestId,
+            question: 'What should the agent check next?',
+            threadId: undefined,
+            context: 'Runtime host boundary test',
+            suggestSearch: true,
+            attachFiles: ['notes.tex'],
+            sessionLinks: undefined,
+            allowBypass: false,
+            streamId,
+          },
+        },
+        {
+          event: 'resolveExternalInquiry',
+          payload: { requestId: show.payload.requestId },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
   });
 
   it('publishes tool-edit bypass changes through the explicit runtime host', () => {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,13 +1,10 @@
 import { z } from 'zod';
 
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolRunContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
-import type { ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@tools/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createStreamApprovalController } from './streamApprovalQueue';
@@ -45,13 +42,19 @@ export async function requestBashApproval(
 
   const context = getCurrentToolRunContext();
   const streamId = request.streamId ?? context?.streamId;
-  const runtimeHost = context?.runtimeHost ?? getAgentRuntimeHost();
 
   if (
     !approvalsEnabled ||
     (streamId && isApprovalBypassedForStream(streamId))
   ) {
     return { accepted: true };
+  }
+
+  const runtimeHost = context?.runtimeHost;
+  if (!runtimeHost) {
+    throw new ToolError(
+      'Bash approval requires a tool runtime host when approvals are enabled.',
+    );
   }
 
   return bashApprovalController.enqueue(() =>
@@ -61,8 +64,8 @@ export async function requestBashApproval(
 
 async function showApprovalPrompt(
   request: BashApprovalRequest,
-  streamId?: StreamTabId,
-  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
+  streamId: StreamTabId | undefined,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<BashApprovalResult> {
   if (streamId && isApprovalBypassedForStream(streamId)) {
     return { accepted: true };

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -10,10 +10,7 @@
 
 import { z } from 'zod';
 
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolRunContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { ExternalInquiryAction, StreamTabId } from '@shared/schemas';
@@ -251,9 +248,15 @@ When you have multiple independent questions for external models, you can call e
 }) {
   protected async execute(input: ExternalInquiryInput): Promise<ToolResult> {
     const context = getCurrentToolRunContext();
+    const runtimeHost = context?.runtimeHost;
+    if (!runtimeHost) {
+      throw new ToolError(
+        'external_inquiry requires a tool runtime host to show the user prompt.',
+      );
+    }
+
     const streamId = context?.streamId;
     const executionId = context?.executionId;
-    const runtimeHost = context?.runtimeHost ?? getAgentRuntimeHost();
 
     const requestId = `inquiry-${Date.now().toString(36)}-${++inquiryCounter}`;
     const threadLabel = input.thread_id ?? 'new';


### PR DESCRIPTION
## Summary

This PR removes two non-boundary runtime-host fallbacks from human-prompt tool paths. Bash approval and external inquiry now use the `AgentRuntimeHost` supplied by the current tool execution instead of resolving the process default host locally.

The modules still own prompt-specific state, queueing, and resolve events. The caller-owned runtime host is now the single source of truth for where progress-view events are published.

Closes part of #3925 and advances the runtime-host boundary cleanup tracked in #3372.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/eslint src/tools/approval/bashApproval.ts src/tools/inquiry/ExternalInquiryTool.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes fallback to the process default runtime host for bash approvals and external inquiries, so callers without a tool-run `runtimeHost` will now throw `ToolError` when approvals/prompts are needed. Risk is limited to these human-prompt paths but can break integrations/tests that relied on implicit defaults.
> 
> **Overview**
> **Requires an explicit `runtimeHost` for human-prompt flows.** `requestBashApproval` and `ExternalInquiryTool.execute` no longer fall back to `getAgentRuntimeHost()`; they now error with `ToolError` when approvals/prompts are enabled but no tool-run `runtimeHost` is present.
> 
> Updates `HumanPromptProgressEvents.vitest.ts` to validate events are emitted only to the *explicit* host provided via `withToolFileInteractionContext`, even when a different default host is set (and asserts the fallback host receives no events).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c5e8c36956dc3286c886bd0e427b16959c5228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->