### PR TITLE
perf: bound execution listing storage work

### DIFF
--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -9,6 +9,8 @@
  * into per-execution KV stores, then deletes the legacy sources.
  */
 
+import pMap from 'p-map';
+
 import { type AgentConfig, AgentConfigSchema } from '@agent/core/AgentConfig';
 import * as logger from '@agent/core/logger';
 import { getWorkspaceState } from '@agent/core/stateStore';
@@ -27,6 +29,7 @@ const CHANNEL = 'ExecutionListing';
 const INDEX_PATH = 'executions/index.json';
 const LEGACY_HISTORY_KEY = 'texra.agentHistory';
 const EXECUTION_ID_PATTERN = /^[0-9a-f][-0-9a-f]*$/i;
+const EXECUTION_STORAGE_CONCURRENCY = 32;
 
 // ============================================================================
 // Public types
@@ -108,9 +111,11 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     )
     .map(([name]) => name as ExecutionId);
 
-  // Read meta + config in parallel
-  const results = await Promise.all(
-    executionDirs.map(async (id): Promise<ExecutionListingEntry | null> => {
+  // Read meta + config with bounded concurrency. Large histories should not
+  // enqueue one storage read pair per execution all at once.
+  const results = await pMap(
+    executionDirs,
+    async (id): Promise<ExecutionListingEntry | null> => {
       try {
         const store = getExecutionStore(id);
         const [meta, cfg] = await Promise.all([
@@ -137,7 +142,8 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
         });
         return null;
       }
-    }),
+    },
+    { concurrency: EXECUTION_STORAGE_CONCURRENCY },
   );
 
   const listing = results
@@ -184,9 +190,14 @@ export async function deleteAllExecutions(
     )
     .map(([name]) => name as ExecutionId);
 
-  await Promise.all(executionDirs.map((id) => getExecutionStore(id).clear()));
-
-  invalidateListingCache();
+  try {
+    await pMap(executionDirs, (id) => getExecutionStore(id).clear(), {
+      concurrency: EXECUTION_STORAGE_CONCURRENCY,
+      stopOnError: false,
+    });
+  } finally {
+    invalidateListingCache();
+  }
 }
 
 // ============================================================================
@@ -249,8 +260,9 @@ function getWorkspaceStorageKey(): string {
  * Only writes if meta.json doesn't already exist (no overwriting).
  */
 async function backfillEntries(entries: unknown[]): Promise<void> {
-  await Promise.all(
-    entries.map(async (rawEntry) => {
+  await pMap(
+    entries,
+    async (rawEntry) => {
       if (!rawEntry || typeof rawEntry !== 'object') return;
 
       const candidate = rawEntry as {
@@ -284,6 +296,10 @@ async function backfillEntries(entries: unknown[]): Promise<void> {
         }),
         store.writeConfig(normalizedConfig),
       ]);
-    }),
+    },
+    {
+      concurrency: EXECUTION_STORAGE_CONCURRENCY,
+      stopOnError: false,
+    },
   );
 }


### PR DESCRIPTION
## Summary\n\n- Cap per-execution storage work in execution-history listing so a large history does not enqueue one meta/config read pair per entry at once.\n- Apply the same bounded storage work to delete-all and legacy history backfill paths.\n- Keep the existing listing shape, cache behavior, sorting, and per-entry corrupt-history handling unchanged.\n\n## Design note\n\nThis is deliberately a small performance boundary. The execution listing module still owns directory scanning and KV reads; the change only controls fan-out pressure on the extension host. It avoids adding a new cache, resolver, or pagination contract.\n\nRefs #3372.\n\n## Validation\n\n- npm run typecheck\n- npm run compile:fast\n- ../../node_modules/.bin/eslint src/agent/storage/executionListing.ts\n- ../../node_modules/.bin/prettier --check src/agent/storage/executionListing.ts\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces bounded-concurrency storage operations and changes bulk paths to continue on individual failures, which could mask per-execution errors or alter timing under load.
> 
> **Overview**
> Adds bounded concurrency (via `p-map`, default `32`) for per-execution storage reads when building the execution listing, preventing large histories from spawning unbounded parallel `meta`/`config` reads.
> 
> Applies the same bounded-concurrency approach to `deleteAllExecutions` and legacy `backfillEntries`, with `stopOnError: false` and a `finally`-guarded cache invalidation so bulk operations attempt all entries while still clearing the listing cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6d62cb83e288688af84c0eb119a6cab61d47ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->