### PR TITLE
refactor: microscopic round-2 (extension + controllers + utils)

### DIFF
--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -302,11 +302,14 @@ async function promptGitMissing(): Promise<void> {
   const command =
     option && isToolAvailable(option.tool) ? option.command : null;
 
-  const message = command
-    ? `Git not found in PATH. Install it with:\n  ${command}`
-    : option
-      ? `Git not found in PATH. Install ${option.tool} and run "${option.command}", or download git from ${GIT_DOWNLOAD_URL}.`
-      : `Git not found in PATH. See ${GIT_DOWNLOAD_URL} to install it.`;
+  let message: string;
+  if (command) {
+    message = `Git not found in PATH. Install it with:\n  ${command}`;
+  } else if (option) {
+    message = `Git not found in PATH. Install ${option.tool} and run "${option.command}", or download git from ${GIT_DOWNLOAD_URL}.`;
+  } else {
+    message = `Git not found in PATH. See ${GIT_DOWNLOAD_URL} to install it.`;
+  }
 
   const actions = command
     ? (['Copy Command', 'Run in Terminal', 'Open git-scm.com'] as const)

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -80,8 +80,8 @@ export async function buildUserVars(
     latexStyleRules,
     attachedMemories,
   ] = await Promise.all([
-    getRequiredFileVars(agentSetting, agentPath, logger),
-    getPatternBasedFileVars(agentConfig, agentSetting, logger),
+    getRequiredFileVars(agentSetting, agentPath),
+    getPatternBasedFileVars(agentConfig, agentSetting),
     // Load shared LaTeX style rules (best-effort; empty string if missing)
     AbsoluteFS.read(path.join(agentPath, SHARED_LATEX_RULES_REL)).catch(
       () => '',
@@ -316,7 +316,6 @@ async function logFileCategoriesWithExistence(
 
 async function processRequiredFileMap(
   fileMap: Record<string, string> | undefined,
-  logger: AgentLogger,
   source: string,
   basePath?: string,
 ): Promise<FileVarsResult> {
@@ -329,14 +328,7 @@ async function processRequiredFileMap(
     if (!filePath) continue;
 
     const fullPath = basePath ? path.join(basePath, filePath) : filePath;
-    const ok = await setVarFromFile(
-      fullPath,
-      varName,
-      vars,
-      logger,
-      source,
-      Boolean(basePath),
-    );
+    const ok = await setVarFromFile(fullPath, varName, vars, Boolean(basePath));
     files.push({
       path: fullPath,
       ok,
@@ -351,14 +343,12 @@ async function processRequiredFileMap(
 async function getRequiredFileVars(
   agentSetting: AgentSetting,
   agentPath: string,
-  logger: AgentLogger,
 ): Promise<FileVarsResult> {
   // Process file maps in parallel - each returns its own vars object to avoid shared mutation
   const [required, internal] = await Promise.all([
-    processRequiredFileMap(agentSetting.requiredFiles, logger, 'requiredFiles'),
+    processRequiredFileMap(agentSetting.requiredFiles, 'requiredFiles'),
     processRequiredFileMap(
       agentSetting.requiredFilesInternal,
-      logger,
       'requiredFilesInternal',
       agentPath,
     ),
@@ -374,7 +364,6 @@ async function getRequiredFileVars(
 async function getPatternBasedFileVars(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
-  logger: AgentLogger,
 ): Promise<FileVarsResult> {
   const userVars: UserVars = {};
   const files: LoadedFileEntry[] = [];
@@ -394,13 +383,7 @@ async function getPatternBasedFileVars(
     // Helper to try setting a var from a file that matches the pattern
     async function trySetVar(filePath: string): Promise<boolean> {
       if (!filePath.toLowerCase().includes(pattern)) return false;
-      const ok = await setVarFromFile(
-        filePath,
-        varName,
-        userVars,
-        logger,
-        source,
-      );
+      const ok = await setVarFromFile(filePath, varName, userVars);
       files.push({ path: filePath, ok, varName, source });
       return ok;
     }

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -130,13 +130,12 @@ export class ProgressWorkflowActionsController {
     taskState: WorkflowTaskState,
   ): string[] {
     const generatedPaths = this.deps.state.getKnownWorkspaceOutputPaths(stream);
-    const outputFiles = [
+    return [
       ...new Set(
         [...taskState.agentConfig.outputFiles, ...generatedPaths].filter(
           Boolean,
         ),
       ),
     ];
-    return outputFiles;
   }
 }

--- a/src/controllers/settingsView/SettingsAgentVisibilityController.ts
+++ b/src/controllers/settingsView/SettingsAgentVisibilityController.ts
@@ -71,23 +71,19 @@ export class SettingsAgentVisibilityController {
     const current =
       raw ?? allAgents.map((entry) => agentKey(entry.source, entry.name));
 
-    const updated = input.enabled
-      ? this.enableAllForSource(current, targetKeys)
-      : current.filter(
-          (key) => !targetKeys.has(key) && !targetLegacyNames.has(key),
-        );
+    let updated: string[];
+    if (input.enabled) {
+      const currentSet = new Set(current);
+      updated = [
+        ...current,
+        ...[...targetKeys].filter((key) => !currentSet.has(key)),
+      ];
+    } else {
+      updated = current.filter(
+        (key) => !targetKeys.has(key) && !targetLegacyNames.has(key),
+      );
+    }
 
     await this.deps.state.setEnabledAgentKeys(input.category, updated);
-  }
-
-  private enableAllForSource(
-    current: string[],
-    targetKeys: Set<string>,
-  ): string[] {
-    const currentSet = new Set(current);
-    return [
-      ...current,
-      ...[...targetKeys].filter((key) => !currentSet.has(key)),
-    ];
   }
 }

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -70,32 +70,25 @@ export async function runCleanSingle(
   const onlyInputFileFound =
     filesToDelete.length === 1 && filesToDelete[0] === inputFile;
 
-  let result: FileOpResult;
-
   if (onlyInputFileFound || filesToDelete.length === 0) {
     logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
-    result = { status: 'noFiles' };
-  } else {
-    try {
-      logger.debug(CHANNEL, `Files to delete:\n${filesToDelete.join('\n')}`);
-      for (const filePath of filesToDelete) {
-        await WorkspaceFS.delete(filePath);
-      }
-      logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);
-      result = { status: 'success' };
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error during cleanup of ${inputFile}: ${toErrorMessage(err)}`,
-      );
-      result = {
-        status: 'error',
-        error: toErrorMessage(err),
-      };
-    }
+    return { status: 'noFiles' };
   }
 
-  return result;
+  try {
+    logger.debug(CHANNEL, `Files to delete:\n${filesToDelete.join('\n')}`);
+    for (const filePath of filesToDelete) {
+      await WorkspaceFS.delete(filePath);
+    }
+    logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);
+    return { status: 'success' };
+  } catch (err) {
+    logger.error(
+      CHANNEL,
+      `Error during cleanup of ${inputFile}: ${toErrorMessage(err)}`,
+    );
+    return { status: 'error', error: toErrorMessage(err) };
+  }
 }
 
 export async function runCleanMultiple(

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -11,7 +11,7 @@ interface ModelListState {
   update(key: string, value: unknown): PromiseLike<void>;
 }
 
-export interface EnabledModelReconciliation {
+interface EnabledModelReconciliation {
   models: string[];
   added: string[];
   removed: string[];

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -14,7 +14,6 @@ export const SETTINGS_QUERY = {
 } as const;
 
 // Time constants
-export const SHORT_SLEEP_MS = 50;
 export const REFRESH_THRESHOLD_MS = 200;
 export const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 

--- a/src/utils/files/varsUtils.ts
+++ b/src/utils/files/varsUtils.ts
@@ -1,21 +1,14 @@
-import type { AgentLogger } from '@logger/AgentLogger';
-
 import { AbsoluteFS } from './absoluteFS';
 import { WorkspaceFS } from './workspaceFS';
 
 /**
  * Reads a file and populates user variable fields with its path and content.
  * Sets `${varName}_FILE` and `${varName}_CONTENT` in the provided userVars object.
- *
- * Note: Logger and source parameters are accepted for API compatibility but
- * logging is aggregated by callers in buildUserVars.
  */
 export async function setVarFromFile(
   filePath: string,
   varName: string,
   userVars: Record<string, unknown>,
-  _logger: AgentLogger,
-  _source: string,
   absolute: boolean = false,
 ): Promise<boolean> {
   try {

--- a/src/utils/text/sanitizeTag.ts
+++ b/src/utils/text/sanitizeTag.ts
@@ -12,17 +12,15 @@
  * structurally intact.
  */
 
-const VALID_TAG_NAME = /^[a-z][a-z0-9-]*$/i;
+import { escapeRegExp } from '@utils/core/stringCore';
 
-function escapeRegex(s: string): string {
-  return s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+const VALID_TAG_NAME = /^[a-z][a-z0-9-]*$/i;
 
 export function sanitizeTag(tagName: string, body: string): string {
   if (!VALID_TAG_NAME.test(tagName)) {
     throw new Error(`Invalid tag name for sanitizer: ${tagName}`);
   }
-  const re = new RegExp(`<\\s*/?\\s*${escapeRegex(tagName)}\\s*>`, 'gi');
+  const re = new RegExp(`<\\s*/?\\s*${escapeRegExp(tagName)}\\s*>`, 'gi');
   const ZWSP = String.fromCharCode(0x200b);
   const broken = `${tagName[0]}${ZWSP}${tagName.slice(1)}`;
   return body.replaceAll(re, (match) =>


### PR DESCRIPTION
## Summary

Microscopic simplifier round-2 across extension command handlers, host-neutral controllers, housekeeping, and utility modules. Complements #3948 (shared core) and #3929 (broad cleanup); none of the files here overlap with those.

## Changes

**Extension commands:**
- `gitCommands.promptGitMissing`: replace nested ternary with explicit `if/else if/else` per CLAUDE.md.

**Controllers:**
- `SettingsAgentVisibilityController`: inline single-use `enableAllForSource` helper.
- `ProgressWorkflowActionsController.resolveOutputFiles`: drop redundant intermediate local.

**Housekeeping:**
- `clean.runCleanSingle`: drop the `let result` accumulator; return directly from each branch.

**Utils:**
- `varsUtils.setVarFromFile`: drop unused `logger` / `source` parameters that all callers were ignoring; update `userVars` callers.
- `userVars`: prune now-unused `logger` arg from `processRequiredFileMap` / `getRequiredFileVars`.
- `text/sanitizeTag`: dedupe local `escapeRegex` by importing `escapeRegExp` from `@utils/core/stringCore`.
- `config/constants`: remove unused `SHORT_SLEEP_MS`.
- `model/modelListRefresh`: downgrade `EnabledModelReconciliation` to a file-local interface (no external consumers).

## Test plan

- [x] `npm run typecheck` clean (baseline OpenRouter SDK errors unchanged)
- [x] Prettier pre-commit hook passes
- [ ] Manual smoke test of agent execution (touches varsUtils / userVars)
- [ ] Manual smoke test of git-missing prompt
- [ ] Manual smoke test of clean command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactors, but it changes the `setVarFromFile` API used during prompt/user-var construction, which could break variable loading if any call sites were missed or assumptions changed.
> 
> **Overview**
> Simplifies several code paths by replacing nested expressions/accumulators with direct `if/else` branches and returns (e.g., `promptGitMissing`, `runCleanSingle`, and controller output/visibility helpers).
> 
> Tightens utility boundaries by removing unused parameters from `setVarFromFile` and updating `userVars` callers accordingly, and by reusing shared `escapeRegExp` in `sanitizeTag`.
> 
> Removes/limits a couple of unused exports/constants (`SHORT_SLEEP_MS`, `EnabledModelReconciliation`) to reduce public surface area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0df9c9c995ed3528b8185bf0704ca8144b53a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->