### PR TITLE
feat: add ask user question tool

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -8,6 +8,7 @@ import {
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local imports - tools
+import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
 import {
   setToolEditApprovalHandler,
@@ -253,6 +254,105 @@ function handleExternalInquiry(
   })();
 }
 
+function formatUserQuestionPrompt(
+  payload: ProgressEventPayloads['showUserQuestion'],
+): string {
+  return payload.questions
+    .map((question, index) => {
+      const options = question.options
+        .map((option, optionIndex) => {
+          const description = option.description
+            ? ` - ${option.description}`
+            : '';
+          return `  ${optionIndex + 1}. ${option.label}${description}`;
+        })
+        .join('\n');
+      const multi = question.multiSelect
+        ? ' Select comma-separated numbers.'
+        : '';
+      const free = question.allowFreeText ? ' Or type a custom answer.' : '';
+      return `${index + 1}. ${question.question}\n${options}\n${multi}${free}`;
+    })
+    .join('\n\n');
+}
+
+function parseUserQuestionAnswer(
+  raw: string,
+  question: ProgressEventPayloads['showUserQuestion']['questions'][number],
+): string | string[] | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  const selected = trimmed
+    .split(',')
+    .map((part) => Number.parseInt(part.trim(), 10))
+    .filter((value) => Number.isInteger(value))
+    .map((index) => question.options[index - 1]?.label)
+    .filter((value): value is string => Boolean(value));
+
+  if (selected.length > 0) {
+    return question.multiSelect ? selected : selected[0];
+  }
+  return question.allowFreeText ? trimmed : undefined;
+}
+
+function handleUserQuestion(
+  payload: ProgressEventPayloads['showUserQuestion'],
+  context: CliContext,
+): void {
+  if (!approvalPromptAllowed(context)) {
+    const feedback =
+      context.approvalPolicy === 'yolo'
+        ? 'User question requires human input; yolo mode cannot synthesize an answer.'
+        : denyMessage(context.approvalPolicy);
+    if (context.approvalPolicy !== 'yolo') markApprovalDenied(context);
+    void handleUserQuestionAction({
+      requestId: payload.requestId,
+      action: 'skip',
+      feedback,
+    });
+    return;
+  }
+
+  void (async () => {
+    const answers: Record<string, string | string[]> = {};
+    try {
+      for (const question of payload.questions) {
+        const answer = await enqueueCliPrompt(context, () =>
+          askCliApprovalQuestion(context, {
+            kind: 'approval',
+            summary: payload.context
+              ? `${payload.context}\n\n${formatUserQuestionPrompt({
+                  ...payload,
+                  questions: [question],
+                })}`
+              : formatUserQuestionPrompt({ ...payload, questions: [question] }),
+            prompt: 'Answer (blank to skip): ',
+          }),
+        );
+        const parsed = parseUserQuestionAnswer(answer, question);
+        if (parsed != null) answers[question.question] = parsed;
+      }
+    } catch {
+      markApprovalDenied(context);
+      await handleUserQuestionAction({
+        requestId: payload.requestId,
+        action: 'skip',
+        feedback: 'CLI user question prompt failed.',
+      });
+      return;
+    }
+
+    const submitted = Object.keys(answers).length > 0;
+    await handleUserQuestionAction({
+      requestId: payload.requestId,
+      action: submitted ? 'submit' : 'skip',
+      answers: submitted ? answers : undefined,
+      feedback: submitted ? undefined : 'User question skipped by user.',
+    });
+  })();
+}
+
 async function decideToolEdit(
   request: ToolEditApprovalRequest,
   context: CliContext,
@@ -277,6 +377,14 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
   if (event === 'showExternalInquiry') {
     handleExternalInquiry(
       payload as ProgressEventPayloads['showExternalInquiry'],
+      context,
+    );
+    return true;
+  }
+
+  if (event === 'showUserQuestion') {
+    handleUserQuestion(
+      payload as ProgressEventPayloads['showUserQuestion'],
       context,
     );
     return true;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -69,6 +69,7 @@ import {
   cleanupApprovalsForStream,
   handleProgressViewBashApprovalAction,
 } from '@tools/approval';
+import { handleUserQuestionAction } from '@tools/userQuestion';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
   createExternalLocation,
@@ -847,6 +848,27 @@ export class DesktopProgressBridge {
         });
         break;
       }
+      case 'showUserQuestion': {
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'show',
+          permission: {
+            kind: 'userQuestion',
+            data: payload as ProgressEventPayloads['showUserQuestion'],
+          },
+        });
+        break;
+      }
+      case 'resolveUserQuestion': {
+        const data = payload as ProgressEventPayloads['resolveUserQuestion'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'resolve',
+          kind: 'userQuestion',
+          id: data.requestId,
+        });
+        break;
+      }
       case 'updateSuperYoloBypassState': {
         const data =
           payload as ProgressEventPayloads['updateSuperYoloBypassState'];
@@ -1134,6 +1156,15 @@ export class DesktopProgressBridge {
       action: message.action,
       ...(message.action === 'reject' && { feedback: message.feedback }),
     });
