### PR TITLE
perf: lazy-load memory previews

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -42,7 +42,10 @@ import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
-import { loadMemoryItems } from '@settingsView/utils/memoryFileSystem';
+import {
+  loadMemoryItems,
+  loadMemoryPreview,
+} from '@settingsView/utils/memoryFileSystem';
 import type { ExecutionId } from '@shared/schemas';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -349,6 +352,7 @@ export function createDesktopSettingsIpc(
       },
     },
     loadMemoryItems,
+    loadMemoryPreview,
     isMemoryEnabled: () =>
       globalState.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true) ?? true,
     setMemoryEnabled: async (enabled) => {
@@ -499,6 +503,19 @@ export function createDesktopSettingsIpc(
 
   async function postMemoryData(): Promise<void> {
     options.postToRenderer(await memoryController.getMemoryDataMessage());
+  }
+
+  async function postMemoryPreview(storagePath: string): Promise<void> {
+    try {
+      options.postToRenderer(
+        await memoryController.getMemoryPreviewMessage(storagePath),
+      );
+    } catch (error) {
+      onError(error);
+      options.postToRenderer(
+        memoryController.getMemoryPreviewErrorMessage(storagePath),
+      );
+    }
   }
 
   function postMemoryEnabled(): void {
@@ -1138,6 +1155,9 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.GET_MEMORY_DATA:
           runAsync(postMemoryData());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW:
+          runAsync(postMemoryPreview(result.data.storagePath));
           return true;
         case SETTINGS_VIEW_COMMANDS.GET_MEMORY_ENABLED:
           postMemoryEnabled();

--- a/packages/desktop/tests/e2e/settingsPersistence.spec.ts
+++ b/packages/desktop/tests/e2e/settingsPersistence.spec.ts
@@ -86,38 +86,57 @@ async function refreshMemoryData(launched: LaunchedApp): Promise<void> {
   });
 }
 
-async function waitForMemoryEntry(launched: LaunchedApp): Promise<void> {
-  await launched.page.waitForFunction(
-    ({ displayPath, previewText }) => {
-      const settingsApp = document.querySelector('settings-app');
-      const root = settingsApp?.shadowRoot;
-      const memoryTab = root?.querySelector('memory-tab') as
-        | (HTMLElement & { shadowRoot: ShadowRoot })
-        | null;
-      const memoryList = memoryTab?.shadowRoot?.querySelector('memory-list') as
-        | (HTMLElement & { shadowRoot: ShadowRoot })
-        | null;
-      const itemElements = Array.from(
-        memoryList?.shadowRoot?.querySelectorAll('memory-item') ?? [],
-      ) as Array<
-        HTMLElement & {
-          item?: { displayPath?: string; preview?: string };
-        }
-      >;
+interface RenderedMemoryItem {
+  displayPath?: string;
+  storagePath?: string;
+  preview?: string;
+}
 
-      return itemElements.some((element) => {
-        const item = element.item;
-        return (
-          item?.displayPath === displayPath &&
-          item.preview?.includes(previewText)
-        );
-      });
-    },
-    {
-      displayPath: MEMORY_DISPLAY_PATH,
-      previewText: MEMORY_PREVIEW_TEXT,
-    },
-    { timeout: 10_000 },
+async function readRenderedMemoryItems(
+  launched: LaunchedApp,
+): Promise<RenderedMemoryItem[]> {
+  return launched.page
+    .locator('settings-app memory-tab memory-list memory-item')
+    .evaluateAll((elements) =>
+      elements.map(
+        (element) =>
+          (element as HTMLElement & { item?: RenderedMemoryItem }).item ?? {},
+      ),
+    );
+}
+
+async function waitForRenderedMemoryItem(
+  launched: LaunchedApp,
+  predicate: (item: RenderedMemoryItem) => boolean,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => (await readRenderedMemoryItems(launched)).some(predicate),
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}
+
+async function waitForMemoryEntry(launched: LaunchedApp): Promise<void> {
+  await waitForRenderedMemoryItem(
+    launched,
+    (item) => item.displayPath === MEMORY_DISPLAY_PATH,
+  );
+
+  const item = (await readRenderedMemoryItems(launched)).find(
+    (candidate) => candidate.displayPath === MEMORY_DISPLAY_PATH,
+  );
+  if (item?.storagePath) {
+    await launched.page.evaluate((storagePath) => {
+      window.postMessage({ command: 'getMemoryPreview', storagePath }, '*');
+    }, item.storagePath);
+  }
+
+  await waitForRenderedMemoryItem(
+    launched,
+    (candidate) =>
+      candidate.displayPath === MEMORY_DISPLAY_PATH &&
+      candidate.preview?.includes(MEMORY_PREVIEW_TEXT) === true,
   );
 
   await expect(launched.page.locator('settings-app')).toHaveCount(1);

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -149,7 +149,7 @@ import {
 } from '@utils/config/providerConfig';
 import { getConfig, updateConfig } from '@utils/config/configUtils';
 import { setToolEnabled } from '@utils/config/constants';
-import { loadMemoryItems } from './utils/memoryFileSystem';
+import { loadMemoryItems, loadMemoryPreview } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import { AgentHandlers } from './handlers/agentHandlers';
 import { LatexSettingsHandlers } from './handlers/latexSettingsHandlers';
@@ -288,6 +288,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     this.memoryController = new SettingsMemoryController({
       prompt: new VscodePromptHost(),
       loadMemoryItems,
+      loadMemoryPreview,
       isMemoryEnabled: () =>
         globalSM?.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true) ?? true,
       setMemoryEnabled: setToolUseMemoryEnabled,
@@ -349,6 +350,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       // Memory handlers
       [SETTINGS_VIEW_COMMANDS.GET_MEMORY_DATA]: () =>
         this.withActiveWebview((w) => this.sendMemoryData(w)),
+      [SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW]: (data) =>
+        this.handleGetMemoryPreview(data),
       [SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FILE]: (data) =>
         this.handleOpenMemoryFile(data),
       [SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FOLDER]: () =>
@@ -715,6 +718,25 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await webview.postMessage(
       await this.memoryController.getMemoryDataMessage(),
     );
+  }
+
+  private async handleGetMemoryPreview(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.GET_MEMORY_PREVIEW>,
+  ): Promise<void> {
+    try {
+      await this.postSettingsMemoryMessage(
+        await this.memoryController.getMemoryPreviewMessage(data.storagePath),
+      );
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to load memory preview',
+        error,
+      );
+      await this.postSettingsMemoryMessage(
+        this.memoryController.getMemoryPreviewErrorMessage(data.storagePath),
+      );
+    }
   }
 
   public async sendMemoryEnabled(webview: vscode.Webview): Promise<void> {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -406,6 +406,10 @@ export class SettingsApp extends SettingsAppBase {
     });
   }
 
+  private handleMemoryLoadPreview = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+  );
+
   private handleMemoryPinItem = forwardDetail(
     SETTINGS_VIEW_COMMANDS.PIN_MEMORY,
   );
@@ -957,6 +961,7 @@ export class SettingsApp extends SettingsAppBase {
               @memory-toggle-enabled=${this.handleMemoryToggleEnabled}
               @memory-open-item=${this.handleMemoryOpenItem}
               @memory-delete-item=${this.handleMemoryDeleteItem}
+              @memory-load-preview=${this.handleMemoryLoadPreview}
               @memory-pin-item=${this.handleMemoryPinItem}
               @memory-unpin-item=${this.handleMemoryUnpinItem}
             ></memory-tab>

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -1,6 +1,13 @@
 /** Single memory entry with metadata and collapsible markdown preview. */
 
-import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  nothing,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
@@ -75,6 +82,8 @@ export class MemoryItem extends LitElement {
   /** Tracks whether the collapsible has been opened at least once to defer markdown rendering. */
   @state() private contentsOpened = false;
 
+  private requestedPreviewFor: string | null = null;
+
   /** Cached markdown render to avoid re-parsing on every Lit update cycle. */
   private cachedPreviewSource: string | null = null;
   private cachedPreviewHtml = '';
@@ -117,6 +126,17 @@ export class MemoryItem extends LitElement {
   private handleContentsShow(event: Event): void {
     if (event.target !== event.currentTarget) return;
     this.contentsOpened = true;
+    this.requestPreviewIfNeeded();
+  }
+
+  private requestPreviewIfNeeded(): void {
+    if (!this.item || this.item.preview !== undefined) return;
+    if (this.item.previewError) return;
+    if (this.requestedPreviewFor === this.item.storagePath) return;
+    this.requestedPreviewFor = this.item.storagePath;
+    this.dispatchEvent(
+      MemoryViewEvents.loadPreview({ storagePath: this.item.storagePath }),
+    );
   }
 
   private renderMeta(item: MemoryViewItem): string {
@@ -125,7 +145,9 @@ export class MemoryItem extends LitElement {
       parts.push('Pinned');
     }
     parts.push(formatBytes(item.size ?? 0));
-    parts.push(formatLineCount(item.lineCount ?? 0));
+    if (typeof item.lineCount === 'number') {
+      parts.push(formatLineCount(item.lineCount));
+    }
     parts.push(formatUpdatedDate(item.mtime));
     if (item.modifiedBy) {
       parts.push(`by ${item.modifiedBy}`);
@@ -133,11 +155,36 @@ export class MemoryItem extends LitElement {
     return parts.join(' · ');
   }
 
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (!changedProperties.has('item')) return;
+    const previous = changedProperties.get('item') as
+      | MemoryViewItem
+      | undefined;
+    if (previous?.storagePath === this.item?.storagePath) {
+      if (previous !== this.item && this.item?.preview === undefined) {
+        this.requestedPreviewFor = null;
+      }
+      return;
+    }
+    this.contentsOpened = false;
+    this.requestedPreviewFor = null;
+    this.cachedPreviewSource = null;
+    this.cachedPreviewHtml = '';
+  }
+
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('item') && this.contentsOpened) {
+      this.requestPreviewIfNeeded();
+    }
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (!this.item) {
       return nothing;
     }
 
+    const previewLoaded = this.item.preview !== undefined;
+    const previewError = this.item.previewError === true;
     const previewText = this.item.preview?.trim() ? this.item.preview : null;
 
     return html`
@@ -177,11 +224,17 @@ export class MemoryItem extends LitElement {
         >
           ${this.contentsOpened
             ? html`<div class="memory-preview">
-                ${previewText
-                  ? html`<div class="markdown-content">
-                      ${unsafeHTML(this.renderMarkdown(previewText))}
-                    </div>`
-                  : html`<em class="text-secondary">This note is empty.</em>`}
+                ${!previewLoaded
+                  ? previewError
+                    ? html`<em class="text-secondary"
+                        >Unable to load contents.</em
+                      >`
+                    : html`<em class="text-secondary">Loading contents...</em>`
+                  : previewText
+                    ? html`<div class="markdown-content">
+                        ${unsafeHTML(this.renderMarkdown(previewText))}
+                      </div>`
+                    : html`<em class="text-secondary">This note is empty.</em>`}
               </div>`
             : nothing}
         </wa-details>

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -29,6 +29,16 @@ import {
   type PageChangeDetail,
 } from '../shared/Pagination';
 
+function hasSameMemoryOrder(
+  previous: readonly MemoryViewItem[] | undefined,
+  next: readonly MemoryViewItem[],
+): boolean {
+  if (!previous || previous.length !== next.length) return false;
+  return previous.every(
+    (item, index) => item.storagePath === next[index]?.storagePath,
+  );
+}
+
 @customElement('memory-list')
 export class MemoryList extends LitElement {
   static override styles = [
@@ -52,9 +62,13 @@ export class MemoryList extends LitElement {
   @state() private page = 0;
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    // Reset to first page when items change (e.g. refresh, delete, pin/unpin)
     if (changedProperties.has('items')) {
-      this.page = 0;
+      const previous = changedProperties.get('items') as
+        | MemoryViewItem[]
+        | undefined;
+      if (!hasSameMemoryOrder(previous, this.items)) {
+        this.page = 0;
+      }
     }
   }
 

--- a/packages/extension/src/settingsView/frontend/components/memory/events.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/events.ts
@@ -10,6 +10,8 @@ export const MemoryViewEvents = {
     createEvent('memory-open-item', detail),
   deleteItem: (detail: MemoryItemActionDetail) =>
     createEvent('memory-delete-item', detail),
+  loadPreview: (detail: { storagePath: string }) =>
+    createEvent('memory-load-preview', detail),
   pinItem: (detail: { storagePath: string }) =>
     createEvent('memory-pin-item', detail),
   unpinItem: (detail: { storagePath: string }) =>

--- a/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -15,6 +15,7 @@ import {
   UpdateLatexSettingsStatusMessageSchema,
   UpdateMemoryEnabledMessageSchema,
   UpdateMemoryMessageSchema,
+  UpdateMemoryPreviewMessageSchema,
   UpdateModelSelectionMessageSchema,
   UpdatePRSubscriptionsMessageSchema,
   UpdateProfileMessageSchema,
@@ -35,6 +36,7 @@ import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 
 interface WritableSignal<T> {
+  get(): T;
   set(value: T): void;
 }
 
@@ -145,6 +147,32 @@ export function dispatchSettingsViewMessage(
       if (!data) return false;
       ctx.memoryEnabled.set(data.enabled);
       ctx.memoryToggleDisabled.set(false);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW: {
+      const data = parseMessage(raw, UpdateMemoryPreviewMessageSchema, ctx);
+      if (!data) return false;
+      const { storagePath, preview, lineCount, error } = data.preview;
+      ctx.memoryItems.set(
+        ctx.memoryItems.get().map((item) =>
+          item.storagePath === storagePath
+            ? error
+              ? {
+                  ...item,
+                  preview: undefined,
+                  lineCount: undefined,
+                  previewError: true,
+                }
+              : {
+                  ...item,
+                  preview,
+                  ...(lineCount === undefined ? {} : { lineCount }),
+                  previewError: undefined,
+                }
+            : item,
+        ),
+      );
       return true;
     }
 

--- a/packages/extension/src/settingsView/utils/memoryFileSystem.ts
+++ b/packages/extension/src/settingsView/utils/memoryFileSystem.ts
@@ -8,7 +8,10 @@
 import * as path from 'path';
 
 import { isDirectory, isSymlink } from '@common/files/fsEntryType';
-import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
+import type {
+  MemoryPreview,
+  MemoryViewItem,
+} from '@shared/schemas/settingsViewMessages';
 import {
   MEMORY_STORAGE_ROOT,
   MAX_PREVIEW_LINES,
@@ -18,22 +21,57 @@ import {
 import { relativeToDisplayPath } from '@tools/memory/memoryUtils';
 import { parseFrontmatter, formatAttribution } from '@tools/memory/memoryMeta';
 import { StorageFS } from '@utils/files';
-import { splitContentLines } from '@utils/text/stringUtils';
+import {
+  normalizeLineEndings,
+  splitContentLines,
+} from '@utils/text/stringUtils';
+
+const FRONTMATTER_SCAN_BYTES = 16 * 1024;
+const PREVIEW_SCAN_BYTES = 64 * 1024;
+
+async function readStoragePrefix(
+  storagePath: string,
+  maxBytes: number,
+  stats?: { size: number },
+): Promise<{ text: string; truncated: boolean }> {
+  const fileStats = stats ?? (await StorageFS.stat(storagePath));
+  if (fileStats.size === 0) {
+    return { text: '', truncated: false };
+  }
+
+  const chunks: Buffer[] = [];
+  const end = Math.min(maxBytes, fileStats.size) - 1;
+  for await (const chunk of StorageFS.createReadStream(storagePath, {
+    start: 0,
+    end,
+  })) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return {
+    text: normalizeLineEndings(Buffer.concat(chunks).toString('utf-8')),
+    truncated: fileStats.size > maxBytes,
+  };
+}
 
 /**
  * Builds a preview of content with truncation info.
  * @param content - The full file content to preview
- * @returns Preview text and total line count
+ * @returns Preview text and line count when the caller supplied complete content
  */
-export function buildPreview(content: string): {
+export function buildPreview(
+  content: string,
+  options?: { truncated?: boolean; exactLineCount?: boolean },
+): {
   preview: string;
-  lineCount: number;
+  lineCount?: number;
 } {
   const lines = splitContentLines(content);
-  const lineCount = lines.length;
+  const exactLineCount = options?.exactLineCount ?? true;
+  const lineCount = exactLineCount ? lines.length : undefined;
   const previewLines = lines.slice(0, MAX_PREVIEW_LINES);
   let preview = previewLines.join('\n');
-  let truncated = lineCount > MAX_PREVIEW_LINES;
+  let truncated =
+    lines.length > MAX_PREVIEW_LINES || (options?.truncated ?? false);
 
   if (preview.length > MAX_PREVIEW_CHARS) {
     preview = preview.slice(0, MAX_PREVIEW_CHARS);
@@ -45,6 +83,29 @@ export function buildPreview(content: string): {
   }
 
   return { preview, lineCount };
+}
+
+async function readMemoryMeta(storagePath: string, stats: { size: number }) {
+  const { text: raw } = await readStoragePrefix(
+    storagePath,
+    FRONTMATTER_SCAN_BYTES,
+    stats,
+  );
+  return parseFrontmatter(raw).meta;
+}
+
+export async function loadMemoryPreview(
+  storagePath: string,
+): Promise<MemoryPreview> {
+  const { text: raw, truncated } = await readStoragePrefix(
+    storagePath,
+    PREVIEW_SCAN_BYTES,
+  );
+  const { content } = parseFrontmatter(raw);
+  return {
+    storagePath,
+    ...buildPreview(content, { truncated, exactLineCount: !truncated }),
+  };
 }
 
 /**
@@ -81,9 +142,7 @@ export async function walkMemoryDirectory(
     }
 
     const stats = await StorageFS.stat(nextStoragePath);
-    const raw = await StorageFS.read(nextStoragePath);
-    const { meta, content } = parseFrontmatter(raw);
-    const previewData = buildPreview(content);
+    const meta = await readMemoryMeta(nextStoragePath, stats);
     const displayPath = relativeToDisplayPath(nextRelative);
 
     results.push({
@@ -91,8 +150,6 @@ export async function walkMemoryDirectory(
       storagePath: nextStoragePath,
       size: stats.size,
       mtime: new Date(stats.mtime).toISOString(),
-      lineCount: previewData.lineCount,
-      preview: previewData.preview,
       modifiedBy: meta ? formatAttribution(meta) : undefined,
       pinned: meta?.pinned,
     });

--- a/src/common/webview/memoryViewCommands.ts
+++ b/src/common/webview/memoryViewCommands.ts
@@ -7,7 +7,9 @@ import { COMMON_COMMANDS } from './commonCommands';
 export const MEMORY_VIEW_COMMANDS = {
   ...COMMON_COMMANDS,
   GET_MEMORY_DATA: 'getMemoryData',
+  GET_MEMORY_PREVIEW: 'getMemoryPreview',
   UPDATE_MEMORY: 'updateMemory',
+  UPDATE_MEMORY_PREVIEW: 'updateMemoryPreview',
   OPEN_MEMORY_FILE: 'openMemoryFile',
   OPEN_MEMORY_FOLDER: 'openMemoryFolder',
   DELETE_MEMORY: 'deleteMemory',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -14,6 +14,7 @@ export const SETTINGS_VIEW_CMD = {
   OPEN_VSCODE_SETTINGS: 'openVscodeSettings',
   // Memory commands
   GET_MEMORY_DATA: 'getMemoryData',
+  GET_MEMORY_PREVIEW: 'getMemoryPreview',
   OPEN_MEMORY_FILE: 'openMemoryFile',
   OPEN_MEMORY_FOLDER: 'openMemoryFolder',
   DELETE_MEMORY: 'deleteMemory',
@@ -127,6 +128,7 @@ export const SETTINGS_VIEW_COMMANDS = {
   ...SETTINGS_VIEW_CMD,
   // Outbound-only commands (backend → frontend, not schema-validated)
   UPDATE_MEMORY: 'updateMemory',
+  UPDATE_MEMORY_PREVIEW: 'updateMemoryPreview',
   UPDATE_MEMORY_ENABLED: 'updateMemoryEnabled',
   UPDATE_HISTORY: 'updateHistory',
   HISTORY_CLEARED: 'historyCleared',

--- a/src/controllers/settingsView/SettingsMemoryController.ts
+++ b/src/controllers/settingsView/SettingsMemoryController.ts
@@ -5,7 +5,10 @@ import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import type { PromptHost } from '@hosts/promptHost';
 
 // Local imports - shared
-import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
+import type {
+  MemoryPreview,
+  MemoryViewItem,
+} from '@shared/schemas/settingsViewMessages';
 
 // Local imports - memory
 import type { MemoryFileMeta } from '@tools/memory/memoryMeta';
@@ -21,6 +24,7 @@ export type SettingsMemoryMeta = MemoryFileMeta;
 export interface SettingsMemoryControllerDeps {
   prompt: Pick<PromptHost, 'confirm' | 'warning'>;
   loadMemoryItems(): Promise<MemoryViewItem[]>;
+  loadMemoryPreview(storagePath: string): Promise<MemoryPreview>;
   isMemoryEnabled(): boolean;
   setMemoryEnabled(enabled: boolean): Promise<void>;
   resolveStoragePath(storagePath: string): string;
@@ -44,6 +48,10 @@ export type SettingsMemoryMessage =
       items: MemoryViewItem[];
     }
   | {
+      command: typeof SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW;
+      preview: MemoryPreview;
+    }
+  | {
       command: typeof SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED;
       enabled: boolean;
     };
@@ -55,6 +63,26 @@ export class SettingsMemoryController {
     return {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY,
       items: await this.deps.loadMemoryItems(),
+    };
+  }
+
+  async getMemoryPreviewMessage(
+    storagePath: string,
+  ): Promise<SettingsMemoryMessage> {
+    const resolvedPath = this.deps.resolveStoragePath(storagePath);
+    return {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
+      preview: await this.deps.loadMemoryPreview(resolvedPath),
+    };
+  }
+
+  getMemoryPreviewErrorMessage(storagePath: string): SettingsMemoryMessage {
+    return {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
+      preview: {
+        storagePath: this.deps.resolveStoragePath(storagePath),
+        error: true,
+      },
     };
   }
 

--- a/src/shared/schemas/memoryViewMessages.ts
+++ b/src/shared/schemas/memoryViewMessages.ts
@@ -22,14 +22,23 @@ export const MemoryViewItemSchema = z.object({
   storagePath: z.string(),
   size: z.number(),
   mtime: z.string(),
-  lineCount: z.number(),
-  preview: z.string(),
+  lineCount: z.number().optional(),
+  preview: z.string().optional(),
+  previewError: z.boolean().optional(),
   /** Agent that last modified this file (from frontmatter attribution). */
   modifiedBy: z.string().optional(),
   /** Whether this memory is pinned as a core long-term insight. */
   pinned: z.boolean().optional(),
 });
 export type MemoryViewItem = z.infer<typeof MemoryViewItemSchema>;
+
+export const MemoryPreviewSchema = z.object({
+  storagePath: z.string(),
+  lineCount: z.number().optional(),
+  preview: z.string().optional(),
+  error: z.boolean().optional(),
+});
+export type MemoryPreview = z.infer<typeof MemoryPreviewSchema>;
 
 // ============================================================
 // Outbound message schemas (backend → frontend)
@@ -40,6 +49,14 @@ export const UpdateMemoryMessageSchema = z.object({
   items: z.array(MemoryViewItemSchema),
 });
 export type UpdateMemoryMessage = z.infer<typeof UpdateMemoryMessageSchema>;
+
+export const UpdateMemoryPreviewMessageSchema = z.object({
+  command: z.literal(MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW),
+  preview: MemoryPreviewSchema,
+});
+export type UpdateMemoryPreviewMessage = z.infer<
+  typeof UpdateMemoryPreviewMessageSchema
+>;
 
 export const UpdateMemoryEnabledMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED),
@@ -85,6 +102,11 @@ export const GetMemoryDataMessageSchema = commandOnly(
   MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA,
 );
 
+export const GetMemoryPreviewMessageSchema = z.object({
+  command: z.literal(MEMORY_VIEW_COMMANDS.GET_MEMORY_PREVIEW),
+  storagePath: z.string().min(1),
+});
+
 export const OpenMemoryFileMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FILE),
   storagePath: z.string().min(1),
@@ -123,6 +145,7 @@ export const UnpinMemoryMessageSchema = MemoryPathMessageSchema.extend({
 
 export const MemoryViewInboundMessageSchema = z.discriminatedUnion('command', [
   GetMemoryDataMessageSchema,
+  GetMemoryPreviewMessageSchema,
   OpenMemoryFileMessageSchema,
   OpenMemoryFolderMessageSchema,
   DeleteMemoryMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -37,6 +37,7 @@ import {
   DeleteMemoryMessageSchema,
   GetMemoryDataMessageSchema,
   GetMemoryEnabledMessageSchema,
+  GetMemoryPreviewMessageSchema,
   OpenMemoryFileMessageSchema,
   OpenMemoryFolderMessageSchema,
   PinMemoryMessageSchema,
@@ -103,7 +104,9 @@ const CMD = SETTINGS_VIEW_CMD;
 // Re-export data schemas from individual view messages
 export {
   MemoryViewItemSchema,
+  MemoryPreviewSchema,
   type MemoryViewItem,
+  type MemoryPreview,
   type MemoryPathMessage,
   type MemoryDeleteMessage,
   type MemoryEnabledMessage,
@@ -919,6 +922,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetInlineCriticismEnabledMessageSchema,
     // Memory messages
     GetMemoryDataMessageSchema,
+    GetMemoryPreviewMessageSchema,
     OpenMemoryFileMessageSchema,
     OpenMemoryFolderMessageSchema,
     DeleteMemoryMessageSchema,

--- a/src/test/controllers/SettingsMemoryController.test.ts
+++ b/src/test/controllers/SettingsMemoryController.test.ts
@@ -96,10 +96,13 @@ function createController(options?: {
           storagePath: 'item.md',
           size: 13,
           mtime: '2026-05-03T00:00:00.000Z',
-          lineCount: 1,
-          preview: 'remember this',
         },
       ],
+      loadMemoryPreview: async (storagePath) => ({
+        storagePath,
+        lineCount: 1,
+        preview: 'remember this',
+      }),
       isMemoryEnabled: () => memoryEnabled,
       setMemoryEnabled: async (enabled) => {
         memoryEnabled = enabled;
@@ -137,10 +140,33 @@ describe('SettingsMemoryController', () => {
           storagePath: 'item.md',
           size: 13,
           mtime: '2026-05-03T00:00:00.000Z',
-          lineCount: 1,
-          preview: 'remember this',
         },
       ],
+    });
+  });
+
+  it('builds preview messages through the resolved storage path', async () => {
+    const { controller } = createController();
+
+    assert.deepEqual(await controller.getMemoryPreviewMessage('item.md'), {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
+      preview: {
+        storagePath: 'mem/item.md',
+        lineCount: 1,
+        preview: 'remember this',
+      },
+    });
+  });
+
+  it('builds preview error messages through the resolved storage path', () => {
+    const { controller } = createController();
+
+    assert.deepEqual(controller.getMemoryPreviewErrorMessage('item.md'), {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
+      preview: {
+        storagePath: 'mem/item.md',
+        error: true,
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- Load the Settings Memory tab with file metadata only, instead of reading every memory file body during the initial list refresh.
- Add an explicit memory-preview request/response path for VS Code and desktop hosts.
- Hydrate an item's preview when its contents panel is opened, then merge the preview back into the existing list item.

## Why

The previous refresh path scaled with the total size of all memory files. Large memory folders could make the extension host do unnecessary file reads and preview construction even when the user only needed the list.

## Validation

- ./node_modules/.bin/tsc --noEmit
- npm run compile-tests
- npm run lint (passes with existing warnings)
- env VITE_WEBVIEW=settingsView ../../node_modules/.bin/vite build --mode development
- focused ESLint and Prettier checks on the changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the settings-view memory data flow to fetch file contents on-demand via a new preview IPC/message path, which could impact UI state consistency and error handling across desktop and VS Code hosts.
> 
> **Overview**
> The Memory tab now loads *metadata-only* entries on refresh and lazy-fetches note contents via a new `GET_MEMORY_PREVIEW` / `UPDATE_MEMORY_PREVIEW` message pair shared across desktop and VS Code hosts.
> 
> This adds preview loading + error-state handling in the backend controllers and schema layer, updates the frontend to request previews when a memory item’s “Contents” panel is opened (showing loading/error placeholders), and adjusts pagination/test logic to avoid resetting state when only preview fields hydrate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60f6a1f579c22886382eea6328596807b994d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->