### PR TITLE
perf: skip inactive progress log bridge flushes

### DIFF
--- a/packages/extension/src/progressView/managers/WebviewBridge.ts
+++ b/packages/extension/src/progressView/managers/WebviewBridge.ts
@@ -17,6 +17,7 @@ export class WebviewBridge {
     private readonly getActiveStream: () => StreamTabId | null,
   ) {
     this.unsubscribe = this.store.onChange((streamId) => {
+      if (streamId !== this.getActiveStream()) return;
       this.changedStreams.add(streamId);
       this.scheduleFlush();
     });

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -1,0 +1,128 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - common webview
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - logger
+import { StreamLogStore } from '@logger/StreamLogStore';
+import type { StreamLogAppendInput } from '@logger/StreamLog';
+
+// Local imports - progress view
+import { WebviewBridge } from '@progressView/managers/WebviewBridge';
+
+// Local imports - shared schemas
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamTabId,
+} from '@shared/schemas';
+
+function logEntry(
+  id: string,
+  text: string,
+  timestamp: number,
+): StreamLogAppendInput {
+  return {
+    id,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp,
+    messageType: MESSAGE_TYPES.DEFAULT,
+    text,
+  };
+}
+
+describe('WebviewBridge', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes active stream log deltas', async () => {
+    vi.useFakeTimers();
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    const postMessage = vi.fn();
+    const bridge = new WebviewBridge(
+      store,
+      () => [{ postMessage } as never],
+      () => activeStream,
+    );
+
+    store.append(activeStream, logEntry('active-1', 'active log', 100));
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [
+        expect.objectContaining({
+          id: 'active-1',
+          text: 'active log',
+        }),
+      ],
+      updates: [],
+    });
+
+    bridge.dispose();
+  });
+
+  it('does not queue inactive stream flushes that race with tab switches', async () => {
+    vi.useFakeTimers();
+    const store = new StreamLogStore();
+    let activeStream = 'active' as StreamTabId;
+    const postMessage = vi.fn();
+    const bridge = new WebviewBridge(
+      store,
+      () => [{ postMessage } as never],
+      () => activeStream,
+    );
+
+    store.append(
+      'inactive' as StreamTabId,
+      logEntry('inactive-1', 'inactive log', 100),
+    );
+    activeStream = 'inactive' as StreamTabId;
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(postMessage).not.toHaveBeenCalled();
+
+    bridge.dispose();
+  });
+
+  it('syncs inactive stream history explicitly on tab switch', async () => {
+    vi.useFakeTimers();
+    const store = new StreamLogStore();
+    let activeStream = 'active' as StreamTabId;
+    const postMessage = vi.fn();
+    const bridge = new WebviewBridge(
+      store,
+      () => [{ postMessage } as never],
+      () => activeStream,
+    );
+
+    store.append(
+      'inactive' as StreamTabId,
+      logEntry('inactive-1', 'inactive log', 100),
+    );
+
+    activeStream = 'inactive' as StreamTabId;
+    bridge.syncStream(activeStream);
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [
+        expect.objectContaining({
+          id: 'inactive-1',
+          text: 'inactive log',
+        }),
+      ],
+      updates: [],
+    });
+
+    bridge.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid scheduling progress log bridge frame flushes for streams that are not currently active.
- Preserve explicit tab-switch hydration through syncStream, so inactive stream history still renders when the user opens that stream.
- Add WebviewBridge kernel tests covering active flushes, inactive no-op behavior, and explicit tab-switch sync.

## Design Notes
This is a narrow performance slice from the newly opened #3925 audit and the VS Code responsiveness concern. The bridge already sends only the active stream in flush, so queuing frame timers for inactive stream changes was redundant work when many streams or background processes are producing log updates.

External Codex and Claude Code consultations were attempted from the shell as requested, but the environment policy blocks both CLIs from inspecting local repository files because that would send workspace code to external services. This PR is based on local inspection only.

## Validation
- node_modules/.bin/vitest run src/test-kernel/progressView/WebviewBridge.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- git diff --check
- npm run compile:fast
- npm run lint

Related: #3925

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization in the progress-view logging bridge; behavior change is limited to skipping queued flush work for inactive streams, with test coverage added to prevent regressions around tab switching.
> 
> **Overview**
> Prevents `WebviewBridge` from scheduling frame flush timers for stream log updates unless the updated stream is the currently active tab, reducing redundant work under high background logging.
> 
> Adds Vitest kernel coverage for active-stream delta flushing, ensuring inactive-stream updates don’t trigger queued flushes during tab switches, and confirming `syncStream()` still hydrates history when a user opens an inactive stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6499787c5dd2fe2bda209bb771e434deec9f7056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->