+  }
+
+  async handleUserQuestionAction(
+    message: Extract<
+      ProgressViewInboundMessage,
+      { command: typeof PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION }
+    >,
+  ): Promise<void> {
+    await handleUserQuestionAction(message);
   }
 
   async handleAgentProposalAction(

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -86,6 +86,9 @@ export function createDesktopProgressIpc(
         case PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION:
           options.progress.handlePlanApprovalAction(result.data);
           return true;
+        case PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION:
+          runAsync(options.progress.handleUserQuestionAction(result.data));
+          return true;
         case PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION:
           runAsync(options.progress.handleAgentProposalAction(result.data));
           return true;

--- a/packages/extension/resources/tool_use_agents/chat.yaml
+++ b/packages/extension/resources/tool_use_agents/chat.yaml
@@ -20,6 +20,7 @@ settings:
     - crossref_search
     - crossref_doi
     - external_inquiry
+    - ask_user_question
 prompts:
   systemPrompt: |
     You are a scientist and a collaborator of the user on a research project. Reason deeply.

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -42,6 +42,7 @@ import {
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 import { handleExternalInquiryAction } from '@tools/inquiry';
+import { handleUserQuestionAction } from '@tools/userQuestion';
 import {
   handleProgressViewBashApprovalAction,
   toggleToolEditApprovalSessionBypass,
@@ -289,6 +290,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handlePlanApprovalAction(data),
       [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: (data) =>
         handleExternalInquiryAction(data),
+      [PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION]: (data) =>
+        handleUserQuestionAction(data),
 
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: async () => {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -98,6 +98,10 @@ export class ProgressViewProvider
     ExternalInquiryPermission,
     'requestId'
   >;
+  private readonly userQuestionHandler: ApprovalRequestHandler<
+    ProgressEventPayloads['showUserQuestion'],
+    'requestId'
+  >;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -162,6 +166,16 @@ export class ProgressViewProvider
       (id) => u.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
       canSend,
     );
+    this.userQuestionHandler = new ApprovalRequestHandler(
+      'requestId',
+      (p) =>
+        u.showPermission({
+          kind: PERMISSION_KIND.USER_QUESTION,
+          data: p,
+        }),
+      (id) => u.resolvePermission(PERMISSION_KIND.USER_QUESTION, id),
+      canSend,
+    );
 
     this.eventHandler = new ProgressEventHandler(
       this.state,
@@ -188,6 +202,8 @@ export class ProgressViewProvider
         resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
         showExternalInquiry: (p) => this.externalInquiryHandler.show(p),
         resolveExternalInquiry: (id) => this.externalInquiryHandler.resolve(id),
+        showUserQuestion: (p) => this.userQuestionHandler.show(p),
+        resolveUserQuestion: (id) => this.userQuestionHandler.resolve(id),
       },
       (streamId) => this.hasPendingPermissionsForStream(streamId),
     );

--- a/packages/extension/src/progressView/events/UIEvents.ts
+++ b/packages/extension/src/progressView/events/UIEvents.ts
@@ -48,6 +48,10 @@ export interface UICallbacks {
     payload: ProgressEventPayloads['showExternalInquiry'],
   ) => void;
   resolveExternalInquiry: (requestId: string) => void;
+  showUserQuestion: (
+    payload: ProgressEventPayloads['showUserQuestion'],
+  ) => void;
+  resolveUserQuestion: (requestId: string) => void;
 }
 
 /** Helper to register an event with error handling wrapper. */
@@ -185,6 +189,22 @@ export function registerUIEvents(
     'resolveExternalInquiry',
     (p) => callbacks.resolveExternalInquiry(p.requestId),
     'failed to resolve external inquiry',
+    signal,
+  );
+
+  // User question events
+  registerEvent(
+    bus,
+    'showUserQuestion',
+    callbacks.showUserQuestion,
+    'failed to show user question',
+    signal,
+  );
+  registerEvent(
+    bus,
+    'resolveUserQuestion',
+    (p) => callbacks.resolveUserQuestion(p.requestId),
+    'failed to resolve user question',
     signal,
   );
 }

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -18,6 +18,7 @@ import type {
   PlanApprovalPermission,
   RetryPermission,
   ToolEditPermission,
+  UserQuestionPermission,
   WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
@@ -59,6 +60,10 @@ export type PermissionState =
   | {
       kind: typeof PERMISSION_KIND.EXTERNAL_INQUIRY;
       data: ExternalInquiryPermission;
+    }
+  | {
+      kind: typeof PERMISSION_KIND.USER_QUESTION;
+      data: UserQuestionPermission;
     };
 
 /** Action button configuration */
@@ -81,6 +86,7 @@ const PERMISSION_ICONS: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.PROPOSAL]: 'rocket',
   [PERMISSION_KIND.PLAN_APPROVAL]: 'tasklist',
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'globe',
+  [PERMISSION_KIND.USER_QUESTION]: 'circle-question',
 };
 
 /** Title for each permission type */
@@ -91,6 +97,7 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.PROPOSAL]: 'Approve task',
   [PERMISSION_KIND.PLAN_APPROVAL]: 'Approve plan',
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'External inquiry',
+  [PERMISSION_KIND.USER_QUESTION]: 'Question',
 };
 
 /** Primary actions (approve/reject) for each permission type */
