### PR TITLE
refactor: require stream status emission owner

### DIFF
--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -331,7 +331,7 @@ export class ProgressViewState {
 
   async clearStream(stream: StreamTabId): Promise<void> {
     // Clear in-memory state
-    StreamStatusService.clear(stream);
+    StreamStatusService.clear(stream, { emit: false });
     this.outputFiles.evict(stream);
     this.usageStats.evict(stream);
     this.meta.evict(stream);
@@ -359,7 +359,7 @@ export class ProgressViewState {
     );
 
     // Clear in-memory state
-    StreamStatusService.clearAll();
+    StreamStatusService.clearAll({ emit: false });
     this.outputFiles.evictAll();
     this.usageStats.evictAll();
     this.meta.evictAll();

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,6 +1,7 @@
 /** Retry state management: Node retry config, error tracking, and retryable node base class. */
 
 import { Node, type NonIterableObject } from '@agent/node';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { type RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import { waitForRetry } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -45,6 +46,7 @@ export type InvocationResult<TSuccess> =
 
 interface RetryableNodeServices {
   streamId: string;
+  runtimeHost: AgentRuntimeHost;
   logger: AgentLogger;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
@@ -252,7 +254,7 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { streamId, logger } = this.services;
+    const { streamId, logger, runtimeHost } = this.services;
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 
@@ -265,7 +267,9 @@ export abstract class RetryableInvocationNode<
       formatted,
     );
 
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+      runtimeHost,
+    });
     const result: RetryResult = await waitForRetry(streamId, {
       operation: operationName,
       errorMessage: formatted.message,
@@ -275,7 +279,9 @@ export abstract class RetryableInvocationNode<
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
+      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+        runtimeHost,
+      });
       return { shouldRetry: true, userCancelled: false };
     }
 
@@ -284,7 +290,9 @@ export abstract class RetryableInvocationNode<
         ? 'Retry timed out (no response)'
         : 'Retry cancelled by user';
     logger.info(message, { messageType: MESSAGE_TYPES.PROGRESS_STATUS });
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+      runtimeHost,
+    });
     return { shouldRetry: false, userCancelled: true };
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -37,8 +37,13 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
-    const { checkInterruption, session, streamId, onBeforeWaiting } =
-      this.services;
+    const {
+      checkInterruption,
+      session,
+      streamId,
+      onBeforeWaiting,
+      runtimeHost,
+    } = this.services;
 
     if (checkInterruption()) {
       return { kind: 'stop' };
@@ -56,7 +61,9 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     if (!session.hasQueuedFollowUp()) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+        runtimeHost,
+      });
     }
 
     const items = await session.waitForFollowUp(checkInterruption);
@@ -80,7 +87,7 @@ export class ToolUseWaitNode<C> extends Node<
     _prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, streamId, logger, modelHandler } =
