### PR TITLE
fix: avoid desktop keychain prompt at startup

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -62,7 +62,6 @@ import {
 import { reportFatalStartupError } from './fatalStartupError.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeDesktopCrashReporting } from './desktopCrashReporting.js';
-import { prewarmElectronKeychain } from './platform/electronSecrets.js';
 import { initializeElectronPlatform } from './platform/index.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
@@ -610,12 +609,6 @@ if (protocolLifecycle.shouldContinue) {
   app
     .whenReady()
     .then(async () => {
-      // Trigger the OS keychain prompt deterministically at launch (before
-      // the renderer asks for any saved secret) so the user sees one dialog
-      // up-front rather than a surprise mid-startup. ElectronSecrets.get()
-      // also has a per-key fallback that returns undefined on decrypt
-      // failure, so a denied prompt won't crash the renderer either way.
-      await prewarmElectronKeychain();
       const platformInit = await initializeElectronPlatform(__dirname);
       const { lifecycle } = platformInit;
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -155,46 +155,8 @@ export class ElectronSecrets implements PlatformSecrets {
   }
 }
 
-/**
- * Force the OS keychain prompt to appear at app launch (before the renderer
- * loads) by performing one harmless `safeStorage.encryptString` call. macOS
- * (and Linux keyring backends) trigger the "@texra/desktop wants to use your
- * confidential information" dialog on the first encrypt/decrypt; running it
- * here turns that into a deterministic startup event instead of a surprise
- * during user interaction. Subsequent calls reuse the unlocked key without
- * prompting.
- *
- * Safe to call multiple times — the first invocation does the work and the
- * rest are no-ops. Returns `true` when the prewarm encrypt succeeded; returns
- * `false` when `safeStorage.isEncryptionAvailable()` is false (e.g., Linux
- * without a configured keyring) or when the encrypt itself threw (e.g., the
- * user denied the OS keychain prompt). The latch is only set on success so
- * the caller can retry on a subsequent boot once permissions change.
- */
-let keychainPrewarmed = false;
-export async function prewarmElectronKeychain(): Promise<boolean> {
-  if (keychainPrewarmed) return true;
-  if (isKeychainDisabled()) {
-    warnKeychainDisabledOnce();
-    return false;
-  }
-  if (!safeStorage.isEncryptionAvailable()) return false;
-  try {
-    safeStorage.encryptString('texra-keychain-prewarm');
-    keychainPrewarmed = true;
-    return true;
-  } catch (error) {
-    console.warn(
-      `prewarmElectronKeychain: encryptString failed; continuing without prewarm. ` +
-        `Cause: ${toErrorMessage(error)}`,
-    );
-    return false;
-  }
-}
-
 /** Test-only: reset latched module-level state so unit tests can re-exercise the path. */
 export function __resetKeychainStateForTests(): void {
-  keychainPrewarmed = false;
   warnedAboutKeychainDisabled = false;
 }
 

--- a/packages/desktop/tests/e2e/README.md
+++ b/packages/desktop/tests/e2e/README.md
@@ -49,15 +49,15 @@ secrets layer (`packages/desktop/src/main/platform/electronSecrets.ts`)
 honors by skipping `safeStorage` entirely:
 
 - `getSecretStorageMode()` returns `'unavailable'` without touching
-  `safeStorage`, so the launch-time keychain prewarm never prompts.
+  `safeStorage`.
 - `ElectronSecrets.get()` returns `undefined` for any persisted key (env-var
   API key overrides still work).
 - `ElectronSecrets.set()` silently no-ops with a one-time `console.warn`.
 
 This keeps headless Playwright runs from blocking on the macOS keychain
-prompt and crashing startup with the
-`Cannot read properties of undefined (reading 'kind')` fallback. To run
-locally exactly as CI does, prefix your invocation:
+prompt and preserves the renderer bootstrap fallback for
+`Cannot read properties of undefined (reading 'kind')`. To run locally exactly
+as CI does, prefix your invocation:
 
 ```bash
 TEXRA_DISABLE_KEYCHAIN=1 pnpm --filter @texra/desktop test:e2e

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -48,9 +48,9 @@ export interface LaunchedApp {
  * `build:renderer` scripts). The harness intentionally does NOT rebuild on
  * every test — that would blow the per-suite budget.
  *
- * On macOS the first launch may trigger a keychain prompt because the app
- * touches `safeStorage`. Set `TEXRA_DISABLE_KEYCHAIN=1` (handled by the app
- * platform layer) or run the suite under a CI keychain to avoid the freeze.
+ * Set `TEXRA_DISABLE_KEYCHAIN=1` (handled by the app platform layer) so the
+ * harness never blocks on a macOS keychain prompt while reading or writing
+ * saved secrets.
  */
 export async function launchTexraApp(
   options: LaunchOptions = {},

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -20,7 +20,6 @@ interface ElectronSecretsModule {
     get(key: string): Promise<string | undefined>;
     set(key: string, value: string): Promise<void>;
   };
-  prewarmElectronKeychain: () => Promise<boolean>;
   __resetKeychainStateForTests: () => void;
   KEYCHAIN_DENIED_WARNING_MESSAGE: string;
 }
@@ -118,30 +117,6 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
 
     expect(warnings).toHaveLength(1);
   });
-
-  it('prewarmElectronKeychain returns true when safeStorage encrypts cleanly', async () => {
-    const { prewarmElectronKeychain, __resetKeychainStateForTests } =
-      await loadElectronSecrets();
-    __resetKeychainStateForTests();
-
-    expect(await prewarmElectronKeychain()).toBe(true);
-    // Idempotent — second call short-circuits.
-    expect(await prewarmElectronKeychain()).toBe(true);
-  });
-
-  it('prewarmElectronKeychain returns false when safeStorage is unavailable', async () => {
-    const electron = (await import('electron')) as unknown as {
-      safeStorage: { isEncryptionAvailable: () => boolean };
-    };
-    vi.spyOn(electron.safeStorage, 'isEncryptionAvailable').mockReturnValue(
-      false,
-    );
-    const { prewarmElectronKeychain, __resetKeychainStateForTests } =
-      await loadElectronSecrets();
-    __resetKeychainStateForTests();
-
-    expect(await prewarmElectronKeychain()).toBe(false);
-  });
 });
 
 describe('desktop renderer bootstrap fallback', () => {
@@ -207,29 +182,6 @@ describe('TEXRA_DISABLE_KEYCHAIN env var (Playwright e2e shim)', () => {
 
     expect(mod.getSecretStorageMode()).toBe('unavailable');
     expect(isAvailableSpy).not.toHaveBeenCalled();
-  });
-
-  it('prewarmElectronKeychain returns false and never calls safeStorage', async () => {
-    process.env.TEXRA_DISABLE_KEYCHAIN = '1';
-    const electron = (await import('electron')) as unknown as {
-      safeStorage: {
-        isEncryptionAvailable: () => boolean;
-        encryptString: (value: string) => Buffer;
-      };
-    };
-    const isAvailableSpy = vi.spyOn(
-      electron.safeStorage,
-      'isEncryptionAvailable',
-    );
-    const encryptSpy = vi.spyOn(electron.safeStorage, 'encryptString');
-
-    const { prewarmElectronKeychain, __resetKeychainStateForTests } =
-      await loadElectronSecrets();
-    __resetKeychainStateForTests();
-
-    expect(await prewarmElectronKeychain()).toBe(false);
-    expect(isAvailableSpy).not.toHaveBeenCalled();
-    expect(encryptSpy).not.toHaveBeenCalled();
   });
 
   it('ElectronSecrets.get() returns undefined without calling safeStorage', async () => {
@@ -305,19 +257,13 @@ describe('TEXRA_DISABLE_KEYCHAIN env var (Playwright e2e shim)', () => {
   });
 });
 
-describe('desktop main process keychain prewarm', () => {
-  it('calls prewarmElectronKeychain immediately after app.whenReady()', () => {
+describe('desktop main process keychain access', () => {
+  it('does not force a keychain prewarm during startup', () => {
     const source = readFileSync(
       repoPath('packages/desktop/src/main/index.ts'),
       'utf8',
     );
-    expect(source).toContain('prewarmElectronKeychain');
-    // The prewarm must run BEFORE initializeElectronPlatform — that is the
-    // function that constructs ElectronSecrets and starts the chain that
-    // eventually triggers crash-reporting / auth secret reads.
-    const prewarmIndex = source.indexOf('await prewarmElectronKeychain()');
-    const initIndex = source.indexOf('await initializeElectronPlatform(');
-    expect(prewarmIndex).toBeGreaterThan(0);
-    expect(initIndex).toBeGreaterThan(prewarmIndex);
+    expect(source).not.toContain('prewarmElectronKeychain');
+    expect(source).not.toContain('safeStorage.encryptString');
   });
 });


### PR DESCRIPTION
## Summary

- Remove the desktop launch-time `safeStorage` prewarm that forces macOS to ask for keychain access before a saved secret is needed.
- Keep the existing per-secret decrypt fallback, so denied or unavailable keychain access still degrades to an unset secret instead of crashing startup.
- Update the desktop secret bootstrap tests and e2e keychain notes to match the lazy-access behavior.

Fixes #4021.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts`
- `corepack pnpm --filter @texra/desktop typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Electron `safeStorage` is invoked by removing launch-time keychain access, which can affect persisted secret availability and auth/session behavior on first use across platforms.
> 
> **Overview**
> Avoids triggering the macOS/Linux keychain prompt during desktop startup by removing the launch-time `safeStorage` prewarm (`prewarmElectronKeychain`) and its startup invocation.
> 
> Updates desktop bootstrap tests and e2e docs to reflect *lazy* keychain access and to assert the main process no longer forces encryption calls during launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7682158138102fc2d561cd4b3007e7a6d057ef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->