### PR TITLE
refactor: require executeAgent runtime host

### DIFF
--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,7 +1,5 @@
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
-import { tryUseRunContext } from './RunContext';
-
 export interface AgentRuntimeHost {
   emit<K extends keyof ProgressEventPayloads>(
     event: K,
@@ -21,8 +19,4 @@ export function setDefaultAgentRuntimeHost(host: AgentRuntimeHost): void {
 
 export function getDefaultAgentRuntimeHost(): AgentRuntimeHost {
   return defaultAgentRuntimeHost;
-}
-
-export function getAgentRuntimeHost(): AgentRuntimeHost {
-  return tryUseRunContext()?.runtimeHost ?? getDefaultAgentRuntimeHost();
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -37,8 +37,6 @@ import {
 import { TaskRunFileService } from '@utils/files';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
-import { StreamStatusService } from './StreamStatusService';
-import { getAgentRuntimeHost, type AgentRuntimeHost } from './AgentRuntimeHost';
 import {
   buildAgentLaunchContext,
   withExecutionRunContext,
@@ -53,6 +51,8 @@ import {
 } from './executionRegistry';
 import { generateSessionDescription } from './sessionDescription';
 import { getRunStorageService } from './RunStorageService';
+import { StreamStatusService } from './StreamStatusService';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type {
   AgentFlowResult,
   CompileFailureSummary,
@@ -284,7 +284,7 @@ function buildFallbackNotification(config: AgentConfig) {
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions {
   /** Host services used by the runtime to report progress/UI events. */
-  runtimeHost?: AgentRuntimeHost;
+  runtimeHost: AgentRuntimeHost;
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /**
@@ -319,23 +319,27 @@ export interface ExecuteAgentOptions {
 
 export async function executeAgent(
   configPayload: AgentConfigPayload,
-  executionId?: ExecutionId,
-  options?: ExecuteAgentOptions,
+  executionId: ExecutionId | undefined,
+  options: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
-  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
+  if (options == null || options.runtimeHost == null) {
+    throw new Error('executeAgent requires an explicit runtimeHost');
+  }
+
+  const { runtimeHost } = options;
   const ctx = await buildAgentLaunchContext({
     configPayload,
     executionId,
     runtimeHost,
-    onBeforeActivation: options?.onStreamResolved,
-    enforceCategory: options?.enforceCategory,
-    suppressErrorNotification: options?.isSubagent,
+    onBeforeActivation: options.onStreamResolved,
+    enforceCategory: options.enforceCategory,
+    suppressErrorNotification: options.isSubagent,
   });
-  ctx.delegationDepth = options?.delegationDepth ?? 0;
+  ctx.delegationDepth = options.delegationDepth ?? 0;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
     const { agent: agentName } = config;
-    const { isSubagent } = options ?? {};
+    const { isSubagent } = options;
 
     // Fire-and-forget: generate AI session description from the user's instruction.
     // Triggered at the start so cancelled/errored sessions still get descriptions.
@@ -392,7 +396,7 @@ export async function executeAgent(
                 ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
               setting: ctx.setting as AgentToolUseSetting,
               isSubagent,
-              onBeforeWaiting: options?.onBeforeWaiting,
+              onBeforeWaiting: options.onBeforeWaiting,
               onProgress: (update) => {
                 if (update.kind === 'overview') {
                   toolUseTurns++;
@@ -404,13 +408,13 @@ export async function executeAgent(
                     },
                   });
                 }
-                options?.onProgress?.(update);
+                options.onProgress?.(update);
               },
               onFollowUpConsumed: () => {
                 ctx.runtimeHost.emit('updateQueuedFollowUps', {
                   streamId: ctx.streamId,
                 });
-                options?.onFollowUpConsumed?.();
+                options.onFollowUpConsumed?.();
               },
             });
             return {
@@ -427,7 +431,7 @@ export async function executeAgent(
             ctx.executionId,
             streamId,
             ctx.runtimeHost,
-            options?.onProgress,
+            options.onProgress,
           );
           const result = await runReflectionFlow({
             ...ctx,
@@ -454,8 +458,8 @@ export async function executeAgent(
           setting.agentCategory === AgentCategory.ToolUse
             ? 'toolUse'
             : 'workflow',
-        parentStreamId: options?.parentStreamId,
-        onCompleted: options?.onCompleted,
+        parentStreamId: options.parentStreamId,
+        onCompleted: options.onCompleted,
       },
     );
   });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -308,6 +308,19 @@ async function executeSubagent(
   const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
   const runtimeHost = parentContext?.runtimeHost;
 
+  if (!runtimeHost) {
+    return {
+      summary: 'Delegation tool runtime host unavailable',
+      error:
+        'delegate_agent and delegate_workflow require an active tool runtime host. Run delegation from an active agent session, or ensure the tool run context provides runtimeHost.',
+      isError: true,
+      diagnostics: {
+        type: 'missing_runtime_host',
+        tools: ['delegate_agent', 'delegate_workflow'],
+      },
+    };
+  }
+
   const gated = depthGateError(
     parentDelegationDepth,
     parentContext?.delegationConfig,


### PR DESCRIPTION
## Summary
- require executeAgent callers to pass an explicit AgentRuntimeHost
- remove the now-unused getAgentRuntimeHost ambient/default fallback helper
- make delegation refuse to launch a subagent if the tool run has no runtime host

## Issues
Refs #3925.
Refs #3372.

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/eslint src/agent/runtime/executeAgent.ts src/agent/runtime/AgentRuntimeHost.ts src/tools/DelegationTools.ts
- npm run compile-tests
- npm run compile:fast
- npm run lint (existing 66-warning baseline, 0 errors)
- npm run typecheck
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change for `executeAgent`/delegation call paths; missing updates will now throw or return errors instead of silently falling back, potentially impacting agent execution in edge flows.
> 
> **Overview**
> `executeAgent` now **requires** callers to pass `options.runtimeHost` (and `options` itself), removing the previous implicit fallback to an ambient/default host and adding a hard runtime check that throws when absent.
> 
> `AgentRuntimeHost.ts` drops the `getAgentRuntimeHost` helper tied to run context, leaving only the configurable default/noop host.
> 
> Delegation tools (`delegate_agent`/`delegate_workflow`) now fail fast with a structured `ToolResult` error when the tool run context has no `runtimeHost`, instead of attempting to launch subagents without UI/progress hosting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5a6d8f588e5b5cb84b4f1807fe89ae8fdeefa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->