### PR TITLE
fix: handle user question follow-ups

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -20,6 +20,7 @@ import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool'
 // Local imports - CLI runtime
 import { type CliContext, type CliPromptRequest } from './cliContext';
 import { askCliQuestion, writeTextStderr } from './logSinks';
+import { parseUserQuestionAnswer } from './userQuestionAnswer';
 
 interface ApprovalDecision {
   readonly accepted: boolean;
@@ -274,26 +275,6 @@ function formatUserQuestionPrompt(
       return `${index + 1}. ${question.question}\n${options}\n${multi}${free}`;
     })
     .join('\n\n');
-}
-
-function parseUserQuestionAnswer(
-  raw: string,
-  question: ProgressEventPayloads['showUserQuestion']['questions'][number],
-): string | string[] | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) return undefined;
-
-  const selected = trimmed
-    .split(',')
-    .map((part) => Number.parseInt(part.trim(), 10))
-    .filter((value) => Number.isInteger(value))
-    .map((index) => question.options[index - 1]?.label)
-    .filter((value): value is string => Boolean(value));
-
-  if (selected.length > 0) {
-    return question.multiSelect ? selected : selected[0];
-  }
-  return question.allowFreeText ? trimmed : undefined;
 }
 
 function handleUserQuestion(

--- a/packages/cli/src/runtime/userQuestionAnswer.ts
+++ b/packages/cli/src/runtime/userQuestionAnswer.ts
@@ -1,0 +1,26 @@
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export function parseUserQuestionAnswer(
+  raw: string,
+  question: ProgressEventPayloads['showUserQuestion']['questions'][number],
+): string | string[] | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  const parts = trimmed
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  const selected = parts.every((part) => /^\d+$/.test(part))
+    ? parts
+        .map((part) => Number(part))
+        .map((index) => question.options[index - 1]?.label)
+        .filter((value): value is string => Boolean(value))
+    : [];
+
+  if (selected.length > 0) {
+    return question.multiSelect ? selected : selected[0];
+  }
+  return question.allowFreeText ? trimmed : undefined;
+}

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -411,7 +411,8 @@ export class ProgressViewProvider
       this.bashApprovalHandler.hasPendingForStream(streamId) ||
       this.agentProposalHandler.hasPendingForStream(streamId) ||
       this.planApprovalHandler.hasPendingForStream(streamId) ||
