### PR TITLE
refactor: require explicit runtimeHost in executeAgent

### DIFF
--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,7 +1,5 @@
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
-import { tryUseRunContext } from './RunContext';
-
 export interface AgentRuntimeHost {
   emit<K extends keyof ProgressEventPayloads>(
     event: K,
@@ -15,14 +13,17 @@ export const noopAgentRuntimeHost: AgentRuntimeHost = {
 
 let defaultAgentRuntimeHost: AgentRuntimeHost = noopAgentRuntimeHost;
 
+/**
+ * Install the ambient runtime host. Only retained for legacy singleton
+ * coordinators (`planApprovalCoordinator`, `proposalCoordinator`,
+ * `retryCoordinator`) which use `getDefaultAgentRuntimeHost` as a lazy
+ * lookup. New code must pass an explicit host to `executeAgent` and to
+ * coordinator constructors — do not reach for this global.
+ */
 export function setDefaultAgentRuntimeHost(host: AgentRuntimeHost): void {
   defaultAgentRuntimeHost = host;
 }
 
 export function getDefaultAgentRuntimeHost(): AgentRuntimeHost {
   return defaultAgentRuntimeHost;
-}
-
-export function getAgentRuntimeHost(): AgentRuntimeHost {
-  return tryUseRunContext()?.runtimeHost ?? getDefaultAgentRuntimeHost();
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -38,7 +38,6 @@ import { TaskRunFileService } from '@utils/files';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 import { StreamStatusService } from './StreamStatusService';
-import { getAgentRuntimeHost, type AgentRuntimeHost } from './AgentRuntimeHost';
 import {
   buildAgentLaunchContext,
   withExecutionRunContext,
@@ -53,6 +52,7 @@ import {
 } from './executionRegistry';
 import { generateSessionDescription } from './sessionDescription';
 import { getRunStorageService } from './RunStorageService';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type {
   AgentFlowResult,
   CompileFailureSummary,
@@ -284,7 +284,7 @@ function buildFallbackNotification(config: AgentConfig) {
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions {
   /** Host services used by the runtime to report progress/UI events. */
-  runtimeHost?: AgentRuntimeHost;
+  runtimeHost: AgentRuntimeHost;
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /**
@@ -319,23 +319,23 @@ export interface ExecuteAgentOptions {
 
 export async function executeAgent(
   configPayload: AgentConfigPayload,
-  executionId?: ExecutionId,
-  options?: ExecuteAgentOptions,
+  executionId: ExecutionId | undefined,
+  options: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
-  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
+  const { runtimeHost } = options;
   const ctx = await buildAgentLaunchContext({
     configPayload,
     executionId,
     runtimeHost,
-    onBeforeActivation: options?.onStreamResolved,
-    enforceCategory: options?.enforceCategory,
-    suppressErrorNotification: options?.isSubagent,
+    onBeforeActivation: options.onStreamResolved,
+    enforceCategory: options.enforceCategory,
+    suppressErrorNotification: options.isSubagent,
   });
-  ctx.delegationDepth = options?.delegationDepth ?? 0;
+  ctx.delegationDepth = options.delegationDepth ?? 0;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
     const { agent: agentName } = config;
-    const { isSubagent } = options ?? {};
+    const { isSubagent } = options;
 
     // Fire-and-forget: generate AI session description from the user's instruction.
     // Triggered at the start so cancelled/errored sessions still get descriptions.
@@ -392,7 +392,7 @@ export async function executeAgent(
                 ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
               setting: ctx.setting as AgentToolUseSetting,
               isSubagent,
-              onBeforeWaiting: options?.onBeforeWaiting,
+              onBeforeWaiting: options.onBeforeWaiting,
               onProgress: (update) => {
                 if (update.kind === 'overview') {
                   toolUseTurns++;
@@ -404,13 +404,13 @@ export async function executeAgent(
                     },
                   });
                 }
-                options?.onProgress?.(update);
+                options.onProgress?.(update);
               },
               onFollowUpConsumed: () => {
                 ctx.runtimeHost.emit('updateQueuedFollowUps', {
                   streamId: ctx.streamId,
                 });
-                options?.onFollowUpConsumed?.();
+                options.onFollowUpConsumed?.();
               },
             });
             return {
@@ -427,7 +427,7 @@ export async function executeAgent(
             ctx.executionId,
             streamId,
             ctx.runtimeHost,
-            options?.onProgress,
+            options.onProgress,
           );
           const result = await runReflectionFlow({
             ...ctx,
@@ -454,8 +454,8 @@ export async function executeAgent(
           setting.agentCategory === AgentCategory.ToolUse
             ? 'toolUse'
             : 'workflow',
-        parentStreamId: options?.parentStreamId,
-        onCompleted: options?.onCompleted,
+        parentStreamId: options.parentStreamId,
+        onCompleted: options.onCompleted,
       },
     );
   });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -304,9 +304,14 @@ async function executeSubagent(
   options?: { enableYoloOnChild?: boolean; approvalMeta?: ApprovalMeta },
 ): Promise<ToolResult> {
   const parentContext = getCurrentToolRunContext();
-  const parentExecutionId = parentContext?.executionId;
-  const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
-  const runtimeHost = parentContext?.runtimeHost;
+  if (!parentContext?.runtimeHost) {
+    throw new Error(
+      'executeSubagent requires a parent tool run context with an explicit runtimeHost',
+    );
+  }
+  const parentExecutionId = parentContext.executionId;
+  const parentDelegationDepth = parentContext.delegationDepth ?? 0;
+  const runtimeHost = parentContext.runtimeHost;
 
   const gated = depthGateError(
     parentDelegationDepth,


### PR DESCRIPTION
Eliminate the ambient host fallback at executeAgent.ts:325 — the chain
`options?.runtimeHost ?? tryUseRunContext()?.runtimeHost ?? defaultHost`
encoded three sources for one value, exactly the pattern #3925 calls out.

All five production call sites (extension setup, CLI commands, CLI chat,
runValidatedExecutionRequest, DelegationTools) already pass runtimeHost
explicitly, so removing the fallback is a no-op for runtime behavior but
removes a global mutable state read from the SDK entry point.

Changes:
- ExecuteAgentOptions.runtimeHost is now required.
- Delete getAgentRuntimeHost() and its tryUseRunContext.runtimeHost path.
- executeSubagent throws if invoked outside a parent tool run context
  (was silently falling back to ambient host).

Retained: setDefaultAgentRuntimeHost / getDefaultAgentRuntimeHost and
the defaultAgentRuntimeHost global remain in place — they are the lazy
provider for singleton coordinators (planApprovalCoordinator,
proposalCoordinator, retryCoordinator). Those singletons + the
CoordinatorRuntimeHost union are a separate refactor that needs to move
coordinator ownership fully into the launch context first.

Aligns with #3372 (single explicit host/sink path) and partially closes
the host-resolution leg of #3925.

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-breaking refactor that removes ambient/global fallback host resolution, so any missed call sites will now fail at compile time or throw at runtime for subagent execution. Behavior should be unchanged where callers already pass a host, but it tightens invariants around runtime context usage.
> 
> **Overview**
> `executeAgent` now **requires** an explicit `runtimeHost` (and an `options` object) instead of lazily falling back to run-context/default globals, removing the `getAgentRuntimeHost()` helper and related `tryUseRunContext()` path.
> 
> Delegation now fails fast when invoked without a parent tool-run context: `executeSubagent` throws if `runtimeHost` is missing rather than silently continuing with an ambient host. `AgentRuntimeHost` docs were updated to clarify the remaining `set/getDefaultAgentRuntimeHost` global is legacy-only for singleton coordinators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5456d0058b936c3bbd2e8e75f73264b9ca1c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->