### PR TITLE
feat(ai-agents): polish settings tab, add Claude Agent pickers

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -78,6 +78,11 @@ import {
   parseCodexReasoningEffort,
   parseCodexSandboxMode,
 } from '@tools/codexConfig';
+import {
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  parseClaudeAgentModel,
+  parseClaudeAgentPermissionMode,
+} from '@tools/claudeAgentConfig';
 import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
 import {
   MEMORY_STORAGE_ROOT,
@@ -731,6 +736,18 @@ export function createDesktopSettingsIpc(
           'never',
         ) ?? 'never',
       ),
+      claudeAgentModel: parseClaudeAgentModel(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+          CLAUDE_AGENT_DEFAULT_MODEL,
+        ) ?? CLAUDE_AGENT_DEFAULT_MODEL,
+      ),
+      claudeAgentPermissionMode: parseClaudeAgentPermissionMode(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+          'acceptEdits',
+        ) ?? 'acceptEdits',
+      ),
     });
   }
 
@@ -938,7 +955,7 @@ export function createDesktopSettingsIpc(
     ]);
   }
 
-  async function updateCodexSetting(
+  async function updateAgentSetting(
     key: WorkspaceStateKey,
     value: string,
   ): Promise<void> {
@@ -1300,7 +1317,7 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE:
           runAsync(
-            updateCodexSetting(
+            updateAgentSetting(
               WorkspaceStateKey.CODEX_SANDBOX_MODE,
               result.data.mode,
             ),
@@ -1308,7 +1325,7 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT:
           runAsync(
-            updateCodexSetting(
+            updateAgentSetting(
               WorkspaceStateKey.CODEX_REASONING_EFFORT,
               result.data.effort,
             ),
@@ -1316,9 +1333,25 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY:
           runAsync(
-            updateCodexSetting(
+            updateAgentSetting(
               WorkspaceStateKey.CODEX_APPROVAL_POLICY,
               result.data.policy,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_MODEL:
+          runAsync(
+            updateAgentSetting(
+              WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+              result.data.model,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_PERMISSION_MODE:
+          runAsync(
+            updateAgentSetting(
+              WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+              result.data.mode,
             ),
           );
           return true;

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -80,6 +80,7 @@ import {
 } from '@tools/codexConfig';
 import {
   CLAUDE_AGENT_DEFAULT_MODEL,
+  parseClaudeAgentEffort,
   parseClaudeAgentModel,
   parseClaudeAgentPermissionMode,
 } from '@tools/claudeAgentConfig';
@@ -748,6 +749,12 @@ export function createDesktopSettingsIpc(
           'acceptEdits',
         ) ?? 'acceptEdits',
       ),
+      claudeAgentEffort: parseClaudeAgentEffort(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+          'high',
+        ) ?? 'high',
+      ),
     });
   }
 
@@ -1352,6 +1359,14 @@ export function createDesktopSettingsIpc(
             updateAgentSetting(
               WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
               result.data.mode,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_EFFORT:
+          runAsync(
+            updateAgentSetting(
+              WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+              result.data.effort,
             ),
           );
           return true;

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -110,6 +110,10 @@ import {
   parseCodexReasoningEffort,
   parseCodexApprovalPolicy,
 } from '@tools/codexConfig';
+import {
+  getClaudeAgentModel,
+  getClaudeAgentPermissionMode,
+} from '@tools/claudeAgentConfig';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
   issuePollingSource,
@@ -574,19 +578,29 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED]: (data) =>
         this.handleSetApprovalEnabled(BASH_APPROVAL_CONFIG_KEY, data.enabled),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE]: (data) =>
-        this.updateCodexSetting(
+        this.updateAgentSetting(
           WorkspaceStateKey.CODEX_SANDBOX_MODE,
           data.mode,
         ),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT]: (data) =>
-        this.updateCodexSetting(
+        this.updateAgentSetting(
           WorkspaceStateKey.CODEX_REASONING_EFFORT,
           data.effort,
         ),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY]: (data) =>
-        this.updateCodexSetting(
+        this.updateAgentSetting(
           WorkspaceStateKey.CODEX_APPROVAL_POLICY,
           data.policy,
+        ),
+      [SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_MODEL]: (data) =>
+        this.updateAgentSetting(
+          WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+          data.model,
+        ),
+      [SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_PERMISSION_MODE]: (data) =>
+        this.updateAgentSetting(
+          WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+          data.mode,
         ),
 
       // Tool dashboard handlers
@@ -1092,6 +1106,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           'never',
         ) ?? 'never',
       ),
+      claudeAgentModel: getClaudeAgentModel(),
+      claudeAgentPermissionMode: getClaudeAgentPermissionMode(),
     });
   }
 
@@ -1106,7 +1122,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
   }
 
-  private async updateCodexSetting(
+  private async updateAgentSetting(
     key: WorkspaceStateKey,
     value: string,
   ): Promise<void> {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -111,8 +111,10 @@ import {
   parseCodexApprovalPolicy,
 } from '@tools/codexConfig';
 import {
-  getClaudeAgentModel,
-  getClaudeAgentPermissionMode,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  parseClaudeAgentEffort,
+  parseClaudeAgentModel,
+  parseClaudeAgentPermissionMode,
 } from '@tools/claudeAgentConfig';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
@@ -601,6 +603,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.updateAgentSetting(
           WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
           data.mode,
+        ),
+      [SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_EFFORT]: (data) =>
+        this.updateAgentSetting(
+          WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+          data.effort,
         ),
 
       // Tool dashboard handlers
@@ -1106,8 +1113,24 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           'never',
         ) ?? 'never',
       ),
-      claudeAgentModel: getClaudeAgentModel(),
-      claudeAgentPermissionMode: getClaudeAgentPermissionMode(),
+      claudeAgentModel: parseClaudeAgentModel(
+        workspaceSM.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+          CLAUDE_AGENT_DEFAULT_MODEL,
+        ) ?? CLAUDE_AGENT_DEFAULT_MODEL,
+      ),
+      claudeAgentPermissionMode: parseClaudeAgentPermissionMode(
+        workspaceSM.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+          'acceptEdits',
+        ) ?? 'acceptEdits',
+      ),
+      claudeAgentEffort: parseClaudeAgentEffort(
+        workspaceSM.get<string>(
+          WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+          'high',
+        ) ?? 'high',
+      ),
     });
   }
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -36,6 +36,8 @@ import {
 } from '@shared/wa/webAwesomeIcons';
 import {
   type AgentSelectionItem,
+  type ClaudeAgentModel,
+  type ClaudeAgentPermissionMode,
   type LatexConfigValues,
   type NumberVscodeSetting,
   type PRSubscriptionEntry,
@@ -283,8 +285,12 @@ export class SettingsApp extends SettingsAppBase {
   private readonly codexSandboxMode = signal<string>('workspace-write');
   private readonly codexReasoningEffort = signal<string>('high');
   private readonly codexApprovalPolicy = signal<string>('never');
-  private readonly claudeAgentModel = signal<string>('claude-opus-4-7');
-  private readonly claudeAgentPermissionMode = signal<string>('acceptEdits');
+  private readonly claudeAgentModel = signal<ClaudeAgentModel>(
+    'claude-opus-4-7',
+  );
+  private readonly claudeAgentPermissionMode = signal<ClaudeAgentPermissionMode>(
+    'acceptEdits',
+  );
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -36,6 +36,7 @@ import {
 } from '@shared/wa/webAwesomeIcons';
 import {
   type AgentSelectionItem,
+  type ClaudeAgentEffort,
   type ClaudeAgentModel,
   type ClaudeAgentPermissionMode,
   type LatexConfigValues,
@@ -289,6 +290,7 @@ export class SettingsApp extends SettingsAppBase {
     signal<ClaudeAgentModel>('claude-opus-4-7');
   private readonly claudeAgentPermissionMode =
     signal<ClaudeAgentPermissionMode>('acceptEdits');
+  private readonly claudeAgentEffort = signal<ClaudeAgentEffort>('high');
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
@@ -349,6 +351,7 @@ export class SettingsApp extends SettingsAppBase {
       codexApprovalPolicy: this.codexApprovalPolicy,
       claudeAgentModel: this.claudeAgentModel,
       claudeAgentPermissionMode: this.claudeAgentPermissionMode,
+      claudeAgentEffort: this.claudeAgentEffort,
       toolDashboardItems: this.toolDashboardItems,
       toolDashboardLoaded: this.toolDashboardLoaded,
       gitMarkCommits: this.gitMarkCommits,
@@ -670,6 +673,10 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleClaudeAgentPermissionModeChange = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_PERMISSION_MODE,
+  );
+
+  private handleClaudeAgentEffortChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_EFFORT,
   );
 
   // Git settings event handlers
@@ -1104,6 +1111,7 @@ export class SettingsApp extends SettingsAppBase {
               .codexApprovalPolicy=${this.codexApprovalPolicy.get()}
               .claudeAgentModel=${this.claudeAgentModel.get()}
               .claudeAgentPermissionMode=${this.claudeAgentPermissionMode.get()}
+              .claudeAgentEffort=${this.claudeAgentEffort.get()}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-run-command=${this.handleToolRunCommand}
@@ -1117,6 +1125,7 @@ export class SettingsApp extends SettingsAppBase {
               @claude-agent-model-change=${this.handleClaudeAgentModelChange}
               @claude-agent-permission-mode-change=${this
                 .handleClaudeAgentPermissionModeChange}
+              @claude-agent-effort-change=${this.handleClaudeAgentEffortChange}
             ></ai-agents-tab>
           </wa-tab-panel>
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -285,12 +285,10 @@ export class SettingsApp extends SettingsAppBase {
   private readonly codexSandboxMode = signal<string>('workspace-write');
   private readonly codexReasoningEffort = signal<string>('high');
   private readonly codexApprovalPolicy = signal<string>('never');
-  private readonly claudeAgentModel = signal<ClaudeAgentModel>(
-    'claude-opus-4-7',
-  );
-  private readonly claudeAgentPermissionMode = signal<ClaudeAgentPermissionMode>(
-    'acceptEdits',
-  );
+  private readonly claudeAgentModel =
+    signal<ClaudeAgentModel>('claude-opus-4-7');
+  private readonly claudeAgentPermissionMode =
+    signal<ClaudeAgentPermissionMode>('acceptEdits');
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -283,6 +283,8 @@ export class SettingsApp extends SettingsAppBase {
   private readonly codexSandboxMode = signal<string>('workspace-write');
   private readonly codexReasoningEffort = signal<string>('high');
   private readonly codexApprovalPolicy = signal<string>('never');
+  private readonly claudeAgentModel = signal<string>('claude-opus-4-7');
+  private readonly claudeAgentPermissionMode = signal<string>('acceptEdits');
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
@@ -341,6 +343,8 @@ export class SettingsApp extends SettingsAppBase {
       codexSandboxMode: this.codexSandboxMode,
       codexReasoningEffort: this.codexReasoningEffort,
       codexApprovalPolicy: this.codexApprovalPolicy,
+      claudeAgentModel: this.claudeAgentModel,
+      claudeAgentPermissionMode: this.claudeAgentPermissionMode,
       toolDashboardItems: this.toolDashboardItems,
       toolDashboardLoaded: this.toolDashboardLoaded,
       gitMarkCommits: this.gitMarkCommits,
@@ -654,6 +658,14 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleCodexApprovalPolicyChange = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY,
+  );
+
+  private handleClaudeAgentModelChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_MODEL,
+  );
+
+  private handleClaudeAgentPermissionModeChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_PERMISSION_MODE,
   );
 
   // Git settings event handlers
@@ -1086,6 +1098,8 @@ export class SettingsApp extends SettingsAppBase {
               .codexSandboxMode=${this.codexSandboxMode.get()}
               .codexReasoningEffort=${this.codexReasoningEffort.get()}
               .codexApprovalPolicy=${this.codexApprovalPolicy.get()}
+              .claudeAgentModel=${this.claudeAgentModel.get()}
+              .claudeAgentPermissionMode=${this.claudeAgentPermissionMode.get()}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-run-command=${this.handleToolRunCommand}
@@ -1096,6 +1110,9 @@ export class SettingsApp extends SettingsAppBase {
                 .handleCodexReasoningEffortChange}
               @codex-approval-policy-change=${this
                 .handleCodexApprovalPolicyChange}
+              @claude-agent-model-change=${this.handleClaudeAgentModelChange}
+              @claude-agent-permission-mode-change=${this
+                .handleClaudeAgentPermissionModeChange}
             ></ai-agents-tab>
           </wa-tab-panel>
 

--- a/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -26,6 +26,8 @@ import {
   type LatexConfigValues,
   type LatexSettingsStatus,
   type MemoryViewItem,
+  type ClaudeAgentModel,
+  type ClaudeAgentPermissionMode,
   type ModelSelectionItem,
   type NumberVscodeSetting,
   type PRSubscriptionEntry,
@@ -76,8 +78,8 @@ export interface SettingsMessageHandlerContext {
   codexSandboxMode: WritableSignal<string>;
   codexReasoningEffort: WritableSignal<string>;
   codexApprovalPolicy: WritableSignal<string>;
-  claudeAgentModel: WritableSignal<string>;
-  claudeAgentPermissionMode: WritableSignal<string>;
+  claudeAgentModel: WritableSignal<ClaudeAgentModel>;
+  claudeAgentPermissionMode: WritableSignal<ClaudeAgentPermissionMode>;
   toolDashboardItems: WritableSignal<ToolDashboardItem[]>;
   toolDashboardLoaded: WritableSignal<boolean>;
   gitMarkCommits: WritableSignal<boolean>;

--- a/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -26,6 +26,7 @@ import {
   type LatexConfigValues,
   type LatexSettingsStatus,
   type MemoryViewItem,
+  type ClaudeAgentEffort,
   type ClaudeAgentModel,
   type ClaudeAgentPermissionMode,
   type ModelSelectionItem,
@@ -80,6 +81,7 @@ export interface SettingsMessageHandlerContext {
   codexApprovalPolicy: WritableSignal<string>;
   claudeAgentModel: WritableSignal<ClaudeAgentModel>;
   claudeAgentPermissionMode: WritableSignal<ClaudeAgentPermissionMode>;
+  claudeAgentEffort: WritableSignal<ClaudeAgentEffort>;
   toolDashboardItems: WritableSignal<ToolDashboardItem[]>;
   toolDashboardLoaded: WritableSignal<boolean>;
   gitMarkCommits: WritableSignal<boolean>;
@@ -251,6 +253,7 @@ export function dispatchSettingsViewMessage(
       ctx.codexApprovalPolicy.set(data.codexApprovalPolicy);
       ctx.claudeAgentModel.set(data.claudeAgentModel);
       ctx.claudeAgentPermissionMode.set(data.claudeAgentPermissionMode);
+      ctx.claudeAgentEffort.set(data.claudeAgentEffort);
       return true;
     }
 

--- a/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -76,6 +76,8 @@ export interface SettingsMessageHandlerContext {
   codexSandboxMode: WritableSignal<string>;
   codexReasoningEffort: WritableSignal<string>;
   codexApprovalPolicy: WritableSignal<string>;
+  claudeAgentModel: WritableSignal<string>;
+  claudeAgentPermissionMode: WritableSignal<string>;
   toolDashboardItems: WritableSignal<ToolDashboardItem[]>;
   toolDashboardLoaded: WritableSignal<boolean>;
   gitMarkCommits: WritableSignal<boolean>;
@@ -245,6 +247,8 @@ export function dispatchSettingsViewMessage(
       ctx.codexSandboxMode.set(data.codexSandboxMode);
       ctx.codexReasoningEffort.set(data.codexReasoningEffort);
       ctx.codexApprovalPolicy.set(data.codexApprovalPolicy);
+      ctx.claudeAgentModel.set(data.claudeAgentModel);
+      ctx.claudeAgentPermissionMode.set(data.claudeAgentPermissionMode);
       return true;
     }
 

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -20,6 +20,7 @@ import type {
   CodexSandboxMode,
   CodexReasoningEffort,
   CodexApprovalPolicy,
+  ClaudeAgentEffort,
   ClaudeAgentModel,
   ClaudeAgentPermissionMode,
 } from '@shared/schemas/settingsViewMessages';
@@ -80,6 +81,17 @@ const CLAUDE_PERMISSION_MODE_OPTIONS: readonly {
   { value: 'acceptEdits', label: 'Auto-accept edits' },
   { value: 'bypassPermissions', label: 'Bypass all (dangerous)' },
   { value: 'plan', label: 'Plan only (read-only)' },
+] as const;
+
+const CLAUDE_EFFORT_OPTIONS: readonly {
+  value: ClaudeAgentEffort;
+  label: string;
+}[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra high' },
+  { value: 'max', label: 'Maximum' },
 ] as const;
 
 @customElement('ai-agents-tab')
@@ -152,6 +164,7 @@ export class AIAgentsTab extends LitElement {
     'claude-opus-4-7';
   @property({ type: String })
   claudeAgentPermissionMode: ClaudeAgentPermissionMode = 'acceptEdits';
+  @property({ type: String }) claudeAgentEffort: ClaudeAgentEffort = 'high';
 
   private handleRecheck(): void {
     this.dispatchEvent(createEvent('tool-recheck'));
@@ -183,6 +196,10 @@ export class AIAgentsTab extends LitElement {
 
   private handleClaudeAgentPermissionModeChange = (e: Event): void => {
     this.emitSelect('claude-agent-permission-mode-change', 'mode', e);
+  };
+
+  private handleClaudeAgentEffortChange = (e: Event): void => {
+    this.emitSelect('claude-agent-effort-change', 'effort', e);
   };
 
   private renderSelectRow(
@@ -238,6 +255,12 @@ export class AIAgentsTab extends LitElement {
           this.claudeAgentModel,
           CLAUDE_MODEL_OPTIONS,
           this.handleClaudeAgentModelChange,
+        )}
+        ${this.renderSelectRow(
+          'Reasoning effort',
+          this.claudeAgentEffort,
+          CLAUDE_EFFORT_OPTIONS,
+          this.handleClaudeAgentEffortChange,
         )}
         ${this.renderSelectRow(
           'Permission mode',

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -148,8 +148,10 @@ export class AIAgentsTab extends LitElement {
   @property({ type: String }) codexSandboxMode = 'workspace-write';
   @property({ type: String }) codexReasoningEffort = 'high';
   @property({ type: String }) codexApprovalPolicy = 'never';
-  @property({ type: String }) claudeAgentModel = 'claude-opus-4-7';
-  @property({ type: String }) claudeAgentPermissionMode = 'acceptEdits';
+  @property({ type: String }) claudeAgentModel: ClaudeAgentModel =
+    'claude-opus-4-7';
+  @property({ type: String })
+  claudeAgentPermissionMode: ClaudeAgentPermissionMode = 'acceptEdits';
 
   private handleRecheck(): void {
     this.dispatchEvent(createEvent('tool-recheck'));

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -249,7 +249,8 @@ export class AIAgentsTab extends LitElement {
 
   private renderInlineSettingsFor(itemId: string): TemplateResult | null {
     if (itemId === 'codex') return this.renderCodexInlineSettings();
-    if (itemId === 'claude-agent') return this.renderClaudeAgentInlineSettings();
+    if (itemId === 'claude-agent')
+      return this.renderClaudeAgentInlineSettings();
     return null;
   }
 
@@ -299,7 +300,9 @@ export class AIAgentsTab extends LitElement {
                   items,
                   (item) => item.id,
                   (item) => {
-                    const inlineSettings = this.renderInlineSettingsFor(item.id);
+                    const inlineSettings = this.renderInlineSettingsFor(
+                      item.id,
+                    );
                     return html`
                       <tool-card .item=${item}>
                         ${inlineSettings

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -20,6 +20,8 @@ import type {
   CodexSandboxMode,
   CodexReasoningEffort,
   CodexApprovalPolicy,
+  ClaudeAgentModel,
+  ClaudeAgentPermissionMode,
 } from '@shared/schemas/settingsViewMessages';
 
 // Side-effect imports - register WA components
@@ -61,6 +63,25 @@ const APPROVAL_POLICY_OPTIONS: readonly {
   { value: 'on-failure', label: 'Ask on failure' },
 ] as const;
 
+const CLAUDE_MODEL_OPTIONS: readonly {
+  value: ClaudeAgentModel;
+  label: string;
+}[] = [
+  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+] as const;
+
+const CLAUDE_PERMISSION_MODE_OPTIONS: readonly {
+  value: ClaudeAgentPermissionMode;
+  label: string;
+}[] = [
+  { value: 'default', label: 'Prompt for risky actions' },
+  { value: 'acceptEdits', label: 'Auto-accept edits' },
+  { value: 'bypassPermissions', label: 'Bypass all (dangerous)' },
+  { value: 'plan', label: 'Plan only (read-only)' },
+] as const;
+
 @customElement('ai-agents-tab')
 export class AIAgentsTab extends LitElement {
   static override styles = [
@@ -96,7 +117,7 @@ export class AIAgentsTab extends LitElement {
         margin-bottom: var(--wa-space-m);
       }
 
-      .codex-inline-settings {
+      .agent-inline-settings {
         padding: var(--wa-space-2xs) var(--wa-space-xs);
         margin-bottom: var(--wa-space-2xs);
         border-radius: var(--border-radius);
@@ -127,6 +148,8 @@ export class AIAgentsTab extends LitElement {
   @property({ type: String }) codexSandboxMode = 'workspace-write';
   @property({ type: String }) codexReasoningEffort = 'high';
   @property({ type: String }) codexApprovalPolicy = 'never';
+  @property({ type: String }) claudeAgentModel = 'claude-opus-4-7';
+  @property({ type: String }) claudeAgentPermissionMode = 'acceptEdits';
 
   private handleRecheck(): void {
     this.dispatchEvent(createEvent('tool-recheck'));
@@ -152,6 +175,14 @@ export class AIAgentsTab extends LitElement {
     this.emitSelect('codex-approval-policy-change', 'policy', e);
   };
 
+  private handleClaudeAgentModelChange = (e: Event): void => {
+    this.emitSelect('claude-agent-model-change', 'model', e);
+  };
+
+  private handleClaudeAgentPermissionModeChange = (e: Event): void => {
+    this.emitSelect('claude-agent-permission-mode-change', 'mode', e);
+  };
+
   private renderSelectRow(
     label: string,
     value: string,
@@ -174,7 +205,7 @@ export class AIAgentsTab extends LitElement {
 
   private renderCodexInlineSettings(): TemplateResult {
     return html`
-      <div class="codex-inline-settings">
+      <div class="agent-inline-settings">
         ${this.renderSelectRow(
           'Sandbox mode',
           this.codexSandboxMode,
@@ -195,6 +226,31 @@ export class AIAgentsTab extends LitElement {
         )}
       </div>
     `;
+  }
+
+  private renderClaudeAgentInlineSettings(): TemplateResult {
+    return html`
+      <div class="agent-inline-settings">
+        ${this.renderSelectRow(
+          'Model',
+          this.claudeAgentModel,
+          CLAUDE_MODEL_OPTIONS,
+          this.handleClaudeAgentModelChange,
+        )}
+        ${this.renderSelectRow(
+          'Permission mode',
+          this.claudeAgentPermissionMode,
+          CLAUDE_PERMISSION_MODE_OPTIONS,
+          this.handleClaudeAgentPermissionModeChange,
+        )}
+      </div>
+    `;
+  }
+
+  private renderInlineSettingsFor(itemId: string): TemplateResult | null {
+    if (itemId === 'codex') return this.renderCodexInlineSettings();
+    if (itemId === 'claude-agent') return this.renderClaudeAgentInlineSettings();
+    return null;
   }
 
   private aiAgentItems(): ToolDashboardItem[] {
@@ -242,15 +298,16 @@ export class AIAgentsTab extends LitElement {
                 ${repeat(
                   items,
                   (item) => item.id,
-                  (item) => html`
-                    <tool-card .item=${item}>
-                      ${item.id === 'codex'
-                        ? html`<div slot="details">
-                            ${this.renderCodexInlineSettings()}
-                          </div>`
-                        : nothing}
-                    </tool-card>
-                  `,
+                  (item) => {
+                    const inlineSettings = this.renderInlineSettingsFor(item.id);
+                    return html`
+                      <tool-card .item=${item}>
+                        ${inlineSettings
+                          ? html`<div slot="details">${inlineSettings}</div>`
+                          : nothing}
+                      </tool-card>
+                    `;
+                  },
                 )}
               </div>
             `}

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -44,6 +44,10 @@ export enum WorkspaceStateKey {
   CODEX_REASONING_EFFORT = 'texra.codexReasoningEffort',
   CODEX_APPROVAL_POLICY = 'texra.codexApprovalPolicy',
 
+  // Claude Agent settings
+  CLAUDE_AGENT_MODEL = 'texra.claudeAgentModel',
+  CLAUDE_AGENT_PERMISSION_MODE = 'texra.claudeAgentPermissionMode',
+
   // Git commit author settings
   GIT_MARK_COMMITS = 'texra.git.markCommits',
   GIT_AUTHOR_NAME = 'texra.git.authorName',

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -47,6 +47,7 @@ export enum WorkspaceStateKey {
   // Claude Agent settings
   CLAUDE_AGENT_MODEL = 'texra.claudeAgentModel',
   CLAUDE_AGENT_PERMISSION_MODE = 'texra.claudeAgentPermissionMode',
+  CLAUDE_AGENT_EFFORT = 'texra.claudeAgentEffort',
 
   // Git commit author settings
   GIT_MARK_COMMITS = 'texra.git.markCommits',

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -32,6 +32,8 @@ const WORKTREE_SHARED_KEYS: ReadonlySet<WorkspaceStateKey> =
     WorkspaceStateKey.CODEX_SANDBOX_MODE,
     WorkspaceStateKey.CODEX_REASONING_EFFORT,
     WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+    WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+    WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
     WorkspaceStateKey.GIT_MARK_COMMITS,
     WorkspaceStateKey.GIT_AUTHOR_NAME,
     WorkspaceStateKey.GIT_AUTHOR_EMAIL,

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -34,6 +34,7 @@ const WORKTREE_SHARED_KEYS: ReadonlySet<WorkspaceStateKey> =
     WorkspaceStateKey.CODEX_APPROVAL_POLICY,
     WorkspaceStateKey.CLAUDE_AGENT_MODEL,
     WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+    WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
     WorkspaceStateKey.GIT_MARK_COMMITS,
     WorkspaceStateKey.GIT_AUTHOR_NAME,
     WorkspaceStateKey.GIT_AUTHOR_EMAIL,

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -81,6 +81,8 @@ export const SETTINGS_VIEW_CMD = {
   SET_CODEX_SANDBOX_MODE: 'setCodexSandboxMode',
   SET_CODEX_REASONING_EFFORT: 'setCodexReasoningEffort',
   SET_CODEX_APPROVAL_POLICY: 'setCodexApprovalPolicy',
+  SET_CLAUDE_AGENT_MODEL: 'setClaudeAgentModel',
+  SET_CLAUDE_AGENT_PERMISSION_MODE: 'setClaudeAgentPermissionMode',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -83,6 +83,7 @@ export const SETTINGS_VIEW_CMD = {
   SET_CODEX_APPROVAL_POLICY: 'setCodexApprovalPolicy',
   SET_CLAUDE_AGENT_MODEL: 'setClaudeAgentModel',
   SET_CLAUDE_AGENT_PERMISSION_MODE: 'setClaudeAgentPermissionMode',
+  SET_CLAUDE_AGENT_EFFORT: 'setClaudeAgentEffort',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -366,6 +366,16 @@ export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
 
+/** Claude Agent effort levels (mirrors CLAUDE_AGENT_EFFORT_LEVELS). */
+export const ClaudeAgentEffortSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+export type ClaudeAgentEffort = z.infer<typeof ClaudeAgentEffortSchema>;
+
 /** Outbound: backend → frontend approval settings */
 export const UpdateApprovalSettingsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS),
@@ -375,6 +385,7 @@ export const UpdateApprovalSettingsMessageSchema = z.object({
   codexApprovalPolicy: CodexApprovalPolicySchema,
   claudeAgentModel: ClaudeAgentModelSchema,
   claudeAgentPermissionMode: ClaudeAgentPermissionModeSchema,
+  claudeAgentEffort: ClaudeAgentEffortSchema,
 });
 export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
@@ -921,6 +932,10 @@ const SetClaudeAgentPermissionModeMessageSchema = z.object({
   command: z.literal(CMD.SET_CLAUDE_AGENT_PERMISSION_MODE),
   mode: ClaudeAgentPermissionModeSchema,
 });
+const SetClaudeAgentEffortMessageSchema = z.object({
+  command: z.literal(CMD.SET_CLAUDE_AGENT_EFFORT),
+  effort: ClaudeAgentEffortSchema,
+});
 
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
@@ -1036,6 +1051,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetCodexApprovalPolicyMessageSchema,
     SetClaudeAgentModelMessageSchema,
     SetClaudeAgentPermissionModeMessageSchema,
+    SetClaudeAgentEffortMessageSchema,
     // Agent team messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -346,6 +346,26 @@ export const CodexApprovalPolicySchema = z.enum([
 ]);
 export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
 
+/** Claude Agent model options surfaced in the picker. The SDK accepts any
+ * string, but the dropdown is fixed to the canonical Anthropic families. */
+export const ClaudeAgentModelSchema = z.enum([
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5-20251001',
+]);
+export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
+
+/** Claude Agent permission modes (mirrors CLAUDE_AGENT_PERMISSION_MODES). */
+export const ClaudeAgentPermissionModeSchema = z.enum([
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+]);
+export type ClaudeAgentPermissionMode = z.infer<
+  typeof ClaudeAgentPermissionModeSchema
+>;
+
 /** Outbound: backend → frontend approval settings */
 export const UpdateApprovalSettingsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS),
@@ -353,6 +373,8 @@ export const UpdateApprovalSettingsMessageSchema = z.object({
   codexSandboxMode: CodexSandboxModeSchema,
   codexReasoningEffort: CodexReasoningEffortSchema,
   codexApprovalPolicy: CodexApprovalPolicySchema,
+  claudeAgentModel: ClaudeAgentModelSchema,
+  claudeAgentPermissionMode: ClaudeAgentPermissionModeSchema,
 });
 export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
@@ -891,6 +913,14 @@ const SetCodexApprovalPolicyMessageSchema = z.object({
   command: z.literal(CMD.SET_CODEX_APPROVAL_POLICY),
   policy: CodexApprovalPolicySchema,
 });
+const SetClaudeAgentModelMessageSchema = z.object({
+  command: z.literal(CMD.SET_CLAUDE_AGENT_MODEL),
+  model: ClaudeAgentModelSchema,
+});
+const SetClaudeAgentPermissionModeMessageSchema = z.object({
+  command: z.literal(CMD.SET_CLAUDE_AGENT_PERMISSION_MODE),
+  mode: ClaudeAgentPermissionModeSchema,
+});
 
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
@@ -1004,6 +1034,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetCodexSandboxModeMessageSchema,
     SetCodexReasoningEffortMessageSchema,
     SetCodexApprovalPolicyMessageSchema,
+    SetClaudeAgentModelMessageSchema,
+    SetClaudeAgentPermissionModeMessageSchema,
     // Agent team messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
@@ -60,6 +60,7 @@ function runTurn(logger: AgentLogger) {
     abortController: new AbortController(),
     model: 'claude-sonnet-4-6',
     permissionMode: 'acceptEdits',
+    effort: 'high',
     cwd: undefined,
     additionalDirectories: undefined,
     env: {},

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -78,6 +78,7 @@ import {
   buildClaudeUsageStats,
   CLAUDE_AGENT_EFFORT_LEVELS,
   CLAUDE_AGENT_PERMISSION_MODES,
+  modelSupportsAdaptiveThinking,
   type ClaudeAgentEffort,
   type ClaudeAgentPermissionMode,
   type ClaudeMessageBlock,
@@ -357,11 +358,13 @@ export async function runStreamedTurn(params: {
     model: params.model,
     permissionMode: params.permissionMode,
     effort: params.effort,
-    thinking: { type: 'adaptive' },
     env: params.env,
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settingSources: ['user', 'project', 'local'],
   };
+  if (modelSupportsAdaptiveThinking(params.model)) {
+    sdkOptions.thinking = { type: 'adaptive' };
+  }
   if (params.permissionMode === 'bypassPermissions') {
     sdkOptions.allowDangerouslySkipPermissions = true;
   }

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -76,7 +76,9 @@ import { createChildStream } from './childStream';
 import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
+  CLAUDE_AGENT_EFFORT_LEVELS,
   CLAUDE_AGENT_PERMISSION_MODES,
+  type ClaudeAgentEffort,
   type ClaudeAgentPermissionMode,
   type ClaudeMessageBlock,
 } from './claudeAgentShared';
@@ -110,6 +112,12 @@ const ClaudeAgentInputSchema = z.strictObject({
     .describe(
       "Claude model to use (e.g. 'claude-opus-4-7', 'claude-sonnet-4-6'). Defaults to user-configured model.",
     ),
+  effort: z
+    .enum(CLAUDE_AGENT_EFFORT_LEVELS)
+    .nullish()
+    .describe(
+      'Reasoning depth hint passed to the SDK (defaults to user-configured effort, typically high).',
+    ),
   session_id: z
     .string()
     .nullish()
@@ -130,6 +138,7 @@ interface ActiveSession {
   executionId: ExecutionId;
   model: string;
   permissionMode: ClaudeAgentPermissionMode;
+  effort: ClaudeAgentEffort;
   cwd?: string;
   additionalDirectories?: string[];
 }
@@ -331,6 +340,7 @@ export async function runStreamedTurn(params: {
   abortController: AbortController;
   model: string;
   permissionMode: ClaudeAgentPermissionMode;
+  effort: ClaudeAgentEffort;
   cwd: string | undefined;
   additionalDirectories: string[] | undefined;
   env: NodeJS.ProcessEnv;
@@ -346,6 +356,8 @@ export async function runStreamedTurn(params: {
     abortController: params.abortController,
     model: params.model,
     permissionMode: params.permissionMode,
+    effort: params.effort,
+    thinking: { type: 'adaptive' },
     env: params.env,
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settingSources: ['user', 'project', 'local'],
@@ -507,6 +519,7 @@ function startClaudeAgentLoop(params: {
   initialPrompt: string;
   model: string;
   permissionMode: ClaudeAgentPermissionMode;
+  effort: ClaudeAgentEffort;
   cwd: string | undefined;
   additionalDirectories: string[] | undefined;
   env: NodeJS.ProcessEnv;
@@ -562,6 +575,7 @@ function startClaudeAgentLoop(params: {
             abortController: ac,
             model: params.model,
             permissionMode: params.permissionMode,
+            effort: params.effort,
             cwd: params.cwd,
             additionalDirectories: params.additionalDirectories,
             env: params.env,
@@ -589,6 +603,7 @@ function startClaudeAgentLoop(params: {
             executionId,
             model: params.model,
             permissionMode: params.permissionMode,
+            effort: params.effort,
             cwd: params.cwd,
             additionalDirectories: params.additionalDirectories,
           });
@@ -655,6 +670,7 @@ export class ClaudeAgentTool extends defineTool({
     const permissionMode =
       input.permission_mode ?? config.getClaudeAgentPermissionMode();
     const model = input.model ?? config.getClaudeAgentModel();
+    const effort = input.effort ?? config.getClaudeAgentEffort();
 
     const approvalLabel = `[claude_agent ${permissionMode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });
@@ -681,6 +697,7 @@ export class ClaudeAgentTool extends defineTool({
       input,
       permissionMode,
       model,
+      effort,
       runContext?.streamId,
       runContext?.executionId,
       runContext?.workingDirectory,
@@ -693,6 +710,7 @@ async function launchClaudeAgentSession(
   input: ClaudeAgentInput,
   permissionMode: ClaudeAgentPermissionMode,
   model: string,
+  effort: ClaudeAgentEffort,
   parentStreamId: StreamTabId | undefined,
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
@@ -747,6 +765,7 @@ async function launchClaudeAgentSession(
     initialPrompt: input.prompt,
     model,
     permissionMode,
+    effort,
     cwd: workspace.cwd,
     additionalDirectories: workspace.additionalDirectories,
     env,

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -3,12 +3,15 @@ import { platform } from '@platform/platform';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { getWorkspaceState } from '@agent/core/stateStore';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,
+  CLAUDE_AGENT_MODELS,
   CLAUDE_AGENT_PERMISSION_MODES,
+  type ClaudeAgentModel,
   type ClaudeAgentPermissionMode,
 } from './claudeAgentShared';
 
@@ -17,19 +20,26 @@ import {
 // ============================================================================
 
 /** Default Claude model passed to the Agent SDK. */
-export const CLAUDE_AGENT_DEFAULT_MODEL = 'claude-opus-4-7';
+export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-opus-4-7';
 
-const MODEL_KEY = 'texra.claudeAgentModel';
+export function parseClaudeAgentModel(raw: string): ClaudeAgentModel {
+  return (CLAUDE_AGENT_MODELS as readonly string[]).includes(raw)
+    ? (raw as ClaudeAgentModel)
+    : CLAUDE_AGENT_DEFAULT_MODEL;
+}
 
-export function getClaudeAgentModel(): string {
-  return getWorkspaceState().get<string>(MODEL_KEY, CLAUDE_AGENT_DEFAULT_MODEL);
+export function getClaudeAgentModel(): ClaudeAgentModel {
+  const raw = getWorkspaceState().get<string>(
+    WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+    CLAUDE_AGENT_DEFAULT_MODEL,
+  );
+  return parseClaudeAgentModel(raw);
 }
 
 // ============================================================================
 // Permission mode
 // ============================================================================
 
-const PERMISSION_MODE_KEY = 'texra.claudeAgentPermissionMode';
 const PERMISSION_MODE_DEFAULT: ClaudeAgentPermissionMode = 'acceptEdits';
 
 export function parseClaudeAgentPermissionMode(
@@ -42,7 +52,7 @@ export function parseClaudeAgentPermissionMode(
 
 export function getClaudeAgentPermissionMode(): ClaudeAgentPermissionMode {
   const raw = getWorkspaceState().get<string>(
-    PERMISSION_MODE_KEY,
+    WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
     PERMISSION_MODE_DEFAULT,
   );
   return parseClaudeAgentPermissionMode(raw);

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -9,8 +9,10 @@ import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,
+  CLAUDE_AGENT_EFFORT_LEVELS,
   CLAUDE_AGENT_MODELS,
   CLAUDE_AGENT_PERMISSION_MODES,
+  type ClaudeAgentEffort,
   type ClaudeAgentModel,
   type ClaudeAgentPermissionMode,
 } from './claudeAgentShared';
@@ -56,6 +58,26 @@ export function getClaudeAgentPermissionMode(): ClaudeAgentPermissionMode {
     PERMISSION_MODE_DEFAULT,
   );
   return parseClaudeAgentPermissionMode(raw);
+}
+
+// ============================================================================
+// Effort — adaptive thinking depth hint passed via `effort` SDK option
+// ============================================================================
+
+const EFFORT_DEFAULT: ClaudeAgentEffort = 'high';
+
+export function parseClaudeAgentEffort(raw: string): ClaudeAgentEffort {
+  return (CLAUDE_AGENT_EFFORT_LEVELS as readonly string[]).includes(raw)
+    ? (raw as ClaudeAgentEffort)
+    : EFFORT_DEFAULT;
+}
+
+export function getClaudeAgentEffort(): ClaudeAgentEffort {
+  const raw = getWorkspaceState().get<string>(
+    WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+    EFFORT_DEFAULT,
+  );
+  return parseClaudeAgentEffort(raw);
 }
 
 // ============================================================================

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -14,6 +14,17 @@ export const CLAUDE_AGENT_PERMISSION_MODES = [
 export type ClaudeAgentPermissionMode =
   (typeof CLAUDE_AGENT_PERMISSION_MODES)[number];
 
+/** Effort levels mirror the SDK's `EffortLevel` (low → max). Claude decides
+ * adaptively how much thinking to do, scaled by this hint. */
+export const CLAUDE_AGENT_EFFORT_LEVELS = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
+export type ClaudeAgentEffort = (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number];
+
 /** Canonical Claude model IDs surfaced by the settings dropdown.
  * The SDK accepts arbitrary model strings; this list is what we expose in the
  * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts.

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -37,6 +37,15 @@ export const CLAUDE_AGENT_MODELS = [
 ] as const;
 export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];
 
+/**
+ * Adaptive thinking is only supported on Opus 4.6+ and Sonnet 4.6+. Haiku
+ * (and any earlier model) rejects the `thinking: { type: 'adaptive' }`
+ * option — gate the SDK option on this predicate to keep Haiku usable.
+ */
+export function modelSupportsAdaptiveThinking(model: string): boolean {
+  return model.startsWith('claude-opus-') || model.startsWith('claude-sonnet-');
+}
+
 const SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -14,6 +14,16 @@ export const CLAUDE_AGENT_PERMISSION_MODES = [
 export type ClaudeAgentPermissionMode =
   (typeof CLAUDE_AGENT_PERMISSION_MODES)[number];
 
+/** Canonical Claude model IDs surfaced by the settings dropdown.
+ * The SDK accepts arbitrary model strings; this list is what we expose in the
+ * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts. */
+export const CLAUDE_AGENT_MODELS = [
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5-20251001',
+] as const;
+export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];
+
 const SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -16,7 +16,9 @@ export type ClaudeAgentPermissionMode =
 
 /** Canonical Claude model IDs surfaced by the settings dropdown.
  * The SDK accepts arbitrary model strings; this list is what we expose in the
- * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts. */
+ * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts.
+ * Opus and Sonnet use the alias form; Haiku 4.5 ships with a dated snapshot
+ * suffix (its only published identifier at time of writing). */
 export const CLAUDE_AGENT_MODELS = [
   'claude-opus-4-7',
   'claude-sonnet-4-6',

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -327,10 +327,10 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     name: 'External Chat Handoff',
     category: 'ai-agents',
     description:
-      'Lets agents ask you to query an external chat model such as ChatGPT, Claude, or Gemini and paste the answer back into the run.',
+      'Tap your premium chat subscriptions — ChatGPT Pro, Claude Opus, Gemini Deep Think, Grok, and similar — without an API key. The agent drafts a question, you paste the answer back, and the run continues. Useful for the deep-reasoning tiers that aren’t available through the API.',
     configNotes:
       'No local install required. Uses your own external chat subscription and a human-in-the-loop copy/paste flow.',
-    authNote: 'Uses external chat subscription',
+    authNote: 'Uses your premium chat subscription',
     toggleable: true,
     check: async () => true,
   },
@@ -404,10 +404,10 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   {
     id: 'claude-agent',
     tools: ['claude_agent'],
-    name: 'Claude Code Agent',
+    name: 'Claude Agent',
     category: 'ai-agents',
     description:
-      'Anthropic Claude Code agent runtime. Spins off a Claude agent in the workspace for code analysis, generation, and research.',
+      'Spin off a Claude agent that works in your workspace. It can read files, run commands, edit code, and search the web on your behalf — great for delegating focused exploration or implementation while another agent stays in charge.',
     installGuide:
       'Install the Claude Code CLI (choose one):\n\n' +
       '  npm install -g @anthropic-ai/claude-code\n' +


### PR DESCRIPTION
Follow-ups on the AI Agents tab that didn't land before #4012 was merged.

## Summary

- Rewrite the **External Chat Handoff** description to name the premium tiers users actually bridge to (ChatGPT Pro, Claude Opus, Gemini Deep Think, Grok), instead of the generic "ChatGPT, Claude, or Gemini" phrasing.
- Rename **Claude Code Agent → Claude Agent** to match Anthropic's branding guidance and replace the "Anthropic Claude Code agent runtime" copy with a user-facing description.
- Add inline **Model + Permission mode** pickers on the Claude Agent card, mirroring the Codex sandbox/reasoning/approval pickers already on that tab.
  - New `WorkspaceStateKey`s: `CLAUDE_AGENT_MODEL`, `CLAUDE_AGENT_PERMISSION_MODE`
  - New schemas, commands, and dispatcher cases follow the existing Codex pattern
  - Model options: Opus 4.7 / Sonnet 4.6 / Haiku 4.5
  - Permission options: Prompt for risky actions / Auto-accept edits / Bypass all / Plan only
- Rename the backend helper `updateCodexSetting → updateAgentSetting` now that it serves both agents.

## Test plan

- [ ] Open Settings → AI Agents — Claude Agent card shows new copy + dropdowns
- [ ] Change model dropdown; restart and verify it persists
- [ ] Change permission mode; launch a `claude_agent` tool call and verify the SDK receives the chosen mode
- [ ] External Chat Handoff card shows the new description with premium tier names

https://claude.ai/code/session_01QYaeStjUtMP9ridx62FXQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYaeStjUtMP9ridx62FXQZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted workspace settings and UI controls for Claude Agent model/permission/effort, and changes the `claude_agent` tool’s SDK invocation (including adaptive-thinking gating), which could affect agent runtime behavior across workspaces.
> 
> **Overview**
> Polishes the **AI Agents** settings by adding inline pickers for **Claude Agent** `model`, `permissionMode`, and new `effort` (reasoning depth), persisting these via new `WorkspaceStateKey`s and new settings-view commands/schemas across desktop IPC and the extension webview.
> 
> Updates the `claude_agent` tool to accept/pass through `effort`, store it in session state, and enable `thinking: { type: 'adaptive' }` only for supported Opus/Sonnet models; also refreshes agent card copy/branding (e.g., “Claude Code Agent” → “Claude Agent”, richer External Chat Handoff description) and generalizes `updateCodexSetting` → `updateAgentSetting`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0621abd5cb05c6687d4c62967c4bbf6d84476cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->