### PR TITLE
refactor: require subscription unbind host

### DIFF
--- a/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
@@ -159,7 +159,9 @@ describe('GitHub subscription progress events', () => {
     registry.bind('stream-a' as StreamTabId, 'owner/repo', host.host);
     host.events.length = 0;
 
-    expect(registry.unbind('stream-a' as StreamTabId, 'owner/repo')).toBe(true);
+    expect(
+      registry.unbind('stream-a' as StreamTabId, 'owner/repo', host.host),
+    ).toBe(true);
 
     expect(host.events).toEqual([
       { event: 'repoSubscriptionBindingsChanged', payload: undefined },

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -140,7 +140,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   unbind(
     streamId: StreamTabId,
     input: Input,
-    runtimeHost?: AgentRuntimeHost,
+    runtimeHost: AgentRuntimeHost,
   ): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perStream.get(streamId);
@@ -148,7 +148,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     if (!bound || !binding) return false;
     this.removeBoundKey(streamId, bound, key);
     this.disposeSafe(binding.disposable, 'explicit unsubscribe');
-    this.emitBindingsChanged([runtimeHost ?? binding.runtimeHost]);
+    this.emitBindingsChanged([runtimeHost]);
     return true;
   }
 
@@ -157,7 +157,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
    * bindings removed. Lets the settings UI cancel a subscription globally
    * without needing to know which stream owns it.
    */
-  unbindAll(key: string, runtimeHost?: AgentRuntimeHost): number {
+  unbindAll(key: string, runtimeHost: AgentRuntimeHost): number {
     const removedBindings: BoundSubscription[] = [];
     const runtimeHosts: AgentRuntimeHost[] = [];
     for (const [streamId, bound] of [...this.perStream]) {
@@ -171,7 +171,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       for (const binding of removedBindings) {
         this.disposeSafe(binding.disposable, 'unbindAll');
       }
-      if (runtimeHost) runtimeHosts.push(runtimeHost);
+      runtimeHosts.push(runtimeHost);
       this.emitBindingsChanged(runtimeHosts);
     }
     return removedBindings.length;

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -50,14 +50,14 @@ export function bindPRSubscription(
 export function unbindPRSubscription(
   streamId: StreamTabId,
   pr: PRSubscribeInput,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
   return prSubscriptions.unbind(streamId, pr, runtimeHost);
 }
 
 export function unbindAllForPR(
   key: string,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): number {
   return prSubscriptions.unbindAll(key, runtimeHost);
 }
@@ -116,14 +116,14 @@ export function bindRepoSubscription(
 export function unbindRepoSubscription(
   streamId: StreamTabId,
   input: RepoBindInput,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
   return repoSubscriptions.unbind(streamId, input, runtimeHost);
 }
 
 export function unbindAllForRepo(
   key: string,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): number {
   return repoSubscriptions.unbindAll(key, runtimeHost);
 }
@@ -169,14 +169,14 @@ export function bindIssueSubscription(
 export function unbindIssueSubscription(
   streamId: StreamTabId,
   issue: IssueKey,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): boolean {
   return issueSubscriptions.unbind(streamId, issue, runtimeHost);
 }
 
 export function unbindAllForIssue(
   key: string,
-  runtimeHost?: AgentRuntimeHost,
+  runtimeHost: AgentRuntimeHost,
 ): number {
   return issueSubscriptions.unbindAll(key, runtimeHost);
 }


### PR DESCRIPTION
## Summary

This is a small ownership cleanup for the GitHub subscription path.

- Makes PR/repo/issue subscription unbind APIs require the caller owned AgentRuntimeHost.
- Keeps internal registry cleanup owned by stored bindings, while explicit unsubscribe actions name the host that should receive binding-change events.
- Updates the focused subscription progress-event test to pass the explicit host.

Refs #3925 and #3372.

## Validation

- node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node_modules/.bin/eslint src/tools/github/StreamSubscriptionRegistry.ts src/tools/github/subscriptionBindings.ts src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
- npm run compile:fast
- npm run lint (existing 66 warnings, 0 errors)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that tightens TypeScript APIs for subscription unbinding and slightly changes which host receives bindings-changed events; main risk is missed call-site updates causing compile errors or UI refresh not firing in some flows.
> 
> **Overview**
> Unbind and unbind-all operations for PR/repo/issue GitHub subscriptions now **require an explicit `AgentRuntimeHost`**, rather than accepting an optional host.
> 
> `StreamSubscriptionRegistry.unbind`/`unbindAll` now always emit bindings-changed progress events to the caller-provided host (instead of falling back to the stored binding host), and the affected vitest case is updated to pass the host explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69ca67f8c61fae5e70963d933538c5affcd735f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->