### PR TITLE
[codex] add CLI install guide

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -159,6 +159,7 @@ const baseConfig = {
               text: 'Working with Overleaf',
               link: '/guide/working-with-overleaf',
             },
+            { text: 'TeXRA CLI', link: '/guide/texra-cli' },
             { text: 'Codex CLI', link: '/guide/codex-cli' },
             { text: 'File Management', link: '/guide/file-management' },
             { text: 'ProgressBoard', link: '/guide/progress-board' },

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -22,10 +22,10 @@ These `.yaml` files have two main parts (and thankfully, YAML is usually less pr
     - _(Other settings control output format, inheritance, etc. See [Configuration](./configuration.md) and [Custom Agents](./custom-agents.md) for full details)._
 2.  **`prompts`**: Contain text templates that TeXRA fills with your specific context (input files, instructions) to guide the LLM at different stages:
     - `systemPrompt`: Sets the overall role and high-level instructions for the LLM.
-    - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `{{ INPUT_CONTENT }}`) and the specific instruction you typed in the UI (available via `{{ INSTRUCTION }}`).
+    - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `&#123;&#123; INPUT_CONTENT &#125;&#125;`) and the specific instruction you typed in the UI (available via `&#123;&#123; INSTRUCTION &#125;&#125;`).
     - `userRequest`: Asks the LLM to perform the initial task (Round 0). Often instructs the LLM to think within `<scratchpad>` tags and then output the main content wrapped within the XML tags defined by `settings.documentTag` (e.g., `<document>...</document>`). You can also provide an **array** here: the first entry becomes the round 0 request, and any additional entries drive automatic reflection rounds (Round 1+). When a run consumes more rounds than entries you specify, the first reflection template is reused.
 
-\_(Prompts use Jinja2 templating. For a detailed list of available variables like `{{ INPUT_CONTENT }}` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)\*
+\_(Prompts use Jinja2 templating. For a detailed list of available variables like `&#123;&#123; INPUT_CONTENT &#125;&#125;` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)\*
 
 ::: tip Transparency & Customization
 The prompts described above (`systemPrompt`, `userPrefix`, etc.) represent TeXRA's structured approach to guiding the LLM. This structured, template-based system means the agent's behavior is transparent and highly customizable through the `.yaml` file, not a hidden black box.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -4,9 +4,7 @@ TeXRA provides extensive configuration options that allow you to customize its b
 
 ## The TeXRA Dashboard
 
-The **Dashboard** is your one-stop shop for managing everything in TeXRA. Open it from the Command Palette (`Ctrl+Shift+P`) with **TeXRA: Show Dashboard**:
-
-![TeXRA Dashboard](/images/dashboard-overview.png)
+The **Dashboard** is your one-stop shop for managing everything in TeXRA. Open it from the Command Palette (`Ctrl+Shift+P`) with **TeXRA: Show Dashboard**.
 
 - **Memory** - See what your tool-use agents have remembered across sessions, and delete entries you no longer need.
 - **History** - Search and browse past runs. Handy for finding that polish job you ran last week.
@@ -40,15 +38,11 @@ Agent visibility is managed through the **Agents** tab in the TeXRA Dashboard
 you toggle individual agents on or off for the current workspace. Agents with a
 matching `_multiple.yaml` file are flagged with a multi-output badge.
 
-![Agents Tab](/images/agents-tab.png)
-
 ### Model Configuration
 
 Which models appear in the selection dropdown is managed through the **Models**
 tab in the TeXRA Dashboard. Toggle individual models on or off per provider.
 See the [Models Guide](./models.md) for the full list of supported models.
-
-![Models Tab](/images/models-tab.png)
 
 ### API Provider Settings
 
@@ -412,8 +406,6 @@ Now that you understand how to configure TeXRA, you may want to learn about:
 ## Agent Execution Settings (Webview Interface)
 
 These settings, accessible directly in the main TeXRA webview, control how agents run:
-
-![Agent Execution Settings](/images/agent-execution-settings.png)
 
 **Tool Configuration Dropdown** (<wa-icon library="texra" name="tools"></wa-icon> ○<wa-icon library="texra" name="chevron-down"></wa-icon> next to Instruction label):
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -109,9 +109,9 @@ prompts:
 
 #### <wa-icon library="texra" name="symbol-variable"></wa-icon> Using Variables in Prompts (Jinja2 Templating)
 
-Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `{{ variable_name }}` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
+Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `&#123;&#123; variable_name &#125;&#125;` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
 
-This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `{{ INPUT_CONTENT }}` while the full list of selected files can be accessed through `{{ ALL_INPUTS }}`. When you run the agent these placeholders are replaced with real data.
+This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `&#123;&#123; INPUT_CONTENT &#125;&#125;` while the full list of selected files can be accessed through `&#123;&#123; ALL_INPUTS &#125;&#125;`. When you run the agent these placeholders are replaced with real data.
 
 **Common Variables:**
 
