### PR TITLE
perf: reduce background output fan-out

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -150,30 +150,12 @@ export const streamMetaHandlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data, ctx) => {
     const { stream, executionId, stdout, stderr } = data;
-    ctx.setState((prev) => {
-      // Only prune stale entries when this stream is active — badge data
-      // (activeProcesses) is only refreshed for the active stream, so for
-      // inactive streams the set would be stale and we'd incorrectly delete
-      // output for still-running sibling processes. For inactive streams,
-      // pruning is handled by UPDATE_STREAM_BADGES when the user switches back.
-      const isActiveStream = prev.activeStreamId === stream;
-      return create(prev, (draft) => {
+    ctx.setState((prev) =>
+      create(prev, (draft) => {
         let streamOutputs = draft.processOutputs.get(stream);
         if (!streamOutputs) {
           streamOutputs = new Map();
           draft.processOutputs.set(stream, streamOutputs);
-        }
-        if (isActiveStream) {
-          const streamState = prev.streamStates.get(stream);
-          const activeIds = new Set(
-            (streamState?.activeProcesses ?? []).map(
-              (p: { executionId: string }) => p.executionId,
-            ),
-          );
-          for (const id of [...streamOutputs.keys()]) {
-            if (id !== executionId && !activeIds.has(id))
-              streamOutputs.delete(id);
-          }
         }
         const existing = streamOutputs.get(executionId) ?? {
           stdout: '',
@@ -183,7 +165,7 @@ export const streamMetaHandlers: HandlerRegistry = {
           stdout: capOutput(existing.stdout, stdout),
           stderr: capOutput(existing.stderr, stderr),
         });
-      });
-    });
+      }),
+    );
   },
 };

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -1,6 +1,9 @@
 // Node imports
 import * as fs from 'fs';
 
+// Third-party imports
+import pMap from 'p-map';
+
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
 
@@ -18,6 +21,9 @@ const OUTPUT_POLL_INTERVAL_MS = 500;
 
 /** Max bytes to read per file per poll to prevent huge allocations. */
 const MAX_READ_PER_POLL = 128 * 1024;
+
+/** Max process output sources read concurrently on each poll tick. */
+const OUTPUT_POLL_CONCURRENCY = 8;
 
 /** Tracks byte offsets already sent per executionId per stream. */
 const outputOffsets = new Map<string, { stdout: number; stderr: number }>();
