### PR TITLE
fix: address closed PR review follow-ups

### DIFF
--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -7,12 +7,15 @@ npm package.
 ## Install From a Checkout
 
 Clone the repository, install workspace dependencies, build the CLI package, and
-link it into the global pnpm bin directory:
+link the bundled CLI binary into the global pnpm bin directory:
 
 ```bash
 corepack pnpm install
 corepack pnpm --filter @texra/cli build
-corepack pnpm --dir packages/cli link --global
+corepack pnpm setup    # one-time; then restart your shell or source its rc file
+PNPM_BIN="$(corepack pnpm bin -g)"
+mkdir -p "$PNPM_BIN"
+ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_BIN/texra"
 ```
 
 Verify the command:
@@ -30,14 +33,8 @@ changing CLI code or shared runtime code:
 corepack pnpm --filter @texra/cli build
 ```
 
-If `pnpm link --global` reports that no global binary directory is configured,
-run:
-
-```bash
-corepack pnpm setup
-```
-
-Then restart the shell and repeat the link command.
+The symlink is used instead of `pnpm link --global` because the CLI package
+still has workspace-only dependencies, while the built binary is self-contained.
 
 ## Run Without Linking
 
@@ -57,7 +54,7 @@ node packages/cli/dist/bin/texra.js run polish --input paper.tex --output paper.
 ## Remove the Linked Command
 
 ```bash
-corepack pnpm --global remove @texra/cli
+rm "$(corepack pnpm bin -g)/texra"
 ```
 
 ## Validation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,8 +27,10 @@ checkout:
 ```sh
 corepack pnpm install
 corepack pnpm --filter @texra/cli build
-corepack pnpm setup    # one-time; ensures $PNPM_HOME/bin is on PATH
-ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_HOME/bin/texra"
+corepack pnpm setup    # one-time; then restart your shell or source its rc file
+PNPM_BIN="$(corepack pnpm bin -g)"
+mkdir -p "$PNPM_BIN"
+ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_BIN/texra"
 texra --help
 ```
 
@@ -46,7 +48,7 @@ valid.
 To remove the linked command:
 
 ```sh
-rm "$PNPM_HOME/bin/texra"
+rm "$(corepack pnpm bin -g)/texra"
 ```
 
 ## Run locally

--- a/packages/cli/src/chat/runChat.ts
+++ b/packages/cli/src/chat/runChat.ts
@@ -542,6 +542,7 @@ export async function runChat(context: CliContext): Promise<ChatResult> {
               const authSession = await signInCliSupabase({
                 provider: loginArgs.provider,
                 openBrowser: !loginArgs.noBrowser,
+                manualBrowserHint: '/login --no-browser',
                 onAuthUrl: loginArgs.noBrowser
                   ? (url) => renderer.info(`Open this URL to sign in:\n${url}`)
                   : undefined,

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -217,6 +217,7 @@ async function login(context: CliContext): Promise<CliResult> {
     session = await signInCliSupabase({
       provider,
       openBrowser: !noBrowser,
+      manualBrowserHint: 'texra login --no-browser',
       onAuthUrl: (url) => {
         if (noBrowser) {
           const writeAuthUrl =

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -51,6 +51,7 @@ export interface CliLoginOptions {
   openBrowser?: boolean;
   log?: LogBackend;
   onAuthUrl?: (url: string) => void;
+  manualBrowserHint?: string;
 }
 
 let coordinator: SupabaseSessionCoordinator | undefined;
@@ -111,7 +112,11 @@ export async function signInCliSupabase(
 
     options.onAuthUrl?.(data.url);
     if (options.openBrowser ?? true) {
-      await openBrowser(data.url, options.log);
+      await openBrowser(
+        data.url,
+        options.log,
+        options.manualBrowserHint ?? 'texra login --no-browser',
+      );
     }
 
     const session = await callbackServer.waitForSession();
@@ -400,7 +405,11 @@ function escapeHtml(value: string): string {
     .replaceAll("'", '&#39;');
 }
 
-function openBrowser(url: string, log: LogBackend | undefined): Promise<void> {
+function openBrowser(
+  url: string,
+  log: LogBackend | undefined,
+  manualBrowserHint: string,
+): Promise<void> {
   const command =
     process.platform === 'darwin'
       ? 'open'
@@ -444,7 +453,7 @@ function openBrowser(url: string, log: LogBackend | undefined): Promise<void> {
       );
       reject(
         new Error(
-          `Could not open the browser automatically: ${message}. Run texra login --no-browser to open the sign-in URL manually.`,
+          `Could not open the browser automatically: ${message}. Run ${manualBrowserHint} to open the sign-in URL manually.`,
         ),
       );
     }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -424,13 +424,11 @@ export class DesktopProgressBridge {
     });
   }
 
-  private readonly probedWorktreeDirs = new Set<string>();
-
   private ensureWorktreeProbe(workingDirectory: string): void {
-    if (this.probedWorktreeDirs.has(workingDirectory)) return;
-    this.probedWorktreeDirs.add(workingDirectory);
+    // Fire-and-forget; the resolver owns TTL/in-flight de-duplication. Calling
+    // it on each render lets branch/dirty state refresh after the cache expires.
     void resolveWorktreeInfo(workingDirectory).catch(() => {
-      this.probedWorktreeDirs.delete(workingDirectory);
+      /* best-effort chip enrichment */
     });
   }
 

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -38,6 +38,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
 
   override render(): TemplateResult {
     const data = this.permission.data as UserQuestionPermission;
+    const canSubmit = this.hasAnyAnswer(data);
 
     return html`
       <div class="user-question-request">
