### PR TITLE
fix: keep bash output out of progress summaries

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -132,6 +132,15 @@ function truncatePrompt(text: string, maxLength: number): string {
   return truncateWithEllipsis(oneLine, maxLength);
 }
 
+/** Truncate tool header text without pulling streamed stdout/stderr into it. */
+function truncateHeaderSummary(text: string, maxLength: number): string {
+  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
+  const outputMarker = oneLine.search(/\s+<(?:stdout|stderr)>/i);
+  const summary =
+    outputMarker >= 0 ? oneLine.slice(0, outputMarker).trim() : oneLine;
+  return truncateWithEllipsis(summary || oneLine, maxLength);
+}
+
 /** Join template sections with horizontal rule separators. */
 function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
   return html`${sections.map(
@@ -734,6 +743,7 @@ export function formatToolUseTemplate(
       headerSummary = truncatePrompt(input.command, 60);
     }
   }
+  headerSummary = truncateHeaderSummary(headerSummary, 120);
   const titleText = headerSummary
     ? `${titleBase} — ${headerSummary}`
     : titleBase;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7783,7 +7783,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.12.3
+      '@types/node': 22.19.17
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -1,0 +1,51 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared schemas
+import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () =>
+    import('@progressView/frontend/formatters/logFormatters/toolFormatters'),
+);
+
+describe('tool-use formatter', () => {
+  it('keeps streamed bash output out of the collapsed error summary', async () => {
+    const { formatToolUseTemplate } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
+    const { render } = await import('lit');
+    const stdout = Array.from(
+      { length: 20 },
+      (_, i) => `[${i}/100] Built Mathlib.Example.Module${i}`,
+    ).join(' ');
+    const message: LogMessageData = {
+      id: 'bash-timeout',
+      text: '',
+      level: LOG_LEVELS.ERROR,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'bash',
+        input: { command: 'lake build' },
+        error: `Foreground command timed out after 600s. <stdout>${stdout}`,
+        isError: true,
+      },
+    };
+
+    const container = document.createElement('div');
+    render(formatToolUseTemplate(message), container);
+
+    const title = container.querySelector('.tool-use-title');
+    const body = container.querySelector('.banner-content');
+
+    expect(title?.textContent).toContain('bash');
+    expect(title?.textContent).toContain(
+      'Foreground command timed out after 600s.',
+    );
+    expect(title?.textContent).not.toContain('Built Mathlib');
+    expect(body?.textContent).toContain('Built Mathlib.Example.Module19');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4070.

This PR keeps long streamed bash stdout/stderr text out of the collapsed progress-view tool summary. The summary now reports the concise failure reason, while the full terminal output remains available in the expanded tool body.

It also repairs a stale pnpm lockfile reference where @types/yauzl pointed to missing @types/node@24.12.3. CI failed before running project checks because pnpm could not install with --frozen-lockfile.

## Verification

- ./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/ToolUseFormatter.vitest.mts src/test-kernel/progressView/ToolUseStyles.vitest.mts
- ./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p tsconfig.json
- ./node_modules/.bin/eslint packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts src/test-kernel/progressView/ToolUseFormatter.vitest.mts
- CI=true corepack pnpm install --frozen-lockfile --lockfile-only