### PR TITLE
refactor: consolidate work plan state

### DIFF
--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -488,8 +488,7 @@ export class ProgressEventHandler {
     this.webviewBridge.syncStream(stream);
 
     const { extras } = this.prepareStreamSyncExtras(stream);
-    const todos = this.state.getTodos(stream);
-    const plan = this.state.getPlan(stream);
+    const { todos, plan } = this.state.getWorkPlan(stream);
     const queuedFollowUps = ToolUseFollowUpQueue.getAll(stream);
     const agentCategory = this.getStreamCategory(stream);
 

--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -26,7 +26,6 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  TodoItemSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
@@ -34,7 +33,8 @@ import {
   type StreamTabId,
   type TodoItem,
   type Plan,
-  PlanSchema,
+  type WorkPlanSnapshot,
+  WorkPlanSnapshotSchema,
 } from '@shared/schemas';
 import {
   PersistedState,
@@ -53,8 +53,7 @@ export type StreamHints = z.infer<typeof StreamHintsSchema>;
 /** Ephemeral session state per stream (not persisted). */
 const StreamSessionStateSchema = z.object({
   hints: StreamHintsSchema.prefault({}),
-  todos: z.array(TodoItemSchema).prefault([]),
-  plan: PlanSchema.nullable().prefault(null),
+  workPlan: WorkPlanSnapshotSchema.prefault({}),
   contextState: ContextStateDataSchema.nullable().prefault(null),
 });
 
@@ -225,19 +224,35 @@ export class ProgressViewState {
   }
 
   setTodos(stream: StreamTabId, todos: TodoItem[]): void {
-    this.getOrCreateSession(stream).todos = todos;
+    const state = this.getOrCreateSession(stream);
+    state.workPlan = WorkPlanSnapshotSchema.parse({
+      ...state.workPlan,
+      todos,
+    });
   }
 
   getTodos(stream: StreamTabId): TodoItem[] {
-    return this._sessionState.get(stream)?.todos ?? [];
+    return this._sessionState.get(stream)?.workPlan.todos ?? [];
   }
 
   setPlan(stream: StreamTabId, plan: Plan | null): void {
-    this.getOrCreateSession(stream).plan = plan;
+    const state = this.getOrCreateSession(stream);
+    state.workPlan = WorkPlanSnapshotSchema.parse({
+      ...state.workPlan,
+      plan,
+      planSummary: plan?.summary ?? null,
+    });
   }
 
   getPlan(stream: StreamTabId): Plan | null {
-    return this._sessionState.get(stream)?.plan ?? null;
+    return this._sessionState.get(stream)?.workPlan.plan ?? null;
+  }
+
+  getWorkPlan(stream: StreamTabId): WorkPlanSnapshot {
+    return (
+      this._sessionState.get(stream)?.workPlan ??
+      WorkPlanSnapshotSchema.parse({})
+    );
   }
 
   getContextState(stream: StreamTabId): ContextStateData | undefined {

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -2,13 +2,14 @@ import { z } from 'zod';
 
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import {
-  TodoItemSchema,
-  PlanSchema,
   FileLocationSchema,
+  WorkPlanSnapshotSchema,
   type TodoItem,
   type Plan,
   type FileLocation,
+  type WorkPlanSnapshot,
 } from '@shared/schemas';
+import { isPlainObject } from '@shared/utils/string';
 import { FlattenedEditRecordSchema } from '@tools/result';
 import { pathToLocation } from '@utils/files';
 
@@ -230,44 +231,77 @@ const ServerToolContentStateSchema = z.object({
 
 type ServerToolContentState = z.output<typeof ServerToolContentStateSchema>;
 
-/** Internal schema for todo state snapshot. */
-const TodoStateSnapshotSchema = z.object({
-  todos: z.array(TodoItemSchema).prefault([]),
-});
-
-type TodoStateSnapshot = z.output<typeof TodoStateSnapshotSchema>;
-
-export class TodoState {
+export class WorkPlanState {
   private _todos: TodoItem[] = [];
-  private _onUpdate?: (todos: TodoItem[]) => void;
+  private _plan: Plan | null = null;
+  private _planSummary: string | null = null;
+  private _onTodosUpdate?: (todos: TodoItem[]) => void;
+  private _onPlanUpdate?: (plan: Plan | null) => void;
 
-  static fromSnapshot(snapshot: unknown): TodoState {
-    const parsed = TodoStateSnapshotSchema.parse(snapshot);
-    const state = new TodoState();
+  static fromSnapshot(snapshot: unknown): WorkPlanState {
+    const parsed = WorkPlanSnapshotSchema.parse(snapshot);
+    const state = new WorkPlanState();
     state._todos = [...parsed.todos];
+    state._plan = parsed.plan;
+    state._planSummary = parsed.planSummary;
     return state;
   }
 
-  toSnapshot(): TodoStateSnapshot {
-    return { todos: [...this._todos] };
+  toSnapshot(): WorkPlanSnapshot {
+    return WorkPlanSnapshotSchema.parse({
+      todos: [...this._todos],
+      plan: this._plan
+        ? {
+            ...this._plan,
+            steps: this._plan.steps.map((s) => ({ ...s, files: [...s.files] })),
+          }
+        : null,
+      planSummary: this._plan?.summary ?? this._planSummary,
+    });
   }
 
   get todos(): TodoItem[] {
     return this._todos;
   }
 
-  setOnUpdate(callback: (todos: TodoItem[]) => void): void {
-    this._onUpdate = callback;
+  get plan(): Plan | null {
+    return this._plan;
+  }
+
+  get planSummary(): string | null {
+    return this._plan?.summary ?? this._planSummary;
+  }
+
+  setOnUpdate(callbacks: {
+    onTodosUpdate?: (todos: TodoItem[]) => void;
+    onPlanUpdate?: (plan: Plan | null) => void;
+  }): void {
+    this._onTodosUpdate = callbacks.onTodosUpdate;
+    this._onPlanUpdate = callbacks.onPlanUpdate;
   }
 
   clearOnUpdate(): void {
-    this._onUpdate = undefined;
+    this._onTodosUpdate = undefined;
+    this._onPlanUpdate = undefined;
   }
 
   updateTodos(todos: TodoItem[]): void {
     if (this._todosEqual(this._todos, todos)) return;
     this._todos = todos;
-    this._onUpdate?.(todos);
+    this._onTodosUpdate?.(todos);
+  }
+
+  updatePlan(plan: Plan | null): void {
+    const nextPlanSummary = plan?.summary ?? null;
+    if (
+      this._planEqual(this._plan, plan) &&
+      this._planSummary === nextPlanSummary
+    ) {
+      return;
+    }
+    this._plan = plan;
+    this._planSummary = nextPlanSummary;
+    this._onPlanUpdate?.(plan);
   }
 
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
@@ -275,7 +309,7 @@ export class TodoState {
     for (let i = 0; i < a.length; i++) {
       const ai = a[i],
         bi = b[i];
-      if (!ai || !bi) return false; // Guard against sparse arrays
+      if (!ai || !bi) return false;
       if (
         ai.content !== bi.content ||
         ai.status !== bi.status ||
@@ -285,58 +319,6 @@ export class TodoState {
       }
     }
     return true;
-  }
-
-  reset(): void {
-    this._todos = [];
-  }
-}
-
-/** Internal schema for plan state snapshot. */
-const PlanStateSnapshotSchema = z.object({
-  plan: PlanSchema.nullable().prefault(null),
-});
-
-type PlanStateSnapshot = z.output<typeof PlanStateSnapshotSchema>;
-
-export class PlanState {
-  private _plan: Plan | null = null;
-  private _onUpdate?: (plan: Plan | null) => void;
-
-  static fromSnapshot(snapshot: unknown): PlanState {
-    const parsed = PlanStateSnapshotSchema.parse(snapshot);
-    const state = new PlanState();
-    state._plan = parsed.plan;
-    return state;
-  }
-
-  toSnapshot(): PlanStateSnapshot {
-    return {
-      plan: this._plan
-        ? {
-            ...this._plan,
-            steps: this._plan.steps.map((s) => ({ ...s, files: [...s.files] })),
-          }
-        : null,
-    };
-  }
-
-  get plan(): Plan | null {
-    return this._plan;
-  }
-
-  setOnUpdate(callback: (plan: Plan | null) => void): void {
-    this._onUpdate = callback;
-  }
-
-  clearOnUpdate(): void {
-    this._onUpdate = undefined;
-  }
-
-  updatePlan(plan: Plan | null): void {
-    if (this._planEqual(this._plan, plan)) return;
-    this._plan = plan;
-    this._onUpdate?.(plan);
   }
 
   private _planEqual(a: Plan | null, b: Plan | null): boolean {
@@ -362,27 +344,50 @@ export class PlanState {
   }
 
   reset(): void {
+    this._todos = [];
     this._plan = null;
+    this._planSummary = null;
   }
 }
 
-export const AgentWorkspaceStateSnapshotSchema = z.object({
-  assembly: ResponseAssemblyStateSchema.prefault({
-    lastResponse: '',
-    accumulatedOutput: '',
+function unwrapLegacyStateValue(value: unknown, key: string): unknown {
+  if (Array.isArray(value)) return value;
+  if (!isPlainObject(value)) return undefined;
+  return value[key] ?? value;
+}
+
+function normalizeAgentWorkspaceSnapshot(input: unknown): unknown {
+  const record = isPlainObject(input) ? input : {};
+  const workPlan = record.workPlan ?? {
+    todos: unwrapLegacyStateValue(record.todos, 'todos'),
+    plan: unwrapLegacyStateValue(record.plan, 'plan'),
+  };
+
+  return {
+    ...record,
+    workPlan,
+  };
+}
+
+export const AgentWorkspaceStateSnapshotSchema = z.preprocess(
+  normalizeAgentWorkspaceSnapshot,
+  z.object({
+    assembly: ResponseAssemblyStateSchema.prefault({
+      lastResponse: '',
+      accumulatedOutput: '',
+    }),
+    media: MediaAttachmentStateSnapshotSchema.prefault({ files: [] }),
+    reasoning: ReasoningCacheStateSchema.prefault({
+      thinkingBlocks: [],
+      thinkingAdded: false,
+    }),
+    interactions: FileInteractionStateSnapshotSchema.prefault({
+      readFiles: [],
+      edits: [],
+    }),
+    workPlan: WorkPlanSnapshotSchema.prefault({}),
   }),
-  media: MediaAttachmentStateSnapshotSchema.prefault({ files: [] }),
-  reasoning: ReasoningCacheStateSchema.prefault({
-    thinkingBlocks: [],
-    thinkingAdded: false,
-  }),
-  interactions: FileInteractionStateSnapshotSchema.prefault({
-    readFiles: [],
-    edits: [],
-  }),
-  todos: TodoStateSnapshotSchema.prefault({ todos: [] }),
-  plan: PlanStateSnapshotSchema.prefault({ plan: null }),
-});
+);
 
 export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema
@@ -394,8 +399,7 @@ export class AgentWorkspaceState {
   public readonly reasoning: ReasoningCacheState;
   public readonly interactions: FileInteractionState;
   public readonly serverToolContent: ServerToolContentState;
-  public readonly todos: TodoState;
-  public readonly plan: PlanState;
+  public readonly workPlan: WorkPlanState;
 
   private constructor(
     assembly: ResponseAssemblyState,
@@ -403,16 +407,14 @@ export class AgentWorkspaceState {
     reasoning: ReasoningCacheState,
     interactions: FileInteractionState,
     serverToolContent: ServerToolContentState,
-    todos: TodoState,
-    plan: PlanState,
+    workPlan: WorkPlanState,
   ) {
     this.assembly = assembly;
     this.media = media;
     this.reasoning = reasoning;
     this.interactions = interactions;
     this.serverToolContent = serverToolContent;
-    this.todos = todos;
-    this.plan = plan;
+    this.workPlan = workPlan;
   }
 
   static create(): AgentWorkspaceState {
@@ -422,8 +424,7 @@ export class AgentWorkspaceState {
       ReasoningCacheStateSchema.parse({}),
       new FileInteractionState(),
       ServerToolContentStateSchema.parse({}),
-      new TodoState(),
-      new PlanState(),
+      new WorkPlanState(),
     );
   }
 
@@ -444,8 +445,7 @@ export class AgentWorkspaceState {
       parsed.reasoning,
       FileInteractionState.fromSnapshot(parsed.interactions),
       ServerToolContentStateSchema.parse({}),
-      TodoState.fromSnapshot(parsed.todos),
-      PlanState.fromSnapshot(parsed.plan),
+      WorkPlanState.fromSnapshot(parsed.workPlan),
     );
   }
 
@@ -464,8 +464,7 @@ export class AgentWorkspaceState {
         thinkingBlocks: [...this.reasoning.thinkingBlocks],
       },
       interactions: this.interactions.toSnapshot(),
-      todos: this.todos.toSnapshot(),
-      plan: this.plan.toSnapshot(),
+      workPlan: this.workPlan.toSnapshot(),
     };
   }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -643,8 +643,7 @@ export function createResponseCycleFlow<C>(): Flow<
       return formatPostCompactionContext(
         subagents,
         processes,
-        services.workspace.todos.todos,
-        services.workspace.plan.plan,
+        services.workspace.workPlan.toSnapshot(),
       );
     },
     getDebugSaveOptions: (shared, services) => ({

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -30,8 +30,7 @@ import {
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type {
   FileInteractionState,
-  PlanState,
-  TodoState,
+  WorkPlanState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ToolResult } from '@agent/core/ToolTypes';
 import { getActiveChildren } from '@agent/runtime/executionRegistry';
@@ -726,8 +725,7 @@ class ToolUseDispatchNode<C> extends Node<
       call,
       this.services,
       workspace.interactions,
-      workspace.todos,
-      workspace.plan,
+      workspace.workPlan,
     );
   }
 
@@ -745,8 +743,7 @@ class ToolUseDispatchNode<C> extends Node<
     parsedInput: unknown,
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
-    todoState: TodoState,
-    planState: PlanState,
+    workPlanState: WorkPlanState,
     onExecutionReady?: () => void,
     onToolOutput?: (chunk: string) => void,
   ): Promise<ToolResult> {
@@ -758,8 +755,7 @@ class ToolUseDispatchNode<C> extends Node<
       return await withToolFileInteractionContext(
         {
           tracker,
-          todoState,
-          planState,
+          workPlanState,
           toolCallId: call.callId,
           onExecutionReady,
           onToolOutput,
@@ -777,8 +773,7 @@ class ToolUseDispatchNode<C> extends Node<
     call: SdkToolCall,
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
-    todoState: TodoState,
-    planState: PlanState,
+    workPlanState: WorkPlanState,
   ): Promise<ToolExecutionResult> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
@@ -834,8 +829,7 @@ class ToolUseDispatchNode<C> extends Node<
       parsedInput,
       options,
       tracker,
-      todoState,
-      planState,
+      workPlanState,
       onExecutionReady,
       onToolOutput,
     );
@@ -1028,8 +1022,7 @@ export function createToolUseCycleFlow<C>(): Flow<
       return formatPostCompactionContext(
         subagents,
         processes,
-        services.workspace.todos.todos,
-        services.workspace.plan.plan,
+        services.workspace.workPlan.toSnapshot(),
       );
     },
     getDebugSaveOptions: (shared, services) => ({

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -51,8 +51,7 @@ export class ToolUseCycleNode<C> extends Node<
     } = this.services;
 
     if (prepRes.shouldSkip) {
-      const { todos } = prepRes.workspaceState.todos;
-      const { plan } = prepRes.workspaceState.plan;
+      const { todos, plan } = prepRes.workspaceState.workPlan;
       if (todos.length) {
         runtimeHost.emit('updateTodos', { streamId, todos });
       }
@@ -89,18 +88,20 @@ export class ToolUseCycleNode<C> extends Node<
 
     const { onProgress, persistTodos } = this.services;
     let todoPersistChain = Promise.resolve();
-    prepRes.workspaceState.todos.setOnUpdate((todos) => {
-      runtimeHost.emit('updateTodos', { streamId, todos });
-      if (persistTodos) {
-        todoPersistChain = todoPersistChain
-          .then(() => persistTodos(todos))
-          .catch(() => {});
-      }
-      onProgress?.({ kind: 'todos', todos });
-    });
-    prepRes.workspaceState.plan.setOnUpdate((plan) => {
-      runtimeHost.emit('updatePlan', { streamId, plan });
-      onProgress?.({ kind: 'plan', plan });
+    prepRes.workspaceState.workPlan.setOnUpdate({
+      onTodosUpdate: (todos) => {
+        runtimeHost.emit('updateTodos', { streamId, todos });
+        if (persistTodos) {
+          todoPersistChain = todoPersistChain
+            .then(() => persistTodos(todos))
+            .catch(() => {});
+        }
+        onProgress?.({ kind: 'todos', todos });
+      },
+      onPlanUpdate: (plan) => {
+        runtimeHost.emit('updatePlan', { streamId, plan });
+        onProgress?.({ kind: 'plan', plan });
+      },
     });
 
     try {
@@ -118,8 +119,7 @@ export class ToolUseCycleNode<C> extends Node<
       }
       return { outcome: 'completed', messages: cycleShared.messages };
     } finally {
-      prepRes.workspaceState.todos.clearOnUpdate();
-      prepRes.workspaceState.plan.clearOnUpdate();
+      prepRes.workspaceState.workPlan.clearOnUpdate();
       // Drain in-flight persist writes before returning so they don't
       // race with the projection's writeTodos after this node completes.
       await todoPersistChain;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -233,7 +233,7 @@ export async function runToolUseFlow<C = unknown>(
     >(prepareNode, kv);
     pf.setServices(services);
     pf.setProjection(async (s, store) => {
-      const todos = s.stateSlices?.workspaceSnapshot?.todos?.todos;
+      const todos = s.stateSlices?.workspaceSnapshot?.workPlan?.todos;
       if (Array.isArray(todos) && todos.length) await store.writeTodos(todos);
       if (s.messages.length) await store.writeConversation(s.messages);
     });

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -4,8 +4,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 // Type imports
 import type {
   FileInteractionState,
-  PlanState,
-  TodoState,
+  WorkPlanState,
 } from '@agent/core/AgentWorkspaceState';
 import {
   tryUseRunContext,
@@ -18,10 +17,8 @@ export type { ToolRunContext } from '@agent/runtime/RunContext';
 export interface ToolCallContext {
   toolCallId?: string;
   tracker: FileInteractionState;
-  /** Todo state for managing task lists. Absent in contexts without todo support. */
-  todoState?: TodoState;
-  /** Plan state for managing implementation plans. Absent in contexts without plan support. */
-  planState?: PlanState;
+  /** Plan and todo progress state. Absent in contexts without work-plan support. */
+  workPlanState?: WorkPlanState;
   /** Called by tools with approval flows to trigger in-progress log after approval. */
   onExecutionReady?: () => void;
   /** Called by tools to push partial output for live streaming to the UI. */
@@ -60,8 +57,7 @@ const TOOL_RUN_CONTEXT_KEYS = {
 const TOOL_CALL_CONTEXT_KEYS = {
   toolCallId: true,
   tracker: true,
-  todoState: true,
-  planState: true,
+  workPlanState: true,
   onExecutionReady: true,
   onToolOutput: true,
 } satisfies ContextKeyMap<ToolCallContext>;

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -22,6 +22,7 @@ export * from './taskGroup';
 export * from './todo';
 export * from './todoDisplay';
 export * from './plan';
+export * from './workPlan';
 export * from './subagentProgress';
 export * from './prompts';
 export * from './diffResult';

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+import { isPlainObject } from '@shared/utils/string';
+
+import { PlanSchema, type Plan } from './plan';
+import { TodoItemSchema } from './todo';
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function parsePlan(value: unknown): Plan | null {
+  const result = PlanSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+function extractPlanSummary(value: unknown): string | null {
+  return isPlainObject(value) ? nonEmptyString(value.summary) : null;
+}
+
+function normalizeWorkPlanSnapshot(input: unknown): unknown {
+  const record = isPlainObject(input) ? input : {};
+  const plan = parsePlan(record.plan);
+  const planSummary =
+    plan?.summary ??
+    nonEmptyString(record.planSummary) ??
+    extractPlanSummary(record.plan);
+
+  return {
+    todos: record.todos,
+    plan,
+    planSummary,
+  };
+}
+
+/** Current serializable shape for workspace plan and todo progress state. */
+export const WorkPlanSnapshotSchema = z.preprocess(
+  normalizeWorkPlanSnapshot,
+  z.strictObject({
+    todos: z.array(TodoItemSchema).prefault([]),
+    plan: PlanSchema.nullable().prefault(null),
+    planSummary: z.string().nullable().prefault(null),
+  }),
+);
+
+export type WorkPlanSnapshot = z.output<typeof WorkPlanSnapshotSchema>;

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -1,0 +1,80 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import type { Plan, TodoItem } from '@shared/schemas';
+import { formatPostCompactionContext } from '@tools/subagentResults';
+
+const todo: TodoItem = {
+  content: 'Consolidate plan and todo state',
+  status: 'in_progress',
+  activeForm: 'Consolidating plan and todo state',
+};
+
+const plan: Plan = {
+  summary: 'Use one workspace owner for plan and todo progress.',
+  steps: [
+    {
+      title: 'Introduce owner',
+      description: 'Move plan and todo progress behind WorkPlanState.',
+      status: 'pending',
+      files: ['src/agent/core/AgentWorkspaceState.ts'],
+    },
+  ],
+};
+
+describe('agent workspace work-plan state', () => {
+  it('migrates legacy todo and plan snapshots into the current workPlan shape', () => {
+    const state = AgentWorkspaceState.fromSnapshot({
+      todos: { todos: [todo] },
+      plan: { plan },
+    });
+
+    expect(state.workPlan.todos).toEqual([todo]);
+    expect(state.workPlan.plan).toEqual(plan);
+
+    const snapshot = state.toSnapshot();
+    expect(Object.hasOwn(snapshot, 'todos')).toBe(false);
+    expect(Object.hasOwn(snapshot, 'plan')).toBe(false);
+    expect(snapshot.workPlan).toEqual({
+      todos: [todo],
+      plan,
+      planSummary: plan.summary,
+    });
+  });
+
+  it('keeps a legacy summary-only plan visible after compaction', () => {
+    const state = AgentWorkspaceState.fromSnapshot({
+      plan: {
+        plan: {
+          summary: 'Retain the plan summary even when no steps remain.',
+          steps: [],
+        },
+      },
+    });
+
+    expect(state.workPlan.plan).toBeNull();
+    expect(state.workPlan.planSummary).toBe(
+      'Retain the plan summary even when no steps remain.',
+    );
+
+    const context = formatPostCompactionContext(
+      [],
+      [],
+      state.workPlan.toSnapshot(),
+    );
+
+    expect(context).toContain(
+      '<current-plan summary="Retain the plan summary even when no steps remain.">',
+    );
+    expect(context).not.toContain('<step ');
+
+    state.workPlan.updatePlan(null);
+
+    expect(state.workPlan.planSummary).toBeNull();
+    expect(
+      formatPostCompactionContext([], [], state.workPlan.toSnapshot()) ?? '',
+    ).not.toContain('<current-plan');
+  });
+});

--- a/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
@@ -43,8 +43,8 @@ describe('tool-use progress events', () => {
   it('publishes skipped-cycle todo and plan events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
     const workspaceState = AgentWorkspaceState.create();
-    workspaceState.todos.updateTodos([todo]);
-    workspaceState.plan.updatePlan(plan);
+    workspaceState.workPlan.updateTodos([todo]);
+    workspaceState.workPlan.updatePlan(plan);
 
     const node = new ToolUseCycleNode().setServices({
       streamId: 'stream:tool-use-cycle',

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -1,0 +1,108 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  default: {},
+  Disposable: class {
+    constructor(private readonly callback: () => void) {}
+
+    dispose(): void {
+      this.callback();
+    }
+  },
+  window: {},
+  workspace: {},
+  Uri: {},
+}));
+
+// Local imports
+import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler';
+import type { WebviewBridge } from '@progressView/managers/WebviewBridge';
+import type {
+  SyncStreamContentPayload,
+  WebviewUpdater,
+} from '@progressView/managers/WebviewUpdater';
+import type { MementoStorage } from '@progressView/persistence/PersistentMapManager';
+import { ProgressViewState } from '@progressView/state/ProgressViewState';
+import type { Plan, TodoItem } from '@shared/schemas';
+
+class MemoryMementoStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  update<T>(key: string, value: T): Thenable<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+const todo: TodoItem = {
+  content: 'Hydrate work-plan state',
+  status: 'pending',
+  activeForm: 'Hydrating work-plan state',
+};
+
+const plan: Plan = {
+  summary: 'Hydrate plan and todo state from one backend owner.',
+  steps: [
+    {
+      title: 'Sync active stream',
+      description: 'Read todos and plan from ProgressViewState.workPlan.',
+      status: 'pending',
+      files: [
+        'packages/extension/src/progressView/events/ProgressEventHandler.ts',
+      ],
+    },
+  ],
+};
+
+describe('progress view work-plan hydration', () => {
+  it('syncs todos and plan from the current package progress-view state', async () => {
+    const state = new ProgressViewState(new MemoryMementoStorage());
+    await Promise.all([
+      state.outputFiles.load([]),
+      state.usageStats.load([]),
+      state.meta.load([]),
+    ]);
+    const messages: SyncStreamContentPayload[] = [];
+    const updater = {
+      isAvailable: () => true,
+      sendSyncStreamContent: (payload: SyncStreamContentPayload) => {
+        messages.push(payload);
+      },
+    } as unknown as WebviewUpdater;
+    const bridge = {
+      syncStream: vi.fn(),
+      clearAll: vi.fn(),
+    } as unknown as WebviewBridge;
+    const handler = new ProgressEventHandler(
+      state,
+      updater,
+      bridge,
+      {} as never,
+      () => false,
+    );
+
+    state.setTodos('stream:work-plan', [todo]);
+    state.setPlan('stream:work-plan', plan);
+    handler.syncStreamContent('stream:work-plan');
+
+    expect(bridge.syncStream).toHaveBeenCalledWith('stream:work-plan');
+    expect(messages.at(-1)).toMatchObject({
+      stream: 'stream:work-plan',
+      action: 'render',
+      todos: [todo],
+      plan,
+    });
+    expect(state.getWorkPlan('stream:work-plan')).toEqual({
+      todos: [todo],
+      plan,
+      planSummary: plan.summary,
+    });
+  });
+});

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -1,0 +1,102 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  FileInteractionState,
+  WorkPlanState,
+} from '@agent/core/AgentWorkspaceState';
+import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import {
+  createRunContext,
+  withRunContext,
+  type RunCoordinators,
+} from '@agent/runtime/RunContext';
+import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import type { Plan } from '@shared/schemas';
+import { PlanTool } from '@tools/plan/PlanTool';
+import { createRecordingHost } from '../agent/progressTestUtils';
+
+const plan: Plan = {
+  summary: 'Refactor the plan state boundary.',
+  steps: [
+    {
+      title: 'Move ownership',
+      description: 'Store plan progress in WorkPlanState.',
+      status: 'pending',
+      files: ['src/agent/core/AgentWorkspaceState.ts'],
+    },
+  ],
+};
+
+describe('PlanTool work-plan state', () => {
+  it('clears a rejected plan from displayed work-plan state', async () => {
+    const { events, host } = createRecordingHost();
+    const coordinator = new PlanApprovalCoordinator(host);
+    const workPlanState = new WorkPlanState();
+    const tool = new PlanTool();
+
+    const resultPromise = withRunContext(
+      createRunContext({
+        runtimeHost: host,
+        coordinators: { plan: coordinator } as unknown as RunCoordinators,
+      }),
+      () =>
+        withToolFileInteractionContext(
+          {
+            streamId: 'stream:plan-reject',
+            tracker: new FileInteractionState(),
+            workPlanState,
+          },
+          () => tool.call({ plan }),
+        ),
+    );
+
+    const approval = events.find((entry) => entry.event === 'showPlanApproval');
+    expect(approval).toBeDefined();
+    coordinator.resolveRequest(
+      (approval!.payload as { approvalId: string }).approvalId,
+      { action: 'reject', feedback: 'Too broad.' },
+    );
+
+    const result = await resultPromise;
+    expect(result.isError).toBe(true);
+    expect(workPlanState.plan).toBeNull();
+    expect(workPlanState.planSummary).toBeNull();
+  });
+
+  it('clears a timed-out plan from displayed work-plan state', async () => {
+    const { events, host } = createRecordingHost();
+    const coordinator = new PlanApprovalCoordinator(host);
+    const workPlanState = new WorkPlanState();
+    const tool = new PlanTool();
+
+    const resultPromise = withRunContext(
+      createRunContext({
+        runtimeHost: host,
+        coordinators: { plan: coordinator } as unknown as RunCoordinators,
+      }),
+      () =>
+        withToolFileInteractionContext(
+          {
+            streamId: 'stream:plan-timeout',
+            tracker: new FileInteractionState(),
+            workPlanState,
+          },
+          () => tool.call({ plan }),
+        ),
+    );
+
+    const approval = events.find((entry) => entry.event === 'showPlanApproval');
+    expect(approval).toBeDefined();
+    coordinator.resolveRequest(
+      (approval!.payload as { approvalId: string }).approvalId,
+      { action: 'timeout' },
+    );
+
+    const result = await resultPromise;
+    expect(result.isError).toBe(true);
+    expect(workPlanState.plan).toBeNull();
+    expect(workPlanState.planSummary).toBeNull();
+  });
+});

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -15,7 +15,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { PlanState } from '@agent/core/AgentWorkspaceState';
+import type { WorkPlanState } from '@agent/core/AgentWorkspaceState';
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import { waitForPlanApproval } from '@agent/runtime/runCoordinators';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
@@ -102,9 +102,9 @@ Best practices:
     const callContext = contexts?.callContext;
     const runContext = contexts?.runContext;
 
-    if (!callContext?.planState) {
+    if (!callContext?.workPlanState) {
       logger.warn(
-        'plan called without planState in context — plan will not persist or display in UI',
+        'plan called without workPlanState in context — plan will not persist or display in UI',
       );
       return {
         summary: 'Created plan (no active session)',
@@ -121,7 +121,7 @@ Best practices:
     );
 
     // Show the plan in the UI immediately
-    callContext.planState.updatePlan(input.plan);
+    callContext.workPlanState.updatePlan(input.plan);
 
     if (isNewPlan) {
       if (!runContext?.streamId) {
@@ -135,7 +135,7 @@ Best practices:
         return this.requestApproval(
           input.plan,
           runContext.streamId,
-          callContext.planState,
+          callContext.workPlanState,
         );
       }
     }
@@ -149,7 +149,7 @@ Best practices:
   private async requestApproval(
     plan: Plan,
     streamId: string,
-    planState: PlanState,
+    workPlanState: WorkPlanState,
   ): Promise<ToolResult> {
     const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
 
@@ -166,7 +166,7 @@ Best practices:
     }
 
     // Rejected or timed out — clear the plan from UI
-    planState.updatePlan(null);
+    workPlanState.updatePlan(null);
 
     if (result.action === 'timeout') {
       logger.warn('Plan approval timed out');

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -17,7 +17,7 @@ import type {
   ActiveChildInfo,
   SubagentProgressUpdate,
   TodoItem,
-  Plan,
+  WorkPlanSnapshot,
 } from '@shared/schemas';
 import { countByStatus, STATUS_DISPLAY } from '@shared/schemas/todoDisplay';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
@@ -342,12 +342,12 @@ export function formatBashError(
 export function formatPostCompactionContext(
   subagents: ActiveChildInfo[],
   processes: ActiveChildInfo[],
-  todos?: TodoItem[],
-  plan?: Plan | null,
+  workPlan?: WorkPlanSnapshot | null,
 ): string | null {
   const hasChildren = subagents.length > 0 || processes.length > 0;
-  const hasTodos = todos != null && todos.length > 0;
-  const hasPlan = plan != null;
+  const todos = workPlan?.todos ?? [];
+  const hasTodos = todos.length > 0;
+  const hasPlan = workPlan?.plan != null || workPlan?.planSummary != null;
 
   if (!hasChildren && !hasTodos && !hasPlan) {
     return null;
@@ -394,7 +394,7 @@ export function formatPostCompactionContext(
   }
 
   if (hasPlan) {
-    lines.push(...formatPlanContext(plan));
+    lines.push(...formatPlanContext(workPlan));
   }
 
   lines.push('</post-compaction-context>');
@@ -418,19 +418,23 @@ function formatTodoContext(todos: TodoItem[]): string[] {
 /**
  * Format plan as XML lines for post-compaction context.
  */
-function formatPlanContext(plan: Plan): string[] {
-  const lines: string[] = [
-    `<current-plan summary="${escapeAttr(plan.summary)}">`,
-  ];
-  for (let i = 0; i < plan.steps.length; i++) {
-    const step = plan.steps[i]!;
-    const filesAttr =
-      step.files.length > 0
-        ? ` files="${escapeAttr(step.files.join(', '))}"`
-        : '';
-    lines.push(
-      `  <step index="${i + 1}" status="${escapeAttr(step.status)}" title="${escapeAttr(step.title)}"${filesAttr}>${escapeText(step.description)}</step>`,
-    );
+function formatPlanContext(workPlan: WorkPlanSnapshot): string[] {
+  const plan = workPlan.plan;
+  const summary = plan?.summary ?? workPlan.planSummary;
+  if (!summary) return [];
+
+  const lines: string[] = [`<current-plan summary="${escapeAttr(summary)}">`];
+  if (plan) {
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i]!;
+      const filesAttr =
+        step.files.length > 0
+          ? ` files="${escapeAttr(step.files.join(', '))}"`
+          : '';
+      lines.push(
+        `  <step index="${i + 1}" status="${escapeAttr(step.status)}" title="${escapeAttr(step.title)}"${filesAttr}>${escapeText(step.description)}</step>`,
+      );
+    }
   }
   lines.push('</current-plan>');
   return lines;

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -81,10 +81,10 @@ Best practices:
   protected async execute(input: TodoWriteInput): Promise<ToolResult> {
     const context = getCurrentToolCallContext();
 
-    if (!context?.todoState) {
+    if (!context?.workPlanState) {
       // No context available - log warning and still format output
       logger.warn(
-        'todo_write called without todoState in context - todos will not persist or display in UI',
+        'todo_write called without workPlanState in context - todos will not persist or display in UI',
       );
       return {
         summary: 'Updated todo list (no active session)',
@@ -97,7 +97,7 @@ Best practices:
 
     // Update the todos in workspace state
     // This triggers the onUpdate callback which emits events to the UI
-    context.todoState.updateTodos(input.todos);
+    context.workPlanState.updateTodos(input.todos);
 
     const { completed, inProgress, pending } = countByStatus(input.todos);
 


### PR DESCRIPTION
## Summary

- Introduce WorkPlanState as the single workspace owner for plan and todo progress.
- Normalize legacy persisted { todos, plan } snapshots into workPlan at load time, while preserving legacy todos, plans, and summary-only plans.
- Keep plan and todo tools as meaningful public tool boundaries, but route both through the same work-plan state owner.
- Hydrate progress-view stream sync from the current packages/extension/src/progressView state path.

## Validation

- npm run test:kernel -- src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
- npm run typecheck
- npm run lint (passes with existing unrelated warnings)
- npm run compile:fast
- npm run test:kernel

Closes #3932

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors shared workspace/progress-view state shapes and adds migration/normalization logic for legacy snapshots, which could impact persisted/resumed sessions and UI hydration if any edge cases were missed.
> 
> **Overview**
> Consolidates plan and todo progress into a single `workPlan` owner across the agent workspace, tool-use flows, and the extension progress view, replacing separate `todos`/`plan` state slices.
> 
> Introduces `WorkPlanSnapshotSchema` (with `planSummary` support) and updates post-compaction context formatting and tool execution contexts to consume `workPlan` snapshots, including normalization/migration of legacy persisted `{ todos, plan }` shapes.
> 
> Updates `PlanTool` and `TodoWriteTool` to write through `workPlanState`, adjusts persistence projection to read `workspaceSnapshot.workPlan.todos`, and adds kernel tests covering legacy migration, summary-only plan retention, skipped-cycle progress events, and progress-view hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090a9427a5cdaf2f3f54fa8285a909720c020348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->