### PR TITLE
perf: bound memory listing metadata reads

### DIFF
--- a/packages/extension/src/settingsView/utils/memoryFileSystem.ts
+++ b/packages/extension/src/settingsView/utils/memoryFileSystem.ts
@@ -7,6 +7,8 @@
 
 import * as path from 'path';
 
+import pMap from 'p-map';
+
 import { isDirectory, isSymlink } from '@common/files/fsEntryType';
 import type {
   MemoryPreview,
@@ -28,6 +30,12 @@ import {
 
 const FRONTMATTER_SCAN_BYTES = 16 * 1024;
 const PREVIEW_SCAN_BYTES = 64 * 1024;
+const MEMORY_LISTING_CONCURRENCY = 8;
+
+interface DirectoryToWalk {
+  storagePath: string;
+  relativeRoot: string;
+}
 
 async function readStoragePrefix(
   storagePath: string,
@@ -109,7 +117,7 @@ export async function loadMemoryPreview(
 }
 
 /**
- * Recursively walks the memory directory and collects all memory items.
+ * Walks the memory directory and collects all memory items.
  * @param storagePath - Current directory path to walk
  * @param relativeRoot - Path relative to MEMORY_STORAGE_ROOT (for display)
  * @returns Array of memory items found in the directory
@@ -118,44 +126,71 @@ export async function walkMemoryDirectory(
   storagePath: string,
   relativeRoot = '',
 ): Promise<MemoryViewItem[]> {
-  const entries = await StorageFS.readDir(storagePath);
-  const results: MemoryViewItem[] = [];
+  const items: MemoryViewItem[] = [];
+  const pendingDirectories: DirectoryToWalk[] = [{ storagePath, relativeRoot }];
 
-  for (const [name, type] of entries) {
-    if (shouldSkipEntry(name)) {
-      continue;
+  for (let index = 0; index < pendingDirectories.length; index++) {
+    const directory = pendingDirectories[index];
+    const entries = await StorageFS.readDir(directory.storagePath);
+
+    const results = await pMap(
+      entries,
+      async ([name, type]): Promise<{
+        item?: MemoryViewItem;
+        directory?: DirectoryToWalk;
+      } | null> => {
+        if (shouldSkipEntry(name)) {
+          return null;
+        }
+
+        // Skip symlinks to avoid cycles; we have no realpath/visited guard.
+        if (isSymlink(type)) {
+          return null;
+        }
+
+        const nextRelative = directory.relativeRoot
+          ? path.join(directory.relativeRoot, name)
+          : name;
+        const nextStoragePath = path.join(MEMORY_STORAGE_ROOT, nextRelative);
+
+        if (isDirectory(type)) {
+          return {
+            directory: {
+              storagePath: nextStoragePath,
+              relativeRoot: nextRelative,
+            },
+          };
+        }
+
+        const stats = await StorageFS.stat(nextStoragePath);
+        const meta = await readMemoryMeta(nextStoragePath, stats);
+        const displayPath = relativeToDisplayPath(nextRelative);
+
+        return {
+          item: {
+            displayPath,
+            storagePath: nextStoragePath,
+            size: stats.size,
+            mtime: new Date(stats.mtime).toISOString(),
+            modifiedBy: meta ? formatAttribution(meta) : undefined,
+            pinned: meta?.pinned,
+          },
+        };
+      },
+      { concurrency: MEMORY_LISTING_CONCURRENCY },
+    );
+
+    for (const result of results) {
+      if (result?.directory) {
+        pendingDirectories.push(result.directory);
+      }
+      if (result?.item) {
+        items.push(result.item);
+      }
     }
-
-    // Skip symlinks to avoid cycles; we have no realpath/visited guard.
-    if (isSymlink(type)) {
-      continue;
-    }
-
-    const nextRelative = relativeRoot ? path.join(relativeRoot, name) : name;
-    const nextStoragePath = path.join(MEMORY_STORAGE_ROOT, nextRelative);
-
-    if (isDirectory(type)) {
-      results.push(
-        ...(await walkMemoryDirectory(nextStoragePath, nextRelative)),
-      );
-      continue;
-    }
-
-    const stats = await StorageFS.stat(nextStoragePath);
-    const meta = await readMemoryMeta(nextStoragePath, stats);
-    const displayPath = relativeToDisplayPath(nextRelative);
-
-    results.push({
-      displayPath,
-      storagePath: nextStoragePath,
-      size: stats.size,
-      mtime: new Date(stats.mtime).toISOString(),
-      modifiedBy: meta ? formatAttribution(meta) : undefined,
-      pinned: meta?.pinned,
-    });
   }
 
-  return results;
+  return items;
 }
 
 /**

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -1,0 +1,100 @@
+// Standard library imports
+import { Buffer } from 'node:buffer';
+import * as path from 'node:path';
+import { Readable } from 'node:stream';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Platform imports
+import { FileType, type FileStat } from '@platform/interfaces/filesystem';
+
+// Local imports - settings memory
+import { walkMemoryDirectory } from '@settingsView/utils/memoryFileSystem';
+import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
+import { StorageFS } from '@utils/files';
+
+const MEMORY_LISTING_CONCURRENCY = 8;
+const FILE_COUNT_PER_DIRECTORY = 12;
+const TEST_TIMESTAMP = Date.parse('2026-01-01T00:00:00.000Z');
+const TEST_FRONTMATTER = [
+  '---',
+  'modifiedBy: test-agent',
+  'modifiedAt: 2026-01-01T00:00:00.000Z',
+  '---',
+  'body',
+].join('\n');
+
+function memoryFiles(): [string, number][] {
+  return Array.from(
+    { length: FILE_COUNT_PER_DIRECTORY },
+    (_, index): [string, number] => [`note-${index}.md`, FileType.File],
+  );
+}
+
+function readStreamFromText(
+  text: string,
+): ReturnType<typeof StorageFS.createReadStream> {
+  return Readable.from([Buffer.from(text)]) as unknown as ReturnType<
+    typeof StorageFS.createReadStream
+  >;
+}
+
+function testFileStat(): FileStat {
+  return {
+    type: FileType.File,
+    ctime: TEST_TIMESTAMP,
+    mtime: TEST_TIMESTAMP,
+    size: Buffer.byteLength(TEST_FRONTMATTER),
+  };
+}
+
+describe('memory filesystem listing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('bounds metadata reads while walking large memory directories', async () => {
+    vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
+      if (target === MEMORY_STORAGE_ROOT) {
+        return [
+          ['alpha', FileType.Directory],
+          ['beta', FileType.Directory],
+        ];
+      }
+      if (
+        target === path.join(MEMORY_STORAGE_ROOT, 'alpha') ||
+        target === path.join(MEMORY_STORAGE_ROOT, 'beta')
+      ) {
+        return memoryFiles();
+      }
+      throw new Error(`Unexpected readDir target: ${target}`);
+    });
+
+    let activeMetadataReads = 0;
+    let maxActiveMetadataReads = 0;
+    vi.spyOn(StorageFS, 'stat').mockImplementation(async () => {
+      activeMetadataReads += 1;
+      maxActiveMetadataReads = Math.max(
+        maxActiveMetadataReads,
+        activeMetadataReads,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeMetadataReads -= 1;
+      return testFileStat();
+    });
+
+    vi.spyOn(StorageFS, 'createReadStream').mockImplementation(() =>
+      readStreamFromText(TEST_FRONTMATTER),
+    );
+
+    const items = await walkMemoryDirectory(MEMORY_STORAGE_ROOT);
+
+    expect(items).toHaveLength(FILE_COUNT_PER_DIRECTORY * 2);
+    expect(maxActiveMetadataReads).toBeGreaterThan(1);
+    expect(maxActiveMetadataReads).toBeLessThanOrEqual(
+      MEMORY_LISTING_CONCURRENCY,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Walk memory directories with bounded concurrent metadata reads instead of one serial stat/frontmatter read at a time.
- Use an explicit directory queue so the concurrency bound does not multiply through recursive calls.
- Add a kernel test that exercises a large nested memory listing and asserts the metadata-read bound.

Refs #3959.

## Validation
- vitest run --config vitest.config.mjs src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
- tsc --noEmit
- tsc --noEmit -p tsconfig.test-kernel.json
- packages/extension: tsc --noEmit
- packages/cli: tsc --noEmit -p tsconfig.json
- eslint src packages/extension/src packages/desktop/src packages/cli/src (existing warnings only)
- extension fast build via clean-extension-dist, esbuild, and Vite dev builds for progressView/settingsView/webview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the memory directory traversal strategy and introduces bounded concurrency for `stat`/frontmatter reads, which could impact listing completeness/performance or expose new race/timing issues under unusual filesystem conditions.
> 
> **Overview**
> Improves SettingsView memory listing performance by replacing recursive, serial directory walking with an explicit directory queue and `p-map`-based *bounded* concurrency for per-file metadata reads.
> 
> Adds a Vitest kernel test that simulates large nested memory directories and asserts the maximum concurrent `StorageFS.stat` calls never exceeds the configured limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c653d0a792695465c702cf7c4c6c11694c2eace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->