### PR TITLE
fix: simplify desktop launcher chrome

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -39,8 +39,6 @@ const DESKTOP_MENU_GROUPS = [
     'texra.showMainView',
     'texra.showProgressView',
     DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
-    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
-    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
     DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
     'texra.openSettings',
     'texra.mainView.reset',
@@ -64,16 +62,26 @@ const DESKTOP_MENU_GROUPS = [
   | DesktopLocalCommandId
 )[])[];
 
+const DESKTOP_FILE_COMMANDS = [
+  DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+  DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
+] as const satisfies readonly DesktopLocalCommandId[];
+
 const DESKTOP_HELP_COMMANDS = [
   DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
 ] as const satisfies readonly DesktopLocalCommandId[];
 
 type DesktopMenuCommandId = (typeof DESKTOP_MENU_GROUPS)[number][number];
+type DesktopFileCommandId = (typeof DESKTOP_FILE_COMMANDS)[number];
 type DesktopHelpCommandId = (typeof DESKTOP_HELP_COMMANDS)[number];
-export type DesktopCommandId = DesktopMenuCommandId | DesktopHelpCommandId;
+export type DesktopCommandId =
+  | DesktopFileCommandId
+  | DesktopMenuCommandId
+  | DesktopHelpCommandId;
 
 export const DESKTOP_COMMAND_IDS: readonly DesktopCommandId[] = [
+  ...DESKTOP_FILE_COMMANDS,
   ...DESKTOP_MENU_GROUPS.flat(),
   ...DESKTOP_HELP_COMMANDS,
 ];
@@ -138,7 +146,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
     {
       id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
       label: 'Open Folder',
-      category: 'TeXRA',
+      category: 'File',
       accelerator: 'CommandOrControl+O',
       enabled: true,
     },
@@ -148,7 +156,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
     {
       id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
       label: 'New Window',
-      category: 'TeXRA',
+      category: 'File',
       accelerator: 'CommandOrControl+Shift+N',
       enabled: true,
     },
@@ -434,14 +442,19 @@ export function buildDesktopMenuTemplate(
       ...DESKTOP_MENU_GROUPS[1].map(commandItem),
     ],
   };
+  const fileMenu: MenuItemConstructorOptions = {
+    label: 'File',
+    submenu: [
+      ...DESKTOP_FILE_COMMANDS.map(commandItem),
+      { type: 'separator' },
+      platform === 'darwin' ? { role: 'close' } : { role: 'quit' },
+    ],
+  };
 
   return [
     ...(platform === 'darwin'
-      ? ([
-          { role: 'appMenu' },
-          { role: 'fileMenu' },
-        ] satisfies MenuItemConstructorOptions[])
-      : ([{ role: 'fileMenu' }] satisfies MenuItemConstructorOptions[])),
+      ? ([{ role: 'appMenu' }, fileMenu] satisfies MenuItemConstructorOptions[])
+      : ([fileMenu] satisfies MenuItemConstructorOptions[])),
     customMenu,
     { role: 'editMenu' },
     { role: 'viewMenu' },

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -86,7 +86,6 @@ import {
   DESKTOP_LOCAL_COMMANDS,
   formatDesktopAccelerator,
   getDesktopCommandMenuEntries,
-  SETTINGS_TAB,
   type DesktopCommandActions,
   type DesktopCommandId,
 } from '../desktopCommandSurface';
