### PR TITLE
refactor: tighten agent runtime zod number schemas

### DIFF
--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -14,7 +14,7 @@ import { getToolUsePersistenceEnabled } from '@utils/config';
 
 export const ResumeAgentResultSchema = z.object({
   success: z.boolean(),
-  lostFollowUps: z.number().nonnegative().optional(),
+  lostFollowUps: z.int().nonnegative().optional(),
 });
 
 export type ResumeAgentResult = z.infer<typeof ResumeAgentResultSchema>;

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -34,7 +34,7 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
     .literal(AgentCategory.Workflow)
     .prefault(AgentCategory.Workflow),
   isRewrite: z.boolean().prefault(true),
-  rounds: z.number().prefault(2),
+  rounds: z.int().positive().prefault(2),
   prefills: z.array(z.string()).prefault([]),
 });
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -35,7 +35,7 @@ type ResponseAssemblyState = z.output<typeof ResponseAssemblyStateSchema>;
 const FileInteractionStateSnapshotSchema = z.object({
   readFiles: z.array(z.string()).prefault([]),
   edits: z.array(FlattenedEditRecordSchema).prefault([]),
-  toolCallCount: z.number().nonnegative().prefault(0),
+  toolCallCount: z.int().nonnegative().prefault(0),
 });
 
 type FileInteractionStateSnapshot = z.output<

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -27,24 +27,26 @@ export const DEFAULT_TOTALS = {
   totalServerToolRequests: 0,
 } as const;
 
