### PR TITLE
refactor: tighten line change schemas

### DIFF
--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -38,7 +38,7 @@ export const ToolEditApprovalResultSchema = z.object({
   userPatch: z.string().optional(),
   lineChanges: LineChangesSchema.optional(),
   /** 1-based line number where the first change occurs (for navigation) */
-  startLine: z.number().optional(),
+  startLine: z.int().positive().optional(),
 });
 export type ToolEditApprovalResult = z.infer<
   typeof ToolEditApprovalResultSchema

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -12,9 +12,11 @@ import type { ZodIssue } from 'zod';
  * Schema for line change statistics.
  * Single source of truth - used by ToolResult, edits, and model handlers.
  */
+const LineCountSchema = z.int().nonnegative();
+
 export const LineChangesSchema = z.object({
-  added: z.number(),
-  removed: z.number(),
+  added: LineCountSchema,
+  removed: LineCountSchema,
 });
 export type LineChanges = z.infer<typeof LineChangesSchema>;
 
@@ -51,7 +53,7 @@ export const EditRecordSchema = z.object({
   path: z.string(),
   lineChanges: LineChangesSchema.optional(),
   /** 1-based line number where the edit starts (for navigation) */
-  startLine: z.number().optional(),
+  startLine: z.int().positive().optional(),
 });
 export type EditRecord = z.infer<typeof EditRecordSchema>;
 
@@ -64,8 +66,8 @@ export type EditRecord = z.infer<typeof EditRecordSchema>;
  */
 export const FlattenedEditRecordSchema = z.object({
   path: z.string(),
-  added: z.number().prefault(0),
-  removed: z.number().prefault(0),
+  added: LineCountSchema.prefault(0),
+  removed: LineCountSchema.prefault(0),
 });
 export type FlattenedEditRecord = z.infer<typeof FlattenedEditRecordSchema>;
 


### PR DESCRIPTION
## Summary
- Closes #4009.
- Make LineChangesSchema use nonnegative integer counts for added and removed lines.
- Apply the same integer bounds to flattened edit records and 1-based startLine fields used by edit approval/tool results.

## Validation
- ./node_modules/.bin/eslint src/tools/result.ts src/tools/approval/toolEditApproval.ts src/agent/types/DiffTypes.ts
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/vitest run src/test/tools/ToolEditApprovalGate.test.ts src/test-kernel/tools/ToolStatusFormatting.vitest.ts
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-tightening change, but it may surface new validation failures if any callers were emitting negative, fractional, or zero/undefined `startLine` values.
> 
> **Overview**
> Tightens Zod validation for edit/diff metadata by requiring **nonnegative integer** `added`/`removed` line counts and a **positive integer** 1-based `startLine` across tool results and edit approval responses.
> 
> This introduces a shared `LineCountSchema` and applies it to `LineChangesSchema`, `FlattenedEditRecordSchema` defaults, and `ToolEditApprovalResultSchema`/`EditRecordSchema` `startLine` fields, making invalid line stats fail validation earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3993b876bb1c59ace2698455286b7b14bd6829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->