### PR TITLE
refactor: route native approval through runtime host

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -340,7 +340,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
   registerFileDecorations(context);
 
-  initializeNativeToolEditApproval(context);
+  initializeNativeToolEditApproval(context, extensionAgentRuntimeHost);
   setLeanVscodeServices(leanVscodeIntegration);
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
   setToolMissingHandler(async (message, openDocsCommand) => {

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -74,7 +74,9 @@ function getStorageDir(): string {
 
 function getRuntimeHost(): AgentRuntimeHost {
   if (!runtimeHost) {
-    throw new Error('Tool edit approval has not been initialized.');
+    throw new Error(
+      'Tool edit approval runtime host has not been initialized.',
+    );
   }
   return runtimeHost;
 }

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -14,8 +14,8 @@ import * as path from 'path';
 
 import * as vscode from 'vscode';
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { isLatexFile } from '@common/files/fileTypeUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   type DiffSession,
   type DiffSource,
@@ -63,12 +63,20 @@ let approvalCounter = 0;
 const pendingApprovals = new Map<string, PendingApprovalEntry>();
 const diffViewHost: DiffViewHost = new VscodeDiffViewHost();
 let storageDirectory: string | undefined;
+let runtimeHost: AgentRuntimeHost | undefined;
 
 function getStorageDir(): string {
   if (!storageDirectory) {
     throw new Error('Tool edit approval has not been initialized.');
   }
   return storageDirectory;
+}
+
+function getRuntimeHost(): AgentRuntimeHost {
+  if (!runtimeHost) {
+    throw new Error('Tool edit approval has not been initialized.');
+  }
+  return runtimeHost;
 }
 
 async function ensureStorageDir(): Promise<string> {
@@ -121,11 +129,11 @@ async function showProgressViewApprovalPrompt(
 
   // Activate the stream that needs approval so user sees the prompt immediately
   if (streamId) {
-    bus.emit('setActiveStream', { streamId });
+    getRuntimeHost().emit('setActiveStream', { streamId });
   }
 
   const isBypassed = streamId ? isApprovalBypassedForStream(streamId) : false;
-  bus.emit('showToolEditPermission', {
+  getRuntimeHost().emit('showToolEditPermission', {
     requestId,
     path: request.path,
     relativePath,
@@ -139,7 +147,7 @@ async function showProgressViewApprovalPrompt(
 }
 
 function resolveProgressViewApprovalPrompt(requestId: string): void {
-  bus.emit('resolveToolEditPermission', { requestId });
+  getRuntimeHost().emit('resolveToolEditPermission', { requestId });
 }
 
 async function nativeRequestApproval(
@@ -346,8 +354,10 @@ export async function handleProgressViewToolEditApprovalAction(
  */
 export function initializeNativeToolEditApproval(
   context: vscode.ExtensionContext,
+  host: AgentRuntimeHost,
 ): void {
   const baseDir = context.storageUri ?? context.globalStorageUri;
   storageDirectory = path.join(baseDir.fsPath, 'tool-edit-previews');
+  runtimeHost = host;
   setToolEditApprovalHandler(nativeRequestApproval);
 }


### PR DESCRIPTION
## Summary

This PR continues the #3372 progress-boundary cleanup in a narrow extension-owned slice.

- The VS Code native tool-edit approval module no longer imports the global progress bus directly.
- Extension activation passes `extensionAgentRuntimeHost` into `initializeNativeToolEditApproval`.
- Approval prompt publication still stays in the native approval module, while the event target is now owned by the extension runtime host boundary.

This is intentionally small and does not close #3372. It removes one remaining approval-path reach-through without changing approval behavior.

## Validation

- `./node_modules/.bin/eslint packages/extension/src/frontend/approval/nativeToolEditApproval.ts packages/extension/src/extension.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (passes with the existing warning baseline)
- `npm run compile:fast`
- `git diff --check`

Refs #3372.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the tool-edit approval prompt plumbing; mis-wiring or missed initialization of the injected runtime host could break approval prompts or stream activation in the progress view.
> 
> **Overview**
> Native tool-edit approval no longer publishes progress-view events through the global `ProgressEventBus`; it now requires an injected `AgentRuntimeHost` and emits `setActiveStream` / `showToolEditPermission` / `resolveToolEditPermission` through that host.
> 
> Extension activation is updated to pass `extensionAgentRuntimeHost` into `initializeNativeToolEditApproval`, and the approval module adds initialization guards to ensure the host is set before emitting events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58d3d1d88509517ea0ee68f007c275354565a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->