### PR TITLE
fix: isolate remote agent schema fallback

### DIFF
--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -30,6 +30,49 @@ import {
 const CHANNEL = 'RemoteAgentLoader';
 logger.initialize(CHANNEL);
 
+const REMOTE_AGENT_LIST_COLUMNS =
+  'id, name, description, visibility, tools, agent_category';
+const LEGACY_REMOTE_AGENT_LIST_COLUMNS =
+  'id, name, description, visibility, agent_category';
+
+interface RemoteAgentListRow {
+  id: string;
+  name: string;
+  description?: string | null;
+  visibility?: string[] | null;
+  tools?: string[] | null;
+  agent_category?: string | null;
+}
+
+interface RemoteAgentListQueryError {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+}
+
+/**
+ * True only for the pre-migration database shape where `remote_agents.tools`
+ * does not exist yet. Other query errors should surface directly.
+ */
+export function isMissingRemoteAgentToolsColumnError(
+  error: RemoteAgentListQueryError | null | undefined,
+): boolean {
+  if (!error) return false;
+
+  const text = [error.message, error.details, error.hint]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+  const schemaError =
+    error.code === 'PGRST204' ||
+    error.code === '42703' ||
+    text.includes('schema cache') ||
+    text.includes('column');
+
+  return schemaError && /\btools\b/.test(text);
+}
+
 /** Maps HTTP status codes to user-friendly error messages. */
 function mapHttpError(
   status: number,
@@ -62,14 +105,7 @@ function mapHttpError(
 }
 
 /** Parse DB row to RemoteAgentListItem, returning null on validation failure. */
-function parseListItemRow(row: {
-  id: string;
-  name: string;
-  description?: string | null;
-  visibility?: string[] | null;
-  tools?: string[] | null;
-  agent_category?: string | null;
-}): RemoteAgentListItem | null {
+function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
   const result = RemoteAgentListItemSchema.safeParse({
     id: row.id,
     name: row.name,
@@ -149,25 +185,7 @@ export class RemoteAgentLoader {
         refresh_token: tokens.refreshToken,
       });
 
-      // Query with tools column; fall back without it for pre-migration databases.
-      // PostgREST returns 400 if the column doesn't exist.
-      let { data, error } = await supabase
-        .from('remote_agents')
-        .select('id, name, description, visibility, tools, agent_category')
-        .order('name');
-
-      if (error) {
-        logger.debug(
-          CHANNEL,
-          `Query with tools column failed, retrying without: ${error.message}`,
-        );
-        const fallback = await supabase
-          .from('remote_agents')
-          .select('id, name, description, visibility, agent_category')
-          .order('name');
-        data = fallback.data as typeof data;
-        error = fallback.error;
-      }
+      const { data, error } = await queryRemoteAgentListRows(supabase);
 
       if (error) {
         logger.error(CHANNEL, `Failed to list remote agents: ${error.message}`);
@@ -185,6 +203,44 @@ export class RemoteAgentLoader {
       return [];
     }
   }
+}
+
+async function queryRemoteAgentListRows(
+  supabase: ReturnType<typeof SupabaseClient.getClient>,
+): Promise<{
+  data: RemoteAgentListRow[] | null;
+  error: RemoteAgentListQueryError | null;
+}> {
+  const current = await supabase
+    .from('remote_agents')
+    .select(REMOTE_AGENT_LIST_COLUMNS)
+    .order('name');
+
+  if (!current.error) {
+    return {
+      data: current.data as RemoteAgentListRow[] | null,
+      error: null,
+    };
+  }
+
+  if (!isMissingRemoteAgentToolsColumnError(current.error)) {
+    return { data: null, error: current.error };
+  }
+
+  logger.debug(
+    CHANNEL,
+    `Remote agent tools column unavailable; using legacy list query: ${current.error.message}`,
+  );
+
+  const legacy = await supabase
+    .from('remote_agents')
+    .select(LEGACY_REMOTE_AGENT_LIST_COLUMNS)
+    .order('name');
+
+  return {
+    data: legacy.data as RemoteAgentListRow[] | null,
+    error: legacy.error,
+  };
 }
 
 async function fetchAgentConfigWithLegacyFallback(

--- a/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isMissingRemoteAgentToolsColumnError,
+  RemoteAgentLoader,
+} from '@agent/remote/RemoteAgentLoader';
+import { SupabaseClient } from '@auth/SupabaseClient';
+
+function installRemoteAgentListClient(
+  ...results: Array<{
+    data: unknown[] | null;
+    error: { code?: string; message?: string } | null;
+  }>
+): string[] {
+  const selectedColumns: string[] = [];
+  const queue = [...results];
+  const supabase = {
+    auth: {
+      setSession: vi.fn().mockResolvedValue({}),
+    },
+    from: vi.fn(() => ({
+      select: (columns: string) => {
+        selectedColumns.push(columns);
+        return {
+          order: vi.fn(
+            async () => queue.shift() ?? { data: null, error: null },
+          ),
+        };
+      },
+    })),
+  };
+
+  vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+  vi.spyOn(SupabaseClient, 'getSessionTokens').mockResolvedValue({
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+  });
+  vi.spyOn(SupabaseClient, 'getClient').mockReturnValue(
+    supabase as unknown as ReturnType<typeof SupabaseClient.getClient>,
+  );
+
+  return selectedColumns;
+}
+
+describe('remote agent schema compatibility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('recognizes the pre-migration missing tools column error', () => {
+    expect(
+      isMissingRemoteAgentToolsColumnError({
+        code: 'PGRST204',
+        message:
+          "Could not find the 'tools' column of 'remote_agents' in the schema cache",
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat unrelated Supabase errors as schema compatibility', () => {
+    expect(
+      isMissingRemoteAgentToolsColumnError({
+        code: '42501',
+        message: 'permission denied for table remote_agents',
+      }),
+    ).toBe(false);
+
+    expect(
+      isMissingRemoteAgentToolsColumnError({
+        code: 'PGRST204',
+        message:
+          "Could not find the 'visibility' column of 'remote_agents' in the schema cache",
+      }),
+    ).toBe(false);
+  });
+
+  it('uses the legacy list query only for the missing tools column', async () => {
+    const selectedColumns = installRemoteAgentListClient(
+      {
+        data: null,
+        error: {
+          code: 'PGRST204',
+          message:
+            "Could not find the 'tools' column of 'remote_agents' in the schema cache",
+        },
+      },
+      {
+        data: [
+          {
+            id: 'agent-1',
+            name: 'legacy-agent',
+            description: 'Legacy row',
+            visibility: ['public'],
+            agent_category: null,
+          },
+        ],
+        error: null,
+      },
+    );
+
+    const agents = await RemoteAgentLoader.listRemoteAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.name).toBe('legacy-agent');
+    expect(selectedColumns).toEqual([
+      'id, name, description, visibility, tools, agent_category',
+      'id, name, description, visibility, agent_category',
+    ]);
+  });
+
+  it('does not hide unrelated list-query errors behind legacy fallback', async () => {
+    const selectedColumns = installRemoteAgentListClient({
+      data: null,
+      error: {
+        code: '42501',
+        message: 'permission denied for table remote_agents',
+      },
+    });
+
+    const agents = await RemoteAgentLoader.listRemoteAgents();
+
+    expect(agents).toEqual([]);
+    expect(selectedColumns).toEqual([
+      'id, name, description, visibility, tools, agent_category',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This is a narrow #3925 cleanup slice. Remote agent listing now treats the legacy no-`tools`-column query as a compatibility path, not as a fallback for every Supabase list error.

## Changes

- Adds a small `RemoteAgentListRow` shape and current/legacy column constants for the list query.
- Moves list querying into `queryRemoteAgentListRows` so the compatibility branch has one owner.
- Falls back to the legacy list query only when PostgREST reports the `remote_agents.tools` column is missing.
- Leaves ordinary Supabase errors on the normal error path instead of retrying with a different schema.
- Adds test-kernel coverage for the missing-column classifier and for the list-query behavior.

## Validation

- `./node_modules/.bin/vitest run src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts`
- `./node_modules/.bin/eslint src/agent/remote/RemoteAgentLoader.ts src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run compile:fast`
- `npm run lint` (passes with the existing 63-warning baseline)

This does not close #3925.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-agent listing error handling so legacy schema fallback only triggers for specific PostgREST “missing tools column” errors; misclassification could affect agent discovery in some environments. Added tests reduce regression risk but behavior around Supabase error shapes is still a dependency.
> 
> **Overview**
> Remote agent listing now **only falls back to the legacy `remote_agents` schema** (without `tools`) when Supabase/PostgREST indicates the `tools` column is missing, rather than retrying on any list-query error.
> 
> This refactors the list query into `queryRemoteAgentListRows`, adds `isMissingRemoteAgentToolsColumnError` to classify the compatibility case, and adds vitest coverage to ensure unrelated errors don’t trigger the legacy query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02fa89a53569dc0fd4b69df9b04922550aff9504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->