### PR TITLE
fix: compact background task rows

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -62,25 +62,26 @@ export class BackgroundTasksPanel extends LitElement {
       .task-list {
         display: flex;
         flex-direction: column;
-        gap: var(--wa-space-3xs);
       }
 
       .section-content {
-        max-height: 16rem;
+        max-height: clamp(12rem, 42vh, 24rem);
         overflow-y: auto;
         scrollbar-gutter: stable;
       }
 
       .task-item {
-        margin-bottom: var(--wa-space-3xs);
+        margin-bottom: 0;
       }
 
       .task-header {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
-        padding: var(--wa-space-3xs) 0;
+        min-height: 1.5rem;
+        padding: 1px 0;
         font-size: var(--font-size-sm);
+        line-height: var(--line-height-tight);
       }
 
       .task-icon {
@@ -97,8 +98,8 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-name {
-        flex-shrink: 0;
-        max-width: 40%;
+        flex: 0 1 auto;
+        max-width: min(14rem, 40%);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -117,7 +118,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-description {
-        flex: 1;
+        flex: 1 1 8rem;
         min-width: 0;
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
@@ -130,6 +131,18 @@ export class BackgroundTasksPanel extends LitElement {
         flex-shrink: 0;
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
+      }
+
+      wa-tag.task-status {
+        flex: 0 0 auto;
+        margin-left: auto;
+      }
+
+      wa-tag.task-status::part(base) {
+        min-height: 1.25rem;
+        padding: 0 var(--wa-space-xs);
+        font-size: var(--font-size-xs);
+        line-height: 1;
       }
 
       .section-label {
@@ -351,7 +364,10 @@ export class BackgroundTasksPanel extends LitElement {
           ${child.elapsed
             ? html`<span class="task-elapsed">(${child.elapsed})</span>`
             : nothing}
-          <wa-tag variant=${waiting ? 'neutral' : 'warning'} size="small"
+          <wa-tag
+            class="task-status"
+            variant=${waiting ? 'neutral' : 'warning'}
+            size="small"
             >${waiting ? 'waiting' : 'running'}</wa-tag
           >
         </div>


### PR DESCRIPTION
## Summary

- Reduce background task row spacing and use a viewport-adaptive max height for the expanded task list.
- Make waiting/running status tags compact and non-shrinking so they remain visible while long task descriptions truncate.

Fixes #4036

## Validation

- `corepack pnpm exec vitest run src/test-kernel/progressView/ProcessOutputState.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors, existing warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentation/layout changes to the background tasks panel; low risk aside from potential minor CSS regressions across themes/sizes.
> 
> **Overview**
> Makes the Background Tasks panel more compact by tightening row spacing/line-height and removing per-item bottom margins.
> 
> Updates the expanded list to use a viewport-adaptive `max-height` via `clamp()`, and styles the waiting/running `wa-tag` as a non-shrinking, compact status pill so it stays visible while long descriptions truncate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237e9cb9a6fbf5be4fa6e723ff9c1eba1cb43534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->