-      this.externalInquiryHandler.hasPendingForStream(streamId)
+      this.externalInquiryHandler.hasPendingForStream(streamId) ||
+      this.userQuestionHandler.hasPendingForStream(streamId)
     );
   }
 

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -73,7 +73,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
   }
 
   override handleKeyboardShortcut(key: string): boolean {
-    if (key === 'y' && !this.showFeedback) {
+    if (key === 'y') {
+      if (this.showFeedback) return false;
       this.submitAnswers();
       return true;
     }

--- a/src/test-kernel/cli/UserQuestionAnswer.vitest.ts
+++ b/src/test-kernel/cli/UserQuestionAnswer.vitest.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseUserQuestionAnswer } from '../../../packages/cli/src/runtime/userQuestionAnswer';
+
+const question = {
+  question: 'How long should this take?',
+  options: [{ label: 'Short' }, { label: 'Long' }],
+  allowFreeText: true,
+};
+
+describe('CLI user question answer parsing', () => {
+  it('selects numbered options only for exact numeric answers', () => {
+    expect(parseUserQuestionAnswer('2', question)).toBe('Long');
+  });
+
+  it('keeps leading-digit free text as text', () => {
+    expect(parseUserQuestionAnswer('1 hour', question)).toBe('1 hour');
+    expect(parseUserQuestionAnswer('2nd option', question)).toBe('2nd option');
+  });
+
+  it('parses comma-separated numeric answers for multi-select prompts', () => {
+    expect(
+      parseUserQuestionAnswer('1, 2', { ...question, multiSelect: true }),
+    ).toEqual(['Short', 'Long']);
+  });
+});

--- a/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
@@ -1,0 +1,37 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readProgressViewProvider(): string {
+  return readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/src/progressView/ProgressViewProvider.ts',
+    ),
+    'utf8',
+  );
+}
+
+describe('ProgressViewProvider pending permissions', () => {
+  it('keeps streams with pending user questions active', () => {
+    const source = readProgressViewProvider();
+    const methodStart = source.indexOf('hasPendingPermissionsForStream');
+    const methodEnd = source.indexOf('private canSendToWebview', methodStart);
+    expect(methodStart).toBeGreaterThanOrEqual(0);
+    expect(methodEnd).toBeGreaterThan(methodStart);
+    const method = source.slice(methodStart, methodEnd);
+
+    expect(method).toContain(
+      'this.userQuestionHandler.hasPendingForStream(streamId)',
+    );
+  });
+});

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
@@ -1,0 +1,134 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { PermissionState } from '@progressView/frontend/components/PermissionCard';
+import type { UserQuestionPanel } from '@progressView/frontend/components/UserQuestionPanel';
+
+// Local imports - shared constants
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+
+// Local imports - test utilities
+import { installAttachInternalsFallback } from '../settings/litComponentTestUtils';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  customElements: globalThis.customElements,
+  HTMLElement: globalThis.HTMLElement,
+  Element: globalThis.Element,
+  Document: globalThis.Document,
+  ShadowRoot: globalThis.ShadowRoot,
+  CSSStyleSheet: globalThis.CSSStyleSheet,
+  Event: globalThis.Event,
+  CustomEvent: globalThis.CustomEvent,
+  ResizeObserver: globalThis.ResizeObserver,
+  Node: (globalThis as { Node?: unknown }).Node,
+};
+
+class NoopResizeObserver implements ResizeObserver {
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+function installDom(): JSDOM {
+  const dom = new JSDOM('<!doctype html><body></body>', {
+    url: 'http://localhost',
+  });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.customElements = dom.window.customElements;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Element = dom.window.Element;
+  globalThis.Document = dom.window.Document;
+  globalThis.ShadowRoot = dom.window.ShadowRoot;
+  globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.ResizeObserver = NoopResizeObserver;
+  (globalThis as { Node: unknown }).Node = dom.window.Node;
+  installAttachInternalsFallback(
+    dom.window as unknown as Parameters<
+      typeof installAttachInternalsFallback
+    >[0],
+  );
+  return dom;
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+  globalThis.customElements = originalGlobals.customElements;
+  globalThis.HTMLElement = originalGlobals.HTMLElement;
+  globalThis.Element = originalGlobals.Element;
+  globalThis.Document = originalGlobals.Document;
+  globalThis.ShadowRoot = originalGlobals.ShadowRoot;
+  globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
+  globalThis.Event = originalGlobals.Event;
+  globalThis.CustomEvent = originalGlobals.CustomEvent;
+  globalThis.ResizeObserver = originalGlobals.ResizeObserver;
+  if (originalGlobals.Node === undefined) {
+    delete (globalThis as { Node?: unknown }).Node;
+  } else {
+    (globalThis as { Node: unknown }).Node = originalGlobals.Node;
+  }
+}
+
+function createPermission(): PermissionState {
+  return {
+    kind: PERMISSION_KIND.USER_QUESTION,
+    data: {
+      requestId: 'question-1',
+      allowBypass: false,
+      streamId: 'stream-1',
+      questions: [
+        {
+          question: 'Choose an answer',
+          options: [{ label: 'A' }, { label: 'B' }],
+          allowFreeText: true,
+        },
+      ],
+    },
+  };
+}
+
+async function mountPanel(): Promise<UserQuestionPanel> {
+  const element = document.createElement(
+    'user-question-panel',
+  ) as UserQuestionPanel;
+  element.permission = createPermission();
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+beforeAll(async () => {
+  installDom();
+  await import('@progressView/frontend/components/UserQuestionPanel');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+afterAll(() => {
+  restoreDom();
+});
+
+describe('user-question-panel', () => {
+  it('does not emit inherited approve action while rejection feedback is open', async () => {
+    const element = await mountPanel();
+    const actions: string[] = [];
+    element.addEventListener('permission-action', (event) => {
+      actions.push((event as CustomEvent<{ action: string }>).detail.action);
+    });
+
+    expect(element.handleKeyboardShortcut('n')).toBe(true);
+    await element.updateComplete;
+
+    expect(element.handleKeyboardShortcut('y')).toBe(false);
+    expect(actions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep leading-digit free-text CLI answers, such as `1 hour`, from being coerced into numbered choices.
- Keep streams with pending user questions active by including `userQuestionHandler` in the progress-view pending-permission check.
- Suppress the inherited `y -> approve` shortcut while a user-question rejection feedback field is open.

Closes #4051
Closes #4052
Closes #4053

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/UserQuestionAnswer.vitest.ts src/test-kernel/progressView/UserQuestionPanel.vitest.mts src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts`
- `npm run typecheck`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/approvalAdapter.ts packages/cli/src/runtime/userQuestionAnswer.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts src/test-kernel/cli/UserQuestionAnswer.vitest.ts src/test-kernel/progressView/UserQuestionPanel.vitest.mts src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow behavior fixes to CLI answer parsing and progress-view pending/keyboard handling, with added tests to lock in expected UX.
> 
> **Overview**
> Fixes user-question handling across CLI and progress view.
> 
> CLI now parses user-question responses more strictly so *only* exact numeric inputs (including comma-separated multi-select) map to option labels, preserving leading-digit free text (e.g. `1 hour`), and extracts this parsing into a shared `parseUserQuestionAnswer` helper with tests.
> 
> Progress view now treats pending user questions as stream-blocking permissions and prevents the `y` submit shortcut from firing while rejection feedback is open, with regression tests covering both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b62aaed502e09e29c730531f7e3bbe0b7c18d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->