### PR TITLE
feat: add Claude Code Agent SDK as a subagent tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "zod-v3-to-v4": "^1.21.1"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
     "@anthropic-ai/sdk": "^0.96.0",
     "@awesome.me/webawesome": "^3.7.0",
     "@cantoo/pdf-lib": "^2.6.5",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -33,6 +33,7 @@
     "vite": "^8.0.13"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@openai/codex-sdk": "^0.130.0",
     "@sentry/electron": "^7.13.0",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -20,6 +20,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import type { TerminalRunResult } from '@hosts/terminalHost';
 import { interruptAllCodexSessions } from '@tools/codex';
+import { interruptAllClaudeAgentSessions } from '@tools/claudeAgent';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
@@ -622,6 +623,9 @@ if (protocolLifecycle.shouldContinue) {
       );
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
         interruptAllCodexSessions(),
+      );
+      lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+        interruptAllClaudeAgentSessions(),
       );
 
       // before-quit semantics: hold every quit event until shutdown handlers

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1544,6 +1544,7 @@
   },
   "homepage": "https://texra.ai",
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
     "@anthropic-ai/sdk": "^0.96.0",
     "@awesome.me/webawesome": "^3.7.0",
     "@cantoo/pdf-lib": "^2.6.5",

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -78,6 +78,7 @@ import { UsageLogService } from '@logger/UsageLogService';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { interruptAllCodexSessions } from '@tools/codex';
+import { interruptAllClaudeAgentSessions } from '@tools/claudeAgent';
 import { setExtensionChecker } from '@tools/externalToolDefs';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
