### PR TITLE
fix: wrap tool command summaries

### DIFF
--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -14,9 +14,9 @@ export const toolUseStyles = css`
 
   .tool-use-title {
     flex: 1;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     min-width: 0;
     user-select: text;
     cursor: text;

--- a/src/test-kernel/progressView/ToolUseStyles.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseStyles.vitest.mts
@@ -1,0 +1,34 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readToolUseStyles(): string {
+  return readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/src/progressView/frontend/styles/toolUseStyles.ts',
+    ),
+    'utf8',
+  );
+}
+
+describe('tool-use progress styles', () => {
+  it('wraps long tool summary titles instead of truncating command lines', () => {
+    const source = readToolUseStyles();
+    const titleRule = source.match(/\.tool-use-title\s*\{[^}]+\}/)?.[0] ?? '';
+
+    expect(titleRule).toContain('white-space: normal');
+    expect(titleRule).toContain('overflow-wrap: anywhere');
+    expect(titleRule).not.toContain('white-space: nowrap');
+    expect(titleRule).not.toContain('text-overflow: ellipsis');
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes long tool-use summary titles, such as bash command headers, so they wrap onto multiple lines instead of being truncated with an ellipsis.

The change is confined to the progress-view tool-use title styles:

- replace the single-line `white-space: nowrap`/ellipsis rule with normal wrapping;
- allow long path-like command fragments to break with `overflow-wrap: anywhere`;
- add a source-level regression test for the wrapping rule.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/ToolUseStyles.vitest.mts`
- `npm run typecheck`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/extension/src/progressView/frontend/styles/toolUseStyles.ts src/test-kernel/progressView/ToolUseStyles.vitest.mts`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change to tool-use title wrapping, plus a small regression test that asserts the style rules at the source level.
> 
> **Overview**
> Updates progress-view tool-use header styling so long command/title text *wraps onto multiple lines* instead of being truncated with `…` (switches from `white-space: nowrap`/ellipsis to `white-space: normal` with `overflow-wrap: anywhere` and `word-break`).
> 
> Adds a Vitest regression test (`ToolUseStyles.vitest.mts`) that reads `toolUseStyles.ts` and asserts the wrapping rules are present and truncation rules are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa4e386ff67063252d497ab44df052981b7e85f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->