### PR TITLE
perf: append background terminal output

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -36,6 +36,36 @@ const MIN_SCROLLBACK = 4_000;
 /** Maximum visible rows before terminal scrolls internally. */
 const MAX_VISIBLE_ROWS = 20;
 
+export interface TerminalTextUpdatePlan {
+  reset: boolean;
+  textToWrite: string;
+}
+
+export function planTerminalTextUpdate(
+  renderedText: string,
+  nextText: string,
+): TerminalTextUpdatePlan {
+  if (nextText.startsWith(renderedText)) {
+    return {
+      reset: false,
+      textToWrite: nextText.slice(renderedText.length),
+    };
+  }
+
+  return {
+    reset: true,
+    textToWrite: nextText,
+  };
+}
+
+export function countTerminalRows(text: string): number {
+  let rows = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) rows += 1;
+  }
+  return rows;
+}
+
 /**
  * Read-only terminal renderer for shell output.
  * Uses xterm.js for ANSI colors/formatting without interactive input.
@@ -68,6 +98,7 @@ export class TerminalOutput extends LitElement {
   private isFlushingText = false;
   private needsFlush = false;
   private pendingText = '';
+  private renderedText = '';
 
   private readonly handleDetailsToggle = (): void => {
     this.refitIfVisible();
@@ -174,7 +205,8 @@ export class TerminalOutput extends LitElement {
         const distanceFromBottom = previousBaseY - previousViewportY;
         const wasPinnedToBottom = distanceFromBottom <= 1;
 
-        const lineCount = text.split('\n').length;
+        const updatePlan = planTerminalTextUpdate(this.renderedText, text);
+        const lineCount = countTerminalRows(text);
         const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
         if (terminal.options.scrollback !== scrollback) {
           terminal.options = {
@@ -183,21 +215,14 @@ export class TerminalOutput extends LitElement {
           };
         }
 
-        terminal.reset();
-        await new Promise<void>((resolve) => {
-          let resolved = false;
-          const complete = (): void => {
-            if (resolved) return;
-            resolved = true;
-            resolve();
-          };
-
-          terminal.write(text, complete);
-          setTimeout(complete, 100);
-        });
+        if (updatePlan.reset) {
+          terminal.reset();
+        }
+        await this.writeTerminalText(terminal, updatePlan.textToWrite);
 
         if (!this.terminal || this.terminal !== terminal) continue;
 
+        this.renderedText = text;
         if (!wasPinnedToBottom) {
           const nextBaseY = terminal.buffer.active.baseY;
           const targetViewportY = Math.max(0, nextBaseY - distanceFromBottom);
@@ -212,6 +237,25 @@ export class TerminalOutput extends LitElement {
         this.renderTerminalText();
       }
     }
+  }
+
+  private async writeTerminalText(
+    terminal: Terminal,
+    text: string,
+  ): Promise<void> {
+    if (!text) return;
+
+    await new Promise<void>((resolve) => {
+      let resolved = false;
+      const complete = (): void => {
+        if (resolved) return;
+        resolved = true;
+        resolve();
+      };
+
+      terminal.write(text, complete);
+      setTimeout(complete, 100);
+    });
   }
 
   /** Resolve theme colors and font family from VS Code CSS variables in a single getComputedStyle call. */

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -31,13 +31,15 @@ export function takePendingDescription(
 
 /** Max characters retained per output stream (stdout/stderr) per process. */
 const MAX_OUTPUT = 100_000;
+/** Trim below the cap so new output can append for a while before the next reset. */
+const TRIMMED_OUTPUT_LENGTH = 80_000;
 
 /** Append delta to prev, capping to MAX_OUTPUT by trimming the front. */
 function capOutput(prev: string, delta: string): string {
   if (!delta) return prev;
   const combined = prev + delta;
   return combined.length > MAX_OUTPUT
-    ? combined.slice(combined.length - MAX_OUTPUT)
+    ? combined.slice(combined.length - TRIMMED_OUTPUT_LENGTH)
     : combined;
 }
 

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -34,7 +34,7 @@ const MAX_OUTPUT = 100_000;
 /** Trim below the cap so new output can append for a while before the next reset. */
 const TRIMMED_OUTPUT_LENGTH = 80_000;
 
-/** Append delta to prev, capping to MAX_OUTPUT by trimming the front. */
+/** Append delta to prev, trimming below MAX_OUTPUT when the cap is crossed. */
 function capOutput(prev: string, delta: string): string {
   if (!delta) return prev;
   const combined = prev + delta;

--- a/src/test-kernel/progressView/TerminalOutput.vitest.ts
+++ b/src/test-kernel/progressView/TerminalOutput.vitest.ts
@@ -1,0 +1,40 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/TerminalOutput'),
+);
+
+describe('terminal-output text update planning', () => {
+  it('writes only the appended suffix when output grows', async () => {
+    const { planTerminalTextUpdate } =
+      await import('@progressView/frontend/components/TerminalOutput');
+
+    expect(planTerminalTextUpdate('alpha\n', 'alpha\nbeta\n')).toEqual({
+      reset: false,
+      textToWrite: 'beta\n',
+    });
+  });
+
+  it('falls back to a reset when retained output is replaced', async () => {
+    const { planTerminalTextUpdate } =
+      await import('@progressView/frontend/components/TerminalOutput');
+
+    expect(planTerminalTextUpdate('alpha\nbeta\n', 'beta\n')).toEqual({
+      reset: true,
+      textToWrite: 'beta\n',
+    });
+  });
+
+  it('counts terminal rows without allocating split arrays', async () => {
+    const { countTerminalRows } =
+      await import('@progressView/frontend/components/TerminalOutput');
+
+    expect(countTerminalRows('')).toBe(1);
+    expect(countTerminalRows('one')).toBe(1);
+    expect(countTerminalRows('one\ntwo\n')).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Make background-task terminal output append new suffixes instead of resetting xterm and replaying the full retained buffer on every poll.
- Add output-cap hysteresis so very large retained output trims below the cap, then resumes append-only updates until the cap is reached again.
- Add focused tests for terminal update planning and row counting.

Closes #3968.

## Validation

- `npm run format`
- `node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/TerminalOutput.vitest.ts src/test-kernel/progressView/TaskGroupListIndex.vitest.ts`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/TerminalOutput.ts packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts src/test-kernel/progressView/TerminalOutput.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how retained process output is trimmed and how `terminal-output` updates xterm content; regressions could drop/duplicate output or cause incorrect scrollback/viewport behavior under heavy output.
> 
> **Overview**
> Progress-view terminal rendering now tracks `renderedText` and **appends only the new suffix** to xterm when output grows, falling back to a reset only when the retained buffer is replaced (via new `planTerminalTextUpdate` and `writeTerminalText`).
> 
> Scrollback sizing is computed via a lightweight newline counter (`countTerminalRows`) instead of `split`, and process output retention now trims to `TRIMMED_OUTPUT_LENGTH` once `MAX_OUTPUT` is exceeded to reduce frequent reset/replay churn.
> 
> Adds focused Vitest coverage for the update planning and row-count logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e139dbf8bf8dab8cacb8eb145f6dab23f0875a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->