### PR TITLE
[codex] Open desktop workspaces in new windows

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -24,6 +24,7 @@ export const DESKTOP_LOCAL_COMMANDS = {
   SHOW_LOGS: 'texra.desktop.showLogs',
   OPEN_LOG_FOLDER: 'texra.desktop.openLogFolder',
   OPEN_WORKSPACE_FOLDER: 'texra.desktop.openWorkspaceFolder',
+  OPEN_WORKSPACE_IN_NEW_WINDOW: 'texra.desktop.openWorkspaceInNewWindow',
   SHOW_FIRST_RUN_WALKTHROUGH: 'texra.desktop.showFirstRunWalkthrough',
   OPEN_DESKTOP_DOCS: 'texra.desktop.openDesktopDocs',
 } as const;
@@ -39,6 +40,7 @@ const DESKTOP_MENU_GROUPS = [
     'texra.showProgressView',
     DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
     DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
     DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
     'texra.openSettings',
     'texra.mainView.reset',
@@ -92,6 +94,7 @@ export interface DesktopCommandActions {
   openDesktopDocs?(): void;
   openLogFolder?(): void;
   openWorkspaceFolder?(): void;
+  openWorkspaceInNewWindow?(): void;
   showFirstRunWalkthrough?(): void;
   resetMainView?(): void;
 }
@@ -137,6 +140,16 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       label: 'Open Folder',
       category: 'TeXRA',
       accelerator: 'CommandOrControl+O',
+      enabled: true,
+    },
+  ],
+  [
+    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
+    {
+      id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
+      label: 'New Window',
+      category: 'TeXRA',
+      accelerator: 'CommandOrControl+Shift+N',
       enabled: true,
     },
   ],
