### PR TITLE
docs(prd): add Skills feature PRD

### DIFF
--- a/docs/prd/skills.md
+++ b/docs/prd/skills.md
@@ -1,9 +1,9 @@
 # PRD: Skills for TeXRA
 
-**Status:** Draft
+## Status: Draft
+
 **Tracking issue:** [LionSR/TeXRA#4031](https://github.com/LionSR/TeXRA/issues/4031)
-**Author:** sirui.lu@mpq.mpg.de
-**Last updated:** 2026-05-14
+**Last updated:** 2026-05-15
 
 ---
 
@@ -94,7 +94,7 @@ What is missing is **runtime integration** — `src/skills/` has no loader, no p
 - **FR-1.2.** `src/skills/frontmatter.ts` exports `extractFrontmatter(content): { frontmatter: unknown, body: string }`. Codex-strict framing: opening `---` and closing `---` each on their own line; body must be non-empty. Whitespace in `name`/`description` collapsed via `sanitizeSingleLine`.
 - **FR-1.3.** `src/skills/loadSkills.ts` exports `discoverSkills(root: string): { skills: Skill[], errors: SkillError[] }`. One-level scan: each `<root>/<dirname>/SKILL.md` is one skill. Real-path canonicalization for symlink dedup. Collect per-skill errors instead of failing the whole load. Missing `description` → error, skill not loaded; other rule violations → warning, skill loaded.
 - **FR-1.4.** Vitest suite in `src/test-kernel/skills/` covering: valid skill, missing description, name mismatch with directory, invalid YAML, symlink dedup, name collision (first wins).
-- **FR-1.5.** Host-agnostic (no `vscode` imports). Per CLAUDE.md `src/skills/` is a VS Code-free zone.
+- **FR-1.5.** Host-agnostic (no `vscode` imports). `src/skills/` should be treated as a VS Code-free zone alongside the others listed in CLAUDE.md (`src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, etc.); update CLAUDE.md's canonical list when this lands.
 
 ### M2 — Prompt injection (1 day; ~150 LoC)
 
@@ -218,7 +218,7 @@ Opt-in interop with `.claude/`, `.codex/` via settings.
 
 ### D5. Frontmatter parser strictness
 
-**Decision:** Codex-strict — `---` opening and closing each on own line, body non-empty. Use the `yaml` package (already a transitive dep via `js-yaml` in the workspace).
+**Decision:** Codex-strict — `---` opening and closing each on own line, body non-empty. Use the `yaml` package (already a direct dependency at the workspace root and in `packages/extension`, version `^2.9.0`).
 
 **Rationale:** Permissive parsers (e.g., `gray-matter`) silently accept malformed files. Codex's strict mode catches issues at load time, surfaces them in the errors list, and prevents downstream confusion.
 
@@ -236,7 +236,7 @@ Opt-in interop with `.claude/`, `.codex/` via settings.
 
 ### Phase A — Land M1+M2+M3 (~3-4 days)
 
-Loader, prompt injection, skill tool. Tests but no UI. Verify with one hand-written skill in `packages/extension/resources/skills/polish/SKILL.md` invoked from an existing command.
+Loader, prompt injection, skill tool. Tests but no UI. Verify against one of the existing skills under `<repoRoot>/skills/` (per D4 the bundled discovery root) — e.g., `skills/manuscript-review/SKILL.md` — invoked from an existing command. No new `packages/extension/resources/skills/` directory is created.
 
 ### Phase B — M4+M5 (~3 days)
 

--- a/docs/prd/skills.md
+++ b/docs/prd/skills.md
@@ -1,0 +1,321 @@
+# PRD: Skills for TeXRA
+
+**Status:** Draft
+**Tracking issue:** [LionSR/TeXRA#4031](https://github.com/LionSR/TeXRA/issues/4031)
+**Author:** sirui.lu@mpq.mpg.de
+**Last updated:** 2026-05-14
+
+---
+
+## TL;DR
+
+Adopt the open [Agent Skills standard](https://agentskills.io/specification) (`SKILL.md` directories) as the primary format for prompt-shaped TeXRA "agents." Skills decouple **prompt content** from the **agent runtime** (Direct / CoT / Workflow / Merge / ToolUse). Most of the 139 YAML prompts at `texra-agent-prompts/` become skills; multi-round CoT agents and orchestrators (`leanOrchestrator`, `merge`) stay as YAML agents but reference skills via a new `inherits_skill:` field. Cross-vendor by construction — works identically for all our model providers, and TeXRA skills are usable in Claude Code, OpenAI Codex, Gemini CLI, and pi.
+
+## Current state
+
+The repo already has the skill _authoring_ foundation:
+
+- `skills/` contains 13 authored skills (`manuscript-review`, `lean-proof-assistant`, `math-ocr`, `scientific-presenter`, `tikz-figure-builder`, `inline-paper-critic`, `mathematical-enhancer`, `scientific-simplifier`, `writing-commenter`, `literature-search`, `lean-blueprint`, `lean-search`, `lean-simplifier`).
+- Each follows the codex-style layout: `SKILL.md` + optional `references/` + optional `agents/openai.yaml` side-car.
+- `docs/skills/skill-authoring.md` codifies the authoring conventions ("standalone, self-contained, no project-specific context").
+- `.claude/skills/code-review/` exists for Claude Code interop.
+
+What is missing is **runtime integration** — `src/skills/` has no loader, no parser, no prompt injection, no `Skill` tool. This PRD scopes the runtime work to land that integration without disrupting the existing authoring conventions.
+
+---
+
+## Problem
+
+1. **The YAML-agent schema is overloaded.** It encodes both reasoning strategy and prompt content. Most of our 139 agent files are pure prompt content with `agentType: Direct` — they don't need the YAML runtime, just text.
+2. **No interop.** Our prompts can't be consumed by Claude Code, Codex, Gemini CLI, or pi. Likewise we can't pull in skills from the 40,000+ public ecosystem.
+3. **Hard to share or fork.** YAML agents have a TeXRA-specific schema. Skills are filesystem directories — `git clone`-able, package-shareable.
+4. **Orchestrator dispatch is awkward.** A future orchestrator (e.g., a "write a paper" agent) currently has no clean way to attach prompt content per dispatched sub-task. Skills give it a per-branch preload list.
+
+## Goals
+
+- **G1.** Implement an Agent Skills spec-compliant loader: discover `SKILL.md` files, parse frontmatter, expose a list of `{name, description, body, baseDir}` to the runtime.
+- **G2.** Prompt injection at turn boundaries: surface available skill names + descriptions to the model. Provider-agnostic format (plain text). Token-budgeted.
+- **G3.** Skill activation: model can invoke a skill (via dedicated tool or file-read) and have its `SKILL.md` body injected.
+- **G4.** Interop discovery: read skills from `.texra/skills/`, `~/.texra/skills/`, and (opt-in) `.claude/skills/`, `~/.claude/skills/`, `.codex/skills/`, `~/.codex/skills/`.
+- **G5.** `inherits_skill:` mechanism in YAML agents so multi-round CoT agents (`critiqueFix`, `verifyFix`) can keep their runtime while sourcing prompt content from a skill.
+- **G6.** Migrate single-round prompt agents from `texra-agent-prompts/` to skills. ~70-80% of the 139.
+- **G7.** Settings UI tab listing discovered skills (similar to existing Agents tab).
+
+## Non-goals
+
+- Replacing the YAML agent schema. Agents and skills coexist permanently.
+- Multi-round runtime semantics in the skills format itself. Multi-round stays in YAML.
+- Plugin marketplace / skill registry / remote skill fetching.
+- MCP-hosted skills.
+- Conditional skills (codex `paths:` glob triggering).
+- Skill-level hooks (Claude Code's `hooks:` frontmatter).
+- Forked sub-agent execution (`context: fork` in Claude Code) — TeXRA's agent runtime handles dispatch already.
+
+## Users
+
+| User                             | Use case                                                                                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TeXRA end-user** (researcher)  | Picks a skill from a list ("polish my LaTeX," "convert paper to slides"). May write a personal skill in `.texra/skills/` for project-specific style. |
+| **Power user**                   | Forks community skills from `.claude/skills/` or `.codex/skills/` into TeXRA. Shares their own skills as `git`-able directories.                     |
+| **Orchestrator agent (machine)** | Dispatches sub-tasks with the right skill attached per branch.                                                                                       |
+| **Contributor**                  | Adds a new prompt-shaped capability by writing `SKILL.md` — no TypeScript changes needed.                                                            |
+
+---
+
+## Background — three reference implementations studied
+
+- **pi** (`earendil-works/pi`, TypeScript): `packages/coding-agent/src/core/skills.ts` (~500 LoC, one file). Provider-agnostic, no dedicated skill tool — model loads `SKILL.md` via the normal `read` tool when triggered.
+- **Claude Code** (Anthropic, TypeScript): `src/skills/loadSkillsDir.ts`, `src/tools/SkillTool/`, `src/utils/frontmatterParser.ts`. Most polished. Per-turn `<system-reminder>`-wrapped attachment with 1%-of-context budget, 250-char per-entry cap, names-only fallback. Dedicated `Skill` tool with `{skill, args?}` schema.
+- **Codex** (OpenAI, Rust): `codex-rs/core-skills/`. Strictest validation. Distinguishes `SKILL.md` frontmatter from a side-car `agents/openai.yaml` for UI metadata. `<skills_instructions>` block + `<skill>` injection on `$mention`. Token-budgeted with alias-path optimization for plugin caches. No dedicated tool — relies on `$mention` sigil or implicit task-description match.
+
+**Convergent core** (what all three agree on):
+
+- YAML frontmatter delimited by `---...---`
+- Required: `name` (or fall back to parent dir), `description`
+- Length caps: `name ≤ 64`, `description ≤ 1024`
+- Name rules: `^[a-z0-9-]+$`, no leading/trailing `-`, no `--`
+- Symlink dedup via real-path canonicalization
+- First-wins on name collisions
+
+**Where they diverge** (TeXRA must pick):
+
+- Activation mechanism (Skill tool vs. `read` vs. mention sigil)
+- Prompt-injection format and budget
+- Frontmatter field set beyond name/description
+- Multi-source discovery + scope precedence
+
+---
+
+## Functional requirements
+
+### M1 — Loader foundation (half day; ~300 LoC)
+
+- **FR-1.1.** `src/skills/SkillSchema.ts` exports Zod schema with `name` (≤64 chars, `^[a-z0-9-]+$`, no leading/trailing `-`, no `--`), `description` (1-1024 chars, required). Use `.passthrough()` on the rest so future fields (codex `metadata.short-description`, Claude Code `when_to_use`, etc.) don't bump the schema.
+- **FR-1.2.** `src/skills/frontmatter.ts` exports `extractFrontmatter(content): { frontmatter: unknown, body: string }`. Codex-strict framing: opening `---` and closing `---` each on their own line; body must be non-empty. Whitespace in `name`/`description` collapsed via `sanitizeSingleLine`.
+- **FR-1.3.** `src/skills/loadSkills.ts` exports `discoverSkills(root: string): { skills: Skill[], errors: SkillError[] }`. One-level scan: each `<root>/<dirname>/SKILL.md` is one skill. Real-path canonicalization for symlink dedup. Collect per-skill errors instead of failing the whole load. Missing `description` → error, skill not loaded; other rule violations → warning, skill loaded.
+- **FR-1.4.** Vitest suite in `src/test-kernel/skills/` covering: valid skill, missing description, name mismatch with directory, invalid YAML, symlink dedup, name collision (first wins).
+- **FR-1.5.** Host-agnostic (no `vscode` imports). Per CLAUDE.md `src/skills/` is a VS Code-free zone.
+
+### M2 — Prompt injection (1 day; ~150 LoC)
+
+- **FR-2.1.** `src/skills/render.ts` exports `renderSkillListing(skills: Skill[], budget: { maxChars: number, perEntryMaxChars: number }): string`. Format: Claude Code-style `<system-reminder>`-wrapped block (works across providers since it's just text), but with codex's `<skills_instructions>` opening tag for spec-alignment. Each entry: `- {name}: {description}`. Adaptive truncation: 250 char per-entry cap; if total exceeds budget, fair-share truncate; if budget would push per-entry below 20 chars, fall back to names-only.
+- **FR-2.2.** Budget defaults: 1% of model context window in characters (Claude Code's value), fallback 8000 chars.
+- **FR-2.3.** Hook into the agent runtime at the point where the system prompt is composed in `src/agent/`. New skills appear at turn-1; subsequent turns can elide already-injected skills (delta tracking deferred to M5).
+- **FR-2.4.** Reaches host services via `platform()` (per CLAUDE.md).
+
+### M3 — Skill activation (1-2 days; ~250 LoC)
+
+- **FR-3.1.** Implement a `skill` tool in `src/tools/` with schema `{ skill: string, args?: string }`. Validates against the loaded skill list. Returns the `SKILL.md` body wrapped per codex's `<skill><name>...</name><path>...</path>...</skill>` shape.
+- **FR-3.2.** Slash command `/skill-name args` resolves through the same path (matches `cmd.name`, accepts leading `/`, splits on first whitespace).
+- **FR-3.3.** `${TEXRA_SKILL_DIR}` substitution in the injected body so `SKILL.md` can reference `scripts/foo.py` and the model gets the absolute path.
+- **FR-3.4.** Per-skill `disable-model-invocation: true` filters from the listing but keeps slash-command access.
+
+### M4 — Multi-source discovery + interop (1 day; ~150 LoC)
+
+- **FR-4.1.** Default discovery sources, in scan order:
+  1. `<repoRoot>/skills/` (bundled — the existing 13-skill directory, scope `bundled`)
+  2. `~/.texra/skills/` (user, scope `user`)
+  3. `<workspaceRoot>/.texra/skills/` (project, scope `project`)
+- **FR-4.2.** Opt-in interop sources (toggleable in settings):
+  - `~/.claude/skills/`, `~/.codex/skills/`
+  - `<workspaceRoot>/.claude/skills/`, `<workspaceRoot>/.codex/skills/`
+- **FR-4.3.** Each skill tagged with `scope`. Collision precedence: `project > user > interop > bundled`. First-wins within a scope.
+- **FR-4.4.** Settings: array of additional skill paths (CLI-style `skills` setting, codex-shaped).
+
+### M5 — Settings UI (1-2 days)
+
+- **FR-5.1.** New "Skills" tab in the existing settingsView webview. Lists discovered skills with: name, description, scope tag, source path. Disable/enable toggle per skill (codex-style: rule by name or path, stored in settings).
+- **FR-5.2.** Show error skills in a separate section with the per-skill error message.
+- **FR-5.3.** "Reload skills" button.
+- **FR-5.4.** Delta tracking (`sentSkillNames` per session) for prompt-cache stability across turns.
+
+### M6 — `inherits_skill` mechanism for multi-round agents (1-2 days)
+
+- **FR-6.1.** Extend YAML agent schema with optional `inherits_skill: string` field.
+- **FR-6.2.** Agent loader: if `inherits_skill` is set, look up the skill by name, substitute its `SKILL.md` body into the agent's `systemPrompt` (or `userPrefix` — TBD per agent type).
+- **FR-6.3.** Round/prefill semantics remain in the YAML agent. Skill body provides the _content_, agent runtime provides the _control flow_.
+- **FR-6.4.** Backward compat: existing YAML agents without `inherits_skill` work unchanged.
+
+### M7 — Migration of `texra-agent-prompts/` (bulk; ~1 week)
+
+Convert the 139 YAMLs to skills/agents per the categorization below. Done in batches per directory.
+
+---
+
+## Migration categorization
+
+Surveyed `texra-agent-prompts/`. Breakdown:
+
+| Category                                                  | Count | Disposition                                                                                                           |
+| --------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------- |
+| **Single-round prompts** (no `rounds:`, no toolUse)       | ~100  | → Pure `SKILL.md`. Body = `systemPrompt + userPrefix + userRequest`. Templates/`.sty`/`.tex` → `assets/`.             |
+| **Multi-round CoT** (`rounds: 2+`, `prefills: [...]`)     | ~30   | → Skill (content) + thin YAML agent (`inherits_skill:` + `rounds:` + `prefills:`).                                    |
+| **Tool-use / orchestrator** (`leanOrchestrator`, `merge`) | ~5    | → Stay full YAML agents. May attach skills to dispatched sub-tasks.                                                   |
+| **`_multiple` variants**                                  | ~30   | → Either single skill with frontmatter toggle (preferred), or sibling skill with `_multiple` suffix. Decide per case. |
+
+**`inherits:` chains** (e.g., `correct_more` inherits `correct`): preserved during migration. Skill format doesn't have inheritance, so `correct_more` either:
+
+- Becomes a standalone skill with its content fully expanded (recommended), or
+- Stays a YAML agent inheriting from a skill via `inherits_skill: correct` plus its own additional prompt.
+
+---
+
+## Technical design — key decisions
+
+### D1. Activation mechanism
+
+**Decision:** Implement a dedicated `skill` tool (Claude Code style), not pure `$mention` (codex) or pure `read` (pi).
+
+**Rationale:** Our agent runtime already orchestrates tool calls — a `skill` tool slots in cleanly. The `read`-via-file-tool approach (pi) requires every TeXRA agent to have file-read capability, which many of our agents don't. The mention-sigil approach (codex) requires user-text parsing we don't currently do.
+
+### D2. Prompt-injection format
+
+**Decision:** `<system-reminder>` wrapper (Claude Code), with `<skills_instructions>` inner tag (codex spec-alignment). Format works as plain text on all our providers.
+
+```
+<system-reminder>
+<skills_instructions>
+The following skills are available for use with the skill tool:
+
+- polish: Polishes LaTeX research papers for clarity and style. Use when ...
+- correct: Proofreads LaTeX for math errors and typos. Use when ...
+...
+</skills_instructions>
+</system-reminder>
+```
+
+### D3. Frontmatter field set (M1)
+
+**Decision:** Accept the agentskills.io spec fields. Schema is `.passthrough()`, so unknown fields are preserved but not validated.
+
+```yaml
+---
+name: polish # required, ≤64, ^[a-z0-9-]+$, matches dir
+description: ... # required, ≤1024
+license: ... # optional, informational
+compatibility: ... # optional, informational
+metadata: { ... } # optional, key-value map
+allowed-tools: ... # optional, experimental
+disable-model-invocation: # optional, boolean
+---
+```
+
+Later phases may add: `when_to_use` (Claude Code), `metadata.short-description` (codex), `argument-hint` (Claude Code).
+
+### D4. Discovery directory naming
+
+**Decision:** Three layers, in scan order:
+
+- `<repoRoot>/skills/` — bundled (the existing 13-skill directory)
+- `~/.texra/skills/` — user
+- `<workspaceRoot>/.texra/skills/` — project
+
+Opt-in interop with `.claude/`, `.codex/` via settings.
+
+**Not** using `.agents/skills/` as the bundled location because the repo has already committed to `skills/` at root and the existing authoring docs reference that path.
+
+**Open:** Should we ship a `.agents/skills/` _additional_ source for cross-tool interop? Codex's choice suggests the spec is moving toward `.agents/` as the cross-vendor canonical. Defer until ecosystem signal stronger.
+
+### D5. Frontmatter parser strictness
+
+**Decision:** Codex-strict — `---` opening and closing each on own line, body non-empty. Use the `yaml` package (already a transitive dep via `js-yaml` in the workspace).
+
+**Rationale:** Permissive parsers (e.g., `gray-matter`) silently accept malformed files. Codex's strict mode catches issues at load time, surfaces them in the errors list, and prevents downstream confusion.
+
+### D6. Validation strategy
+
+**Decision:** Codex-style `{ skills, errors }` outcome. Missing `description` → error, skill not loaded. All other violations → load with warning. Errors surfaced in settings UI.
+
+### D7. Multi-round handling
+
+**Decision:** Skills are single-shot. Multi-round logic stays in YAML via `inherits_skill:` (M6). See [issue comment](https://github.com/LionSR/TeXRA/issues/4031#issuecomment-4454650473).
+
+---
+
+## Migration strategy
+
+### Phase A — Land M1+M2+M3 (~3-4 days)
+
+Loader, prompt injection, skill tool. Tests but no UI. Verify with one hand-written skill in `packages/extension/resources/skills/polish/SKILL.md` invoked from an existing command.
+
+### Phase B — M4+M5 (~3 days)
+
+Multi-source discovery, settings UI tab. End-to-end usable.
+
+### Phase C — M6 (~1-2 days)
+
+`inherits_skill:` mechanism. Unblocks multi-round migration.
+
+### Phase D — Bulk migration of `texra-agent-prompts/` (~1 week)
+
+Per-directory batches:
+
+1. `article/*` (40 files, mostly single-round) — pilot
+2. `write/*` (15 files) — paper2slide/paper2poster moved here, with `.tex` templates → `assets/`
+3. `lecture/*` (35 files) — similar shape
+4. `lecture2text/`, `meeting2text/`, `txt2tex/`, `audio/`, `statement/`, `talk/`, `grant/`, `neurips/`, `paper2note/`, `prl/`, `yuanshi/` — straightforward
+5. Multi-round variants (`critiqueFix`, `verifyFix`, `_more`, `_iterate`): two-file conversion (skill + thin YAML)
+
+### Phase E — Deprecation (TBD)
+
+Once skills carry the prompt content, the legacy YAML files in `packages/extension/resources/agents/` can be slimmed down or removed. **Not a goal of this PRD** — let coexistence settle first.
+
+---
+
+## Success criteria
+
+- **SC-1.** End-to-end: a user can drop a `SKILL.md` into `.texra/skills/`, see it in the settings UI, invoke it from a TeXRA command, and have the body inject into the prompt.
+- **SC-2.** Interop: a skill from `~/.claude/skills/` or `~/.codex/skills/` is discoverable when the user opts in.
+- **SC-3.** Migration: ≥80% of `article/*` agents work as skills end-to-end with no regression on test fixtures.
+- **SC-4.** Multi-round: `critiqueFix` runs with skill-sourced content and produces identical output to its pre-migration YAML version on a held-out fixture.
+- **SC-5.** Cross-provider parity: the same skill produces equivalent output on at least one Anthropic, one OpenAI, and one Google model.
+- **SC-6.** No regression in extension build time or webview cold-start.
+
+---
+
+## Open questions
+
+- **OQ-1.** `.texra/skills/` vs `.agents/skills/` as canonical project location. Currently leaning `.texra/`; revisit if codex-style `.agents/` standard solidifies.
+- **OQ-2.** Should `_multiple` agent variants collapse into one skill with a frontmatter flag, or stay as siblings? Probably case-by-case, but a default convention helps.
+- **OQ-3.** How aggressively to bundle skills with the extension. Top-N most-used? Or none (ship clean, let users opt in)?
+- **OQ-4.** Where the orchestrator-attaches-skills wiring lives. Likely a `skills: string[]` field on agent definitions (mirroring Claude Code's `AgentDefinition.skills`), but the dispatch path needs design work.
+- **OQ-5.** Backward compat for the YAML agent file paths shipped with current users — leave as-is during the transition, or relocate.
+- **OQ-6.** Telemetry: track which skills get invoked? Off by default per TeXRA's privacy stance, probably.
+
+---
+
+## Risks and mitigations
+
+| Risk                                                             | Mitigation                                                                                                                  |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Skill descriptions blow context window                           | Codex-style fair-share truncation; names-only fallback when over budget                                                     |
+| Models on non-Anthropic providers ignore `<system-reminder>` tag | Tag is just text; descriptions still parse semantically. Verify cross-provider in SC-5.                                     |
+| Migration churn breaks user workflows                            | Skills + YAML agents coexist. No removal in this PRD.                                                                       |
+| `SKILL.md` body too long → context bloat per invocation          | Adopt agentskills.io recommendation: `SKILL.md` ≤ 500 lines, push detail to `references/` loaded on-demand via `read` tool. |
+| Skill collisions across multi-source discovery                   | First-wins precedence with clear scope tags; surface collisions in settings UI.                                             |
+| Future agentskills.io spec changes                               | `.passthrough()` Zod schema absorbs new fields without breaking loaders.                                                    |
+
+---
+
+## Out of scope
+
+- Skill marketplace, registry, or remote fetching
+- MCP-server-hosted skills
+- Skill-level hooks
+- Conditional skills (auto-activate based on touched file paths)
+- Forked sub-agent execution per skill
+- Plugin namespacing
+- File-watching skill directories for hot reload
+- Replacing the YAML agent schema
+- Migrating `merge.yaml`, `leanOrchestrator.yaml`, or other reasoning-strategy agents
+
+---
+
+## References
+
+- [Agent Skills specification](https://agentskills.io/specification)
+- [LionSR/TeXRA#4031 — tracking issue](https://github.com/LionSR/TeXRA/issues/4031)
+- [pi `skills.ts`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/skills.ts)
+- [Anthropic Claude Code Skills source](https://github.com/anthropics/claude-code) (`src/skills/`, `src/tools/SkillTool/`)
+- [OpenAI Codex Skills source](https://github.com/openai/codex) (`codex-rs/core-skills/`, `codex-rs/skills/`)
+- Internal study reports (in conversation 2026-05-14)

--- a/docs/prd/skills.md
+++ b/docs/prd/skills.md
@@ -319,4 +319,4 @@ Once skills carry the prompt content, the legacy YAML files in `packages/extensi
 - [pi `skills.ts`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/skills.ts)
 - [Anthropic Claude Code Skills source](https://github.com/anthropics/claude-code) (`src/skills/`, `src/tools/SkillTool/`)
 - [OpenAI Codex Skills source](https://github.com/openai/codex) (`codex-rs/core-skills/`, `codex-rs/skills/`)
-- Internal study reports (in conversation 2026-05-14)
+- [LionSR/TeXRA#4031 — implementation notes & cross-implementation comparison](https://github.com/LionSR/TeXRA/issues/4031#issuecomment-4454571034) (issue comments capture the pi / Claude Code / Codex study findings underpinning §D1–§D6)

--- a/docs/prd/skills.md
+++ b/docs/prd/skills.md
@@ -36,7 +36,7 @@ What is missing is **runtime integration** — `src/skills/` has no loader, no p
 - **G1.** Implement an Agent Skills spec-compliant loader: discover `SKILL.md` files, parse frontmatter, expose a list of `{name, description, body, baseDir}` to the runtime.
 - **G2.** Prompt injection at turn boundaries: surface available skill names + descriptions to the model. Provider-agnostic format (plain text). Token-budgeted.
 - **G3.** Skill activation: model can invoke a skill (via dedicated tool or file-read) and have its `SKILL.md` body injected.
-- **G4.** Interop discovery: read skills from `.texra/skills/`, `~/.texra/skills/`, and (opt-in) `.claude/skills/`, `~/.claude/skills/`, `.codex/skills/`, `~/.codex/skills/`.
+- **G4.** Multi-source discovery: read skills from `<repoRoot>/skills/` (bundled), `~/.texra/skills/` (user), `<workspace>/.texra/skills/` (project), and (opt-in) `.claude/skills/`, `~/.claude/skills/`, `.codex/skills/`, `~/.codex/skills/`.
 - **G5.** `inherits_skill:` mechanism in YAML agents so multi-round CoT agents (`critiqueFix`, `verifyFix`) can keep their runtime while sourcing prompt content from a skill.
 - **G6.** Migrate single-round prompt agents from `texra-agent-prompts/` to skills. ~70-80% of the 139.
 - **G7.** Settings UI tab listing discovered skills (similar to existing Agents tab).
@@ -146,12 +146,13 @@ Convert the 139 YAMLs to skills/agents per the categorization below. Done in bat
 
 Surveyed `texra-agent-prompts/`. Breakdown:
 
-| Category                                                  | Count | Disposition                                                                                                           |
-| --------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------- |
-| **Single-round prompts** (no `rounds:`, no toolUse)       | ~100  | → Pure `SKILL.md`. Body = `systemPrompt + userPrefix + userRequest`. Templates/`.sty`/`.tex` → `assets/`.             |
-| **Multi-round CoT** (`rounds: 2+`, `prefills: [...]`)     | ~30   | → Skill (content) + thin YAML agent (`inherits_skill:` + `rounds:` + `prefills:`).                                    |
-| **Tool-use / orchestrator** (`leanOrchestrator`, `merge`) | ~5    | → Stay full YAML agents. May attach skills to dispatched sub-tasks.                                                   |
-| **`_multiple` variants**                                  | ~30   | → Either single skill with frontmatter toggle (preferred), or sibling skill with `_multiple` suffix. Decide per case. |
+| Category                                                  | Count | Disposition                                                                                                                               |
+| --------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Single-round prompts** (no `rounds:`, no toolUse)       | ~104  | → Pure `SKILL.md`. Body = `systemPrompt + userPrefix + userRequest`. Templates/`.sty`/`.tex` → `references/` (per existing skill layout). |
+| **Multi-round CoT** (`rounds: 2+`, `prefills: [...]`)     | ~30   | → Skill (content) + thin YAML agent (`inherits_skill:` + `rounds:` + `prefills:`).                                                        |
+| **Tool-use / orchestrator** (`leanOrchestrator`, `merge`) | ~5    | → Stay full YAML agents. May attach skills to dispatched sub-tasks.                                                                       |
+
+The `_multiple` variants (~30 files total, e.g., `polish_multiple.yaml`, `correct_multiple.yaml`) are not a separate category — they fall under single-round or multi-round depending on their settings. Counts above include them. Per-case decision during migration: collapse into one skill with a frontmatter toggle, or keep as a sibling with `_multiple` suffix.
 
 **`inherits:` chains** (e.g., `correct_more` inherits `correct`): preserved during migration. Skill format doesn't have inheritance, so `correct_more` either:
 


### PR DESCRIPTION
## Summary

- Adds `docs/prd/skills.md` — a PRD for adopting the open [Agent Skills standard](https://agentskills.io/specification) (`SKILL.md` directories) as the primary format for prompt-shaped TeXRA agents.
- Skills decouple **prompt content** from **agent runtime** (Direct/CoT/Workflow/Merge/ToolUse). Most of the 139 YAML prompts at `texra-agent-prompts/` become skills; multi-round CoT agents (`critiqueFix`, `verifyFix`) keep their YAML runtime and source content via a new `inherits_skill:` field.
- Derived from a cross-reference study of three reference implementations: pi (TS, ~500 LoC, one file), Claude Code (TS, polished with budgeted prompt injection), and OpenAI Codex (Rust, strict frontmatter parsing + side-car UI metadata).

Tracks #4031.

## Context

The repo already has the skill *authoring* foundation:
- `skills/` contains 13 authored skills (`manuscript-review`, `lean-proof-assistant`, `math-ocr`, `scientific-presenter`, `tikz-figure-builder`, etc.) following the codex-style layout.
- `docs/skills/skill-authoring.md` codifies authoring conventions.
- `.claude/skills/code-review/` exists for Claude Code interop.

What's missing is **runtime integration** — there is no loader, no parser, no prompt injection, and no `Skill` tool in `src/`. This PRD scopes the runtime work needed to land that foundation.

## Key decisions captured

- **Cross-vendor by construction** — works identically across our Anthropic / OpenAI / Google / DeepSeek / Kimi / GLM / MiniMax / xAI / OpenRouter model handlers since the wire format is just text.
- **Activation:** dedicated `Skill` tool (Claude Code style), not `$mention` (codex) or `read` (pi).
- **Prompt format:** `<system-reminder>` wrapper with `<skills_instructions>` inner tag, character-budgeted at ~1% of context window with 250-char per-entry cap and names-only fallback.
- **Multi-round handling:** scripted multi-round CoT agents (`critiqueFix` with `rounds: 2`, `verifyFix` with `rounds: 3`) keep their YAML runtime and reference skills via `inherits_skill:` for content. Skills are single-shot by design.
- **Migration:** ~70-80% of 139 YAMLs become pure skills; ~20% become thin YAML + skill pairs; ~5% (`merge`, `leanOrchestrator`) stay as full agents.
- **Discovery layers:** `<repoRoot>/skills/` (bundled), `~/.texra/skills/` (user), `<workspace>/.texra/skills/` (project). Opt-in interop with `.claude/skills/` and `.codex/skills/`.

## Phased rollout

- **M1 (½ day, ~300 LoC):** Loader + parser + Zod schema + tests. Codex-strict frontmatter framing, `{skills, errors}` outcome shape.
- **M2 (1 day):** Prompt injection with adaptive budgeting.
- **M3 (1-2 days):** `Skill` tool + slash-command dispatch.
- **M4 (1 day):** Multi-source discovery + interop opt-ins.
- **M5 (1-2 days):** Settings UI tab.
- **M6 (1-2 days):** `inherits_skill:` mechanism for multi-round agents.
- **M7 (~1 week):** Bulk migration of `texra-agent-prompts/`.

Total estimate: ~2 weeks for runtime + bulk migration.

## Test plan

- [ ] PRD renders correctly in the docs site (VitePress)
- [ ] Cross-references to #4031 and reference implementations resolve
- [ ] Pre-commit hooks (Prettier) pass
- [ ] Reviewers confirm phased rollout is sequenceable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new PRD; no runtime or behavior changes.
> 
> **Overview**
> Adds a new draft PRD at `docs/prd/skills.md` proposing adoption of the Agent Skills (`SKILL.md`) directory standard and outlining a phased implementation plan (loader/frontmatter parsing, prompt injection, a `skill` tool, multi-source discovery, settings UI, and `inherits_skill` for YAML agents).
> 
> Also documents migration guidance for converting most existing single-round YAML prompts into skills while keeping multi-round/orchestrator agents in YAML, plus open questions, risks, and success criteria.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c676bbf59e741c7b0652de07c2843b45273d380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->