### PR TITLE
perf: compact stream log persistence

### DIFF
--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -28,10 +28,21 @@ async function withNotFoundFallback<T>(
   }
 }
 
+export interface KVStoreOptions {
+  /**
+   * Write JSON without indentation. Use this for high-churn machine-owned
+   * stores where repeated pretty-printing adds avoidable CPU and disk I/O.
+   */
+  compactJson?: boolean;
+}
+
 export class KVStore {
   private dirEnsured = false;
 
-  constructor(private readonly dir: string) {}
+  constructor(
+    private readonly dir: string,
+    private readonly options: KVStoreOptions = {},
+  ) {}
 
   private keyToPath(key: string): string {
     return path.join(this.dir, `${encodeURIComponent(key)}.json`);
@@ -53,7 +64,11 @@ export class KVStore {
       await StorageFS.ensureDir(this.dir);
       this.dirEnsured = true;
     }
-    await StorageFS.writeJson(this.keyToPath(key), value);
+    const indent = this.options.compactJson ? undefined : 2;
+    await StorageFS.write(
+      this.keyToPath(key),
+      JSON.stringify(value, null, indent),
+    );
   }
 
   async delete(key: string): Promise<void> {

--- a/src/logger/StreamLog.ts
+++ b/src/logger/StreamLog.ts
@@ -112,4 +112,12 @@ export class StreamLog {
   toJSON(): StreamLogEntry[] {
     return [...this.entries];
   }
+
+  /**
+   * Internal persistence view. Callers must treat the returned array as
+   * immutable; avoiding a defensive copy matters on the stream-log save path.
+   */
+  toPersistedEntries(): readonly StreamLogEntry[] {
+    return this.entries;
+  }
 }

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -30,7 +30,7 @@ export class StreamLogStore {
   private readonly logs = new Map<StreamTabId, StreamLog>();
   private readonly listeners = new Set<StreamLogListener>();
   private readonly dirtyStreamIds = new Set<StreamTabId>();
-  private readonly kv = new KVStore(STREAM_LOGS_DIR);
+  private readonly kv = new KVStore(STREAM_LOGS_DIR, { compactJson: true });
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at load
@@ -615,7 +615,7 @@ export class StreamLogStore {
       dirtyIds.map((streamId) => {
         const logInstance = this.logs.get(streamId);
         return logInstance
-          ? this.kv.write(streamId, logInstance.toJSON())
+          ? this.kv.write(streamId, logInstance.toPersistedEntries())
           : Promise.resolve();
       }),
     )


### PR DESCRIPTION
## Summary
- write stream-log JSON in compact form because it is machine-owned and flushed frequently during long runs
- avoid copying the whole stream log entry array on each persistence flush
- keep the generic KV store pretty-printing default for lower-churn human-inspectable state files

## Why
Long active streams currently pay repeated O(N) work every debounced save: copy the full entry array, pretty-print it, and write the large JSON file. This keeps the same file-backed store and schema but reduces the CPU and disk cost of each flush.

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/eslint src/common/storage/KVStore.ts src/logger/StreamLog.ts src/logger/StreamLogStore.ts
- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the generic file-backed persistence layer (`KVStore.write`) and changes the on-disk formatting of stream log files, which could surface edge cases in readers or tooling that assumed pretty-printed JSON.
> 
> **Overview**
> Stream log persistence is optimized by writing stream log JSON in **compact** form and avoiding an O(N) copy of the entries array on each flush.
> 
> `KVStore` now supports a `compactJson` option (defaulting to pretty-printed) and uses `StorageFS.write` with explicit `JSON.stringify` indentation control. `StreamLogStore` enables compact writes for `streamLogs` and persists via `StreamLog.toPersistedEntries()` to reuse the internal entries array instead of calling `toJSON()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2655c96936e640ea8e102177750bd06e011fdab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->