@@ -187,6 +188,9 @@ export async function activate(context: vscode.ExtensionContext) {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killBackgroundProcesses());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
     interruptAllCodexSessions(),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    interruptAllClaudeAgentSessions(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -72,6 +72,7 @@ import './tabs/ModelsTab';
 import './tabs/AgentsTab';
 import './tabs/MultiAgentTab';
 import './tabs/ToolsTab';
+import './tabs/AIAgentsTab';
 import './tabs/GitTab';
 import './tabs/LaTeXTab';
 import './components/profile/ProviderKeyModal';
@@ -932,6 +933,15 @@ export class SettingsApp extends SettingsAppBase {
             ></wa-icon>
             Tools</wa-tab
           >
+          <wa-tab panel="ai-agents"
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="robot"
+              variant="solid"
+            ></wa-icon>
+            AI Agents</wa-tab
+          >
           <wa-tab panel="git"
             ><wa-icon
               class="settings-tab-icon"
@@ -1053,9 +1063,6 @@ export class SettingsApp extends SettingsAppBase {
               .items=${this.toolDashboardItems.get()}
               .loaded=${this.toolDashboardLoaded.get()}
               .bashApprovalEnabled=${this.bashApprovalEnabled.get()}
-              .codexSandboxMode=${this.codexSandboxMode.get()}
-              .codexReasoningEffort=${this.codexReasoningEffort.get()}
-              .codexApprovalPolicy=${this.codexApprovalPolicy.get()}
               .showDesktopCrashReporting=${this.isDesktopHost}
               .desktopCrashReportingEnabled=${this.desktopCrashReportingEnabled.get()}
               .desktopCrashReportingConfigured=${this.desktopCrashReportingConfigured.get()}
@@ -1065,16 +1072,31 @@ export class SettingsApp extends SettingsAppBase {
               @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @bash-approval-toggle=${this.handleBashApprovalToggle}
-              @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
-              @codex-reasoning-effort-change=${this
-                .handleCodexReasoningEffortChange}
-              @codex-approval-policy-change=${this
-                .handleCodexApprovalPolicyChange}
               @desktop-crash-reporting-toggle=${this
                 .handleDesktopCrashReportingToggle}
               @desktop-crash-reporting-dsn-set=${this
                 .handleDesktopCrashReportingDsnSet}
             ></tools-tab>
+          </wa-tab-panel>
+
+          <wa-tab-panel name="ai-agents">
+            <ai-agents-tab
+              .items=${this.toolDashboardItems.get()}
+              .loaded=${this.toolDashboardLoaded.get()}
+              .codexSandboxMode=${this.codexSandboxMode.get()}
+              .codexReasoningEffort=${this.codexReasoningEffort.get()}
+              .codexApprovalPolicy=${this.codexApprovalPolicy.get()}
+              @tool-open-url=${this.handleToolOpenUrl}
+              @tool-install-extension=${this.handleToolInstallExtension}
+              @tool-run-command=${this.handleToolRunCommand}
+              @tool-recheck=${this.handleToolRecheck}
+              @tool-toggle=${this.handleToolToggle}
+              @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
+              @codex-reasoning-effort-change=${this
+                .handleCodexReasoningEffortChange}
+              @codex-approval-policy-change=${this
+                .handleCodexApprovalPolicyChange}
+            ></ai-agents-tab>
           </wa-tab-panel>
 
           <wa-tab-panel name="git">

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -1,0 +1,266 @@
+/**
+ * AI Agents tab — shows third-party agent integrations (Codex, Claude Code,
+ * external chat handoffs) grouped on their own panel. Reuses the same
+ * `tool-card` component as the Tools tab, plus the Codex-specific inline
+ * settings that used to live inside ToolsTab.
+ */
+
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import { commonViewStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared schemas
+import { createEvent } from '@shared/utils/events';
+import type {
+  ToolDashboardItem,
+  CodexSandboxMode,
+  CodexReasoningEffort,
+  CodexApprovalPolicy,
+} from '@shared/schemas/settingsViewMessages';
+
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+
+// Side-effect: register tool card component
+import '../components/tools/ToolCard';
+
+const SANDBOX_MODE_OPTIONS: readonly {
+  value: CodexSandboxMode;
+  label: string;
+}[] = [
+  { value: 'read-only', label: 'Read-only' },
+  { value: 'workspace-write', label: 'Workspace write' },
+  { value: 'danger-full-access', label: 'Full access' },
+] as const;
+
+const REASONING_EFFORT_OPTIONS: readonly {
+  value: CodexReasoningEffort;
+  label: string;
+}[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra high' },
+] as const;
+
+const APPROVAL_POLICY_OPTIONS: readonly {
+  value: CodexApprovalPolicy;
+  label: string;
+}[] = [
+  { value: 'never', label: 'Auto approve' },
+  { value: 'on-request', label: 'Ask when requested' },
+  { value: 'untrusted', label: 'Ask for untrusted' },
+  { value: 'on-failure', label: 'Ask on failure' },
+] as const;
+
+@customElement('ai-agents-tab')
+export class AIAgentsTab extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .ai-agents-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--wa-space-s);
+      }
+
+      .ai-agents-intro {
+        margin: 0 0 var(--wa-space-s) 0;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        line-height: 1.5;
+      }
+
+      .ai-agents-empty {
+        padding: var(--wa-space-l);
+        text-align: center;
+        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-sm);
+      }
+
+      .category-section {
+        margin-bottom: var(--wa-space-m);
+      }
+
+      .codex-inline-settings {
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        margin-bottom: var(--wa-space-2xs);
+        border-radius: var(--border-radius);
+        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
+      }
+
+      .setting-row {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+      }
+
+      .setting-row label {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+      }
+
+      .setting-select {
+        min-width: 10rem;
+        max-width: 14rem;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) items: ToolDashboardItem[] = [];
+  @property({ type: Boolean }) loaded = false;
+  @property({ type: String }) codexSandboxMode = 'workspace-write';
+  @property({ type: String }) codexReasoningEffort = 'high';
+  @property({ type: String }) codexApprovalPolicy = 'never';
+
+  private handleRecheck(): void {
+    this.dispatchEvent(createEvent('tool-recheck'));
+  }
+
+  private emitSelect(eventName: string, key: string, e: Event): void {
+    const select = e.currentTarget as WaSelect | null;
+    const value = typeof select?.value === 'string' ? select.value : '';
+    if (value) {
+      this.dispatchEvent(createEvent(eventName, { [key]: value }));
+    }
+  }
+
+  private handleCodexSandboxModeChange = (e: Event): void => {
+    this.emitSelect('codex-sandbox-mode-change', 'mode', e);
+  };
+
+  private handleCodexReasoningEffortChange = (e: Event): void => {
+    this.emitSelect('codex-reasoning-effort-change', 'effort', e);
+  };
+
+  private handleCodexApprovalPolicyChange = (e: Event): void => {
+    this.emitSelect('codex-approval-policy-change', 'policy', e);
+  };
+
+  private renderSelectRow(
+    label: string,
+    value: string,
+    options: readonly { value: string; label: string }[],
+    onChange: (e: Event) => void,
+  ): TemplateResult {
+    return html`
+      <div class="setting-row">
+        <label>${label}</label>
+        <wa-select class="setting-select" .value=${value} @change=${onChange}>
+          ${options.map(
+            (opt) => html`
+              <wa-option value=${opt.value}>${opt.label}</wa-option>
+            `,
+          )}
+        </wa-select>
+      </div>
+    `;
+  }
+
+  private renderCodexInlineSettings(): TemplateResult {
+    return html`
+      <div class="codex-inline-settings">
+        ${this.renderSelectRow(
+          'Sandbox mode',
+          this.codexSandboxMode,
+          SANDBOX_MODE_OPTIONS,
+          this.handleCodexSandboxModeChange,
+        )}
+        ${this.renderSelectRow(
+          'Reasoning effort',
+          this.codexReasoningEffort,
+          REASONING_EFFORT_OPTIONS,
+          this.handleCodexReasoningEffortChange,
+        )}
+        ${this.renderSelectRow(
+          'Approval policy',
+          this.codexApprovalPolicy,
+          APPROVAL_POLICY_OPTIONS,
+          this.handleCodexApprovalPolicyChange,
+        )}
+      </div>
+    `;
+  }
+
+  private aiAgentItems(): ToolDashboardItem[] {
+    return this.items.filter((item) => item.category === 'ai-agents');
+  }
+
+  override render(): TemplateResult {
+    if (!this.loaded) {
+      return html`
+        <div class="tab-content-container">
+          <div class="ai-agents-empty">
+            <wa-spinner></wa-spinner>
+            Loading integrations…
+          </div>
+        </div>
+      `;
+    }
+
+    const items = this.aiAgentItems();
+
+    return html`
+      <div class="tab-content-container">
+        <div class="ai-agents-header">
+          <p class="ai-agents-intro">
+            Delegate work to third-party AI coding agents. Each integration uses
+            its own authentication (OAuth login, OAuth token, or API key) and
+            runs locally on your machine.
+          </p>
+          <button
+            class="tab-action-btn"
+            @click=${this.handleRecheck}
+            title="Re-check integration availability"
+          >
+            <wa-icon library="texra" name="refresh"></wa-icon>
+            Re-check
+          </button>
+        </div>
+
+        ${items.length === 0
+          ? html`<div class="ai-agents-empty">
+              No AI agent integrations registered.
+            </div>`
+          : html`
+              <div class="category-section">
+                ${repeat(
+                  items,
+                  (item) => item.id,
+                  (item) => html`
+                    <tool-card .item=${item}>
+                      ${item.id === 'codex'
+                        ? html`<div slot="details">
+                            ${this.renderCodexInlineSettings()}
+                          </div>`
+                        : nothing}
+                    </tool-card>
+                  `,
+                )}
+              </div>
+            `}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ai-agents-tab': AIAgentsTab;
+  }
+}

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -213,7 +213,6 @@ export class ToolsTab extends LitElement {
         margin-top: var(--wa-space-2xs);
         flex-wrap: wrap;
       }
-
     `,
   ];
 

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -317,9 +317,11 @@ export class ToolsTab extends LitElement {
     return this.items.filter((item) => TOOLS_TAB_CATEGORIES.has(item.category));
   }
 
-  private groupByCategory(): Map<ToolCategory, ToolDashboardItem[]> {
+  private groupByCategory(
+    items: readonly ToolDashboardItem[],
+  ): Map<ToolCategory, ToolDashboardItem[]> {
     const groups = new Map<ToolCategory, ToolDashboardItem[]>();
-    for (const item of this.visibleItems()) {
+    for (const item of items) {
       const list = groups.get(item.category) ?? [];
       list.push(item);
       groups.set(item.category, list);
@@ -327,8 +329,9 @@ export class ToolsTab extends LitElement {
     return groups;
   }
 
-  private renderSummary(): TemplateResult | typeof nothing {
-    const items = this.visibleItems();
+  private renderSummary(
+    items: readonly ToolDashboardItem[],
+  ): TemplateResult | typeof nothing {
     if (items.length === 0) return nothing;
 
     let available = 0;
@@ -415,8 +418,6 @@ export class ToolsTab extends LitElement {
   }
 
   override render(): TemplateResult {
-    const groups = this.groupByCategory();
-
     if (!this.loaded) {
       return html`
         <div class="tools-container tab-content-container">
@@ -428,11 +429,14 @@ export class ToolsTab extends LitElement {
       `;
     }
 
+    const items = this.visibleItems();
+    const groups = this.groupByCategory(items);
+
     return html`
       <div class="tools-container tab-content-container">
         <div class="tools-header">
           <div class="tools-header-actions">
-            ${this.renderSummary()}
+            ${this.renderSummary(items)}
             <button
               class="tab-action-btn"
               @click=${this.handleRecheck}

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -8,56 +8,21 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 
-// Side-effect imports - register WA icon and spinner components
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
-import '@awesome.me/webawesome/dist/components/select/select.js';
-import '@awesome.me/webawesome/dist/components/option/option.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
-
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
 import type {
   ToolDashboardItem,
   ToolCategory,
-  CodexSandboxMode,
-  CodexReasoningEffort,
-  CodexApprovalPolicy,
 } from '@shared/schemas/settingsViewMessages';
+
+// Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 // Side-effect: register tool card component
 import '../components/tools/ToolCard';
-
-const SANDBOX_MODE_OPTIONS: readonly {
-  value: CodexSandboxMode;
-  label: string;
-}[] = [
-  { value: 'read-only', label: 'Read-only' },
-  { value: 'workspace-write', label: 'Workspace write' },
-  { value: 'danger-full-access', label: 'Full access' },
-] as const;
-
-const REASONING_EFFORT_OPTIONS: readonly {
-  value: CodexReasoningEffort;
-  label: string;
-}[] = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra high' },
-] as const;
-
-const APPROVAL_POLICY_OPTIONS: readonly {
-  value: CodexApprovalPolicy;
-  label: string;
-}[] = [
-  { value: 'never', label: 'Auto approve' },
-  { value: 'on-request', label: 'Ask when requested' },
-  { value: 'untrusted', label: 'Ask for untrusted' },
-  { value: 'on-failure', label: 'Ask on failure' },
-] as const;
 
 /** Per-category display metadata. */
 interface CategoryMeta {
@@ -80,9 +45,13 @@ const CATEGORY_META: Record<ToolCategory, CategoryMeta> = {
   lean: { label: 'Lean 4', icon: 'beaker' },
   workflow: { label: 'Memory & Workflow', icon: 'type-hierarchy' },
   system: { label: 'System Dependencies', icon: 'gear' },
+  // ai-agents lives on its own tab (AIAgentsTab); keep the meta entry so the
+  // Record stays exhaustive and the type checker enforces it.
+  'ai-agents': { label: 'AI Agents', icon: 'robot' },
 };
 
-/** Canonical category display order. */
+/** Canonical category display order. The 'ai-agents' category is rendered by
+ * the dedicated AIAgentsTab, so it is intentionally omitted here. */
 const CATEGORY_ORDER: ToolCategory[] = [
   'file',
   'latex',
@@ -245,38 +214,12 @@ export class ToolsTab extends LitElement {
         flex-wrap: wrap;
       }
 
-      .codex-inline-settings {
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
-        margin-bottom: var(--wa-space-2xs);
-        border-radius: var(--border-radius);
-        background: var(--wa-color-surface-lowered, rgba(128, 128, 128, 0.08));
-      }
-
-      .setting-row {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-xs);
-      }
-
-      .setting-row label {
-        font-size: var(--font-size-sm);
-        color: var(--color-text-secondary);
-        white-space: nowrap;
-      }
-
-      .setting-select {
-        min-width: 10rem;
-        max-width: 14rem;
-      }
     `,
   ];
 
   @property({ attribute: false }) items: ToolDashboardItem[] = [];
   @property({ type: Boolean }) loaded = false;
   @property({ type: Boolean }) bashApprovalEnabled = true;
-  @property({ type: String }) codexSandboxMode = 'workspace-write';
-  @property({ type: String }) codexReasoningEffort = 'high';
-  @property({ type: String }) codexApprovalPolicy = 'never';
   @property({ attribute: false }) showDesktopCrashReporting = false;
   @property({ attribute: false }) desktopCrashReportingEnabled = false;
   @property({ attribute: false }) desktopCrashReportingConfigured = false;
@@ -294,28 +237,6 @@ export class ToolsTab extends LitElement {
 
   private handleBashApprovalToggle = (e: Event): void => {
     this.emitToggle('bash-approval-toggle', e);
-  };
-
-  private emitSelect(eventName: string, key: string, e: Event): void {
-    // Read from currentTarget (the wa-select host) to avoid relying on the
-    // shadow-DOM retargeted target, which is brittle for Web Components.
-    const select = e.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
-    if (value) {
-      this.dispatchEvent(createEvent(eventName, { [key]: value }));
-    }
-  }
-
-  private handleCodexSandboxModeChange = (e: Event): void => {
-    this.emitSelect('codex-sandbox-mode-change', 'mode', e);
-  };
-
-  private handleCodexReasoningEffortChange = (e: Event): void => {
-    this.emitSelect('codex-reasoning-effort-change', 'effort', e);
-  };
-
-  private handleCodexApprovalPolicyChange = (e: Event): void => {
-    this.emitSelect('codex-approval-policy-change', 'policy', e);
   };
 
   private handleDesktopCrashReportingToggle = (e: Event): void => {
@@ -339,54 +260,9 @@ export class ToolsTab extends LitElement {
             ?checked=${this.bashApprovalEnabled}
             @change=${this.handleBashApprovalToggle}
           >
-            Require approval for shell commands &amp; Codex sessions
+            Require approval for shell commands &amp; agent sessions
           </wa-checkbox>
         </div>
-      </div>
-    `;
-  }
-
-  private renderSelectRow(
-    label: string,
-    value: string,
-    options: readonly { value: string; label: string }[],
-    onChange: (e: Event) => void,
-  ): TemplateResult {
-    return html`
-      <div class="setting-row">
-        <label>${label}</label>
-        <wa-select class="setting-select" .value=${value} @change=${onChange}>
-          ${options.map(
-            (opt) => html`
-              <wa-option value=${opt.value}> ${opt.label} </wa-option>
-            `,
-          )}
-        </wa-select>
-      </div>
-    `;
-  }
-
-  private renderCodexInlineSettings(): TemplateResult {
-    return html`
-      <div class="codex-inline-settings">
-        ${this.renderSelectRow(
-          'Sandbox mode',
-          this.codexSandboxMode,
-          SANDBOX_MODE_OPTIONS,
-          this.handleCodexSandboxModeChange,
-        )}
-        ${this.renderSelectRow(
-          'Reasoning effort',
-          this.codexReasoningEffort,
-          REASONING_EFFORT_OPTIONS,
-          this.handleCodexReasoningEffortChange,
-        )}
-        ${this.renderSelectRow(
-          'Approval policy',
-          this.codexApprovalPolicy,
-          APPROVAL_POLICY_OPTIONS,
-          this.handleCodexApprovalPolicyChange,
-        )}
       </div>
     `;
   }
@@ -527,15 +403,7 @@ export class ToolsTab extends LitElement {
         ${repeat(
           items,
           (item) => item.id,
-          (item) => html`
-            <tool-card .item=${item}>
-              ${category === 'computation' && item.id === 'codex'
-                ? html`<div slot="details">
-                    ${this.renderCodexInlineSettings()}
-                  </div>`
-                : nothing}
-            </tool-card>
-          `,
+          (item) => html`<tool-card .item=${item}></tool-card>`,
         )}
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -62,6 +62,7 @@ const CATEGORY_ORDER: ToolCategory[] = [
   'workflow',
   'system',
 ];
+const TOOLS_TAB_CATEGORIES = new Set<ToolCategory>(CATEGORY_ORDER);
 
 @customElement('tools-tab')
 export class ToolsTab extends LitElement {
@@ -312,9 +313,13 @@ export class ToolsTab extends LitElement {
     `;
   }
 
+  private visibleItems(): ToolDashboardItem[] {
+    return this.items.filter((item) => TOOLS_TAB_CATEGORIES.has(item.category));
+  }
+
   private groupByCategory(): Map<ToolCategory, ToolDashboardItem[]> {
     const groups = new Map<ToolCategory, ToolDashboardItem[]>();
-    for (const item of this.items) {
+    for (const item of this.visibleItems()) {
       const list = groups.get(item.category) ?? [];
       list.push(item);
       groups.set(item.category, list);
@@ -323,17 +328,18 @@ export class ToolsTab extends LitElement {
   }
 
   private renderSummary(): TemplateResult | typeof nothing {
-    if (this.items.length === 0) return nothing;
+    const items = this.visibleItems();
+    if (items.length === 0) return nothing;
 
     let available = 0;
     let missing = 0;
-    for (const item of this.items) {
+    for (const item of items) {
       if (item.status === 'available') available++;
       else if (item.status === 'not-found') missing++;
     }
 
     // Early return above guarantees items.length > 0.
-    const total = this.items.length;
+    const total = items.length;
     const r = 14;
     const circ = 2 * Math.PI * r;
     const availPct = available / total;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.140
+        version: 0.2.140(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: ^0.96.0
         version: 0.96.0(zod@4.4.3)
@@ -686,6 +689,65 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
+    resolution: {integrity: sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
+    resolution: {integrity: sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
+    resolution: {integrity: sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
+    resolution: {integrity: sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
+    resolution: {integrity: sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
+    resolution: {integrity: sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
+    resolution: {integrity: sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
+    resolution: {integrity: sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.140':
+    resolution: {integrity: sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/sdk@0.96.0':
     resolution: {integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==}
@@ -6217,6 +6279,54 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.140(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.140
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.96.0(zod@4.4.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
 
   packages/desktop:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.140
+        version: 0.2.140(zod@4.4.3)
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
@@ -380,6 +383,9 @@ importers:
 
   packages/extension:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.140
+        version: 0.2.140(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: ^0.96.0
         version: 0.96.0(zod@4.4.3)

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -74,6 +74,7 @@ export const SETTINGS_TAB_ORDER = [
   'AGENTS',
   'MULTI_AGENT',
   'TOOLS',
+  'AI_AGENTS',
   'GIT',
   'LATEX',
 ] as const;
@@ -272,6 +273,7 @@ export const ToolCategorySchema = z.enum([
   'lean',
   'workflow',
   'system',
+  'ai-agents',
 ]);
 export type ToolCategory = z.infer<typeof ToolCategorySchema>;
 

--- a/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
@@ -1,0 +1,199 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+
+// Local imports - shared
+import { MESSAGE_TYPES } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - tools
+import { runStreamedTurn } from '@tools/claudeAgent';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock('@tools/claudeAgentImport', () => ({
+  importClaudeAgentSdk: async () => mocks.query,
+  findClaudeBinaryPath: () => undefined,
+}));
+
+const streamId = 'stream:claude-child' as StreamTabId;
+
+async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
+  for (const message of messages) {
+    yield message;
+  }
+}
+
+async function runWithLoggerStore<T>(
+  fn: (store: StreamLogStore, logger: AgentLogger) => Promise<T>,
+): Promise<T> {
+  const previousStore = AgentLogger.getStreamLogStore();
+  const store = new StreamLogStore();
+  AgentLogger.setStreamLogStore(store);
+  await store.clear();
+
+  try {
+    return await fn(store, new AgentLogger(streamId, true));
+  } finally {
+    AgentLogger.setStreamLogStore(previousStore);
+  }
+}
+
+function collectToolLogs(store: StreamLogStore): unknown[] {
+  const log = store.get(streamId);
+  const entries = log?.getRange(0, log.head) ?? [];
+  return entries
+    .filter((entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE)
+    .map((entry) => entry.data);
+}
+
+function runTurn(logger: AgentLogger) {
+  return runStreamedTurn({
+    prompt: 'Run lint',
+    childStreamId: streamId,
+    logger,
+    abortController: new AbortController(),
+    model: 'claude-sonnet-4-6',
+    permissionMode: 'acceptEdits',
+    cwd: undefined,
+    additionalDirectories: undefined,
+    env: {},
+    resumeSessionId: undefined,
+    pathToClaudeCodeExecutable: undefined,
+  });
+}
+
+describe('claude agent progress events', () => {
+  afterEach(() => {
+    mocks.query.mockReset();
+  });
+
+  it('updates Claude tool-use logs without dropping the original tool metadata', async () => {
+    mocks.query.mockReturnValue(
+      streamMessages([
+        { type: 'system', subtype: 'init', session_id: 'sess-1' },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu-1',
+                name: 'Bash',
+                input: { command: 'npm run lint' },
+              },
+              { type: 'text', text: 'I will run lint.' },
+            ],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu-1',
+                content: 'lint passed',
+              },
+            ],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'sess-2',
+          result: 'Lint passed.',
+          usage: { input_tokens: 12, output_tokens: 4 },
+          total_cost_usd: 0.01,
+        },
+      ]),
+    );
+
+    await runWithLoggerStore(async (store, logger) => {
+      const result = await runTurn(logger);
+
+      expect(result).toMatchObject({
+        finalResponse: 'I will run lint.\n\nLint passed.',
+        sessionId: 'sess-2',
+        usage: { input_tokens: 12, output_tokens: 4 },
+        totalCostUsd: 0.01,
+        isError: false,
+      });
+
+      expect(collectToolLogs(store)).toEqual([
+        expect.objectContaining({
+          toolName: 'claude:Bash',
+          summary: 'npm run lint',
+          input: { command: 'npm run lint' },
+          output: 'lint passed',
+          status: 'completed',
+        }),
+      ]);
+    });
+  });
+
+  it('keeps Claude tool-result errors on the completed tool log', async () => {
+    mocks.query.mockReturnValue(
+      streamMessages([
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu-err',
+                name: 'Read',
+                input: { file_path: 'missing.tex' },
+              },
+            ],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu-err',
+                content: [{ type: 'text', text: 'File not found' }],
+                is_error: true,
+              },
+            ],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'error',
+          session_id: 'sess-error',
+          result: 'Claude failed',
+        },
+      ]),
+    );
+
+    await runWithLoggerStore(async (store, logger) => {
+      const result = await runTurn(logger);
+
+      expect(result).toMatchObject({
+        sessionId: 'sess-error',
+        isError: true,
+        errorMessage: 'Claude failed',
+      });
+
+      expect(collectToolLogs(store)).toEqual([
+        expect.objectContaining({
+          toolName: 'claude:Read',
+          summary: 'Read missing.tex',
+          input: { file_path: 'missing.tex' },
+          error: 'File not found',
+          isError: true,
+          status: 'completed',
+        }),
+      ]);
+    });
+  });
+});

--- a/src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts
+++ b/src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts
@@ -1,0 +1,44 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - tools
+import { buildAgentWorkspaceOptions } from '@tools/agentWorkspaceOptions';
+
+// Local imports - files
+import { WorkspaceFS } from '@utils/files';
+
+describe('agent workspace options', () => {
+  const originalGetPath = WorkspaceFS.getPath;
+
+  afterEach(() => {
+    WorkspaceFS.getPath = originalGetPath;
+  });
+
+  it('defaults to the workspace root when no working directory is provided', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    expect(buildAgentWorkspaceOptions()).toEqual({
+      workingDirectory: '/tmp/workspace',
+    });
+  });
+
+  it('keeps the workspace root available for subdirectory runs', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    expect(buildAgentWorkspaceOptions('packages/app')).toEqual({
+      workingDirectory: path.resolve('/tmp/workspace', 'packages/app'),
+      additionalDirectories: ['/tmp/workspace'],
+    });
+  });
+
+  it('does not add the current workspace for external worktree paths', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    expect(buildAgentWorkspaceOptions('/tmp/worktrees/feature-a')).toEqual({
+      workingDirectory: '/tmp/worktrees/feature-a',
+    });
+  });
+});

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -1,0 +1,51 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - model
+import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
+
+let secretStore: Map<string, string>;
+
+async function loadBuildClaudeAgentEnv(): Promise<
+  typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
+> {
+  vi.doMock('@platform/platform', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@platform/platform')>();
+    return {
+      ...actual,
+      platform: () => ({
+        secrets: {
+          async get(key: string) {
+            return secretStore.get(key);
+          },
+        },
+      }),
+    };
+  });
+
+  return (await import('@tools/claudeAgentConfig')).buildClaudeAgentEnv;
+}
+
+describe('Claude Agent configuration', () => {
+  beforeEach(() => {
+    secretStore = new Map();
+    vi.resetModules();
+    invalidateApiKeyCache();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('@platform/platform');
+    invalidateApiKeyCache();
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the managed Anthropic key over the inherited process env', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    await expect(buildClaudeAgentEnv()).resolves.toMatchObject({
+      ANTHROPIC_API_KEY: 'from-secret',
+    });
+  });
+});

--- a/src/tools/agentWorkspaceOptions.ts
+++ b/src/tools/agentWorkspaceOptions.ts
@@ -1,0 +1,54 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - files
+import { WorkspaceFS } from '@utils/files';
+
+export interface AgentWorkspaceOptions {
+  workingDirectory?: string;
+  additionalDirectories?: string[];
+}
+
+/**
+ * Resolve the working directory and any extra workspace roots for external
+ * agent SDKs that need access to the current project.
+ */
+export function buildAgentWorkspaceOptions(
+  workingDirectoryInput?: string | null,
+): AgentWorkspaceOptions {
+  const workspacePath = WorkspaceFS.getPath();
+  const trimmed = workingDirectoryInput?.trim();
+
+  if (!workspacePath) {
+    return trimmed ? { workingDirectory: trimmed } : {};
+  }
+
+  const workingDirectory = trimmed
+    ? path.isAbsolute(trimmed)
+      ? trimmed
+      : path.resolve(workspacePath, trimmed)
+    : workspacePath;
+
+  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const resolvedWorkingDirectory = path.resolve(workingDirectory);
+
+  if (resolvedWorkingDirectory === resolvedWorkspacePath) {
+    return { workingDirectory };
+  }
+
+  const relativeToWorkspace = path.relative(
+    resolvedWorkspacePath,
+    resolvedWorkingDirectory,
+  );
+  const isInsideWorkspace =
+    relativeToWorkspace.length > 0 &&
+    !relativeToWorkspace.startsWith('..') &&
+    !path.isAbsolute(relativeToWorkspace);
+
+  return isInsideWorkspace
+    ? {
+        workingDirectory,
+        additionalDirectories: [workspacePath],
+      }
+    : { workingDirectory };
+}

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -76,20 +76,10 @@ import { createChildStream } from './childStream';
 import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
+  CLAUDE_AGENT_PERMISSION_MODES,
+  type ClaudeAgentPermissionMode,
   type ClaudeMessageBlock,
 } from './claudeAgentShared';
-
-// ============================================================================
-// Permission modes — must be inlined for the zod schema; deeper config is
-// lazy-loaded from claudeAgentConfig.ts to keep src/tools/ free of vscode.
-// ============================================================================
-
-const CLAUDE_AGENT_SCHEMA_PERMISSION_MODES = [
-  'default',
-  'acceptEdits',
-  'bypassPermissions',
-  'plan',
-] as const;
 
 let _configModule: typeof import('./claudeAgentConfig') | null = null;
 async function getClaudeAgentConfig(): Promise<
@@ -109,7 +99,7 @@ const ClaudeAgentInputSchema = z.strictObject({
       'Instruction for the Claude Code agent. For a new session, describe the task. For a resume (session_id set), describe the follow-up.',
     ),
   permission_mode: z
-    .enum(CLAUDE_AGENT_SCHEMA_PERMISSION_MODES)
+    .enum(CLAUDE_AGENT_PERMISSION_MODES)
     .nullish()
     .describe(
       'Permission behavior for the agent (defaults to user-configured mode, typically acceptEdits).',
@@ -139,13 +129,10 @@ interface ActiveSession {
   parentStreamId: StreamTabId;
   executionId: ExecutionId;
   model: string;
-  permissionMode: ClaudeAgentPermissionModeLocal;
+  permissionMode: ClaudeAgentPermissionMode;
   cwd?: string;
   additionalDirectories?: string[];
 }
-
-type ClaudeAgentPermissionModeLocal =
-  (typeof CLAUDE_AGENT_SCHEMA_PERMISSION_MODES)[number];
 
 const sessionRegistry = new Map<string, ActiveSession>();
 
@@ -211,7 +198,7 @@ function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
   return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
 }
 
-export function finalizeClaudeAgentLoopStatus(
+function finalizeClaudeAgentLoopStatus(
   childStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
@@ -287,7 +274,7 @@ type ClaudeToolLogRef = ReturnType<AgentLogger['emitToolUse']> & {
   toolLog: ToolUseLog;
 };
 
-export function publishClaudeAgentStreamUsage(
+function publishClaudeAgentStreamUsage(
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   usage: TokenUsageStats,
@@ -343,7 +330,7 @@ export async function runStreamedTurn(params: {
   logger: AgentLogger;
   abortController: AbortController;
   model: string;
-  permissionMode: ClaudeAgentPermissionModeLocal;
+  permissionMode: ClaudeAgentPermissionMode;
   cwd: string | undefined;
   additionalDirectories: string[] | undefined;
   env: NodeJS.ProcessEnv;
@@ -519,7 +506,7 @@ function startClaudeAgentLoop(params: {
   logger: AgentLogger;
   initialPrompt: string;
   model: string;
-  permissionMode: ClaudeAgentPermissionModeLocal;
+  permissionMode: ClaudeAgentPermissionMode;
   cwd: string | undefined;
   additionalDirectories: string[] | undefined;
   env: NodeJS.ProcessEnv;
@@ -704,7 +691,7 @@ export class ClaudeAgentTool extends defineTool({
 
 async function launchClaudeAgentSession(
   input: ClaudeAgentInput,
-  permissionMode: ClaudeAgentPermissionModeLocal,
+  permissionMode: ClaudeAgentPermissionMode,
   model: string,
   parentStreamId: StreamTabId | undefined,
   parentExecutionId: ExecutionId | undefined,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -451,14 +451,13 @@ function handleAssistantBlocks(
         break;
       case 'tool_use': {
         if (typeof block.name !== 'string') break;
+        if (typeof block.id !== 'string' || block.id.length === 0) break;
         const toolLog = buildClaudeToolUseLog({
           toolName: block.name,
           input: block.input,
           status: 'in_progress',
         });
-        const blockId = (block as unknown as { id?: unknown }).id;
-        const id = typeof blockId === 'string' ? blockId : block.name;
-        refs.set(id, { ...logger.emitToolUse(toolLog), toolLog });
+        refs.set(block.id, { ...logger.emitToolUse(toolLog), toolLog });
         break;
       }
     }
@@ -637,11 +636,11 @@ function startClaudeAgentLoop(params: {
       }
     } finally {
       logger.endGroup(groupId, 'stopped');
-      unregisterInterruptible(childStreamId);
-      ToolUseFollowUpQueue.release(childStreamId);
       for (const sessionId of storedSessionIds) {
         sessionRegistry.delete(sessionId);
       }
+      unregisterInterruptible(childStreamId);
+      ToolUseFollowUpQueue.release(childStreamId);
       await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
       finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -124,7 +124,7 @@ const ClaudeAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      "Resume an existing Claude Code session with a follow-up instruction. The prompt is enqueued as the next turn; if the session is currently processing, the prompt waits in its queue.",
+      'Resume an existing Claude Code session with a follow-up instruction. The prompt is enqueued as the next turn; if the session is currently processing, the prompt waits in its queue.',
     ),
 });
 
@@ -216,7 +216,9 @@ export function finalizeClaudeAgentLoopStatus(
   runtimeHost: AgentRuntimeHost,
 ): void {
   if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, { runtimeHost });
+    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
+      runtimeHost,
+    });
   }
 }
 
@@ -384,7 +386,12 @@ async function runStreamedTurn(params: {
     if (raw.session_id) sessionId = raw.session_id;
 
     if (raw.type === 'assistant' && raw.message?.content) {
-      handleAssistantBlocks(raw.message.content, logger, toolLogRefs, responseParts);
+      handleAssistantBlocks(
+        raw.message.content,
+        logger,
+        toolLogRefs,
+        responseParts,
+      );
       continue;
     }
     if (raw.type === 'user' && raw.message?.content) {
@@ -429,7 +436,9 @@ function handleAssistantBlocks(
     switch (block.type) {
       case 'text':
         if (typeof block.text === 'string' && block.text.length > 0) {
-          logger.info(block.text, { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+          logger.info(block.text, {
+            messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+          });
           responseParts.push(block.text);
         }
         break;
@@ -537,7 +546,9 @@ function startClaudeAgentLoop(params: {
   const groupId = logger.startGroup('Claude Code session');
 
   queue.enqueue(initialPrompt);
-  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, { runtimeHost });
+  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+    runtimeHost,
+  });
 
   let resumeSessionId: string | undefined;
 
@@ -653,7 +664,8 @@ export class ClaudeAgentTool extends defineTool({
 }) {
   protected async execute(input: ClaudeAgentInput): Promise<ToolResult> {
     const config = await getClaudeAgentConfig();
-    const permissionMode = input.permission_mode ?? config.getClaudeAgentPermissionMode();
+    const permissionMode =
+      input.permission_mode ?? config.getClaudeAgentPermissionMode();
     const model = input.model ?? config.getClaudeAgentModel();
 
     const approvalLabel = `[claude_agent ${permissionMode}] ${input.prompt}`;

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -670,7 +670,7 @@ export class ClaudeAgentTool extends defineTool({
     const runContext = contexts?.runContext;
     callContext?.onExecutionReady?.();
 
-    if (input.session_id && sessionRegistry.has(input.session_id)) {
+    if (input.session_id) {
       return resumeClaudeAgentSession(
         input.session_id,
         input.prompt,
@@ -766,11 +766,11 @@ async function launchClaudeAgentSession(
   };
 }
 
-async function resumeClaudeAgentSession(
+function resumeClaudeAgentSession(
   sessionId: string,
   prompt: string,
   callerStreamId: StreamTabId | undefined,
-): Promise<ToolResult> {
+): ToolResult {
   const stored = sessionRegistry.get(sessionId);
   if (!stored) {
     throw new ToolError(

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -1,0 +1,798 @@
+/**
+ * Claude Agent tool — spin off a Claude Code agent via @anthropic-ai/claude-agent-sdk.
+ *
+ * Mirrors the codex / delegate_agent model: every call is async. Without a
+ * session_id, a new Claude Code session is started and the result is delivered
+ * as a follow-up to the parent stream. With a session_id, the prompt is
+ * enqueued as a follow-up instruction to an existing session via the SDK's
+ * `resume:` option (or via streaming-input on the live session). Each turn's
+ * result is delivered back to the parent's follow-up queue, so the
+ * orchestrator sees responses uniformly whether it or the user drove the turn.
+ *
+ * Authentication: the SDK spawns the Claude Code CLI as a subprocess, which
+ * picks up whichever auth the user has configured:
+ *   - ANTHROPIC_API_KEY env var (or stored in TeXRA Settings → API Keys)
+ *   - CLAUDE_CODE_OAUTH_TOKEN env var (long-lived OAuth token from
+ *     `claude setup-token`)
+ *   - OAuth session from `claude login` (Pro/Max subscription)
+ *   - Bedrock / Vertex (configured via CLI/env vars)
+ *
+ * Requires the native `claude` CLI binary — gated by the availability check
+ * in externalToolDefs.ts.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import {
+  getExecutionStore,
+  registerExecution,
+  writeTerminalStatus,
+} from '@agent/storage';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { untrackExecution } from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
+import {
+  getInterruptible,
+  registerInterruptible,
+  unregisterInterruptible,
+  type IInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
+import { toErrorMessage } from '@common/errors';
+import { AgentLogger } from '@logger/AgentLogger';
+import type {
+  StreamTabId,
+  ExecutionId,
+  StorageKey,
+  StreamStatus,
+  TokenUsageStats,
+  ToolUseLog,
+} from '@shared/schemas';
+import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
+import { ToolError, type ToolResult } from '@tools/result';
+import { parseWorkingDirectory } from '@tools/pathResolution';
+import {
+  requestBashApproval,
+  buildBashApprovalRejectedResult,
+} from '@tools/approval/bashApproval';
+import { formatDuration } from '@utils/core';
+import { generateExecutionId } from '@utils/core/executionId';
+import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
+
+// Local file imports
+import { defineTool } from './core/define';
+import {
+  importClaudeAgentSdk,
+  findClaudeBinaryPath,
+} from './claudeAgentImport';
+import { createChildStream } from './childStream';
+import {
+  buildClaudeToolUseLog,
+  buildClaudeUsageStats,
+  type ClaudeMessageBlock,
+} from './claudeAgentShared';
+
+// ============================================================================
+// Permission modes — must be inlined for the zod schema; deeper config is
+// lazy-loaded from claudeAgentConfig.ts to keep src/tools/ free of vscode.
+// ============================================================================
+
+const CLAUDE_AGENT_SCHEMA_PERMISSION_MODES = [
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+] as const;
+
+let _configModule: typeof import('./claudeAgentConfig') | null = null;
+async function getClaudeAgentConfig(): Promise<
+  typeof import('./claudeAgentConfig')
+> {
+  return (_configModule ??= await import('./claudeAgentConfig'));
+}
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const ClaudeAgentInputSchema = z.strictObject({
+  prompt: z
+    .string()
+    .describe(
+      'Instruction for the Claude Code agent. For a new session, describe the task. For a resume (session_id set), describe the follow-up.',
+    ),
+  permission_mode: z
+    .enum(CLAUDE_AGENT_SCHEMA_PERMISSION_MODES)
+    .nullish()
+    .describe(
+      'Permission behavior for the agent (defaults to user-configured mode, typically acceptEdits).',
+    ),
+  model: z
+    .string()
+    .nullish()
+    .describe(
+      "Claude model to use (e.g. 'claude-opus-4-7', 'claude-sonnet-4-6'). Defaults to user-configured model.",
+    ),
+  session_id: z
+    .string()
+    .nullish()
+    .describe(
+      "Resume an existing Claude Code session with a follow-up instruction. The prompt is enqueued as the next turn; if the session is currently processing, the prompt waits in its queue.",
+    ),
+});
+
+export type ClaudeAgentInput = z.infer<typeof ClaudeAgentInputSchema>;
+
+// ============================================================================
+// Session registry — keeps sessions alive between turns for follow-ups
+// ============================================================================
+
+interface ActiveSession {
+  childStreamId: StreamTabId;
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  model: string;
+  permissionMode: ClaudeAgentPermissionModeLocal;
+  cwd?: string;
+  additionalDirectories?: string[];
+}
+
+type ClaudeAgentPermissionModeLocal =
+  (typeof CLAUDE_AGENT_SCHEMA_PERMISSION_MODES)[number];
+
+const sessionRegistry = new Map<string, ActiveSession>();
+
+function storeSession(sessionId: string, entry: ActiveSession): void {
+  sessionRegistry.set(sessionId, entry);
+  void getExecutionStore(entry.executionId)
+    .write('claude_agent_session_id', sessionId)
+    .catch(() => {});
+}
+
+export function interruptAllClaudeAgentSessions(): void {
+  for (const { childStreamId } of [...sessionRegistry.values()]) {
+    getInterruptible(childStreamId)?.interrupt();
+  }
+}
+
+// ============================================================================
+// Interruptible session — runs the SDK query loop and accepts follow-ups
+// ============================================================================
+
+class ClaudeAgentSession implements IInterruptible {
+  private interrupted = false;
+  private queue: FollowUpQueue | null = null;
+  private turnAbortController: AbortController | null = null;
+
+  interrupt(): void {
+    this.interrupted = true;
+    this.queue?.cancelWait();
+    this.turnAbortController?.abort();
+  }
+
+  setQueue(q: FollowUpQueue): void {
+    this.queue = q;
+  }
+
+  isInterrupted(): boolean {
+    return this.interrupted;
+  }
+
+  startTurn(): AbortController {
+    this.turnAbortController = new AbortController();
+    return this.turnAbortController;
+  }
+
+  finishTurn(): void {
+    this.turnAbortController = null;
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+function isCleanInterruption(
+  err: unknown,
+  signal: AbortSignal,
+  session: ClaudeAgentSession,
+): boolean {
+  return signal.aborted || session.isInterrupted() || isAbortError(err);
+}
+
+function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
+  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
+}
+
+export function finalizeClaudeAgentLoopStatus(
+  childStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
+    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, { runtimeHost });
+  }
+}
+
+// ============================================================================
+// Result formatting
+// ============================================================================
+
+interface TurnResult {
+  finalResponse: string;
+  usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  } | null;
+  sessionId: string | undefined;
+  totalCostUsd?: number;
+  isError: boolean;
+  errorMessage?: string;
+}
+
+function formatClaudeDelivery(
+  executionId: string,
+  prompt: string,
+  wallTimeMs: number,
+  turn: TurnResult,
+): string {
+  const durationSec = (wallTimeMs / 1000).toFixed(1);
+  const response = turn.finalResponse || '(no response)';
+  const lines = [
+    `<claude-agent-result id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}"${turn.sessionId ? ` session-id="${escapeAttr(turn.sessionId)}"` : ''}>`,
+    `<wall-time>${durationSec}s</wall-time>`,
+    `<response>${escapeText(response)}</response>`,
+  ];
+
+  if (turn.usage) {
+    lines.push(
+      `<usage input="${turn.usage.input_tokens ?? 0}" output="${turn.usage.output_tokens ?? 0}" />`,
+    );
+  }
+  if (typeof turn.totalCostUsd === 'number' && turn.totalCostUsd > 0) {
+    lines.push(`<cost-usd>${turn.totalCostUsd.toFixed(4)}</cost-usd>`);
+  }
+
+  lines.push('</claude-agent-result>');
+  return lines.join('\n');
+}
+
+function formatClaudeError(
+  executionId: string,
+  prompt: string,
+  err: unknown,
+): string {
+  return [
+    `<claude-agent-error id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}">`,
+    `<message>${escapeText(toErrorMessage(err))}</message>`,
+    '</claude-agent-error>',
+  ].join('\n');
+}
+
+// ============================================================================
+// Stream tab helpers
+// ============================================================================
+
+type ClaudeToolLogRef = ReturnType<AgentLogger['emitToolUse']>;
+
+export function publishClaudeAgentStreamUsage(
+  childStreamId: StreamTabId,
+  executionId: ExecutionId,
+  usage: TokenUsageStats,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  runtimeHost.emit('updateStreamUsage', {
+    streamId: childStreamId,
+    storageKey: executionId as StorageKey,
+    executionId,
+    usage,
+  });
+}
+
+function logTurnSummary(
+  logger: AgentLogger,
+  wallTimeMs: number,
+  usage: TurnResult['usage'],
+): void {
+  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
+  if (usage) {
+    logger.info(
+      `Tokens: ${usage.input_tokens ?? 0} in / ${usage.output_tokens ?? 0} out`,
+    );
+  }
+}
+
+// ============================================================================
+// SDK type aliases — we keep these loose to avoid pulling the SDK's full type
+// surface (which depends on a private @anthropic-ai/sdk MessageParam shape)
+// into VS Code-free zones.
+// ============================================================================
+
+interface SdkMessage {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  message?: { content?: ClaudeMessageBlock[] };
+  parent_tool_use_id?: string | null;
+  result?: string;
+  is_error?: boolean;
+  total_cost_usd?: number;
+  usage?: TurnResult['usage'];
+}
+
+// ============================================================================
+// Streamed turn — drains the SDK's async generator into log entries + a
+// TurnResult for follow-up delivery.
+// ============================================================================
+
+async function runStreamedTurn(params: {
+  prompt: string;
+  childStreamId: StreamTabId;
+  logger: AgentLogger;
+  abortController: AbortController;
+  model: string;
+  permissionMode: ClaudeAgentPermissionModeLocal;
+  cwd: string | undefined;
+  additionalDirectories: string[] | undefined;
+  env: NodeJS.ProcessEnv;
+  resumeSessionId: string | undefined;
+  pathToClaudeCodeExecutable: string | undefined;
+}): Promise<TurnResult> {
+  const { logger, prompt } = params;
+  logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
+
+  const query = await importClaudeAgentSdk();
+
+  const sdkOptions: Record<string, unknown> = {
+    abortController: params.abortController,
+    model: params.model,
+    permissionMode: params.permissionMode,
+    env: params.env,
+    systemPrompt: { type: 'preset', preset: 'claude_code' },
+    settingSources: ['user', 'project', 'local'],
+  };
+  if (params.permissionMode === 'bypassPermissions') {
+    sdkOptions.allowDangerouslySkipPermissions = true;
+  }
+  if (params.cwd) sdkOptions.cwd = params.cwd;
+  if (params.additionalDirectories?.length) {
+    sdkOptions.additionalDirectories = params.additionalDirectories;
+  }
+  if (params.resumeSessionId) sdkOptions.resume = params.resumeSessionId;
+  if (params.pathToClaudeCodeExecutable) {
+    sdkOptions.pathToClaudeCodeExecutable = params.pathToClaudeCodeExecutable;
+  }
+
+  const stream = query({ prompt, options: sdkOptions });
+  const responseParts: string[] = [];
+  const toolLogRefs = new Map<string, ClaudeToolLogRef>();
+  let usage: TurnResult['usage'] = null;
+  let sessionId: string | undefined;
+  let totalCostUsd: number | undefined;
+  let isError = false;
+  let errorMessage: string | undefined;
+
+  for await (const raw of stream as AsyncIterable<SdkMessage>) {
+    if (raw.session_id) sessionId = raw.session_id;
+
+    if (raw.type === 'assistant' && raw.message?.content) {
+      handleAssistantBlocks(raw.message.content, logger, toolLogRefs, responseParts);
+      continue;
+    }
+    if (raw.type === 'user' && raw.message?.content) {
+      handleToolResults(raw.message.content, logger, toolLogRefs);
+      continue;
+    }
+    if (raw.type === 'result') {
+      usage = raw.usage ?? null;
+      totalCostUsd = raw.total_cost_usd;
+      if (raw.subtype === 'success') {
+        if (typeof raw.result === 'string' && raw.result.length > 0) {
+          responseParts.push(raw.result);
+        }
+      } else {
+        isError = true;
+        errorMessage = raw.result ?? raw.subtype ?? 'Claude Code error';
+      }
+      continue;
+    }
+    if (raw.type === 'system' && raw.subtype === 'init' && raw.session_id) {
+      logger.info(`Claude session ${raw.session_id} started`);
+    }
+  }
+
+  return {
+    finalResponse: responseParts.join('\n\n'),
+    usage,
+    sessionId,
+    totalCostUsd,
+    isError,
+    errorMessage,
+  };
+}
+
+function handleAssistantBlocks(
+  blocks: ClaudeMessageBlock[],
+  logger: AgentLogger,
+  refs: Map<string, ClaudeToolLogRef>,
+  responseParts: string[],
+): void {
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'text':
+        if (typeof block.text === 'string' && block.text.length > 0) {
+          logger.info(block.text, { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+          responseParts.push(block.text);
+        }
+        break;
+      case 'thinking':
+        if (typeof block.thinking === 'string' && block.thinking.length > 0) {
+          logger.info(block.thinking, { messageType: MESSAGE_TYPES.THINKING });
+        }
+        break;
+      case 'tool_use': {
+        if (typeof block.name !== 'string') break;
+        const toolLog = buildClaudeToolUseLog({
+          toolName: block.name,
+          input: block.input,
+          status: 'in_progress',
+        });
+        const blockId = (block as unknown as { id?: unknown }).id;
+        const id = typeof blockId === 'string' ? blockId : block.name;
+        refs.set(id, logger.emitToolUse(toolLog));
+        break;
+      }
+    }
+  }
+}
+
+function handleToolResults(
+  blocks: ClaudeMessageBlock[],
+  logger: AgentLogger,
+  refs: Map<string, ClaudeToolLogRef>,
+): void {
+  for (const block of blocks) {
+    if (block.type !== 'tool_result') continue;
+    const id = block.tool_use_id;
+    if (typeof id !== 'string') continue;
+    const ref = refs.get(id);
+    if (!ref) continue;
+
+    const isError = block.is_error === true;
+    const update: Partial<ToolUseLog> = {
+      ...(block.content !== undefined && {
+        output: block.content as ToolUseLog['output'],
+      }),
+      ...(isError && {
+        error: extractToolErrorMessage(block.content) ?? 'Tool error',
+        isError: true,
+      }),
+    };
+    logger.updateToolUse(
+      ref.logId,
+      update,
+      ref.groupId,
+      isError ? 'completed' : 'completed',
+    );
+    refs.delete(id);
+  }
+}
+
+function extractToolErrorMessage(content: unknown): string | undefined {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return undefined;
+  for (const block of content) {
+    if (
+      block != null &&
+      typeof block === 'object' &&
+      'text' in block &&
+      typeof (block as { text?: unknown }).text === 'string'
+    ) {
+      return (block as { text: string }).text;
+    }
+  }
+  return undefined;
+}
+
+// ============================================================================
+// Session loop — drains follow-ups, runs turns, delivers results to parent
+// ============================================================================
+
+function startClaudeAgentLoop(params: {
+  childStreamId: StreamTabId;
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  logger: AgentLogger;
+  initialPrompt: string;
+  model: string;
+  permissionMode: ClaudeAgentPermissionModeLocal;
+  cwd: string | undefined;
+  additionalDirectories: string[] | undefined;
+  env: NodeJS.ProcessEnv;
+  pathToClaudeCodeExecutable: string | undefined;
+  runtimeHost: AgentRuntimeHost;
+}): void {
+  const {
+    childStreamId,
+    parentStreamId,
+    executionId,
+    logger,
+    initialPrompt,
+    runtimeHost,
+  } = params;
+
+  const session = new ClaudeAgentSession();
+  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  session.setQueue(queue);
+  registerInterruptible(childStreamId, session);
+
+  const groupId = logger.startGroup('Claude Code session');
+
+  queue.enqueue(initialPrompt);
+  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, { runtimeHost });
+
+  let resumeSessionId: string | undefined;
+
+  void (async () => {
+    try {
+      while (!session.isInterrupted()) {
+        const messages = await queue.waitAndDrainAll(() =>
+          session.isInterrupted(),
+        );
+        if (!messages || session.isInterrupted()) break;
+
+        const prompt = messages.join('\n\n');
+        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
+          runtimeHost,
+        });
+        const startedAt = Date.now();
+        const ac = session.startTurn();
+
+        let turn: TurnResult | null = null;
+        let err: unknown = null;
+        try {
+          turn = await runStreamedTurn({
+            prompt,
+            childStreamId,
+            logger,
+            abortController: ac,
+            model: params.model,
+            permissionMode: params.permissionMode,
+            cwd: params.cwd,
+            additionalDirectories: params.additionalDirectories,
+            env: params.env,
+            resumeSessionId,
+            pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
+          });
+          if (turn.sessionId) resumeSessionId = turn.sessionId;
+          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
+          if (turn.isError && turn.errorMessage) {
+            logger.error(turn.errorMessage);
+          }
+        } catch (caught) {
+          if (isCleanInterruption(caught, ac.signal, session)) break;
+          err = caught;
+          logger.error(toErrorMessage(caught));
+        } finally {
+          session.finishTurn();
+        }
+
+        const wallTimeMs = Date.now() - startedAt;
+        if (turn?.sessionId && !sessionRegistry.has(turn.sessionId)) {
+          storeSession(turn.sessionId, {
+            childStreamId,
+            parentStreamId,
+            executionId,
+            model: params.model,
+            permissionMode: params.permissionMode,
+            cwd: params.cwd,
+            additionalDirectories: params.additionalDirectories,
+          });
+        }
+
+        if (turn?.usage) {
+          publishClaudeAgentStreamUsage(
+            childStreamId,
+            executionId,
+            buildClaudeUsageStats(turn.usage),
+            runtimeHost,
+          );
+        }
+
+        const msg =
+          turn && !err
+            ? formatClaudeDelivery(executionId, prompt, wallTimeMs, turn)
+            : formatClaudeError(executionId, prompt, err);
+        try {
+          await getExecutionStore(executionId).writeReport(msg);
+        } catch {
+          // Best-effort; delivery must not block on storage.
+        }
+        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+
+        if (!session.isInterrupted()) {
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+            runtimeHost,
+          });
+        }
+      }
+    } finally {
+      logger.endGroup(groupId, 'stopped');
+      unregisterInterruptible(childStreamId);
+      ToolUseFollowUpQueue.release(childStreamId);
+      if (resumeSessionId) sessionRegistry.delete(resumeSessionId);
+      await writeTerminalStatus(executionId, 'completed').catch(() => {});
+      untrackExecution(executionId);
+      finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);
+    }
+  })();
+}
+
+// ============================================================================
+// Tool
+// ============================================================================
+
+export class ClaudeAgentTool extends defineTool({
+  name: 'claude_agent',
+  description:
+    'Spin off a Claude Code agent (via @anthropic-ai/claude-agent-sdk) to perform code analysis, generation, or research. ' +
+    'The agent runs the native `claude` binary locally and can read files, run commands, and make edits within its permission mode. ' +
+    'Requires the Claude Code CLI (auto-installed with @anthropic-ai/claude-agent-sdk, or via `npm install -g @anthropic-ai/claude-code`). ' +
+    'Auth: ANTHROPIC_API_KEY (via TeXRA Settings → API Keys or env var), CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token`), or `claude login` OAuth session. ' +
+    'Always async: returns immediately with an execution ID; each turn is delivered back as a follow-up message (including the session_id). ' +
+    'Pass session_id on a later call to send a follow-up to an existing session — mirrors delegate_agent(execution_id=…).',
+  schema: ClaudeAgentInputSchema,
+}) {
+  protected async execute(input: ClaudeAgentInput): Promise<ToolResult> {
+    const config = await getClaudeAgentConfig();
+    const permissionMode = input.permission_mode ?? config.getClaudeAgentPermissionMode();
+    const model = input.model ?? config.getClaudeAgentModel();
+
+    const approvalLabel = `[claude_agent ${permissionMode}] ${input.prompt}`;
+    const approval = await requestBashApproval({ command: approvalLabel });
+    if (!approval.accepted) {
+      return buildBashApprovalRejectedResult(
+        approvalLabel,
+        approval.userMessage,
+      );
+    }
+
+    const contexts = getCurrentToolContexts();
+    const callContext = contexts?.callContext;
+    const runContext = contexts?.runContext;
+    callContext?.onExecutionReady?.();
+
+    if (input.session_id && sessionRegistry.has(input.session_id)) {
+      return resumeClaudeAgentSession(
+        input.session_id,
+        input.prompt,
+        runContext?.streamId,
+      );
+    }
+    return launchClaudeAgentSession(
+      input,
+      permissionMode,
+      model,
+      runContext?.streamId,
+      runContext?.executionId,
+      runContext?.workingDirectory,
+      runContext?.runtimeHost,
+    );
+  }
+}
+
+async function launchClaudeAgentSession(
+  input: ClaudeAgentInput,
+  permissionMode: ClaudeAgentPermissionModeLocal,
+  model: string,
+  parentStreamId: StreamTabId | undefined,
+  parentExecutionId: ExecutionId | undefined,
+  parentWorkingDirectory: string | undefined,
+  runtimeHost: AgentRuntimeHost | undefined,
+): Promise<ToolResult> {
+  if (!parentStreamId || !runtimeHost) {
+    throw new ToolError(
+      'Claude Agent requires a parent stream runtime context — it must be called from an active tool-use agent.',
+    );
+  }
+
+  const config = await getClaudeAgentConfig();
+  const workingDir = parseWorkingDirectory(parentWorkingDirectory);
+  const workspace = config.buildClaudeAgentWorkspaceOptions(workingDir);
+  const env = await config.buildClaudeAgentEnv();
+
+  const executionId = generateExecutionId();
+  await ensureRunDir(executionId);
+
+  const agentConfig = config.buildClaudeAgentConfig(input.prompt);
+
+  try {
+    await registerExecution(
+      executionId,
+      agentConfig,
+      'claude_agent',
+      parentExecutionId,
+    );
+  } catch {
+    throw new ToolError('Failed to register Claude Agent execution.');
+  }
+
+  const { childStreamId, logger } = createChildStream(
+    executionId,
+    parentStreamId,
+    {
+      streamPrefix: 'claude@agent-sdk',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'claude_agent',
+      description: input.prompt,
+      config: agentConfig,
+      toolName: 'claude_agent',
+      runtimeHost,
+    },
+  );
+
+  startClaudeAgentLoop({
+    childStreamId,
+    parentStreamId,
+    executionId,
+    logger,
+    initialPrompt: input.prompt,
+    model,
+    permissionMode,
+    cwd: workspace.cwd,
+    additionalDirectories: workspace.additionalDirectories,
+    env,
+    pathToClaudeCodeExecutable: findClaudeBinaryPath(),
+    runtimeHost,
+  });
+
+  const preview = truncateWithEllipsis(input.prompt, 60);
+  return {
+    summary: `Launched Claude Agent: ${preview}`,
+    output: [
+      `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,
+      `Execution ID: ${executionId}`,
+      `Stream tab: ${childStreamId}`,
+      `Result will be delivered as a follow-up message when the turn completes. The delivery includes the session_id — pass it back on a later call to send a follow-up.`,
+    ].join('\n'),
+  };
+}
+
+async function resumeClaudeAgentSession(
+  sessionId: string,
+  prompt: string,
+  callerStreamId: StreamTabId | undefined,
+): Promise<ToolResult> {
+  const stored = sessionRegistry.get(sessionId);
+  if (!stored) {
+    throw new ToolError(
+      `Claude Agent session '${sessionId}' is not active. It may have completed or been stopped; start a new session without session_id.`,
+    );
+  }
+
+  if (callerStreamId && stored.parentStreamId !== callerStreamId) {
+    throw new ToolError(
+      `Claude Agent session '${sessionId}' is owned by a different session; start a new session without session_id to run in this context.`,
+    );
+  }
+
+  const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
+  queue.enqueue(prompt);
+
+  const preview = truncateWithEllipsis(prompt, 60);
+  return {
+    summary: `Follow-up queued for Claude Agent: ${preview}`,
+    output: [
+      `Follow-up instruction queued for Claude Code session '${sessionId}'. The agent will process it and deliver a new result automatically.`,
+      `Execution ID: ${stored.executionId}`,
+    ].join('\n'),
+  };
+}

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -283,7 +283,9 @@ function formatClaudeError(
 // Stream tab helpers
 // ============================================================================
 
-type ClaudeToolLogRef = ReturnType<AgentLogger['emitToolUse']>;
+type ClaudeToolLogRef = ReturnType<AgentLogger['emitToolUse']> & {
+  toolLog: ToolUseLog;
+};
 
 export function publishClaudeAgentStreamUsage(
   childStreamId: StreamTabId,
@@ -335,7 +337,7 @@ interface SdkMessage {
 // TurnResult for follow-up delivery.
 // ============================================================================
 
-async function runStreamedTurn(params: {
+export async function runStreamedTurn(params: {
   prompt: string;
   childStreamId: StreamTabId;
   logger: AgentLogger;
@@ -456,7 +458,7 @@ function handleAssistantBlocks(
         });
         const blockId = (block as unknown as { id?: unknown }).id;
         const id = typeof blockId === 'string' ? blockId : block.name;
-        refs.set(id, logger.emitToolUse(toolLog));
+        refs.set(id, { ...logger.emitToolUse(toolLog), toolLog });
         break;
       }
     }
@@ -476,6 +478,7 @@ function handleToolResults(
     if (!ref) continue;
 
     const isError = block.is_error === true;
+    const { status: _status, ...baseLog } = ref.toolLog;
     const update: Partial<ToolUseLog> = {
       ...(block.content !== undefined && {
         output: block.content as ToolUseLog['output'],
@@ -485,12 +488,7 @@ function handleToolResults(
         isError: true,
       }),
     };
-    logger.updateToolUse(
-      ref.logId,
-      update,
-      ref.groupId,
-      isError ? 'completed' : 'completed',
-    );
+    logger.updateToolUse(ref.logId, { ...baseLog, ...update }, ref.groupId);
     refs.delete(id);
   }
 }
@@ -551,6 +549,7 @@ function startClaudeAgentLoop(params: {
   });
 
   let resumeSessionId: string | undefined;
+  const storedSessionIds = new Set<string>();
 
   void (async () => {
     try {
@@ -607,6 +606,7 @@ function startClaudeAgentLoop(params: {
             cwd: params.cwd,
             additionalDirectories: params.additionalDirectories,
           });
+          storedSessionIds.add(turn.sessionId);
         }
 
         if (turn?.usage) {
@@ -639,7 +639,9 @@ function startClaudeAgentLoop(params: {
       logger.endGroup(groupId, 'stopped');
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
-      if (resumeSessionId) sessionRegistry.delete(resumeSessionId);
+      for (const sessionId of storedSessionIds) {
+        sessionRegistry.delete(sessionId);
+      }
       await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
       finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -1,13 +1,10 @@
-// Standard library imports
-import * as path from 'path';
-
 // Local imports - agent config
 import { platform } from '@platform/platform';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { getWorkspaceState } from '@agent/core/stateStore';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
-import { WorkspaceFS } from '@utils/files';
+import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,
@@ -100,35 +97,17 @@ export interface ClaudeAgentWorkspaceOptions {
 export function buildClaudeAgentWorkspaceOptions(
   workingDirectoryInput?: string | null,
 ): ClaudeAgentWorkspaceOptions {
-  const workspacePath = WorkspaceFS.getPath();
-  const trimmed = workingDirectoryInput?.trim();
+  const workspace = buildAgentWorkspaceOptions(workingDirectoryInput);
+  const options: ClaudeAgentWorkspaceOptions = {};
 
-  if (!workspacePath) {
-    return trimmed ? { cwd: trimmed } : {};
+  if (workspace.workingDirectory) {
+    options.cwd = workspace.workingDirectory;
+  }
+  if (workspace.additionalDirectories) {
+    options.additionalDirectories = workspace.additionalDirectories;
   }
 
-  const cwd = trimmed
-    ? path.isAbsolute(trimmed)
-      ? trimmed
-      : path.resolve(workspacePath, trimmed)
-    : workspacePath;
-
-  const resolvedWorkspacePath = path.resolve(workspacePath);
-  const resolvedCwd = path.resolve(cwd);
-
-  if (resolvedCwd === resolvedWorkspacePath) {
-    return { cwd };
-  }
-
-  const relativeToWorkspace = path.relative(resolvedWorkspacePath, resolvedCwd);
-  const isInsideWorkspace =
-    relativeToWorkspace.length > 0 &&
-    !relativeToWorkspace.startsWith('..') &&
-    !path.isAbsolute(relativeToWorkspace);
-
-  return isInsideWorkspace
-    ? { cwd, additionalDirectories: [workspacePath] }
-    : { cwd };
+  return options;
 }
 
 // ============================================================================

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -11,6 +11,8 @@ import { WorkspaceFS } from '@utils/files';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,
+  CLAUDE_AGENT_PERMISSION_MODES,
+  type ClaudeAgentPermissionMode,
 } from './claudeAgentShared';
 
 // ============================================================================
@@ -30,22 +32,13 @@ export function getClaudeAgentModel(): string {
 // Permission mode
 // ============================================================================
 
-const PERMISSION_MODES = [
-  'default',
-  'acceptEdits',
-  'bypassPermissions',
-  'plan',
-] as const;
-export const CLAUDE_AGENT_PERMISSION_MODES = PERMISSION_MODES;
-export type ClaudeAgentPermissionMode = (typeof PERMISSION_MODES)[number];
-
 const PERMISSION_MODE_KEY = 'texra.claudeAgentPermissionMode';
 const PERMISSION_MODE_DEFAULT: ClaudeAgentPermissionMode = 'acceptEdits';
 
 export function parseClaudeAgentPermissionMode(
   raw: string,
 ): ClaudeAgentPermissionMode {
-  return (PERMISSION_MODES as readonly string[]).includes(raw)
+  return (CLAUDE_AGENT_PERMISSION_MODES as readonly string[]).includes(raw)
     ? (raw as ClaudeAgentPermissionMode)
     : PERMISSION_MODE_DEFAULT;
 }

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -73,7 +73,7 @@ export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
     () => undefined,
   );
-  if (managed && !env[apiKeyEnvName('anthropic')]) {
+  if (managed) {
     env[apiKeyEnvName('anthropic')] = managed;
   }
 

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -1,0 +1,152 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - agent config
+import { platform } from '@platform/platform';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { getWorkspaceState } from '@agent/core/stateStore';
+import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
+import { WorkspaceFS } from '@utils/files';
+import {
+  CLAUDE_AGENT_NAME,
+  CLAUDE_AGENT_DISPLAY_MODEL,
+} from './claudeAgentShared';
+
+// ============================================================================
+// Model — defaults to Opus 4.7; users can override per-call or via workspace state
+// ============================================================================
+
+/** Default Claude model passed to the Agent SDK. */
+export const CLAUDE_AGENT_DEFAULT_MODEL = 'claude-opus-4-7';
+
+const MODEL_KEY = 'texra.claudeAgentModel';
+
+export function getClaudeAgentModel(): string {
+  return getWorkspaceState().get<string>(MODEL_KEY, CLAUDE_AGENT_DEFAULT_MODEL);
+}
+
+// ============================================================================
+// Permission mode
+// ============================================================================
+
+const PERMISSION_MODES = [
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+] as const;
+export const CLAUDE_AGENT_PERMISSION_MODES = PERMISSION_MODES;
+export type ClaudeAgentPermissionMode = (typeof PERMISSION_MODES)[number];
+
+const PERMISSION_MODE_KEY = 'texra.claudeAgentPermissionMode';
+const PERMISSION_MODE_DEFAULT: ClaudeAgentPermissionMode = 'acceptEdits';
+
+export function parseClaudeAgentPermissionMode(
+  raw: string,
+): ClaudeAgentPermissionMode {
+  return (PERMISSION_MODES as readonly string[]).includes(raw)
+    ? (raw as ClaudeAgentPermissionMode)
+    : PERMISSION_MODE_DEFAULT;
+}
+
+export function getClaudeAgentPermissionMode(): ClaudeAgentPermissionMode {
+  const raw = getWorkspaceState().get<string>(
+    PERMISSION_MODE_KEY,
+    PERMISSION_MODE_DEFAULT,
+  );
+  return parseClaudeAgentPermissionMode(raw);
+}
+
+// ============================================================================
+// Auth env — pulls ANTHROPIC_API_KEY from secrets if set
+// ============================================================================
+
+/**
+ * Build the env block passed to the Claude Code subprocess.
+ *
+ * Resolution order matches user expectations:
+ *   1. Workspace-managed secret (Settings → API Keys → Anthropic) wins, so
+ *      a key set in TeXRA "just works."
+ *   2. Otherwise we leave `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN`
+ *      alone — the CLI handles them itself, and if neither is set it falls
+ *      back to the `~/.claude/` config produced by `claude login`.
+ *
+ * The SDK identifies itself in the User-Agent via CLAUDE_AGENT_SDK_CLIENT_APP.
+ */
+export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+
+  const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
+    () => undefined,
+  );
+  if (managed && !env[apiKeyEnvName('anthropic')]) {
+    env[apiKeyEnvName('anthropic')] = managed;
+  }
+
+  env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
+  return env;
+}
+
+// ============================================================================
+// Workspace options — mirrors codex behavior so subagents can see the project
+// ============================================================================
+
+export interface ClaudeAgentWorkspaceOptions {
+  cwd?: string;
+  additionalDirectories?: string[];
+}
+
+/**
+ * Compute the cwd + extra-roots the SDK should see.
+ *
+ * When the call is made from inside the workspace, the agent runs in that
+ * directory but is also granted read access to the workspace root so it can
+ * inspect sibling files. Out-of-workspace cwds run isolated (matches codex).
+ */
+export function buildClaudeAgentWorkspaceOptions(
+  workingDirectoryInput?: string | null,
+): ClaudeAgentWorkspaceOptions {
+  const workspacePath = WorkspaceFS.getPath();
+  const trimmed = workingDirectoryInput?.trim();
+
+  if (!workspacePath) {
+    return trimmed ? { cwd: trimmed } : {};
+  }
+
+  const cwd = trimmed
+    ? path.isAbsolute(trimmed)
+      ? trimmed
+      : path.resolve(workspacePath, trimmed)
+    : workspacePath;
+
+  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const resolvedCwd = path.resolve(cwd);
+
+  if (resolvedCwd === resolvedWorkspacePath) {
+    return { cwd };
+  }
+
+  const relativeToWorkspace = path.relative(resolvedWorkspacePath, resolvedCwd);
+  const isInsideWorkspace =
+    relativeToWorkspace.length > 0 &&
+    !relativeToWorkspace.startsWith('..') &&
+    !path.isAbsolute(relativeToWorkspace);
+
+  return isInsideWorkspace
+    ? { cwd, additionalDirectories: [workspacePath] }
+    : { cwd };
+}
+
+// ============================================================================
+// Synthetic execution metadata for child streams
+// ============================================================================
+
+export function buildClaudeAgentConfig(prompt: string): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: CLAUDE_AGENT_NAME,
+    model: CLAUDE_AGENT_DISPLAY_MODEL,
+    instruction: prompt,
+    agentCategory: AgentCategory.ToolUse,
+  });
+}

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -1,0 +1,245 @@
+/**
+ * Helpers for the Claude Agent tool.
+ *
+ * 1. `importClaudeAgentSdk()` — import `query` from `@anthropic-ai/claude-agent-sdk`.
+ *    The SDK is ESM-only; esbuild converts it to CJS at bundle time (so it must
+ *    NOT be listed in esbuild's `external` array). The dynamic import() below
+ *    is rewritten to require() by esbuild.
+ *
+ * 2. `findClaudeBinaryPath()` — locate the native Claude Code CLI binary. The
+ *    SDK bundles its own platform binary as an optional dependency, but in a
+ *    packaged Electron/VSIX build it cannot resolve that binary via Node's
+ *    package resolution. We probe Electron's `app.asar.unpacked` resources,
+ *    the local `node_modules`, the global npm prefix, and PATH (in that
+ *    priority order) and pass the result as `pathToClaudeCodeExecutable` to
+ *    `query()`. Results are cached for the session.
+ */
+
+import { execSync } from 'child_process';
+import { createRequire } from 'module';
+import * as path from 'path';
+import { existsSync } from 'fs';
+
+type QueryFn = (params: {
+  prompt: string | AsyncIterable<unknown>;
+  options?: Record<string, unknown>;
+}) => AsyncGenerator<unknown, void>;
+
+type PlatformInfo = { pkg: string };
+type ElectronProcess = NodeJS.Process & {
+  defaultApp?: boolean;
+  resourcesPath?: string;
+};
+
+// ---------------------------------------------------------------------------
+// SDK import
+// ---------------------------------------------------------------------------
+
+let cachedQuery: QueryFn | undefined;
+
+/**
+ * Import the `query` function from `@anthropic-ai/claude-agent-sdk`.
+ *
+ * The SDK is ESM-only ("type": "module"). esbuild converts the dynamic import
+ * to a CJS require at build time — keep the package OUT of esbuild's
+ * `external` array.
+ */
+export async function importClaudeAgentSdk(): Promise<QueryFn> {
+  if (cachedQuery) return cachedQuery;
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import('@anthropic-ai/claude-agent-sdk');
+  } catch (err: unknown) {
+    const code = (err as { code?: string }).code;
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        '@anthropic-ai/claude-agent-sdk package not found. Install with: npm install -g @anthropic-ai/claude-code',
+      );
+    }
+    throw err;
+  }
+
+  const queryFn =
+    mod.query ??
+    (mod.default as Record<string, unknown> | undefined)?.query ??
+    mod.default;
+
+  if (typeof queryFn !== 'function') {
+    const keys = Object.keys(mod).join(', ');
+    throw new Error(
+      `query() not found in @anthropic-ai/claude-agent-sdk. Module keys: [${keys}]. ` +
+        'Ensure @anthropic-ai/claude-agent-sdk is NOT in esbuild externals.',
+    );
+  }
+
+  cachedQuery = queryFn as QueryFn;
+  return cachedQuery;
+}
+
+// ---------------------------------------------------------------------------
+// Binary resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Platform key → npm package name for the bundled `claude` binary.
+ * The Claude Agent SDK ships one platform package per OS/arch; each contains
+ * a single `claude` binary at the package root.
+ */
+const PLATFORM_INFO: Record<string, PlatformInfo> = {
+  'linux-x64': { pkg: '@anthropic-ai/claude-agent-sdk-linux-x64' },
+  'linux-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-linux-arm64' },
+  'darwin-x64': { pkg: '@anthropic-ai/claude-agent-sdk-darwin-x64' },
+  'darwin-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-darwin-arm64' },
+  'win32-x64': { pkg: '@anthropic-ai/claude-agent-sdk-win32-x64' },
+  'win32-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-win32-arm64' },
+};
+
+/** Cached result — found paths are cached; misses are retried. */
+let cachedBinaryPath: string | undefined;
+
+/**
+ * Locate the native Claude Code CLI binary. Results are cached for the session
+ * (misses are always retried so mid-session installs are picked up).
+ *
+ * The caller should pass the result as `pathToClaudeCodeExecutable` to the
+ * SDK's `query()` options. Returning `undefined` lets the SDK fall back to
+ * its own resolution.
+ */
+export function findClaudeBinaryPath(): string | undefined {
+  if (cachedBinaryPath !== undefined) return cachedBinaryPath;
+
+  const result = findClaudeBinaryPathUncached();
+  if (result) cachedBinaryPath = result;
+  return result;
+}
+
+function findClaudeBinaryPathUncached(): string | undefined {
+  const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
+  if (!info) return undefined;
+
+  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
+
+  // Strategy 1: packaged Electron app.asar.unpacked resources
+  // Highest priority when present — packaged apps cannot execute binaries
+  // from inside app.asar.
+  {
+    const resourcesPath = getPackagedElectronResourcesPath();
+    const result =
+      resourcesPath == null
+        ? undefined
+        : findClaudeBinaryInElectronResources(resourcesPath);
+    if (result) return result;
+  }
+
+  // Strategy 2: resolve from local project's node_modules
+  // Preferred in VS Code extension development — matches package.json.
+  {
+    const result = resolveClaudeBinary(path.join(__dirname, '..'), info);
+    if (result) return result;
+  }
+
+  // Strategy 3: resolve from global npm prefix
+  // Preferred over PATH because the npm-installed binary matches the SDK.
+  try {
+    const prefix = execSync('npm prefix -g', {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+
+    const roots = [
+      path.join(
+        prefix,
+        'lib',
+        'node_modules',
+        '@anthropic-ai',
+        'claude-agent-sdk',
+      ),
+      path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+    ];
+
+    for (const sdkRoot of roots) {
+      const result = resolveClaudeBinary(sdkRoot, info);
+      if (result) return result;
+    }
+  } catch {
+    // npm prefix -g failed
+  }
+
+  // Strategy 4: PATH lookup (native installer, Homebrew, manual install)
+  // The Claude Code CLI's recommended installer drops a `claude` binary into
+  // ~/.local/bin (or similar) that the SDK is happy to invoke directly.
+  try {
+    const whichCmd =
+      process.platform === 'win32' ? 'where claude' : 'which claude';
+    const pathHits = execSync(whichCmd, {
+      encoding: 'utf8',
+      timeout: 5000,
+    })
+      .trim()
+      .split(/\r?\n/);
+
+    // On Windows, skip .cmd/.ps1 shims (npm wrappers) — the SDK spawns
+    // the binary directly without shell:true, so shims aren't executable.
+    for (const hit of pathHits) {
+      const p = hit.trim();
+      if (!p) continue;
+      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
+      if (existsSync(p)) return p;
+    }
+  } catch {
+    // claude not on PATH
+  }
+
+  return undefined;
+}
+
+/**
+ * Locate the Claude binary inside an Electron packaged app's unpacked
+ * resources directory.
+ */
+export function findClaudeBinaryInElectronResources(
+  resourcesPath: string,
+): string | undefined {
+  const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
+  if (!info) return undefined;
+
+  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
+  const platformPkgDir = path.join(
+    resourcesPath,
+    'app.asar.unpacked',
+    'node_modules',
+    ...info.pkg.split('/'),
+  );
+
+  const binary = path.join(platformPkgDir, binaryName);
+  return existsSync(binary) ? binary : undefined;
+}
+
+function getPackagedElectronResourcesPath(): string | undefined {
+  const electronProcess = process as ElectronProcess;
+  if (electronProcess.versions.electron == null) return undefined;
+  if (electronProcess.defaultApp === true) return undefined;
+  return electronProcess.resourcesPath;
+}
+
+/**
+ * Resolve the native Claude binary from a directory that contains (or nests)
+ * the platform-specific package. Returns the binary path if found, or
+ * `undefined`.
+ */
+function resolveClaudeBinary(
+  baseDir: string,
+  platformInfo: PlatformInfo,
+): string | undefined {
+  try {
+    const req = createRequire(path.join(baseDir, 'package.json'));
+    const platformPkgJson = req.resolve(`${platformInfo.pkg}/package.json`);
+    const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
+    const binary = path.join(path.dirname(platformPkgJson), binaryName);
+    if (existsSync(binary)) return binary;
+  } catch {
+    // Platform package not resolvable
+  }
+  return undefined;
+}

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -25,7 +25,7 @@ type QueryFn = (params: {
   options?: Record<string, unknown>;
 }) => AsyncGenerator<unknown, void>;
 
-type PlatformInfo = { pkg: string };
+type PlatformInfo = { pkgs: readonly string[] };
 type ElectronProcess = NodeJS.Process & {
   defaultApp?: boolean;
   resourcesPath?: string;
@@ -54,7 +54,7 @@ export async function importClaudeAgentSdk(): Promise<QueryFn> {
     const code = (err as { code?: string }).code;
     if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
       throw new Error(
-        '@anthropic-ai/claude-agent-sdk package not found. Install with: npm install -g @anthropic-ai/claude-code',
+        '@anthropic-ai/claude-agent-sdk package not found. Reinstall TeXRA or run corepack pnpm install in the TeXRA workspace.',
       );
     }
     throw err;
@@ -82,17 +82,27 @@ export async function importClaudeAgentSdk(): Promise<QueryFn> {
 // ---------------------------------------------------------------------------
 
 /**
- * Platform key → npm package name for the bundled `claude` binary.
- * The Claude Agent SDK ships one platform package per OS/arch; each contains
- * a single `claude` binary at the package root.
+ * Platform key → npm package names for the bundled `claude` binary.
+ * Linux has separate glibc and musl packages; trying both keeps the resolver
+ * independent of libc detection.
  */
 const PLATFORM_INFO: Record<string, PlatformInfo> = {
-  'linux-x64': { pkg: '@anthropic-ai/claude-agent-sdk-linux-x64' },
-  'linux-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-linux-arm64' },
-  'darwin-x64': { pkg: '@anthropic-ai/claude-agent-sdk-darwin-x64' },
-  'darwin-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-darwin-arm64' },
-  'win32-x64': { pkg: '@anthropic-ai/claude-agent-sdk-win32-x64' },
-  'win32-arm64': { pkg: '@anthropic-ai/claude-agent-sdk-win32-arm64' },
+  'linux-x64': {
+    pkgs: [
+      '@anthropic-ai/claude-agent-sdk-linux-x64',
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl',
+    ],
+  },
+  'linux-arm64': {
+    pkgs: [
+      '@anthropic-ai/claude-agent-sdk-linux-arm64',
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl',
+    ],
+  },
+  'darwin-x64': { pkgs: ['@anthropic-ai/claude-agent-sdk-darwin-x64'] },
+  'darwin-arm64': { pkgs: ['@anthropic-ai/claude-agent-sdk-darwin-arm64'] },
+  'win32-x64': { pkgs: ['@anthropic-ai/claude-agent-sdk-win32-x64'] },
+  'win32-arm64': { pkgs: ['@anthropic-ai/claude-agent-sdk-win32-arm64'] },
 };
 
 /** Cached result — found paths are cached; misses are retried. */
@@ -117,8 +127,6 @@ export function findClaudeBinaryPath(): string | undefined {
 function findClaudeBinaryPathUncached(): string | undefined {
   const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
   if (!info) return undefined;
-
-  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
 
   // Strategy 1: packaged Electron app.asar.unpacked resources
   // Highest priority when present — packaged apps cannot execute binaries
@@ -205,15 +213,17 @@ export function findClaudeBinaryInElectronResources(
   if (!info) return undefined;
 
   const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
-  const platformPkgDir = path.join(
-    resourcesPath,
-    'app.asar.unpacked',
-    'node_modules',
-    ...info.pkg.split('/'),
-  );
-
-  const binary = path.join(platformPkgDir, binaryName);
-  return existsSync(binary) ? binary : undefined;
+  for (const pkg of info.pkgs) {
+    const platformPkgDir = path.join(
+      resourcesPath,
+      'app.asar.unpacked',
+      'node_modules',
+      ...pkg.split('/'),
+    );
+    const binary = path.join(platformPkgDir, binaryName);
+    if (existsSync(binary)) return binary;
+  }
+  return undefined;
 }
 
 function getPackagedElectronResourcesPath(): string | undefined {
@@ -232,14 +242,16 @@ function resolveClaudeBinary(
   baseDir: string,
   platformInfo: PlatformInfo,
 ): string | undefined {
-  try {
-    const req = createRequire(path.join(baseDir, 'package.json'));
-    const platformPkgJson = req.resolve(`${platformInfo.pkg}/package.json`);
-    const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
-    const binary = path.join(path.dirname(platformPkgJson), binaryName);
-    if (existsSync(binary)) return binary;
-  } catch {
-    // Platform package not resolvable
+  const req = createRequire(path.join(baseDir, 'package.json'));
+  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
+  for (const pkg of platformInfo.pkgs) {
+    try {
+      const platformPkgJson = req.resolve(`${pkg}/package.json`);
+      const binary = path.join(path.dirname(platformPkgJson), binaryName);
+      if (existsSync(binary)) return binary;
+    } catch {
+      // Platform package not resolvable
+    }
   }
   return undefined;
 }

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -17,6 +17,7 @@ type ToolUseStatus = NonNullable<ToolUseLog['status']>;
  */
 export interface ClaudeMessageBlock {
   type: string;
+  id?: string;
   text?: string;
   thinking?: string;
   name?: string;

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,0 +1,133 @@
+// Shared constants and helpers for the Claude Agent tool.
+
+import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
+
+export const CLAUDE_AGENT_NAME = 'claude_agent';
+export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
+export const CLAUDE_AGENT_TOOL_USE_NAME = 'claude_tool_use';
+
+const SUMMARY_MAX_LENGTH = 60;
+type ToolUseStatus = NonNullable<ToolUseLog['status']>;
+
+/**
+ * Subset of the SDK's `SDKAssistantMessage.message` shape we need to log
+ * (kept as `unknown` indices in the public type to avoid importing the
+ * private MessageParam shape from `@anthropic-ai/sdk` into VS Code-free
+ * zones).
+ */
+export interface ClaudeMessageBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+/** Format a usage object into TeXRA's TokenUsageStats. */
+export function buildClaudeUsageStats(usage: {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}): TokenUsageStats {
+  return {
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+    cost: 0,
+    ...(usage.cache_read_input_tokens != null &&
+      usage.cache_read_input_tokens > 0 && {
+        cacheReadInputTokens: usage.cache_read_input_tokens,
+      }),
+    ...(usage.cache_creation_input_tokens != null &&
+      usage.cache_creation_input_tokens > 0 && {
+        cacheCreationInputTokens: usage.cache_creation_input_tokens,
+      }),
+  };
+}
+
+function truncateSummary(text: string, maxLength: number): string {
+  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
+  return truncateWithEllipsis(oneLine, maxLength);
+}
+
+/**
+ * Build a tool-use log entry for a Claude `tool_use` content block.
+ * Mirrors the rendering of Codex's command/file-change events but uses a
+ * single generic `claude_tool_use` toolName since Claude's built-in tool set
+ * (Bash, Read, Edit, Glob, etc.) is dynamic.
+ */
+export function buildClaudeToolUseLog(params: {
+  toolName: string;
+  input: unknown;
+  status: ToolUseStatus;
+  isError?: boolean;
+  output?: unknown;
+  errorMessage?: string;
+}): ToolUseLog {
+  const summarySource = describeToolInput(params.toolName, params.input);
+  return {
+    toolName: `claude:${params.toolName}`,
+    summary: truncateSummary(summarySource, SUMMARY_MAX_LENGTH),
+    input: params.input as Record<string, unknown>,
+    ...(params.output !== undefined && {
+      output: params.output as Record<string, unknown>,
+    }),
+    ...(params.isError &&
+      params.errorMessage && {
+        error: params.errorMessage,
+        isError: true,
+      }),
+    status: params.status,
+  };
+}
+
+/**
+ * Produce a short summary line for the supported built-in tools. Falls back
+ * to the tool name when the input shape isn't recognized.
+ */
+function describeToolInput(toolName: string, input: unknown): string {
+  if (input == null || typeof input !== 'object') return toolName;
+  const record = input as Record<string, unknown>;
+
+  switch (toolName) {
+    case 'Bash':
+      if (typeof record.command === 'string') return record.command;
+      break;
+    case 'Read':
+    case 'Edit':
+    case 'Write':
+    case 'NotebookEdit':
+      if (typeof record.file_path === 'string') {
+        return `${toolName} ${record.file_path}`;
+      }
+      break;
+    case 'Glob':
+      if (typeof record.pattern === 'string') {
+        return `Glob ${record.pattern}`;
+      }
+      break;
+    case 'Grep':
+      if (typeof record.pattern === 'string') {
+        return `Grep ${record.pattern}`;
+      }
+      break;
+    case 'WebFetch':
+      if (typeof record.url === 'string') return `WebFetch ${record.url}`;
+      break;
+    case 'WebSearch':
+      if (typeof record.query === 'string') return `WebSearch ${record.query}`;
+      break;
+    case 'TodoWrite':
+      return 'TodoWrite';
+    case 'Task':
+      if (typeof record.description === 'string') {
+        return `Task ${record.description}`;
+      }
+      break;
+  }
+  return toolName;
+}

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -5,7 +5,6 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 export const CLAUDE_AGENT_NAME = 'claude_agent';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
-export const CLAUDE_AGENT_TOOL_USE_NAME = 'claude_tool_use';
 
 const SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;
@@ -56,9 +55,8 @@ function truncateSummary(text: string, maxLength: number): string {
 
 /**
  * Build a tool-use log entry for a Claude `tool_use` content block.
- * Mirrors the rendering of Codex's command/file-change events but uses a
- * single generic `claude_tool_use` toolName since Claude's built-in tool set
- * (Bash, Read, Edit, Glob, etc.) is dynamic.
+ * Mirrors the rendering of Codex's command/file-change events while retaining
+ * Claude's concrete built-in tool name.
  */
 export function buildClaudeToolUseLog(params: {
   toolName: string;

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -5,6 +5,14 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 export const CLAUDE_AGENT_NAME = 'claude_agent';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
+export const CLAUDE_AGENT_PERMISSION_MODES = [
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+] as const;
+export type ClaudeAgentPermissionMode =
+  (typeof CLAUDE_AGENT_PERMISSION_MODES)[number];
 
 const SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -1,11 +1,11 @@
-// Standard library imports
-import * as path from 'path';
-
 // Local imports - agent config
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { getWorkspaceState } from '@agent/core/stateStore';
-import { WorkspaceFS } from '@utils/files';
+import {
+  buildAgentWorkspaceOptions,
+  type AgentWorkspaceOptions,
+} from './agentWorkspaceOptions';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
 // Type-only imports
@@ -145,10 +145,7 @@ export function buildCodexConfig(prompt: string): AgentConfig {
   });
 }
 
-export interface CodexWorkspaceOptions {
-  workingDirectory?: string;
-  additionalDirectories?: string[];
-}
+export type CodexWorkspaceOptions = AgentWorkspaceOptions;
 
 /**
  * Compute Codex workspace access options.
@@ -163,39 +160,5 @@ export interface CodexWorkspaceOptions {
 export function buildCodexWorkspaceOptions(
   workingDirectoryInput?: string | null,
 ): CodexWorkspaceOptions {
-  const workspacePath = WorkspaceFS.getPath();
-  const trimmed = workingDirectoryInput?.trim();
-
-  if (!workspacePath) {
-    return trimmed ? { workingDirectory: trimmed } : {};
-  }
-
-  const workingDirectory = trimmed
-    ? path.isAbsolute(trimmed)
-      ? trimmed
-      : path.resolve(workspacePath, trimmed)
-    : workspacePath;
-
-  const resolvedWorkspacePath = path.resolve(workspacePath);
-  const resolvedWorkingDirectory = path.resolve(workingDirectory);
-
-  if (resolvedWorkingDirectory === resolvedWorkspacePath) {
-    return { workingDirectory };
-  }
-
-  const relativeToWorkspace = path.relative(
-    resolvedWorkspacePath,
-    resolvedWorkingDirectory,
-  );
-  const isInsideWorkspace =
-    relativeToWorkspace.length > 0 &&
-    !relativeToWorkspace.startsWith('..') &&
-    !path.isAbsolute(relativeToWorkspace);
-
-  return isInsideWorkspace
-    ? {
-        workingDirectory,
-        additionalDirectories: [workspacePath],
-      }
-    : { workingDirectory };
+  return buildAgentWorkspaceOptions(workingDirectoryInput);
 }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -13,7 +13,7 @@
 
 // Local imports
 import { platform } from '@platform/platform';
-import { lookupApiKey } from '@model/apiProviders';
+import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
@@ -459,13 +459,19 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         );
       }
 
-      const hasKey =
-        (await lookupApiKey(platform().secrets, 'anthropic').catch(
-          () => undefined,
-        )) != null;
+      const anthropicApiKeyEnv = apiKeyEnvName('anthropic');
+      const keyOrigin = await lookupApiKeyOrigin(
+        platform().secrets,
+        'anthropic',
+      ).catch(() => (process.env[anthropicApiKeyEnv] ? 'env' : 'none'));
       const hasOauthToken = !!process.env.CLAUDE_CODE_OAUTH_TOKEN;
       const authBits: string[] = [];
-      if (hasKey) authBits.push('ANTHROPIC_API_KEY (TeXRA Settings or env)');
+      if (keyOrigin === 'secret') {
+        authBits.push(`${anthropicApiKeyEnv} (TeXRA Settings)`);
+      }
+      if (keyOrigin === 'env') {
+        authBits.push(`${anthropicApiKeyEnv} (environment)`);
+      }
       if (hasOauthToken) authBits.push('CLAUDE_CODE_OAUTH_TOKEN');
       const authNote =
         authBits.length > 0

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -324,8 +324,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   {
     id: 'external-inquiry',
     tools: ['external_inquiry'],
-    name: 'External Inquiry',
-    category: 'workflow',
+    name: 'External Chat Handoff',
+    category: 'ai-agents',
     description:
       'Lets agents ask you to query an external chat model such as ChatGPT, Claude, or Gemini and paste the answer back into the run.',
     configNotes:
@@ -339,7 +339,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     id: 'codex',
     tools: ['codex'],
     name: 'OpenAI Codex CLI',
-    category: 'computation',
+    category: 'ai-agents',
     description:
       'OpenAI Codex agent runtime. Required by the Codex SDK for local code generation and analysis.',
     installGuide:
@@ -405,7 +405,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     id: 'claude-agent',
     tools: ['claude_agent'],
     name: 'Claude Code Agent',
-    category: 'computation',
+    category: 'ai-agents',
     description:
       'Anthropic Claude Code agent runtime. Spins off a Claude agent in the workspace for code analysis, generation, and research.',
     installGuide:

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -12,9 +12,15 @@
  */
 
 // Local imports
+import { platform } from '@platform/platform';
+import { lookupApiKey } from '@model/apiProviders';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
+import {
+  importClaudeAgentSdk,
+  findClaudeBinaryPath,
+} from '@tools/claudeAgentImport';
 import { getGitHubToken } from '@tools/github/githubAuth';
 import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
@@ -392,6 +398,81 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       }
 
       return `Codex CLI ready. Binary: ${codexPath}`;
+    },
+  },
+
+  {
+    id: 'claude-agent',
+    tools: ['claude_agent'],
+    name: 'Claude Code Agent',
+    category: 'computation',
+    description:
+      'Anthropic Claude Code agent runtime. Spins off a Claude agent in the workspace for code analysis, generation, and research.',
+    installGuide:
+      'Install the Claude Code CLI (choose one):\n\n' +
+      '  npm install -g @anthropic-ai/claude-code\n' +
+      '  brew install --cask claude-code     (macOS)\n' +
+      '  winget install Anthropic.ClaudeCode (Windows)\n\n' +
+      'Or use the native installer from https://claude.com/code (recommended).\n' +
+      'See: https://code.claude.com/docs/en/setup\n\n' +
+      'Authentication (choose one):\n' +
+      '  • Set ANTHROPIC_API_KEY in TeXRA Settings → API Keys → Anthropic\n' +
+      '  • claude login          — OAuth sign-in (Pro/Max subscription, recommended)\n' +
+      '  • claude setup-token    — long-lived OAuth token (CLAUDE_CODE_OAUTH_TOKEN)\n' +
+      '  • ANTHROPIC_API_KEY     — environment variable with Console API key',
+    installUrl: 'https://code.claude.com/docs/en/setup',
+    installCommand: 'npm install -g @anthropic-ai/claude-code',
+    authCommand: 'claude login',
+    configNotes:
+      'Requires the native `claude` binary. Supports OAuth (`claude login`), long-lived tokens (`claude setup-token` → CLAUDE_CODE_OAUTH_TOKEN), or ANTHROPIC_API_KEY (resolved from TeXRA Settings → API Keys or the environment).',
+    authNote: 'OAuth, OAuth token, or API key',
+    toggleable: true,
+    check: async () => {
+      try {
+        await importClaudeAgentSdk();
+        return findClaudeBinaryPath() != null;
+      } catch {
+        return false;
+      }
+    },
+    detailCheck: async () => {
+      try {
+        await importClaudeAgentSdk();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (
+          msg.includes('not found') ||
+          msg.includes('MODULE_NOT_FOUND') ||
+          msg.includes('Cannot find package')
+        ) {
+          return '@anthropic-ai/claude-agent-sdk not found. Reinstall TeXRA or run: npm install @anthropic-ai/claude-agent-sdk';
+        }
+        return `Claude Agent SDK import failed: ${msg}`;
+      }
+
+      const claudePath = findClaudeBinaryPath();
+      if (!claudePath) {
+        return (
+          'Claude Agent SDK loaded but native `claude` binary not found. ' +
+          'Install via: npm install -g @anthropic-ai/claude-code' +
+          (isWSL() ? ' (run this inside WSL, not on the Windows side)' : '')
+        );
+      }
+
+      const hasKey =
+        (await lookupApiKey(platform().secrets, 'anthropic').catch(
+          () => undefined,
+        )) != null;
+      const hasOauthToken = !!process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      const authBits: string[] = [];
+      if (hasKey) authBits.push('ANTHROPIC_API_KEY (TeXRA Settings or env)');
+      if (hasOauthToken) authBits.push('CLAUDE_CODE_OAUTH_TOKEN');
+      const authNote =
+        authBits.length > 0
+          ? `Auth detected: ${authBits.join(', ')}.`
+          : 'No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN detected — the CLI will use whatever `claude login` session you have.';
+
+      return `Claude CLI ready. Binary: ${claudePath}. ${authNote}`;
     },
   },
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -41,6 +41,7 @@ import {
   ZoteroExportTool,
 } from './zotero';
 import { CodexTool } from './codex';
+import { ClaudeAgentTool } from './claudeAgent';
 import {
   LeanDiagnosticsTool,
   LeanFileTool,
@@ -116,6 +117,7 @@ function createDefaultTools() {
     lean_inspect: new LeanInspectTool(),
     lean_loogle: new LeanLoogleTool(),
     codex: new CodexTool(),
+    claude_agent: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),


### PR DESCRIPTION
Mirrors the codex subagent integration so users can delegate work to a
Claude Code session from inside a TeXRA tool-use agent. Authentication
piggybacks on whatever the CLI is configured to use:
  - ANTHROPIC_API_KEY from TeXRA Settings → API Keys or env var
  - CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`
  - OAuth session from `claude login` (Pro/Max subscription)

The Tools dashboard surfaces availability, the install command, and the
detected auth path.

https://claude.ai/code/session_01QYaeStjUtMP9ridx62FXQZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new subagent tool that spawns the local `claude` CLI and persists/resumes sessions, plus new dependency/binary resolution paths; issues here could affect tool-use execution and shutdown behavior. Changes are mostly additive and gated by availability checks, but touch process env/secrets and runtime lifecycle hooks.
> 
> **Overview**
> Adds a new `claude_agent` tool powered by `@anthropic-ai/claude-agent-sdk`, including session lifecycle (launch/resume), streamed turn logging (tool-use + usage), workspace/env resolution (preferring stored Anthropic API key), and a best-effort `claude` binary locator for packaged builds.
> 
> Updates tooling UI to split **AI agent integrations** into a new Settings tab (`AI Agents`), moving Codex-specific inline settings there and re-categorizing Codex/external chat handoff under a new `ai-agents` tool category; also adds a new dashboard entry for Claude Code with install/auth diagnostics.
> 
> Wires Claude agent session interruption into VS Code extension and Electron desktop shutdown, and factors shared workspace directory logic into `buildAgentWorkspaceOptions` used by both Codex and Claude agent integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138ac32149bae508a234828e3db3129fb23aac3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->