### PR TITLE
refactor: expose terminal runner port

### DIFF
--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -1,9 +1,10 @@
 /**
  * Setup-tool integrated-terminal runner.
  *
- * Implements `SetupTerminalAdapter.runCommand`. Prefers VS Code's stable
- * `Terminal.shellIntegration` API (since 1.93) so the agent gets exit
- * code + output. When integration isn't available — custom shell, user
+ * Implements the host-neutral `TerminalRunner.runCommand` contract.
+ * Prefers VS Code's stable `Terminal.shellIntegration` API (since 1.93)
+ * so the agent gets exit code + output. When integration isn't available —
+ * custom shell, user
  * disabled the auto-inject, remote SSH edge cases — falls back to
  * `sendText` and returns an empty captured result; the caller sees the
  * same shape as a Ctrl+C interruption and re-probes with `verify_setup`.
@@ -13,20 +14,21 @@
 import * as vscode from 'vscode';
 import stripAnsi from 'strip-ansi';
 
-// Local imports
-import type { TerminalRunResult } from '@tools/setup';
+// Local imports - hosts
+import type {
+  TerminalRunRequest,
+  TerminalRunResult,
+} from '@hosts/terminalHost';
 
 const OUTPUT_MAX_CHARS = 12_000;
 const SHELL_INTEGRATION_WAIT_MS = 2_000;
 const READER_DRAIN_MS = 250;
 
-export async function runTerminalCommand(args: {
-  name: string;
-  command: string;
-  timeoutMs: number;
-}): Promise<TerminalRunResult> {
+export async function runTerminalCommand(
+  args: TerminalRunRequest,
+): Promise<TerminalRunResult> {
   const { name, command, timeoutMs } = args;
-  const terminal = revealTerminal(name);
+  const terminal = revealTerminal(args);
   const integration = await waitForShellIntegration(
     terminal,
     SHELL_INTEGRATION_WAIT_MS,
@@ -45,11 +47,15 @@ export async function runTerminalCommand(args: {
  * pile up tabs. Already-exited terminals stay in `terminals` until the
  * user closes them; treat those as gone.
  */
-function revealTerminal(name: string): vscode.Terminal {
-  const existing = vscode.window.terminals.find(
-    (t) => t.name === name && t.exitStatus === undefined,
-  );
-  const terminal = existing ?? vscode.window.createTerminal({ name });
+function revealTerminal(request: TerminalRunRequest): vscode.Terminal {
+  const { name, cwd, env } = request;
+  const hasLaunchOverrides = cwd !== undefined || env !== undefined;
+  const existing = hasLaunchOverrides
+    ? undefined
+    : vscode.window.terminals.find(
+        (t) => t.name === name && t.exitStatus === undefined,
+      );
+  const terminal = existing ?? vscode.window.createTerminal({ name, cwd, env });
   terminal.show();
   return terminal;
 }

--- a/src/hosts/index.ts
+++ b/src/hosts/index.ts
@@ -17,5 +17,8 @@ export type {
   TerminalHandle,
   TerminalHost,
   TerminalOptions,
+  TerminalRunner,
+  TerminalRunRequest,
+  TerminalRunResult,
 } from './terminalHost';
 export type { UIHosts } from './uiHosts';

--- a/src/hosts/terminalHost.ts
+++ b/src/hosts/terminalHost.ts
@@ -4,6 +4,20 @@ export interface TerminalOptions {
   env?: Record<string, string | undefined>;
 }
 
+export interface TerminalRunRequest extends TerminalOptions {
+  command: string;
+  /** Hard cap on how long to wait for captured execution. */
+  timeoutMs: number;
+}
+
+export interface TerminalRunResult {
+  /** Undefined when the host cannot observe the command exit code. */
+  exitCode: number | undefined;
+  /** ANSI-stripped, length-capped tail of command output when available. */
+  output: string;
+  timedOut: boolean;
+}
+
 export interface TerminalHandle {
   readonly name: string;
   sendText(text: string, shouldExecute?: boolean): void;
@@ -15,4 +29,8 @@ export interface TerminalHost {
   createTerminal(options: TerminalOptions): TerminalHandle;
   findTerminal(name: string): TerminalHandle | undefined;
   getTerminals(): readonly TerminalHandle[];
+}
+
+export interface TerminalRunner {
+  runCommand(request: TerminalRunRequest): Promise<TerminalRunResult>;
 }

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -8,6 +8,12 @@
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
 
+import type {
+  TerminalRunRequest,
+  TerminalRunResult,
+  TerminalRunner,
+} from '@hosts/terminalHost';
+
 /** Per-provider API key surface. */
 export interface SetupSecretsAdapter {
   setApiKey(provider: string, key: string): Promise<void>;
@@ -78,22 +84,8 @@ export interface SetupConfigAdapter {
  * same as "user interrupted", since neither path tells us anything
  * actionable.
  */
-export interface SetupTerminalAdapter {
-  runCommand(args: {
-    name: string;
-    command: string;
-    /** Hard cap on how long to wait for the captured run before giving up. */
-    timeoutMs: number;
-  }): Promise<TerminalRunResult>;
-}
-
-export interface TerminalRunResult {
-  /** `undefined` if shell integration was unavailable, or the run was interrupted. */
-  exitCode: number | undefined;
-  /** ANSI-stripped, length-capped tail of the command's output. May be empty. */
-  output: string;
-  timedOut: boolean;
-}
+export type SetupTerminalAdapter = TerminalRunner;
+export type { TerminalRunRequest, TerminalRunResult };
 
 /** Aggregated setup platform. */
 export interface SetupPlatform {


### PR DESCRIPTION
## Summary

First #3808 slice: make command-running terminal ownership a host boundary instead of a setup-tool-local shape.

- Adds TerminalRunRequest, TerminalRunResult, and TerminalRunner to the shared terminal host contract.
- Makes the setup platform terminal adapter use that shared TerminalRunner contract.
- Updates the VS Code setup terminal runner to import the shared host type directly.

This intentionally does not wire the Desktop installer button yet. The next slice can implement the Desktop runner and then route Settings -> Tools install commands through it without inventing a second command execution shape.

Refs #3808.

## Validation

- node_modules/.bin/tsc --noEmit
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node_modules/.bin/eslint src/hosts/terminalHost.ts src/hosts/index.ts src/tools/setup/platform.ts packages/extension/src/frontend/setupTerminalRunner.ts src/test/tools/setup/SendToTerminalTool.test.ts src/test/tools/setup/fixtures.ts
- npm run compile-tests
- node_modules/.bin/mocha --require ./out/src/test/setup.js out/src/test/tools/setup/SendToTerminalTool.test.js
- npm run compile:fast
- npm run lint (existing 66 warnings, 0 errors)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shared terminal host API and the setup platform terminal adapter shape, which can break host implementations or call sites if any are missed. Runtime behavior is mostly unchanged, aside from new `cwd`/`env` launch override handling that affects terminal reuse/creation.
> 
> **Overview**
> Refactors terminal command execution so setup tools depend on a host-level `TerminalRunner` interface instead of a setup-local adapter/type, introducing shared `TerminalRunRequest`/`TerminalRunResult` in `src/hosts/terminalHost.ts` and re-exporting them from `src/hosts/index.ts`.
> 
> Updates the VS Code `setupTerminalRunner` to accept the new request shape and to **avoid reusing** existing terminals when `cwd` or `env` overrides are provided, creating a new terminal with those launch options instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50433b6836934115587e126c2f881c15f6b7ad80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->