@@ -94,8 +100,9 @@ function schedulePoll(): void {
 }
 
 async function pollProcessOutputs(): Promise<void> {
-  await Promise.all(
-    [...processOutputs.values()].map((source) => {
+  await pMap(
+    [...processOutputs.values()],
+    (source) => {
       const { outputPaths } = source.handle;
       if (!outputPaths) return Promise.resolve();
       return readIncremental(
@@ -105,7 +112,8 @@ async function pollProcessOutputs(): Promise<void> {
         outputPaths.stderr,
         source.runtimeHost,
       );
-    }),
+    },
+    { concurrency: OUTPUT_POLL_CONCURRENCY },
   );
 }
 

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -1,0 +1,145 @@
+// Third-party imports
+import { create } from 'mutative';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - common webview
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - progress view frontend
+import { streamMetaHandlers } from '@progressView/frontend/slices/streamMetaSlice';
+import {
+  createInitialState,
+  type ProgressState,
+  type StreamLogs,
+  type StreamState,
+} from '@progressView/frontend/store';
+import type { MessageHandlerContext } from '@progressView/frontend/messageDispatcher';
+
+// Local imports - shared schemas
+import {
+  AGENT_CATEGORY,
+  createStreamState,
+  STREAM_STATUS,
+  type ProgressViewOutboundMessage,
+  type StreamTabId,
+} from '@shared/schemas';
+
+function createContext(initialState: ProgressState): {
+  ctx: MessageHandlerContext;
+  getState: () => ProgressState;
+} {
+  let state = initialState;
+  const ctx: MessageHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    },
+    setStreamState: (streamId, updater) => {
+      const current = state.streamStates.get(streamId);
+      if (!current) return;
+      const updated = updater(current);
+      if (updated === current) return;
+      state = create(state, (draft) => {
+        draft.streamStates.set(streamId, updated);
+      });
+    },
+    setStreamLogs: (
+      _streamId,
+      _updater: (prev: StreamLogs) => StreamLogs,
+    ) => {},
+    savePrefs: () => {},
+    getPermissions: () => [],
+    setPermissions: () => {},
+    setPlacement: () => {},
+  };
+  return { ctx, getState: () => state };
+}
+
+function createProcessState(streamId: StreamTabId): ProgressState {
+  const state = createInitialState();
+  state.activeStreamId = streamId;
+  state.streamStates.set(
+    streamId,
+    createStreamState(AGENT_CATEGORY.WORKFLOW, {
+      activeProcesses: [
+        {
+          executionId: 'active-process',
+          agentName: 'bash',
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    } satisfies Partial<StreamState>),
+  );
+  state.processOutputs.set(
+    streamId,
+    new Map([
+      ['active-process', { stdout: 'old-active', stderr: '' }],
+      ['stale-process', { stdout: 'old-stale', stderr: '' }],
+    ]),
+  );
+  return state;
+}
+
+function dispatch(
+  message: ProgressViewOutboundMessage,
+  ctx: MessageHandlerContext,
+) {
+  const handler = streamMetaHandlers[message.command];
+  expect(handler).toBeDefined();
+  handler?.(message as never, ctx);
+}
+
+describe('process output frontend state', () => {
+  it('appends output without pruning sibling process entries', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const { ctx, getState } = createContext(createProcessState(streamId));
+
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
+        stream: streamId,
+        executionId: 'active-process',
+        stdout: '-new',
+        stderr: 'warn',
+      },
+      ctx,
+    );
+
+    const outputs = getState().processOutputs.get(streamId);
+    expect(outputs?.get('active-process')).toEqual({
+      stdout: 'old-active-new',
+      stderr: 'warn',
+    });
+    expect(outputs?.get('stale-process')).toEqual({
+      stdout: 'old-stale',
+      stderr: '',
+    });
+  });
+
+  it('prunes stale process entries when badges change', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const { ctx, getState } = createContext(createProcessState(streamId));
+
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+        stream: streamId,
+        activeSubagents: [],
+        finishedSubagentCount: 0,
+        activeProcesses: [
+          {
+            executionId: 'active-process',
+            agentName: 'bash',
+            status: STREAM_STATUS.RUNNING,
+          },
+        ],
+        finishedProcessCount: 0,
+      },
+      ctx,
+    );
+
+    const outputs = getState().processOutputs.get(streamId);
+    expect(outputs?.has('active-process')).toBe(true);
+    expect(outputs?.has('stale-process')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Bounds background process-output polling so a tick does not start filesystem reads for every active process at once.
- Moves stale process-output pruning to the badge-change path, which already owns active process membership, so stdout/stderr deltas only append bounded output.
- Adds focused frontend state tests for the output append and badge-prune contract.

Closes #3970.

## Validation

- npm run format
- node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/ProcessOutputState.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node_modules/.bin/tsc --noEmit
- npm run compile:fast
- npm run lint (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how process output is polled and retained, which can affect log completeness/ordering and UI state consistency under load. Concurrency limits and altered pruning behavior could expose edge cases with many simultaneous processes.
> 
> **Overview**
> Reduces background load from process output polling by switching `ProcessOutputPoller` to concurrency-limited reads (via `p-map`) instead of firing filesystem reads for all active processes at once.
> 
> Adjusts the progress view frontend so `UPDATE_PROCESS_OUTPUT` only appends/caps stdout/stderr, and *stale per-process output entries* are now pruned exclusively when `UPDATE_STREAM_BADGES` updates the active process set.
> 
> Adds `ProcessOutputState.vitest.ts` to assert the new contract: output updates don’t delete sibling entries, and badge updates remove stale process outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d8e2d22dfeda4a4154265ed58e5631b2251a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->