+const TokenCountSchema = z.int().nonnegative();
+
 /** Schema for run usage totals. Internal only. */
 const RunUsageTotalsSchema = z.object({
-  firstInputTokens: z.number().prefault(0),
-  totalInputTokens: z.number().prefault(0),
-  totalOutputTokens: z.number().prefault(0),
-  totalCost: z.number().prefault(0),
-  totalCacheReadInputTokens: z.number().prefault(0),
-  totalCacheMissInputTokens: z.number().prefault(0),
-  totalCacheCreationInputTokens: z.number().prefault(0),
-  totalReasoningTokens: z.number().prefault(0),
-  totalToolUsePromptTokens: z.number().prefault(0),
-  totalServerToolRequests: z.number().prefault(0),
+  firstInputTokens: TokenCountSchema.prefault(0),
+  totalInputTokens: TokenCountSchema.prefault(0),
+  totalOutputTokens: TokenCountSchema.prefault(0),
+  totalCost: z.number().nonnegative().prefault(0),
+  totalCacheReadInputTokens: TokenCountSchema.prefault(0),
+  totalCacheMissInputTokens: TokenCountSchema.prefault(0),
+  totalCacheCreationInputTokens: TokenCountSchema.prefault(0),
+  totalReasoningTokens: TokenCountSchema.prefault(0),
+  totalToolUsePromptTokens: TokenCountSchema.prefault(0),
+  totalServerToolRequests: TokenCountSchema.prefault(0),
 });
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
 /** Schema for normalized usage snapshot. Internal only. */
 const NormalizedUsageSnapshotSchema = z.object({
-  round: z.number(),
+  round: z.int().nonnegative(),
   usage: NormalizedUsageSchema,
 });
 

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -17,7 +17,7 @@ export const BaseCycleFieldsSchema = z.object({
   shouldStop: z.boolean(),
   /** Distinguishes: completion (true) vs cancellation/failure (false) */
   endTurn: z.boolean(),
-  responseTimeMs: z.number().optional(),
+  responseTimeMs: z.number().nonnegative().optional(),
   stopReason: z.string().nullish(),
   lastError: RetryErrorInfoSchema.optional(),
 });

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -166,12 +166,12 @@ export const ToolUseCycleFieldsSchema = BaseCycleFieldsSchema.extend({
    * Used for debug file naming and usage tracking. Incremented after each
    * successful cycle in ToolUseProcessNode.post().
    */
-  cycleIndex: z.number(),
+  cycleIndex: z.int().nonnegative(),
   /**
    * Accumulated response time for current cycle (milliseconds).
    * Reset after finalization when continuing to next cycle.
    */
-  cycleResponseTimeMs: z.number(),
+  cycleResponseTimeMs: z.number().nonnegative(),
   /**
    * Normalized usage for current cycle.
    * Reset after finalization when continuing to next cycle.

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -23,8 +23,8 @@ const RoundContextSchema = z.object({
 export type RoundContext = z.infer<typeof RoundContextSchema>;
 
 export const ReflectionFlowStateSchema = z.object({
-  currentRound: z.number(),
-  totalRounds: z.number(),
+  currentRound: z.int().nonnegative(),
+  totalRounds: z.int().nonnegative(),
 
   workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
   context: RoundContextSchema.nullable(),

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
@@ -18,7 +18,7 @@ export const ToolUseSessionSnapshotSchema = z.strictObject({
   run: AgentRunStateSnapshotSchema,
   workspace: AgentWorkspaceStateSnapshotSchema,
   user: UserVariableChannelsSchema,
-  lastUpdated: z.number(),
+  lastUpdated: z.int().nonnegative(),
 });
 
 export type ToolUseSessionSnapshot = z.infer<

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -7,19 +7,19 @@ import {
 } from '@shared/schemas';
 
 export const OutputFileSummarySchema = z.object({
-  round: z.number(),
+  round: z.int().nonnegative(),
   relativePath: z.string(),
   absolutePath: z.string(),
   location: z.enum(['workspace', 'runStorage', 'external']),
   originalPath: z.string().nullable(),
-  added: z.number().nullable(),
-  removed: z.number().nullable(),
+  added: z.int().nonnegative().nullable(),
+  removed: z.int().nonnegative().nullable(),
 });
 
 export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
 
 export const CompileFailureSummarySchema = z.object({
-  round: z.number(),
+  round: z.int().nonnegative(),
   displayName: z.string(),
   outputPath: z.string(),
   logPath: z.string(),

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -114,8 +114,8 @@ type NormalizedToolUseState = z.infer<typeof ToolUseFlowRecordStateSchema>;
  * Full validation happens when the flow actually resumes.
  */
 const WorkflowFlowRecordStateSchema = z.object({
-  currentRound: z.number(),
-  totalRounds: z.number(),
+  currentRound: z.int().nonnegative(),
+  totalRounds: z.int().nonnegative(),
 });
 
 // =============================================================================

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -81,8 +81,8 @@ export interface ChildRecord extends ChildRecordData {
 
 /** Result metadata for background bash processes. */
 export const ResultMetaSchema = z.object({
-  exitCode: z.number().optional(),
-  wallTimeMs: z.number().optional(),
+  exitCode: z.int().optional(),
+  wallTimeMs: z.number().nonnegative().optional(),
   success: z.boolean().optional(),
   timedOut: z.boolean().optional(),
   command: z.string().optional(),

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -6,6 +6,8 @@ import { z } from 'zod';
 
 import { TokenUsageStatsSchema } from '@shared/schemas';
 
+const TokenCountSchema = z.int().nonnegative();
+
 /** Provider identifiers for usage tracking. */
 export const UsageProviderSchema = z.enum([
   'anthropic',
@@ -27,25 +29,25 @@ export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 /** Normalized usage statistics from any model provider. */
 export const NormalizedUsageSchema = TokenUsageStatsSchema.extend({
   /** Response time in milliseconds */
-  responseTimeMs: z.number(),
+  responseTimeMs: z.number().nonnegative(),
   /** Provider that generated this usage data */
   provider: UsageProviderSchema,
 
   // Optional metrics (when supported by provider)
   /** Tokens served from cache (reduces cost) */
-  cachedInputTokens: z.number().optional(),
+  cachedInputTokens: TokenCountSchema.optional(),
   /** Tokens that missed provider prompt cache and were billed at full input rate */
-  cacheMissInputTokens: z.number().optional(),
+  cacheMissInputTokens: TokenCountSchema.optional(),
   /** Tokens written to cache - Anthropic only (increases cost by 1.25x) */
-  cacheCreationTokens: z.number().optional(),
+  cacheCreationTokens: TokenCountSchema.optional(),
   /** Percentage of input tokens served from cache */
-  percentageCached: z.number().optional(),
+  percentageCached: z.number().nonnegative().optional(),
   /** Tokens used for reasoning (o1, DeepSeek-R1, Gemini thinking) */
-  reasoningTokens: z.number().optional(),
+  reasoningTokens: TokenCountSchema.optional(),
   /** Tokens consumed by tool use prompts (Google) */
-  toolUsePromptTokens: z.number().optional(),
+  toolUsePromptTokens: TokenCountSchema.optional(),
   /** Number of server-side tool executions (Anthropic web search) */
-  serverToolRequests: z.number().optional(),
+  serverToolRequests: TokenCountSchema.optional(),
   /** Original API response payload (for debugging) */
   _native: z.unknown().optional(),
 });

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -14,7 +14,7 @@ const ExecResultSchema = z.strictObject({
   /** True if the command timed out */
   timedOut: z.boolean().optional(),
   /** Exit code from the command (undefined if not available) */
-  exitCode: z.number().optional(),
+  exitCode: z.int().optional(),
 });
 
 export type ExecResult = z.infer<typeof ExecResultSchema>;

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -9,24 +9,27 @@ export const ContextManagementAction = z.enum([
 ]);
 export type ContextManagementAction = z.infer<typeof ContextManagementAction>;
 
+const TokenCountSchema = z.int().nonnegative();
+const PositiveTokenCountSchema = z.int().positive();
+
 export const ContextManagementDataSchema = z.object({
   action: ContextManagementAction,
-  tokensBefore: z.number().nonnegative(),
-  tokensAfter: z.number().nonnegative().optional(),
-  contextWindow: z.number().positive(),
+  tokensBefore: TokenCountSchema,
+  tokensAfter: TokenCountSchema.optional(),
+  contextWindow: PositiveTokenCountSchema,
   utilizationBefore: z.number().nonnegative(),
   utilizationAfter: z.number().nonnegative().optional(),
   details: z.string().optional(),
   summary: z.string().optional(),
-  originalMaxTokens: z.number().positive().optional(),
-  reducedMaxTokens: z.number().positive().optional(),
+  originalMaxTokens: PositiveTokenCountSchema.optional(),
+  reducedMaxTokens: PositiveTokenCountSchema.optional(),
 });
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 
 export const ContextStateDataSchema = z.object({
-  inputTokens: z.number().nonnegative(),
-  contextWindow: z.number().positive(),
+  inputTokens: TokenCountSchema,
+  contextWindow: PositiveTokenCountSchema,
   utilizationPercent: z.number().nonnegative(),
 });
 

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
+const TokenCountSchema = z.int().nonnegative();
+
 export const TokenUsageStatsSchema = z.strictObject({
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cost: z.number(),
-  cacheReadInputTokens: z.number().optional(),
-  cacheMissInputTokens: z.number().optional(),
-  cacheCreationInputTokens: z.number().optional(),
+  inputTokens: TokenCountSchema,
+  outputTokens: TokenCountSchema,
+  cost: z.number().nonnegative(),
+  cacheReadInputTokens: TokenCountSchema.optional(),
+  cacheMissInputTokens: TokenCountSchema.optional(),
+  cacheCreationInputTokens: TokenCountSchema.optional(),
 });
 
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
@@ -48,10 +50,10 @@ export function sumUsageStats(
  * calculated from accumulated session totals for overall caching effectiveness.
  */
 export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
-  elapsedTime: z.number().optional(),
-  percentageCached: z.number().optional(),
-  reasoningTokens: z.number().optional(),
-  toolUseTokens: z.number().optional(),
+  elapsedTime: z.number().nonnegative().optional(),
+  percentageCached: z.number().nonnegative().optional(),
+  reasoningTokens: TokenCountSchema.optional(),
+  toolUseTokens: TokenCountSchema.optional(),
 });
 
 export type ExtendedTokenUsageStats = z.infer<


### PR DESCRIPTION
## Summary
- Closes #4005.
- Use Zod v4 integer schemas for discrete quantities: rounds, cycle indices, token counts, line counts, exit codes, timestamps, context-window token counts, and lost follow-up counts.
- Keep continuous quantities such as costs, response durations, and cache percentages as nonnegative numbers.
- Confirmed the other issue-named schema files that were already modern, including AgentState.ts and UsageLogTypes.ts, did not need additional edits.

## Validation
- npm run format
- focused ESLint for the touched schema files
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/vitest run src/test/agent/core/ConfigSchemas.test.ts src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test/progressView/streamTabSchemas.test.ts
- npm run compile:fast
- npm run lint
- git diff --check