### PR TITLE
refactor: microscopic round-2 (shared core)

### DIFF
--- a/src/auth/serviceLogger.ts
+++ b/src/auth/serviceLogger.ts
@@ -4,12 +4,6 @@ export interface AuthServiceLogger {
 }
 
 export const NOOP_AUTH_SERVICE_LOGGER: AuthServiceLogger = {
-  info(channel, message) {
-    void channel;
-    void message;
-  },
-  error(channel, message) {
-    void channel;
-    void message;
-  },
+  info() {},
+  error() {},
 };

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -127,37 +127,38 @@ export class LatexMediaManager {
           const compiled = await compileLatex2Pdf(file, {
             outputDirectory: buildDir,
           });
-          if (!compiled) {
-            return undefined;
-          }
+          if (!compiled) return undefined;
+
           const pdfFile = path.join(
             buildDir,
             path.basename(file.absolutePath).replace(/\.tex$/, '.pdf'),
           );
           const pdfLocation = pathToLocation(pdfFile);
-          if (!(await flexibleFS.exists(pdfLocation))) {
-            return undefined;
-          }
-          try {
-            const stats = await flexibleFS.stat(pdfLocation);
-            if (stats.size === 0) {
-              this.logger.warn(
-                `Compiled PDF is empty for ${file.absolutePath}: ${pdfLocation.absolutePath}`,
-              );
-              return undefined;
-            }
-          } catch (err) {
+          if (!(await flexibleFS.exists(pdfLocation))) return undefined;
+
+          // Stat failures are noisier than other compile failures because an
+          // existing-but-unreadable PDF likely indicates a permissions/IO bug.
+          const stats = await flexibleFS.stat(pdfLocation).catch((err) => {
             this.logger.error(
               `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
             );
             return undefined;
+          });
+          if (!stats) return undefined;
+          if (stats.size === 0) {
+            this.logger.warn(
+              `Compiled PDF is empty for ${file.absolutePath}: ${pdfLocation.absolutePath}`,
+            );
+            return undefined;
           }
+
           this.logger.info(
             `Compiled PDF for ${file.absolutePath}: ${pdfLocation.absolutePath}`,
           );
           return pdfLocation;
         } catch {
-          // pMap with stopOnError: false continues on individual failures
+          // Silent skip: pMap with stopOnError: false continues past
+          // individual compile failures (compileLatex2Pdf already logs).
           return undefined;
         }
       },
@@ -385,6 +386,9 @@ export class LatexMediaManager {
           const figures = await extractFigurePathsFromLatex(file);
           return { file, figures };
         } catch {
+          // Silent skip: malformed or unreadable .tex files should not abort
+          // the surrounding pMap. Existence/format errors here are common
+          // (e.g. file deleted mid-run) and not worth user-visible noise.
           return { file, figures: [] };
         }
       },
@@ -445,6 +449,9 @@ export class LatexMediaManager {
         try {
           return await tikzPictureManager.compile(file);
         } catch {
+          // Silent skip: TikZ compilation failures are reported by the
+          // tikzPictureManager itself; pMap with stopOnError: false must
+          // continue past individual failures.
           return [];
         }
       },

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -7,7 +7,7 @@ import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { joinLatexPath } from '@utils/core/pathCore';
 
-import { resolveLatexDir } from './latexParsingUtils';
+import { findExistingLatexPath, resolveLatexDir } from './latexParsingUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -48,7 +48,8 @@ function parseGraphicspath(content: string): string[] {
 }
 
 /**
- * Resolve a figure path by searching through possible base paths and extensions
+ * Resolve a figure path by searching through possible base paths and
+ * extensions. Returns a path relative to `latexDir`, or null.
  */
 async function resolveFigurePath(
   figPath: string,
@@ -56,23 +57,12 @@ async function resolveFigurePath(
   latexDir: string,
 ): Promise<string | null> {
   const extensions = figPath.includes('.') ? [''] : FIGURE_EXTENSIONS;
-
-  for (const basePath of searchPaths) {
-    const normPath = path.normalize(path.join(basePath, figPath));
-
-    for (const ext of extensions) {
-      const pathToCheck = normPath + ext;
-      if (
-        await flexibleFS.exists({
-          kind: 'external',
-          absolutePath: pathToCheck,
-        })
-      ) {
-        return path.relative(latexDir, pathToCheck);
-      }
-    }
-  }
-  return null;
+  const absolute = await findExistingLatexPath(
+    figPath,
+    searchPaths,
+    extensions,
+  );
+  return absolute === null ? null : path.relative(latexDir, absolute);
 }
 
 /**

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -19,6 +19,7 @@ import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 // Local file imports
 import {
   collectBibliographyPaths,
+  existingExternalPath,
   stripLatexComments,
 } from './latexParsingUtils';
 
@@ -26,8 +27,14 @@ const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
 const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
 
 /**
- * Resolve a TeX input path to an existing absolute path.
- * Checks as-is first, then with .tex appended.
+ * Resolve a TeX input path (\input / \include argument) to an existing
+ * absolute path. Tries the literal path first, then with `.tex` appended
+ * (case-insensitive — `chapter.TEX` is not double-extended). Returns null
+ * for empty/whitespace input or when neither candidate exists.
+ *
+ * Uses `joinLatexPath` (not `path.join`) so leading slashes in TeX paths
+ * are stripped and absolute paths are preserved, matching LaTeX's own
+ * `\input` resolution.
  */
 async function resolveTexInputPath(
   rawPath: string,
@@ -37,29 +44,12 @@ async function resolveTexInputPath(
   if (!trimmed) return null;
 
   const absolute = joinLatexPath(baseDir, trimmed);
-  if (await flexibleFS.exists({ kind: 'external', absolutePath: absolute })) {
-    return absolute;
-  }
+  const hit = await existingExternalPath(absolute);
+  if (hit) return hit;
 
   const withExt = ensureExtension(absolute, '.tex');
-  if (
-    withExt !== absolute &&
-    (await flexibleFS.exists({ kind: 'external', absolutePath: withExt }))
-  ) {
-    return withExt;
-  }
-
-  return null;
-}
-
-/**
- * Return the candidate path if it exists on disk, otherwise null.
- */
-async function existingPath(absolute: string): Promise<string | null> {
-  if (await flexibleFS.exists({ kind: 'external', absolutePath: absolute })) {
-    return absolute;
-  }
-  return null;
+  if (withExt === absolute) return null;
+  return existingExternalPath(withExt);
 }
 
 /**
@@ -92,7 +82,9 @@ export async function extractLatexFileDependencies(
 
   const [texResolved, bibResolved] = await Promise.all([
     Promise.all(texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir))),
-    Promise.all(bibCandidates.map((absolute) => existingPath(absolute))),
+    Promise.all(
+      bibCandidates.map((absolute) => existingExternalPath(absolute)),
+    ),
   ]);
 
   const results = new Set<string>();

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -9,6 +9,7 @@
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
+import { flexibleFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 /** Strips everything after an unescaped % on each line. */
@@ -35,6 +36,45 @@ const BIB_DIRECTIVE_PATTERN = new RegExp(
 export async function resolveLatexDir(absolutePath: string): Promise<string> {
   const resolved = await fs.realpath(absolutePath).catch(() => absolutePath);
   return path.dirname(resolved);
+}
+
+/**
+ * Return `absolutePath` if it exists on disk, otherwise null. Centralizes
+ * the `flexibleFS.exists({ kind: 'external', ... })` boilerplate used by
+ * the various LaTeX dependency resolvers.
+ */
+export async function existingExternalPath(
+  absolutePath: string,
+): Promise<string | null> {
+  if (await flexibleFS.exists({ kind: 'external', absolutePath })) {
+    return absolutePath;
+  }
+  return null;
+}
+
+/**
+ * Search `searchPaths × extensions` for the first existing file and return
+ * its normalized absolute path, or null if nothing exists.
+ *
+ * - `relativePath` is joined against each entry in `searchPaths`.
+ * - Each `extensions` entry is appended to the joined path; pass `''` to test
+ *   the path as-is.
+ * - The search is ordered: outer loop over `searchPaths`, inner over
+ *   `extensions`. The first hit wins.
+ */
+export async function findExistingLatexPath(
+  relativePath: string,
+  searchPaths: string[],
+  extensions: string[],
+): Promise<string | null> {
+  for (const basePath of searchPaths) {
+    const joined = path.normalize(path.join(basePath, relativePath));
+    for (const ext of extensions) {
+      const hit = await existingExternalPath(ext ? `${joined}${ext}` : joined);
+      if (hit !== null) return hit;
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/logger/utils/index.ts
+++ b/src/logger/utils/index.ts
@@ -7,8 +7,6 @@ const EMOJI_BY_LEVEL: Record<LogLevel, string> = {
   [LOG_LEVELS.DEBUG]: '🔍',
 };
 
-const DEFAULT_EMOJI = '•';
-
 export function getColorForLevel(level: LogLevel): string {
-  return EMOJI_BY_LEVEL[level] ?? DEFAULT_EMOJI;
+  return EMOJI_BY_LEVEL[level];
 }

--- a/src/replacement/constants.ts
+++ b/src/replacement/constants.ts
@@ -89,11 +89,6 @@ export const FENCED_LATEX_BLOCK_PATTERN_MULTILINE = String.raw`(^|${LINE_BREAK_P
 
 export const FENCED_LATEX_BLOCK_PATTERN_INLINE = String.raw`(^|${LINE_BREAK_PATTERN})([ \t]*):::\s*(${FENCED_LATEX_ENVIRONMENT_PATTERN})[^\S\r\n]*()([^\r\n]*)[ \t]*:::(?=${LINE_BREAK_PATTERN}|$)`;
 
-export const FENCED_LATEX_BLOCK_PATTERNS = [
-  FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
-  FENCED_LATEX_BLOCK_PATTERN_INLINE,
-];
-
 // Union of common LaTeX environments used across rules
 // prettier-ignore
 const BASE_LATEX_ENVIRONMENTS = [

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -14,7 +14,6 @@ export {
   FENCED_LATEX_ENVIRONMENT_PATTERN,
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
   FENCED_LATEX_BLOCK_PATTERN_INLINE,
-  FENCED_LATEX_BLOCK_PATTERNS,
 } from './constants';
 
 // ============================================================================

--- a/src/tools/inquiry/externalInquiryResultFormatter.ts
+++ b/src/tools/inquiry/externalInquiryResultFormatter.ts
@@ -91,12 +91,6 @@ export function collectKnownSessionLinks(
   return known.length ? known : undefined;
 }
 
-function getKnownSessionLinks(
-  persisted: PersistedExternalInquiryTurn,
-): string[] | undefined {
-  return collectKnownSessionLinks(persisted.manifest);
-}
-
 export function buildRejectedExternalInquiryResult(
   feedback?: string,
 ): ToolResult {
@@ -123,7 +117,7 @@ function buildExternalInquiryOutput(
     answer,
   ];
 
-  const knownSessionLinks = getKnownSessionLinks(persisted);
+  const knownSessionLinks = collectKnownSessionLinks(persisted.manifest);
   appendContinuationGuidance(lines, persisted, knownSessionLinks);
   appendSessionLinks(lines, knownSessionLinks);
   appendManifestHint(lines, currentManifestPath(persisted));
@@ -217,7 +211,9 @@ export function buildExternalInquiryResult(params: {
       'Use the executions tool with path=/executions/current/report to inspect it.',
     ];
 
-    const knownSessionLinks = getKnownSessionLinks(params.persisted);
+    const knownSessionLinks = collectKnownSessionLinks(
+      params.persisted.manifest,
+    );
     appendContinuationGuidance(lines, params.persisted, knownSessionLinks);
     appendSessionLinks(lines, knownSessionLinks);
     appendManifestHint(lines, currentManifestPath(params.persisted));

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -154,18 +154,6 @@ async function copyGlobalDirectoryToExecution(
   }
 }
 
-function buildExecutionThreadMirrorPaths(params: {
-  executionId: ExecutionId;
-  threadId: ExternalInquiryThreadId;
-}): ExternalInquiryThreadMirrorPaths {
-  const threadPath = `/executions/${params.executionId}/${EXEC_DIR}/${params.threadId}`;
-  return {
-    executionId: params.executionId,
-    threadPath,
-    manifestPath: `${threadPath}/manifest.json`,
-  };
-}
-
 export async function ensureExternalInquiryThreadMirror(params: {
   executionId: ExecutionId;
   threadId: ExternalInquiryThreadId;
@@ -175,7 +163,12 @@ export async function ensureExternalInquiryThreadMirror(params: {
     path.join('executions', params.executionId, EXEC_DIR, params.threadId),
   );
 
-  return buildExecutionThreadMirrorPaths(params);
+  const threadPath = `/executions/${params.executionId}/${EXEC_DIR}/${params.threadId}`;
+  return {
+    executionId: params.executionId,
+    threadPath,
+    manifestPath: `${threadPath}/manifest.json`,
+  };
 }
 
 async function mirrorThreadToExecution(params: {
@@ -201,22 +194,6 @@ async function mirrorThreadToExecution(params: {
   };
 }
 
-function buildNewThreadManifest(
-  threadId: ExternalInquiryThreadId,
-  timestamp: string,
-): ExternalInquiryThreadManifest {
-  return {
-    threadId,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    turns: [],
-  };
-}
-
-function createStoredThreadId(): ExternalInquiryThreadId {
-  return `ei_${randomBytes(6).toString('hex')}` as ExternalInquiryThreadId;
-}
-
 function normalizeSessionLinks(links?: string[]): string[] | undefined {
   if (!links?.length) return undefined;
 
@@ -237,7 +214,9 @@ export async function persistExternalInquiryTurn(params: {
   sessionLinks?: string[];
   executionId?: ExecutionId;
 }): Promise<PersistedExternalInquiryTurn> {
-  const threadId = params.threadId ?? createStoredThreadId();
+  const threadId =
+    params.threadId ??
+    (`ei_${randomBytes(6).toString('hex')}` as ExternalInquiryThreadId);
 
   return withThreadLock(threadId, async () => {
     const existingManifest = await readThreadManifest(threadId);
@@ -247,8 +226,12 @@ export async function persistExternalInquiryTurn(params: {
     }
 
     const timestamp = new Date().toISOString();
-    const manifest =
-      existingManifest ?? buildNewThreadManifest(threadId, timestamp);
+    const manifest: ExternalInquiryThreadManifest = existingManifest ?? {
+      threadId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      turns: [],
+    };
     const turnIndex = manifest.turns.length + 1;
     const turnPath = threadTurnDir(threadId, turnIndex);
     const trimmedContext = params.context?.trim() || undefined;

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -51,10 +51,9 @@ export class ExtractLatexFiguresTool extends defineTool({
         describe: () => `Figure referenced by ${display}`,
       });
 
-    const formattedList = limitedPaths.map((figurePath) => {
-      const { display } = resolveAndFormat(figurePath);
-      return `- ${display}`;
-    });
+    const formattedList = limitedPaths.map(
+      (figurePath) => `- ${resolveAndFormat(figurePath).display}`,
+    );
     const header = `Figures referenced in ${display}`;
     const output = formatToolOutput(header, formattedList);
     const summary = `Found ${limitedPaths.length} figure file${

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -83,33 +83,20 @@ function extractEntryIdentifier(rawId: unknown): string | null {
   return id ? normaliseArxivIdentifier(id) : null;
 }
 
-/** Extract author names, optionally limiting to maxAuthors */
-function getAuthorNames(
-  authors: ArxivEntry['authors'],
-  maxAuthors?: number,
-): string[] {
-  const names = authors.map((author) => author.name);
-  return maxAuthors != null ? names.slice(0, maxAuthors) : names;
-}
-
-/** Normalize entry title by trimming whitespace */
-function normalizeEntryTitle(title: string): string {
-  return title.trim();
-}
-
 /** Extract base paper metadata from an arXiv entry */
 export function extractBasePaperMetadata(
   entry: ArxivEntry,
   maxAuthors?: number,
 ): ArxivPaperBase {
-  const identifier = extractEntryIdentifier(entry.id);
+  const authorNames = entry.authors.map((author) => author.name);
   return {
-    id: identifier,
+    id: extractEntryIdentifier(entry.id),
     doi: entry.doi?.id ?? null,
-    title: normalizeEntryTitle(entry.title),
+    title: entry.title.trim(),
     published: entry.published ?? null,
     updated: entry.updated ?? null,
-    authors: getAuthorNames(entry.authors, maxAuthors),
+    authors:
+      maxAuthors != null ? authorNames.slice(0, maxAuthors) : authorNames,
     primaryCategory: entry.primaryCategory ?? null,
   };
 }


### PR DESCRIPTION
## Summary

Microscopic simplifier round-2 across shared core modules — single-use helpers inlined, unused exports removed, two-layer factories flattened. These are the leftover micro-wins not covered by #3929.

## Changes

**LaTeX path resolution** (consolidate three overlapping resolvers per CLAUDE.md):
- `latexParsingUtils`: add `existingExternalPath` + `findExistingLatexPath` helpers.
- `extractFigure`: `resolveFigurePath` delegates to the shared helper.
- `extractFileDependencies`: `resolveTexInputPath` routes existence checks through `existingExternalPath`; private `existingPath` dropped.
- `LatexMediaManager`: flatten nested stat try/catch in `compilePdfs`.

**Tools (inquiry / latex):**
- `externalInquiryStorage`: inline three single-use factories.
- `externalInquiryResultFormatter`: drop trivial `getKnownSessionLinks` wrapper.
- `arxivShared`: inline `getAuthorNames` and `normalizeEntryTitle`.
- `ExtractFiguresTool`: collapse `formattedList` block-body arrow.

**Logger / replacement / auth:**
- `logger/utils`: remove dead `DEFAULT_EMOJI` fallback.
- `replacement`: drop unused `FENCED_LATEX_BLOCK_PATTERNS` + re-export.
- `auth/serviceLogger`: empty bodies for NOOP logger methods.

## Test plan

- [x] `npm run typecheck` clean (baseline OpenRouter SDK errors unchanged)
- [x] Prettier pre-commit hook passes
- [ ] Manual smoke test of LaTeX figure extraction
- [ ] Manual smoke test of inquiry storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly small refactors and logging/comment tweaks; the main behavioral risk is subtle changes to LaTeX dependency/figure path existence checks and PDF stat error handling during compilation.
> 
> **Overview**
> Refactors LaTeX media/dependency handling by centralizing external-path existence checks and search logic in `latexParsingUtils` (new `existingExternalPath`/`findExistingLatexPath`), then routing figure resolution (`extractFigure`) and `\input`/bib dependency discovery (`extractFileDependencies`) through those shared helpers.
> 
> Tweaks LaTeX processing robustness/clarity in `LatexMediaManager` by flattening compile/stat error handling (explicitly logging stat failures, silently skipping per-file compile/parse failures) and adding explanatory comments for `pMap` continue-on-error behavior.
> 
> Cleans up small single-use utilities and unused exports across tools and shared code: inlines tiny wrappers in external inquiry storage/formatting, simplifies arXiv metadata extraction, removes `FENCED_LATEX_BLOCK_PATTERNS` re-export, trims the NOOP auth service logger bodies, and drops the logger emoji fallback so `getColorForLevel` returns only known level mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c321ca9cd9f718183b964a2b3cc2b10bff590bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->