### PR TITLE
perf: index progress log updates

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -176,6 +176,9 @@ export class TaskGroupList extends LitElement {
     | { key: string; time: number; tree: GroupTree }
   > = [];
 
+  /** O(1) lookup from ungrouped message ID → cachedTimeline index. */
+  private timelineMessageIndex = new Map<string, number>();
+
   /** Reference to the scroll container */
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
   private scrollContainer?: HTMLElement;
@@ -575,7 +578,7 @@ export class TaskGroupList extends LitElement {
 
   /** Build full chronological timeline from cached tree + ungrouped. */
   private buildFullTimeline(): typeof this.cachedTimeline {
-    return [
+    const timeline = [
       ...this.cachedUngrouped.map((m) => ({
         key: m.id,
         time: m.timestamp ?? 0,
@@ -587,6 +590,8 @@ export class TaskGroupList extends LitElement {
         tree: t,
       })),
     ].sort((a, b) => a.time - b.time);
+    this.rebuildTimelineMessageIndex(timeline);
+    return timeline;
   }
 
   /**
@@ -610,11 +615,17 @@ export class TaskGroupList extends LitElement {
           ? this.cachedTimeline.at(-1)!.time
           : -Infinity;
       if (entry.time >= lastTime) {
+        this.timelineMessageIndex.set(entry.key, this.cachedTimeline.length);
         this.cachedTimeline.push(entry);
       } else {
         const idx = this.cachedTimeline.findIndex((e) => e.time > entry.time);
-        if (idx >= 0) this.cachedTimeline.splice(idx, 0, entry);
-        else this.cachedTimeline.push(entry);
+        if (idx >= 0) {
+          this.cachedTimeline.splice(idx, 0, entry);
+          this.reindexTimelineMessagesFrom(idx);
+        } else {
+          this.timelineMessageIndex.set(entry.key, this.cachedTimeline.length);
+          this.cachedTimeline.push(entry);
+        }
       }
     }
   }
@@ -644,12 +655,32 @@ export class TaskGroupList extends LitElement {
     for (const index of indices) {
       const msg = this.messages[index];
       if (!msg) continue;
-      for (let i = this.cachedTimeline.length - 1; i >= 0; i--) {
-        const item = this.cachedTimeline[i];
-        if ('msg' in item && item.key === msg.id) {
-          (item as { msg: LogMessageData }).msg = msg;
-          break;
-        }
+      const timelineIndex = this.timelineMessageIndex.get(msg.id);
+      if (timelineIndex === undefined) continue;
+      const item = this.cachedTimeline[timelineIndex];
+      if (item && 'msg' in item && item.key === msg.id) {
+        item.msg = msg;
+      }
+    }
+  }
+
+  private rebuildTimelineMessageIndex(
+    timeline: typeof this.cachedTimeline = this.cachedTimeline,
+  ): void {
+    this.timelineMessageIndex.clear();
+    for (let i = 0; i < timeline.length; i++) {
+      const item = timeline[i];
+      if ('msg' in item) {
+        this.timelineMessageIndex.set(item.key, i);
+      }
+    }
+  }
+
+  private reindexTimelineMessagesFrom(startIndex: number): void {
+    for (let i = startIndex; i < this.cachedTimeline.length; i++) {
+      const item = this.cachedTimeline[i];
+      if ('msg' in item) {
+        this.timelineMessageIndex.set(item.key, i);
       }
     }
   }

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -60,13 +60,23 @@ function toLogMessage(entry: StreamLogEntry): LogMessageData {
 
 function updateTaskGroups(
   streamState: StreamState,
+  taskGroupIndex: Map<string, number>,
   entry: StreamLogEntry,
 ): boolean {
   const payload =
     typeof entry.data === 'object' && entry.data !== null
       ? (entry.data as Record<string, unknown>)
       : {};
-  const groupIndex = streamState.taskGroups.findIndex((g) => g.id === entry.id);
+  const cachedIndex = taskGroupIndex.get(entry.id);
+  const groupIndex =
+    cachedIndex !== undefined &&
+    streamState.taskGroups[cachedIndex]?.id === entry.id
+      ? cachedIndex
+      : streamState.taskGroups.findIndex((g) => g.id === entry.id);
+
+  if (groupIndex >= 0 && groupIndex !== cachedIndex) {
+    taskGroupIndex.set(entry.id, groupIndex);
+  }
 
   if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
     const status = isTaskGroupStatus(payload.status)
@@ -81,6 +91,7 @@ function updateTaskGroups(
     };
 
     if (groupIndex === -1) {
+      taskGroupIndex.set(entry.id, streamState.taskGroups.length);
       streamState.taskGroups.push(nextGroup);
     } else {
       streamState.taskGroups[groupIndex] = nextGroup;
@@ -99,6 +110,7 @@ function updateTaskGroups(
     typeof payload.endTime === 'number' ? payload.endTime : undefined;
 
   if (groupIndex === -1) {
+    taskGroupIndex.set(entry.id, streamState.taskGroups.length);
     streamState.taskGroups.push({
       id: entry.id,
       name: entry.text ?? entry.id,
@@ -124,7 +136,11 @@ function applyEntry(
   streamLogs: StreamLogs,
   streamState: StreamState,
 ): { logChanged: boolean; stateChanged: boolean } {
-  let stateChanged = updateTaskGroups(streamState, entry);
+  let stateChanged = updateTaskGroups(
+    streamState,
+    streamLogs.taskGroupIndex,
+    entry,
+  );
 
   if (entry.messageType === MESSAGE_TYPES.CONTEXT_STATE) {
     const contextState = asContextStateData(entry.data);
@@ -163,6 +179,7 @@ export const logHandlers: HandlerRegistry = {
         const streamLogs: StreamLogs = existingStreamLogs ?? {
           logs: [],
           logIndex: new Map<string, number>(),
+          taskGroupIndex: new Map<string, number>(),
           updatedMessageIndices: [],
           updatedMessageBaseGeneration: 0,
           generation: 0,
@@ -197,6 +214,7 @@ export const logHandlers: HandlerRegistry = {
           draft.streamLogs.set(streamId, {
             logs: streamLogs.logs,
             logIndex: streamLogs.logIndex,
+            taskGroupIndex: streamLogs.taskGroupIndex,
             updatedMessageIndices: [...updatedMessageIndices],
             updatedMessageBaseGeneration,
             generation: streamLogs.generation + 1,

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -42,6 +42,8 @@ export interface StreamLogs {
   logs: LogMessageData[];
   /** O(1) lookup: log ID → array index. Maintained by mutation handlers. */
   logIndex: Map<string, number>;
+  /** O(1) lookup: task group ID → array index. Maintained by log handlers. */
+  taskGroupIndex: Map<string, number>;
   /**
    * Existing log-message indices updated by the most recent backend delta.
    * Pure append batches leave this empty so renderers can skip whole-log scans.
@@ -55,6 +57,7 @@ export interface StreamLogs {
 export const EMPTY_STREAM_LOGS: StreamLogs = {
   logs: [],
   logIndex: new Map(),
+  taskGroupIndex: new Map(),
   updatedMessageIndices: [],
   updatedMessageBaseGeneration: 0,
   generation: 0,


### PR DESCRIPTION
## Summary
- Add a task-group index to progress log frontend state so group start/end entries do not scan every group on each delta.
- Add an ungrouped-message timeline index in TaskGroupList so exact updatedMessageIndices patches update cached timeline entries directly.
- Keep the existing full-scan fallbacks for unusual deltas without reliable index metadata.

## Validation
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes incremental update/indexing logic for streamed logs and task groups; bugs could cause missed or incorrect UI updates, though changes are frontend-only with fallbacks to full scans.
> 
> **Overview**
> Improves progress-view streaming performance by adding cached indices to avoid repeated linear scans during deltas.
> 
> On the state side, `StreamLogs` now carries a `taskGroupIndex` map and `logSlice.updateTaskGroups` uses it to locate/update `GROUP_START`/`GROUP_END` entries without scanning `taskGroups` each time.
> 
> On the rendering side, `TaskGroupList` now maintains a `timelineMessageIndex` for ungrouped timeline entries, rebuilding/reindexing it when the timeline changes so `updatedMessageIndices` patches can update cached timeline message references directly (while keeping the existing full-scan fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bbb3fc171c7fe297e28b9904ee85136083a06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->