@@ -140,14 +140,14 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 
 - &#123;&#123; OUTPUT_FILES_ORDER &#125;&#125;: Array of output filenames specified in
   the UI or in `defaultOutputFiles`. Use
-  `{{ OUTPUT_FILES_ORDER[0] }}` for a specific filename and
-  `{{ OUTPUT_FILES_ORDER | join(", ") }}` for a human-readable list. See
+  `&#123;&#123; OUTPUT_FILES_ORDER[0] &#125;&#125;` for a specific filename and
+  `&#123;&#123; OUTPUT_FILES_ORDER | join(", ") &#125;&#125;` for a human-readable list. See
   [Handling Multiple Files](./multiple-output.md).
 
 **Custom Variables (from `settings`):**
 
-- Files specified in `requiredFiles` or `requiredFilesInternal` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ TEMPLATE_CONTENT }}`).
-- Files matched by `filePatternsContain` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ BIBLIOGRAPHY_CONTENT }}`).
+- Files specified in `requiredFiles` or `requiredFilesInternal` are available as `&#123;&#123; VARNAME_CONTENT &#125;&#125;` (e.g., `&#123;&#123; TEMPLATE_CONTENT &#125;&#125;`).
+- Files matched by `filePatternsContain` are available as `&#123;&#123; VARNAME_CONTENT &#125;&#125;` (e.g., `&#123;&#123; BIBLIOGRAPHY_CONTENT &#125;&#125;`).
 - When agents finish, TeXRA automatically captures detected XML segments so orchestrated workflows can reuse them without going through the file picker again (details below).
 
 **Example Usage in `userPrefix`:**

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -49,6 +49,12 @@ re-authenticate and reconfigure local provider, agent, Git, and LaTeX settings.
 See [Migrating to the Desktop App](./desktop-migration.md).
 :::
 
+### CLI Preview
+
+The standalone `texra` command is currently installed from a repository checkout
+rather than from npm. See [TeXRA CLI](./texra-cli.md) for build, local link, and
+uninstall instructions.
+
 ### From VSIX File
 
 1. Open VS Code

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -88,8 +88,8 @@ part of the current agent settings schema. Update existing YAML files to declare
 
 Workflow prompts can branch on `OUTPUT_FILES_ORDER` to request and format
 multiple outputs within the `<latex_documents>` tag. `OUTPUT_FILES_ORDER` is an
