### PR TITLE
test(cli): cover default login provider

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -15,15 +15,17 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 // Local imports - CLI runtime
 import {
   applyCliGlobalArgs,
-  cliFlagName,
-  CLI_BOOLEAN_FLAGS,
   CliUsageError,
   flagValue,
-  GLOBAL_FLAGS_WITH_VALUE,
   resolveCliContext,
-  RUN_FLAGS_WITH_VALUE,
   type CliContext,
 } from '../runtime/cliContext';
+import {
+  CLI_BOOLEAN_FLAGS,
+  GLOBAL_FLAGS_WITH_VALUE,
+  RUN_FLAGS_WITH_VALUE,
+  cliFlagName,
+} from '../runtime/cliFlags';
 import {
   hasCliApprovalDenied,
   installCliApprovalHandlers,

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -10,6 +10,13 @@ import {
   parseCliApprovalPolicy,
   type CliApprovalPolicy,
 } from './approvalPolicy';
+import {
+  CLI_BOOLEAN_FLAGS,
+  FLAGS_WITH_VALUE,
+  GLOBAL_BOOLEAN_FLAGS,
+  GLOBAL_FLAGS_WITH_VALUE,
+  cliFlagName,
+} from './cliFlags';
 
 export type CliMode = 'headless' | 'interactive';
 export type CliOutputFormat = 'text' | 'json' | 'ndjson';
@@ -41,37 +48,6 @@ export class CliUsageError extends Error {
   }
 }
 
-export const GLOBAL_FLAGS_WITH_VALUE = new Set([
-  '--approval-policy',
-  '--cwd',
-  '--output-format',
-]);
-
-export const RUN_FLAGS_WITH_VALUE = new Set([
-  '--input',
-  '-i',
-  '--output',
-  '--model',
-  '-m',
-  '--instruction',
-]);
-
-const FLAGS_WITH_VALUE = new Set([
-  ...GLOBAL_FLAGS_WITH_VALUE,
-  ...RUN_FLAGS_WITH_VALUE,
-  '--agent',
-  '--tool-display',
-]);
-
-const GLOBAL_BOOLEAN_FLAGS = new Set(['--print', '-p']);
-export const CLI_BOOLEAN_FLAGS = new Set([
-  ...GLOBAL_BOOLEAN_FLAGS,
-  '--help',
-  '-h',
-  '--version',
-  '-v',
-]);
-
 interface CliAmbientState {
   readonly isCi: boolean;
   readonly stdinIsTty: boolean;
@@ -92,10 +68,6 @@ function readCliAmbientState(): CliAmbientState {
       process.env.NO_COLOR == null &&
       process.env.TERM !== 'dumb',
   };
-}
-
-export function cliFlagName(arg: string): string {
-  return arg.split('=', 1)[0] ?? arg;
 }
 
 function inlineFlagValue(arg: string, ...names: string[]): string | undefined {

--- a/packages/cli/src/runtime/cliFlags.ts
+++ b/packages/cli/src/runtime/cliFlags.ts
@@ -1,0 +1,35 @@
+export const GLOBAL_FLAGS_WITH_VALUE = new Set([
+  '--approval-policy',
+  '--cwd',
+  '--output-format',
+]);
+
+export const RUN_FLAGS_WITH_VALUE = new Set([
+  '--input',
+  '-i',
+  '--output',
+  '--model',
+  '-m',
+  '--instruction',
+]);
+
+export const GLOBAL_BOOLEAN_FLAGS = new Set(['--print', '-p']);
+
+export const CLI_BOOLEAN_FLAGS = new Set([
+  ...GLOBAL_BOOLEAN_FLAGS,
+  '--help',
+  '-h',
+  '--version',
+  '-v',
+]);
+
+export const FLAGS_WITH_VALUE = new Set([
+  ...GLOBAL_FLAGS_WITH_VALUE,
+  ...RUN_FLAGS_WITH_VALUE,
+  '--agent',
+  '--tool-display',
+]);
+
+export function cliFlagName(arg: string): string {
+  return arg.split('=', 1)[0] ?? arg;
+}

--- a/packages/cli/src/runtime/loginArgs.ts
+++ b/packages/cli/src/runtime/loginArgs.ts
@@ -6,7 +6,7 @@ import {
   cliFlagName,
   CLI_BOOLEAN_FLAGS,
   GLOBAL_FLAGS_WITH_VALUE,
-} from './cliContext';
+} from './cliFlags';
 
 export type LoginArgParseError =
   | { kind: 'missing-value'; flag: string }

--- a/src/test-kernel/cli/LoginArgs.vitest.ts
+++ b/src/test-kernel/cli/LoginArgs.vitest.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseLoginArgs } from '../../../packages/cli/src/runtime/loginArgs';
+
+describe('CLI login arguments', () => {
+  it('defaults texra login to GitHub sign-in', () => {
+    expect(parseLoginArgs([])).toMatchObject({
+      provider: 'github',
+      noBrowser: false,
+    });
+  });
+
+  it('keeps no-browser usable without an explicit provider', () => {
+    expect(parseLoginArgs(['--no-browser'])).toMatchObject({
+      provider: 'github',
+      noBrowser: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a regression test showing that `texra login` defaults to GitHub when no provider is supplied.
- Add coverage for `texra login --no-browser` without an explicit provider.
- Move inert CLI flag constants into a small runtime module so login argument parsing can be tested without importing the full CLI context module.

Follow-up to #4027.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/LoginArgs.vitest.ts`
- `npm run typecheck`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/commands/root.ts packages/cli/src/runtime/cliContext.ts packages/cli/src/runtime/loginArgs.ts packages/cli/src/runtime/cliFlags.ts src/test-kernel/cli/LoginArgs.vitest.ts`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js login --no-browser` reached a GitHub OAuth URL; the local smoke test then terminated the waiting callback server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small regression test and refactors inert CLI flag constants into a standalone module with no behavioral changes expected.
> 
> **Overview**
> Adds a Vitest regression test ensuring `parseLoginArgs` defaults `texra login` to the GitHub provider, including when `--no-browser` is used without an explicit provider.
> 
> Refactors CLI flag parsing by moving flag constant sets and `cliFlagName` out of `cliContext` into a new `cliFlags` module, and updates CLI entrypoints (`root.ts`, `loginArgs.ts`, `cliContext.ts`) to import from it so login arg parsing can be tested without pulling in full context initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ef66e26a433ca03b74d56396f321abf5b286c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->