### PR TITLE
feat(desktop): run setup commands through terminal runner

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,7 +1,10 @@
 import { platform, tryPlatform } from '@platform/platform';
 
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
-import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
+import {
+  isAllowedLatexInstallCommand,
+  LatexToolingController,
+} from '@controllers/settingsView/LatexToolingController';
 import {
   SettingsAgentCatalogController,
   type SettingsAgentCatalogState,
@@ -1435,6 +1438,14 @@ export function createDesktopSettingsIpc(
           );
           return true;
         case SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND:
+          if (!isAllowedLatexInstallCommand(result.data.installCommand)) {
+            onError(
+              new Error(
+                `Rejected unknown install command: ${result.data.installCommand}`,
+              ),
+            );
+            return true;
+          }
           runAsync(
             options.runInstallCommand?.(result.data.installCommand) ??
               Promise.resolve(),

--- a/packages/desktop/src/main/desktopTerminalRunner.ts
+++ b/packages/desktop/src/main/desktopTerminalRunner.ts
@@ -1,0 +1,70 @@
+// Third-party imports
+import stripAnsi from 'strip-ansi';
+
+// Local imports - hosts
+import type { TerminalRunner, TerminalRunRequest } from '@hosts/terminalHost';
+
+// Local imports - system
+import { executeCommand } from '@utils/system/execUtils';
+
+const OUTPUT_MAX_CHARS = 12_000;
+const RAW_OUTPUT_MAX_CHARS = OUTPUT_MAX_CHARS * 2;
+
+export interface DesktopTerminalRunnerOptions {
+  cwd?: string;
+}
+
+/** Desktop implementation of the shared setup terminal-runner contract. */
+export function createDesktopTerminalRunner(
+  options: DesktopTerminalRunnerOptions = {},
+): TerminalRunner {
+  return {
+    async runCommand(request: TerminalRunRequest) {
+      let output = '';
+      const appendOutput = (chunk: string) => {
+        output += chunk;
+        if (output.length > RAW_OUTPUT_MAX_CHARS) {
+          output = output.slice(-RAW_OUTPUT_MAX_CHARS);
+        }
+      };
+      const result = await executeCommand(request.command, {
+        cwd: request.cwd ?? options.cwd,
+        env: normalizeEnv(request.env),
+        timeout: request.timeoutMs,
+        channel: request.name,
+        truncate: true,
+        buffer: false,
+        onStdout: appendOutput,
+        onStderr: appendOutput,
+      });
+      const bufferedOutput = [result.stdout, result.stderr]
+        .filter(Boolean)
+        .join('\n');
+
+      return {
+        exitCode: result.exitCode,
+        output: tail(output || bufferedOutput),
+        timedOut: result.timedOut ?? false,
+      };
+    },
+  };
+}
+
+function normalizeEnv(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+  return Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => {
+      const [, value] = entry;
+      return value !== undefined;
+    }),
+  );
+}
+
+function tail(output: string): string {
+  const stripped = stripAnsi(output);
+  return stripped.length > OUTPUT_MAX_CHARS
+    ? stripped.slice(-OUTPUT_MAX_CHARS)
+    : stripped;
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import type { TerminalRunResult } from '@hosts/terminalHost';
 import { interruptAllCodexSessions } from '@tools/codex';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
@@ -44,6 +45,7 @@ import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopGitHost } from './desktopGitHost.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
+import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
 import {
   createDesktopAuthCallbackState,
   createDesktopAuthCoordinator,
@@ -123,6 +125,7 @@ const PRODUCTION_CSP = [
   "font-src 'self' data:",
   "connect-src 'self' data:",
 ].join('; ');
+const SETUP_COMMAND_TIMEOUT_MS = 10 * 60_000;
 const DEVELOPMENT_CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-eval'",
@@ -141,6 +144,47 @@ function installContentSecurityPolicy(): void {
       },
     });
   });
