### PR TITLE
feat: attach dropped files from main webview

### DIFF
--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -229,6 +229,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleRefreshAllFiles(),
       [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: (m) =>
         this.fileManager.handleAddOpenedFiles(m.fileType),
+      [MAIN_VIEW_COMMANDS.ATTACH_DROPPED_FILES]: (m) =>
+        this.fileManager.handleAttachDroppedFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: (m) =>
         this.fileManager.handleUpdateFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: (m) =>

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
@@ -18,6 +18,11 @@ import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
+import {
+  extractDroppedFilePaths,
+  hasDroppedFilePayload,
+  postDroppedFiles,
+} from '../fileDropHandler';
 import { SESSION_TYPES } from '../constants';
 import { SESSION_DEFAULTS } from '../sessionDefaults';
 import {
@@ -36,6 +41,16 @@ export class FileSelectGroup extends LitElement {
       :host {
         display: block;
       }
+
+      .file-select.drop-active {
+        outline: 1px dashed var(--wa-color-brand-fill-loud);
+        outline-offset: 2px;
+        background: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-quiet) 22%,
+          transparent
+        );
+      }
     `,
   ];
 
@@ -47,6 +62,11 @@ export class FileSelectGroup extends LitElement {
 
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
+
+  @state()
+  private isDragActive = false;
+
+  private dragDepth = 0;
 
   private sortableController = new SortableController(
     this,
@@ -117,6 +137,41 @@ export class FileSelectGroup extends LitElement {
   private handleSelectMultipleFiles(): void {
     this.dispatchEvent(
       MainViewEvents.selectMultipleFiles({ listId: this.listId }),
+    );
+  }
+
+  private handleDragEnter(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth += 1;
+    this.isDragActive = true;
+  }
+
+  private handleDragOver(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  private handleDragLeave(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth = Math.max(0, this.dragDepth - 1);
+    if (this.dragDepth === 0) {
+      this.isDragActive = false;
+    }
+  }
+
+  private handleDrop(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth = 0;
+    this.isDragActive = false;
+    postDroppedFiles(
+      extractDroppedFilePaths(event.dataTransfer),
+      this.config.type,
     );
   }
 
@@ -370,9 +425,16 @@ export class FileSelectGroup extends LitElement {
 
     return html`
       <div
-        class="file-select"
+        class=${classMap({
+          'file-select': true,
+          'drop-active': this.isDragActive,
+        })}
         data-expanded=${String(this.currentListVisible)}
         data-has-current=${String(Boolean(this.currentSelectedValue))}
+        @dragenter=${this.handleDragEnter}
+        @dragover=${this.handleDragOver}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
       >
         <div class="file-select-header">
           <div class="file-select-label-group">

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -13,7 +13,8 @@ import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
@@ -41,6 +42,11 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
+import {
+  extractDroppedFilePaths,
+  hasDroppedFilePayload,
+  postDroppedFiles,
+} from '../fileDropHandler';
 import { handleImagePaste } from '../pasteHandler';
 import { SESSION_TYPES, type SessionType } from '../constants';
 import {
@@ -126,6 +132,31 @@ export class InstructionPanel extends LitElement {
           var(--wa-color-brand-fill-loud) 35%,
           var(--color-border)
         );
+      }
+
+      .instruction-box.drop-active {
+        border-color: var(--wa-color-brand-fill-loud);
+      }
+
+      .instruction-box.drop-active::after {
+        content: 'Drop to attach';
+        position: absolute;
+        inset: var(--wa-space-3xs);
+        z-index: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px dashed var(--wa-color-brand-fill-loud);
+        border-radius: var(--border-radius);
+        background: color-mix(
+          in srgb,
+          var(--wa-color-surface-default) 78%,
+          transparent
+        );
+        color: var(--wa-color-text-normal);
+        font-size: var(--font-size-sm);
+        font-weight: 600;
+        pointer-events: none;
       }
 
       .instruction-header {
@@ -409,9 +440,14 @@ export class InstructionPanel extends LitElement {
 
   @property({ type: Boolean }) showSessionHint = true;
 
+  @state()
+  private isDragActive = false;
+
   /** Reference to instruction textarea for paste handling */
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
+
+  private dragDepth = 0;
 
   /** Get the tooltip for an agent dropdown based on the selected agent's description. */
   private getAgentTooltip(
@@ -511,6 +547,38 @@ export class InstructionPanel extends LitElement {
     }
   };
 
+  private handleDragEnter(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth += 1;
+    this.isDragActive = true;
+  }
+
+  private handleDragOver(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  private handleDragLeave(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth = Math.max(0, this.dragDepth - 1);
+    if (this.dragDepth === 0) {
+      this.isDragActive = false;
+    }
+  }
+
+  private handleDrop(event: DragEvent): void {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth = 0;
+    this.isDragActive = false;
+    postDroppedFiles(extractDroppedFilePaths(event.dataTransfer));
+  }
+
   private handleActionClick(event: MouseEvent): void {
     const button = (event.target as HTMLElement).closest<HTMLElement>(
       '[data-action]',
@@ -569,7 +637,16 @@ export class InstructionPanel extends LitElement {
       return nothing;
     }
     return html`
-      <div class="instruction-box">
+      <div
+        class=${classMap({
+          'instruction-box': true,
+          'drop-active': this.isDragActive,
+        })}
+        @dragenter=${this.handleDragEnter}
+        @dragover=${this.handleDragOver}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
+      >
         <div class="instruction-header">
           <div class="instruction-header-leading">
             <div class="instruction-session-toggle">

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -1,0 +1,121 @@
+// Local imports - common webview
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - shared utilities
+import { postMessage } from '@shared/hostBridge';
+
+// Local imports - shared schemas
+import type { MultipleDocumentFileType } from '@shared/schemas';
+
+type FileWithPath = File & {
+  path?: string;
+};
+
+const FILE_URI_PREFIX = 'file:';
+const FILE_URI_TEXT_TYPES = [
+  'text/uri-list',
+  'application/vnd.code.tree.resource',
+];
+
+function decodeFileUri(value: string): string | null {
+  if (!value.startsWith(FILE_URI_PREFIX)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'file:') return null;
+    const pathname = decodeURIComponent(url.pathname);
+    if (url.hostname && url.hostname !== 'localhost') {
+      return `//${url.hostname}${pathname}`;
+    }
+    return pathname.replace(/^\/([A-Za-z]:)/, '$1');
+  } catch {
+    return null;
+  }
+}
+
+function normalizeLocalPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  return decodeFileUri(trimmed) ?? trimmed;
+}
+
+function normalizeFileUri(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  return decodeFileUri(trimmed);
+}
+
+function addLocalPath(
+  paths: Set<string>,
+  value: string | null | undefined,
+): void {
+  if (!value) return;
+  const path = normalizeLocalPath(value);
+  if (path) paths.add(path);
+}
+
+function addFileUri(
+  paths: Set<string>,
+  value: string | null | undefined,
+): void {
+  if (!value) return;
+  const path = normalizeFileUri(value);
+  if (path) paths.add(path);
+}
+
+function hasFileUri(dataTransfer: DataTransfer, type: string): boolean {
+  const data = dataTransfer.getData(type);
+  if (!data) return false;
+  return data.split(/\r?\n/).some((line) => normalizeFileUri(line) != null);
+}
+
+/** Return true when the drag payload appears to contain files or file URIs. */
+export function hasDroppedFilePayload(
+  dataTransfer: DataTransfer | null,
+): boolean {
+  if (!dataTransfer) return false;
+  const types = [...(dataTransfer.types ?? [])];
+  if (types.includes('Files')) return true;
+  if (types.includes('application/vnd.code.tree.resource')) return true;
+  return types.includes('text/uri-list')
+    ? hasFileUri(dataTransfer, 'text/uri-list')
+    : false;
+}
+
+/** Extract absolute paths or file URIs from a drop payload. */
+export function extractDroppedFilePaths(
+  dataTransfer: DataTransfer | null,
+): string[] {
+  if (!dataTransfer) return [];
+
+  const paths = new Set<string>();
+  for (const file of dataTransfer.files ?? []) {
+    addLocalPath(paths, (file as FileWithPath).path);
+  }
+
+  for (const type of FILE_URI_TEXT_TYPES) {
+    const data = dataTransfer.getData(type);
+    if (!data) continue;
+    for (const line of data.split(/\r?\n/)) {
+      addFileUri(paths, line);
+    }
+  }
+
+  return [...paths];
+}
+
+export function postDroppedFiles(
+  paths: string[],
+  target?: MultipleDocumentFileType,
+): boolean {
+  const uniquePaths = [...new Set(paths.filter(Boolean))];
+  if (uniquePaths.length === 0) return false;
+
+  postMessage(MAIN_VIEW_COMMANDS.ATTACH_DROPPED_FILES, {
+    paths: uniquePaths,
+    ...(target ? { target } : {}),
+  });
+  return true;
+}

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 import * as vscode from 'vscode';
 
@@ -22,7 +23,10 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
-import type { MainViewInboundMessage } from '@shared/schemas';
+import type {
+  MainViewInboundMessage,
+  MultipleDocumentFileType,
+} from '@shared/schemas';
 import {
   WorkspaceFS,
   parseLatexDiffMetadata,
@@ -75,6 +79,10 @@ type SelectMultipleFilesMessage = MessageFor<
   typeof MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES
 >;
 
+type AttachDroppedFilesMessage = MessageFor<
+  typeof MAIN_VIEW_COMMANDS.ATTACH_DROPPED_FILES
+>;
+
 type GetCurrentFileMessage = MessageFor<
   typeof MAIN_VIEW_COMMANDS.GET_CURRENT_FILE
 >;
@@ -89,6 +97,16 @@ type UpdateFilesMessage = MessageFor<
 
 const CHANNEL = 'FileManager';
 logger.initialize(CHANNEL);
+
+const ATTACHABLE_DROP_CATEGORIES = [
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+] as const satisfies readonly MultipleDocumentFileType[];
+
+type AttachableDropCategory = (typeof ATTACHABLE_DROP_CATEGORIES)[number];
+type AllowedDropExtensions = Map<AttachableDropCategory, Set<string>>;
 
 type FileUpdateOptions = {
   notifyWhenEmpty?: boolean;
@@ -416,6 +434,47 @@ export class FileManager extends BaseWebviewManager {
     });
   }
 
+  async handleAttachDroppedFiles(
+    message: AttachDroppedFilesMessage,
+  ): Promise<void> {
+    const grouped = new Map<AttachableDropCategory, Set<string>>(
+      ATTACHABLE_DROP_CATEGORIES.map((category) => [category, new Set()]),
+    );
+    const allowedExtensions = this.getAllowedDropExtensions();
+    let rejectedCount = 0;
+
+    for (const rawPath of message.paths) {
+      const filePath = await this.resolveWorkspaceDropFile(rawPath);
+      const category = filePath
+        ? this.resolveDroppedFileCategory(
+            filePath,
+            allowedExtensions,
+            message.target ?? undefined,
+          )
+        : null;
+      if (!filePath || !category) {
+        rejectedCount += 1;
+        continue;
+      }
+      grouped.get(category)?.add(filePath);
+    }
+
+    let attachedCount = 0;
+    for (const [fileType, files] of grouped) {
+      if (files.size === 0) continue;
+      const droppedFiles = [...files];
+      attachedCount += droppedFiles.length;
+      this.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_OPENED_FILES,
+        files: droppedFiles,
+        fileType,
+        shouldFilter: true,
+      });
+    }
+
+    this.showDroppedFilesResult(attachedCount, rejectedCount);
+  }
+
   handleUpdateFiles(message: UpdateFilesMessage): void {
     const fileType = message.command.replace('update', '');
     logger.debug(
@@ -514,5 +573,129 @@ export class FileManager extends BaseWebviewManager {
 
     logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
     return relevantFiles;
+  }
+
+  private async resolveWorkspaceDropFile(
+    rawPath: string,
+  ): Promise<string | null> {
+    const decodedPath = this.decodeDroppedPath(rawPath);
+    const resolved = WorkspaceFS.locatePath(decodedPath);
+    if (resolved.kind !== 'workspace') return null;
+
+    try {
+      const stat = await vscode.workspace.fs.stat(
+        vscode.Uri.file(resolved.absolutePath),
+      );
+      if ((stat.type & vscode.FileType.File) === 0) return null;
+      return resolved.relativePath;
+    } catch (error) {
+      logger.debug(
+        CHANNEL,
+        `Dropped file could not be read: ${decodedPath}: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private decodeDroppedPath(rawPath: string): string {
+    const trimmed = rawPath.trim();
+    if (!trimmed.startsWith('file:')) return trimmed;
+    try {
+      return fileURLToPath(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+
+  private resolveDroppedFileCategory(
+    filePath: string,
+    allowedExtensions: AllowedDropExtensions,
+    target?: MultipleDocumentFileType,
+  ): AttachableDropCategory | null {
+    if (target) {
+      return this.isAttachableDropCategory(target) &&
+        this.isExtensionAllowed(target, filePath, allowedExtensions)
+        ? target
+        : null;
+    }
+
+    const extension = this.normalizedExtension(filePath);
+    if (this.isExtensionAllowed('media', filePath, allowedExtensions)) {
+      return 'media';
+    }
+    if (
+      (extension === 'bib' || extension === 'bbl') &&
+      this.isExtensionAllowed('reference', filePath, allowedExtensions)
+    ) {
+      return 'reference';
+    }
+    if (
+      (extension === 'cls' || extension === 'sty') &&
+      this.isExtensionAllowed('auxiliary', filePath, allowedExtensions)
+    ) {
+      return 'auxiliary';
+    }
+    if (this.isExtensionAllowed('input', filePath, allowedExtensions)) {
+      return 'input';
+    }
+    if (this.isExtensionAllowed('reference', filePath, allowedExtensions)) {
+      return 'reference';
+    }
+    if (this.isExtensionAllowed('auxiliary', filePath, allowedExtensions)) {
+      return 'auxiliary';
+    }
+    return null;
+  }
+
+  private isAttachableDropCategory(
+    category: MultipleDocumentFileType,
+  ): category is AttachableDropCategory {
+    return (ATTACHABLE_DROP_CATEGORIES as readonly string[]).includes(category);
+  }
+
+  private isExtensionAllowed(
+    category: AttachableDropCategory,
+    filePath: string,
+    allowedExtensions: AllowedDropExtensions,
+  ): boolean {
+    const extension = this.normalizedExtension(filePath);
+    if (!extension) return false;
+    return allowedExtensions.get(category)?.has(extension) ?? false;
+  }
+
+  private getAllowedDropExtensions(): AllowedDropExtensions {
+    return new Map(
+      ATTACHABLE_DROP_CATEGORIES.map((category) => [
+        category,
+        new Set(
+          getIncludedExtensions(category).map((ext) =>
+            this.normalizedExtension(ext),
+          ),
+        ),
+      ]),
+    );
+  }
+
+  private normalizedExtension(filePath: string): string {
+    const extension = path.extname(filePath) || filePath;
+    return extension.trim().toLowerCase().replace(/^\./, '');
+  }
+
+  private showDroppedFilesResult(
+    attachedCount: number,
+    rejectedCount: number,
+  ): void {
+    if (attachedCount > 0 && rejectedCount === 0) return;
+    if (attachedCount > 0) {
+      vscode.window.showInformationMessage(
+        `Attached ${attachedCount} dropped file${attachedCount === 1 ? '' : 's'}; skipped ${rejectedCount} unsupported, folder, or out-of-workspace item${rejectedCount === 1 ? '' : 's'}.`,
+      );
+      return;
+    }
+    if (rejectedCount > 0) {
+      vscode.window.showInformationMessage(
+        'No dropped files were attached. Use regular files inside this workspace with supported TeXRA extensions.',
+      );
+    }
   }
 }

--- a/src/common/webview/mainViewCommands.ts
+++ b/src/common/webview/mainViewCommands.ts
@@ -53,6 +53,7 @@ export const MAIN_VIEW_COMMANDS = {
   GET_DEBUG_MODE: 'getDebugMode',
   GET_CURRENT_FILE: 'getCurrentFile',
   ADD_OPENED_FILES: 'addOpenedFiles',
+  ATTACH_DROPPED_FILES: 'attachDroppedFiles',
   POLISH_INSTRUCTION_TEXT: 'polishInstructionText',
   TRANSCRIBE_INSTRUCTION: 'transcribeInstruction',
   START_RECORDING: 'startRecording',

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -826,6 +826,11 @@ const FileOperationMessages = [
     command: z.literal(MAIN_VIEW_COMMANDS.ADD_OPENED_FILES),
     fileType: ExtendedDocumentFileTypeSchema,
   }),
+  z.object({
+    command: z.literal(MAIN_VIEW_COMMANDS.ATTACH_DROPPED_FILES),
+    paths: z.array(z.string()),
+    target: MultipleDocumentFileTypeSchema.nullish(),
+  }),
   // Note: Use withFilesArray (required files) directly instead of
   // withOptionalFiles + .extend() override pattern
   withFilesArray(MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES).extend({

--- a/src/test-kernel/webview/fileDropHandler.vitest.ts
+++ b/src/test-kernel/webview/fileDropHandler.vitest.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractDroppedFilePaths,
+  hasDroppedFilePayload,
+} from '@webview/frontend/fileDropHandler';
+
+type FakeFile = {
+  path?: string;
+};
+
+function dataTransfer(
+  types: string[],
+  data: Record<string, string> = {},
+  files: FakeFile[] = [],
+): DataTransfer {
+  return {
+    types,
+    files,
+    getData: (type: string) => data[type] ?? '',
+  } as unknown as DataTransfer;
+}
+
+describe('fileDropHandler', () => {
+  it('detects file drop payloads without treating plain text as a file', () => {
+    expect(hasDroppedFilePayload(dataTransfer(['Files']))).toBe(true);
+    expect(
+      hasDroppedFilePayload(
+        dataTransfer(['text/uri-list'], {
+          'text/uri-list': 'file:///Users/a/project/main.tex',
+        }),
+      ),
+    ).toBe(true);
+    expect(hasDroppedFilePayload(dataTransfer(['text/plain']))).toBe(false);
+    expect(
+      hasDroppedFilePayload(
+        dataTransfer(['text/uri-list'], {
+          'text/uri-list': 'https://example.com/paper',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('extracts file paths from dropped File objects', () => {
+    const paths = extractDroppedFilePaths(
+      dataTransfer(['Files'], {}, [{ path: '/Users/a/project/main.tex' }]),
+    );
+
+    expect(paths).toEqual(['/Users/a/project/main.tex']);
+  });
+
+  it('extracts and deduplicates file URIs from text payloads', () => {
+    const paths = extractDroppedFilePaths(
+      dataTransfer(['text/uri-list'], {
+        'text/uri-list': [
+          'file:///Users/a/project/My%20Paper/main.tex',
+          '# Finder comment',
+          'file:///Users/a/project/refs.bib',
+          'file:///Users/a/project/refs.bib',
+        ].join('\n'),
+      }),
+    );
+
+    expect(paths).toEqual([
+      '/Users/a/project/My Paper/main.tex',
+      '/Users/a/project/refs.bib',
+    ]);
+  });
+
+  it('preserves hosts when extracting UNC-style file URIs', () => {
+    const paths = extractDroppedFilePaths(
+      dataTransfer(['text/uri-list'], {
+        'text/uri-list': 'file://server/share/main.tex',
+      }),
+    );
+
+    expect(paths).toEqual(['//server/share/main.tex']);
+  });
+});


### PR DESCRIPTION
## Summary

- add `attachDroppedFiles` as the webview-to-host command for dropped file paths and file URIs
- let the instruction textarea classify dropped files into existing Input, Reference, Auxiliary, and Media lists
- let explicit file groups attach dropped files directly to their own list after host validation
- reject folders, unsupported extensions, and files outside the workspace

Closes #3869.

## Validation

- `npm run format`
- `node_modules/.bin/vitest run src/test-kernel/webview/fileDropHandler.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new webview→host command and backend path/extension validation for drag-and-drop file attachment, which can affect file selection behavior and user messaging. Risk is moderated by workspace-only checks, extension allowlists, and new unit tests for drop payload parsing.
> 
> **Overview**
> Enables drag-and-drop attachment of files/URIs in the main webview via a new `attachDroppedFiles` inbound command.
> 
> The frontend (`InstructionPanel` and `FileSelectGroup`) now accepts file drops with visual affordances and posts extracted paths (optionally targeting a specific list) using the shared `fileDropHandler`.
> 
> The extension host (`FileManager`) validates dropped items (in-workspace, files-not-folders, allowed extensions), auto-classifies untargeted drops into Input/Reference/Auxiliary/Media, attaches them by emitting `SET_OPENED_FILES`, and reports partial/failed drops via info messages; schemas and vitest coverage were added for the new drop parsing helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a48048fc151af7ca445a98429eea8a5050b57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->