### PR TITLE
refactor: require execution request host

### DIFF
--- a/src/agent/runtime/runExecutionRequest.ts
+++ b/src/agent/runtime/runExecutionRequest.ts
@@ -9,13 +9,13 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 
 export interface RunExecutionRequestOptions {
-  runtimeHost?: AgentRuntimeHost;
+  runtimeHost: AgentRuntimeHost;
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
 }
 
 export async function runValidatedExecutionRequest(
   request: ValidatedExecutionRequest,
-  options: RunExecutionRequestOptions = {},
+  options: RunExecutionRequestOptions,
 ): Promise<AgentFlowResult> {
   const executionId =
     request.executionId ?? (generateExecutionId() as ExecutionId);


### PR DESCRIPTION
## Summary

This is a narrow runtime-host ownership cleanup.

- Makes runValidatedExecutionRequest require a runtimeHost in its options.
- Removes the default empty options object that could silently pass an undefined host into executeAgent.
- Leaves executeAgent itself untouched to avoid overlapping the parked execution/storage PR surface.

Refs #3925 and #3372.

## Validation

- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node_modules/.bin/eslint src/agent/runtime/runExecutionRequest.ts packages/extension/src/commands/agent/executeCommand.ts packages/desktop/src/main/desktopAgentExecution.ts (existing desktop import-order warnings only)
- npm run compile:fast
- npm run lint (existing 66 warnings, 0 errors)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, but it is a breaking signature change that may require updating any callers that previously relied on the default empty options object.
> 
> **Overview**
> `runValidatedExecutionRequest` now requires an explicit `options` argument with a non-optional `runtimeHost`, removing the previous default `{}` and optional host.
> 
> This tightens runtime-host ownership by ensuring `executeAgent` is always called with a defined `runtimeHost`, while leaving the execution logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfac945b68a9bfc3b9743716220baff53aa29152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->