### PR TITLE
perf: prefilter history search items

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -1,7 +1,7 @@
 /**
  * Renders the history list with search highlighting.
- * Pagination is active when there is no search term; during search, all
- * items are rendered so match navigation works across the full list.
+ * Pagination is active when there is no search term; during search, a
+ * data-level prefilter renders only plausible matches for mark.js highlighting.
  */
 
 import {
@@ -16,6 +16,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { historyStyles } from '@shared/styles/historyStyles';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -28,8 +29,12 @@ const HISTORY_PAGE_SIZE = 25;
 
 // Local imports - history view
 import { HistoryViewEvents } from './events';
+import {
+  getHistorySearchText,
+  getHistorySearchTokens,
+  historySearchTextMatches,
+} from './historySearch';
 import './HistoryItemElement';
-import { historyStyles } from '@shared/styles/historyStyles';
 import type { HistoryViewState } from './state';
 
 /** Search navigation action (reactive trigger from parent) */
@@ -58,14 +63,35 @@ export class HistoryList extends LitElement {
   @queryAll('history-item')
   private historyItemElements!: Array<
     HTMLElement & {
+      item?: HistoryItemData;
       applySearch: (term: string) => Promise<number>;
       getMarks: () => HTMLElement[];
     }
   >;
 
+  private searchTextCache = new WeakMap<HistoryItemData, string>();
+
   /** Whether pagination is active (no active search). */
   private get paginated(): boolean {
     return !this.searchTerm;
+  }
+
+  private getCachedSearchText(item: HistoryItemData): string {
+    const cached = this.searchTextCache.get(item);
+    if (cached !== undefined) return cached;
+
+    const text = getHistorySearchText(item);
+    this.searchTextCache.set(item, text);
+    return text;
+  }
+
+  private getSearchCandidates(): HistoryItemData[] {
+    const tokens = getHistorySearchTokens(this.searchTerm);
+    if (tokens.length === 0) return this.items;
+
+    return this.items.filter((item) =>
+      historySearchTextMatches(this.getCachedSearchText(item), tokens),
+    );
   }
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
@@ -106,8 +132,7 @@ export class HistoryList extends LitElement {
   }
 
   protected updated(changedProps: Map<string, unknown>): void {
-    // Apply search after DOM update so all items are rendered
-    // (pagination is disabled during search, so we need the full DOM).
+    // Apply search after DOM update so candidate items are rendered.
     if (
       this.searchTerm &&
       (changedProps.has('searchTerm') || changedProps.has('items'))
@@ -176,11 +201,14 @@ export class HistoryList extends LitElement {
     const nextCounts = new Map<string, number>();
     const nextOffsets = new Map<string, number>();
     let total = 0;
-    this.items.forEach((item, i) => {
+    historyItems.forEach((element, i) => {
+      const itemId = element.item?.id;
+      if (itemId == null) return;
+
       const count = counts[i] ?? 0;
-      nextCounts.set(item.id, count);
+      nextCounts.set(itemId, count);
       if (count > 0) {
-        nextOffsets.set(item.id, total);
+        nextOffsets.set(itemId, total);
       }
       total += count;
     });
@@ -231,10 +259,10 @@ export class HistoryList extends LitElement {
     const hasMatches = (this.state?.totalMatches ?? 0) > 0;
     const forceOpen = Boolean(this.searchTerm && hasMatches);
 
-    // When searching, show all items; otherwise paginate
+    // When searching, render only plausible matches; otherwise paginate.
     const displayItems = this.paginated
       ? paginate(this.items, this.page, HISTORY_PAGE_SIZE).paged
-      : this.items;
+      : this.getSearchCandidates();
 
     return html`
       ${this.paginated

--- a/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
@@ -1,0 +1,137 @@
+import type { HistoryItem } from '@shared/schemas';
+import { getAgentCategoryDecorator } from '@shared/utils/icons';
+
+type ToolConfigEntry = [string, unknown];
+
+function normalizeSearchText(text: string): string {
+  return text
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase();
+}
+
+function hasSearchValue(value: unknown): boolean {
+  if (value == null) return false;
+  return !Array.isArray(value) || value.length > 0;
+}
+
+function addSearchValue(parts: string[], value: unknown): void {
+  if (value == null) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      addSearchValue(parts, item);
+    }
+    return;
+  }
+
+  if (typeof value === 'object') {
+    for (const [key, nested] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      parts.push(key);
+      addSearchValue(parts, nested);
+    }
+    return;
+  }
+
+  if (typeof value === 'boolean') {
+    parts.push(value ? 'Yes' : 'No');
+    return;
+  }
+
+  parts.push(String(value));
+}
+
+function addLabelledValue(
+  parts: string[],
+  label: string,
+  value: unknown,
+): boolean {
+  if (!hasSearchValue(value)) return false;
+
+  parts.push(label);
+  addSearchValue(parts, value);
+  return true;
+}
+
+function addConfigSection(
+  parts: string[],
+  sectionLabel: string,
+  entries: ToolConfigEntry[],
+): boolean {
+  const visibleEntries = entries.filter(([, value]) => hasSearchValue(value));
+  if (visibleEntries.length === 0) return false;
+
+  parts.push(sectionLabel);
+  for (const [key, value] of visibleEntries) {
+    parts.push(key);
+    addSearchValue(parts, value);
+  }
+  return true;
+}
+
+/**
+ * Build a lowercase search body matching the fields HistoryItemElement renders.
+ */
+export function getHistorySearchText(item: HistoryItem): string {
+  const parts: string[] = [
+    item.id,
+    item.timestamp,
+    new Date(item.timestamp).toLocaleString(),
+  ];
+  addSearchValue(parts, item.description);
+
+  const config = item.agentConfig;
+  parts.push('Category', getAgentCategoryDecorator(config.agentCategory).label);
+  parts.push('Agent');
+  addSearchValue(parts, config.agent ?? 'Unknown');
+  parts.push('Model');
+  addSearchValue(parts, config.model ?? 'Unknown');
+  parts.push('Instruction');
+  addSearchValue(
+    parts,
+    config.instruction?.trim() ? config.instruction : 'Not set',
+  );
+
+  if (config.agentCategory === 'workflow') {
+    addLabelledValue(parts, 'InputFile', config.inputFile);
+    addLabelledValue(parts, 'InputFiles', config.inputFiles);
+    addLabelledValue(parts, 'MediaFile', config.mediaFile);
+    addLabelledValue(parts, 'MediaFiles', config.mediaFiles);
+
+    const hasMoreDetails = [
+      addConfigSection(parts, 'Reference', [
+        ['ReferenceFile', config.referenceFile],
+        ['ReferenceFiles', config.referenceFiles],
+      ]),
+      addConfigSection(parts, 'Auxiliary', [
+        ['AuxiliaryFile', config.auxiliaryFile],
+        ['AuxiliaryFiles', config.auxiliaryFiles],
+      ]),
+      addConfigSection(parts, 'Output Files', [['Files', config.outputFiles]]),
+      config.toolConfig
+        ? addConfigSection(parts, 'Config', Object.entries(config.toolConfig))
+        : false,
+    ].some(Boolean);
+
+    if (hasMoreDetails) {
+      parts.push('More details');
+    }
+  }
+
+  return normalizeSearchText(parts.join('\n'));
+}
+
+export function getHistorySearchTokens(searchTerm: string): string[] {
+  return normalizeSearchText(searchTerm).trim().split(/\s+/).filter(Boolean);
+}
+
+export function historySearchTextMatches(
+  searchText: string,
+  tokens: readonly string[],
+): boolean {
+  return (
+    tokens.length === 0 || tokens.some((token) => searchText.includes(token))
+  );
+}

--- a/src/test-kernel/settings/HistorySearchPrefilter.vitest.ts
+++ b/src/test-kernel/settings/HistorySearchPrefilter.vitest.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getHistorySearchText,
+  getHistorySearchTokens,
+  historySearchTextMatches,
+} from '@settingsView/frontend/components/history/historySearch';
+import type { HistoryItem } from '@shared/schemas';
+
+const workflowHistoryItem: HistoryItem = {
+  id: 'execution-1',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  description: 'Improve memory listing responsiveness near the café example',
+  agentConfig: {
+    agentCategory: 'workflow',
+    agent: 'orchestrator',
+    model: 'test-model',
+    instruction: 'Summarize the variational argument.',
+    inputFile: 'paper/main.tex',
+    inputFiles: ['paper/appendix.tex'],
+    mediaFiles: ['figures/spectrum.png'],
+    referenceFiles: ['refs/source.tex'],
+    auxiliaryFiles: ['notes/context.md'],
+    outputFiles: ['build/revised.tex'],
+    toolConfig: {
+      latexEngine: 'xelatex',
+      maxRounds: 2,
+    },
+  },
+};
+
+const minimalWorkflowHistoryItem: HistoryItem = {
+  id: 'execution-2',
+  timestamp: '2026-01-02T00:00:00.000Z',
+  agentConfig: {
+    agentCategory: 'workflow',
+  },
+};
+
+describe('history search prefilter', () => {
+  it('matches rendered history fields without requiring DOM construction', () => {
+    const searchText = getHistorySearchText(workflowHistoryItem);
+
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('spectrum')),
+    ).toBe(true);
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('xelatex')),
+    ).toBe(true);
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('cafe')),
+    ).toBe(true);
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('absent')),
+    ).toBe(false);
+  });
+
+  it('does not match workflow labels that are not rendered for an item', () => {
+    const searchText = getHistorySearchText(minimalWorkflowHistoryItem);
+
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('mediafile')),
+    ).toBe(false);
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('not set')),
+    ).toBe(true);
+  });
+
+  it('keeps multi-word searches broad like mark.js separate word search', () => {
+    const searchText = getHistorySearchText(workflowHistoryItem);
+
+    expect(
+      historySearchTextMatches(
+        searchText,
+        getHistorySearchTokens('missing variational'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a data-level History search prefilter so searching large histories does not render every execution before mark.js runs.
- Keep mark.js as the source of exact match counts and highlighting for the candidate items that can plausibly match.
- Cache per-item search text and add a focused kernel test for rendered-field matching and broad multi-word search semantics.

Refs #3959.

## Validation
- vitest run --config vitest.config.mjs src/test-kernel/settings/HistorySearchPrefilter.vitest.ts
- tsc --noEmit
- tsc --noEmit -p tsconfig.test-kernel.json
- packages/extension: tsc --noEmit
- packages/cli: tsc --noEmit -p tsconfig.json
- eslint src packages/extension/src packages/desktop/src packages/cli/src (existing warnings only)
- extension fast build via clean-extension-dist, esbuild, and Vite dev builds for progressView/settingsView/webview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Search behavior changes to rely on token-based prefiltering before `mark.js`, so bugs could hide valid matches or miscount navigation for some edge-case history fields. Scope is limited to the settings history view and includes a focused test suite to reduce regression risk.
> 
> **Overview**
> Improves history search performance by adding a **data-level prefilter**: when a search term is present, `HistoryList` now renders only “plausible match” items instead of disabling pagination and rendering the entire history.
> 
> Introduces `historySearch.ts` to build a normalized per-item search text (matching rendered fields), tokenizes the query, and filters via token inclusion; `HistoryList` caches this text per item and continues to use `mark.js` for exact highlighting and match counts on the rendered candidates. Adds a vitest covering matching semantics (diacritics normalization, rendered-field coverage, and multi-word *broad/OR* behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99630044bf44e78f9a05e539cc1ec1977ae6c689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->