### PR TITLE
fix: classify derived bash stream tabs

### DIFF
--- a/src/agent/index/streamTabInfo.ts
+++ b/src/agent/index/streamTabInfo.ts
@@ -64,7 +64,8 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model`
   // is the schema's prefault, not a real inference model — omit so the
   // tab footer doesn't lie.
-  const processAgent = isProcessAgent(config?.agent ?? hints?.agent);
+  const resolvedAgent = config?.agent ?? hints?.agent ?? agentName;
+  const processAgent = isProcessAgent(resolvedAgent);
 
   // Surface the full untruncated command for process streams (description
   // is capped for tab/tooltip rendering).
@@ -97,7 +98,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
       !processAgent && config?.model
         ? (MODEL_CONFIGS[config.model]?.label ?? config.model)
         : undefined,
-    agent: config?.agent ?? hints?.agent,
+    agent: resolvedAgent,
     agentCategory: category,
     isRemote,
     inputFile,

--- a/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
+++ b/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildStreamTabInfo } from '@agent/index';
+import { AGENT_CATEGORY } from '@shared/schemas';
+import { isProcessAgent } from '@shared/streams/agentKind';
+
+describe('buildStreamTabInfo', () => {
+  it('classifies stream-id-derived bash child streams as process agents', () => {
+    const info = buildStreamTabInfo({
+      streamId: 'bash@tool#exec:child-stream',
+      hints: {
+        agentCategory: AGENT_CATEGORY.TOOL_USE,
+      },
+      creationTimestamp: 1,
+    });
+
+    expect(info.label).toBe('bash');
+    expect(info.agent).toBe('bash');
+    expect(isProcessAgent(info.agent)).toBe(true);
+    expect(info.model).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve the stream-id-derived agent fallback in `StreamTabInfo.agent` when backend hints do not yet include an explicit agent.
- Add a regression test for `bash@tool#...` child streams so they classify as process streams and render with process-stream chrome rather than regular workflow/tool-use chrome.

Fixes #4033

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/index/StreamTabInfo.vitest.ts src/test-kernel/progressView/StreamConversation.vitest.mts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run typecheck`
- `npm run lint` (0 errors, existing warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to stream tab metadata resolution plus a targeted regression test; impact is limited to UI/model display for process-derived streams.
> 
> **Overview**
> Fixes `buildStreamTabInfo` to preserve a stream-id-derived agent fallback when `config.agent`/`hints.agent` are missing, ensuring derived `bash@tool#...` child streams are recognized as process agents and don’t show a misleading model.
> 
> Adds a Vitest regression test covering `bash@tool#exec:child-stream` to verify the tab label/agent resolution and that `model` is omitted for process streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301d7033f606a4381528f323c1c59b83de392d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->