@@ -299,6 +312,11 @@ const DESKTOP_COMMAND_HANDLERS = {
   [DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER]: (actions) => {
     if (!actions.openWorkspaceFolder) return false;
     actions.openWorkspaceFolder();
+    return true;
+  },
+  [DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW]: (actions) => {
+    if (!actions.openWorkspaceInNewWindow) return false;
+    actions.openWorkspaceInNewWindow();
     return true;
   },
   [DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH]: (actions) => {

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -4,6 +4,7 @@ import {
   TEXRA_PROTOCOL,
   TEXRA_PROTOCOL_SCHEME,
 } from '../desktopProtocol.js';
+import { isNewWindowLaunch } from '../workspacePath.js';
 
 export interface DesktopProtocolCallback {
   rawUrl: string;
@@ -156,18 +157,24 @@ export function installDesktopProtocolCallbackLifecycle(
 ): DesktopProtocolLifecycle {
   const { app } = options;
   const router = createDesktopProtocolCallbackRouter({ log: options.log });
+  const isExplicitNewWindow = isNewWindowLaunch({ argv: options.argv });
+  const ownsSingleInstanceLock = app.requestSingleInstanceLock();
 
-  if (!app.requestSingleInstanceLock()) {
+  if (!ownsSingleInstanceLock && !isExplicitNewWindow) {
     app.quit();
     return { router, shouldContinue: false };
   }
 
-  registerProtocolClient(options);
+  if (ownsSingleInstanceLock) {
+    registerProtocolClient(options);
 
-  app.on('second-instance', (_event, argv) => {
-    router.routeArgv(argv);
-    options.focusMainWindow?.();
-  });
+    app.on('second-instance', (_event, argv) => {
+      const routedCount = router.routeArgv(argv);
+      if (!isNewWindowLaunch({ argv }) || routedCount > 0) {
+        options.focusMainWindow?.();
+      }
+    });
+  }
 
   app.on('open-url', (event, url) => {
     event.preventDefault();

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -39,6 +39,7 @@ export interface DesktopShellActionFactoryOptions {
   openExternalUrl?: (url: string) => Promise<void>;
   openLogFolder?: () => Promise<void>;
   openPath?: (filePath: string) => Promise<void>;
+  openWorkspaceInNewWindow?: () => Promise<void>;
   openWorkspaceFolder?: () => Promise<void>;
   signIn?: () => Promise<void>;
   /**
@@ -139,6 +140,10 @@ export function createDesktopShellActions(
     void options.openWorkspaceFolder?.().catch(reportAsyncError);
   }
 
+  function openWorkspaceInNewWindow() {
+    void options.openWorkspaceInNewWindow?.().catch(reportAsyncError);
+  }
+
   function openDesktopDocs() {
     void options.openExternalUrl?.(DESKTOP_DOCS_URL).catch(reportAsyncError);
   }
@@ -161,6 +166,7 @@ export function createDesktopShellActions(
     openAgentDirectory,
     openDesktopDocs,
     openLogFolder,
+    openWorkspaceInNewWindow,
     openWorkspaceFolder,
     resetMainView,
     sendRecentCommits: () => {
@@ -278,6 +284,9 @@ function dispatchDesktopLocalOnShell(
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
       actions.openWorkspaceFolder?.();
+      return true;
+    case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW:
+      actions.openWorkspaceInNewWindow?.();
       return true;
     case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
       actions.showFirstRunWalkthrough?.();

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -12,13 +13,13 @@ import {
 } from 'electron';
 
 import { platform } from '@platform/platform';
+import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { interruptAllCodexSessions } from '@tools/codex';
 import { refreshToolAvailability } from '@tools/toolAvailability';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import {
@@ -59,6 +60,7 @@ import { initializeElectronPlatform } from './platform/index.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
   serializeWorkspacePresenceArg,
+  withNewWindowWorkspaceArgs,
   withWorkspacePathArg,
 } from '../workspacePath.js';
 
@@ -256,6 +258,23 @@ function createWindow(options: {
     });
     app.exit(0);
   };
+  const openWorkspaceInNewWindow = async () => {
+    const result = await dialog.showOpenDialog(window, {
+      title: 'Open Folder in New Window',
+      properties: ['openDirectory'],
+    });
+    const selectedPath = result.canceled ? undefined : result.filePaths[0];
+    if (!selectedPath) return;
+
+    spawn(
+      process.execPath,
+      withNewWindowWorkspaceArgs(process.argv.slice(1), selectedPath),
+      {
+        detached: true,
+        stdio: 'ignore',
+      },
+    ).unref();
+  };
   attachRendererConsoleLog(window.webContents);
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
@@ -435,6 +454,7 @@ function createWindow(options: {
       openExternalUrl: previewHost.openExternal,
       openLogFolder: openLogsFolder,
       openPath: previewHost.openPath,
+      openWorkspaceInNewWindow,
       openWorkspaceFolder,
       signIn: () => desktopAuth.signIn(),
       getRecentCommits: () => gitHost.getRecentCommits(),

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -7,6 +7,7 @@ interface WorkspacePathOptions {
 }
 
 const WORKSPACE_PRESENT_ARG = '--texra-has-workspace=';
+const NEW_WINDOW_ARG = '--texra-new-window';
 const WORKSPACE_PATH_FLAGS = [
   '--texra-workspace-path',
   '--texra-workspace',
@@ -44,6 +45,7 @@ export function withWorkspacePathArg(
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg == null) continue;
+    if (arg === NEW_WINDOW_ARG) continue;
     if (isDesktopProtocolUrl(arg)) continue;
     if (isWorkspacePathFlag(arg)) {
       const value = argv[index + 1];
@@ -57,6 +59,22 @@ export function withWorkspacePathArg(
   }
   nextArgs.push(`${CANONICAL_WORKSPACE_PATH_FLAG}=${workspacePath}`);
   return nextArgs;
+}
+
+export function withNewWindowWorkspaceArgs(
+  argv: readonly string[],
+  workspacePath: string,
+): string[] {
+  const nextArgs = withWorkspacePathArg(argv, workspacePath);
+  nextArgs.push(NEW_WINDOW_ARG);
+  return nextArgs;
+}
+
+export function isNewWindowLaunch(
+  options: Pick<WorkspacePathOptions, 'argv'> = {},
+): boolean {
+  const argv = options.argv ?? process.argv.slice(1);
+  return argv.includes(NEW_WINDOW_ARG);
 }
 
 export function hasResolvedWorkspacePath(

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -21,6 +21,7 @@ interface DesktopCommandSurfaceModule {
     SHOW_LOGS: string;
     OPEN_LOG_FOLDER: string;
     OPEN_WORKSPACE_FOLDER: string;
+    OPEN_WORKSPACE_IN_NEW_WINDOW: string;
     SHOW_FIRST_RUN_WALKTHROUGH: string;
   };
   DESKTOP_COMMAND_IDS: readonly string[];
@@ -175,6 +176,7 @@ describe('desktop command surface', () => {
       openDesktopDocs: vi.fn(),
       openLogFolder: vi.fn(),
       openWorkspaceFolder: vi.fn(),
+      openWorkspaceInNewWindow: vi.fn(),
       showFirstRunWalkthrough: vi.fn(),
       resetMainView: vi.fn(),
       showRoute: vi.fn(),
@@ -195,6 +197,12 @@ describe('desktop command surface', () => {
     expect(
       dispatchDesktopCommand(
         DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchDesktopCommand(
+        DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
         actions,
       ),
     ).toBe(true);
@@ -225,6 +233,7 @@ describe('desktop command surface', () => {
     );
     expect(actions.resetMainView).toHaveBeenCalledOnce();
     expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
+    expect(actions.openWorkspaceInNewWindow).toHaveBeenCalledOnce();
     expect(actions.openLogFolder).toHaveBeenCalledOnce();
     expect(actions.showFirstRunWalkthrough).toHaveBeenCalledOnce();
     expect(
@@ -303,6 +312,7 @@ describe('desktop command surface', () => {
       'Show Progress',
       'Show Logs',
       'Open Folder',
+      'New Window',
       'Open Logs Folder',
       'Open TeXRA Settings',
       'New',
@@ -331,11 +341,11 @@ describe('desktop command surface', () => {
     );
 
     submenu[0].click?.();
-    submenu[8].click?.();
-    submenu[13].click?.();
+    submenu[9].click?.();
+    submenu[14].click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
-    expect(submenu[8]).toMatchObject({
+    expect(submenu[9]).toMatchObject({
       enabled: false,
       toolTip:
         'Use the Launcher execute button after choosing an agent and files.',

--- a/src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
+++ b/src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
@@ -1,0 +1,127 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+import {
+  installDesktopProtocolCallbackLifecycle,
+  type DesktopProtocolApp,
+} from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+
+type SecondInstanceListener = (
+  event: unknown,
+  argv: string[],
+  workingDirectory: string,
+  additionalData?: unknown,
+) => void;
+
+type OpenUrlListener = (event: { preventDefault(): void }, url: string) => void;
+
+class FakeDesktopProtocolApp implements DesktopProtocolApp {
+  readonly isPackaged = true;
+  requestCount = 0;
+  quitCount = 0;
+  protocolRegistrations: string[] = [];
+  private readonly secondInstanceListeners: SecondInstanceListener[] = [];
+  private readonly lockAvailable: boolean;
+
+  constructor(options: { lockAvailable: boolean }) {
+    this.lockAvailable = options.lockAvailable;
+  }
+
+  setAsDefaultProtocolClient(protocol: string): boolean {
+    this.protocolRegistrations.push(protocol);
+    return true;
+  }
+
+  requestSingleInstanceLock(): boolean {
+    this.requestCount += 1;
+    return this.lockAvailable;
+  }
+
+  quit(): void {
+    this.quitCount += 1;
+  }
+
+  on(event: 'second-instance', listener: SecondInstanceListener): void;
+  on(event: 'open-url', listener: OpenUrlListener): void;
+  on(
+    event: 'second-instance' | 'open-url',
+    listener: SecondInstanceListener | OpenUrlListener,
+  ): void {
+    if (event === 'second-instance') {
+      this.secondInstanceListeners.push(listener as SecondInstanceListener);
+      return;
+    }
+  }
+
+  emitSecondInstance(argv: string[]): void {
+    for (const listener of this.secondInstanceListeners) {
+      listener({}, argv, process.cwd());
+    }
+  }
+}
+
+describe('desktop protocol callback lifecycle', () => {
+  it('keeps normal launches behind the single-instance lock', () => {
+    const app = new FakeDesktopProtocolApp({ lockAvailable: false });
+
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+    });
+
+    assert.equal(lifecycle.shouldContinue, false);
+    assert.equal(app.requestCount, 1);
+    assert.equal(app.quitCount, 1);
+    assert.deepEqual(app.protocolRegistrations, []);
+  });
+
+  it('lets explicit new-window launches run as separate processes', () => {
+    const app = new FakeDesktopProtocolApp({ lockAvailable: false });
+
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: ['--texra-new-window', '--texra-workspace-path=/Users/ray/paper'],
+    });
+
+    assert.equal(lifecycle.shouldContinue, true);
+    assert.equal(app.requestCount, 1);
+    assert.equal(app.quitCount, 0);
+    assert.deepEqual(app.protocolRegistrations, []);
+  });
+
+  it('lets explicit new-window launches become primary when no owner exists', () => {
+    const app = new FakeDesktopProtocolApp({ lockAvailable: true });
+
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: ['--texra-new-window', '--texra-workspace-path=/Users/ray/paper'],
+    });
+
+    assert.equal(lifecycle.shouldContinue, true);
+    assert.equal(app.requestCount, 1);
+    assert.equal(app.quitCount, 0);
+    assert.deepEqual(app.protocolRegistrations, ['texra']);
+  });
+
+  it('does not focus the primary window for explicit new-window probes', () => {
+    const app = new FakeDesktopProtocolApp({ lockAvailable: true });
+    let focusCount = 0;
+
+    installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+      focusMainWindow: () => {
+        focusCount += 1;
+      },
+    });
+
+    app.emitSecondInstance([
+      '--texra-new-window',
+      '--texra-workspace-path=/Users/ray/paper',
+    ]);
+    assert.equal(focusCount, 0);
+
+    app.emitSecondInstance(['--texra-workspace-path=/Users/ray/other-paper']);
+    assert.equal(focusCount, 1);
+  });
+});

--- a/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
+++ b/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
@@ -5,8 +5,10 @@ import { describe, it } from 'vitest';
 import { resolveWorkspacePath } from '../../../packages/desktop/src/main/platform/paths';
 import {
   hasResolvedWorkspacePath,
+  isNewWindowLaunch,
   hasWorkspacePath,
   serializeWorkspacePresenceArg,
+  withNewWindowWorkspaceArgs,
   withWorkspacePathArg,
 } from '../../../packages/desktop/src/workspacePath';
 
@@ -136,6 +138,7 @@ describe('desktop workspace path', () => {
         [
           '/Applications/TeXRA.app',
           '--inspect',
+          '--texra-new-window',
           '--texra-workspace',
           'old-workspace',
           '--flag',
@@ -150,6 +153,34 @@ describe('desktop workspace path', () => {
         '--inspect',
         '--flag',
         '--texra-workspace-path=/Users/ray/paper',
+      ],
+    );
+  });
+
+  it('builds separate-process workspace args for desktop new-window launches', () => {
+    assert.equal(
+      isNewWindowLaunch({
+        argv: ['--texra-new-window', '--texra-workspace=/Users/ray/paper'],
+      }),
+      true,
+    );
+    assert.deepEqual(
+      withNewWindowWorkspaceArgs(
+        [
+          '/Applications/TeXRA.app',
+          '--texra-new-window',
+          '--inspect',
+          '--texra-workspace',
+          'old-workspace',
+          'texra://texra-ai.texra/auth-callback?state=old',
+        ],
+        '/Users/ray/new-paper',
+      ),
+      [
+        '/Applications/TeXRA.app',
+        '--inspect',
+        '--texra-workspace-path=/Users/ray/new-paper',
+        '--texra-new-window',
       ],
     );
   });


### PR DESCRIPTION
## Summary
- add a Desktop New Window command that prompts for a workspace and starts a detached TeXRA process for it
- add a namespaced --texra-new-window launch flag and clean workspace argv builder
- let explicit new-window child processes bypass the single-instance lock while keeping protocol ownership with the primary process

## Issues
Refs #3864.

## Validation
- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/desktop/desktopWorkspacePath.vitest.ts src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/eslint packages/desktop/src/workspacePath.ts packages/desktop/src/main/desktopProtocolCallbacks.ts packages/desktop/src/desktopCommandSurface.ts packages/desktop/src/main/desktopShellIpc.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/desktopWorkspacePath.vitest.ts src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
- npm run typecheck
- npm run desktop:build
- npm run lint (existing 66-warning baseline, 0 errors)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new multi-process launch path (detached Electron spawn) and relaxes the single-instance lock for `--texra-new-window`, which could impact startup/protocol-focus behavior if argv handling is wrong.
> 
> **Overview**
> Adds a new desktop menu/command, `texra.desktop.openWorkspaceInNewWindow`, wired through shell IPC to prompt for a folder and spawn a detached TeXRA process targeting that workspace.
> 
> Introduces a namespaced `--texra-new-window` launch flag plus helpers (`withNewWindowWorkspaceArgs`, `isNewWindowLaunch`) and updates protocol/single-instance behavior so explicit new-window launches can run without owning the single-instance lock while keeping protocol registration and focusing logic on the primary instance.
> 
> Updates/extends Vitest coverage for the new command/menu entry and the new-window protocol + argv behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b84174af7ec973fc312c77087d04e4233fba68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->