### PR TITLE
refactor: require host for usage reporter

### DIFF
--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,8 +1,5 @@
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 import type {
   ExtendedTokenUsageStats,
@@ -15,8 +12,8 @@ export class AgentUsageReporter {
   constructor(
     private readonly logger: AgentLogger,
     private readonly streamId: StreamTabId,
-    private readonly agentCategory: AgentCategory = AgentCategory.Workflow,
-    private readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
+    private readonly agentCategory: AgentCategory,
+    private readonly runtimeHost: AgentRuntimeHost,
   ) {}
 
   report(


### PR DESCRIPTION
## Summary
- remove the ambient runtime-host fallback from AgentUsageReporter
- require the launch-owned AgentRuntimeHost when constructing usage reporters
- keep usage events owned by the agent launch context instead of the reporter resolving a process default

## Validation
- ./node_modules/.bin/eslint src/logger/AgentUsageReporter.ts src/test/logger/AgentUsageReporter.test.ts
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- npm run compile-tests
- npm run lint (existing warning baseline only)

Refs #3925
Refs #3372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `AgentUsageReporter` construction to require an explicit `AgentRuntimeHost` and `AgentCategory`, which can break call sites if any still rely on the previous defaults. Behavior is otherwise the same but the wiring now depends on correct host injection from the launch context.
> 
> **Overview**
> Removes `AgentUsageReporter`'s implicit fallbacks by dropping `getAgentRuntimeHost()` and the default `AgentCategory.Workflow`, making both `agentCategory` and `runtimeHost` required constructor parameters.
> 
> Updates the agent launch wiring (and tests) to pass the launch-owned `runtimeHost` into the reporter so usage events are emitted via the correct host context rather than a process-default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3687fd92d1274ee6fe1ff9c7d685cb3f71e982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->