### PR TITLE
perf: lazy-load stream logs at startup

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -430,6 +430,7 @@ export class ProgressViewProvider
 
     const streamsWithRunningGroups = await this.state.endRunningTaskGroups(
       Date.now(),
+      affectedStreams,
     );
 
     for (const streamId of streamsWithRunningGroups) {

--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -313,8 +313,14 @@ export class ProgressViewState {
     return Object.fromEntries(this._streamStates.entries());
   }
 
-  async endRunningTaskGroups(now: number = Date.now()): Promise<StreamTabId[]> {
-    const affectedFromLogs = this.streamLogs.endRunningGroups(now);
+  async endRunningTaskGroups(
+    now: number = Date.now(),
+    streamIds?: readonly StreamTabId[],
+  ): Promise<StreamTabId[]> {
+    const affectedFromLogs = await this.streamLogs.endRunningGroups(
+      now,
+      streamIds,
+    );
     if (affectedFromLogs.length > 0) {
       await this.streamLogs.save();
     }
@@ -456,6 +462,7 @@ export class ProgressViewState {
           const text = legacyInstruction.text.trim();
           if (!text) return;
 
+          await this.streamLogs.ensureLoaded(streamId);
           const log = this.streamLogs.get(streamId);
           if (!log) return;
 

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -90,6 +90,13 @@ export class KVStore {
     return StorageFS.exists(this.keyToPath(key));
   }
 
+  async modifiedAt(key: string): Promise<number | undefined> {
+    return withNotFoundFallback(
+      async () => (await StorageFS.stat(this.keyToPath(key))).mtime,
+      undefined,
+    );
+  }
+
   async listKeys(prefix?: string): Promise<string[]> {
     const entries = await withNotFoundFallback(
       () => StorageFS.readDir(this.dir),

--- a/src/logger/StreamLog.ts
+++ b/src/logger/StreamLog.ts
@@ -1,15 +1,28 @@
-import { StreamLogEntrySchema, type StreamLogEntry } from '@shared/schemas';
+import {
+  STREAM_LOG_ENTRY_TYPES,
+  StreamLogEntrySchema,
+  type StreamLogEntry,
+} from '@shared/schemas';
+import { isObject } from '@utils/core';
 
 export type StreamLogAppendInput = Omit<StreamLogEntry, 'seqNo'>;
 export type StreamLogUpdatePatch = Partial<
   Omit<StreamLogEntry, 'id' | 'seqNo'>
 >;
 
+export function isRunningGroupEntry(entry: StreamLogEntry): boolean {
+  if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START) return false;
+  const data = isObject(entry.data) ? entry.data : {};
+  const status = typeof data.status === 'string' ? data.status : 'running';
+  return status === 'running';
+}
+
 export class StreamLog {
   private entries: StreamLogEntry[] = [];
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
   private readonly dirtyUpdates = new Set<string>();
+  private runningGroupCount = 0;
 
   constructor(entries: StreamLogEntry[] = []) {
     if (entries.length === 0) {
@@ -27,7 +40,11 @@ export class StreamLog {
     this.seqCounter = this.entries.length;
 
     for (let i = 0; i < this.entries.length; i++) {
-      this.indexById.set(this.entries[i].id, i);
+      const entry = this.entries[i];
+      this.indexById.set(entry.id, i);
+      if (isRunningGroupEntry(entry)) {
+        this.runningGroupCount += 1;
+      }
     }
   }
 
@@ -47,6 +64,10 @@ export class StreamLog {
     return this.entries.at(-1)?.timestamp;
   }
 
+  get hasRunningGroup(): boolean {
+    return this.runningGroupCount > 0;
+  }
+
   append(entry: StreamLogAppendInput): StreamLogEntry {
     const fullEntry = StreamLogEntrySchema.parse({
       ...entry,
@@ -55,6 +76,9 @@ export class StreamLog {
     this.seqCounter = fullEntry.seqNo;
     this.indexById.set(fullEntry.id, this.entries.length);
     this.entries.push(fullEntry);
+    if (isRunningGroupEntry(fullEntry)) {
+      this.runningGroupCount += 1;
+    }
     return fullEntry;
   }
 
@@ -72,6 +96,14 @@ export class StreamLog {
       id: current.id,
       seqNo: current.seqNo,
     };
+
+    const wasRunningGroup = isRunningGroupEntry(current);
+    const isNowRunningGroup = isRunningGroupEntry(updated);
+    if (wasRunningGroup && !isNowRunningGroup) {
+      this.runningGroupCount -= 1;
+    } else if (!wasRunningGroup && isNowRunningGroup) {
+      this.runningGroupCount += 1;
+    }
 
     this.entries[index] = updated;
     this.dirtyUpdates.add(id);

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -1,3 +1,5 @@
+import pMap from 'p-map';
+
 import { KVStore } from '@common/storage/KVStore';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type { MementoStorage } from '@progressView/persistence/PersistentMapManager';
@@ -8,8 +10,10 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
+import { isObject } from '@utils/core';
 
 import {
+  isRunningGroupEntry,
   StreamLog,
   type StreamLogAppendInput,
   type StreamLogUpdatePatch,
@@ -18,12 +22,20 @@ import * as log from './logUtils';
 
 const SAVE_DEBOUNCE_MS = 300;
 const STREAM_LOGS_DIR = 'streamLogs';
+const STREAM_LOG_SUMMARIES_DIR = 'streamLogSummaries';
+const STREAM_LOG_LOAD_CONCURRENCY = 8;
 const LOG_TAG = 'StreamLogStore';
 
 type StreamLogListener = (streamId: StreamTabId) => void;
+interface StreamLogSummary {
+  firstTimestamp?: number;
+  lastTimestamp?: number;
+  hasRunningGroup?: boolean;
+}
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+interface StreamLoadResult {
+  streamId: StreamTabId;
+  summary: StreamLogSummary;
 }
 
 export class StreamLogStore {
@@ -31,16 +43,16 @@ export class StreamLogStore {
   private readonly listeners = new Set<StreamLogListener>();
   private readonly dirtyStreamIds = new Set<StreamTabId>();
   private readonly kv = new KVStore(STREAM_LOGS_DIR, { compactJson: true });
+  private readonly summaryKv = new KVStore(STREAM_LOG_SUMMARIES_DIR, {
+    compactJson: true,
+  });
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at load
    * and refreshed on append/update. Survives `releaseEntries` so sidebar
    * metadata stays available for streams whose heavy entries have been evicted.
    */
-  private readonly summaries = new Map<
-    StreamTabId,
-    { firstTimestamp?: number; lastTimestamp?: number }
-  >();
+  private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
 
   /** Deduplicates concurrent `ensureLoaded` calls for the same stream. */
   private readonly pendingLoads = new Map<StreamTabId, Promise<void>>();
@@ -76,6 +88,9 @@ export class StreamLogStore {
   private pendingResolve: (() => void) | null = null;
   private savePromise: Promise<void> | null = null;
   private inFlightWrite: Promise<void> | null = null;
+  private writeGeneration = 0;
+  private readonly writeTombstones = new Set<StreamTabId>();
+  private clearing = false;
 
   onChange(listener: StreamLogListener): () => void {
     this.listeners.add(listener);
@@ -154,8 +169,14 @@ export class StreamLogStore {
     const work = (async () => {
       try {
         const raw = await this.kv.read<unknown[]>(streamId);
-        // If `delete` ran during the read, don't resurrect the stream.
-        if (!this.summaries.has(streamId)) return;
+        // If `delete` or `clear` ran during the read, don't resurrect it.
+        if (
+          this.clearing ||
+          this.writeTombstones.has(streamId) ||
+          !this.summaries.has(streamId)
+        ) {
+          return;
+        }
         const diskEntries = this.parsePersistedEntries(raw);
         const live = this.logs.get(streamId);
         if (live && live.size > 0) {
@@ -260,48 +281,66 @@ export class StreamLogStore {
   }
 
   async delete(streamId: StreamTabId): Promise<void> {
-    this.logs.delete(streamId);
-    this.summaries.delete(streamId);
-    this.dirtyStreamIds.delete(streamId);
-    this.pendingRelease.delete(streamId);
-    this.flushing.delete(streamId);
-    this.loadFailed.delete(streamId);
-    this.pendingLoads.delete(streamId);
-    if (!this.loaded) return;
-
+    this.writeTombstones.add(streamId);
     this.cancelPendingSave();
-    log.info(LOG_TAG, `Deleting stream: ${streamId}`);
-    await this.kv.delete(streamId);
+    this.forgetStreamState(streamId);
+
+    try {
+      await this.inFlightWrite;
+      this.forgetStreamState(streamId);
+      if (!this.loaded) return;
+
+      log.info(LOG_TAG, `Deleting stream: ${streamId}`);
+      await Promise.all([
+        this.kv.delete(streamId),
+        this.summaryKv.delete(streamId),
+      ]);
+    } finally {
+      this.writeTombstones.delete(streamId);
+    }
   }
 
   async clear(): Promise<void> {
-    const count = this.logs.size;
-    this.logs.clear();
-    this.summaries.clear();
-    this.dirtyStreamIds.clear();
-    this.pendingRelease.clear();
-    this.flushing.clear();
-    this.loadFailed.clear();
-    this.pendingLoads.clear();
-    if (!this.loaded) return;
-
+    const count = this.summaries.size;
+    this.clearing = true;
+    this.writeGeneration += 1;
     this.cancelPendingSave();
-    log.info(LOG_TAG, `Clearing all ${count} streams`);
-    await this.kv.deleteDir();
+    this.forgetAllStreamState();
+
+    try {
+      await this.inFlightWrite;
+      this.forgetAllStreamState();
+      if (!this.loaded) return;
+
+      log.info(LOG_TAG, `Clearing all ${count} streams`);
+      await Promise.all([this.kv.deleteDir(), this.summaryKv.deleteDir()]);
+    } finally {
+      this.writeTombstones.clear();
+      this.clearing = false;
+    }
   }
 
-  endRunningGroups(now: number = Date.now()): StreamTabId[] {
+  async endRunningGroups(
+    now: number = Date.now(),
+    streamIds: readonly StreamTabId[] = [],
+  ): Promise<StreamTabId[]> {
+    const streamsToLoad = new Set(streamIds);
+    for (const [streamId, summary] of this.summaries) {
+      if (summary.hasRunningGroup && !this.logs.has(streamId)) {
+        streamsToLoad.add(streamId);
+      }
+    }
+
+    if (streamsToLoad.size > 0) {
+      await Promise.all([...streamsToLoad].map((id) => this.ensureLoaded(id)));
+    }
+
     const affected: StreamTabId[] = [];
     for (const [streamId, logInstance] of this.logs.entries()) {
       let updatedAny = false;
       for (const entry of logInstance.getRange(0, logInstance.head)) {
-        if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START) continue;
+        if (!isRunningGroupEntry(entry)) continue;
         const existingData = isObject(entry.data) ? entry.data : {};
-        const status =
-          typeof existingData.status === 'string'
-            ? existingData.status
-            : 'running';
-        if (status !== 'running') continue;
 
         updatedAny ||= !!logInstance.update(entry.id, {
           type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
@@ -311,6 +350,7 @@ export class StreamLogStore {
 
       if (updatedAny) {
         affected.push(streamId);
+        this.refreshSummary(streamId, logInstance);
         this.markDirty(streamId);
         this.notify(streamId);
       }
@@ -335,43 +375,35 @@ export class StreamLogStore {
     this.flushing.clear();
     this.loadFailed.clear();
     this.pendingLoads.clear();
+    this.writeTombstones.clear();
+    this.clearing = false;
 
     // 1. Scan directory — filenames decode back to stream IDs
     const streamIds = await this.kv.listKeys();
 
     if (streamIds.length > 0) {
-      const results = await Promise.all(
-        streamIds.map(async (streamId) => {
-          try {
-            const raw = await this.kv.read<unknown[]>(streamId);
-            return [streamId, this.parsePersistedEntries(raw)] as const;
-          } catch {
-            log.warn(LOG_TAG, `Skipping corrupt stream log: ${streamId}`);
-            return [streamId, [] as StreamLogEntry[]] as const;
-          }
-        }),
+      const results = await pMap(
+        streamIds,
+        (streamId) => this.loadStreamSummary(streamId as StreamTabId),
+        { concurrency: STREAM_LOG_LOAD_CONCURRENCY },
       );
 
-      const sortedResults = [...results].sort(
-        ([aStreamId, aEntries], [bStreamId, bEntries]) =>
-          (aEntries[0]?.timestamp ?? Number.POSITIVE_INFINITY) -
-            (bEntries[0]?.timestamp ?? Number.POSITIVE_INFINITY) ||
-          aStreamId.localeCompare(bStreamId),
-      );
+      const sortedResults = results
+        .filter((result): result is StreamLoadResult => result !== null)
+        .sort(
+          (a, b) =>
+            (a.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) -
+              (b.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) ||
+            a.streamId.localeCompare(b.streamId),
+        );
 
-      let totalEntries = 0;
-      for (const [streamId, entries] of sortedResults) {
-        if (entries.length > 0) {
-          const logInstance = new StreamLog(entries);
-          this.logs.set(streamId as StreamTabId, logInstance);
-          this.refreshSummary(streamId as StreamTabId, logInstance);
-          totalEntries += entries.length;
-        }
+      for (const { streamId, summary } of sortedResults) {
+        this.summaries.set(streamId, summary);
       }
 
       log.info(
         LOG_TAG,
-        `Loaded ${this.logs.size} streams, ${totalEntries} entries (file-backed)`,
+        `Loaded ${this.summaries.size} stream summaries (file-backed)`,
       );
       this.loaded = true;
       return;
@@ -471,12 +503,172 @@ export class StreamLogStore {
     if (existing) {
       existing.firstTimestamp = logInstance.firstTimestamp;
       existing.lastTimestamp = logInstance.lastTimestamp;
+      existing.hasRunningGroup = logInstance.hasRunningGroup;
     } else {
       this.summaries.set(streamId, {
         firstTimestamp: logInstance.firstTimestamp,
         lastTimestamp: logInstance.lastTimestamp,
+        hasRunningGroup: logInstance.hasRunningGroup,
       });
     }
+  }
+
+  private async loadStreamSummary(
+    streamId: StreamTabId,
+  ): Promise<StreamLoadResult | null> {
+    const persistedSummary = await this.readSummary(streamId);
+    if (persistedSummary) {
+      return { streamId, summary: persistedSummary };
+    }
+
+    try {
+      const raw = await this.kv.read<unknown[]>(streamId);
+      const entries = this.parsePersistedEntries(raw);
+      if (entries.length === 0) return null;
+
+      const summary = this.summarizeEntries(entries);
+      await this.writeSummary(streamId, summary).catch(() => {
+        log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
+      });
+      return { streamId, summary };
+    } catch {
+      log.warn(LOG_TAG, `Skipping corrupt stream log: ${streamId}`);
+      return null;
+    }
+  }
+
+  private async readSummary(
+    streamId: StreamTabId,
+  ): Promise<StreamLogSummary | undefined> {
+    try {
+      const summary = this.parsePersistedSummary(
+        await this.summaryKv.read<unknown>(streamId),
+      );
+      if (!summary) return undefined;
+
+      const [summaryMtime, logMtime] = await Promise.all([
+        this.summaryKv.modifiedAt(streamId),
+        this.kv.modifiedAt(streamId),
+      ]);
+      if (
+        summaryMtime !== undefined &&
+        logMtime !== undefined &&
+        summaryMtime < logMtime
+      ) {
+        return undefined;
+      }
+
+      return summary;
+    } catch {
+      log.warn(LOG_TAG, `Ignoring corrupt stream summary: ${streamId}`);
+      return undefined;
+    }
+  }
+
+  private summarizeEntries(
+    entries: readonly StreamLogEntry[],
+  ): StreamLogSummary {
+    return {
+      firstTimestamp: entries[0]?.timestamp,
+      lastTimestamp: entries.at(-1)?.timestamp,
+      hasRunningGroup: entries.some(isRunningGroupEntry),
+    };
+  }
+
+  private parsePersistedSummary(value: unknown): StreamLogSummary | undefined {
+    if (!isObject(value)) return undefined;
+    const firstTimestamp = this.parseTimestamp(value.firstTimestamp);
+    const lastTimestamp = this.parseTimestamp(value.lastTimestamp);
+    const hasRunningGroup =
+      typeof value.hasRunningGroup === 'boolean'
+        ? value.hasRunningGroup
+        : undefined;
+    if (firstTimestamp === undefined && lastTimestamp === undefined) {
+      return undefined;
+    }
+    return { firstTimestamp, lastTimestamp, hasRunningGroup };
+  }
+
+  private parseTimestamp(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : undefined;
+  }
+
+  private async writeStream(
+    streamId: StreamTabId,
+    logInstance: StreamLog,
+    expectedGeneration: number = this.writeGeneration,
+  ): Promise<void> {
+    if (this.shouldSkipWrite(streamId, expectedGeneration)) return;
+    await this.kv.write(streamId, logInstance.toPersistedEntries());
+    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
+      await Promise.all([
+        this.kv.delete(streamId),
+        this.summaryKv.delete(streamId),
+      ]);
+      return;
+    }
+
+    await this.writeSummaryFromLog(streamId, logInstance).catch(() => {
+      log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
+    });
+    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
+      await Promise.all([
+        this.kv.delete(streamId),
+        this.summaryKv.delete(streamId),
+      ]);
+    }
+  }
+
+  private shouldSkipWrite(
+    streamId: StreamTabId,
+    expectedGeneration: number,
+  ): boolean {
+    return (
+      this.clearing ||
+      expectedGeneration !== this.writeGeneration ||
+      this.writeTombstones.has(streamId) ||
+      !this.summaries.has(streamId)
+    );
+  }
+
+  private forgetStreamState(streamId: StreamTabId): void {
+    this.logs.delete(streamId);
+    this.summaries.delete(streamId);
+    this.dirtyStreamIds.delete(streamId);
+    this.pendingRelease.delete(streamId);
+    this.flushing.delete(streamId);
+    this.loadFailed.delete(streamId);
+    this.pendingLoads.delete(streamId);
+  }
+
+  private forgetAllStreamState(): void {
+    this.logs.clear();
+    this.summaries.clear();
+    this.dirtyStreamIds.clear();
+    this.pendingRelease.clear();
+    this.flushing.clear();
+    this.loadFailed.clear();
+    this.pendingLoads.clear();
+  }
+
+  private async writeSummaryFromLog(
+    streamId: StreamTabId,
+    logInstance: StreamLog,
+  ): Promise<void> {
+    await this.writeSummary(streamId, {
+      firstTimestamp: logInstance.firstTimestamp,
+      lastTimestamp: logInstance.lastTimestamp,
+      hasRunningGroup: logInstance.hasRunningGroup,
+    });
+  }
+
+  private async writeSummary(
+    streamId: StreamTabId,
+    summary: StreamLogSummary,
+  ): Promise<void> {
+    await this.summaryKv.write(streamId, summary);
   }
 
   private markDirty(streamId: StreamTabId): void {
@@ -529,7 +721,7 @@ export class StreamLogStore {
 
     await Promise.all(
       [...this.logs].map(([streamId, logInstance]) =>
-        this.kv.write(streamId, logInstance.toJSON()),
+        this.writeStream(streamId, logInstance),
       ),
     );
 
@@ -602,6 +794,7 @@ export class StreamLogStore {
     }
 
     log.debug(LOG_TAG, `Writing ${dirtyIds.length} dirty stream(s)`);
+    const writeGeneration = this.writeGeneration;
 
     // Mark these as mid-flush so `releaseEntries` defers — we need the
     // in-memory copy preserved until the write resolves, otherwise a failed
@@ -615,7 +808,7 @@ export class StreamLogStore {
       dirtyIds.map((streamId) => {
         const logInstance = this.logs.get(streamId);
         return logInstance
-          ? this.kv.write(streamId, logInstance.toPersistedEntries())
+          ? this.writeStream(streamId, logInstance, writeGeneration)
           : Promise.resolve();
       }),
     )

--- a/src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
@@ -1,0 +1,427 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Platform imports
+import { FileType, type FileStat } from '@platform/interfaces/filesystem';
+
+// Local imports - progress persistence
+import { StreamLogStore } from '@logger/StreamLogStore';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamLogEntry,
+} from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+
+const STREAM_LOGS_DIR = 'streamLogs';
+const STREAM_LOG_SUMMARIES_DIR = 'streamLogSummaries';
+
+interface MockStorageOptions {
+  logs: Record<string, StreamLogEntry[]>;
+  summaries: Record<string, unknown>;
+  logMtimes?: Record<string, number>;
+  summaryMtimes?: Record<string, number>;
+  pauseLogWriteKey?: string;
+}
+
+function storageFile(dir: string, key: string): string {
+  return path.join(dir, `${encodeURIComponent(key)}.json`);
+}
+
+function streamKeyFromFile(target: string): string {
+  return decodeURIComponent(path.basename(target).replace(/\.json$/, ''));
+}
+
+function notFound(): NodeJS.ErrnoException {
+  const error = new Error('not found') as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+function logEntry(
+  streamId: string,
+  seqNo: number,
+  timestamp: number,
+): StreamLogEntry {
+  return {
+    seqNo,
+    id: `${streamId}-${seqNo}`,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp,
+    messageType: MESSAGE_TYPES.DEFAULT,
+    text: `${streamId} entry ${seqNo}`,
+  };
+}
+
+function runningGroupEntry(
+  streamId: string,
+  seqNo: number,
+  timestamp: number,
+): StreamLogEntry {
+  return {
+    seqNo,
+    id: `${streamId}-group-${seqNo}`,
+    type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+    level: LOG_LEVELS.INFO,
+    timestamp,
+    data: { status: 'running' },
+  };
+}
+
+function fileStat(mtime: number): FileStat {
+  return {
+    type: FileType.File,
+    ctime: mtime,
+    mtime,
+    size: 1,
+  };
+}
+
+function mockStorage({
+  logs,
+  summaries,
+  logMtimes = {},
+  summaryMtimes = {},
+  pauseLogWriteKey,
+}: MockStorageOptions): {
+  deletes: string[];
+  fullLogReads: () => number;
+  releasePausedWrite: () => void;
+  waitForPausedWrite: () => Promise<void>;
+  writes: Map<string, unknown>;
+} {
+  let fullLogReads = 0;
+  let pausedLogWriteUsed = false;
+  let releasePausedWriteImpl = (): void => {};
+  let markPausedWriteStarted = (): void => {};
+  const waitForPausedWrite =
+    pauseLogWriteKey == null
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          markPausedWriteStarted = resolve;
+        });
+  const deletes: string[] = [];
+  const writes = new Map<string, unknown>();
+
+  vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
+    if (target !== STREAM_LOGS_DIR) throw notFound();
+    return Object.keys(logs).map((key) => [
+      `${encodeURIComponent(key)}.json`,
+      FileType.File,
+    ]);
+  });
+
+  vi.spyOn(StorageFS, 'readJson').mockImplementation(async (target) => {
+    const key = streamKeyFromFile(target);
+
+    if (target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`)) {
+      if (!Object.hasOwn(summaries, key)) throw notFound();
+      return summaries[key] as never;
+    }
+
+    if (target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
+      if (!Object.hasOwn(logs, key)) throw notFound();
+      fullLogReads += 1;
+      return logs[key] as never;
+    }
+
+    throw new Error(`Unexpected readJson target: ${target}`);
+  });
+
+  vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+  vi.spyOn(StorageFS, 'stat').mockImplementation(async (target) => {
+    const key = streamKeyFromFile(target);
+    if (target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`)) {
+      if (!Object.hasOwn(summaries, key)) throw notFound();
+      return fileStat(summaryMtimes[key] ?? 2);
+    }
+    if (target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
+      if (!Object.hasOwn(logs, key)) throw notFound();
+      return fileStat(logMtimes[key] ?? 1);
+    }
+    throw new Error(`Unexpected stat target: ${target}`);
+  });
+  vi.spyOn(StorageFS, 'write').mockImplementation(async (target, content) => {
+    if (
+      pauseLogWriteKey != null &&
+      !pausedLogWriteUsed &&
+      target === storageFile(STREAM_LOGS_DIR, pauseLogWriteKey)
+    ) {
+      pausedLogWriteUsed = true;
+      markPausedWriteStarted();
+      await new Promise<void>((resolve) => {
+        releasePausedWriteImpl = resolve;
+      });
+    }
+
+    const text =
+      typeof content === 'string'
+        ? content
+        : Buffer.from(content).toString('utf8');
+    writes.set(target, JSON.parse(text));
+  });
+  vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
+    deletes.push(target);
+    writes.delete(target);
+  });
+
+  return {
+    deletes,
+    fullLogReads: () => fullLogReads,
+    releasePausedWrite: () => releasePausedWriteImpl(),
+    waitForPausedWrite: () => waitForPausedWrite,
+    writes,
+  };
+}
+
+describe('StreamLogStore load', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses stream summaries without reading full log files at startup', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 200), logEntry('alpha', 2, 250)],
+        beta: [logEntry('beta', 1, 100), logEntry('beta', 2, 160)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 200,
+          lastTimestamp: 250,
+          hasRunningGroup: false,
+        },
+        beta: {
+          firstTimestamp: 100,
+          lastTimestamp: 160,
+          hasRunningGroup: false,
+        },
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(storage.fullLogReads()).toBe(0);
+    expect(store.keys()).toEqual(['beta', 'alpha']);
+    expect(store.get('alpha')).toBeUndefined();
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(store.getLastTimestamp('alpha')).toBe(250);
+
+    await store.ensureLoaded('alpha');
+
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.get('alpha')?.size).toBe(2);
+  });
+
+  it('falls back once for missing summaries and writes the sidecar cache', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 200), logEntry('alpha', 2, 250)],
+      },
+      summaries: {},
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.keys()).toEqual(['alpha']);
+    expect(store.get('alpha')).toBeUndefined();
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
+    ).toEqual({
+      firstTimestamp: 200,
+      lastTimestamp: 250,
+      hasRunningGroup: false,
+    });
+  });
+
+  it('rebuilds stale summaries before trusting them', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 200), logEntry('alpha', 2, 250)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 1,
+          lastTimestamp: 1,
+          hasRunningGroup: false,
+        },
+      },
+      logMtimes: { alpha: 20 },
+      summaryMtimes: { alpha: 10 },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
+    ).toEqual({
+      firstTimestamp: 200,
+      lastTimestamp: 250,
+      hasRunningGroup: false,
+    });
+  });
+
+  it('rehydrates summarized streams with stale running groups', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [runningGroupEntry('alpha', 1, 100)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: true,
+        },
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(storage.fullLogReads()).toBe(0);
+
+    const affected = await store.endRunningGroups(300);
+    await store.flush();
+    const entry = store.get('alpha')?.getRange(0).at(0);
+
+    expect(affected).toEqual(['alpha']);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(entry?.data).toEqual({ status: 'error', endTime: 300 });
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
+    ).toEqual({
+      firstTimestamp: 100,
+      lastTimestamp: 100,
+      hasRunningGroup: false,
+    });
+  });
+
+  it('lets delete win over an in-flight stream write', async () => {
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      pauseLogWriteKey: 'delete-me',
+    });
+    const store = new StreamLogStore();
+    await store.load();
+
+    store.append('delete-me', {
+      id: 'delete-me-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 500,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'soon deleted',
+    });
+
+    const flush = store.flush();
+    await storage.waitForPausedWrite();
+    const deletion = store.delete('delete-me');
+    storage.releasePausedWrite();
+    await Promise.all([flush, deletion]);
+
+    expect(storage.writes.has(storageFile(STREAM_LOGS_DIR, 'delete-me'))).toBe(
+      false,
+    );
+    expect(
+      storage.writes.has(storageFile(STREAM_LOG_SUMMARIES_DIR, 'delete-me')),
+    ).toBe(false);
+    expect(storage.deletes).toContain(
+      storageFile(STREAM_LOGS_DIR, 'delete-me'),
+    );
+    expect(storage.deletes).toContain(
+      storageFile(STREAM_LOG_SUMMARIES_DIR, 'delete-me'),
+    );
+  });
+
+  it('allows a stream id to be reused after a deleted in-flight write', async () => {
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      pauseLogWriteKey: 'reuse-me',
+    });
+    const store = new StreamLogStore();
+    await store.load();
+
+    store.append('reuse-me', {
+      id: 'old-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 500,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'old entry',
+    });
+
+    const flush = store.flush();
+    await storage.waitForPausedWrite();
+    const deletion = store.delete('reuse-me');
+    storage.releasePausedWrite();
+    await Promise.all([flush, deletion]);
+
+    store.append('reuse-me', {
+      id: 'new-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 700,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'new entry',
+    });
+    await store.flush();
+
+    expect(
+      storage.writes.get(storageFile(STREAM_LOGS_DIR, 'reuse-me')),
+    ).toEqual([
+      expect.objectContaining({
+        id: 'new-entry',
+        text: 'new entry',
+      }),
+    ]);
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'reuse-me')),
+    ).toEqual({
+      firstTimestamp: 700,
+      lastTimestamp: 700,
+      hasRunningGroup: false,
+    });
+  });
+
+  it('writes stream summaries with dirty log flushes', async () => {
+    const storage = mockStorage({ logs: {}, summaries: {} });
+    const store = new StreamLogStore();
+    await store.load();
+
+    store.append('new-stream', {
+      id: 'new-stream-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 500,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'new entry',
+    });
+    await store.flush();
+
+    expect(
+      storage.writes.get(storageFile(STREAM_LOGS_DIR, 'new-stream')),
+    ).toHaveLength(1);
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'new-stream')),
+    ).toEqual({
+      firstTimestamp: 500,
+      lastTimestamp: 500,
+      hasRunningGroup: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR reduces progress-view startup work for workspaces with many persisted stream logs. StreamLogStore now treats the stream-log file list as the authoritative set of streams and persists a small per-stream summary sidecar with the first and last timestamps. Startup reads those summaries to build tab metadata and ordering, then loads full log entries only when a stream is activated or needs mutation.

The summary sidecar is a cache, not a second source of truth. Deleting or clearing a stream still deletes the authoritative log file, and stream discovery still comes from streamLogs.

## Details

- Adds streamLogSummaries sidecars owned by StreamLogStore.
- Replaces startup full-log parsing with bounded summary loading.
- Keeps legacy instruction backfill correct by rehydrating only streams that actually have legacy instruction data.
- Rehydrates restart-recovery group logs only for streams whose running status was reset.

Fixes part of #3959.

## Validation

- node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ../../node_modules/.bin/tsc --noEmit in packages/extension
- ../../node_modules/.bin/tsc --noEmit -p tsconfig.json in packages/cli
- npm run lint passes with existing warnings
- Extension fast-build commands run directly: clean dist, node esbuild.config.mjs, and Vite dev builds for progressView, settingsView, and webview

Note: npm run compile:fast was not used directly in the temporary worktree because pnpm tried to reconcile the symlinked dependency layout and aborted before compiling; the underlying compile steps above passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream-log persistence and startup loading paths, including new concurrency/race handling around delete/clear vs in-flight writes; regressions could affect log ordering, recovery, or data cleanup.
> 
> **Overview**
> Reduces progress-view startup work by introducing a persisted per-stream summary sidecar (first/last timestamp + `hasRunningGroup`) and using it to populate stream metadata/order without parsing full log files; full logs are now rehydrated on demand via `ensureLoaded`.
> 
> Adds summary caching/validation (mtime checks + rebuild on stale/missing), tracks running group state efficiently, and updates restart recovery to only load/mutate streams that are actually affected. Tightens persistence semantics around `delete`/`clear` vs in-flight writes via tombstones/generation checks, and adds targeted Vitest coverage for summary loading, stale-running-group recovery, and race cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686ed61d7c66a88e28ee87eca05cba0711e1c891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->