### PR TITLE
perf: avoid stream log append parsing

### DIFF
--- a/src/logger/StreamLog.ts
+++ b/src/logger/StreamLog.ts
@@ -1,8 +1,4 @@
-import {
-  STREAM_LOG_ENTRY_TYPES,
-  StreamLogEntrySchema,
-  type StreamLogEntry,
-} from '@shared/schemas';
+import { STREAM_LOG_ENTRY_TYPES, type StreamLogEntry } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 export type StreamLogAppendInput = Omit<StreamLogEntry, 'seqNo'>;
@@ -69,10 +65,10 @@ export class StreamLog {
   }
 
   append(entry: StreamLogAppendInput): StreamLogEntry {
-    const fullEntry = StreamLogEntrySchema.parse({
+    const fullEntry: StreamLogEntry = {
       ...entry,
       seqNo: this.seqCounter + 1,
-    });
+    };
     this.seqCounter = fullEntry.seqNo;
     this.indexById.set(fullEntry.id, this.entries.length);
     this.entries.push(fullEntry);
@@ -89,7 +85,7 @@ export class StreamLog {
     const current = this.entries[index];
     // Direct merge — no Zod parse. update() is on the streaming hot path
     // (tool output chunks at ~200/sec) and receives trusted data from
-    // AgentLogger. The schema boundary is append(), not update().
+    // AgentLogger. Persisted entries are parsed when loaded from storage.
     const updated: StreamLogEntry = {
       ...current,
       ...patch,

--- a/src/test-kernel/logger/StreamLog.vitest.ts
+++ b/src/test-kernel/logger/StreamLog.vitest.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { StreamLog } from '@logger/StreamLog';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+} from '@shared/schemas';
+
+describe('StreamLog', () => {
+  it('appends trusted entries while preserving sequence and lookup invariants', () => {
+    const log = new StreamLog();
+
+    log.append({
+      id: 'run',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'run',
+      data: { status: 'running' },
+    });
+
+    for (let i = 0; i < 5_000; i++) {
+      log.append({
+        id: `message-${i}`,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: i + 2,
+        text: `message ${i}`,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        groupId: 'run',
+      });
+    }
+
+    expect(log.head).toBe(5_001);
+    expect(log.size).toBe(5_001);
+    expect(log.hasRunningGroup).toBe(true);
+
+    const entries = log.getRange(0, log.head);
+    expect(entries).toHaveLength(5_001);
+    expect(entries[0]?.seqNo).toBe(1);
+    expect(entries.at(-1)?.seqNo).toBe(5_001);
+
+    const updated = log.update('message-2500', { text: 'changed' });
+    expect(updated?.seqNo).toBe(2_502);
+
+    log.update('run', {
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      data: { status: 'stopped' },
+    });
+    expect(log.hasRunningGroup).toBe(false);
+
+    expect(log.drainDirtyUpdates().map((entry) => entry.id)).toEqual([
+      'run',
+      'message-2500',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3975.

- Remove the Zod parse from `StreamLog.append()`, which is called on the logger hot path during streaming output.
- Keep persisted log validation at the storage/load boundary through the existing persisted-entry schema.
- Add a focused `StreamLog` test that appends 5,000 trusted entries and verifies sequence numbers, indexed updates, dirty update ordering, and running-group tracking.

## Design note

`StreamLog.append()` receives entries produced by in-process logger code, so the method now preserves the small internal invariants directly. This follows the repository rule of validating at true boundaries rather than repeatedly validating trusted internal data.

## Validation

- `node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/logger/StreamLog.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `git diff --check`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes runtime schema validation from `StreamLog.append()`, so malformed internal log entries could now propagate until persistence/load-time parsing. Change is localized but affects a high-frequency logging path and its invariants.
> 
> **Overview**
> Removes Zod validation from `StreamLog.append()` and instead directly constructs the `StreamLogEntry` while maintaining sequence numbering and index/running-group tracking.
> 
> Clarifies that log-entry validation happens at the persistence/load boundary rather than per-append, and adds a Vitest that appends 5,000 entries to assert seqNo ordering, lookup/update behavior, dirty-update ordering, and running-group state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ee52cec7b1188fde2904526eaa54ae2df8e4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->