### PR TITLE
fix: show full desktop stream tab details

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -189,9 +189,7 @@ const railTabs = document.createElement('stream-tabs') as HTMLElement & {
   streamStates: unknown;
   pendingApprovalStreamIds: unknown;
   childStreamsByParent: unknown;
-  compact: boolean;
 };
-railTabs.compact = true;
 
 const settingsView: HTMLElement = document.createElement('settings-app');
 settingsView.setAttribute('data-desktop-view', 'settings');

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1,6 +1,6 @@
 :root {
   --desktop-nav-height: 40px;
-  --desktop-rail-width: 260px;
+  --desktop-rail-width: clamp(320px, 28vw, 390px);
   --desktop-right-width: 0px; /* reserved; collapsed today (PRD § 6) */
   font-family: var(--wa-font-family-body);
   background: var(--wa-color-surface-default);

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -59,6 +59,7 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toMatch(
       /document\.createElement\(\s*'stream-tabs'\s*[,)]/,
     );
+    expect(rendererMain).not.toMatch(/\brailTabs\.compact\s*=/);
   });
 
   it('listens for desktop route pushes from the Electron host', () => {
@@ -83,7 +84,7 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
 
     // Three-pane CSS grid template — left rail width, flexible center,
     // collapsed right column reserved for future diff/approve UX.
-    expect(styles).toContain('--desktop-rail-width');
+    expect(styles).toContain('--desktop-rail-width: clamp(');
     expect(styles).toContain(
       'grid-template-columns: var(--desktop-rail-width)',
     );


### PR DESCRIPTION
## Summary

- Use the shared full `<stream-tabs>` rendering in the desktop rail instead of compact mode.
- Widen the desktop rail responsively so session descriptions, model labels, category icons, and remote markers have room to render.
- Add a renderer shell regression check that the desktop rail is not forced into compact mode.

Fixes #4029.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- `corepack pnpm --filter @texra/desktop typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: removes forced compact rendering for `stream-tabs` and adjusts rail width CSS; main risk is minor layout regressions at different window sizes.
> 
> **Overview**
> Desktop renderer no longer forces the rail’s `stream-tabs` into `compact` mode, allowing full session details (descriptions/labels/icons) to render.
> 
> The left rail width is updated from a fixed value to a responsive `clamp(...)` CSS variable, and the renderer shell Vitest adds assertions to ensure `railTabs.compact` isn’t set and the new rail width rule stays in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dee5d3dd6c82375a46bf857aafd4f1bfb4dd68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->