### PR TITLE
perf: avoid terminal output row recounts

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -66,21 +66,13 @@ export function countTerminalRows(text: string): number {
   return rows;
 }
 
-function countTerminalNewRows(text: string): number {
-  let rows = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 10) rows += 1;
-  }
-  return rows;
-}
-
 export function nextTerminalRowCount(
   previousRowCount: number,
   updatePlan: TerminalTextUpdatePlan,
 ): number {
   return updatePlan.reset
     ? countTerminalRows(updatePlan.textToWrite)
-    : previousRowCount + countTerminalNewRows(updatePlan.textToWrite);
+    : previousRowCount + countTerminalRows(updatePlan.textToWrite) - 1;
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -66,6 +66,23 @@ export function countTerminalRows(text: string): number {
   return rows;
 }
 
+function countTerminalNewRows(text: string): number {
+  let rows = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) rows += 1;
+  }
+  return rows;
+}
+
+export function nextTerminalRowCount(
+  previousRowCount: number,
+  updatePlan: TerminalTextUpdatePlan,
+): number {
+  return updatePlan.reset
+    ? countTerminalRows(updatePlan.textToWrite)
+    : previousRowCount + countTerminalNewRows(updatePlan.textToWrite);
+}
+
 /**
  * Read-only terminal renderer for shell output.
  * Uses xterm.js for ANSI colors/formatting without interactive input.
@@ -99,6 +116,7 @@ export class TerminalOutput extends LitElement {
   private needsFlush = false;
   private pendingText = '';
   private renderedText = '';
+  private renderedRowCount = countTerminalRows('');
 
   private readonly handleDetailsToggle = (): void => {
     this.refitIfVisible();
@@ -206,8 +224,11 @@ export class TerminalOutput extends LitElement {
         const wasPinnedToBottom = distanceFromBottom <= 1;
 
         const updatePlan = planTerminalTextUpdate(this.renderedText, text);
-        const lineCount = countTerminalRows(text);
-        const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
+        const rowCount = nextTerminalRowCount(
+          this.renderedRowCount,
+          updatePlan,
+        );
+        const scrollback = Math.max(MIN_SCROLLBACK, rowCount);
         if (terminal.options.scrollback !== scrollback) {
           terminal.options = {
             ...terminal.options,
@@ -223,6 +244,7 @@ export class TerminalOutput extends LitElement {
         if (!this.terminal || this.terminal !== terminal) continue;
 
         this.renderedText = text;
+        this.renderedRowCount = rowCount;
         if (!wasPinnedToBottom) {
           const nextBaseY = terminal.buffer.active.baseY;
           const targetViewportY = Math.max(0, nextBaseY - distanceFromBottom);

--- a/src/test-kernel/progressView/TerminalOutput.vitest.ts
+++ b/src/test-kernel/progressView/TerminalOutput.vitest.ts
@@ -37,4 +37,22 @@ describe('terminal-output text update planning', () => {
     expect(countTerminalRows('one')).toBe(1);
     expect(countTerminalRows('one\ntwo\n')).toBe(3);
   });
+
+  it('updates row count incrementally for appended output', async () => {
+    const { nextTerminalRowCount, planTerminalTextUpdate } =
+      await import('@progressView/frontend/components/TerminalOutput');
+
+    const updatePlan = planTerminalTextUpdate('alpha\n', 'alpha\nbeta\ngamma');
+
+    expect(nextTerminalRowCount(2, updatePlan)).toBe(3);
+  });
+
+  it('recounts rows when output is reset after trimming', async () => {
+    const { nextTerminalRowCount, planTerminalTextUpdate } =
+      await import('@progressView/frontend/components/TerminalOutput');
+
+    const updatePlan = planTerminalTextUpdate('alpha\nbeta\n', 'beta\ngamma\n');
+
+    expect(nextTerminalRowCount(3, updatePlan)).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- keep terminal output row counts incremental for append-only output
- only rescan retained text when output is reset after trimming/replacement
- add focused tests for append and reset row-count behavior

Related to #3979.

## Validation
- `node_modules/.bin/vitest run src/test-kernel/progressView/TerminalOutput.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/TerminalOutput.ts src/test-kernel/progressView/TerminalOutput.vitest.ts`
- `git diff --check`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how terminal scrollback sizing is computed by maintaining an incremental row count, so off-by-one or reset/trim edge cases could cause incorrect scrollback/scroll positioning in the progress view.
> 
> **Overview**
> Improves `terminal-output` performance by tracking `renderedRowCount` and introducing `nextTerminalRowCount()` to update row counts incrementally for append-only output, only rescanning when `planTerminalTextUpdate()` indicates a reset.
> 
> Updates scrollback sizing to use the incremental row count and adds focused Vitest coverage for both append and reset/trim row-count behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b85496b4d60d07815d2e2dc12e2acbb3159377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->