### PR TITLE
perf: bound stale stream log rehydrates

### DIFF
--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -332,7 +332,9 @@ export class StreamLogStore {
     }
 
     if (streamsToLoad.size > 0) {
-      await Promise.all([...streamsToLoad].map((id) => this.ensureLoaded(id)));
+      await pMap([...streamsToLoad], (id) => this.ensureLoaded(id), {
+        concurrency: STREAM_LOG_LOAD_CONCURRENCY,
+      });
     }
 
     const affected: StreamTabId[] = [];

--- a/src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
@@ -25,6 +25,7 @@ interface MockStorageOptions {
   summaries: Record<string, unknown>;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
+  onLogRead?: (key: string) => Promise<void> | void;
   pauseLogWriteKey?: string;
 }
 
@@ -87,6 +88,7 @@ function mockStorage({
   summaries,
   logMtimes = {},
   summaryMtimes = {},
+  onLogRead,
   pauseLogWriteKey,
 }: MockStorageOptions): {
   deletes: string[];
@@ -127,6 +129,7 @@ function mockStorage({
     if (target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
       if (!Object.hasOwn(logs, key)) throw notFound();
       fullLogReads += 1;
+      await onLogRead?.(key);
       return logs[key] as never;
     }
 
@@ -177,6 +180,17 @@ function mockStorage({
     waitForPausedWrite: () => waitForPausedWrite,
     writes,
   };
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(message);
 }
 
 describe('StreamLogStore load', () => {
@@ -307,6 +321,63 @@ describe('StreamLogStore load', () => {
       lastTimestamp: 100,
       hasRunningGroup: false,
     });
+  });
+
+  it('bounds stale running group rehydrates', async () => {
+    const streamIds = Array.from(
+      { length: 20 },
+      (_, index) => `stream-${index}`,
+    );
+    let releaseReads: () => void = () => {};
+    const readGate = new Promise<void>((resolve) => {
+      releaseReads = resolve;
+    });
+    let activeReads = 0;
+    let maxActiveReads = 0;
+
+    const storage = mockStorage({
+      logs: Object.fromEntries(
+        streamIds.map((streamId, index) => [
+          streamId,
+          [runningGroupEntry(streamId, 1, 100 + index)],
+        ]),
+      ),
+      summaries: Object.fromEntries(
+        streamIds.map((streamId, index) => [
+          streamId,
+          {
+            firstTimestamp: 100 + index,
+            lastTimestamp: 100 + index,
+            hasRunningGroup: true,
+          },
+        ]),
+      ),
+      onLogRead: async () => {
+        activeReads += 1;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        await readGate;
+        activeReads -= 1;
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    const endRunningGroups = store.endRunningGroups(300);
+    await waitForCondition(
+      () => storage.fullLogReads() === 8,
+      'Expected stale stream rehydrate reads to reach the concurrency cap',
+    );
+
+    expect(maxActiveReads).toBe(8);
+
+    releaseReads();
+    const affected = await endRunningGroups;
+    await store.flush();
+
+    expect(affected).toHaveLength(streamIds.length);
+    expect(maxActiveReads).toBe(8);
+    expect(storage.fullLogReads()).toBe(streamIds.length);
   });
 
   it('lets delete win over an in-flight stream write', async () => {


### PR DESCRIPTION
## Summary

- Bound StreamLogStore.endRunningGroups() rehydrate reads with the existing stream-log load concurrency budget.
- Added a regression test that holds stale stream-log reads open and verifies the stale-running-group recovery path does not exceed the cap.

## Verification

- npm run format
- node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/eslint src/logger/StreamLogStore.ts src/test-kernel/progressView/StreamLogStoreLoad.vitest.ts
- npm run compile:fast
- npm run lint

Closes #3972

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance change that only limits parallel disk rehydrate reads in `endRunningGroups`; primary behavioral change is reduced IO burstiness and different load scheduling.
> 
> **Overview**
> `StreamLogStore.endRunningGroups()` now rehydrates stale streams using `p-map` with `STREAM_LOG_LOAD_CONCURRENCY` instead of unbounded `Promise.all`, preventing large numbers of concurrent log reads when many streams have stale running groups.
> 
> Tests extend the storage mock with an `onLogRead` hook and add a regression case that blocks reads to assert the rehydrate path never exceeds the concurrency cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f97d3edc4b911140f9f9286629d558c8858103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->