@@ -119,6 +126,9 @@ const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: [
     { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
   ],
+  [PERMISSION_KIND.USER_QUESTION]: [
+    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
+  ],
 };
 
 /** Secondary actions for each permission type */
@@ -145,6 +155,7 @@ const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
   ],
   [PERMISSION_KIND.PLAN_APPROVAL]: [],
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: [],
+  [PERMISSION_KIND.USER_QUESTION]: [],
 };
 
 // =============================================================================

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -54,6 +54,7 @@ import './RetryRequestPanel';
 import './ProposalRequestPanel';
 import './PlanApprovalRequestPanel';
 import './ExternalInquiryPanel';
+import './UserQuestionPanel';
 
 /** Section configuration for rendering permission groups */
 interface SectionConfig {
@@ -110,6 +111,13 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
     renderPanel: (p) =>
       html`<external-inquiry-panel .permission=${p}></external-inquiry-panel>`,
   },
+  userQuestion: {
+    cssClass: 'user-question-requests',
+    icon: 'circle-question',
+    title: 'Question',
+    renderPanel: (p) =>
+      html`<user-question-panel .permission=${p}></user-question-panel>`,
+  },
 };
 
 @customElement('request-panels')
@@ -152,8 +160,15 @@ export class RequestPanels extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (this.permissions.length === 0) return nothing;
 
