### PR TITLE
refactor: pass host for tool availability refresh

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -192,11 +192,6 @@ async function buildDefaultToolDashboardItems(
   return buildToolDashboardItems(cachedResults);
 }
 
-async function refreshDefaultToolAvailability(): Promise<void> {
-  const { refreshToolAvailability } = await import('@tools/toolAvailability');
-  await refreshToolAvailability();
-}
-
 async function getCachedToolCheckResults(): Promise<
   ExternalToolCheckResult[] | undefined
 > {
@@ -242,8 +237,7 @@ export function createDesktopSettingsIpc(
     options.buildToolDashboardItems == null;
   const buildToolDashboardItems =
     options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
-  const refreshToolAvailability =
-    options.refreshToolAvailability ?? refreshDefaultToolAvailability;
+  const refreshToolAvailability = options.refreshToolAvailability;
   const secrets = options.secrets ?? tryPlatform()?.secrets ?? emptySecrets;
   const getCustomAgentDirectory =
     options.getCustomAgentDirectory ?? (() => getAgentDirectories().custom());
@@ -983,8 +977,11 @@ export function createDesktopSettingsIpc(
   }
 
   async function recheckToolStatus(): Promise<void> {
-    await refreshToolAvailability();
-    await postToolDashboardData({ skipChecks: true });
+    const didRefresh = refreshToolAvailability != null;
+    if (didRefresh) {
+      await refreshToolAvailability();
+    }
+    await postToolDashboardData({ skipChecks: didRefresh });
   }
 
   async function runToolCommand(input: {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { interruptAllCodexSessions } from '@tools/codex';
+import { refreshToolAvailability } from '@tools/toolAvailability';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
@@ -394,6 +395,8 @@ function createWindow(options: {
       });
       if (result.response === 0) clipboard.writeText(command);
     },
+    refreshToolAvailability: () =>
+      refreshToolAvailability(agentExecution.progress.runtimeHost),
     runInstallCommand: async (command) => {
       const result = await dialog.showMessageBox(window, {
         type: 'info',

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -463,20 +463,20 @@ export async function activate(context: vscode.ExtensionContext) {
       // the runtime cache pick up the change automatically.
       void (async () => {
         await refreshGitHubToken();
-        await refreshToolAvailability();
+        await refreshToolAvailability(extensionAgentRuntimeHost);
       })().catch(logRefreshFailure('secret change'));
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.
     vscode.extensions.onDidChange(() => {
-      void refreshToolAvailability().catch(
+      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
         logRefreshFailure('extension change'),
       );
     }),
     // Workspace folders opened/closed can flip `isGitRepository`, which
     // gates the GitHub PR subscription tool group.
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      void refreshToolAvailability().catch(
+      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
         logRefreshFailure('workspace folder change'),
       );
     }),

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -595,7 +595,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION]: (data) =>
         this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
-        refreshToolAvailability(),
+        refreshToolAvailability(extensionAgentRuntimeHost),
       [SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL]: async (data) => {
         await setToolEnabled(data.toolId, data.enabled);
         refreshDisabledToolCache();

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -13,7 +13,7 @@
  */
 
 // Local imports
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
@@ -205,9 +205,11 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * `runExternalToolChecks`, so the dashboard-load probe and a refresh-triggered
  * probe can't race.
  */
-export async function refreshToolAvailability(): Promise<void> {
+export async function refreshToolAvailability(
+  runtimeHost: AgentRuntimeHost,
+): Promise<void> {
   await runExternalToolChecks();
-  getAgentRuntimeHost().emit('toolAvailabilityChanged', undefined);
+  runtimeHost.emit('toolAvailabilityChanged', undefined);
 }
 
 /**


### PR DESCRIPTION
## Summary
- require an explicit AgentRuntimeHost when broadcasting tool availability refreshes
- pass the extension runtime host from extension and settings-view callers
- pass the desktop runtime host from the desktop composition root, and leave desktop settings IPC refresh as an optional injected capability

## Validation
- ./node_modules/.bin/eslint src/tools/toolAvailability.ts packages/extension/src/extension.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts packages/desktop/src/main/index.ts (existing desktop index import-order warnings only)
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p packages/extension/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
- npm run lint (existing warning baseline only)

Refs #3925
Refs #3372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the signature and call sites of `refreshToolAvailability`, which affects how tool-availability updates are broadcast to UIs across both the VS Code extension and desktop app.
> 
> **Overview**
> **Tool availability refreshes now require an explicit `AgentRuntimeHost`.** `refreshToolAvailability` no longer pulls a global host internally; callers (extension, settings view, and desktop composition root) pass the appropriate runtime host when broadcasting `toolAvailabilityChanged`.
> 
> On desktop, `desktopSettingsIpc` stops providing a built-in refresh implementation and treats refresh as an optional injected capability; the “recheck” flow now only skips checks when a refresh was actually performed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21611c08b76063a1b35855dda6fe8cbe259e0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->