### PR TITLE
refactor: require run-owned coordinators for waits

### DIFF
--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -14,7 +14,11 @@ import {
   type RetryRequestOptions,
   type RetryResult,
 } from './RetryRequestCoordinator';
-import { tryUseRunContext, type RunCoordinators } from './RunContext';
+import {
+  tryUseRunContext,
+  useRunContext,
+  type RunCoordinators,
+} from './RunContext';
 
 const legacyCoordinators: RunCoordinators = {
   plan: planApprovalCoordinator,
@@ -22,9 +26,12 @@ const legacyCoordinators: RunCoordinators = {
   retry: retryCoordinator,
 };
 
-/** Return the active run's coordinators, falling back to legacy singletons. */
-function getRunCoordinators(): RunCoordinators {
-  return tryUseRunContext()?.coordinators ?? legacyCoordinators;
+function useRunCoordinators(): RunCoordinators {
+  const coordinators = useRunContext().coordinators;
+  if (!coordinators) {
+    throw new Error('run coordinator request requires active run coordinators');
+  }
+  return coordinators;
 }
 
 const bridgeState = {
@@ -82,7 +89,7 @@ export async function waitForPlanApproval(
   streamId: string,
   options: PlanApprovalRequestOptions,
 ): Promise<PlanApprovalResult> {
-  const coordinators = getRunCoordinators();
+  const coordinators = useRunCoordinators();
   bridgeState.planApprovals.set(options.approvalId, coordinators);
   bridgeState.planApprovalStreams.set(options.approvalId, streamId);
   bridgeState.planStreams.set(streamId, coordinators);
@@ -135,7 +142,7 @@ export async function waitForProposal(
   streamId: string,
   options: ProposalRequestOptions,
 ): Promise<ProposalResult> {
-  const coordinators = getRunCoordinators();
+  const coordinators = useRunCoordinators();
   bridgeState.proposals.set(options.proposalId, coordinators);
   bridgeState.proposalStreams.set(options.proposalId, streamId);
   try {
@@ -184,7 +191,7 @@ export async function waitForRetry(
   streamId: string,
   options: RetryRequestOptions,
 ): Promise<RetryResult> {
-  const coordinators = getRunCoordinators();
+  const coordinators = useRunCoordinators();
   retainRetryCoordinator(coordinators);
   bridgeState.retries.set(streamId, coordinators);
   try {

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -1,0 +1,191 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - runtime
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
+import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
+import {
+  createRunContext,
+  withRunContext,
+  type RunCoordinators,
+} from '@agent/runtime/RunContext';
+import {
+  cleanupAllCoordinatorRequests,
+  resolvePlanApproval,
+  resolveProposal,
+  triggerRetry,
+  waitForPlanApproval,
+  waitForProposal,
+  waitForRetry,
+} from '@agent/runtime/runCoordinators';
+import type { AgentLogger } from '@logger/AgentLogger';
+import {
+  AGENT_CATEGORY,
+  TODO_STATUS,
+  type AgentProposal,
+  type Plan,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = 'stream:run-coordinator-test' as StreamTabId;
+const plan: Plan = {
+  summary: 'Move coordinator ownership into RunContext.',
+  steps: [
+    {
+      title: 'Use run coordinator',
+      description: 'Create interactive waits through the active run context.',
+      status: TODO_STATUS.PENDING,
+      files: ['src/agent/runtime/runCoordinators.ts'],
+    },
+  ],
+};
+const proposal: AgentProposal = {
+  agentCategory: AGENT_CATEGORY.TOOL_USE,
+  agent: 'reviewer',
+  model: 'test-model',
+  instruction: 'Review the runtime boundary.',
+  memories: [],
+};
+
+function createCoordinators(host: AgentRuntimeHost): RunCoordinators {
+  return {
+    plan: new PlanApprovalCoordinator(host),
+    proposal: new AgentProposalCoordinator(host),
+    retry: new RetryRequestCoordinatorImpl(host),
+  };
+}
+
+function createLogger(): AgentLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as AgentLogger;
+}
+
+describe('runCoordinators', () => {
+  afterEach(() => {
+    cleanupAllCoordinatorRequests();
+  });
+
+  it('does not fall back to default coordinators when a run has none', async () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const active = createRecordingHost();
+    const fallback = createRecordingHost();
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      await withRunContext(
+        createRunContext({ runtimeHost: active.host }),
+        async () => {
+          await expect(
+            waitForPlanApproval(streamId, {
+              approvalId: 'approval:missing-coordinators',
+              plan,
+            }),
+          ).rejects.toThrow(/active run coordinators/);
+          await expect(
+            waitForProposal(streamId, {
+              proposalId: 'proposal:missing-coordinators',
+              proposal,
+            }),
+          ).rejects.toThrow(/active run coordinators/);
+          await expect(
+            waitForRetry(streamId, {
+              operation: 'Model invocation',
+              logger: createLogger(),
+            }),
+          ).rejects.toThrow(/active run coordinators/);
+        },
+      );
+
+      expect(active.events).toEqual([]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('routes waits and resolver bridge events through active run coordinators', async () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const active = createRecordingHost();
+    const fallback = createRecordingHost();
+    const coordinators = createCoordinators(active.host);
+    const context = createRunContext({
+      runtimeHost: active.host,
+      coordinators,
+    });
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const planResult = withRunContext(context, () =>
+        waitForPlanApproval(streamId, {
+          approvalId: 'approval:active-coordinator',
+          plan,
+        }),
+      );
+      expect(
+        resolvePlanApproval('approval:active-coordinator', {
+          action: 'approve',
+        }),
+      ).toBe(true);
+      await expect(planResult).resolves.toEqual({ action: 'approve' });
+
+      const proposalResult = withRunContext(context, () =>
+        waitForProposal(streamId, {
+          proposalId: 'proposal:active-coordinator',
+          proposal,
+        }),
+      );
+      expect(
+        resolveProposal('proposal:active-coordinator', {
+          action: 'approve',
+          agent: 'reviewer',
+          model: 'test-model',
+        }),
+      ).toBe(true);
+      await expect(proposalResult).resolves.toEqual({
+        action: 'approve',
+        agent: 'reviewer',
+        model: 'test-model',
+      });
+
+      const retryResult = withRunContext(context, () =>
+        waitForRetry(streamId, {
+          operation: 'Model invocation',
+          logger: createLogger(),
+        }),
+      );
+      expect(triggerRetry(streamId, 'try the request again')).toBe(true);
+      await expect(retryResult).resolves.toEqual({
+        action: 'retry',
+        feedback: 'try the request again',
+      });
+
+      expect(active.events.map((entry) => entry.event)).toEqual([
+        'requestEnsureProgressView',
+        'setActiveStream',
+        'showPlanApproval',
+        'resolvePlanApproval',
+        'requestEnsureProgressView',
+        'setActiveStream',
+        'showAgentProposal',
+        'resolveAgentProposal',
+        'showRetryRequest',
+        'resolveRetryRequest',
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Require plan, proposal, and retry wait creation to use active RunContext coordinators instead of the default singleton fallback.
- Keep the resolver and cleanup bridge compatible while the existing progress-view dismissal path is still being retired.
- Add kernel tests for missing run coordinators and active coordinator routing.

## Design Notes
This is a narrow slice for #3372 and #3925. The single source of truth for new interactive waits is now the run-owned coordinator set created by AgentLaunchContext. Legacy singleton coordinators remain only as a compatibility bridge for old resolver and cleanup paths.

## Validation
- npm run format
- node_modules/.bin/vitest run src/test-kernel/agent/runtime/runCoordinators.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- git diff --check
- npm run compile:fast
- npm run lint

Related: #3372, #3925

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the coordinator selection logic for plan/proposal/retry waits to require `RunContext.coordinators`, which can cause new runtime errors if any call sites create waits without run-owned coordinators. Resolver/cleanup paths still fall back to legacy singletons, limiting impact but leaving some mixed routing behavior during migration.
> 
> **Overview**
> Interactive wait creation (`waitForPlanApproval`, `waitForProposal`, `waitForRetry`) now **requires** `RunContext.coordinators` and throws if a run context is active but no coordinators are provided, removing the previous silent fallback to legacy singleton coordinators.
> 
> Legacy singleton coordinators are retained only for resolver/cleanup bridge paths (e.g., `resolvePlanApproval`, `resolveProposal`, `triggerRetry`) when no run-mapped coordinator is available.
> 
> Adds kernel vitest coverage to assert (1) waits fail without run-owned coordinators and (2) waits + resolver bridge events route through the active run’s coordinators rather than the default runtime host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f46eea8c6020ad0b6574ef4734c1bafecc25f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->