-    const { approval, bash, retry, proposal, planApproval, externalInquiry } =
-      this.permissionGroups;
+    const {
+      approval,
+      bash,
+      retry,
+      proposal,
+      planApproval,
+      externalInquiry,
+      userQuestion,
+    } = this.permissionGroups;
 
     return html`
       ${this.renderSection(SECTION_CONFIGS.approval, approval)}
@@ -162,6 +177,7 @@ export class RequestPanels extends LitElement {
       ${this.renderSection(SECTION_CONFIGS.proposal, proposal)}
       ${this.renderSection(SECTION_CONFIGS.planApproval, planApproval)}
       ${this.renderExternalInquirySection(externalInquiry)}
+      ${this.renderSection(SECTION_CONFIGS.userQuestion, userQuestion)}
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
@@ -6,7 +6,7 @@ import type { BaseRequestPanel } from './BaseRequestPanel';
 import type { PermissionState } from './PermissionCard';
 
 const REQUEST_PANEL_SELECTOR =
-  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel, plan-approval-request-panel, external-inquiry-panel';
+  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel, plan-approval-request-panel, external-inquiry-panel, user-question-panel';
 
 export interface PermissionGroups {
   approval: PermissionState[];
@@ -15,6 +15,7 @@ export interface PermissionGroups {
   proposal: PermissionState[];
   planApproval: PermissionState[];
   externalInquiry: PermissionState[];
+  userQuestion: PermissionState[];
 }
 
 export function createEmptyPermissionGroups(): PermissionGroups {
@@ -25,6 +26,7 @@ export function createEmptyPermissionGroups(): PermissionGroups {
     proposal: [],
     planApproval: [],
     externalInquiry: [],
+    userQuestion: [],
   };
 }
 
@@ -52,6 +54,9 @@ export function groupPermissions(
         break;
       case PERMISSION_KIND.EXTERNAL_INQUIRY:
         groups.externalInquiry.push(permission);
+        break;
+      case PERMISSION_KIND.USER_QUESTION:
+        groups.userQuestion.push(permission);
         break;
     }
   }

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -1,0 +1,192 @@
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Side-effect imports - register Web Awesome components
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+
+// Local imports - shared styles
+import {
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+
+// Local imports - shared schemas
+import type {
+  UserQuestionAnswers,
+  UserQuestionPermission,
+  UserQuestionPrompt,
+} from '@shared/schemas';
+
+// Local imports - shared utilities
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+
+// Local imports - progress view events
+import { ProgressEvents } from '../events';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+@customElement('user-question-panel')
+export class UserQuestionPanel extends BaseFeedbackPanel {
+  static override styles = [designTokens, commonViewStyles, requestPanelStyles];
+
+  @state() private selections: Record<string, string[]> = {};
+  @state() private freeText: Record<string, string> = {};
+
+  override render(): TemplateResult {
+    const data = this.permission.data as UserQuestionPermission;
+
+    return html`
+      <div class="user-question-request">
+        ${data.context
+          ? html`<div class="user-question-request__context">
+              ${data.context}
+            </div>`
+          : nothing}
+        <div class="user-question-request__questions">
+          ${repeat(
+            data.questions,
+            (question) => question.question,
+            (question, index) => this.renderQuestion(question, index),
+          )}
+        </div>
+        <div class="user-question-request__actions">
+          ${renderLabeledActionButton({
+            icon: 'check',
+            text: 'Submit',
+            title: 'Submit answers (y)',
+            action: 'submit',
+            onClick: () => this.submitAnswers(),
+          })}
+          ${this.renderRejectButton('Reject this question (n)')}
+        </div>
+        ${this.renderFeedbackSection(
+          'user-question-request__feedback',
+          'user-question-request__feedback-input',
+          'Why are you not answering?',
+        )}
+      </div>
+    `;
+  }
+
+  override handleKeyboardShortcut(key: string): boolean {
+    if (key === 'y' && !this.showFeedback) {
+      this.submitAnswers();
+      return true;
+    }
+    return super.handleKeyboardShortcut(key);
+  }
+
+  private renderQuestion(
+    question: UserQuestionPrompt,
+    index: number,
+  ): TemplateResult {
+    const current = this.selections[question.question] ?? [];
+    const inputType = question.multiSelect ? 'checkbox' : 'radio';
+    const name = `user-question-${index}`;
+
+    return html`
+      <section class="user-question-request__question">
+        <div class="user-question-request__heading">
+          ${question.header
+            ? html`<span class="user-question-request__header">
+                ${question.header}
+              </span>`
+            : nothing}
+          <span>${question.question}</span>
+        </div>
+        <div class="user-question-request__options">
+          ${repeat(
+            question.options,
+            (option) => option.label,
+            (option) => html`
+              <label class="user-question-request__option">
+                <input
+                  type=${inputType}
+                  name=${name}
+                  .checked=${current.includes(option.label)}
+                  @change=${(event: Event) =>
+                    this.updateSelection(question, option.label, event)}
+                />
+                <span>
+                  <strong>${option.label}</strong>
+                  ${option.description
+                    ? html`<small>${option.description}</small>`
+                    : nothing}
+                </span>
+              </label>
+            `,
+          )}
+        </div>
+        ${question.allowFreeText
+          ? html`<wa-textarea
+              class="user-question-request__free-text"
+              placeholder="Type another answer"
+              rows="2"
+              .value=${this.freeText[question.question] ?? ''}
+              @input=${(event: Event) =>
+                this.updateFreeText(question.question, event)}
+            ></wa-textarea>`
+          : nothing}
+      </section>
+    `;
+  }
+
+  private updateSelection(
+    question: UserQuestionPrompt,
+    label: string,
+    event: Event,
+  ): void {
+    const checked = (event.currentTarget as HTMLInputElement).checked;
+    const current = this.selections[question.question] ?? [];
+    const next = question.multiSelect
+      ? checked
+        ? [...current, label]
+        : current.filter((item) => item !== label)
+      : checked
+        ? [label]
+        : [];
+    this.selections = { ...this.selections, [question.question]: next };
+  }
+
+  private updateFreeText(question: string, event: Event): void {
+    const value = ((event.currentTarget as HTMLElement & { value?: string })
+      .value ?? '') as string;
+    this.freeText = { ...this.freeText, [question]: value };
+  }
+
+  private submitAnswers(): void {
+    const data = this.permission.data as UserQuestionPermission;
+    const answers: UserQuestionAnswers = {};
+
+    for (const question of data.questions) {
+      const custom = this.freeText[question.question]?.trim();
+      if (custom) {
+        answers[question.question] = custom;
+        continue;
+      }
+      const selected = this.selections[question.question] ?? [];
+      if (selected.length === 0) continue;
+      answers[question.question] = question.multiSelect
+        ? selected
+        : selected[0];
+    }
+
+    this.dispatchEvent(
+      ProgressEvents.permissionAction({
+        permission: this.permission,
+        action: 'submit',
+        answers,
+      }),
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'user-question-panel': UserQuestionPanel;
+  }
+}

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -237,7 +237,7 @@ export function handlePermissionAction(
 ): void {
   const { permission, action, feedback, modelOverride, agentOverride, answer } =
     event.detail;
-  const { sessionLinks } = event.detail;
+  const { answers, sessionLinks } = event.detail;
 
   switch (permission.kind) {
     case PERMISSION_KIND.TOOL_EDIT:
@@ -349,6 +349,17 @@ export function handlePermissionAction(
         requestId,
       );
       clearInquiryDraft(requestId);
+      break;
+    }
+    case PERMISSION_KIND.USER_QUESTION: {
+      const { requestId } = permission.data;
+      postMessage(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION, {
+        requestId,
+        action,
+        feedback,
+        answers,
+      });
+      removePrompt(ctx, PERMISSION_KIND.USER_QUESTION, 'requestId', requestId);
       break;
     }
   }

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -4,6 +4,7 @@
  */
 
 import type { StringValueDetail } from '@shared/schemas';
+import type { UserQuestionAnswers } from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
 
 import type { PermissionState } from './components/PermissionCard';
@@ -46,6 +47,8 @@ export interface PermissionActionDetail {
   answer?: string;
   /** External chat/thread links captured from the user (submit action only). */
   sessionLinks?: string[];
+  /** Structured answers from the user-question panel (submit action only). */
+  answers?: UserQuestionAnswers;
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -157,6 +157,9 @@ export const permissionHandlers: HandlerRegistry = {
         removePrompt(ctx, kind, 'requestId', id);
         clearInquiryDraft(id);
         break;
+      case PERMISSION_KIND.USER_QUESTION:
+        removePrompt(ctx, kind, 'requestId', id);
+        break;
       default: {
         const removed = removePrompt(
           ctx,

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -61,6 +61,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
   PLAN_APPROVAL_ACTION: 'planApprovalAction',
   EXTERNAL_INQUIRY_ACTION: 'externalInquiryAction',
+  USER_QUESTION_ACTION: 'userQuestionAction',
   RESTORE_PROPOSAL_CONFIG: 'restoreProposalConfig',
   TOGGLE_SUPER_YOLO_BYPASS: 'toggleSuperYoloBypass',
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -21,6 +21,7 @@ import type {
   ToolEditPermission,
   UpdatePlanPayload,
   UpdateTodosPayload,
+  UserQuestionPermission,
 } from '@shared/schemas';
 
 /** Payload for stream-scoped output events (one run per workflow tab). */
@@ -115,6 +116,8 @@ export interface ProgressEventPayloads {
   resolvePlanApproval: { approvalId: string };
   showExternalInquiry: ExternalInquiryPermission;
   resolveExternalInquiry: { requestId: string };
+  showUserQuestion: UserQuestionPermission;
+  resolveUserQuestion: { requestId: string };
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
   updateConversationProgress: {

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -28,6 +28,9 @@ import {
   PlanApprovalPermissionSchema,
   RetryPermissionSchema,
   ToolEditPermissionSchema,
+  USER_QUESTION_ACTIONS,
+  UserQuestionAnswersSchema,
+  UserQuestionPermissionSchema,
 } from './prompts';
 import { StreamStatusSchema, StreamTabInfoSchema } from './stream';
 import {
@@ -245,6 +248,7 @@ const PermissionKindSchema = z.enum([
   'proposal',
   'planApproval',
   'externalInquiry',
+  'userQuestion',
 ]);
 export type ProgressPermissionKind = z.infer<typeof PermissionKindSchema>;
 
@@ -274,6 +278,10 @@ const PermissionPayloadSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('externalInquiry'),
     data: ExternalInquiryPermissionSchema,
+  }),
+  z.object({
+    kind: z.literal('userQuestion'),
+    data: UserQuestionPermissionSchema,
   }),
 ]);
 export type PermissionPayload = z.infer<typeof PermissionPayloadSchema>;
@@ -663,6 +671,14 @@ const ExternalInquiryActionMessageSchema = z.object({
   sessionLinks: ExternalInquirySessionLinksSchema.optional(),
 });
 
+const UserQuestionActionMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION),
+  requestId: z.string().min(1),
+  action: z.enum([...USER_QUESTION_ACTIONS, 'skip'] as const),
+  answers: UserQuestionAnswersSchema.optional(),
+  feedback: z.string().optional(),
+});
+
 const RestoreProposalConfigMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG),
   proposal: AgentProposalSchema,
@@ -752,6 +768,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     AgentProposalActionMessageSchema,
     PlanApprovalActionMessageSchema,
     ExternalInquiryActionMessageSchema,
+    UserQuestionActionMessageSchema,
     RestoreProposalConfigMessageSchema,
     ShowInformationMessageSchema,
     OpenProfileMessageSchema,

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -138,6 +138,42 @@ export type ExternalInquiryPermission = z.infer<
 >;
 
 // ============================================================================
+// User Question
+// ============================================================================
+
+export const USER_QUESTION_ACTIONS = ['submit', 'reject'] as const;
+export type UserQuestionAction = (typeof USER_QUESTION_ACTIONS)[number];
+
+export const UserQuestionOptionSchema = z.strictObject({
+  label: z.string().min(1),
+  description: z.string().nullish(),
+});
+export type UserQuestionOption = z.infer<typeof UserQuestionOptionSchema>;
+
+export const UserQuestionPromptSchema = z.strictObject({
+  question: z.string().min(1),
+  header: z.string().max(12).nullish(),
+  options: z.array(UserQuestionOptionSchema).min(2).max(4),
+  multiSelect: z.boolean().nullish(),
+  allowFreeText: z.boolean().nullish(),
+});
+export type UserQuestionPrompt = z.infer<typeof UserQuestionPromptSchema>;
+
+export const UserQuestionAnswersSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.array(z.string())]),
+);
+export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
+
+export const UserQuestionPermissionSchema = PermissionBaseSchema.extend({
+  questions: z.array(UserQuestionPromptSchema).min(1).max(3),
+  context: z.string().nullish(),
+});
+export type UserQuestionPermission = z.infer<
+  typeof UserQuestionPermissionSchema
+>;
+
+// ============================================================================
 // Plan Approval
 // ============================================================================
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -14,6 +14,7 @@ const CONTAINER_NAMES = [
   'workflow-proposals',
   'plan-approval-requests',
   'external-inquiry-requests',
+  'user-question-requests',
 ] as const;
 
 /** Item class names (singular, used for individual cards and BEM children). */
@@ -24,6 +25,7 @@ const ITEM_NAMES = [
   'workflow-proposal',
   'plan-approval-request',
   'external-inquiry-request',
+  'user-question-request',
 ] as const;
 
 /** Build a :is()-ready selector group from class names with an optional BEM suffix. */
@@ -190,6 +192,9 @@ export const requestPanelStyles: CSSResult = css`
     border-left: var(--border-medium) solid var(--wa-color-text-link);
   }
   .external-inquiry-request {
+    border-left: var(--border-medium) solid var(--wa-color-focus);
+  }
+  .user-question-request {
     border-left: var(--border-medium) solid var(--wa-color-focus);
   }
 
