### PR TITLE
fix: soften desktop tool id tags

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -100,7 +100,12 @@ export class ToolCard extends LitElement {
         font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-xs);
         padding: var(--border-thin) var(--border-radius-large);
-        background: var(--wa-color-badge-bg, rgba(128, 128, 128, 0.15));
+        background: var(
+          --wa-color-neutral-fill-quiet,
+          rgba(128, 128, 128, 0.15)
+        );
+        border: var(--border-thin) solid
+          var(--wa-color-neutral-border-quiet, transparent);
         color: var(--wa-color-neutral-on-quiet);
         border-radius: var(--border-radius);
       }


### PR DESCRIPTION
## Summary

- Render tool identifier tags on the neutral quiet surface instead of the global badge accent color.
- Add a neutral border so command identifiers remain visible without the saturated blue background shown in the desktop settings screenshot.

Fixes #4022

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors, existing 60 warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change to CSS variables for tool identifier tags; no logic or data flow changes.
> 
> **Overview**
> Updates `ToolCard` tool identifier tag styling to use the *neutral quiet* surface (`--wa-color-neutral-fill-quiet`) instead of the previous badge background token, and adds a subtle neutral border (`--wa-color-neutral-border-quiet`) to improve visibility on desktop themes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0025161ebaeabfba4aefe395962e822b5c5efe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->