@@ -57,8 +58,11 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
           ${renderLabeledActionButton({
             icon: 'check',
             text: 'Submit',
-            title: 'Submit answers (y)',
+            title: canSubmit
+              ? 'Submit answers (y)'
+              : 'Select or type at least one answer before submitting',
             action: 'submit',
+            disabled: !canSubmit,
             onClick: () => this.submitAnswers(),
           })}
           ${this.renderRejectButton('Reject this question (n)')}
@@ -75,6 +79,9 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
   override handleKeyboardShortcut(key: string): boolean {
     if (key === 'y') {
       if (this.showFeedback) return false;
+      if (!this.hasAnyAnswer(this.permission.data as UserQuestionPermission)) {
+        return true;
+      }
       this.submitAnswers();
       return true;
     }
@@ -183,6 +190,13 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
         answers,
       }),
     );
+  }
+
+  private hasAnyAnswer(data: UserQuestionPermission): boolean {
+    return data.questions.some((question) => {
+      if (this.freeText[question.question]?.trim()) return true;
+      return (this.selections[question.question] ?? []).length > 0;
+    });
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -127,6 +127,18 @@ export class WorktreeChip extends LitElement {
         flex-shrink: 0;
       }
 
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
       .pr-number {
         color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
         flex-shrink: 0;
@@ -201,18 +213,30 @@ export class WorktreeChip extends LitElement {
   }
 
   private renderBranch(): TemplateResult | typeof nothing {
-    const branch = this.info.branch;
+    const branch = this.info.branch ?? this.worktreeLabel();
     if (!branch) return nothing;
+    const branchKind = this.info.branch ? 'Branch' : 'Worktree';
     const tooltip = this.info.dirty
-      ? `Branch ${branch} (uncommitted changes)`
-      : `Branch ${branch}`;
+      ? `${branchKind} ${branch} (uncommitted changes)`
+      : `${branchKind} ${branch}`;
     return html`<span class="branch" title=${tooltip}>
       ${waIcon('code-branch')}
       <span class="branch-name">${branch}</span>
       ${this.info.dirty
-        ? html`<span class="dirty-dot" aria-label="uncommitted changes"></span>`
+        ? html`<span
+              class="dirty-dot"
+              role="img"
+              aria-label="uncommitted changes"
+            ></span>
+            <span class="sr-only">uncommitted changes</span>`
         : nothing}
     </span>`;
+  }
+
+  private worktreeLabel(): string | undefined {
+    const path = this.info.workingDirectory?.trim();
+    if (!path) return undefined;
+    return path.split(/[\\/]/).findLast(Boolean) ?? path;
   }
 
   private renderPRDetails(pr: NonNullable<WorktreeInfo['pr']>): TemplateResult {

--- a/packages/extension/src/progressView/streamInfoUtils.ts
+++ b/packages/extension/src/progressView/streamInfoUtils.ts
@@ -8,17 +8,11 @@ import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
 import { compareByNewestCreationTime } from './streamOrdering';
 import type { ProgressViewState } from './state/ProgressViewState';
 
-/** Working directories whose worktree probe has been kicked off. Prevents
- *  re-triggering an async probe on every render while the cache is empty. */
-const probedDirs = new Set<string>();
-
 function ensureWorktreeProbe(workingDirectory: string): void {
-  if (probedDirs.has(workingDirectory)) return;
-  probedDirs.add(workingDirectory);
-  // Fire-and-forget; the cache populates for the next render. Failures fall
-  // back to the minimal `{ workingDirectory }` chip and are ignored here.
+  // Fire-and-forget; the resolver owns TTL/in-flight de-duplication. Calling
+  // it on each render lets branch/dirty state refresh after the cache expires.
   void resolveWorktreeInfo(workingDirectory).catch(() => {
-    probedDirs.delete(workingDirectory);
+    /* best-effort chip enrichment */
   });
 }
 

--- a/prds/prd-odyssey.md
+++ b/prds/prd-odyssey.md
@@ -1,22 +1,21 @@
 # PRD: Odyssey — Autonomous Continuation Mode
 
-**Status:** Draft (v0.2)
+**Status:** Draft (v0.3)
 **Owner:** TBD
 **Date:** 2026-05-14
-**Branch:** `feature/odyssey`
 
 ## 1. Summary
 
-Add **Odyssey** to TeXRA — a per-conversation persistent objective that lets a tool-use agent autonomously continue across many turns until a verifiable stopping condition is met. Inspired by Codex CLI's experimental `/goal` feature ([docs](https://developers.openai.com/codex/use-cases/follow-goals)).
+Add **Odyssey** to TeXRA — a per-conversation persistent objective that lets a tool-use agent autonomously continue across many turns until a verifiable stopping condition is met or a safety checkpoint is reached. Inspired by Codex CLI's experimental `/goal` feature ([docs](https://developers.openai.com/codex/use-cases/follow-goals)).
 
 The user sets an Odyssey from the stream header. While active, after every tool-use turn ends idle, TeXRA injects a hidden continuation message that re-prompts the agent to verify completion against current external state (filesystem, command output, tests) and either keep working or call `odyssey { command: 'complete' }`. The model self-terminates when the objective is met.
 
-No new runtime, no polling loop, no background worker. The mechanism is a small injection around `session.waitForFollowUp` in `ToolUseWaitNode.exec()`.
+No new runtime, no polling loop, no background worker. The mechanism is a small injection before `session.waitForFollowUp` in `ToolUseWaitNode.exec()`.
 
 ## 2. Goals
 
 - One persistent objective per conversation that survives across tool-use turns.
-- Model can self-direct work for many turns without user input until the stopping condition holds.
+- Model can self-direct work for many turns without user input until the stopping condition holds or a configured continuation cap is reached.
 - User retains full control: start, pause, resume, abandon, and edit-objective from the UI at any time.
 - Zero new infrastructure: reuse the existing tool-use cycle, workspaceSM, settings webview tabs, and stream-header toolbar patterns.
 - Feature-gated and opt-in (`texra.experimental.odyssey.enabled`); defaults off; ships as experimental.
@@ -25,7 +24,7 @@ No new runtime, no polling loop, no background worker. The mechanism is a small 
 
 - **No workflow-agent support.** Odyssey only applies to tool-use agents (orchestrator, devise, search, generic chat). Workflow agents (correct, polish, …) run once and emit output; "continuation" is meaningless.
 - **No multi-agent orchestrator-level odyssey.** If a goal-bearing tool-use agent is itself a subagent of an orchestrator, the parent orchestrator owns continuation; the subagent's Odyssey is suspended for that subtree. Surfaces as a hard guard, not a feature.
-- **No token budget.** Codex's public docs do not surface a budget; the internal one is purely accounting. We track tokens used for display only — no cap, no `BudgetLimited` status.
+- **No user-visible token budget.** Codex's public docs do not surface one. We track tokens used for display, but v1 uses a simpler operational stop: a maximum continuation count, after which Odyssey pauses and asks the user whether to continue.
 - **No slash command on extension/desktop.** Entry is the stream-header button and the Settings → Odyssey tab. (CLI host may add `/odyssey` later; out of scope here.)
 - **No model-driven objective edits.** Codex restricts `update_goal` to `status='complete'` for the same reason: the model must not drift the target. The user edits objectives via the OdysseyTab.
 
@@ -34,15 +33,15 @@ No new runtime, no polling loop, no background worker. The mechanism is a small 
 The mechanism is mundane. Every "long-running" turn is many short turns chained:
 
 1. A tool-use turn ends (model emitted final response, no more tool calls).
-2. The runtime checks: is there an active goal? Is the user idle (no queued input)?
+2. The runtime checks: is there an active goal? Is the user idle (no queued input)? Has the continuation cap not been reached?
 3. If yes, the runtime synthesizes a hidden user message:
    > `<goal_context>` Your goal is still: `<objective>`. Verify against the current filesystem/command output — not your memory. Call `update_goal(complete)` if done, else keep working. `</goal_context>`
 4. That message is appended as the next turn's input, and the agent runs again — exactly like the user had said "keep going."
-5. The model either calls `update_goal(complete)` (loop exits) or keeps working (back to step 1).
+5. The model either calls `update_goal(complete)` (loop exits), keeps working (back to step 1), or reaches the continuation cap, at which point the loop pauses for user confirmation.
 
 The model is the only thing that knows when the work is _actually_ done, so the model has to be given a tool that signals "stop the loop." Everything else (status display, pause/resume, accounting) is bookkeeping around that one loop.
 
-TeXRA's `ToolUseWaitNode.post()` is the moral equivalent of Codex's idle hook — it's the function that decides whether to loop back to `ToolUseCycleNode` or exit. That's the entire integration point.
+TeXRA's `ToolUseWaitNode.exec()` is the correct idle hook because it runs before the blocking follow-up wait. `ToolUseWaitNode.post()` remains a simple mapper from the wait result to the next flow transition.
 
 ## 5. Architecture
 
@@ -77,16 +76,20 @@ export const OdysseySchema = z.object({
   streamId: z.string(), // stream-scoped — matches ToolUseWaitNode.services.streamId
   objective: z.string().min(1),
   status: OdysseyStatusSchema,
-  tokensUsed: z.int().nonnegative().default(0),
-  timeUsedMs: z.int().nonnegative().default(0),
+  tokensUsed: z.int().nonnegative().prefault(0),
+  timeUsedMs: z.int().nonnegative().prefault(0),
+  continuationCount: z.int().nonnegative().prefault(0),
+  maxContinuations: z.int().positive().prefault(50),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
   completedReason: z.string().nullish(), // populated by tool's 'complete'
-  history: z.array(OdysseyEventSchema).default([]),
+  history: z.array(OdysseyEventSchema).prefault([]),
 });
 ```
 
 One Odyssey per stream. Persisted via `platform().workspaceState` (host-neutral `StateStore`, see `src/platform/interfaces/state.ts`) under `odysseys:byStream:<streamId>` plus an index `odysseys:index` for the OdysseyTab list view. The same store is backed by VS Code's Memento in the extension host, by an in-memory store under test, and by a file-backed store in CLI/desktop — no `vscode` import in this code path.
+
+The store enforces bounded state growth. `recordEvent` trims `history` to the most recent 200 events after every write. Each injected continuation increments `continuationCount`; if it reaches `maxContinuations`, the store pauses the Odyssey and records a cap-reached event instead of returning another continuation.
 
 ### 5.2 Tool surface
 
@@ -102,12 +105,12 @@ const OdysseyToolInputSchema = z.strictObject({
 });
 ```
 
-| Command    | Use                                                                       | Effect                                                        |
-| ---------- | ------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `view`     | Read situational awareness (objective, status, history, time/tokens used) | No mutation; returns formatted state                          |
-| `start`    | Open an odyssey from conversation when user requests autonomous work      | Creates with status `active`. Fails if one is already active. |
-| `pause`    | Self-pause when blocked and needing user input                            | Status → `paused`. Continuation loop stops.                   |
-| `complete` | Signal objective met                                                      | Status → `complete`. Stores `reason` as audit sentence.       |
+| Command    | Use                                                                       | Effect                                                                                        |
+| ---------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `view`     | Read situational awareness (objective, status, history, time/tokens used) | No mutation; returns formatted state                                                          |
+| `start`    | Open an odyssey from conversation when user requests autonomous work      | Creates with status `active`. Fails if any nonterminal Odyssey already exists for the stream. |
+| `pause`    | Self-pause when blocked and needing user input                            | Status → `paused`. Continuation loop stops.                                                   |
+| `complete` | Signal objective met                                                      | Status → `complete`. Stores `reason` as audit sentence.                                       |
 
 Commands deliberately omitted: `update_objective` (model must not drift the target), `resume` (only the user can clear a block), `abandon` (destructive, user-only).
 
@@ -161,6 +164,10 @@ async function maybeBuildOdysseyContinuation(args: {
   if (!platform().config.get('texra.experimental.odyssey.enabled', false)) return null;
   const odyssey = await OdysseyStore.getForStream(args.streamId);
   if (odyssey?.status !== 'active') return null;
+  if (odyssey.continuationCount >= odyssey.maxContinuations) {
+    await OdysseyStore.pauseForContinuationCap(odyssey.odysseyId);
+    return null;
+  }
   await OdysseyStore.recordEvent(odyssey.odysseyId, 'continuation_injected');
   return buildContinuationFollowUp(odyssey);
 }
@@ -253,7 +260,7 @@ Hosts that don't surface the experimental flag at all simply have it default to 
 Odyssey must work in three hosts: VS Code extension, Electron desktop, and `@texra/cli` (the CLI). The split is:
 
 | Concern                       | Host-neutral (kernel, all three hosts)                                                                                                                                                                                                                        | Host-specific (per host)                                                                                                                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------ | ------- | ----------------------------------------------------------------------------------------------- |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Schema (`OdysseySchema`)      | `src/tools/odyssey/odysseyMeta.ts`                                                                                                                                                                                                                            | —                                                                                                                                                                                                                                                                     |
 | Store (`OdysseyStore`)        | `src/tools/odyssey/odysseyStore.ts` — uses `platform().workspaceState`                                                                                                                                                                                        | Backing implementation lives in each host's platform-defaults; the kernel never imports it.                                                                                                                                                                           |
 | Tool (`OdysseyTool`)          | `src/tools/odyssey/OdysseyTool.ts`                                                                                                                                                                                                                            | —                                                                                                                                                                                                                                                                     |
@@ -264,7 +271,7 @@ Odyssey must work in three hosts: VS Code extension, Electron desktop, and `@tex
 | Stream-header button (PR 2)   | —                                                                                                                                                                                                                                                             | Extension + desktop only (`packages/extension/src/progressView/frontend/components/StreamHeader.ts`; desktop shares the webview).                                                                                                                                     |
 | Settings → Odyssey tab (PR 2) | —                                                                                                                                                                                                                                                             | Extension + desktop only.                                                                                                                                                                                                                                             |
 | Progress board entry (PR 2)   | —                                                                                                                                                                                                                                                             | Extension + desktop only.                                                                                                                                                                                                                                             |
-| CLI control surface           | —                                                                                                                                                                                                                                                             | `texra odyssey start                                                                                                                                                                                                                                                  | pause | resume | abandon | status`(Phase 2). Stdout for`status`, exit codes for the others. Same IPC schema, same handler. |
+| CLI control surface           | —                                                                                                                                                                                                                                                             | `texra odyssey start`, `pause`, `resume`, `abandon`, and `status` subcommands (Phase 2). `status` writes to stdout; mutating commands use exit codes and stderr diagnostics. Same IPC schema, same handler.                                                           |
 
 Two PR-1 invariants follow from this split:
 
@@ -309,10 +316,14 @@ packages/extension/src/settingsView/
   frontend/components/odyssey/OdysseyEditor.ts         NEW   (PR 2)
   utils/odysseyFileSystem.ts                           NEW   (PR 2)
   SettingsViewMessageHandler.ts                        MODIFY (PR 2)
+  frontend/SettingsApp.ts                              MODIFY (PR 2)
+  frontend/tabs/index.ts                               MODIFY (PR 2)
 
 packages/extension/src/progressView/frontend/components/
   StreamHeader.ts                     MODIFY (PR 2)
   constants.ts                        MODIFY (PR 2 — ELEMENT_IDS.ODYSSEY_TOGGLE_BTN)
+
+src/common/webview/commands.ts        MODIFY (PR 2 — settings tab command/schema)
 
 packages/extension/package.json       MODIFY (contributes.configuration entry)
 ```
@@ -347,6 +358,7 @@ packages/desktop/                     no new files; reuses the extension webview
 | Risk                                                             | Mitigation                                                                                                                                                                                                             |
 | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Model drifts away from the stated objective over many turns      | Continuation prompt insists on verifying against _current external state_ (Codex's own guardrail). Model has no tool to edit the objective.                                                                            |
+| Model never calls `complete`                                     | `maxContinuations` defaults to 50 and pauses the Odyssey when reached. The user can resume explicitly.                                                                                                                 |
 | Token accounting becomes stale and the badge shows wrong numbers | TeXRA already emits usage per response; apply to odyssey record at the same time as the existing usage event. Off by ≤1 turn in worst case — acceptable for an informational chip.                                     |
 | Multi-agent orchestration interferes with continuation           | Hard guard in the wait-node hook: skip continuation injection when `this.services.isSubagent` is true (already checked at `ToolUseWaitNode.ts:56` for a different concern). The parent orchestrator owns continuation. |
 | User clears a conversation but the Odyssey record lingers        | Subscribe to the existing conversation-delete event in PR 2; mark odyssey `abandoned` and drop from index.                                                                                                             |
@@ -355,12 +367,11 @@ packages/desktop/                     no new files; reuses the extension webview
 ## 9. Open questions
 
 - Should `start` from the model auto-activate, or require user confirmation? Codex auto-activates. PR 1 ships auto-activate; revisit if it surprises users.
-- Maximum history length for the `events` array? Cap at 200 events per Odyssey, oldest dropped on overflow.
+- Should the default `maxContinuations` be 50, or should it be lower for the first experimental release?
 - CLI control surface (Phase 2) — see §5.8 for the high-level shape. The `texra odyssey` subcommands are a separate PR after PR 2; until then, CLI users get the tool-only flow (model can `start`, `pause`, `complete` from inside any tool-use agent run).
 
 ## 10. References
 
 - Codex `/goal` user-facing docs: https://developers.openai.com/codex/use-cases/follow-goals
-- Codex internals scout (this conversation): turn-end idle hook at `codex-rs/core/src/tasks/mod.rs:802`, continuation candidate check at `codex-rs/core/src/goals.rs:1301`, ThreadGoal schema at `codex-rs/state/src/model/thread_goal.rs:52`.
 - TeXRA tool pattern reference: `src/tools/memory/MemoryTool.ts` (single tool with `command` enum discriminator).
 - TeXRA wait-node integration point: `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts:39-114`.

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -41,11 +41,7 @@ export { toRemoteAgentProfileData } from './remoteAgentProfileData';
 
 export { buildStreamTabInfo, type StreamTabInfoInputs } from './streamTabInfo';
 
-export {
-  peekWorktreeInfo,
-  resolveWorktreeInfo,
-  invalidateWorktreeInfo,
-} from './worktreeInfo';
+export { peekWorktreeInfo, resolveWorktreeInfo } from './worktreeInfo';
 
 export {
   // Types

--- a/src/agent/index/worktreeInfo.ts
+++ b/src/agent/index/worktreeInfo.ts
@@ -57,11 +57,6 @@ export async function resolveWorktreeInfo(
   return probe;
 }
 
-/** Drop any cached entry for `workingDirectory` (e.g. after a git operation). */
-export function invalidateWorktreeInfo(workingDirectory: string): void {
-  cache.delete(workingDirectory);
-}
-
 async function probeWorktree(workingDirectory: string): Promise<WorktreeInfo> {
   const [branch, dirty] = await Promise.all([
     readBranch(workingDirectory),

--- a/src/test-kernel/progressView/WorktreeChip.vitest.mts
+++ b/src/test-kernel/progressView/WorktreeChip.vitest.mts
@@ -3,11 +3,10 @@ import { JSDOM } from 'jsdom';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - progress view component types
-import type { PermissionState } from '@progressView/frontend/components/PermissionCard';
-import type { UserQuestionPanel } from '@progressView/frontend/components/UserQuestionPanel';
+import type { WorktreeChip } from '@progressView/frontend/components/WorktreeChip';
 
-// Local imports - shared constants
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+// Local imports - shared schemas
+import type { WorktreeInfo } from '@shared/schemas';
 
 // Local imports - test utilities
 import { installAttachInternalsFallback } from '../settings/litComponentTestUtils';
@@ -33,7 +32,7 @@ class NoopResizeObserver implements ResizeObserver {
   unobserve(): void {}
 }
 
-function installDom(): JSDOM {
+function installDom(): void {
   const dom = new JSDOM('<!doctype html><body></body>', {
     url: 'http://localhost',
   });
@@ -54,7 +53,6 @@ function installDom(): JSDOM {
       typeof installAttachInternalsFallback
     >[0],
   );
-  return dom;
 }
 
 function restoreDom(): void {
@@ -76,29 +74,9 @@ function restoreDom(): void {
   }
 }
 
-function createPermission(): PermissionState {
-  return {
-    kind: PERMISSION_KIND.USER_QUESTION,
-    data: {
-      requestId: 'question-1',
-      allowBypass: false,
-      streamId: 'stream-1',
-      questions: [
-        {
-          question: 'Choose an answer',
-          options: [{ label: 'A' }, { label: 'B' }],
-          allowFreeText: true,
-        },
-      ],
-    },
-  };
-}
-
-async function mountPanel(): Promise<UserQuestionPanel> {
-  const element = document.createElement(
-    'user-question-panel',
-  ) as UserQuestionPanel;
-  element.permission = createPermission();
+async function mountChip(info: WorktreeInfo): Promise<WorktreeChip> {
+  const element = document.createElement('worktree-chip') as WorktreeChip;
+  element.info = info;
   document.body.append(element);
   await element.updateComplete;
   return element;
@@ -106,7 +84,7 @@ async function mountPanel(): Promise<UserQuestionPanel> {
 
 beforeAll(async () => {
   installDom();
-  await import('@progressView/frontend/components/UserQuestionPanel');
+  await import('@progressView/frontend/components/WorktreeChip');
 });
 
 afterEach(() => {
@@ -117,33 +95,25 @@ afterAll(() => {
   restoreDom();
 });
 
-describe('user-question-panel', () => {
-  it('does not emit inherited approve action while rejection feedback is open', async () => {
-    const element = await mountPanel();
-    const actions: string[] = [];
-    element.addEventListener('permission-action', (event) => {
-      actions.push((event as CustomEvent<{ action: string }>).detail.action);
+describe('worktree-chip', () => {
+  it('renders a working-directory fallback when git metadata is absent', async () => {
+    const element = await mountChip({
+      workingDirectory: '/tmp/texra/issue-4018',
     });
 
-    expect(element.handleKeyboardShortcut('n')).toBe(true);
-    await element.updateComplete;
-
-    expect(element.handleKeyboardShortcut('y')).toBe(false);
-    expect(actions).toEqual([]);
+    expect(element.shadowRoot?.textContent).toContain('issue-4018');
   });
 
-  it('does not submit an empty answer set', async () => {
-    const element = await mountPanel();
-    const actions: string[] = [];
-    element.addEventListener('permission-action', (event) => {
-      actions.push((event as CustomEvent<{ action: string }>).detail.action);
+  it('exposes dirty state to assistive technology', async () => {
+    const element = await mountChip({
+      workingDirectory: '/tmp/texra/issue-4018',
+      branch: 'issue-4018',
+      dirty: true,
     });
 
-    const button = element.shadowRoot?.querySelector(
-      'wa-button[data-action="submit"]',
-    ) as HTMLElement & { disabled?: boolean };
-    expect(button?.disabled).toBe(true);
-    expect(element.handleKeyboardShortcut('y')).toBe(true);
-    expect(actions).toEqual([]);
+    const dirty = element.shadowRoot?.querySelector('.dirty-dot');
+    expect(dirty?.getAttribute('role')).toBe('img');
+    expect(dirty?.getAttribute('aria-label')).toBe('uncommitted changes');
+    expect(element.shadowRoot?.textContent).toContain('uncommitted changes');
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses still-valid bot review comments left on recent closed PRs.

- #4042: let worktree chip probes refresh through the resolver TTL/in-flight cache, remove the unused invalidator, render a directory fallback when git metadata is absent, and expose dirty state to assistive technology.
- #4048: prevent empty user-question submissions in the progress view while preserving the existing keyboard suppression behavior.
- #4027: make the browser-launch failure hint context-specific, so chat `/login` points users to `/login --no-browser` rather than `texra login --no-browser`.
- #4025: align the CLI local-install README and guide around `corepack pnpm bin -g` instead of assuming `$PNPM_HOME` or using `pnpm link --global`.
- #4032: update the Odyssey PRD to include bounded continuation/history state, `.prefault()` persisted-state defaults, unambiguous start semantics, complete Settings-tab registration files, and no inaccessible conversation reference.

Audit note: #4019's remaining visible threads are already satisfied in the current tree by `actions: read`, the `actions` toolset, and the generated lock workflow's hard `AGENTS.md`/`CLAUDE.md` patch allowlist.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/UserQuestionPanel.vitest.mts src/test-kernel/progressView/WorktreeChip.vitest.mts`
- `corepack pnpm --filter @texra/cli build`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation/UI guardrails and small runtime messaging/caching tweaks; main behavior change is more frequent worktree probing via existing TTL/in-flight dedupe.
> 
> **Overview**
> Improves local CLI installation docs to use a direct symlink into `corepack pnpm bin -g` (instead of `pnpm link --global` / `$PNPM_HOME`) and updates uninstall instructions accordingly.
> 
> Refines CLI OAuth sign-in UX by making the “open URL manually” hint configurable, so chat `/login` points to `/login --no-browser` while `texra login` points to `texra login --no-browser`.
> 
> Updates worktree chip enrichment to re-trigger `resolveWorktreeInfo()` on each render (relying on its TTL/in-flight dedupe), removes the now-unused `invalidateWorktreeInfo` export, and enhances the progress view chip to fall back to a directory label and expose dirty state to assistive tech.
> 
> Prevents empty `UserQuestionPanel` submissions by disabling the Submit action and swallowing the `y` shortcut until at least one answer is provided; adds/extends vitest coverage for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739296ed00f82c49d41678052ecaa775cdc22ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->