### PR TITLE
Simplify worktree probe deduplication and add fallback branch display

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -405,7 +405,10 @@ export class DesktopProgressBridge {
     let worktreeInfo;
     if (workingDirectory) {
       worktreeInfo = peekWorktreeInfo(workingDirectory);
-      this.ensureWorktreeProbe(workingDirectory);
+      // Fire-and-forget. The resolver's TTL + in-flight cache handle
+      // de-duping and refresh — callers don't need to track which dirs
+      // they've probed.
+      void resolveWorktreeInfo(workingDirectory);
     }
     return buildStreamTabInfo({
       streamId,
@@ -420,16 +423,6 @@ export class DesktopProgressBridge {
       parentStreamId: this.parentStreams.get(streamId),
       description: this.descriptions.get(streamId),
       worktreeInfo,
-    });
-  }
-
-  private readonly probedWorktreeDirs = new Set<string>();
-
-  private ensureWorktreeProbe(workingDirectory: string): void {
-    if (this.probedWorktreeDirs.has(workingDirectory)) return;
-    this.probedWorktreeDirs.add(workingDirectory);
-    void resolveWorktreeInfo(workingDirectory).catch(() => {
-      this.probedWorktreeDirs.delete(workingDirectory);
     });
   }
 

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -214,9 +214,9 @@ export class WorktreeChip extends LitElement {
     // Display name falls back to the basename of the working directory when
     // a branch hasn't resolved yet (or the path isn't a git repo), so the
     // chip never renders an empty row when `info.workingDirectory` is set.
+    // Uses `||` (not `??`) so empty-string branches also fall back.
     const branch = this.info.branch;
-    const fallback = branch ? undefined : basename(this.info.workingDirectory);
-    const display = branch ?? fallback;
+    const display = branch || basename(this.info.workingDirectory);
     if (!display) return nothing;
 
     const tooltipBase = branch

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -37,6 +37,13 @@ const CI_LABEL: Record<WorktreeCIState, string> = {
   [WORKTREE_CI_STATE.UNKNOWN]: 'CI status unknown',
 };
 
+/** Trailing path segment, posix or windows. Webview-safe — no node:path. */
+function basename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
 /**
  * Compact chip that mirrors GitHub's PR row: state pill, `#NNN` title, and
  * `+A −D` diff stats with a CI dot. Falls back to a branch-only chip when
@@ -201,16 +208,29 @@ export class WorktreeChip extends LitElement {
   }
 
   private renderBranch(): TemplateResult | typeof nothing {
+    // Display name falls back to the basename of the working directory when
+    // a branch hasn't resolved yet (or the path isn't a git repo), so the
+    // chip never renders an empty row when `info.workingDirectory` is set.
     const branch = this.info.branch;
-    if (!branch) return nothing;
+    const fallback = branch ? undefined : basename(this.info.workingDirectory);
+    const display = branch ?? fallback;
+    if (!display) return nothing;
+
+    const tooltipBase = branch
+      ? `Branch ${branch}`
+      : this.info.workingDirectory;
     const tooltip = this.info.dirty
-      ? `Branch ${branch} (uncommitted changes)`
-      : `Branch ${branch}`;
+      ? `${tooltipBase} (uncommitted changes)`
+      : tooltipBase;
     return html`<span class="branch" title=${tooltip}>
       ${waIcon('code-branch')}
-      <span class="branch-name">${branch}</span>
+      <span class="branch-name">${display}</span>
       ${this.info.dirty
-        ? html`<span class="dirty-dot" aria-label="uncommitted changes"></span>`
+        ? html`<span
+            class="dirty-dot"
+            role="img"
+            aria-label="uncommitted changes"
+          ></span>`
         : nothing}
     </span>`;
   }

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -37,9 +37,12 @@ const CI_LABEL: Record<WorktreeCIState, string> = {
   [WORKTREE_CI_STATE.UNKNOWN]: 'CI status unknown',
 };
 
-/** Trailing path segment, posix or windows. Webview-safe — no node:path. */
+/** Trailing path segment, posix or windows. Webview-safe — no node:path.
+ *  Falls back to the original input for separator-only paths (e.g. `/`)
+ *  so callers always get a non-empty label. */
 function basename(p: string): string {
   const trimmed = p.replace(/[\\/]+$/, '');
+  if (!trimmed) return p;
   const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
   return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
 }

--- a/packages/extension/src/progressView/streamInfoUtils.ts
+++ b/packages/extension/src/progressView/streamInfoUtils.ts
@@ -8,20 +8,6 @@ import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
 import { compareByNewestCreationTime } from './streamOrdering';
 import type { ProgressViewState } from './state/ProgressViewState';
 
-/** Working directories whose worktree probe has been kicked off. Prevents
- *  re-triggering an async probe on every render while the cache is empty. */
-const probedDirs = new Set<string>();
-
-function ensureWorktreeProbe(workingDirectory: string): void {
-  if (probedDirs.has(workingDirectory)) return;
-  probedDirs.add(workingDirectory);
-  // Fire-and-forget; the cache populates for the next render. Failures fall
-  // back to the minimal `{ workingDirectory }` chip and are ignored here.
-  void resolveWorktreeInfo(workingDirectory).catch(() => {
-    probedDirs.delete(workingDirectory);
-  });
-}
-
 /**
  * Check if a session category matches the given filter.
  * Returns the resolved category (defaulting to Workflow) or null if filtered out.
@@ -69,7 +55,10 @@ export function buildStreamInfo(
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);
-    ensureWorktreeProbe(workingDirectory);
+    // Fire-and-forget. The resolver's TTL + in-flight cache handle
+    // de-duping and refresh — callers don't need to track which dirs
+    // they've probed.
+    void resolveWorktreeInfo(workingDirectory);
   }
 
   return buildStreamTabInfo({

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -41,11 +41,7 @@ export { toRemoteAgentProfileData } from './remoteAgentProfileData';
 
 export { buildStreamTabInfo, type StreamTabInfoInputs } from './streamTabInfo';
 
-export {
-  peekWorktreeInfo,
-  resolveWorktreeInfo,
-  invalidateWorktreeInfo,
-} from './worktreeInfo';
+export { peekWorktreeInfo, resolveWorktreeInfo } from './worktreeInfo';
 
 export {
   // Types

--- a/src/agent/index/worktreeInfo.ts
+++ b/src/agent/index/worktreeInfo.ts
@@ -57,11 +57,6 @@ export async function resolveWorktreeInfo(
   return probe;
 }
 
-/** Drop any cached entry for `workingDirectory` (e.g. after a git operation). */
-export function invalidateWorktreeInfo(workingDirectory: string): void {
-  cache.delete(workingDirectory);
-}
-
 async function probeWorktree(workingDirectory: string): Promise<WorktreeInfo> {
   const [branch, dirty] = await Promise.all([
     readBranch(workingDirectory),


### PR DESCRIPTION
## Summary

This PR removes redundant worktree probe deduplication logic and improves the worktree chip UI to display a fallback branch name when git metadata hasn't resolved yet.

**Key changes:**
1. **Removed duplicate probe tracking**: Deleted `ensureWorktreeProbe()` and `probedDirs` set from `streamInfoUtils.ts` and the equivalent `ensureWorktreeProbe()` method from `DesktopProgressBridge`. The resolver's built-in TTL and in-flight cache already handle deduplication and refresh, making caller-side tracking unnecessary.
2. **Simplified probe invocation**: Replaced conditional probe calls with unconditional `void resolveWorktreeInfo(workingDirectory)` fire-and-forget calls, relying on the resolver's cache to prevent redundant work.
3. **Enhanced WorktreeChip fallback display**: Added a `basename()` utility to extract the working directory name when branch info hasn't resolved, ensuring the chip never renders an empty row. Updated tooltip logic to show the full path when branch is unavailable.
4. **Improved accessibility**: Added `role="img"` to the dirty-dot indicator for better screen reader support.
5. **Removed unused export**: Deleted the `invalidateWorktreeInfo()` export from the public API since it was never used.

## Issue acceptance gates

N/A — This is a refactoring to simplify probe deduplication and improve UI fallback behavior.

## Single source of truth

The `resolveWorktreeInfo()` resolver in `src/agent/index/worktreeInfo.ts` now owns all deduplication and caching logic via its TTL and in-flight cache. Callers no longer track probed directories.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated two separate implementations of probe deduplication (`probedDirs` set in `streamInfoUtils.ts` and `probedWorktreeDirs` set in `DesktopProgressBridge`)
- Removed the `ensureWorktreeProbe()` wrapper function that added no value over direct resolver calls

**Abstraction added:**
- `basename()` utility in `WorktreeChip.ts` encapsulates cross-platform path parsing for webview-safe display (no `node:path` dependency)

## Host impact

**Extension:** WorktreeChip now displays working directory basename as fallback when branch hasn't resolved; improved accessibility with `role="img"` on dirty indicator.

**Desktop:** Simplified probe invocation in `DesktopProgressBridge`; removed redundant deduplication tracking.

**CLI:** No impact.

## Scheduled refactoring

None.

## Validation

- Code review of logic simplification and fallback display behavior
- Existing tests should pass (no breaking changes to public APIs except removal of unused `invalidateWorktreeInfo()`)

https://claude.ai/code/session_01VDrec5ZiCJeL8HMNTjNo6m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes redundant probe tracking and tweaks worktree chip rendering; main risk is subtle behavior changes in when `resolveWorktreeInfo()` is triggered and what label/tooltip is shown when branch data is missing.
> 
> **Overview**
> Simplifies worktree info probing by removing caller-side “already probed” tracking in both the desktop bridge and extension progress view, and instead always kicking off a fire-and-forget `resolveWorktreeInfo(workingDirectory)` when a working directory is present.
> 
> Improves the `WorktreeChip` UI to never render an empty branch row by falling back to the working directory basename (with updated tooltip behavior), adds a small webview-safe `basename()` helper, and slightly improves accessibility for the dirty indicator.
> 
> Removes the unused `invalidateWorktreeInfo()` API/export from `@agent/index`/`worktreeInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9026bb0ab9df7f5133d52221bc0128d333199a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->