### PR TITLE
refactor: use tool host for accepted files

### DIFF
--- a/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
@@ -2,6 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AcceptRunFilesTool } from '@tools/AcceptRunFilesTool';
@@ -53,44 +57,71 @@ describe('accept_run_files progress events', () => {
   });
 
   it('publishes accepted workspace files through the tool runtime host', async () => {
-    const { events, host } = createRecordingHost();
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
     const tool = new AcceptRunFilesTool();
 
-    StorageFS.exists = async (target) =>
-      target === `executions/${executionId}` ||
-      target === `executions/${executionId}/output.tex`;
-    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
-    WorkspaceFS.locatePath = (target) => ({
-      kind: 'workspace',
-      absolutePath: `${workspacePath}/${target}`,
-      relativePath: target,
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      StorageFS.exists = async (target) =>
+        target === `executions/${executionId}` ||
+        target === `executions/${executionId}/output.tex`;
+      StorageFS.fullPath = (target) => `${storagePath}/${target}`;
+      WorkspaceFS.locatePath = (target) => ({
+        kind: 'workspace',
+        absolutePath: `${workspacePath}/${target}`,
+        relativePath: target,
+      });
+      WorkspaceFS.exists = async () => false;
+      WorkspaceFS.read = async () => '';
+      WorkspaceFS.write = async () => undefined;
+      WorkspaceFS.delete = async () => undefined;
+      flexibleFS.read = async () => 'accepted content';
+
+      setToolEditApprovalHandler(async () => ({ accepted: true }));
+
+      const result = await withToolFileInteractionContext(
+        {
+          streamId,
+          executionId,
+          runtimeHost: explicit.host,
+          tracker: {} as never,
+        },
+        () =>
+          tool.call({
+            execution_id: executionId,
+            files: [{ path: 'output.tex', original: 'paper.tex' }],
+          }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(explicit.events).toContainEqual({
+        event: 'workspaceFilesWritten',
+        payload: { absolutePaths: [`${workspacePath}/paper.tex`] },
+      });
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('fails before workspace writes when the tool runtime host is missing', async () => {
+    const tool = new AcceptRunFilesTool();
+    let writes = 0;
+
+    WorkspaceFS.write = async () => {
+      writes++;
+    };
+
+    const result = await tool.call({
+      execution_id: executionId,
+      files: [{ path: 'output.tex', original: 'paper.tex' }],
     });
-    WorkspaceFS.exists = async () => false;
-    WorkspaceFS.read = async () => '';
-    WorkspaceFS.write = async () => undefined;
-    WorkspaceFS.delete = async () => undefined;
-    flexibleFS.read = async () => 'accepted content';
 
-    setToolEditApprovalHandler(async () => ({ accepted: true }));
-
-    const result = await withToolFileInteractionContext(
-      {
-        streamId,
-        executionId,
-        runtimeHost: host,
-        tracker: {} as never,
-      },
-      () =>
-        tool.call({
-          execution_id: executionId,
-          files: [{ path: 'output.tex', original: 'paper.tex' }],
-        }),
-    );
-
-    expect(result.isError).toBeUndefined();
-    expect(events).toContainEqual({
-      event: 'workspaceFilesWritten',
-      payload: { absolutePaths: [`${workspacePath}/paper.tex`] },
-    });
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('requires a tool runtime host');
+    expect(writes).toBe(0);
   });
 });

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -17,6 +17,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
+import { getCurrentToolRunContext } from '@agent/toolUse/ToolFileInteractionContext';
 
 // Local imports - shared
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
@@ -28,7 +29,6 @@ import type { ExecutionId, FileLocation } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatResultCount, pluralize } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
-import { getCurrentToolRuntimeHost } from '@tools/toolRuntimeHost';
 import {
   buildApprovalRejectedResult,
   requestToolEditApproval,
@@ -126,6 +126,13 @@ Optional:
 }) {
   protected async execute(input: AcceptRunFilesInput): Promise<ToolResult> {
     const { execution_id: executionId, files, strip_criticize } = input;
+    const runtimeHost = getCurrentToolRunContext()?.runtimeHost;
+    if (!runtimeHost) {
+      throw new ToolError(
+        'accept_run_files requires a tool runtime host to publish accepted file updates.',
+      );
+    }
+
     const runDir = await resolveStoragePath(executionId);
     const runDirExists = runDir !== undefined;
 
@@ -253,7 +260,6 @@ Optional:
 
     // Badge all accepted workspace files
     if (acceptedEntries.length > 0) {
-      const runtimeHost = getCurrentToolRuntimeHost();
       runtimeHost.emit('workspaceFilesWritten', {
         absolutePaths: acceptedEntries.map((e) => e.destAbsolutePath),
       });


### PR DESCRIPTION
## Summary

This PR removes another tool-local runtime-host fallback from the accepted-files path. `accept_run_files` now publishes `workspaceFilesWritten` through the current tool run context host instead of the generic tool runtime-host resolver.

The tool still owns file validation, approval, copying, and cleanup. The event target now comes from the caller-owned tool context, which keeps the progress-event boundary explicit.

Closes part of #3925 and advances the runtime-host boundary cleanup tracked in #3372.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/eslint src/tools/AcceptRunFilesTool.ts src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts`
- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `accept_run_files` to require a runtime host from the current tool-run context; callers that previously relied on global fallback will now error, potentially affecting integrations and tests.
> 
> **Overview**
> `accept_run_files` now emits `workspaceFilesWritten` via `getCurrentToolRunContext().runtimeHost` and **fails fast** with a `ToolError` if no tool-run runtime host is present, removing the previous fallback to `getCurrentToolRuntimeHost()`.
> 
> Tests were updated to ensure the explicit per-call host receives events (and the process-level default does not), and to assert the tool errors before any workspace writes when invoked without a runtime host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66730de7f93cf006d51c51ad9d72931e0b3e0dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->