@@ -828,6 +833,95 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__actions vscode-toolbar-button {
+    flex: 1 1 8rem;
+  }
+
+  /* ================================================================
+   * User question requests
+   * ================================================================ */
+
+  .user-question-requests__header wa-icon {
+    color: var(--wa-color-focus);
+  }
+
+  .user-question-request__context {
+    font-size: var(--font-size-sm);
+    color: var(--wa-color-text-quiet);
+    padding: ${sp.small} ${sp.medium};
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.1));
+    border-radius: var(--border-radius-small);
+    line-height: var(--line-height-normal);
+  }
+
+  .user-question-request__questions {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.medium};
+  }
+
+  .user-question-request__question {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.small};
+    padding: ${sp.medium};
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    border-radius: var(--border-radius);
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.05));
+  }
+
+  .user-question-request__heading {
+    display: flex;
+    align-items: baseline;
+    gap: ${sp.small};
+    color: var(--wa-color-text-normal);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-normal);
+  }
+
+  .user-question-request__header {
+    color: var(--wa-color-text-quiet);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    flex: 0 0 auto;
+  }
+
+  .user-question-request__options {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.small};
+  }
+
+  .user-question-request__option {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: ${sp.small};
+    align-items: start;
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+    color: var(--wa-color-text-normal);
+    cursor: pointer;
+  }
+
+  .user-question-request__option input {
+    margin-top: 0.2rem;
+  }
+
+  .user-question-request__option span {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.tiny};
+  }
+
+  .user-question-request__option small {
+    color: var(--wa-color-text-quiet);
+    font-size: var(--font-size-xs);
+  }
+
+  .user-question-request__free-text {
+    width: 100%;
+  }
+
+  .user-question-request__actions vscode-toolbar-button {
     flex: 1 1 8rem;
   }
 `;

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -14,6 +14,7 @@ export const PERMISSION_KIND = {
   PROPOSAL: 'proposal',
   PLAN_APPROVAL: 'planApproval',
   EXTERNAL_INQUIRY: 'externalInquiry',
+  USER_QUESTION: 'userQuestion',
 } as const;
 
 export type PermissionKind =
@@ -26,6 +27,7 @@ export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
   PERMISSION_KIND.PROPOSAL,
   PERMISSION_KIND.PLAN_APPROVAL,
   PERMISSION_KIND.EXTERNAL_INQUIRY,
+  PERMISSION_KIND.USER_QUESTION,
 ]);
 
 /** Generates the getting started banner HTML with command links. */

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -10,6 +10,10 @@ import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type { StreamTabId } from '@shared/schemas';
 import {
+  AskUserQuestionTool,
+  handleUserQuestionAction,
+} from '@tools/userQuestion';
+import {
   cleanupAllApprovals,
   toggleProposalBypass,
   toggleToolEditApprovalSessionBypass,
@@ -148,6 +152,85 @@ describe('human prompt progress events', () => {
         },
         {
           event: 'resolveExternalInquiry',
+          payload: { requestId: show.payload.requestId },
+        },
+      ]);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('publishes user question events through the tool runtime host', async () => {
+    const explicit = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const streamId = 'stream:user-question' as StreamTabId;
+    const tool = new AskUserQuestionTool();
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+
+      const result = withRunContext(
+        createRunContext({ runtimeHost: explicit.host, streamId }),
+        () =>
+          withToolFileInteractionContext({ tracker: {} as never }, () =>
+            tool.call({
+              context: 'Choose the next step.',
+              questions: [
+                {
+                  question: 'Which path should the agent take?',
+                  header: 'Path',
+                  options: [
+                    { label: 'Inspect logs' },
+                    { label: 'Run the build' },
+                  ],
+                },
+              ],
+            }),
+          ),
+      );
+
+      const show = await waitForRecordedEvent(
+        explicit.events,
+        'showUserQuestion',
+      );
+      await handleUserQuestionAction({
+        requestId: show.payload.requestId,
+        action: 'submit',
+        answers: {
+          'Which path should the agent take?': 'Run the build',
+        },
+      });
+
+      await expect(result).resolves.toMatchObject({
+        summary: 'Answered 1 user question(s).',
+      });
+
+      expect(explicit.events).toEqual([
+        { event: 'requestEnsureProgressView', payload: {} },
+        { event: 'setActiveStream', payload: { streamId } },
+        {
+          event: 'showUserQuestion',
+          payload: {
+            requestId: show.payload.requestId,
+            questions: [
+              {
+                question: 'Which path should the agent take?',
+                header: 'Path',
+                options: [
+                  { label: 'Inspect logs' },
+                  { label: 'Run the build' },
+                ],
+              },
+            ],
+            context: 'Choose the next step.',
+            allowBypass: false,
+            streamId,
+          },
+        },
+        {
+          event: 'resolveUserQuestion',
           payload: { requestId: show.payload.requestId },
         },
       ]);

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -16,6 +16,10 @@ import {
   _rejectAllPendingInquiries,
   _rejectPendingInquiriesForStream,
 } from '@tools/inquiry';
+import {
+  _rejectAllPendingUserQuestions,
+  _rejectPendingUserQuestionsForStream,
+} from '@tools/userQuestion';
 
 import { bashApprovalController } from './bashApproval';
 import {
@@ -35,6 +39,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   toolEditApprovalController.rejectPendingForStream(streamId);
   bashApprovalController.rejectPendingForStream(streamId);
   _rejectPendingInquiriesForStream(streamId);
+  _rejectPendingUserQuestionsForStream(streamId);
   toolEditApprovalController.clearBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
   cleanupCoordinatorRequestsForStream(streamId);
@@ -48,6 +53,7 @@ export function cleanupAllApprovals(): void {
   toolEditApprovalController.rejectAllPending();
   bashApprovalController.rejectAllPending();
   _rejectAllPendingInquiries();
+  _rejectAllPendingUserQuestions();
   toolEditApprovalController.clearAllBypass();
   _clearAllProposalBypass();
   cleanupAllCoordinatorRequests();

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -53,6 +53,7 @@ import { WorkflowAgentTool, DelegateAgentTool } from './DelegationTools';
 import { ExecutionsTool } from './ExecutionsTool';
 import { AcceptRunFilesTool } from './AcceptRunFilesTool';
 import { ExternalInquiryTool } from './inquiry';
+import { AskUserQuestionTool } from './userQuestion';
 import { GitHubSubscriptionTool } from './github';
 import {
   ProbeEnvironmentTool,
@@ -123,6 +124,7 @@ function createDefaultTools() {
     executions: new ExecutionsTool(),
     accept_run_files: new AcceptRunFilesTool(),
     external_inquiry: new ExternalInquiryTool(),
+    ask_user_question: new AskUserQuestionTool(),
     github_subscription: new GitHubSubscriptionTool(),
     probe_environment: new ProbeEnvironmentTool(),
     verify_setup: new VerifySetupTool(),

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod';
+
+import { tryUseRunContext } from '@agent/runtime/RunContext';
+import { AgentLogger } from '@logger/AgentLogger';
+import {
+  UserQuestionAnswersSchema,
+  UserQuestionPromptSchema,
+  type StreamTabId,
+  type UserQuestionAnswers,
+} from '@shared/schemas';
+import type { ToolResult } from '@tools/result';
+import { requireRuntimeHost } from '@tools/contextHelpers';
+import { defineTool } from '@tools/core/define';
+
+const logger = new AgentLogger('UserQuestionTool');
+
+const AskUserQuestionInputSchema = z.strictObject({
+  questions: z
+    .array(UserQuestionPromptSchema)
+    .min(1)
+    .max(3)
+    .describe(
+      'One to three questions for the user. Keep each question short and provide two to four clear options.',
+    ),
+  context: z
+    .string()
+    .nullish()
+    .describe('Optional short context explaining why the answer is needed.'),
+});
+
+export type AskUserQuestionInput = z.infer<typeof AskUserQuestionInputSchema>;
+
+interface UserQuestionResult {
+  submitted: boolean;
+  answers?: UserQuestionAnswers;
+  feedback?: string;
+}
+
+let questionCounter = 0;
+const pendingQuestions = new Map<
+  string,
+  {
+    streamId?: StreamTabId;
+    settle: (result: UserQuestionResult) => void;
+    isSettled: () => boolean;
+  }
+>();
+
+async function awaitUserQuestionResponse(params: {
+  requestId: string;
+  input: AskUserQuestionInput;
+  streamId?: StreamTabId;
+}): Promise<UserQuestionResult> {
+  const runtimeHost = requireRuntimeHost(
+    'ask_user_question',
+    tryUseRunContext(),
+  );
+  return new Promise<UserQuestionResult>((resolve) => {
+    let settled = false;
+    const settle = (result: UserQuestionResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    pendingQuestions.set(params.requestId, {
+      streamId: params.streamId,
+      settle,
+      isSettled: () => settled,
+    });
+
+    runtimeHost.emit('requestEnsureProgressView', {});
+    if (params.streamId) {
+      runtimeHost.emit('setActiveStream', { streamId: params.streamId });
+    }
+    runtimeHost.emit('showUserQuestion', {
+      requestId: params.requestId,
+      questions: params.input.questions,
+      context: params.input.context ?? undefined,
+      allowBypass: false,
+      streamId: params.streamId ?? '',
+    });
+  });
+}
+
+export async function handleUserQuestionAction(payload: {
+  requestId: string;
+  action: 'submit' | 'reject' | 'skip';
+  answers?: UserQuestionAnswers;
+  feedback?: string;
+}): Promise<void> {
+  const entry = pendingQuestions.get(payload.requestId);
+  if (!entry || entry.isSettled()) return;
+
+  entry.settle({
+    submitted: payload.action === 'submit',
+    answers: payload.action === 'submit' ? payload.answers : undefined,
+    feedback: payload.action === 'submit' ? undefined : payload.feedback,
+  });
+}
+
+/** @internal Called by unified cleanup. */
+export function _rejectPendingUserQuestionsForStream(
+  streamId: StreamTabId,
+): void {
+  for (const entry of pendingQuestions.values()) {
+    if (entry.streamId === streamId && !entry.isSettled()) {
+      entry.settle({ submitted: false });
+    }
+  }
+}
+
+/** @internal Called by unified cleanup. */
+export function _rejectAllPendingUserQuestions(): void {
+  for (const entry of pendingQuestions.values()) {
+    if (!entry.isSettled()) {
+      entry.settle({ submitted: false });
+    }
+  }
+}
+
+export class AskUserQuestionTool extends defineTool({
+  name: 'ask_user_question',
+  description: `Ask the user one to three short clarification questions and wait for their answers.
+
+Use this when the task has several reasonable paths and continuing without the user's preference would be guesswork. Provide two to four concrete options for each question. Use allowFreeText only when the listed options may not cover the user's answer.
+
+The tool returns a JSON object whose keys are the original question texts and whose values are the selected option labels, arrays of labels for multi-select questions, or free-text answers.`,
+  schema: AskUserQuestionInputSchema,
+}) {
+  protected async execute(input: AskUserQuestionInput): Promise<ToolResult> {
+    const context = tryUseRunContext();
+    const runtimeHost = requireRuntimeHost('ask_user_question', context);
+    const streamId = context?.streamId;
+    const requestId = `user-question-${Date.now().toString(36)}-${++questionCounter}`;
+
+    logger.info(
+      `User question requested: ${input.questions[0]?.question.substring(0, 100) ?? ''}`,
+    );
+
+    try {
+      const result = await awaitUserQuestionResponse({
+        requestId,
+        input,
+        streamId,
+      });
+
+      if (!result.submitted) {
+        return {
+          output: result.feedback
+            ? `The user declined to answer: ${result.feedback}`
+            : 'The user declined to answer.',
+        };
+      }
+
+      const answers = UserQuestionAnswersSchema.parse(result.answers ?? {});
+      if (Object.keys(answers).length === 0) {
+        return {
+          output: 'The user submitted no answers.',
+        };
+      }
+
+      return {
+        output: JSON.stringify({ answers }, null, 2),
+        summary: `Answered ${Object.keys(answers).length} user question(s).`,
+      };
+    } finally {
+      pendingQuestions.delete(requestId);
+      runtimeHost.emit('resolveUserQuestion', { requestId });
+    }
+  }
+}

--- a/src/tools/userQuestion/index.ts
+++ b/src/tools/userQuestion/index.ts
@@ -1,0 +1,6 @@
+export {
+  AskUserQuestionTool,
+  handleUserQuestionAction,
+  _rejectAllPendingUserQuestions,
+  _rejectPendingUserQuestionsForStream,
+} from './UserQuestionTool';


### PR DESCRIPTION
## Summary

This PR adds an `ask_user_question` tool for tool-use agents. The tool asks one to three short structured questions, waits for the user's answer, and returns the selected labels or free-text answers as JSON.

The implementation uses the existing permission-request path so the same prompt works in the VS Code extension, the desktop app, and the CLI:

- extension and desktop render a progress-view question panel with options, optional multi-select, optional free text, submit, and rejection feedback;
- the CLI prompts interactively when approval prompting is available and skips with an explanatory message in non-interactive modes;
- pending questions are cleaned up through the same approval cleanup path used by other human prompts.

The default chat tool-use agent now has access to `ask_user_question`.

Closes #4028.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-surface human-interaction flow (CLI/desktop/VS Code) with new progress-view IPC commands and schemas; risk is mainly UI/message-shape mismatches or unhandled pending prompts causing stuck runs.
> 
> **Overview**
> Adds a new tool, `ask_user_question`, that emits `showUserQuestion`/`resolveUserQuestion` progress events, waits for a structured response (single/multi-select + optional free text), and returns answers as JSON.
> 
> Wires this new permission type end-to-end: new Zod schemas and `PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION`, desktop/extension IPC + handlers to forward actions to `handleUserQuestionAction`, a new Progress View `UserQuestionPanel` plus permission grouping/styling, and CLI support that interactively prompts when allowed or auto-skips with feedback in headless/YOLO modes.
> 
> Integrates cleanup and defaults by rejecting pending questions via `cleanupAllApprovals`/`cleanupApprovalsForStream`, registering the tool in `tools/registry`, enabling it for the default tool-use `chat` agent, and adding a vitest covering event publication and action handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dbf2759ec9cd4d6586be49d4d7ade3c2bde600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->