### PR TITLE
perf: skip full log scans on append deltas

### DIFF
--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -65,6 +65,9 @@ const LogListStateSchema = z
 interface CachedStream {
   groups: TaskGroup[];
   messages: LogMessageData[];
+  updatedMessageIndices: readonly number[];
+  updatedMessageBaseGeneration: number;
+  messageGeneration: number;
   toggleStates: ToggleStateStore;
   ref: Ref<TaskGroupList>;
   status: string | null;
@@ -122,6 +125,10 @@ export class LogList extends LitElement {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
       entry.messages = this.streamContext.logs;
+      entry.updatedMessageIndices = this.streamContext.updatedMessageIndices;
+      entry.updatedMessageBaseGeneration =
+        this.streamContext.updatedMessageBaseGeneration;
+      entry.messageGeneration = this.streamContext.messageGeneration;
       entry.status = this.streamContext.streamStatus;
       entry.terminalMode = this.streamContext.terminalMode;
 
@@ -147,6 +154,9 @@ export class LogList extends LitElement {
           style=${id === this.activeStreamId ? '' : 'display:none'}
           .groups=${data.groups}
           .messages=${data.messages}
+          .updatedMessageIndices=${data.updatedMessageIndices}
+          .updatedMessageBaseGeneration=${data.updatedMessageBaseGeneration}
+          .messageGeneration=${data.messageGeneration}
           .hasStreams=${this.streamContext.hasStreams}
           .streamStatus=${data.status}
           .toggleStates=${data.toggleStates}
@@ -224,6 +234,9 @@ export class LogList extends LitElement {
     entry = {
       groups: [],
       messages: [],
+      updatedMessageIndices: [],
+      updatedMessageBaseGeneration: 0,
+      messageGeneration: 0,
       toggleStates,
       ref: createRef<TaskGroupList>(),
       status: null,

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -125,6 +125,21 @@ export class TaskGroupList extends LitElement {
   /** All log messages to render */
   @property({ attribute: false }) messages: LogMessageData[] = [];
 
+  /**
+   * Existing message indices updated by the most recent backend delta.
+   * Null means the producer did not provide delta metadata, so fall back
+   * to reference scans.
+   */
+  @property({ attribute: false }) updatedMessageIndices:
+    | readonly number[]
+    | null = null;
+
+  /** Generation immediately before updatedMessageIndices was collected. */
+  @property({ attribute: false }) updatedMessageBaseGeneration = 0;
+
+  /** Current generation for the messages array. */
+  @property({ attribute: false }) messageGeneration = 0;
+
   /** Whether there are any streams in the current filter (controls placeholder) */
   @property({ attribute: false }) hasStreams = false;
 
@@ -186,6 +201,9 @@ export class TaskGroupList extends LitElement {
 
   /** True after a terminal cache rebuild, when incremental append is invalid. */
   private terminalCommittedNeedsReset = true;
+
+  /** Message generation represented by the current cached tree/timeline. */
+  private processedMessageGeneration = 0;
 
   /** Handle native scroll events from the log container to track user intent */
   private handleScroll = (): void => {
@@ -267,10 +285,10 @@ export class TaskGroupList extends LitElement {
         // Append-only: classify only the new messages incrementally.
         this.appendNewMessages(prevCount);
         // A LOG_DELTA batch may also contain updates to existing entries
-        // (e.g. tool status → completed). Scan pre-append range for changes.
-        if (prevMessages) {
+        // (e.g. tool status → completed). Use explicit delta metadata when
+        // available so pure appends do not scan the old message array.
+        if (prevMessages)
           this.updateExistingMessageRefs(prevMessages, prevCount);
-        }
       } else {
         // Messages shrunk (e.g. clear) — full rebuild
         [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
@@ -302,6 +320,8 @@ export class TaskGroupList extends LitElement {
   }
 
   override updated(): void {
+    this.processedMessageGeneration = this.messageGeneration;
+
     if (this.terminal) {
       this.syncTerminalCommittedText();
       return;
@@ -356,6 +376,11 @@ export class TaskGroupList extends LitElement {
    * Reference comparison is O(1) per element, making the full scan cheap.
    */
   private updateCachedMessageRefs(prevMessages: LogMessageData[]): void {
+    if (this.canUseUpdatedMessageIndices()) {
+      this.updateCachedMessageRefsByIndex(prevMessages);
+      return;
+    }
+
     for (let i = this.messages.length - 1; i >= 0; i--) {
       if (this.messages[i] !== prevMessages[i]) {
         this.replaceSingleMessage(this.messages[i]);
@@ -372,11 +397,36 @@ export class TaskGroupList extends LitElement {
     prevMessages: LogMessageData[],
     upTo: number,
   ): void {
+    if (this.canUseUpdatedMessageIndices()) {
+      this.updateCachedMessageRefsByIndex(prevMessages, upTo);
+      return;
+    }
+
     for (let i = upTo - 1; i >= 0; i--) {
       if (this.messages[i] !== prevMessages[i]) {
         this.replaceSingleMessage(this.messages[i]);
       }
     }
+  }
+
+  private updateCachedMessageRefsByIndex(
+    prevMessages: LogMessageData[],
+    upTo: number = this.messages.length,
+  ): void {
+    const indices = this.updatedMessageIndices ?? [];
+    for (const index of indices) {
+      if (index < 0 || index >= upTo || index >= this.messages.length) continue;
+      if (this.messages[index] !== prevMessages[index]) {
+        this.replaceSingleMessage(this.messages[index]);
+      }
+    }
+  }
+
+  private canUseUpdatedMessageIndices(): boolean {
+    return (
+      this.updatedMessageIndices !== null &&
+      this.updatedMessageBaseGeneration === this.processedMessageGeneration
+    );
   }
 
   /**
@@ -574,12 +624,32 @@ export class TaskGroupList extends LitElement {
    * Full scan — status updates can target any position, not just the tail.
    */
   private updateTimelineMessageRefs(): void {
+    if (this.canUseUpdatedMessageIndices()) {
+      this.updateTimelineMessageRefsByIndex();
+      return;
+    }
+
     for (let i = this.cachedTimeline.length - 1; i >= 0; i--) {
       const item = this.cachedTimeline[i];
       if (!('msg' in item)) continue;
       const fresh = this.findUngroupedReverse(item.key);
       if (fresh && fresh !== item.msg) {
         (item as { msg: LogMessageData }).msg = fresh;
+      }
+    }
+  }
+
+  private updateTimelineMessageRefsByIndex(): void {
+    const indices = this.updatedMessageIndices ?? [];
+    for (const index of indices) {
+      const msg = this.messages[index];
+      if (!msg) continue;
+      for (let i = this.cachedTimeline.length - 1; i >= 0; i--) {
+        const item = this.cachedTimeline[i];
+        if ('msg' in item && item.key === msg.id) {
+          (item as { msg: LogMessageData }).msg = msg;
+          break;
+        }
       }
     }
   }

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -51,6 +51,12 @@ export const streamStateContext = createContext<StreamContextValue>(
  */
 export interface StreamLogContextValue {
   logs: LogMessageData[];
+  /** Existing log-message indices updated by the most recent backend delta. */
+  updatedMessageIndices: readonly number[];
+  /** Generation immediately before `updatedMessageIndices` was collected. */
+  updatedMessageBaseGeneration: number;
+  /** Current log generation. */
+  messageGeneration: number;
   taskGroups: TaskGroup[];
   isToolUse: boolean;
   hasStreams: boolean;
@@ -64,6 +70,9 @@ export interface StreamLogContextValue {
 
 export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   logs: [],
+  updatedMessageIndices: [],
+  updatedMessageBaseGeneration: 0,
+  messageGeneration: 0,
   taskGroups: [],
   isToolUse: false,
   hasStreams: false,

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -265,9 +265,13 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
   const activeStreamInfo = activeStreamInfo$.get();
   const hasStreams = hasStreams$.get();
   if (!activeStreamInfo) return { ...EMPTY_LOG_CONTEXT, hasStreams };
+  const streamLogs = activeStreamLogs$.get();
 
   return {
-    logs: activeStreamLogs$.get().logs,
+    logs: streamLogs.logs,
+    updatedMessageIndices: streamLogs.updatedMessageIndices,
+    updatedMessageBaseGeneration: streamLogs.updatedMessageBaseGeneration,
+    messageGeneration: streamLogs.generation,
     taskGroups: activeTaskGroups$.get(),
     isToolUse: activeIsToolUse$.get(),
     hasStreams,

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -163,28 +163,42 @@ export const logHandlers: HandlerRegistry = {
         const streamLogs: StreamLogs = existingStreamLogs ?? {
           logs: [],
           logIndex: new Map<string, number>(),
+          updatedMessageIndices: [],
+          updatedMessageBaseGeneration: 0,
           generation: 0,
         };
 
         let logChanged = false;
         let stateChanged = false;
+        const updatedMessageIndices = new Set<number>();
+        const updatedMessageBaseGeneration = streamLogs.generation;
 
         for (const entry of entries) {
+          const existingIndex = streamLogs.logIndex.get(entry.id);
           const changed = applyEntry(entry, streamLogs, streamState);
           logChanged ||= changed.logChanged;
           stateChanged ||= changed.stateChanged;
+          if (changed.logChanged && existingIndex !== undefined) {
+            updatedMessageIndices.add(existingIndex);
+          }
         }
 
         for (const entry of updates) {
+          const existingIndex = streamLogs.logIndex.get(entry.id);
           const changed = applyEntry(entry, streamLogs, streamState);
           logChanged ||= changed.logChanged;
           stateChanged ||= changed.stateChanged;
+          if (changed.logChanged && existingIndex !== undefined) {
+            updatedMessageIndices.add(existingIndex);
+          }
         }
 
         if (logChanged) {
           draft.streamLogs.set(streamId, {
             logs: streamLogs.logs,
             logIndex: streamLogs.logIndex,
+            updatedMessageIndices: [...updatedMessageIndices],
+            updatedMessageBaseGeneration,
             generation: streamLogs.generation + 1,
           });
         }

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -42,12 +42,21 @@ export interface StreamLogs {
   logs: LogMessageData[];
   /** O(1) lookup: log ID → array index. Maintained by mutation handlers. */
   logIndex: Map<string, number>;
+  /**
+   * Existing log-message indices updated by the most recent backend delta.
+   * Pure append batches leave this empty so renderers can skip whole-log scans.
+   */
+  updatedMessageIndices: number[];
+  /** Generation immediately before `updatedMessageIndices` was collected. */
+  updatedMessageBaseGeneration: number;
   generation: number;
 }
 
 export const EMPTY_STREAM_LOGS: StreamLogs = {
   logs: [],
   logIndex: new Map(),
+  updatedMessageIndices: [],
+  updatedMessageBaseGeneration: 0,
   generation: 0,
 };
 


### PR DESCRIPTION
## Summary
- carry the indices of existing log messages updated by each backend log delta
- let TaskGroupList use those indices instead of scanning the full old message array on pure append batches
- preserve the existing reference-scan fallback for callers without delta metadata and full-sync cases

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint packages/extension/src/progressView/frontend/store.ts packages/extension/src/progressView/frontend/contexts/streamContexts.ts packages/extension/src/progressView/frontend/progressState.ts packages/extension/src/progressView/frontend/slices/logSlice.ts packages/extension/src/progressView/frontend/components/LogList.ts packages/extension/src/progressView/frontend/components/TaskGroupList.ts
- env VITE_WEBVIEW=progressView ../../node_modules/.bin/vite build --mode development (from packages/extension)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the incremental log rendering path to rely on new delta metadata and generation checks; incorrect or mismatched indices/generations could cause stale log entries to remain in the cached tree/timeline.
> 
> **Overview**
> Improves Progress View log rendering performance by propagating *delta metadata* (updated message indices + generations) from the log store through `logContext$`/`LogList` into `TaskGroupList`.
> 
> `logSlice` now records which existing log indices were mutated during each `LOG_DELTA`, and `TaskGroupList` uses those indices (when the provided base generation matches the last processed generation) to refresh cached tree/timeline message references instead of scanning the full prior message array; it keeps the existing full-scan fallback when metadata is absent or invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed906a40e22510d15e3ac6a7059eb7ead261f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->