### PR TITLE
refactor: derive runKind from agentCategory in UsageMonitor

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -388,8 +388,7 @@ export async function executeAgent(
             const result = await runToolUseFlow({
               ...ctx,
               ...interrupts,
-              onRoundFinalized: (run) =>
-                ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+              onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
               setting,
               isSubagent,
               onBeforeWaiting: options.onBeforeWaiting,
@@ -432,8 +431,7 @@ export async function executeAgent(
           const result = await runReflectionFlow({
             ...ctx,
             ...interrupts,
-            onRoundFinalized: (run) =>
-              ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+            onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
             setting,
             parentStage: ctx.parentStage,
             onRoundCompleted,
@@ -497,8 +495,7 @@ export async function executeMergeAgent(
         const result = await runReflectionFlow({
           ...ctx,
           ...createInterruptCallbacks(),
-          onRoundFinalized: (run) =>
-            ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+          onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
           setting: ctx.setting,
           getOutputFileLocation:
             createMergeOutputFileLocationGetter(fileService),
@@ -564,8 +561,7 @@ export async function resumeToolUseFromSnapshot(
           {
             ...ctx,
             ...createInterruptCallbacks(),
-            onRoundFinalized: (run) =>
-              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+            onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
             setting,
             resumeSnapshot: snapshot,
             // Derive from the recovered parent chain: any execution with a

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -102,12 +102,12 @@ export class UsageMonitor {
     this.activeGroupId = groupId;
   }
 
-  async recordUsage(
-    stateGlobal: AgentRunStateSnapshot,
-    options?: { runKind?: UsageMonitorRunKind },
-  ): Promise<void> {
+  async recordUsage(stateGlobal: AgentRunStateSnapshot): Promise<void> {
     const { logger, usageReporter } = this.context;
-    const runKind: UsageMonitorRunKind = options?.runKind ?? 'workflow';
+    const runKind: UsageMonitorRunKind =
+      this.metadata?.agentCategory === AgentCategory.ToolUse
+        ? 'tool-use'
+        : 'workflow';
 
     try {
       const totals = stateGlobal.usageAccumulator.totals;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -18,13 +18,15 @@ import type {
 import type { ModelCapabilities, ModelConfig } from 'llm-zoo';
 
 /**
- * Optional metadata for usage logging.
+ * Metadata for usage logging. Required because `agentCategory` controls
+ * the `runKind` derivation in `recordUsage` — a silent default would
+ * misreport usage runs from a future caller that forgot to set it.
  */
 export interface UsageMonitorMetadata {
   /** Agent name for backend logging */
-  agentName?: string;
+  agentName: string;
   /** Agent category: workflow or toolUse */
-  agentCategory?: AgentCategory;
+  agentCategory: AgentCategory;
 }
 
 /**
@@ -89,7 +91,7 @@ export class UsageMonitor {
   constructor(
     private readonly modelInfo: UsageMonitorModelInfo,
     private readonly context: UsageMonitorContext,
-    private readonly metadata?: UsageMonitorMetadata,
+    private readonly metadata: UsageMonitorMetadata,
   ) {}
 
   /**
@@ -105,7 +107,7 @@ export class UsageMonitor {
   async recordUsage(stateGlobal: AgentRunStateSnapshot): Promise<void> {
     const { logger, usageReporter } = this.context;
     const runKind: UsageMonitorRunKind =
-      this.metadata?.agentCategory === AgentCategory.ToolUse
+      this.metadata.agentCategory === AgentCategory.ToolUse
         ? 'tool-use'
         : 'workflow';
 
@@ -232,8 +234,8 @@ export class UsageMonitor {
       UsageLogService.log({
         model: config.fullName,
         provider,
-        agentName: this.metadata?.agentName,
-        agentCategory: this.metadata?.agentCategory,
+        agentName: this.metadata.agentName,
+        agentCategory: this.metadata.agentCategory,
         inputTokens: cacheMissInputTokens,
         outputTokens: usage.outputTokens,
         cost: Number(usage.cost.toFixed(6)),


### PR DESCRIPTION
## Summary

`UsageMonitor.recordUsage` took an optional `{ runKind: 'workflow' | 'tool-use' }` parameter that 4 call sites in `executeAgent.ts` passed verbatim — `'tool-use'` for toolUse paths, `'workflow'` for workflow + merge paths.

The information was already available on `UsageMonitor.metadata.agentCategory` (set at construction). Every call site was duplicating something the monitor already knew.

### What

- Drop the `runKind` parameter from `recordUsage`.
- Derive it inside the method from `this.metadata?.agentCategory` (mapping `AgentCategory.ToolUse → 'tool-use'`, else `'workflow'`).
- The 4 `onRoundFinalized` lambdas collapse from two lines to one each.

### Why

This is one of the concrete findings from the deeper callbacks-audit pass — the 4× duplicated `(run) => ctx.usageMonitor.recordUsage(run, { runKind: '...' })` lambda where the `runKind` argument was always re-deriving information `UsageMonitor` already had. CLAUDE.md anti-pattern: "Optional fields that are never undefined in practice."

### Net impact

**2 files, +9/−13 = −4 net LOC, 0 typecheck errors, 570 kernel tests pass.**

This is one slice of the deferred callbacks→events PR. Bigger pieces (deleting `createRoundProgressCallback`, `onFollowUpConsumed`, `onProgress` wrappers, `SubagentProgressUpdate` schema) need careful sequencing with flow-node restructuring; this commit is the cleanest piece that stands alone.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `pnpm run test:kernel` — 570/570 pass
- [ ] CI matrix

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

---
_Generated by [Claude Code](https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that changes how usage runs are categorized for logging/reporting; main risk is incorrect `agentCategory` at `UsageMonitor` construction would mislabel analytics.
> 
> **Overview**
> Centralizes usage run categorization inside `UsageMonitor.recordUsage` by removing the optional `{ runKind }` parameter and deriving `'workflow'` vs `'tool-use'` from required `metadata.agentCategory`.
> 
> Updates agent execution flows (`executeAgent`, merge, and tool-use resume paths) to call `recordUsage(run)` directly, and makes `UsageMonitorMetadata` fields (`agentName`, `agentCategory`) required to avoid silent misreporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896c04cc5f40df86d2d5854be05e2914b5c72cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->