### PR TITLE
chore: clear lint and build warnings

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -2,20 +2,20 @@ import { access, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
-  buildStreamTabInfo,
-  peekWorktreeInfo,
-  resolveWorktreeInfo,
-} from '@agent/index';
-
-import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
+
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
+import {
+  buildStreamTabInfo,
+  peekWorktreeInfo,
+  resolveWorktreeInfo,
+} from '@agent/index';
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
 import {
   clearRetryRequest,
@@ -63,6 +63,7 @@ import {
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
+import type { RestoredStreamSnapshot } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import {
   cleanupAllApprovals,
@@ -79,12 +80,11 @@ import {
 import { getConfig } from '@utils/config/configUtils';
 
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
-import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
-import type { RestoredStreamSnapshot } from '@shared/schemas';
 import {
   createDesktopToolEditApprovalController,
   type DesktopToolEditApprovalController,
 } from './desktopToolEditApproval.js';
+import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): void;

--- a/packages/desktop/src/main/platform/agentDirectories.ts
+++ b/packages/desktop/src/main/platform/agentDirectories.ts
@@ -1,6 +1,6 @@
+import { platform } from '@platform/platform';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { GlobalStateKey } from '@common/state/stateKeys';
-import { platform } from '@platform/platform';
 
 export async function bootstrapElectronAgentDirectories(
   resourcesPath: string,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,51 +6,12 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
-import type WaDrawer from '@awesome.me/webawesome/dist/components/drawer/drawer.js';
 import { html, nothing, render, type TemplateResult } from 'lit';
-import { Signal } from '@shared/signals';
-import { renderLabeledActionButton } from '@shared/wa/actionButtons';
-import {
-  applyHostBodyTheme,
-  getWindowTargetOrigin,
-} from '@shared/wa/hostTheme';
-import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
-
+import { create as mutate } from 'mutative';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
-import { postMessage } from '@shared/hostBridge';
-import type { DesktopThemeKind } from '@shared/constants/desktopTheme';
-import {
-  SetThemeMessageSchema,
-  type SetThemeMessage,
-} from '@shared/schemas/commonViewMessages';
-import {
-  ProgressViewOutboundMessageSchema,
-  type ProgressViewOutboundMessage,
-} from '@shared/schemas/progressView';
-import { create as mutate } from 'mutative';
-
 import '@progressView/frontend';
 import '@progressView/frontend/components/TexraDiffView';
-import '@settingsView/frontend';
-import '@webview/frontend';
-import {
-  activeStreamId$,
-  appState,
-  childStreamsByParent$,
-  hasAnyStreams$,
-  pendingApprovalIds$,
-  permissions$,
-  placement,
-  setStreamLogsForId,
-  setStreamStateForId,
-  streamFilter$,
-  streamStates$,
-  streams$,
-  tabStreams$,
-} from '@progressView/frontend/progressState';
-import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
 import {
   handleDeleteAll,
   handleFileAction,
@@ -68,7 +29,42 @@ import {
   sendFollowupCommand,
   type FrontendEventHandlerContext,
 } from '@progressView/frontend/eventHandlers';
+import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
+import {
+  activeStreamId$,
+  appState,
+  childStreamsByParent$,
+  hasAnyStreams$,
+  pendingApprovalIds$,
+  permissions$,
+  placement,
+  setStreamLogsForId,
+  setStreamStateForId,
+  streamFilter$,
+  streamStates$,
+  streams$,
+  tabStreams$,
+} from '@progressView/frontend/progressState';
+import '@settingsView/frontend';
+import '@webview/frontend';
+import { postMessage } from '@shared/hostBridge';
 import type { StreamTabId } from '@shared/schemas';
+import { Signal } from '@shared/signals';
+import {
+  SetThemeMessageSchema,
+  type SetThemeMessage,
+} from '@shared/schemas/commonViewMessages';
+import {
+  ProgressViewOutboundMessageSchema,
+  type ProgressViewOutboundMessage,
+} from '@shared/schemas/progressView';
+import type { DesktopThemeKind } from '@shared/constants/desktopTheme';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import {
+  applyHostBodyTheme,
+  getWindowTargetOrigin,
+} from '@shared/wa/hostTheme';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 import {
   DesktopSetRouteMessageSchema,
@@ -110,6 +106,8 @@ import {
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
 import { getRendererPlatform } from './rendererPlatform';
+import type WaDrawer from '@awesome.me/webawesome/dist/components/drawer/drawer.js';
+import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -874,7 +872,7 @@ function openPdfOverlay(payload: DesktopShowPdfMessage): void {
  * invalid URLs for Windows drive-letter and UNC paths.
  */
 function pdfPathToFileUrl(absolutePath: string): string {
-  const normalised = absolutePath.replace(/\\/g, '/');
+  const normalised = absolutePath.replaceAll('\\', '/');
   const encodePath = (path: string): string =>
     path.split('/').map(encodeURIComponent).join('/');
   // Windows UNC: //server/share/file → file://server/share/file

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -14,10 +14,6 @@ import {
   handleCreateAgentWithAI as agentHandleCreateAgentWithAI,
   runExecuteCommand as agentRunExecuteCommand,
 } from '@commands/agent';
-import {
-  setApiKey as apiSetApiKey,
-  removeApiKey as apiRemoveApiKey,
-} from '@commands/api/apiKeyCommands';
 import { downloadArXivSource as latexDownloadArXivSource } from '@commands/latex';
 import { runSetupAssistant as setupRunAssistant } from '@commands/setup';
 import {
@@ -27,6 +23,10 @@ import {
   handleLoadSpecificAgent as sysHandleLoadSpecificAgent,
   showImportOptions as sysShowImportOptions,
 } from '@commands/system';
+import {
+  setApiKey as apiSetApiKey,
+  removeApiKey as apiRemoveApiKey,
+} from '@commands/api/apiKeyCommands';
 import {
   handleIndentTeX,
   handleIndentCurrentTeX as latexIndentCurrentTeX,
@@ -63,8 +63,8 @@ import {
   SIDEBAR_VIEWS,
   getActiveSidebarView,
 } from '@common/webview';
-import { getMainWebview } from '@frontend/system/commandUtils';
 import { type ApiProvider, SecretManager } from '@frontend/secretManager';
+import { getMainWebview } from '@frontend/system/commandUtils';
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import {

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -11,7 +11,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Local imports - shared styles
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -44,6 +43,7 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { PermissionState } from './PermissionCard';
 
 function proposalIdOf(

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -6,8 +6,8 @@ import { provide } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
 
 // Local imports - shared
-import { isProcessAgent } from '@shared/streams/agentKind';
 import { SignalWatcher } from '@shared/signals';
+import { isProcessAgent } from '@shared/streams/agentKind';
 
 // Local imports - progress view
 import {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -14,10 +14,6 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 import {
-  renderProgressBadgeContent,
-  getProgressBadgeTitle,
-} from '../formatters/progressBadgeFormatter';
-import {
   designTokens,
   animationStyles,
   commonViewStyles,
@@ -33,6 +29,10 @@ import './WorktreeChip';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import {
+  renderProgressBadgeContent,
+  getProgressBadgeTitle,
+} from '../formatters/progressBadgeFormatter';
 import { layoutStyles } from '../styles/logStyles';
 import {
   ACTIVE_STREAM_STATUSES,

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -15,7 +15,6 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -26,6 +25,7 @@ import {
 } from '@shared/utils/selectTemplates';
 
 import { ProgressEvents } from '../events';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { FollowupOptionsState } from '../store';
 
 @customElement('workflow-tool-use-followup-section')

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -3,7 +3,6 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -12,6 +11,7 @@ import { historyStyles } from '@shared/styles/historyStyles';
 
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 @customElement('history-search-bar')
 export class SearchBar extends LitElement {

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -10,7 +10,6 @@ import { designTokens } from '@shared/styles';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
-import type WaRadioGroup from '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
@@ -20,6 +19,7 @@ import { profileViewStyles } from './styles';
 
 // Local imports - profile view events
 import { ProfileViewEvents } from './events';
+import type WaRadioGroup from '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 
 @customElement('api-access-section')
 export class ApiAccessSection extends LitElement {

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -13,8 +13,6 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Local imports - shared constants
 import {
@@ -36,6 +34,8 @@ import {
 import { profileViewStyles } from './styles';
 import { ModelSelectionEvents, ProviderKeyEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 /** Display labels for reasoning level options. */
 const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -12,8 +12,6 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - profile view styles and events
 import type {
@@ -23,6 +21,8 @@ import type {
 import { profileViewStyles } from './styles';
 import { ProviderKeyEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
   set: 'Set',

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -3,21 +3,21 @@
  * Sends key values only in the submit event; it never receives stored values.
  */
 
-import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
-import '@awesome.me/webawesome/dist/components/input/input.js';
-import '@awesome.me/webawesome/dist/components/button/button.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 
-// Side-effect imports - register WA icon component
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-
 // Local imports - shared events
 import { createEvent } from '@shared/utils/events';
+
+// Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 @customElement('provider-key-modal')
 export class ProviderKeyModal extends LitElement {

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -11,8 +11,6 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared schemas
 import type { PRSubscriptionEntry } from '@shared/schemas/settingsViewMessages';
@@ -25,6 +23,8 @@ import {
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_AUTHOR_EMAIL,
 } from '@shared/constants/git';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 @customElement('git-tab')
 export class GitTab extends LitElement {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -6,9 +6,6 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
-import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -49,6 +46,9 @@ import {
 // Local imports - shared utilities
 import { copyTextToClipboard } from '@shared/utils/clipboard';
 import { createEvent } from '@shared/utils/events';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 /** Path keys in LatexSettingsStatus for tool paths. */
 type ToolPathKey =

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -11,8 +11,6 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
@@ -27,6 +25,8 @@ import {
   NESTED_DELEGATION_DEPTH_RANGE,
   clampNestedDelegationDepth,
 } from '@shared/constants/delegationPolicy';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
 function clampSetting(value: number, min?: number, max?: number): number {
   let result = value;

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -10,8 +10,8 @@ import {
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { AgentConfigBannerState } from '@shared/schemas';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -10,8 +10,8 @@ import {
 import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { ApiKeyBannerState } from '@shared/schemas';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { capitalize } from '@shared/utils/string';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -13,8 +13,8 @@ import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { DependencyBannerState } from '@shared/schemas';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
 

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -9,7 +9,6 @@ import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 import { SortableController } from '@shared/controllers';
 import { designTokens } from '@shared/styles';
@@ -31,6 +30,7 @@ import {
 } from '../contexts/mainViewContexts';
 import { fileSelectStyles } from '../styles/fileSelectStyles';
 import { DEFAULT_CHECKBOX_VALUES } from '../store';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 @customElement('file-select-group')
 export class FileSelectGroup extends LitElement {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -5,11 +5,6 @@
  * action buttons, agent/model selectors, and execute button.
  */
 
-// Side-effect imports - register WA select & option components
-import '@awesome.me/webawesome/dist/components/select/select.js';
-import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
-
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
@@ -17,12 +12,6 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
-import '@awesome.me/webawesome/dist/components/radio/radio.js';
-import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
-import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas and types
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
@@ -53,6 +42,15 @@ import {
   sessionContext,
   type SessionContextValue,
 } from '../contexts/mainViewContexts';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+import '@awesome.me/webawesome/dist/components/radio/radio.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 type SessionHintKey = SessionType | 'orchestrator';
 

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -3,7 +3,6 @@
 // Side-effect imports - register WA select & option components
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
@@ -23,6 +22,7 @@ import {
   fileSelectLayoutStyles,
   toggleStyles,
 } from '../styles/fileSelectStyles';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 @customElement('latexdiffs-section')
 export class LatexDiffsSection extends LitElement {

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -65,7 +65,7 @@ function createWebviewConfig(webviewName: string, isDev: boolean) {
           entryFileNames: `${webviewName}/bundle.js`,
           assetFileNames: `${webviewName}/[name][extname]`,
           // Inline all imports - required for nonce-only CSP
-          inlineDynamicImports: true,
+          codeSplitting: false,
         },
       },
     },
@@ -124,6 +124,3 @@ export default defineConfig(({ mode }) => {
     },
   };
 });
-
-/** Export webview names for use in build scripts */
-export { webviews };

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -8,11 +8,11 @@ import {
   AgentCategory,
   AgentDefinitionSchema,
 } from '@agent/core/AgentDataclass';
-import { AgentSource } from '@shared/schemas/agent';
 import * as logger from '@agent/core/logger';
 import { getGlobalState, getWorkspaceState } from '@agent/core/stateStore';
 import { GlobalStateKey, WorkspaceStateKey } from '@common/state/stateKeys';
 import type { AgentOptionData } from '@shared/schemas';
+import { AgentSource } from '@shared/schemas/agent';
 import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -1,4 +1,6 @@
 // Local imports - agent index
+import { platform } from '@platform/platform';
+import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { AgentDirectoryService } from './AgentDirectoryService';
 import {
   BundledAgentDirectorySync,
@@ -9,10 +11,8 @@ import {
 import { setAgentDirectories } from './agentDirectoriesRegistry';
 
 // Local imports - common
-import { isFileNotFoundError } from '@common/errors/errorPredicates';
 
 // Local imports - platform
-import { platform } from '@platform/platform';
 
 interface PlatformAgentDirectoryOptions {
   channel: string;

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -1,6 +1,4 @@
 // Third-party imports
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
-import type { ModelConfig } from 'llm-zoo';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -15,6 +13,8 @@ import type { FileLocation } from '@utils/files';
 
 // Local imports - model handlers
 import { ModelHandler } from './ModelHandler';
+import type { ModelConfig } from 'llm-zoo';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type {
   CreateResponseOptions,
   CreateResponseResult,

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -6,6 +6,7 @@ import { getCleanAgentName } from '@agent/index';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Local imports - log
+import { parseWorkflowOutputRoundDir } from '@agent/output/workflowOutputLayout';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -18,7 +19,6 @@ import {
   HISTORY_DIR,
   DEFAULT_MAX_ROUNDS,
 } from './constants';
-import { parseWorkflowOutputRoundDir } from '@agent/output/workflowOutputLayout';
 import {
   generateTimestamp,
   getAgentFirstNameChunk,

--- a/src/shared/controllers/RecordingButtonController.ts
+++ b/src/shared/controllers/RecordingButtonController.ts
@@ -1,9 +1,9 @@
 // Third-party imports
 import { postMessage } from '@shared/hostBridge';
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 // Local imports
-import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 export interface RecordingButtonConfig {
   startCommand: string;

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -157,7 +157,6 @@ const HANDLERS = {
   // `definedHandler`. Matching the registry map's per-entry TArgs widening
   // (`any`) keeps inference per entry without unifying every entry on
   // `unknown`.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } satisfies Record<string, CommandHandler<ExtensionCommandActions, any>>;
 
 function makeActions(): ExtensionCommandActions {
@@ -453,7 +452,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     ] as const)('%s rejection bubbles up', async (id, actionKey) => {
       const actions = makeActions();
       const failure = new Error(`boom-${actionKey}`);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (actions[actionKey] as any).mockRejectedValueOnce(failure);
 
       const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
@@ -463,7 +462,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     it('typed handler texra.compactResponse rejection bubbles up', async () => {
       const actions = makeActions();
       const failure = new Error('boom-compactResponse');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (actions.compactResponse as any).mockRejectedValueOnce(failure);
 
       const result = dispatchCommandFromRegistry(

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -8,12 +8,12 @@
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
 
-import type { ApiProvider } from '@model/apiProviders';
 import type {
   TerminalRunRequest,
   TerminalRunResult,
   TerminalRunner,
 } from '@hosts/terminalHost';
+import type { ApiProvider } from '@model/apiProviders';
 
 /** Per-provider API key surface. */
 export interface SetupSecretsAdapter {


### PR DESCRIPTION
## Summary

This follow-up removes the warnings noted after #4056:

- applies ESLint's import-order fixes across the existing warning set;
- removes obsolete eslint-disable comments in the command registry tests;
- replaces the remaining `String#replace()` warning with `replaceAll()`;
- updates the extension Vite config to use Rolldown's current `codeSplitting: false` option and removes the unused named export that caused mixed-export warnings.

## Validation

- `npm run lint` — no warnings
- `npm run typecheck`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/UserQuestionPanel.vitest.mts src/test-kernel/progressView/WorktreeChip.vitest.mts`
- `npm run compile:fast` — no Vite warning lines
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily import reordering/typing tweaks plus a small Vite build config change (`codeSplitting: false`) and a safe string API swap (`replaceAll`); no core runtime logic changes beyond build output semantics.
> 
> **Overview**
> Cleans up lint/build warnings across desktop + extension packages by applying ESLint import-order fixes and moving Web Awesome type-only imports to avoid mixed import warnings.
> 
> Updates the extension webview Vite/Rollup config to disable splitting via Rolldown’s `codeSplitting: false` and removes an unused `webviews` named export, reducing build-time warnings.
> 
> Replaces a remaining `String#replace(/\\/g, ...)` usage with `replaceAll` in the desktop PDF file URL helper, and drops now-unnecessary `eslint-disable` comments in command registry tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9295271594681d0ce1bb3a3c6d5d00a51d2fc7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->