### PR TITLE
refactor: pass host when detaching children

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -987,7 +987,7 @@ export class DesktopProgressBridge {
   stopStream(streamId: StreamTabId): void {
     clearRetryRequest(streamId);
     if (this.options.detachSubagentsOnStop === true) {
-      detachActiveChildren(streamId);
+      detachActiveChildren(streamId, this.runtimeHost);
     } else {
       interruptActiveChildren(streamId);
     }

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -20,7 +20,7 @@ export function stopAgent(streamId: StreamTabId): void {
   if (
     workspaceSM.get<boolean>(WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP, false)
   ) {
-    detachActiveChildren(streamId);
+    detachActiveChildren(streamId, extensionAgentRuntimeHost);
   } else {
     interruptActiveChildren(streamId);
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,10 +5,7 @@
  * change notification, and subagent lineage tracking in a single module.
  */
 
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 import {
@@ -95,7 +92,8 @@ export function untrackExecution(executionId: string): void {
   const handle = registry.get(executionId);
   registry.delete(executionId);
   notifyWaiters(executionId);
-  const runtimeHost = handle?.runtimeHost ?? getAgentRuntimeHost();
+  if (!handle) return;
+  const runtimeHost = handle.runtimeHost;
 
   // Emit subagent UI update on removal (only for actual subagents)
   if (
@@ -252,7 +250,10 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
  * Subagents continue running independently and deliver results via the
  * follow-up queue. Called when stopping an orchestrator without killing children.
  */
-export function detachActiveChildren(parentStreamId: StreamTabId): void {
+export function detachActiveChildren(
+  parentStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
   for (const handle of registry.values()) {
     if (handle.parentStreamId !== parentStreamId) continue;
     if (
@@ -264,7 +265,7 @@ export function detachActiveChildren(parentStreamId: StreamTabId): void {
       handle.terminate();
     }
   }
-  emitActiveSubagentsUpdate(parentStreamId);
+  emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
 }
 
 /** Get active subagent and process children for a parent stream. */
@@ -289,7 +290,7 @@ export function getActiveChildren(parentStreamId: StreamTabId): {
 /** Emit the current active subagent list for a parent to the progress UI. */
 function emitActiveSubagentsUpdate(
   parentStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost = runtimeHostForParent(parentStreamId),
+  runtimeHost: AgentRuntimeHost,
 ): void {
   const children = collectChildSummary(
     parentStreamId,
@@ -305,7 +306,7 @@ function emitActiveSubagentsUpdate(
 /** Emit the current active processes list for a parent to the progress UI. */
 function emitActiveProcessesUpdate(
   parentStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost = runtimeHostForParent(parentStreamId),
+  runtimeHost: AgentRuntimeHost,
 ): void {
   const processes = collectChildSummary(
     parentStreamId,
@@ -316,25 +317,6 @@ function emitActiveProcessesUpdate(
     parentStreamId,
     processes,
   });
-}
-
-// ============================================================================
-// Internal helpers
-// ============================================================================
-
-function runtimeHostForParent(parentStreamId: StreamTabId): AgentRuntimeHost {
-  for (const handle of registry.values()) {
-    if (handle.parentStreamId === parentStreamId) {
-      return handle.runtimeHost;
-    }
-    if (
-      handle instanceof AgentExecutionHandle &&
-      handle.childStreamId === parentStreamId
-    ) {
-      return handle.runtimeHost;
-    }
-  }
-  return getAgentRuntimeHost();
 }
 
 function addChangeCallback(executionId: string, cb: () => void): void {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -8,6 +8,7 @@ import {
 } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
+  detachActiveChildren,
   trackExecution,
   untrackExecution,
 } from '@agent/runtime/executionRegistry';
@@ -54,6 +55,45 @@ describe('executionRegistry', () => {
           },
         ],
       });
+      expect(explicit.events[2].payload).toEqual({
+        parentStreamId,
+        children: [],
+      });
+      expect(fallback.events).toEqual([]);
+    } finally {
+      untrackExecution(executionId);
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('publishes detach updates through the caller runtime host', () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const executionId = 'exec-detach-runtime-host-test';
+    const parentStreamId = 'parent-detach-runtime-host-test' as StreamTabId;
+    const childStreamId = 'child-detach-runtime-host-test' as StreamTabId;
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+
+      trackExecution(handle);
+      detachActiveChildren(parentStreamId, explicit.host);
+
+      expect(explicit.events.map((entry) => entry.event)).toEqual([
+        'updateActiveSubagents',
+        'setParentStream',
+        'updateActiveSubagents',
+      ]);
       expect(explicit.events[2].payload).toEqual({
         parentStreamId,
         children: [],


### PR DESCRIPTION
## Summary

This PR removes the remaining runtime-host inference inside `executionRegistry` for the detach path. Stop owners now pass their `AgentRuntimeHost` into `detachActiveChildren`, and the registry no longer resolves the default process host when publishing the parent-stream child list.

`untrackExecution` also returns immediately when there is no registered handle, avoiding an unused fallback lookup in the no-handle path.

Closes part of #3925 and advances the runtime-host boundary cleanup tracked in #3372.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit` in `packages/extension`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json` in `packages/desktop`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.main.json` in `packages/desktop`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.preload.json` in `packages/desktop`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.renderer.json` in `packages/desktop`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json` in `packages/cli`
- `./node_modules/.bin/eslint src/agent/runtime/executionRegistry.ts packages/extension/src/commands/agent/agentCommands.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent execution lifecycle and progress UI event routing; incorrect host propagation could cause missing/stale subagent badges when stopping or detaching streams.
> 
> **Overview**
> Removes runtime-host inference from `executionRegistry` for the detach path by making `detachActiveChildren` require an explicit `AgentRuntimeHost`, and ensures detach badge updates emit through that host.
> 
> Updates both Desktop and Extension stop flows to pass their runtime host into `detachActiveChildren`, and simplifies `untrackExecution` by returning early when no handle is registered (avoiding fallback host lookup). Adds a focused test asserting detach updates are published via the caller-provided host rather than a default host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33a72e0058faadafc9627a6abe6c6d5a3f48a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->