### PR TITLE
perf: bound progress log DOM rendering

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -53,6 +53,11 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
 
+const DEFAULT_TIMELINE_ITEM_WINDOW = 120;
+const TIMELINE_ITEM_WINDOW_STEP = 120;
+const DEFAULT_GROUP_MESSAGE_WINDOW = 400;
+const GROUP_MESSAGE_WINDOW_STEP = 400;
+
 const ESCAPE_CHARACTER = String.fromCharCode(27);
 // Null byte used as a sentinel for ANSI erase-line sequences inside processTerminalText.
 // Real null bytes in the input are stripped first so the sentinel is unambiguous.
@@ -181,6 +186,12 @@ export class TaskGroupList extends LitElement {
   /** O(1) lookup from ungrouped message ID → cachedTimeline index. */
   private timelineMessageIndex = new Map<string, number>();
 
+  /** Number of recent top-level timeline entries currently rendered. */
+  private timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
+
+  /** Number of recent message entries rendered for each group. */
+  private groupMessageWindows = new Map<string, number>();
+
   /** Reference to the scroll container */
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
   private scrollContainer?: HTMLElement;
@@ -270,6 +281,7 @@ export class TaskGroupList extends LitElement {
     if (changedProperties.get('terminal') === true) {
       [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
       this.cachedTimeline = this.buildFullTimeline();
+      this.resetRenderWindows();
       return;
     }
 
@@ -305,6 +317,7 @@ export class TaskGroupList extends LitElement {
       } else {
         // Messages shrunk (e.g. clear) — full rebuild
         [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
+        this.resetRenderWindows();
       }
     }
 
@@ -766,6 +779,98 @@ export class TaskGroupList extends LitElement {
     this.ungroupedMessageById.delete(id);
   }
 
+  private resetRenderWindows(): void {
+    this.timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
+    this.groupMessageWindows.clear();
+  }
+
+  private groupMessageScope(groupId: string): string {
+    return `group:${groupId}`;
+  }
+
+  private renderRevealButton(options: {
+    hiddenCount: number;
+    step: number;
+    scope: string;
+    kind: 'timeline' | 'messages';
+    label: string;
+  }): TemplateResult {
+    const revealCount = Math.min(options.hiddenCount, options.step);
+    const suffix = revealCount === 1 ? options.label : `${options.label}s`;
+    return html`
+      <div class="log-reveal-row">
+        <button
+          type="button"
+          class="log-reveal-button"
+          data-reveal-kind=${options.kind}
+          data-reveal-scope=${options.scope}
+          data-hidden-count=${String(options.hiddenCount)}
+          @click=${this.handleRevealOlderRows}
+          aria-label=${`Show ${revealCount} older ${suffix}`}
+        >
+          <wa-icon
+            library="texra"
+            name="chevron-up"
+            aria-hidden="true"
+          ></wa-icon>
+          <span>Show ${revealCount} older ${suffix}</span>
+        </button>
+      </div>
+    `;
+  }
+
+  private renderMessageEntries(
+    messages: readonly LogMessageData[],
+    scope: string,
+  ): TemplateResult {
+    const windowSize =
+      this.groupMessageWindows.get(scope) ?? DEFAULT_GROUP_MESSAGE_WINDOW;
+    const hiddenCount = Math.max(0, messages.length - windowSize);
+    const visibleMessages =
+      hiddenCount > 0 ? messages.slice(hiddenCount) : messages;
+
+    return html`${hiddenCount > 0
+      ? this.renderRevealButton({
+          hiddenCount,
+          step: GROUP_MESSAGE_WINDOW_STEP,
+          scope,
+          kind: 'messages',
+          label: 'message',
+        })
+      : nothing}${repeat(
+      visibleMessages,
+      (m) => m.id,
+      (m) => guard([m], () => formatLogEntry(m)),
+    )}`;
+  }
+
+  private handleRevealOlderRows(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget as HTMLElement;
+    const kind = target.dataset.revealKind;
+    const scope = target.dataset.revealScope;
+    if (!scope) return;
+
+    if (kind === 'timeline') {
+      this.timelineItemWindow += TIMELINE_ITEM_WINDOW_STEP;
+    } else if (kind === 'messages') {
+      const current =
+        this.groupMessageWindows.get(scope) ?? DEFAULT_GROUP_MESSAGE_WINDOW;
+      this.groupMessageWindows.set(scope, current + GROUP_MESSAGE_WINDOW_STEP);
+    }
+    this.requestUpdate();
+  }
+
+  private visibleTimelineEntries(): typeof this.cachedTimeline {
+    if (this.cachedTimeline.length <= this.timelineItemWindow) {
+      return this.cachedTimeline;
+    }
+    return this.cachedTimeline.slice(
+      this.cachedTimeline.length - this.timelineItemWindow,
+    );
+  }
+
   /** Check if a group is expanded */
   private isExpanded(groupId: string): boolean {
     if (!this.toggleStates) return true;
@@ -846,10 +951,9 @@ export class TaskGroupList extends LitElement {
       return html`
         <div id=${detailsId} class="log-group log-run" data-run-id=${group.id}>
           <div id=${contentId} class="log-group-content">
-            ${repeat(
+            ${this.renderMessageEntries(
               messages,
-              (m) => m.id,
-              (m) => guard([m], () => formatLogEntry(m)),
+              this.groupMessageScope(group.id),
             )}
             ${repeat(
               children,
@@ -883,10 +987,9 @@ export class TaskGroupList extends LitElement {
         </summary>
         <div id=${contentId} class="log-group-content">
           ${expanded
-            ? html`${repeat(
+            ? html`${this.renderMessageEntries(
                 messages,
-                (m) => m.id,
-                (m) => guard([m], () => formatLogEntry(m)),
+                this.groupMessageScope(group.id),
               )}${repeat(
                 children,
                 (c) => c.group.id,
@@ -996,18 +1099,30 @@ export class TaskGroupList extends LitElement {
     }
 
     // Interleave ungrouped messages (user input, follow-ups, errors) with run
-    // groups chronologically so the conversation reads top-to-bottom. The
-    // user's original instruction always surfaces at the top because it has
-    // the earliest timestamp. Timeline is memoized in willUpdate() — only
-    // rebuilt when inputs change.
+    // groups chronologically so the conversation reads top-to-bottom. Large
+    // streams render a recent window first; older timeline entries remain in
+    // memory and can be revealed from the top control.
+    const visibleTimeline = this.visibleTimelineEntries();
+    const hiddenTimelineCount =
+      this.cachedTimeline.length - visibleTimeline.length;
+
     return html`
       <div
         id=${ELEMENT_IDS.LOG_CONTENT}
         class="log-container"
         @scroll=${this.handleScroll}
       >
+        ${hiddenTimelineCount > 0
+          ? this.renderRevealButton({
+              hiddenCount: hiddenTimelineCount,
+              step: TIMELINE_ITEM_WINDOW_STEP,
+              scope: 'timeline',
+              kind: 'timeline',
+              label: 'item',
+            })
+          : nothing}
         ${repeat(
-          this.cachedTimeline,
+          visibleTimeline,
           (item) => item.key,
           (item) =>
             'msg' in item

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -45,6 +45,37 @@ export const logEntryStyles = css`
     font-style: italic;
   }
 
+  .log-reveal-row {
+    display: flex;
+    justify-content: center;
+    margin: var(--wa-space-2xs) 0;
+  }
+
+  .log-reveal-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-3xs);
+    min-height: 24px;
+    padding: 0 var(--wa-space-xs);
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    border-radius: var(--border-radius-small);
+    background: var(--wa-color-surface-default);
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+  }
+
+  .log-reveal-button:hover {
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .log-reveal-button:focus-visible {
+    outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: 2px;
+  }
+
   .render-error-icon {
     font-style: normal;
     flex-shrink: 0;

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -25,6 +25,9 @@ interface GroupTreeForTest {
 type TaskGroupListInternals = HTMLElement & {
   groups: TaskGroup[];
   messages: LogMessageData[];
+  hasStreams: boolean;
+  terminal: boolean;
+  updateComplete: Promise<boolean>;
   cachedTree: GroupTreeForTest[];
   cachedUngrouped: LogMessageData[];
   cachedTimeline: TimelineEntry[];
@@ -76,6 +79,21 @@ function createList(messages: LogMessageData[]): TaskGroupListInternals {
   element.messages = messages;
   [element.cachedTree, element.cachedUngrouped] = element.buildGroupTree();
   element.cachedTimeline = element.buildFullTimeline();
+  return element;
+}
+
+async function renderList(
+  groups: TaskGroup[],
+  messages: LogMessageData[],
+): Promise<TaskGroupListInternals> {
+  const element = document.createElement(
+    'task-group-list',
+  ) as unknown as TaskGroupListInternals;
+  element.hasStreams = true;
+  element.groups = groups;
+  element.messages = messages;
+  document.body.append(element);
+  await element.updateComplete;
   return element;
 }
 
@@ -143,5 +161,86 @@ describe('task-group-list ungrouped message indexes', () => {
     expect(list.cachedTree[0]?.group).toBe(stoppedGroup);
     expect(list.cachedTree[0]?.messages).toEqual([message]);
     expect(list.cachedTimeline).toHaveLength(1);
+  });
+
+  it('bounds top-level timeline DOM for large ungrouped streams', async () => {
+    const messages = Array.from({ length: 130 }, (_, index) =>
+      createMessage(`m${index}`, `entry ${index}`, index),
+    );
+
+    const list = await renderList([], messages);
+
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      120,
+    );
+    expect(list.shadowRoot?.textContent).not.toContain('entry 0');
+    expect(list.shadowRoot?.textContent).toContain('entry 129');
+
+    const revealButton = list.shadowRoot?.querySelector<HTMLButtonElement>(
+      '[data-reveal-kind="timeline"]',
+    );
+    expect(revealButton?.dataset.hiddenCount).toBe('10');
+
+    revealButton?.click();
+    await list.updateComplete;
+
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      130,
+    );
+    expect(list.shadowRoot?.textContent).toContain('entry 0');
+  });
+
+  it('bounds rendered message DOM inside large groups', async () => {
+    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const messages = Array.from({ length: 450 }, (_, index) =>
+      createMessage(`m${index}`, `group entry ${index}`, index, group.id),
+    );
+
+    const list = await renderList([group], messages);
+
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      400,
+    );
+    expect(list.shadowRoot?.textContent).not.toContain('group entry 0');
+    expect(list.shadowRoot?.textContent).toContain('group entry 449');
+
+    const revealButton = list.shadowRoot?.querySelector<HTMLButtonElement>(
+      '[data-reveal-kind="messages"]',
+    );
+    expect(revealButton?.dataset.hiddenCount).toBe('50');
+
+    revealButton?.click();
+    await list.updateComplete;
+
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      450,
+    );
+    expect(list.shadowRoot?.textContent).toContain('group entry 0');
+  });
+
+  it('resets expanded render windows when leaving terminal mode', async () => {
+    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const messages = Array.from({ length: 450 }, (_, index) =>
+      createMessage(`m${index}`, `group entry ${index}`, index, group.id),
+    );
+    const list = await renderList([group], messages);
+
+    const revealButton = list.shadowRoot?.querySelector<HTMLButtonElement>(
+      '[data-reveal-kind="messages"]',
+    );
+    revealButton?.click();
+    await list.updateComplete;
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      450,
+    );
+
+    list.terminal = true;
+    await list.updateComplete;
+    list.terminal = false;
+    await list.updateComplete;
+
+    expect(list.shadowRoot?.querySelectorAll('[data-log-id]')).toHaveLength(
+      400,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Bound large non-terminal progress logs to a recent top-level timeline window, with explicit reveal controls for older entries.
- Bound rendered messages inside large task groups the same way, without removing historical log data from memory.
- Added focused renderer tests for large ungrouped streams and large grouped streams.

## Why

The stream store and IPC path already send small deltas, but the VS Code webview still paid for too much DOM when an active progress stream had thousands of entries. This keeps the ordinary renderer simple while making the browser layout work bounded for large streams.

## Validation

- npm run format
- node_modules/.bin/vitest run src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
- node_modules/.bin/tsc --noEmit
- git diff --check
- npm run compile:fast
- npm run lint (0 errors; existing 66 warnings)

Closes #3979.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the progress log renderer to only mount a recent window of timeline/group messages and adds new reveal controls, which could affect log visibility and interaction behavior in large streams.
> 
> **Overview**
> Bounds non-terminal progress log rendering by only mounting the most recent top-level timeline items and most recent messages within each task group, while keeping older entries in memory.
> 
> Adds a reusable “Show older …” control to reveal older timeline items or group messages in fixed-size increments, resets these render windows on rebuilds/clears and when switching out of terminal mode, and introduces styling plus new Vitest coverage for large ungrouped/grouped streams and terminal toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060b88e5242aaf52230b31ce8149314851c3556f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->