### PR TITLE
refactor: replace 'as never' with derived Category type in ArxivSearchTool

### DIFF
--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -7,6 +7,7 @@ import {
   abstract as abstractQuery,
   category as catQuery,
 } from 'arxiv-client';
+type Category = Parameters<typeof catQuery>[0];
 import { z } from 'zod';
 
 // Local imports
@@ -85,9 +86,10 @@ export class ArxivSearchTool extends defineTool({
         const trimmed = cat.trim();
         if (trimmed.length > 0) {
           try {
-            // catQuery expects a strict Category union type (e.g., "cs.AI", "math.CO")
-            // We accept user input as string and handle invalid categories gracefully
-            categoryFilters.push(catQuery(trimmed as never));
+            // catQuery expects a strict Category union ("cs.AI", "math.CO", ...).
+            // User input is unconstrained string — cast to the expected type
+            // and rely on the library's runtime validation (caught below).
+            categoryFilters.push(catQuery(trimmed as Category));
           } catch (error) {
             // Skip invalid categories silently - they won't be used in the query
             continue;

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -7,7 +7,6 @@ import {
   abstract as abstractQuery,
   category as catQuery,
 } from 'arxiv-client';
-type Category = Parameters<typeof catQuery>[0];
 import { z } from 'zod';
 
 // Local imports
@@ -22,6 +21,8 @@ import {
   extractBasePaperMetadata,
   normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
+
+type Category = Parameters<typeof catQuery>[0];
 
 const SortBySchema = z.enum(['relevance', 'lastUpdatedDate', 'submittedDate']);
 const SortOrderSchema = z.enum(['ascending', 'descending']);


### PR DESCRIPTION
## Summary

The last `as never` cast in production code. `ArxivSearchTool.ts:90` had `catQuery(trimmed as never)` because `arxiv-client`'s `category()` function takes a narrow `Category` union (`'cs.AI' | 'math.CO' | ...`) but the user's input is unconstrained string — and the library's `Category` type isn't exported from its index entry.

### What

- Derive the type via `Parameters<typeof catQuery>[0]` to access the actual parameter type without a deep import.
- Cast becomes `as Category` — an honest assertion that we're claiming the string is one of the union members; the library's runtime validation (caught in the existing `try` block) handles invalid input gracefully.

### Why

`as never` is a code smell that translates to "TS knows this is wrong but I'm forcing it." `as Category` translates to "I'm claiming this matches the parameter type; runtime check will catch invalid input" — much more honest, and matches the comment above the line.

This is the **last `as never` cast in production code** outside test fixtures.

### Net impact

**1 file, +5/−3 = +2 net LOC.** Typecheck clean, 574 kernel tests pass.

## Test plan

- [x] `npm run typecheck`
- [x] `pnpm run test:kernel` — 574/574

https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV

---
_Generated by [Claude Code](https://claude.ai/code/session_011tk5cuEbZ59AjmWqLCv5VV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor confined to `ArxivSearchTool` query building; runtime behavior should be unchanged aside from relying on the existing try/catch for invalid categories.
> 
> **Overview**
> Replaces the remaining `as never` cast in `ArxivSearchTool` by introducing a derived `Category` type (`Parameters<typeof catQuery>[0]`) and casting user-provided category strings as `Category` when calling `catQuery`.
> 
> Updates the inline comment to clarify that invalid categories are still handled via the existing `try/catch` runtime validation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15c3a0f48d04f3a7392ea5358b8cb243eefd6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->