### PR TITLE
refactor: pass extension runtime host on launch

### DIFF
--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -7,6 +7,7 @@ import { AgentConfigSchema } from '@agent/core';
 import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
 import { formatZodError } from '@common/errors';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 
@@ -42,7 +43,10 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
 
     await runValidatedExecutionRequest(
       { config, executionId: wrapped?.executionId },
-      { openWorkflowOutput: openFinalOutputIfAvailable },
+      {
+        runtimeHost: extensionAgentRuntimeHost,
+        openWorkflowOutput: openFinalOutputIfAvailable,
+      },
     );
   } catch (error) {
     if (error instanceof ZodError) {

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -12,6 +12,7 @@ import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as logger from '@logger/logUtils';
 import { generateExecutionId } from '@utils/core/executionId';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
@@ -330,7 +331,9 @@ export async function runSetupAssistant(): Promise<void> {
     const launch = async () => {
       const executionId = generateExecutionId();
       await registerExecution(executionId, config, config.agent);
-      await executeAgent(config, executionId);
+      await executeAgent(config, executionId, {
+        runtimeHost: extensionAgentRuntimeHost,
+      });
     };
 
     if (resolution.requiresOpenRouter) {


### PR DESCRIPTION
## Summary
- pass `extensionAgentRuntimeHost` explicitly from extension launch commands
- keep `executeAgent` and validated request ownership at the extension composition boundary
- avoid adding new layers or behavior changes

Fixes part of #3372.

## Validation
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint packages/extension/src/commands/agent/executeCommand.ts packages/extension/src/commands/setup/setupAssistantCommand.ts`
- `git diff --check`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only threads an explicit `runtimeHost` option through existing execution calls; behavior should be unchanged aside from ensuring the extension host is used.
> 
> **Overview**
> Ensures agent runs launched from the VS Code extension explicitly provide `extensionAgentRuntimeHost` to the runtime.
> 
> `runExecuteCommand` now passes `runtimeHost` into `runValidatedExecutionRequest`, and the setup assistant launch path passes the same `runtimeHost` option into `executeAgent`, keeping runtime-host ownership at the extension composition boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a163d10aa52efeeb70d613b958ea758153becf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->