+}
+
+async function showSetupCommandResult(
+  window: BrowserWindow,
+  command: string,
+  result: TerminalRunResult,
+): Promise<void> {
+  const output = result.output.trim();
+  const hasOutput = output.length > 0;
+  const timedOut = result.timedOut;
+  const failed =
+    !timedOut && result.exitCode !== undefined && result.exitCode !== 0;
+  const unknownExit = !timedOut && result.exitCode === undefined;
+  const buttons = hasOutput
+    ? ['Copy Output', 'Copy Command', 'Close']
+    : ['Copy Command', 'Close'];
+  const response = await dialog.showMessageBox(window, {
+    type: timedOut || unknownExit ? 'warning' : failed ? 'error' : 'info',
+    message: timedOut
+      ? 'Setup command timed out'
+      : failed
+        ? `Setup command failed with exit code ${result.exitCode}`
+        : unknownExit
+          ? 'Setup command finished without an observable exit code'
+          : 'Setup command finished',
+    detail: [`Command:\n${command}`, output ? `Output:\n${output}` : '']
+      .filter(Boolean)
+      .join('\n\n'),
+    buttons,
+    defaultId: 0,
+    cancelId: buttons.length - 1,
+  });
+
+  if (hasOutput && response.response === 0) {
+    clipboard.writeText(output);
+  } else if (
+    (hasOutput && response.response === 1) ||
+    (!hasOutput && response.response === 0)
+  ) {
+    clipboard.writeText(command);
+  }
 }
 
 function createWindow(options: {
@@ -187,6 +231,19 @@ function createWindow(options: {
   } = {};
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
+  };
+  const setupCommandCwd = options.workspacePath ?? app.getPath('home');
+  const setupTerminalRunner = createDesktopTerminalRunner({
+    cwd: setupCommandCwd,
+  });
+  const runSetupCommand = async (command: string) => {
+    const result = await setupTerminalRunner.runCommand({
+      name: 'TeXRA Setup',
+      command,
+      cwd: setupCommandCwd,
+      timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
+    });
+    await showSetupCommandResult(window, command, result);
   };
   const previewHost = createDesktopPreviewHost({
     shell,
@@ -401,31 +458,12 @@ function createWindow(options: {
       }
     },
     runToolCommand: async ({ command }) => {
-      // Add a 'Copy' affordance — without it the user has to manually
-      // select-and-copy from a non-selectable Electron native dialog,
-      // which is a common friction point reported on the desktop build.
-      const result = await dialog.showMessageBox(window, {
-        type: 'info',
-        message: 'Run this setup command in a terminal',
-        detail: command,
-        buttons: ['Copy', 'Close'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (result.response === 0) clipboard.writeText(command);
+      await runSetupCommand(command);
     },
     refreshToolAvailability: () =>
       refreshToolAvailability(agentExecution.progress.runtimeHost),
     runInstallCommand: async (command) => {
-      const result = await dialog.showMessageBox(window, {
-        type: 'info',
-        message: 'Run this setup command in a terminal',
-        detail: command,
-        buttons: ['Copy', 'Close'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (result.response === 0) clipboard.writeText(command);
+      await runSetupCommand(command);
     },
     onError: reportAsyncError,
   });

--- a/src/controllers/settingsView/LatexToolingController.ts
+++ b/src/controllers/settingsView/LatexToolingController.ts
@@ -49,12 +49,16 @@ const ALLOWED_INSTALL_COMMANDS: ReadonlySet<string> = new Set([
   ),
 ]);
 
+export function isAllowedLatexInstallCommand(command: string): boolean {
+  return ALLOWED_INSTALL_COMMANDS.has(command);
+}
+
 /** Builds the LaTeX settings status from tool probes and host-provided facts. */
 export class LatexToolingController {
   constructor(private readonly deps: LatexToolingControllerDeps) {}
 
   isAllowedInstallCommand(command: string): boolean {
-    return ALLOWED_INSTALL_COMMANDS.has(command);
+    return isAllowedLatexInstallCommand(command);
   }
 
   async detectStatus(): Promise<LatexSettingsStatus> {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -6,6 +6,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/constants/git';
+import { HOMEBREW_INSTALL_COMMAND } from '@shared/constants/latex';
 import {
   isWorktreeSupportEnabled,
   setWorktreeSupportEnabled,
@@ -538,6 +539,60 @@ describe('desktop settings IPC', () => {
         texDistributionInstalled: true,
         latexdiffInstalled: true,
       }),
+    });
+  });
+
+  it('runs allowlisted LaTeX install commands through the desktop host', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const commands: string[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      runInstallCommand: async (command) => {
+        commands.push(command);
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND,
+        installCommand: HOMEBREW_INSTALL_COMMAND,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(commands).toEqual([HOMEBREW_INSTALL_COMMAND]);
+  });
+
+  it('rejects unknown desktop LaTeX install commands', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const commands: string[] = [];
+    const errors: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      runInstallCommand: async (command) => {
+        commands.push(command);
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND,
+        installCommand: 'echo not-allowlisted',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(commands).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: 'Rejected unknown install command: echo not-allowlisted',
     });
   });
 

--- a/src/test-kernel/desktop/DesktopTerminalRunner.vitest.mts
+++ b/src/test-kernel/desktop/DesktopTerminalRunner.vitest.mts
@@ -1,0 +1,98 @@
+import { mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopTerminalRunnerModule {
+  createDesktopTerminalRunner(options?: { cwd?: string }): {
+    runCommand(request: {
+      name: string;
+      command: string;
+      cwd?: string;
+      env?: Record<string, string | undefined>;
+      timeoutMs: number;
+    }): Promise<{
+      exitCode: number | undefined;
+      output: string;
+      timedOut: boolean;
+    }>;
+  };
+}
+
+async function loadDesktopTerminalRunner(): Promise<DesktopTerminalRunnerModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopTerminalRunner.ts'))
+  ) as Promise<DesktopTerminalRunnerModule>;
+}
+
+function nodeCommand(script: string): string {
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+describe('desktop terminal runner', () => {
+  it('captures command output and exit status', async () => {
+    const { createDesktopTerminalRunner } = await loadDesktopTerminalRunner();
+    const cwd = await mkdtemp(join(tmpdir(), 'texra-terminal-runner-'));
+    const runner = createDesktopTerminalRunner({ cwd });
+
+    const result = await runner.runCommand({
+      name: 'TeXRA Setup Test',
+      command: nodeCommand(
+        "process.stdout.write('stdout ok'); process.stderr.write('stderr ok')",
+      ),
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+    });
+    expect(result.output).toContain('stdout ok');
+    expect(result.output).toContain('stderr ok');
+  });
+
+  it('passes defined environment values and drops undefined values', async () => {
+    const { createDesktopTerminalRunner } = await loadDesktopTerminalRunner();
+    const cwd = await mkdtemp(join(tmpdir(), 'texra-terminal-runner-'));
+    const runner = createDesktopTerminalRunner({ cwd });
+
+    const result = await runner.runCommand({
+      name: 'TeXRA Setup Env Test',
+      command: nodeCommand(
+        [
+          "process.stdout.write(process.env.TEXRA_RUNNER_VALUE ?? 'missing')",
+          "process.stdout.write(process.env.TEXRA_RUNNER_UNSET === undefined ? ':unset' : ':set')",
+        ].join(';'),
+      ),
+      env: {
+        TEXRA_RUNNER_VALUE: 'value',
+        TEXRA_RUNNER_UNSET: undefined,
+      },
+      timeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('value:unset');
+  });
+
+  it('keeps only a bounded output tail while streaming', async () => {
+    const { createDesktopTerminalRunner } = await loadDesktopTerminalRunner();
+    const cwd = await mkdtemp(join(tmpdir(), 'texra-terminal-runner-'));
+    const runner = createDesktopTerminalRunner({ cwd });
+
+    const result = await runner.runCommand({
+      name: 'TeXRA Setup Long Output Test',
+      command: nodeCommand(
+        "process.stdout.write('a'.repeat(13000)); process.stdout.write('tail')",
+      ),
+      timeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output.length).toBeLessThanOrEqual(12_000);
+    expect(result.output.endsWith('tail')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Desktop TerminalRunner backed by the shared command execution utility with capped, ANSI-stripped output
- route Desktop Settings tool commands and LaTeX install commands through that runner instead of the copy-only dialog
- validate Desktop LaTeX install-command requests against the same allowlist used by the VS Code settings handler

## Notes
This is a bounded #3808 slice. It makes Desktop execute allowlisted setup commands and report the captured result, but it does not claim the full embedded live terminal panel yet.

## Validation
- vitest run for DesktopSettingsIpc and DesktopTerminalRunner
- desktop main TypeScript check
- test-kernel TypeScript check
- npm run format
- npm run typecheck
- npm run lint (existing 63-warning baseline, 0 errors)
- npm run compile:fast
- corepack pnpm --filter @texra/desktop build
- corepack pnpm --filter @texra/cli build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables the desktop app to execute setup/install shell commands (instead of just copying them), which can impact user environments if the allowlist or execution wiring is wrong, though LaTeX install commands are now explicitly validated against an allowlist and output is bounded.
> 
> **Overview**
> Desktop setup commands (tool setup + LaTeX install) are now executed in-app via a new `createDesktopTerminalRunner` wrapper around `executeCommand`, streaming stdout/stderr and returning an ANSI-stripped, size-capped output tail.
> 
> Electron main now routes `runToolCommand`/`runInstallCommand` through this runner with a 10-minute timeout and shows a result dialog that includes exit status/timeout handling plus *Copy Output*/*Copy Command* affordances.
> 
> `DesktopSettingsIpc` now rejects `RUN_INSTALL_COMMAND` requests not present in the shared LaTeX install-command allowlist (exported as `isAllowedLatexInstallCommand`), with new vitest coverage for both the allowlist enforcement and the terminal runner behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f419341561cf781b1e188bf40691d431ef92fe1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->