@@ -137,10 +136,6 @@ const appRoot = root;
 
 let currentRoute: DesktopRoute = 'main';
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
-const workspacePath = window.texraDesktop?.workspacePath;
-const workspaceFolderName = workspacePath
-  ? workspacePath.split(/[\\/]/).pop() || workspacePath
-  : undefined;
 const rendererPlatform = getRendererPlatform(document.defaultView);
 const desktopCommandEntriesById = new Map(
   getDesktopCommandMenuEntries(undefined, rendererPlatform).map((entry) => [
@@ -245,36 +240,10 @@ function emptyStreamsTemplate(): TemplateResult {
     <section class="desktop-empty-streams" aria-label="First run suggestions">
       <div class="desktop-empty-streams-copy">
         <h2>Start from the launcher</h2>
-        <p>
-          Choose files and an agent above, or check model access before the
-          first run.
-        </p>
+        <p>Choose files and an agent above before the first run.</p>
         <p class="desktop-empty-streams-example">
           Try: <q>polish the abstract</q>
         </p>
-      </div>
-      <div class="desktop-empty-streams-actions">
-        <wa-button
-          appearance="outlined"
-          size="small"
-          @click=${() => openSettingsTab(SETTINGS_TAB.MODELS)}
-        >
-          ${waIcon('key', { slot: 'start' })} Models
-        </wa-button>
-        <wa-button
-          appearance="outlined"
-          size="small"
-          @click=${() => openSettingsTab(SETTINGS_TAB.AGENTS)}
-        >
-          ${waIcon('robot', { slot: 'start' })} Agents
-        </wa-button>
-        <wa-button
-          appearance="outlined"
-          size="small"
-          @click=${openCommandPalette}
-        >
-          ${waIcon('terminal', { slot: 'start' })} Commands
-        </wa-button>
       </div>
     </section>
   `;
@@ -330,19 +299,13 @@ function isProgressOutboundMessage(
 // =============================================================================
 
 interface ChromeIconButtonSpec {
-  readonly key: 'settings' | 'logs';
+  readonly key: 'logs';
   readonly icon: TeXRAIconName;
   readonly label: string;
   readonly onClick: () => void;
 }
 
 const CHROME_ICON_BUTTONS: ReadonlyArray<ChromeIconButtonSpec> = [
-  {
-    key: 'settings',
-    icon: 'gear',
-    label: 'Settings',
-    onClick: openSettingsOverlay,
-  },
   { key: 'logs', icon: 'file-lines', label: 'Logs', onClick: openLogsDrawer },
 ] as const;
 
@@ -376,18 +339,6 @@ function shellTemplate(): TemplateResult {
         >
           Commands
         </wa-button>
-        <wa-button
-          class="desktop-folder-button"
-          appearance="outlined"
-          size="small"
-          title=${commandTitle(
-            DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
-            'Open Folder',
-          )}
-          @click=${openWorkspaceFolder}
-        >
-          ${waIcon('folder-open', { slot: 'start' })} Open Folder
-        </wa-button>
         ${CHROME_ICON_BUTTONS.map(
           (spec) => html`
             <wa-button
@@ -397,9 +348,7 @@ function shellTemplate(): TemplateResult {
               data-route-button=${spec.key}
               aria-label=${spec.label}
               title=${commandTitle(
-                spec.key === 'settings'
-                  ? 'texra.openSettings'
-                  : DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+                DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
                 spec.label,
               )}
               @click=${spec.onClick}
@@ -413,14 +362,6 @@ function shellTemplate(): TemplateResult {
         <aside class="desktop-rail" aria-label="Sessions">
           <header class="desktop-rail-header">
             <div class="desktop-rail-header-content">
-              ${workspaceFolderName
-                ? html`<div
-                    class="desktop-workspace-name"
-                    title=${workspacePath}
-                  >
-                    ${workspaceFolderName}
-                  </div>`
-                : nothing}
               <span class="desktop-rail-title">Sessions</span>
             </div>
             <wa-button
@@ -994,6 +935,9 @@ const commandPalette = bootstrapFailed
         openWorkspaceFolder: () => {
           postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
         },
+        openWorkspaceInNewWindow: () => {
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW);
+        },
         showFirstRunWalkthrough: () => {
           firstRunWalkthrough?.show();
         },
@@ -1011,10 +955,6 @@ if (commandPalette) appRoot.append(commandPalette.element);
 
 function openCommandPalette(): void {
   commandPalette?.open();
-}
-
-function openWorkspaceFolder(): void {
-  postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
 }
 
 function switchToStream(streamId: StreamTabId): void {

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -65,8 +65,7 @@ wa-button.desktop-icon-button[aria-pressed='true']::part(base) {
   color: var(--wa-color-brand-on-quiet);
 }
 
-wa-button.desktop-command-button::part(base),
-wa-button.desktop-folder-button::part(base) {
+wa-button.desktop-command-button::part(base) {
   height: 28px;
   padding: 0 var(--wa-space-s);
   border-radius: var(--wa-border-radius-m, 3px);
@@ -116,21 +115,8 @@ wa-button.desktop-command-button {
 }
 
 .desktop-rail-header-content {
-  display: flex;
-  flex-direction: column;
   flex: 1 1 auto;
   min-width: 0;
-  gap: 2px;
-}
-
-.desktop-workspace-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--wa-color-text-quiet);
-  font-size: 10px;
-  opacity: 0.8;
 }
 
 .desktop-rail-title {
@@ -597,10 +583,6 @@ wa-input.desktop-command-palette-input::part(base) {
 }
 
 .desktop-empty-streams {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--wa-space-m);
-  align-items: center;
   padding: var(--wa-space-s) var(--wa-space-l);
   border-top: 1px solid var(--wa-color-surface-border);
   background: var(--wa-color-surface-lowered);
@@ -627,28 +609,6 @@ wa-input.desktop-command-palette-input::part(base) {
 .desktop-empty-streams-copy .desktop-empty-streams-example {
   margin-top: var(--wa-space-2xs);
   color: var(--wa-color-text-normal);
-}
-
-.desktop-empty-streams-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: var(--wa-space-xs);
-}
-
-.desktop-empty-streams-actions wa-button::part(base) {
-  border-radius: var(--wa-border-radius-m, 3px);
-}
-
-@media (max-width: 720px) {
-  .desktop-empty-streams {
-    grid-template-columns: 1fr;
-    align-items: start;
-  }
-
-  .desktop-empty-streams-actions {
-    justify-content: flex-start;
-  }
 }
 
 .desktop-bootstrap-fallback {

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -137,7 +137,7 @@
   /* Neutral variant — mirrors the extension bridge in common.css where
      `neutral-fill-quiet` maps to `--vscode-button-secondaryBackground`.
      Source from `--desktop-color-button-secondary` so secondary buttons
-     and quiet surfaces (e.g. .desktop-command-button, .desktop-folder-button)
+     and quiet surfaces (e.g. .desktop-command-button)
      match the prior --texra-button-secondaryBackground value. */
   --wa-color-neutral-fill-quiet: var(--desktop-color-button-secondary);
   --wa-color-neutral-border-quiet: light-dark(#d0d7de, #2b2b2b);

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -70,10 +70,14 @@ async function setRoute(
   }, route);
   await launched.page.waitForFunction(
     (target) => {
-      const section = document.querySelector<HTMLElement>(
-        `.desktop-route[data-route="${target}"]`,
-      );
-      return section != null && section.hidden === false;
+      if (document.body.dataset.desktopRoute !== target) return false;
+      if (target === 'main') {
+        const launcher = document.querySelector<HTMLElement>(
+          '.desktop-pane[data-pane="launcher"]',
+        );
+        return launcher != null && launcher.hidden === false;
+      }
+      return true;
     },
     route,
     { timeout: 5000 },
@@ -88,10 +92,7 @@ async function setSettingsTab(tabIndex: number): Promise<void> {
   // Best-effort: wait for the settings-app shadow DOM to mount.
   await launched.page.waitForFunction(
     () => {
-      const settingsSection = document.querySelector(
-        '.desktop-route[data-route="settings"]',
-      );
-      const settingsApp = settingsSection?.querySelector('settings-app');
+      const settingsApp = document.querySelector('settings-app');
       return settingsApp?.shadowRoot != null;
     },
     undefined,
@@ -105,7 +106,7 @@ async function setSettingsTab(tabIndex: number): Promise<void> {
  */
 test('first launch shows a usable launcher chrome', async () => {
   await setRoute('main');
-  // The chrome brand and Open Folder button must be reachable from the user.
+  // The chrome brand and command palette button must be reachable from the user.
   // The brand label is styled uppercase via CSS, but the underlying text
   // node is "TeXRA". Match case-insensitively so a future style flip won't
   // destabilise the test.
@@ -114,13 +115,13 @@ test('first launch shows a usable launcher chrome', async () => {
     .first()
     .innerText();
   expect(brand.toLowerCase()).toContain('texra');
-  const folderButton = launched.page.locator('.desktop-folder-button');
-  await expect(folderButton).toBeVisible();
+  await expect(launched.page.locator('.desktop-command-button')).toBeVisible();
+  await expect(launched.page.locator('.desktop-folder-button')).toHaveCount(0);
   // The main view itself either renders <main-app> or the no-workspace empty
   // state — both are valid first-launch outcomes. The audit doc tracks which
   // one each user actually hits.
   const mainSection = launched.page.locator(
-    '.desktop-route[data-route="main"]',
+    '.desktop-pane[data-pane="launcher"]',
   );
   await expect(mainSection).toBeVisible();
 });
@@ -138,9 +139,7 @@ test('settings → models tab mounts and the auth surface is reachable', async (
   // the previous tab's render and report a false positive.
   await launched.page.waitForFunction(
     () => {
-      const settingsApp = document.querySelector(
-        '.desktop-route[data-route="settings"] settings-app',
-      );
+      const settingsApp = document.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       const activePanel = root?.querySelector(
         'wa-tab-panel[name="models"][active]',
@@ -155,9 +154,7 @@ test('settings → models tab mounts and the auth surface is reachable', async (
   // surface). The actual auth banner text and provider list live one or
   // two shadow roots deep, so we only assert structural presence here.
   const panelHasChild = await launched.page.evaluate(() => {
-    const settingsApp = document.querySelector(
-      '.desktop-route[data-route="settings"] settings-app',
-    );
+    const settingsApp = document.querySelector('settings-app');
     const panel = settingsApp?.shadowRoot?.querySelector(
       'wa-tab-panel[name="models"][active]',
     );
@@ -175,9 +172,7 @@ test('settings → memory tab mounts', async () => {
   await setSettingsTab(SETTINGS_TAB_INDEX.MEMORY);
   await launched.page.waitForFunction(
     () => {
-      const settingsApp = document.querySelector(
-        '.desktop-route[data-route="settings"] settings-app',
-      );
+      const settingsApp = document.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       const activePanel = root?.querySelector(
         'wa-tab-panel[name="memory"][active]',
@@ -216,9 +211,7 @@ test('settings → tools tab mounts', async () => {
   await setSettingsTab(SETTINGS_TAB_INDEX.TOOLS);
   await launched.page.waitForFunction(
     () => {
-      const settingsApp = document.querySelector(
-        '.desktop-route[data-route="settings"] settings-app',
-      );
+      const settingsApp = document.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       const activePanel = root?.querySelector(
         'wa-tab-panel[name="tools"][active]',

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -65,6 +65,7 @@ interface DesktopCommandSurfaceModule {
 
 interface DesktopMenuItem {
   label?: string;
+  role?: string;
   accelerator?: string;
   enabled?: boolean;
   toolTip?: string;
@@ -96,13 +97,27 @@ describe('desktop command surface', () => {
           expect(entry.category).toBe('Help');
           continue;
         }
-        expect(['TeXRA', 'Help']).toContain(entry.category);
+        expect(['File', 'TeXRA', 'Help']).toContain(entry.category);
         continue;
       }
       expect(catalogEntry).toBeDefined();
       expect(entry.label).toBe(catalogEntry?.shortTitle ?? catalogEntry?.title);
       expect(entry.category).toBe(catalogEntry?.category);
     }
+    expect(entries).toContainEqual({
+      id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+      label: 'Open Folder',
+      category: 'File',
+      accelerator: 'Command+O',
+      enabled: true,
+    });
+    expect(entries).toContainEqual({
+      id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
+      label: 'New Window',
+      category: 'File',
+      accelerator: 'Command+Shift+N',
+      enabled: true,
+    });
     expect(entries).toContainEqual({
       id: 'texra.showMainView',
       label: 'Show Launcher',
@@ -285,10 +300,15 @@ describe('desktop command surface', () => {
   });
 
   it('wires menu clicks to the catalog-backed dispatcher', async () => {
-    const { buildDesktopMenuTemplate, getDesktopCommandMenuEntries } =
-      await loadDesktopCommandSurface();
+    const {
+      DESKTOP_LOCAL_COMMANDS,
+      buildDesktopMenuTemplate,
+      getDesktopCommandMenuEntries,
+    } = await loadDesktopCommandSurface();
     const actions = {
       openDesktopDocs: vi.fn(),
+      openWorkspaceFolder: vi.fn(),
+      openWorkspaceInNewWindow: vi.fn(),
       resetMainView: vi.fn(),
       showFirstRunWalkthrough: vi.fn(),
       showRoute: vi.fn(),
@@ -298,21 +318,29 @@ describe('desktop command surface', () => {
 
     expect(menu.map((item) => item.label ?? item.role)).toEqual([
       'appMenu',
-      'fileMenu',
+      'File',
       'TeXRA',
       'editMenu',
       'viewMenu',
       'windowMenu',
       'Help',
     ]);
+    const fileMenu = menu.find((item) => item.label === 'File');
+    const fileSubmenu = fileMenu?.submenu ?? [];
+    expect(
+      fileSubmenu.map((item) => item.label ?? item.role ?? item.type),
+    ).toEqual(['Open Folder', 'New Window', 'separator', 'close']);
+    fileSubmenu[0].click?.();
+    fileSubmenu[1].click?.();
+    expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
+    expect(actions.openWorkspaceInNewWindow).toHaveBeenCalledOnce();
+
     const texraMenu = menu.find((item) => item.label === 'TeXRA');
     const submenu = texraMenu?.submenu ?? [];
     expect(submenu.map((item) => item.label ?? item.type)).toEqual([
       'Show Launcher',
       'Show Progress',
       'Show Logs',
-      'Open Folder',
-      'New Window',
       'Open Logs Folder',
       'Open TeXRA Settings',
       'New',
@@ -336,16 +364,24 @@ describe('desktop command surface', () => {
         .map((item) => item.label),
     ).toEqual(
       getDesktopCommandMenuEntries(undefined, 'darwin')
-        .filter((entry) => entry.category !== 'Help')
+        .filter(
+          (entry) =>
+            entry.category !== 'Help' &&
+            entry.id !== DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER &&
+            entry.id !== DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
+        )
         .map((entry) => entry.label),
     );
 
-    submenu[0].click?.();
-    submenu[9].click?.();
-    submenu[14].click?.();
+    const launcherItem = submenu.find((item) => item.label === 'Show Launcher');
+    const executeItem = submenu.find((item) => item.label === 'Execute Agent');
+    const modelsItem = submenu.find((item) => item.label === 'Show Models');
+    launcherItem?.click?.();
+    executeItem?.click?.();
+    modelsItem?.click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
-    expect(submenu[9]).toMatchObject({
+    expect(executeItem).toMatchObject({
       enabled: false,
       toolTip:
         'Use the Launcher execute button after choosing an agent and files.',

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -99,11 +99,11 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     );
     expect(rendererMain).toContain('desktop-empty-streams');
     expect(rendererMain).toContain('Try: <q>polish the abstract</q>');
-    expect(rendererMain).toContain('SETTINGS_TAB.MODELS');
-    expect(rendererMain).toContain('SETTINGS_TAB.AGENTS');
     expect(rendererMain).toContain('openCommandPalette');
+    expect(rendererMain).not.toContain('SETTINGS_TAB.MODELS');
+    expect(rendererMain).not.toContain('SETTINGS_TAB.AGENTS');
     expect(styles).toContain('.desktop-launcher-surface--empty');
-    expect(styles).toContain('.desktop-empty-streams-actions');
+    expect(styles).not.toContain('.desktop-empty-streams-actions');
   });
 
   it('renders the launcher back action as an icon-only chrome button', () => {


### PR DESCRIPTION
## Summary

Addresses #4026.

- Moves workspace folder commands into the native File menu instead of the desktop chrome.
- Removes duplicated launcher actions for Models, Agents, and Commands from the empty launcher state.
- Keeps Settings in the session rail footer and removes the duplicate top-chrome settings icon.
- Removes the workspace folder name from the session rail header, where it was visually misplaced for the single-workspace desktop shell.
- Updates desktop shell tests for the current three-pane renderer structure and new menu layout.

## Validation

- `corepack pnpm --filter @texra/desktop typecheck`
- `corepack pnpm --filter @texra/desktop build`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- `corepack pnpm --dir packages/desktop exec playwright test tests/e2e/trajectories.spec.ts -g "first launch shows a usable launcher chrome"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/menu restructuring in the Electron renderer and command surface; main risk is regressions in menu wiring/shortcuts and e2e selectors due to moved/removed chrome controls.
> 
> **Overview**
> Moves the workspace folder actions (`Open Folder`, `New Window`) out of the TeXRA menu/chrome and into a dedicated native `File` menu, updating `DesktopCommandId`/`DESKTOP_COMMAND_IDS`, menu template construction, and command categories/accelerators.
> 
> Simplifies the Electron renderer chrome by removing the top settings icon, the chrome “Open Folder” button, and the extra empty-launcher action buttons; also removes the workspace folder name from the sessions rail header and trims related CSS/theme token references.
> 
> Updates Vitest + Playwright coverage to match the new menu layout and three-pane DOM structure (route detection via `document.body.dataset.desktopRoute`, new selectors, and menu click assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8e2ccb6fd0f8e88cc1638792002b2305a3230e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->