### PR TITLE
refactor: tighten ApiProvider typing — drop 'as never' casts

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -219,7 +219,6 @@ async function findToolCommand(
   return kind === 'install' ? def?.installCommand : def?.authCommand;
 }
 
-
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
 ): DesktopSettingsIpc {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -37,8 +37,8 @@ import {
   API_PROVIDERS,
   apiKeySecretName,
   invalidateApiKeyCache,
+  isApiProvider,
   loadApiKeyStatusMap,
-  type ApiProvider,
 } from '@model/apiProviders';
 import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
 import {
@@ -219,9 +219,6 @@ async function findToolCommand(
   return kind === 'install' ? def?.installCommand : def?.authCommand;
 }
 
-function isApiProvider(provider: string): provider is ApiProvider {
-  return (API_PROVIDERS as readonly string[]).includes(provider);
-}
 
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -41,7 +41,7 @@ import {
 } from '@common/state';
 import { isTerminalStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
-import { SecretManager, type ApiProvider } from '@frontend/secretManager';
+import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
   configureLatexSettings,
@@ -356,20 +356,19 @@ export async function activate(context: vscode.ExtensionContext) {
       providers: SecretManager.API_PROVIDERS,
       setApiKey: (provider, key) =>
         SecretManager.set(
-          SecretManager.getApiKeySecretName(provider as ApiProvider),
+          SecretManager.getApiKeySecretName(provider),
           key,
         ),
       deleteApiKey: (provider) =>
         SecretManager.delete(
-          SecretManager.getApiKeySecretName(provider as ApiProvider),
+          SecretManager.getApiKeySecretName(provider),
         ),
-      apiKeyExists: (provider) =>
-        SecretManager.apiKeyExists(provider as ApiProvider),
+      apiKeyExists: (provider) => SecretManager.apiKeyExists(provider),
       hasUsableApiKey: (provider) =>
-        SecretManager.hasUsableApiKey(provider as ApiProvider),
+        SecretManager.hasUsableApiKey(provider),
       storedApiKeyExists: async (provider) => {
         const stored = await SecretManager.get(
-          SecretManager.getApiKeySecretName(provider as ApiProvider),
+          SecretManager.getApiKeySecretName(provider),
         );
         return stored !== undefined;
       },

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -41,7 +41,7 @@ import {
 } from '@common/state';
 import { isTerminalStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
-import { SecretManager } from '@frontend/secretManager';
+import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
   configureLatexSettings,
@@ -356,19 +356,19 @@ export async function activate(context: vscode.ExtensionContext) {
       providers: SecretManager.API_PROVIDERS,
       setApiKey: (provider, key) =>
         SecretManager.set(
-          SecretManager.getApiKeySecretName(provider as never),
+          SecretManager.getApiKeySecretName(provider as ApiProvider),
           key,
         ),
       deleteApiKey: (provider) =>
         SecretManager.delete(
-          SecretManager.getApiKeySecretName(provider as never),
+          SecretManager.getApiKeySecretName(provider as ApiProvider),
         ),
-      apiKeyExists: (provider) => SecretManager.apiKeyExists(provider as never),
+      apiKeyExists: (provider) => SecretManager.apiKeyExists(provider as ApiProvider),
       hasUsableApiKey: (provider) =>
-        SecretManager.hasUsableApiKey(provider as never),
+        SecretManager.hasUsableApiKey(provider as ApiProvider),
       storedApiKeyExists: async (provider) => {
         const stored = await SecretManager.get(
-          SecretManager.getApiKeySecretName(provider as never),
+          SecretManager.getApiKeySecretName(provider as ApiProvider),
         );
         return stored !== undefined;
       },

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -363,7 +363,8 @@ export async function activate(context: vscode.ExtensionContext) {
         SecretManager.delete(
           SecretManager.getApiKeySecretName(provider as ApiProvider),
         ),
-      apiKeyExists: (provider) => SecretManager.apiKeyExists(provider as ApiProvider),
+      apiKeyExists: (provider) =>
+        SecretManager.apiKeyExists(provider as ApiProvider),
       hasUsableApiKey: (provider) =>
         SecretManager.hasUsableApiKey(provider as ApiProvider),
       storedApiKeyExists: async (provider) => {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -355,17 +355,11 @@ export async function activate(context: vscode.ExtensionContext) {
     secrets: {
       providers: SecretManager.API_PROVIDERS,
       setApiKey: (provider, key) =>
-        SecretManager.set(
-          SecretManager.getApiKeySecretName(provider),
-          key,
-        ),
+        SecretManager.set(SecretManager.getApiKeySecretName(provider), key),
       deleteApiKey: (provider) =>
-        SecretManager.delete(
-          SecretManager.getApiKeySecretName(provider),
-        ),
+        SecretManager.delete(SecretManager.getApiKeySecretName(provider)),
       apiKeyExists: (provider) => SecretManager.apiKeyExists(provider),
-      hasUsableApiKey: (provider) =>
-        SecretManager.hasUsableApiKey(provider),
+      hasUsableApiKey: (provider) => SecretManager.hasUsableApiKey(provider),
       storedApiKeyExists: async (provider) => {
         const stored = await SecretManager.get(
           SecretManager.getApiKeySecretName(provider),

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -11,6 +11,11 @@ export const API_PROVIDERS = API_KEY_PROVIDER_IDS;
 
 export type ApiProvider = (typeof API_PROVIDERS)[number];
 
+/** Runtime-checked narrowing for provider strings. */
+export function isApiProvider(provider: string): provider is ApiProvider {
+  return (API_PROVIDERS as readonly string[]).includes(provider);
+}
+
 /** Secret storage key for a provider's API key. */
 export function apiKeySecretName(provider: ApiProvider): string {
   return `apiKey.${provider}`;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -18,7 +18,7 @@ import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 // Local imports - sibling
-import { API_PROVIDERS, apiKeyExists, type ApiProvider } from './apiProviders';
+import { apiKeyExists, isApiProvider } from './apiProviders';
 import {
   buildModelHint,
   formatContext,
@@ -46,8 +46,8 @@ async function getPersonalAccessKindForModel(
     return hasOpenRouter ? 'openrouter-key' : null;
   }
 
-  const provider = config.provider as ApiProvider;
-  if (!(API_PROVIDERS as readonly string[]).includes(provider)) {
+  const { provider } = config;
+  if (!isApiProvider(provider)) {
     return 'provider-key';
   }
 

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { invalidateApiKeyCache, isApiProvider } from '@model/apiProviders';
+import {
+  API_PROVIDERS,
+  invalidateApiKeyCache,
+  isApiProvider,
+} from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -71,7 +75,7 @@ export class SetApiKeyTool extends defineTool({
 
     if (!isApiProvider(provider)) {
       throw new ToolError(
-        `Unknown provider "${provider}". Supported: ${platform.secrets.providers.join(', ')}.`,
+        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
       );
     }
 

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { invalidateApiKeyCache } from '@model/apiProviders';
+import { invalidateApiKeyCache, isApiProvider } from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -69,7 +69,7 @@ export class SetApiKeyTool extends defineTool({
     const platform = getSetupPlatform();
     const provider = input.provider.trim();
 
-    if (!platform.secrets.providers.includes(provider)) {
+    if (!isApiProvider(provider)) {
       throw new ToolError(
         `Unknown provider "${provider}". Supported: ${platform.secrets.providers.join(', ')}.`,
       );

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { invalidateApiKeyCache, isApiProvider } from '@model/apiProviders';
+import {
+  API_PROVIDERS,
+  invalidateApiKeyCache,
+  isApiProvider,
+} from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -30,7 +34,7 @@ export class UnsetApiKeyTool extends defineTool({
 
     if (!isApiProvider(provider)) {
       throw new ToolError(
-        `Unknown provider "${provider}". Supported: ${platform.secrets.providers.join(', ')}.`,
+        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
       );
     }
 

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { invalidateApiKeyCache } from '@model/apiProviders';
+import { invalidateApiKeyCache, isApiProvider } from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -28,7 +28,7 @@ export class UnsetApiKeyTool extends defineTool({
     const platform = getSetupPlatform();
     const provider = input.provider.trim();
 
-    if (!platform.secrets.providers.includes(provider)) {
+    if (!isApiProvider(provider)) {
       throw new ToolError(
         `Unknown provider "${provider}". Supported: ${platform.secrets.providers.join(', ')}.`,
       );

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -8,6 +8,7 @@
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
 
+import type { ApiProvider } from '@model/apiProviders';
 import type {
   TerminalRunRequest,
   TerminalRunResult,
@@ -16,27 +17,27 @@ import type {
 
 /** Per-provider API key surface. */
 export interface SetupSecretsAdapter {
-  setApiKey(provider: string, key: string): Promise<void>;
-  deleteApiKey(provider: string): Promise<void>;
-  apiKeyExists(provider: string): Promise<boolean>;
+  setApiKey(provider: ApiProvider, key: string): Promise<void>;
+  deleteApiKey(provider: ApiProvider): Promise<void>;
+  apiKeyExists(provider: ApiProvider): Promise<boolean>;
   /**
    * Like `apiKeyExists` but rejects empty values. A stale
    * `PROVIDER_API_KEY=""` env var is "present" but unusable at launch,
    * so setup-readiness checks must use this helper rather than raw
    * `apiKeyExists` to avoid misleading the agent (and the user).
    */
-  hasUsableApiKey(provider: string): Promise<boolean>;
+  hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
   /**
    * Like `apiKeyExists` but only reports SecretStorage entries — ignores
    * environment-variable-backed keys. Needed by `unset_api_key` so the
    * agent doesn't claim to have removed a key that still comes from
    * `PROVIDER_API_KEY` in the user's shell.
    */
-  storedApiKeyExists(provider: string): Promise<boolean>;
+  storedApiKeyExists(provider: ApiProvider): Promise<boolean>;
   anyApiKeyExists(): Promise<boolean>;
   gitHubTokenExists(): Promise<'secret' | 'env' | 'none'>;
   /** List of provider names known to TeXRA (matches SecretManager.API_PROVIDERS). */
-  providers: readonly string[];
+  providers: readonly ApiProvider[];
 }
 
 /** Per-command surface. */


### PR DESCRIPTION
## Summary

Same shape as #4011: a load-bearing field typed too loosely, papered over with escape-hatch casts.

`SetupSecretsAdapter` declared `provider: string` while `SecretManager` methods expect a narrow `ApiProvider` union. The mismatch caused **5 `as never` casts in `extension.ts`** — TypeScript escape hatches that silently bypass type errors. Setup tools were even more permissive: a runtime `platform.secrets.providers.includes(provider)` check that didn't narrow the type either.

### What

- **Promote `isApiProvider`** type guard from `desktopSettingsIpc.ts` (where it lived as a local function) into `@model/apiProviders` so it's shared across hosts and tools.
- **Narrow `SetupSecretsAdapter`** to `provider: ApiProvider` on all 5 methods, and `providers: readonly ApiProvider[]`.
- **`SetApiKeyTool` / `UnsetApiKeyTool`** use `isApiProvider` for their existing runtime check — same throw on unknown provider, but TS now narrows `provider` to `ApiProvider` for the downstream `setApiKey` / `deleteApiKey` calls (no cast needed).
- **`extension.ts`** drops 5 `as never` casts — the closures naturally type-check now.
- **Desktop** drops its local copy of `isApiProvider`.

### Why

`as never` is a code smell that translates to "TS knows this is wrong but I'm forcing it." Each cast hid a real type-flow gap. Now the chain is honest: API surface declares `ApiProvider`, callers use a runtime type guard that narrows, no casts needed.

Mirrors the audit's findings on type tightening (#5 from the type-tightening audit).

### Net impact

**6 files, +23/−20 = +3 net LOC**, eliminates the `as never` smell in 5 sites + dedups the type guard across 2 hosts. Typecheck clean (full + workspace), 570 kernel tests pass, lint 0 errors.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run workspace:typecheck`
- [x] `pnpm run test:kernel` — 570/570
- [x] `npm run lint` — 0 errors

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

---
_Generated by [Claude Code](https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-safety refactor that mainly changes TypeScript surface types and shared narrowing logic around API-key provider names; runtime behavior should be unchanged aside from clearer unknown-provider validation.
> 
> **Overview**
> Centralizes the `isApiProvider` type guard in `@model/apiProviders` and removes the desktop app’s local copy.
> 
> Tightens setup/extension API-key plumbing by typing `SetupSecretsAdapter` provider parameters as `ApiProvider`, updating `SetApiKeyTool`/`UnsetApiKeyTool` to use `isApiProvider` for narrowing, and removing multiple `as never` casts in `extension.ts` when calling `SecretManager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb5b1107b8355ef2ed5cbce23a5f0a1067f8f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->