### PR TITLE
refactor: widen MementoStorage.update value to T | undefined

### DIFF
--- a/packages/extension/src/progressView/persistence/PersistentMapManager.ts
+++ b/packages/extension/src/progressView/persistence/PersistentMapManager.ts
@@ -5,5 +5,9 @@
 export interface MementoStorage {
   get<T>(key: string): T | undefined;
   get<T>(key: string, defaultValue: T): T;
-  update<T>(key: string, value: T): Thenable<void>;
+  /**
+   * Set a key's value, or pass `undefined` to delete the entry. Mirrors
+   * `vscode.Memento.update`, which uses `undefined` as the delete sentinel.
+   */
+  update<T>(key: string, value: T | undefined): Thenable<void>;
 }

--- a/packages/extension/src/progressView/persistence/mementoMigration.ts
+++ b/packages/extension/src/progressView/persistence/mementoMigration.ts
@@ -135,14 +135,14 @@ export async function migrateFromMemento(
   // Clear legacy workspace state keys
   logger.info('[Migration] Clearing legacy workspace state keys');
   await Promise.all([
-    storage.update(WorkspaceStateKey.TASK_STATES, undefined as never),
-    storage.update(WorkspaceStateKey.EXECUTION_IDS, undefined as never),
-    storage.update(WorkspaceStateKey.ACTIVE_RUN_IDS, undefined as never),
-    storage.update(WorkspaceStateKey.PARENT_STREAM_IDS, undefined as never),
-    storage.update(WorkspaceStateKey.RUN_INSTRUCTIONS, undefined as never),
-    storage.update(WorkspaceStateKey.OUTPUT_FILES, undefined as never),
-    storage.update(WorkspaceStateKey.MISSING_OUTPUTS, undefined as never),
-    storage.update(WorkspaceStateKey.USAGE_STATS, undefined as never),
+    storage.update(WorkspaceStateKey.TASK_STATES, undefined),
+    storage.update(WorkspaceStateKey.EXECUTION_IDS, undefined),
+    storage.update(WorkspaceStateKey.ACTIVE_RUN_IDS, undefined),
+    storage.update(WorkspaceStateKey.PARENT_STREAM_IDS, undefined),
+    storage.update(WorkspaceStateKey.RUN_INSTRUCTIONS, undefined),
+    storage.update(WorkspaceStateKey.OUTPUT_FILES, undefined),
+    storage.update(WorkspaceStateKey.MISSING_OUTPUTS, undefined),
+    storage.update(WorkspaceStateKey.USAGE_STATS, undefined),
   ]);
 
   logger.info('[Migration] Migration complete');


### PR DESCRIPTION
## Summary

Same shape as #4011 and #4013: a load-bearing escape-hatch cast covering up a real type signature gap.

`packages/extension/src/progressView/persistence/mementoMigration.ts` had 8 `storage.update(key, undefined as never)` calls — the canonical "delete this entry" idiom for `vscode.Memento`, but forced into an `as never` escape hatch because the local `MementoStorage` mirror was typed `value: T` (strict, no undefined allowed).

### What

- Widen `MementoStorage.update<T>(key, value: T)` to `value: T | undefined`.
- Document the delete-sentinel semantics inline (mirrors `vscode.Memento.update`'s actual behavior).
- The 8 `as never` casts in the migration drop to bare `undefined`.

### Why

`MementoStorage` exists to mirror `vscode.Memento` — and `vscode.Memento.update` documents `undefined` as the delete sentinel. The local mirror happened to be stricter than the real thing, and the cost of that mismatch was 8 `as never` casts hiding the actual contract.

### Net impact

**2 files, +13/−9 = +4 net LOC overall but eliminates the cast in 8 sites.** Typecheck (full + workspace) clean, 574 kernel tests pass, lint 0 errors.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run workspace:typecheck`
- [x] `pnpm run test:kernel` — 574/574
- [x] `npm run lint` — 0 errors

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

---
_Generated by [Claude Code](https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-signature alignment that only affects how workspace-state keys are cleared during a one-time migration; runtime behavior remains the same (passing `undefined` deletes keys).
> 
> **Overview**
> Updates `MementoStorage.update` to accept `T | undefined` and documents `undefined` as the delete sentinel to mirror `vscode.Memento.update`.
> 
> Simplifies the one-time memento-to-disk migration cleanup by removing `undefined as never` casts and calling `storage.update(key, undefined)` directly when clearing legacy workspace-state keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b99644cd025dc4316f26fc74fb1be26fa4db42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->