### PR TITLE
[codex] reuse progress group cache on status updates

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -273,12 +273,20 @@ export class TaskGroupList extends LitElement {
       return;
     }
 
+    const prevGroups = groupsChanged
+      ? (changedProperties.get('groups') as TaskGroup[] | undefined)
+      : undefined;
+    const patchedGroupMetadata =
+      groupsChanged && prevGroups
+        ? this.patchGroupMetadataIfShapeStable(prevGroups)
+        : false;
+
     const prevMessages = messagesChanged
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;
     const prevCount = prevMessages?.length ?? 0;
 
-    if (groupsChanged) {
+    if (groupsChanged && !patchedGroupMetadata) {
       // Structural change — always full rebuild
       [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
     } else if (messagesChanged) {
@@ -304,11 +312,14 @@ export class TaskGroupList extends LitElement {
     // Used by both tool-use and workflow streams so the user's original
     // instruction (the earliest ungrouped message) stays at the top.
     if (groupsChanged || messagesChanged) {
-      if (groupsChanged || this.messages.length < prevCount) {
+      if (
+        (groupsChanged && !patchedGroupMetadata) ||
+        this.messages.length < prevCount
+      ) {
         // Structural change, or messages shrunk (e.g. clear/resync) —
         // removed IDs must be pruned from cachedTimeline, so rebuild.
         this.cachedTimeline = this.buildFullTimeline();
-      } else if (this.messages.length > prevCount) {
+      } else if (messagesChanged && this.messages.length > prevCount) {
         // Append-only: classify each new message and insert ungrouped ones
         // into the timeline. Iterate the messages slice (not the ungrouped
         // array) so a new message spliced into the middle of cachedUngrouped
@@ -316,12 +327,42 @@ export class TaskGroupList extends LitElement {
         this.appendToTimeline(prevCount);
         // LOG_DELTA may also mutate existing timeline entries in the same batch.
         this.updateTimelineMessageRefs();
-      } else {
+      } else if (messagesChanged) {
         // Same length — streaming update. guard([item.msg]) in render()
         // detects new refs on existing timeline entries.
         this.updateTimelineMessageRefs();
       }
     }
+  }
+
+  /**
+   * Patch status/name/end-time changes into the existing group tree.
+   * This avoids re-sorting and reclassifying every log message for ordinary
+   * group-completion updates, while still rebuilding when the tree shape changes.
+   */
+  private patchGroupMetadataIfShapeStable(
+    previousGroups: readonly TaskGroup[],
+  ): boolean {
+    if (previousGroups.length !== this.groups.length) return false;
+
+    for (let i = 0; i < this.groups.length; i++) {
+      const previous = previousGroups[i];
+      const next = this.groups[i];
+      if (!previous || !next) return false;
+      if (
+        previous.id !== next.id ||
+        previous.parentGroupId !== next.parentGroupId ||
+        previous.startTime !== next.startTime
+      ) {
+        return false;
+      }
+      if (!this.groupNodeIndex.has(next.id)) return false;
+    }
+
+    for (const group of this.groups) {
+      this.groupNodeIndex.get(group.id)!.group = group;
+    }
+    return true;
   }
 
   override updated(): void {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports - shared schemas
 import {
   LOG_LEVELS,
+  STREAM_STATUS,
   type LogMessageData,
   type TaskGroup,
 } from '@shared/schemas';
@@ -13,20 +14,27 @@ import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
 type TimelineEntry =
   | { key: string; time: number; msg: LogMessageData }
-  | { key: string; time: number; tree: unknown };
+  | { key: string; time: number; tree: GroupTreeForTest };
+
+interface GroupTreeForTest {
+  group: TaskGroup;
+  children: GroupTreeForTest[];
+  messages: LogMessageData[];
+}
 
 type TaskGroupListInternals = HTMLElement & {
   groups: TaskGroup[];
   messages: LogMessageData[];
-  cachedTree: unknown[];
+  cachedTree: GroupTreeForTest[];
   cachedUngrouped: LogMessageData[];
   cachedTimeline: TimelineEntry[];
   ungroupedMessageById: Map<string, LogMessageData>;
   ungroupedMessageIndex: Map<string, number>;
-  buildGroupTree: () => [unknown[], LogMessageData[]];
+  buildGroupTree: () => [GroupTreeForTest[], LogMessageData[]];
   buildFullTimeline: () => TimelineEntry[];
   replaceSingleMessage: (message: LogMessageData) => void;
   updateTimelineMessageRefs: () => void;
+  willUpdate: (changedProperties: Map<string, unknown>) => void;
 };
 
 useLitComponentTestDom(
@@ -37,12 +45,26 @@ function createMessage(
   id: string,
   text: string,
   timestamp: number,
+  groupId?: string,
 ): LogMessageData {
   return {
     id,
     text,
     timestamp,
     level: LOG_LEVELS.INFO,
+    ...(groupId ? { groupId } : {}),
+  };
+}
+
+function createGroup(
+  id: string,
+  status: typeof STREAM_STATUS.RUNNING | typeof STREAM_STATUS.STOPPED,
+): TaskGroup {
+  return {
+    id,
+    name: id,
+    startTime: 1,
+    status,
   };
 }
 
@@ -91,5 +113,35 @@ describe('task-group-list ungrouped message indexes', () => {
     list.updateTimelineMessageRefs();
 
     expect(timelineEntry?.msg).toBe(updated);
+  });
+
+  it('patches stable group metadata without rebuilding the message tree', () => {
+    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const message = createMessage('m1', 'grouped', 2, group.id);
+    const list = createList([message]);
+    list.groups = [group];
+    [list.cachedTree, list.cachedUngrouped] = list.buildGroupTree();
+    list.cachedTimeline = list.buildFullTimeline();
+
+    const originalTree = list.cachedTree[0];
+    const stoppedGroup = {
+      ...group,
+      status: STREAM_STATUS.STOPPED,
+      endTime: 3,
+    };
+    list.groups = [stoppedGroup];
+    list.buildGroupTree = () => {
+      throw new Error('unexpected full group tree rebuild');
+    };
+    list.updateTimelineMessageRefs = () => {
+      throw new Error('unexpected timeline message scan');
+    };
+
+    list.willUpdate(new Map([['groups', [group]]]));
+
+    expect(list.cachedTree[0]).toBe(originalTree);
+    expect(list.cachedTree[0]?.group).toBe(stoppedGroup);
+    expect(list.cachedTree[0]?.messages).toEqual([message]);
+    expect(list.cachedTimeline).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Reuse the existing `TaskGroupList` group tree when task-group shape is stable and only metadata such as status/end time changes.
- Avoid the redundant timeline message-ref scan for group-only metadata updates.
- Add a focused regression test that fails if this path rebuilds the message tree or scans timeline messages.

## Why
Large active progress streams can contain many log entries. A group completion update should not re-sort and reclassify every message when no message ownership changed.

## Validation
- node_modules/.bin/vitest run src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/TaskGroupList.ts src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
- npm run format
- git diff --check
- npm run compile:fast
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optimizes incremental rendering by mutating cached group nodes in-place, which could cause stale/incorrect UI state if the “shape stable” detection misses an edge case.
> 
> **Overview**
> Avoids rebuilding `TaskGroupList`’s cached group/message tree and timeline work when `groups` change only by metadata (e.g. status/name/endTime) and the group “shape” (id/parent/startTime ordering) is unchanged.
> 
> Adds `patchGroupMetadataIfShapeStable()` to update cached nodes in-place and adjusts `willUpdate()` so group-only metadata updates skip full tree rebuilds and skip timeline message-ref scans; includes a regression test to ensure this path doesn’t call `buildGroupTree()` or scan timeline messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065bad9fdf7192d371ae3d234deed3a883ec068e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->