### PR TITLE
refactor: delete explicitCoordinators parameter from runCoordinators bridge

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -18,7 +18,6 @@ import {
   clearPlanApprovalForStream,
   clearRetryRequest,
 } from '@agent/runtime/runCoordinators';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
@@ -172,12 +171,11 @@ export async function runReflectionFlow<C = unknown>(
       return canonical;
     });
 
-  const runCoordinators = tryUseRunContext()?.coordinators;
   const interruptible: IInterruptible = {
     interrupt(): void {
       input.onInterrupt?.();
-      clearRetryRequest(streamId, runCoordinators);
-      clearPlanApprovalForStream(streamId, runCoordinators);
+      clearRetryRequest(streamId);
+      clearPlanApprovalForStream(streamId);
     },
   };
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -7,7 +7,6 @@ import {
   clearPlanApprovalForStream,
   clearRetryRequest,
 } from '@agent/runtime/runCoordinators';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
 import {
   PersistedFlow,
   flowKey,
@@ -161,7 +160,6 @@ export async function runToolUseFlow<C = unknown>(
   );
 
   const kv = getExecutionStore(executionId);
-  const runCoordinators = tryUseRunContext()?.coordinators;
 
   const services: ToolUseServices<C> = {
     ...input,
@@ -183,8 +181,8 @@ export async function runToolUseFlow<C = unknown>(
     runtimeHost,
     interrupt(): void {
       onInterrupt?.();
-      clearRetryRequest(streamId, runCoordinators);
-      clearPlanApprovalForStream(streamId, runCoordinators);
+      clearRetryRequest(streamId);
+      clearPlanApprovalForStream(streamId);
       sessionLifecycle.interrupt();
     },
   };

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -111,14 +111,11 @@ export function resolvePlanApproval(
   ).resolveRequest(approvalId, result);
 }
 
-export function clearPlanApprovalForStream(
-  streamId: string,
-  explicitCoordinators = tryUseRunContext()?.coordinators,
-): void {
+export function clearPlanApprovalForStream(streamId: string): void {
   (
     bridgeState.planStreams.get(streamId)?.plan ??
     bridgeState.runStreams.get(streamId)?.plan ??
-    explicitCoordinators?.plan ??
+    tryUseRunContext()?.coordinators?.plan ??
     legacyCoordinators.plan
   ).clearForStream(streamId);
   clearPlanBridgeForStream(streamId);
@@ -214,16 +211,14 @@ export function cancelRetry(streamId: string): boolean {
   ).cancelRetry(streamId);
 }
 
-export function clearRetryRequest(
-  streamId: string,
-  explicitCoordinators = tryUseRunContext()?.coordinators,
-): void {
+export function clearRetryRequest(streamId: string): void {
   const coordinators = new Set<RunCoordinators>();
   const mappedCoordinators = bridgeState.retries.get(streamId);
   if (mappedCoordinators) coordinators.add(mappedCoordinators);
   const runCoordinators = bridgeState.runStreams.get(streamId);
   if (runCoordinators) coordinators.add(runCoordinators);
-  if (explicitCoordinators) coordinators.add(explicitCoordinators);
+  const ambient = tryUseRunContext()?.coordinators;
+  if (ambient) coordinators.add(ambient);
   coordinators.add(legacyCoordinators);
   for (const coordinator of coordinators) {
     coordinator.retry.clearRequest(streamId);
@@ -247,13 +242,10 @@ export function clearAllRetryRequests(): void {
   bridgeState.retries.clear();
 }
 
-export function cleanupCoordinatorRequestsForStream(
-  streamId: string,
-  explicitCoordinators = tryUseRunContext()?.coordinators,
-): void {
-  clearPlanApprovalForStream(streamId, explicitCoordinators);
+export function cleanupCoordinatorRequestsForStream(streamId: string): void {
+  clearPlanApprovalForStream(streamId);
   clearProposalForStream(streamId);
-  clearRetryRequest(streamId, explicitCoordinators);
+  clearRetryRequest(streamId);
 }
 
 export function cleanupAllCoordinatorRequests(): void {


### PR DESCRIPTION
## Summary

Delete the `explicitCoordinators` parameter from the run-coordinators bridge — first slice of the deferred approval-consolidation work.

### What
`clearPlanApprovalForStream`, `clearRetryRequest`, and `cleanupCoordinatorRequestsForStream` accepted an `explicitCoordinators` parameter defaulting to `tryUseRunContext()?.coordinators`. The only purpose was letting callers pre-fetch the value once and pass it through, saving one AsyncLocalStorage lookup.

The two flow callers (`runToolUseFlow` and `runReflectionFlow`) did exactly that, threading a `runCoordinators` local through 2-3 cleanup calls. Removing the parameter:
- Drops the parameter from 3 functions in `runCoordinators.ts`
- Drops the `runCoordinators` local + the threading from both flow files. The interrupt body shrinks from 6 lines to 4 in each.
- `tryUseRunContext` import becomes orphan in both flow files — dropped.

### Why
This is **audit RunContext-F4**: the `explicitCoordinators` parameter encoded ambient-vs-explicit ownership ambiguity that #3925 specifically calls out. The chain of `bridgeState ?? explicitCoordinators ?? legacyCoordinators` had 4 sources for one value; this slice drops one.

Behavior preserved — the inner function still resolves coordinators via the same `bridgeState ?? tryUseRunContext()?.coordinators ?? legacyCoordinators` fallback chain. Just one fewer indirection layer.

### Net impact

**3 files, +12/−24 = −12 net LOC, 0 typecheck/lint errors, 570 kernel tests pass.**

### Subsequent PRs in this thread

Each ~1-step-at-a-time after this:
- **PR B2** — collapse `bridgeState` entirely (~−180 LOC); the coordinators' own `requests` Map IS the registry
- **PR B3** — replace 3 coordinator subclasses (`Plan`, `Proposal`, `Retry`) with a single `defineApproval(config)` factory (~−90 LOC); move show-prelude into config; self-registering cleanables list
- **PR C** — callbacks → events (delete 5 redundant callback families; ~−240 LOC)
- **PR D** — `onDelivery` lifecycle hook + `activeSubagentDelivery` deletion (~−50 LOC)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (63 warnings, all pre-existing)
- [x] `pnpm run test:kernel` — 570/570 pass
- [ ] CI matrix

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

---
_Generated by [Claude Code](https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interruption/cleanup paths for plan approvals and retry requests; behavior should be equivalent but mistakes could leave stale coordinator requests or clear the wrong coordinator in edge cases.
> 
> **Overview**
> Refactors `runCoordinators` cleanup helpers by removing the `explicitCoordinators` parameter from `clearPlanApprovalForStream`, `clearRetryRequest`, and `cleanupCoordinatorRequestsForStream`, and instead always resolving coordinators via `bridgeState`, `tryUseRunContext()`, then legacy fallbacks.
> 
> Updates `runReflectionFlow` and `runToolUseFlow` to stop importing `tryUseRunContext`, drop their cached `runCoordinators` local, and call the simplified cleanup functions during interruption handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09acaad43f10f5c111b87651b57e3e11cc98518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->