### PR TITLE
perf: bound progress stream data loads

### DIFF
--- a/packages/extension/src/progressView/managers/OutputFilesManager.ts
+++ b/packages/extension/src/progressView/managers/OutputFilesManager.ts
@@ -1,7 +1,10 @@
 import { AgentLogger } from '@logger/AgentLogger';
 import { RoundKeySchema } from '@progressView/persistence/streamTabSchemas';
 import { mapToRecord } from '@progressView/persistence/serializationUtils';
-import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
+import {
+  getStreamTabStore,
+  mapStreamTabStorage,
+} from '@progressView/persistence/StreamTabStore';
 import {
   CompileFailureSchema,
   OutputFileInfoListSchema,
@@ -206,26 +209,23 @@ export class OutputFilesManager {
     this._missingOutputs.clear();
     this._compileFailures.clear();
 
-    await Promise.all(
-      streamIds.map(async (streamId) => {
-        const store = getStreamTabStore(streamId);
-        const [outputFiles, missingOutputs, compileFailures] =
-          await Promise.all([
-            store.readOutputFiles(),
-            store.readMissingOutputs(),
-            store.readCompileFailures(),
-          ]);
-        if (outputFiles?.size) {
-          this.items.set(streamId, outputFiles);
-        }
-        if (missingOutputs?.size) {
-          this._missingOutputs.set(streamId, missingOutputs);
-        }
-        if (compileFailures?.size) {
-          this._compileFailures.set(streamId, compileFailures);
-        }
-      }),
-    );
+    await mapStreamTabStorage(streamIds, async (streamId) => {
+      const store = getStreamTabStore(streamId);
+      const [outputFiles, missingOutputs, compileFailures] = await Promise.all([
+        store.readOutputFiles(),
+        store.readMissingOutputs(),
+        store.readCompileFailures(),
+      ]);
+      if (outputFiles?.size) {
+        this.items.set(streamId, outputFiles);
+      }
+      if (missingOutputs?.size) {
+        this._missingOutputs.set(streamId, missingOutputs);
+      }
+      if (compileFailures?.size) {
+        this._compileFailures.set(streamId, compileFailures);
+      }
+    });
 
     this.loaded = true;
   }

--- a/packages/extension/src/progressView/managers/StreamMetaManager.ts
+++ b/packages/extension/src/progressView/managers/StreamMetaManager.ts
@@ -7,7 +7,10 @@ import {
   isWorkflowTaskState,
   type TaskState,
 } from '@logger/TaskState';
-import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
+import {
+  getStreamTabStore,
+  mapStreamTabStorage,
+} from '@progressView/persistence/StreamTabStore';
 import type { StreamTabMeta } from '@progressView/persistence/streamTabSchemas';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -154,13 +157,11 @@ export class StreamMetaManager {
   async load(streamIds: StreamTabId[]): Promise<void> {
     this.evictAll();
 
-    const results = await Promise.all(
-      streamIds.map(async (streamId) => {
-        const store = getStreamTabStore(streamId);
-        const meta = await store.readMeta();
-        return { streamId, meta };
-      }),
-    );
+    const results = await mapStreamTabStorage(streamIds, async (streamId) => {
+      const store = getStreamTabStore(streamId);
+      const meta = await store.readMeta();
+      return { streamId, meta };
+    });
 
     let loadedTasks = 0;
     let skippedTasks = 0;
@@ -211,15 +212,20 @@ export class StreamMetaManager {
     );
     if (missing.length === 0) return;
 
-    const results = await Promise.all(
-      missing.map(async ([streamId, executionId]) => {
+    const results = await mapStreamTabStorage(
+      missing.map(([streamId]) => streamId),
+      async (streamId) => {
+        const executionId = this.executionIds.get(streamId);
+        if (!executionId) {
+          return { streamId, description: undefined };
+        }
         try {
           const meta = await getExecutionStore(executionId).readMeta();
           return { streamId, description: meta?.description };
         } catch {
           return { streamId, description: undefined };
         }
-      }),
+      },
     );
 
     const backfilled: StreamTabId[] = [];
@@ -233,14 +239,12 @@ export class StreamMetaManager {
     // Persist backfilled descriptions so future loads skip this I/O.
     // save() is gated on `this.loaded`, so write directly here.
     if (backfilled.length > 0) {
-      await Promise.all(
-        backfilled.map((streamId) => {
-          const meta = this.buildMeta(streamId);
-          return getStreamTabStore(streamId)
-            .writeMeta(meta)
-            .catch(() => {});
-        }),
-      );
+      await mapStreamTabStorage(backfilled, (streamId) => {
+        const meta = this.buildMeta(streamId);
+        return getStreamTabStore(streamId)
+          .writeMeta(meta)
+          .catch(() => {});
+      });
       this.logger.info(
         `Backfilled ${backfilled.length} description(s) from ExecutionMeta`,
       );

--- a/packages/extension/src/progressView/managers/UsageStatsManager.ts
+++ b/packages/extension/src/progressView/managers/UsageStatsManager.ts
@@ -4,7 +4,10 @@ import {
   TokenUsageStatsParsingSchema,
   isEmptyUsage,
 } from '@progressView/persistence/streamTabSchemas';
-import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
+import {
+  getStreamTabStore,
+  mapStreamTabStorage,
+} from '@progressView/persistence/StreamTabStore';
 import {
   emptyUsageStats,
   sumUsageStats,
@@ -79,15 +82,13 @@ export class UsageStatsManager {
   async load(streamIds: StreamTabId[]): Promise<void> {
     this.items.clear();
 
-    await Promise.all(
-      streamIds.map(async (streamId) => {
-        const store = getStreamTabStore(streamId);
-        const usageStats = await store.readUsageStats();
-        if (usageStats?.size) {
-          this.items.set(streamId, usageStats);
-        }
-      }),
-    );
+    await mapStreamTabStorage(streamIds, async (streamId) => {
+      const store = getStreamTabStore(streamId);
+      const usageStats = await store.readUsageStats();
+      if (usageStats?.size) {
+        this.items.set(streamId, usageStats);
+      }
+    });
 
     this.loaded = true;
 

--- a/packages/extension/src/progressView/persistence/StreamTabStore.ts
+++ b/packages/extension/src/progressView/persistence/StreamTabStore.ts
@@ -18,6 +18,7 @@
  */
 
 import * as path from 'path';
+import pMap from 'p-map';
 
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
@@ -249,7 +250,15 @@ class StreamTabKVStore extends KVStore {
 // ============================================================================
 
 const MAX_STORE_CACHE_SIZE = 50;
+export const STREAM_TAB_IO_CONCURRENCY = 8;
 const storeCache = new Map<StreamTabId, StreamTabKVStore>();
+
+export function mapStreamTabStorage<T>(
+  streamIds: readonly StreamTabId[],
+  mapper: (streamId: StreamTabId, index: number) => Promise<T> | T,
+): Promise<T[]> {
+  return pMap(streamIds, mapper, { concurrency: STREAM_TAB_IO_CONCURRENCY });
+}
 
 export function getStreamTabStore(streamTabId: StreamTabId): StreamTabKVStore {
   const cached = storeCache.get(streamTabId);

--- a/packages/extension/src/progressView/persistence/mementoMigration.ts
+++ b/packages/extension/src/progressView/persistence/mementoMigration.ts
@@ -12,7 +12,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { getStreamTabStore } from './StreamTabStore';
+import { getStreamTabStore, mapStreamTabStorage } from './StreamTabStore';
 import type {
   StreamTabMeta,
   OutputFilesRecord,
@@ -119,19 +119,17 @@ export async function migrateFromMemento(
   const taskStateEntries = extractTaskStateEntries(taskStatesRaw);
 
   // Migrate each stream's data to disk
-  await Promise.all(
-    [...allStreamIds].map((streamId) =>
-      migrateStreamToStore(streamId, {
-        taskStateEntries,
-        executionIdsRaw,
-        activeRunIdsRaw,
-        parentStreamIdsRaw,
-        runInstructionsRaw,
-        outputFilesRaw,
-        missingOutputsRaw,
-        usageStatsRaw,
-      }),
-    ),
+  await mapStreamTabStorage([...allStreamIds], (streamId) =>
+    migrateStreamToStore(streamId, {
+      taskStateEntries,
+      executionIdsRaw,
+      activeRunIdsRaw,
+      parentStreamIdsRaw,
+      runInstructionsRaw,
+      outputFilesRaw,
+      missingOutputsRaw,
+      usageStatsRaw,
+    }),
   );
 
   // Clear legacy workspace state keys

--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -15,6 +15,7 @@ import type { MementoStorage } from '@progressView/persistence/PersistentMapMana
 import {
   getStreamTabStore,
   deleteAllStreamData,
+  mapStreamTabStorage,
 } from '@progressView/persistence/StreamTabStore';
 import {
   needsMigrationFromMemento,
@@ -402,12 +403,10 @@ export class ProgressViewState {
     // earlier memento→StreamTabStore migration) to the archival
     // `legacyInstructions.json` so older workflow tabs can still restore
     // their original instruction into the log stream.
-    await Promise.all(
-      this.streamLogs.keys().map((id) =>
-        getStreamTabStore(id)
-          .migrateOnDiskRunInstructions()
-          .catch(() => {}),
-      ),
+    await mapStreamTabStorage(this.streamLogs.keys(), (id) =>
+      getStreamTabStore(id)
+        .migrateOnDiskRunInstructions()
+        .catch(() => {}),
     );
 
     const restoredLegacyInstructionCount =
@@ -451,57 +450,54 @@ export class ProgressViewState {
   private async backfillLegacyWorkflowInstructions(): Promise<number> {
     let restoredCount = 0;
 
-    await Promise.all(
-      this.streamLogs.keys().map(async (streamId) => {
-        try {
-          const store = getStreamTabStore(streamId);
-          const legacyInstruction =
-            await store.readPreferredLegacyInstruction();
-          if (!legacyInstruction) return;
+    await mapStreamTabStorage(this.streamLogs.keys(), async (streamId) => {
+      try {
+        const store = getStreamTabStore(streamId);
+        const legacyInstruction = await store.readPreferredLegacyInstruction();
+        if (!legacyInstruction) return;
 
-          const text = legacyInstruction.text.trim();
-          if (!text) return;
+        const text = legacyInstruction.text.trim();
+        if (!text) return;
 
-          await this.streamLogs.ensureLoaded(streamId);
-          const log = this.streamLogs.get(streamId);
-          if (!log) return;
+        await this.streamLogs.ensureLoaded(streamId);
+        const log = this.streamLogs.get(streamId);
+        if (!log) return;
 
-          const alreadyPresent = log
-            .getRange(0, log.head)
-            .some(
-              (entry) =>
-                entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
-                entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
-                entry.text?.trim() === text,
-            );
-          if (alreadyPresent) return;
-
-          const firstTimestamp = log.firstTimestamp;
-          const baseTimestamp =
-            legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
-          const timestamp =
-            firstTimestamp == null
-              ? baseTimestamp
-              : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
-
-          this.streamLogs.append(streamId, {
-            id: `legacy-instruction:${streamId}:${timestamp}`,
-            type: STREAM_LOG_ENTRY_TYPES.LOG,
-            level: LOG_LEVELS.INFO,
-            timestamp,
-            messageType: MESSAGE_TYPES.USER_MESSAGE,
-            text: legacyInstruction.text,
-            data: { source: 'legacyInstruction' },
-          });
-          restoredCount++;
-        } catch (err) {
-          this.logger.warn(
-            `[Persistence] Failed to backfill legacy instruction for ${streamId}: ${toErrorMessage(err)}`,
-            { data: err },
+        const alreadyPresent = log
+          .getRange(0, log.head)
+          .some(
+            (entry) =>
+              entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+              entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
+              entry.text?.trim() === text,
           );
-        }
-      }),
-    );
+        if (alreadyPresent) return;
+
+        const firstTimestamp = log.firstTimestamp;
+        const baseTimestamp =
+          legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
+        const timestamp =
+          firstTimestamp == null
+            ? baseTimestamp
+            : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
+
+        this.streamLogs.append(streamId, {
+          id: `legacy-instruction:${streamId}:${timestamp}`,
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp,
+          messageType: MESSAGE_TYPES.USER_MESSAGE,
+          text: legacyInstruction.text,
+          data: { source: 'legacyInstruction' },
+        });
+        restoredCount++;
+      } catch (err) {
+        this.logger.warn(
+          `[Persistence] Failed to backfill legacy instruction for ${streamId}: ${toErrorMessage(err)}`,
+          { data: err },
+        );
+      }
+    });
 
     return restoredCount;
   }

--- a/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapStreamTabStorage,
+  STREAM_TAB_IO_CONCURRENCY,
+} from '@progressView/persistence/StreamTabStore';
+import type { StreamTabId } from '@shared/schemas';
+
+describe('mapStreamTabStorage', () => {
+  it('bounds concurrent per-stream storage work', async () => {
+    const streamIds = Array.from(
+      { length: STREAM_TAB_IO_CONCURRENCY + 4 },
+      (_, index) => `stream-${index}` as StreamTabId,
+    );
+    const pending: Array<() => void> = [];
+    let active = 0;
+    let maxActive = 0;
+    let started = 0;
+
+    const resultPromise = mapStreamTabStorage(streamIds, async (streamId) => {
+      active++;
+      started++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => pending.push(resolve));
+      active--;
+      return streamId;
+    });
+
+    await waitFor(() => started === STREAM_TAB_IO_CONCURRENCY);
+    expect(maxActive).toBe(STREAM_TAB_IO_CONCURRENCY);
+    expect(started).toBe(STREAM_TAB_IO_CONCURRENCY);
+
+    while (started < streamIds.length) {
+      for (const resolve of pending.splice(0)) {
+        resolve();
+      }
+      await waitFor(() => pending.length > 0 || started === streamIds.length);
+    }
+
+    for (const resolve of pending.splice(0)) {
+      resolve();
+      await Promise.resolve();
+    }
+
+    const results = await resultPromise;
+    expect(results).toEqual(streamIds);
+    expect(maxActive).toBeLessThanOrEqual(STREAM_TAB_IO_CONCURRENCY);
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('Timed out waiting for condition');
+}


### PR DESCRIPTION
## Summary

Closes #3966.

This PR bounds progress-view per-stream storage I/O during startup and legacy migration. Stream log summary loading already had a bounded loader; this extends the same discipline to the adjacent stream-tab data paths so a large history does not create one storage task per stream all at once.

## Changes

- Adds a `StreamTabStore`-owned `mapStreamTabStorage` helper and shared `STREAM_TAB_IO_CONCURRENCY` policy.
- Uses that policy for output-file, usage, meta, legacy-instruction, and memento migration stream loops.
- Adds a focused Vitest test that verifies the per-stream storage mapper never exceeds the configured concurrency.

## Validation

- npm run format
- node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- npm run lint (passes with existing warnings)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view persistence load/migration paths and changes their execution model from unbounded `Promise.all` to bounded concurrency, which could surface ordering/timing assumptions or new contention bugs during startup.
> 
> **Overview**
> Reduces progress-view startup and migration load spikes by adding `mapStreamTabStorage` (backed by `p-map`) and a shared `STREAM_TAB_IO_CONCURRENCY` limit in `StreamTabStore`.
> 
> Replaces several unbounded `Promise.all(streamIds.map(...))` loops with the bounded mapper in `OutputFilesManager`, `UsageStatsManager`, `StreamMetaManager` (including description backfill writes), `mementoMigration`, and `ProgressViewState` legacy-instruction promotion/backfill.
> 
> Adds a focused Vitest (`StreamTabStorageConcurrency.vitest.ts`) to assert the mapper never exceeds the configured concurrency and preserves result ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b4b11e3e945b49a4eb49995db760f4f729d810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->