### PR TITLE
perf: index progress ungrouped messages

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -161,6 +161,8 @@ export class TaskGroupList extends LitElement {
   /** Memoized tree output from buildGroupTree() - recomputed only when inputs change */
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
+  private ungroupedMessageById = new Map<string, LogMessageData>();
+  private ungroupedMessageIndex = new Map<string, number>();
 
   /** Raw partial-line buffer: unprocessed bytes after the last '\n', capped at 64 KiB */
   private cachedRawTail = '';
@@ -344,9 +346,10 @@ export class TaskGroupList extends LitElement {
       const msg = this.messages[i];
       const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
       if (node) {
+        this.removeUngroupedMessageIndex(msg.id);
         this.insertMessageInPlace(node.messages, msg);
       } else {
-        this.insertMessageInPlace(this.cachedUngrouped, msg);
+        this.insertUngroupedMessageInPlace(msg);
       }
     }
   }
@@ -358,17 +361,27 @@ export class TaskGroupList extends LitElement {
   private insertMessageInPlace(
     target: LogMessageData[],
     message: LogMessageData,
-  ): void {
+  ): number {
     const msgTime = message.timestamp ?? 0;
     const lastTs =
       target.length > 0 ? (target.at(-1)!.timestamp ?? 0) : -Infinity;
     if (msgTime >= lastTs) {
       target.push(message);
+      return target.length - 1;
     } else {
       const idx = target.findIndex((e) => (e.timestamp ?? 0) > msgTime);
-      if (idx >= 0) target.splice(idx, 0, message);
-      else target.push(message);
+      if (idx >= 0) {
+        target.splice(idx, 0, message);
+        return idx;
+      }
+      target.push(message);
+      return target.length - 1;
     }
+  }
+
+  private insertUngroupedMessageInPlace(message: LogMessageData): void {
+    const index = this.insertMessageInPlace(this.cachedUngrouped, message);
+    this.reindexUngroupedMessagesFrom(index);
   }
 
   /**
@@ -445,6 +458,7 @@ export class TaskGroupList extends LitElement {
     if (msg.groupId) {
       const node = this.groupNodeIndex.get(msg.groupId);
       if (node) {
+        this.removeUngroupedMessageIndex(msg.id);
         const idx = node.messages.findIndex((m) => m.id === msg.id);
         if (idx >= 0) {
           node.messages[idx] = msg;
@@ -453,9 +467,18 @@ export class TaskGroupList extends LitElement {
       }
     }
 
+    const indexed = this.ungroupedMessageIndex.get(msg.id);
+    if (indexed !== undefined && this.cachedUngrouped[indexed]?.id === msg.id) {
+      this.cachedUngrouped[indexed] = msg;
+      this.ungroupedMessageById.set(msg.id, msg);
+      return;
+    }
+
     const idx = this.cachedUngrouped.findIndex((m) => m.id === msg.id);
     if (idx >= 0) {
       this.cachedUngrouped[idx] = msg;
+      this.ungroupedMessageIndex.set(msg.id, idx);
+      this.ungroupedMessageById.set(msg.id, msg);
     }
   }
 
@@ -536,6 +559,8 @@ export class TaskGroupList extends LitElement {
     );
     const messagesByGroup = new Map<string, LogMessageData[]>();
     const ungrouped: LogMessageData[] = [];
+    this.ungroupedMessageById.clear();
+    this.ungroupedMessageIndex.clear();
 
     for (const msg of sortedMessages) {
       if (msg.groupId && groupMap.has(msg.groupId)) {
@@ -543,6 +568,8 @@ export class TaskGroupList extends LitElement {
         bucket.push(msg);
         messagesByGroup.set(msg.groupId, bucket);
       } else {
+        this.ungroupedMessageIndex.set(msg.id, ungrouped.length);
+        this.ungroupedMessageById.set(msg.id, msg);
         ungrouped.push(msg);
       }
     }
@@ -643,7 +670,7 @@ export class TaskGroupList extends LitElement {
     for (let i = this.cachedTimeline.length - 1; i >= 0; i--) {
       const item = this.cachedTimeline[i];
       if (!('msg' in item)) continue;
-      const fresh = this.findUngroupedReverse(item.key);
+      const fresh = this.ungroupedMessageById.get(item.key);
       if (fresh && fresh !== item.msg) {
         (item as { msg: LogMessageData }).msg = fresh;
       }
@@ -685,12 +712,17 @@ export class TaskGroupList extends LitElement {
     }
   }
 
-  /** Find a message in cachedUngrouped by scanning from end (O(1) for tail changes). */
-  private findUngroupedReverse(id: string): LogMessageData | undefined {
-    for (let i = this.cachedUngrouped.length - 1; i >= 0; i--) {
-      if (this.cachedUngrouped[i].id === id) return this.cachedUngrouped[i];
+  private reindexUngroupedMessagesFrom(startIndex: number): void {
+    for (let i = startIndex; i < this.cachedUngrouped.length; i++) {
+      const message = this.cachedUngrouped[i];
+      this.ungroupedMessageIndex.set(message.id, i);
+      this.ungroupedMessageById.set(message.id, message);
     }
-    return undefined;
+  }
+
+  private removeUngroupedMessageIndex(id: string): void {
+    this.ungroupedMessageIndex.delete(id);
+    this.ungroupedMessageById.delete(id);
   }
 
   /** Check if a group is expanded */

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -1,0 +1,95 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared schemas
+import {
+  LOG_LEVELS,
+  type LogMessageData,
+  type TaskGroup,
+} from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+type TimelineEntry =
+  | { key: string; time: number; msg: LogMessageData }
+  | { key: string; time: number; tree: unknown };
+
+type TaskGroupListInternals = HTMLElement & {
+  groups: TaskGroup[];
+  messages: LogMessageData[];
+  cachedTree: unknown[];
+  cachedUngrouped: LogMessageData[];
+  cachedTimeline: TimelineEntry[];
+  ungroupedMessageById: Map<string, LogMessageData>;
+  ungroupedMessageIndex: Map<string, number>;
+  buildGroupTree: () => [unknown[], LogMessageData[]];
+  buildFullTimeline: () => TimelineEntry[];
+  replaceSingleMessage: (message: LogMessageData) => void;
+  updateTimelineMessageRefs: () => void;
+};
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/TaskGroupList'),
+);
+
+function createMessage(
+  id: string,
+  text: string,
+  timestamp: number,
+): LogMessageData {
+  return {
+    id,
+    text,
+    timestamp,
+    level: LOG_LEVELS.INFO,
+  };
+}
+
+function createList(messages: LogMessageData[]): TaskGroupListInternals {
+  const element = document.createElement(
+    'task-group-list',
+  ) as unknown as TaskGroupListInternals;
+  element.groups = [];
+  element.messages = messages;
+  [element.cachedTree, element.cachedUngrouped] = element.buildGroupTree();
+  element.cachedTimeline = element.buildFullTimeline();
+  return element;
+}
+
+describe('task-group-list ungrouped message indexes', () => {
+  it('refreshes fallback timeline message refs through the ungrouped-message index', () => {
+    const original = [
+      createMessage('m1', 'one', 1),
+      createMessage('m2', 'two', 2),
+      createMessage('m3', 'three', 3),
+    ];
+    const list = createList(original);
+    const updated = { ...original[1], text: 'two updated' };
+
+    list.replaceSingleMessage(updated);
+
+    expect(list.cachedUngrouped[1]).toBe(updated);
+    expect(list.ungroupedMessageById.get('m2')).toBe(updated);
+    expect(list.ungroupedMessageIndex.get('m2')).toBe(1);
+
+    const timelineEntry = list.cachedTimeline.find(
+      (entry): entry is Extract<TimelineEntry, { msg: LogMessageData }> =>
+        entry.key === 'm2' && 'msg' in entry,
+    );
+    expect(timelineEntry?.msg).toBe(original[1]);
+
+    list.cachedUngrouped = new Proxy(list.cachedUngrouped, {
+      get(target, property, receiver) {
+        if (typeof property === 'string' && /^\d+$/.test(property)) {
+          throw new Error('unexpected ungrouped array scan');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    }) as LogMessageData[];
+
+    list.updateTimelineMessageRefs();
+
+    expect(timelineEntry?.msg).toBe(updated);
+  });
+});

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -34,6 +34,7 @@ const domGlobalKeys = [
   'MouseEvent',
   'ShadowRoot',
   'Node',
+  'CSSStyleSheet',
   'AbortController',
   'AbortSignal',
   'getComputedStyle',
@@ -258,6 +259,7 @@ export function useLitComponentTestDom(
       MouseEvent: dom.window.MouseEvent,
       ShadowRoot: dom.window.ShadowRoot,
       Node: dom.window.Node,
+      CSSStyleSheet: dom.window.CSSStyleSheet,
       // wa-dialog (and other Web Awesome components) rely on these browser
       // globals; use the jsdom-backed implementations so AbortSignal/Event
       // identity matches the EventTarget instances they're attached to.


### PR DESCRIPTION
Closes #3964.

## Summary

- Add private TaskGroupList indexes for cached ungrouped messages by id and by array position.
- Use the id map for fallback timeline message-ref refreshes instead of scanning cached ungrouped messages for each timeline entry.
- Use the index map for ungrouped replacement when the cached position is still valid, with reindexing only after ungrouped splices.
- Extend the Lit component test DOM helper with CSSStyleSheet so progress-view components using constructable stylesheets can be tested under jsdom.

## Design note

The normal delta fast path is unchanged. This patch only makes the fallback path cheaper when a full sync or non-delta update reaches TaskGroupList. The render model, log message contract, and timeline structure stay the same.

## Validation

- npm run format
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
- ./node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/TaskGroupList.ts src/test-kernel/progressView/TaskGroupListIndex.vitest.ts src/test-kernel/settings/litComponentTestUtils.ts
- npm run lint (existing warning baseline: 66 warnings, 0 errors)
- Direct progress-view Vite development build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the progress-view log caching/indexing logic; while behavior should be identical, mistakes could cause missed/incorrect log updates or timeline ordering under non-delta/full-sync paths.
> 
> **Overview**
> Improves `TaskGroupList`’s non-terminal render performance by adding `ungroupedMessageById` and `ungroupedMessageIndex` to avoid repeated scans of `cachedUngrouped` when refreshing timeline message references and replacing a single updated message.
> 
> Ungrouped insertions now reindex only from the splice point, and messages that later become grouped remove their ungrouped index entries. Adds a Vitest regression test to ensure fallback timeline ref refresh uses the new index (no array scan), and extends `useLitComponentTestDom` to expose `CSSStyleSheet` for components using constructable stylesheets under jsdom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afba07edfc202387c0eb54248b19b5f9430319bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->