### PR TITLE
perf: precompute history search offsets

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -48,6 +48,8 @@ export class HistoryList extends LitElement {
 
   @state() private matchCounts: Map<string, number> = new Map();
 
+  private matchOffsets: Map<string, number> = new Map();
+
   @state() private searchVersion = 0;
 
   /** Current zero-based page index (used when not searching). */
@@ -117,6 +119,7 @@ export class HistoryList extends LitElement {
 
   private clearSearch(): void {
     this.matchCounts = new Map();
+    this.matchOffsets = new Map();
     ++this.searchVersion;
     this.state?.setSearchIndex(-1);
     this.state?.setTotalMatches(0);
@@ -146,21 +149,12 @@ export class HistoryList extends LitElement {
     if (!this.state || this.state.searchIndex < 0) return null;
 
     const globalIndex = this.state.searchIndex;
-    let cumulativeIndex = 0;
+    const itemOffset = this.matchOffsets.get(itemId);
+    if (itemOffset == null) return null;
 
-    for (const item of this.items) {
-      const count = this.matchCounts.get(item.id) ?? 0;
-      if (item.id === itemId) {
-        // Check if the global index falls within this item's range
-        if (
-          globalIndex >= cumulativeIndex &&
-          globalIndex < cumulativeIndex + count
-        ) {
-          return globalIndex - cumulativeIndex;
-        }
-        return null;
-      }
-      cumulativeIndex += count;
+    const count = this.matchCounts.get(itemId) ?? 0;
+    if (globalIndex >= itemOffset && globalIndex < itemOffset + count) {
+      return globalIndex - itemOffset;
     }
     return null;
   }
@@ -179,11 +173,20 @@ export class HistoryList extends LitElement {
       return;
     }
 
-    this.matchCounts = new Map(
-      this.items.map((item, i) => [item.id, counts[i] ?? 0]),
-    );
+    const nextCounts = new Map<string, number>();
+    const nextOffsets = new Map<string, number>();
+    let total = 0;
+    this.items.forEach((item, i) => {
+      const count = counts[i] ?? 0;
+      nextCounts.set(item.id, count);
+      if (count > 0) {
+        nextOffsets.set(item.id, total);
+      }
+      total += count;
+    });
 
-    const total = counts.reduce((sum, count) => sum + count, 0);
+    this.matchOffsets = nextOffsets;
+    this.matchCounts = nextCounts;
     this.state?.setTotalMatches(total);
     if (total > 0) {
       this.state?.setSearchIndex(0);


### PR DESCRIPTION
## Summary

- Precompute per-history-item match offsets after mark.js finishes a search pass.
- Use the offset map to resolve the highlighted match for each rendered item in constant time.

## Why

The previous search render path recomputed each item highlighted-match index by scanning from the beginning of the full history list. During a search render this creates an O(N squared) pass over history items on top of mark.js work.

## Validation

- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint packages/extension/src/settingsView/frontend/components/history/HistoryList.ts (existing import-order warning only)
- npm run lint (passes with existing warnings)
- env VITE_WEBVIEW=settingsView ../../node_modules/.bin/vite build --mode development
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the logic that maps the global search match index to per-item highlighted marks, so regressions could break match highlighting/navigation across history items. Scope is limited to the history search UI and is primarily a performance optimization.
> 
> **Overview**
> Improves history search rendering performance by precomputing a `matchOffsets` map (per item start index within the global match list) after each `applySearchToItems` pass.
> 
> Updates `getHighlightedMatchIndex` to use the precomputed offsets (instead of cumulatively scanning `items`) and ensures offsets are reset on `clearSearch`, keeping match navigation/highlighting behavior while avoiding an O(N²) render-time loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46fceb5f4e4ada16ae6c39aa44c02839400116f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->