-array of filenames, so templates can use `{{ OUTPUT_FILES_ORDER[0] }}` for a
-specific filename and `{{ OUTPUT_FILES_ORDER | join(", ") }}` when the prompt
+array of filenames, so templates can use `&#123;&#123; OUTPUT_FILES_ORDER[0] &#125;&#125;` for a
+specific filename and `&#123;&#123; OUTPUT_FILES_ORDER | join(", ") &#125;&#125;` when the prompt
 needs a readable list.
 
 ```yaml

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -1,0 +1,76 @@
+# TeXRA CLI
+
+The TeXRA CLI provides a local `texra` command for running TeXRA agents from a
+terminal. It is currently a repository-built preview package, not a published
+npm package.
+
+## Install From a Checkout
+
+Clone the repository, install workspace dependencies, build the CLI package, and
+link it into the global pnpm bin directory:
+
+```bash
+corepack pnpm install
+corepack pnpm --filter @texra/cli build
+corepack pnpm --dir packages/cli link --global
+```
+
+Verify the command:
+
+```bash
+texra --help
+texra version
+texra agents list
+```
+
+The linked command points to `packages/cli/dist/bin/texra.js`. Rebuild after
+changing CLI code or shared runtime code:
+
+```bash
+corepack pnpm --filter @texra/cli build
+```
+
+If `pnpm link --global` reports that no global binary directory is configured,
+run:
+
+```bash
+corepack pnpm setup
+```
+
+Then restart the shell and repeat the link command.
+
+## Run Without Linking
+
+After building, the generated binary can also be run directly:
+
+```bash
+node packages/cli/dist/bin/texra.js --help
+node packages/cli/dist/bin/texra.js agents list
+```
+
+Run a workflow agent from a project directory:
+
+```bash
+node packages/cli/dist/bin/texra.js run polish --input paper.tex --output paper.polished.tex --print
+```
+
+## Remove the Linked Command
+
+```bash
+corepack pnpm --global remove @texra/cli
+```
+
+## Validation
+
+The CLI build performs type checking, architecture checks, bundling, and resource
+copying:
+
+```bash
+corepack pnpm --filter @texra/cli build
+```
+
+For a deterministic local run check that does not require provider credentials:
+
+```bash
+corepack pnpm --filter @texra/cli validate:run
+```

--- a/docs/pocketflow/core_abstraction/communication.md
+++ b/docs/pocketflow/core_abstraction/communication.md
@@ -14,7 +14,6 @@ Nodes and Flows **communicate** in 2 ways:
    - Great for data results, large content, or anything multiple nodes need.
    - You shall design the data structure and populate it ahead.
    - > **Separation of Concerns:** Use `Shared Store` for almost all cases to separate _Data Schema_ from _Compute Logic_! This approach is both flexible and easy to manage, resulting in more maintainable code. `Params` is more a syntax sugar for [Batch](./batch.md).
-     > {: .best-practice }
 
 2. **Params (only for [Batch](./batch.md))**
    - Each node has a local, ephemeral `params` dict passed in by the **parent Flow**, used as an identifier for tasks. Parameter keys and values shall be **immutable**.
@@ -114,7 +113,6 @@ Here:
 > Only set the uppermost Flow params because others will be overwritten by the parent Flow.
 >
 > If you need to set child node params, see [Batch](./batch.md).
-> {: .warning }
 
 Typically, **Params** are identifiers (e.g., file name, page number). Use them to fetch the task you assigned or write to a specific part of the shared store.
 

--- a/docs/pocketflow/core_abstraction/flow.md
+++ b/docs/pocketflow/core_abstraction/flow.md
@@ -132,7 +132,6 @@ flowchart TD
 > This is mainly for debugging or testing a single node.
 >
 > Always use `flow.run(...)` in production to ensure the full pipeline runs correctly.
-> {: .warning }
 
 ## 4. Nested Flows
 

--- a/docs/pocketflow/core_abstraction/node.md
+++ b/docs/pocketflow/core_abstraction/node.md
@@ -33,7 +33,6 @@ A **Node** is the smallest building block. Each Node has 3 steps `prep->exec->po
 > **Why 3 steps?** To enforce the principle of _separation of concerns_. The data storage and data processing are operated separately.
 >
 > All steps are _optional_. E.g., you can only implement `prep` and `post` if you just need to process data.
-> {: .note }
 
 ### Fault Tolerance & Retries
 

--- a/docs/pocketflow/core_abstraction/parallel.md
+++ b/docs/pocketflow/core_abstraction/parallel.md
@@ -10,12 +10,10 @@ nav_order: 6
 **Parallel** Nodes and Flows let you run multiple operations **concurrently**—for example, summarizing multiple texts at once. This can improve performance by overlapping I/O and compute.
 
 > Parallel nodes and flows excel at overlapping I/O-bound work—like LLM calls, database queries, API requests, or file I/O. TypeScript's Promise-based implementation allows for truly concurrent execution of asynchronous operations.
-> {: .warning }
 
 > - **Ensure Tasks Are Independent**: If each item depends on the output of a previous item, **do not** parallelize.
 > - **Beware of Rate Limits**: Parallel calls can **quickly** trigger rate limits on LLM services. You may need a **throttling** mechanism.
 > - **Consider Single-Node Batch APIs**: Some LLMs offer a **batch inference** API where you can send multiple prompts in a single call. This is more complex to implement but can be more efficient than launching many parallel requests and mitigates rate limits.
->   {: .best-practice }
 
 ## ParallelBatchNode
 

