### PR TITLE
perf: avoid duplicate file refresh scan

### DIFF
--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -272,7 +272,7 @@ export class FileManager extends BaseWebviewManager {
       mediaFiles,
     });
 
-    await this.updateBaseFileSelect();
+    this.postBaseFileSelect(inputFiles);
     this.postGettingStartedBanner(inputFiles.length === 0);
   }
 
@@ -483,8 +483,7 @@ export class FileManager extends BaseWebviewManager {
     });
   }
 
-  private async updateBaseFileSelect(): Promise<void> {
-    const baseFiles = await getFileLister().list('input');
+  private postBaseFileSelect(baseFiles: string[]): void {
     this.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
       files: baseFiles,


### PR DESCRIPTION
## Summary
- reuse the input-file list already computed by `handleRefreshAllFiles` when updating the base-file selector
- remove the immediate second `getFileLister().list(input)` workspace scan from the same refresh path
- keep the existing message contract and base-file preserve behavior unchanged

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint packages/extension/src/webview/managers/FileManager.ts
- ./node_modules/.bin/prettier --check packages/extension/src/webview/managers/FileManager.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor limited to `FileManager.handleRefreshAllFiles`, reusing an already-fetched file list and keeping the same `SET_BASE_FILE` message payload.
> 
> **Overview**
> Avoids a redundant workspace scan during full file refresh by reusing the `inputFiles` list already computed in `handleRefreshAllFiles` when updating the base-file selector.
> 
> Refactors `updateBaseFileSelect()` into `postBaseFileSelect(baseFiles)` to accept the precomputed list while preserving the existing `SET_BASE_FILE` message contract (including `preserveBaseFile: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d24fbfd90d2c52e3e929f175df34e2eb29736eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->