### PR TITLE
perf: throttle streaming logger updates

### DIFF
--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -429,6 +429,7 @@ export class ProgressViewState {
    * Flush pending writes from all managers.
    */
   async flush(): Promise<void> {
+    AgentLogger.flushPendingStreamUpdates();
     await Promise.all([
       this.streamLogs.flush(),
       this.meta.flush(),

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -26,6 +26,8 @@ import {
 } from './StreamLogStore';
 import type { LogOptions } from './logOptions';
 
+const STREAM_UPDATE_THROTTLE_MS = 50;
+
 export interface LoggerScopeOptions {
   parentGroupId?: string;
   skip?: boolean;
@@ -497,33 +499,69 @@ export class AgentLogger {
     const progressEnabled = options.progressViewEnabled ?? true;
 
     let buffer = '';
+    let pendingChunks: string[] = [];
     let created = false;
+    let storeEnabled = progressEnabled;
+    let updateTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const materializePending = (): void => {
+      if (pendingChunks.length === 0) return;
+      buffer += pendingChunks.join('');
+      pendingChunks = [];
+    };
 
     const emitNow = (): void => {
-      if (!progressEnabled) return;
+      materializePending();
+      if (!storeEnabled) return;
 
       if (!created) {
-        created = !!this.appendToStore(level, type, {
+        const appended = this.appendToStore(level, type, {
           id,
           timestamp: Date.now(),
           groupId,
           text: buffer,
         });
+        created = !!appended;
+        if (!created) storeEnabled = false;
         return;
       }
 
       this.updateStore(id, { text: buffer });
     };
 
+    const scheduleUpdate = (): void => {
+      if (updateTimer) return;
+      updateTimer = setTimeout(() => {
+        updateTimer = null;
+        emitNow();
+      }, STREAM_UPDATE_THROTTLE_MS);
+    };
+
+    const flushPendingUpdate = (): void => {
+      if (updateTimer) {
+        clearTimeout(updateTimer);
+        updateTimer = null;
+      }
+      emitNow();
+    };
+
     return {
       append: (text: string) => {
         if (!text) return;
-        buffer += text;
-        emitNow();
+        pendingChunks.push(text);
+        if (!storeEnabled) return;
+        if (!created) {
+          emitNow();
+        } else {
+          scheduleUpdate();
+        }
       },
       finalize: (finalText?: string) => {
-        if (typeof finalText === 'string') buffer = finalText;
-        emitNow();
+        if (typeof finalText === 'string') {
+          buffer = finalText;
+          pendingChunks = [];
+        }
+        flushPendingUpdate();
         this.debug(`Final ${type} length: ${buffer.length}`, { groupId });
         return buffer;
       },

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -120,6 +120,7 @@ export interface AgentLogStream {
 
 export class AgentLogger {
   private static streamLogStore: StreamLogStore | undefined;
+  private static pendingStreamFlushers = new Set<() => void>();
 
   static setStreamLogStore(store: StreamLogStore): void {
     setDefaultStreamLogStore(store);
@@ -129,6 +130,12 @@ export class AgentLogger {
   static getStreamLogStore(): StreamLogStore {
     AgentLogger.streamLogStore ??= getDefaultStreamLogStore();
     return AgentLogger.streamLogStore;
+  }
+
+  static flushPendingStreamUpdates(): void {
+    for (const flush of [...AgentLogger.pendingStreamFlushers]) {
+      flush();
+    }
   }
 
   private get store(): StreamLogStore {
@@ -504,6 +511,14 @@ export class AgentLogger {
     let storeEnabled = progressEnabled;
     let updateTimer: ReturnType<typeof setTimeout> | null = null;
 
+    const registerPendingFlush = (): void => {
+      AgentLogger.pendingStreamFlushers.add(flushPendingUpdate);
+    };
+
+    const unregisterPendingFlush = (): void => {
+      AgentLogger.pendingStreamFlushers.delete(flushPendingUpdate);
+    };
+
     const materializePending = (): void => {
       if (pendingChunks.length === 0) return;
       buffer += pendingChunks.join('');
@@ -534,7 +549,9 @@ export class AgentLogger {
       updateTimer = setTimeout(() => {
         updateTimer = null;
         emitNow();
+        unregisterPendingFlush();
       }, STREAM_UPDATE_THROTTLE_MS);
+      registerPendingFlush();
     };
 
     const flushPendingUpdate = (): void => {
@@ -543,6 +560,7 @@ export class AgentLogger {
         updateTimer = null;
       }
       emitNow();
+      unregisterPendingFlush();
     };
 
     return {

--- a/src/test-kernel/logger/AgentLoggerStream.vitest.ts
+++ b/src/test-kernel/logger/AgentLoggerStream.vitest.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentLogger } from '@logger/AgentLogger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+import { MESSAGE_TYPES } from '@shared/schemas';
+
+describe('AgentLogger stream output', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces streaming text updates and flushes on finalize', () => {
+    vi.useFakeTimers();
+
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger('stream', true);
+      const stream = logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE);
+
+      stream.append('a');
+      let entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.text).toBe('a');
+
+      stream.append('b');
+      stream.append('c');
+      entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries[0]?.text).toBe('a');
+
+      vi.advanceTimersByTime(49);
+      entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries[0]?.text).toBe('a');
+
+      vi.advanceTimersByTime(1);
+      entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries[0]?.text).toBe('abc');
+
+      stream.append('d');
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('abc');
+
+      expect(stream.finalize()).toBe('abcd');
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('abcd');
+
+      vi.runOnlyPendingTimers();
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('abcd');
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('accumulates disabled progress streams without scheduled updates', () => {
+    vi.useFakeTimers();
+
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger('stream', true);
+      const stream = logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE, {
+        progressViewEnabled: false,
+      });
+
+      stream.append('a');
+      stream.append('b');
+      stream.append('c');
+
+      expect(store.get('stream')).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(stream.finalize()).toBe('abc');
+      expect(store.get('stream')).toBeUndefined();
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+});

--- a/src/test-kernel/logger/AgentLoggerStream.vitest.ts
+++ b/src/test-kernel/logger/AgentLoggerStream.vitest.ts
@@ -51,6 +51,31 @@ describe('AgentLogger stream output', () => {
     }
   });
 
+  it('drains pending stream updates for shutdown persistence', () => {
+    vi.useFakeTimers();
+
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger('stream', true);
+      const stream = logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE);
+
+      stream.append('a');
+      stream.append('b');
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('a');
+
+      AgentLogger.flushPendingStreamUpdates();
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('ab');
+      expect(vi.getTimerCount()).toBe(0);
+
+      expect(stream.finalize()).toBe('ab');
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
   it('accumulates disabled progress streams without scheduled updates', () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary

Closes #3977.

- Keep the first streamed logger entry immediate so progress appears quickly.
- Coalesce subsequent stream text deltas on a short timer before updating the stored log entry.
- Accumulate pending chunks and materialize the growing string only when an update is emitted.
- Flush pending text synchronously in `finalize()`, including progress-disabled streams.

## Design note

This addresses a scaling pattern in model-output streams: many small deltas were repeatedly rebuilding and publishing a full accumulated text entry. The change keeps the existing log entry shape and webview contract while reducing extension-host and progress-pipeline churn during long outputs.

## Validation

- `node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/logger/AgentLoggerStream.vitest.ts src/test-kernel/logger/StreamLog.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `node_modules/.bin/eslint src/logger/AgentLogger.ts src/test-kernel/logger/AgentLoggerStream.vitest.ts`
- `git diff --check`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing/ordering of streamed log persistence by batching updates on a timer and introducing a global flush path, which could affect progress-view responsiveness or missed final deltas if edge cases aren’t covered.
> 
> **Overview**
> Reduces progress-view churn from model-output streaming by making `AgentLogger.createStream()` write the **first** chunk immediately, then coalesce subsequent `append()` deltas and update the stored log entry on a short (`50ms`) throttle.
> 
> Adds a global `AgentLogger.flushPendingStreamUpdates()` registry to synchronously drain any scheduled stream updates, and calls it from `ProgressViewState.flush()` so shutdown persistence captures the latest text.
> 
> Introduces `AgentLoggerStream.vitest.ts` coverage for throttling behavior, finalize-time flushing, shutdown draining, and `progressViewEnabled: false` streams not scheduling timers or writing to the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40230c24729d7f9ec1f4d789488cbc6bec5adda8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->