+    const { onFollowUpConsumed, streamId, logger, modelHandler, runtimeHost } =
       this.services;
 
     if (execRes.kind === 'stop') {
@@ -94,7 +101,9 @@ export class ToolUseWaitNode<C> extends Node<
     shared.userCancelledRetry = undefined;
 
     onFollowUpConsumed?.();
-    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
+    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+      runtimeHost,
+    });
     logger.userMessage(execRes.followUp);
     shared.messages = await modelHandler.createUserFollowUpMessages(
       shared.messages,

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,7 +1,4 @@
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   isActiveStatus,
   isInFlightStatus,
@@ -21,17 +18,24 @@ export interface StreamStatusChange {
   previousStatus: StreamStatus;
 }
 
-interface SetOptions {
-  emit?: boolean;
+interface EmitSetOptions {
+  emit?: true;
+  runtimeHost: AgentRuntimeHost;
+}
+
+interface SilentSetOptions {
+  emit: false;
   runtimeHost?: AgentRuntimeHost;
 }
+
+type SetOptions = EmitSetOptions | SilentSetOptions;
 
 export const StreamStatusService = {
   get(stream: StreamTabId): StreamStatus | undefined {
     return statusMemory.get(stream);
   },
 
-  tryAcquire(stream: StreamTabId, options: SetOptions = {}): boolean {
+  tryAcquire(stream: StreamTabId, options: SetOptions): boolean {
     if (isInFlightStatus(statusMemory.get(stream))) {
       return false;
     }
@@ -39,19 +43,13 @@ export const StreamStatusService = {
     return true;
   },
 
-  releaseIfInitializing(stream: StreamTabId, options: SetOptions = {}): void {
+  releaseIfInitializing(stream: StreamTabId, options: SetOptions): void {
     if (statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
       this.clear(stream, options);
     }
   },
 
-  set(
-    stream: StreamTabId,
-    status: StreamStatus,
-    options: SetOptions = {},
-  ): void {
-    const { emit = true } = options;
-
+  set(stream: StreamTabId, status: StreamStatus, options: SetOptions): void {
     const previousStatus = statusMemory.get(stream) ?? STREAM_STATUS.READY;
 
     if (status === STREAM_STATUS.READY) {
@@ -60,30 +58,27 @@ export const StreamStatusService = {
       statusMemory.set(stream, status);
     }
 
-    if (emit) {
+    if (options.emit !== false) {
       const change: StreamStatusChange = {
         streamId: stream,
         status,
         previousStatus,
       };
-      (options.runtimeHost ?? getAgentRuntimeHost()).emit(
-        'updateStreamStatus',
-        change,
-      );
+      options.runtimeHost.emit('updateStreamStatus', change);
       for (const listener of statusListeners) {
         listener(change);
       }
     }
   },
 
-  clear(stream: StreamTabId, options: SetOptions = {}): void {
+  clear(stream: StreamTabId, options: SetOptions): void {
     this.set(stream, STREAM_STATUS.READY, options);
   },
 
   /** Reset every stream to READY. Used by ProgressViewState.clearAll(). */
-  clearAll(): void {
+  clearAll(options: SetOptions): void {
     for (const stream of [...statusMemory.keys()]) {
-      this.clear(stream);
+      this.clear(stream, options);
     }
   },
 

--- a/src/test-kernel/tools/CodexLoopStatus.vitest.ts
+++ b/src/test-kernel/tools/CodexLoopStatus.vitest.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports - agent runtime
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 // Local imports - schemas
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
@@ -15,6 +16,8 @@ const streamIds = [
   'stream:codex-loop-waiting',
   'stream:codex-loop-stopped',
 ] as const satisfies readonly StreamTabId[];
+
+const runtimeHost = { emit: () => {} } satisfies AgentRuntimeHost;
 
 function effectiveStatus(streamId: StreamTabId): string {
   return StreamStatusService.get(streamId) ?? STREAM_STATUS.READY;
@@ -31,7 +34,7 @@ describe('finalizeCodexLoopStatus', () => {
     const streamId = streamIds[0];
     StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
 
-    finalizeCodexLoopStatus(streamId);
+    finalizeCodexLoopStatus(streamId, runtimeHost);
 
     expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
   });
@@ -40,7 +43,7 @@ describe('finalizeCodexLoopStatus', () => {
     const streamId = streamIds[1];
     StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { emit: false });
 
-    finalizeCodexLoopStatus(streamId);
+    finalizeCodexLoopStatus(streamId, runtimeHost);
 
     expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
   });
@@ -49,7 +52,7 @@ describe('finalizeCodexLoopStatus', () => {
     const streamId = streamIds[2];
     StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
 
-    finalizeCodexLoopStatus(streamId);
+    finalizeCodexLoopStatus(streamId, runtimeHost);
 
     expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
   });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -231,9 +231,14 @@ function isCodexLoopOwnedStatus(status: StreamStatus | undefined): boolean {
  * Explicit terminal statuses set by other runtime paths, such as STOPPED or
  * ERROR, are left intact.
  */
-export function finalizeCodexLoopStatus(childStreamId: StreamTabId): void {
+export function finalizeCodexLoopStatus(
+  childStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
   if (isCodexLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
+      runtimeHost,
+    });
   }
 }
 
@@ -557,7 +562,9 @@ function startCodexLoop(params: {
 
   // Seed the initial prompt; the loop drains it as the first turn.
   queue.enqueue(initialPrompt);
-  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+    runtimeHost,
+  });
 
   void (async () => {
     try {
@@ -568,7 +575,9 @@ function startCodexLoop(params: {
         if (!messages || session.isInterrupted()) break;
 
         const prompt = messages.join('\n\n');
-        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
+          runtimeHost,
+        });
         const startedAt = Date.now();
         const signal = session.startTurn();
 
@@ -630,7 +639,9 @@ function startCodexLoop(params: {
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
         if (!session.isInterrupted()) {
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+            runtimeHost,
+          });
         }
       }
     } finally {
@@ -644,7 +655,7 @@ function startCodexLoop(params: {
       await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
 
-      finalizeCodexLoopStatus(childStreamId);
+      finalizeCodexLoopStatus(childStreamId, runtimeHost);
     }
   })();
 }


### PR DESCRIPTION
Refs #3372 and #3925.

## Summary

- Require StreamStatusService callers that emit progress to provide the owning AgentRuntimeHost.
- Keep progress-state clear/delete paths local with explicit emit: false status updates.
- Pass the runtime host through retry, wait, and Codex-loop status transitions, including Codex-loop finalization.

## Design note

StreamStatusService now owns stream status memory and the status-change event shape, but it no longer decides which host should publish the event. That ownership belongs to the runtime, tool, or progress caller that already knows the stream boundary. This removes one ambient getAgentRuntimeHost fallback without adding a new forwarding layer.

## Validation

- npm run format
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/tools/CodexLoopStatus.vitest.ts
- npm run lint (existing warning baseline: 66 warnings, 0 errors)
- Extension fast compile equivalent: clean-extension-dist, esbuild.config.mjs, and Vite development builds for progressView, settingsView, and webview

Note: npm run compile:fast was not used directly in this linked worktree because pnpm tried to purge the symlinked node_modules directory and aborted without a TTY. The underlying extension compile steps were run directly instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream-status transition plumbing by requiring an explicit `AgentRuntimeHost` for any emitting update; missing/incorrect host wiring could lead to dropped or misrouted progress updates at runtime.
> 
> **Overview**
> Removes the implicit `getAgentRuntimeHost` fallback from `StreamStatusService` and makes callers explicitly provide the owning `AgentRuntimeHost` whenever a status change is emitted.
> 
> Updates retry/wait/Codex loop flows to thread `runtimeHost` through and pass it into `StreamStatusService.set` and `finalizeCodexLoopStatus`, while persistence clear paths (`ProgressViewState.clearStream`/`clearAll`) now do silent status resets via `{ emit: false }` to avoid broadcasting during deletion/reset.
> 
> Adjusts tests accordingly by providing a stub `runtimeHost` when finalizing Codex loop status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7394424390a6b55db980e3b09560247fdb06fec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->