--- a/docs/pocketflow/design_pattern/mapreduce.md
+++ b/docs/pocketflow/design_pattern/mapreduce.md
@@ -93,4 +93,3 @@ flow.run({
 ```
 
 > **Performance Tip**: The example above works sequentially. You can speed up the map phase by using `ParallelBatchNode` instead of `BatchNode`. See [(Advanced) Parallel](../core_abstraction/parallel.md) for more details.
-> {: .note }

--- a/docs/pocketflow/design_pattern/multi_agent.md
+++ b/docs/pocketflow/design_pattern/multi_agent.md
@@ -11,7 +11,6 @@ Multiple [Agents](./flow.md) can work together by handling subtasks and communic
 Communication between agents is typically implemented using message queues in shared storage.
 
 > Most of time, you don't need Multi-Agents. Start with a simple solution first.
-> {: .best-practice }
 
 ### Example Agent Communication: Message Queue
 

--- a/docs/pocketflow/design_pattern/workflow.md
+++ b/docs/pocketflow/design_pattern/workflow.md
@@ -17,7 +17,6 @@ Many real-world tasks are too complex for one LLM call. The solution is to **Tas
 > - You don't want to make each task **too granular**, because then _the LLM call doesn't have enough context_ and results are _not consistent across nodes_.
 >
 > You usually need multiple _iterations_ to find the _sweet spot_. If the task has too many _edge cases_, consider using [Agents](./agent.md).
-> {: .best-practice }
 
 ### Example: Article Writing
 

--- a/docs/pocketflow/human-design-ai-code.md
+++ b/docs/pocketflow/human-design-ai-code.md
@@ -6,7 +6,6 @@ title: 'Agentic Coding'
 # Agentic Coding: Humans Design, Agents code!
 
 > If you are an AI agents involved in building LLM Systems, read this guide **VERY, VERY** carefully! This is the most important chapter in the entire document. Throughout development, you should always (1) start with a small and simple solution, (2) design at a high level (`docs/design.md`) before implementation, and (3) frequently ask humans for feedback and clarification.
-> {: .warning }
 
 ## Agentic Coding Steps
 
@@ -53,8 +52,7 @@ Agentic Coding should be a collaboration between Human System Design and Agent I
          process --> endNode[End]
      ```
 
-   - > **If Humans can't specify the flow, AI Agents can't automate it!** Before building an LLM system, thoroughly understand the problem and potential solution by manually solving example inputs to develop intuition.  
-     > {: .best-practice }
+   - > **If Humans can't specify the flow, AI Agents can't automate it!** Before building an LLM system, thoroughly understand the problem and potential solution by manually solving example inputs to develop intuition.
 
 3. **Utilities**: Based on the Flow Design, identify and implement necessary utility functions.
    - Think of your AI system as the brain. It needs a body—these _external utility functions_—to interact with the real world:
@@ -91,7 +89,6 @@ Agentic Coding should be a collaboration between Human System Design and Agent I
      ```
 
    - > **Sometimes, design Utilies before Flow:** For example, for an LLM project to automate a legacy system, the bottleneck will likely be the available interface to that system. Start by designing the hardest utilities for interfacing, and then build the flow around them.
-     > {: .best-practice }
 
 4. **Node Design**: Plan how each node will read and write data, and use utility functions.
    - One core design principle for PocketFlow is to use a [shared store](./core_abstraction/communication.md), so start with a shared store design:
@@ -146,7 +143,6 @@ Agentic Coding should be a collaboration between Human System Design and Agent I
    - > **You'll likely iterate a lot!** Expect to repeat Steps 3–6 hundreds of times.
      >
      > <div align="center"><img src="https://github.com/the-pocket/.github/raw/main/assets/success.png?raw=true" width="400"/></div>
-     > {: .best-practice }
 
 7. **Reliability**
    - **Node Retries**: Add checks in the node `exec` to ensure outputs meet requirements, and consider increasing `maxRetries` and `wait` times.

--- a/docs/pocketflow/utility_function/chunking.md
+++ b/docs/pocketflow/utility_function/chunking.md
@@ -12,7 +12,6 @@ We recommend some implementations of commonly used text chunking approaches.
 > Text Chunking is more a micro optimization, compared to the Flow Design.
 >
 > It's recommended to start with the Naive Chunking and optimize later.
-> {: .best-practice }
 
 ---
 

--- a/docs/pocketflow/utility_function/embedding.md
+++ b/docs/pocketflow/utility_function/embedding.md
@@ -12,7 +12,6 @@ Below you will find an overview table of various text embedding APIs, along with
 > Embedding is more a micro optimization, compared to the Flow Design.
 >
 > It's recommended to start with the most convenient one and optimize later.
-> {: .best-practice }
 
 | **API**              | **Free Tier**                           | **Pricing Model**                   | **Docs**                                                                                                                  |
 | -------------------- | --------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pocketflow/utility_function/llm.md
+++ b/docs/pocketflow/utility_function/llm.md
@@ -29,7 +29,6 @@ Here, we provide some minimal example implementations:
    ```
 
    > Store the API key in an environment variable like OPENAI_API_KEY for security.
-   > {: .best-practice }
 
 2. Claude (Anthropic)
 


### PR DESCRIPTION
## Summary
- Add a user-facing TeXRA CLI installation guide and link it from the installation guide and sidebar.
- Remove stale documentation syntax and missing image references that prevented the VitePress docs build from completing.

## Validation
- npm run format
- npm run docs:build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; primary risk is broken links or formatting regressions in the generated site navigation/pages.
> 
> **Overview**
> Adds a new `TeXRA CLI` documentation page with install/link/uninstall and validation steps, and links it from both the Installation guide and the VitePress sidebar.
> 
> Fixes docs build/rendering issues by escaping Jinja `{{ ... }}` examples (to avoid being interpreted by the docs renderer) and removing/adjusting stale syntax and missing image references across several guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdd9d1b2d5490ca7a00153248a209f786392460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->