### PR TITLE
test: cover bash error feedback to model

### DIFF
--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -1,0 +1,108 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+
+// Local imports - agent state
+import * as agentConfig from '@agent/core/config';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+
+// Local imports - model handlers
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import { extractToolAttachments } from '@agent/modelHandlers/utils/toolAttachmentUtils';
+import type { OpenAIResponseToolCall } from '@agent/modelHandlers/types/IModelHandler';
+
+// Local imports - tools
+import { BashTool } from '@tools/bash';
+import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
+
+// Local imports - system utilities
+import * as execUtils from '@utils/system/execUtils';
+
+class TestOpenAIResponseHandler extends ModelHandlerOpenAIResponse {
+  async getClient(): Promise<never> {
+    throw new Error('not used');
+  }
+
+  override async createResponse(): Promise<never> {
+    throw new Error('not used');
+  }
+
+  override extractResponse(): never {
+    throw new Error('not used');
+  }
+}
+
+function createHandler(): TestOpenAIResponseHandler {
+  return new TestOpenAIResponseHandler({
+    name: 'test',
+    label: 'Test',
+    fullName: 'test',
+    shortName: 'test',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 10,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 1000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+}
+
+function createBashCall(): OpenAIResponseToolCall {
+  return {
+    provider: 'openai-response',
+    callId: 'bash-1',
+    name: 'bash',
+    input: { command: 'echo long' },
+    raw: {
+      type: 'function_call',
+      call_id: 'bash-1',
+      name: 'bash',
+      arguments: '{"command":"echo long"}',
+    } as OpenAIResponseToolCall['raw'],
+  };
+}
+
+describe('BashTool error feedback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns foreground command failures in the model tool-result payload', async () => {
+    vi.spyOn(agentConfig, 'getConfig').mockImplementation(
+      <T>(key: string, defaultValue?: T): T => {
+        if (key === BASH_APPROVAL_CONFIG_KEY) return false as T;
+        return defaultValue as T;
+      },
+    );
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValueOnce({
+      success: false,
+      stdout: 'stdout failure guidance',
+      stderr: 'stderr failure details',
+      timedOut: false,
+      exitCode: 2,
+    });
+
+    const result = await new BashTool().call({ command: 'echo long' });
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Command failed');
+    expect(result.error).toContain('stderr failure details');
+    expect(result.error).toContain('stdout failure guidance');
+
+    const { attachments, sanitizedResult } = extractToolAttachments(result);
+    const messages = await createHandler().createToolUseFollowUpMessages(
+      undefined,
+      createBashCall(),
+      sanitizedResult,
+      attachments,
+      AgentWorkspaceState.create(),
+    );
+    const toolResult = messages.find(
+      (message) => message.type === 'function_call_output',
+    );
+
+    expect(toolResult?.output).toContain('Command failed');
+    expect(toolResult?.output).toContain('stderr failure details');
+    expect(toolResult?.output).toContain('stdout failure guidance');
+  });
+});


### PR DESCRIPTION
## Summary

This adds a regression test for the bash tool error-feedback path. The test verifies that a foreground bash command failure is marked as an error and that the failure text, including both stderr and stdout, is included in the OpenAI Responses tool-result payload returned to the model.

## Motivation

Issue #4072 asks whether bash tool errors are returned to the model. The existing implementation already propagates failed foreground bash commands through `ToolError`, `BaseTool.call`, and the OpenAI Responses follow-up message. This test records that contract so future formatter or attachment changes do not silently remove the diagnostic text seen by the model.

Fixes #4072

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/tools/BashToolErrorFeedback.vitest.ts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- `./node_modules/.bin/eslint src/test-kernel/tools/BashToolErrorFeedback.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Vitest test only, asserting existing error propagation behavior for failed foreground `bash` commands.
> 
> **Overview**
> Adds a regression test (`BashToolErrorFeedback.vitest.ts`) that simulates a failed foreground `bash` command and asserts the call returns an error containing both `stderr` and `stdout`.
> 
> The test also verifies that the OpenAI Responses follow-up `function_call_output` message includes the same failure text in the tool-result payload sent back to the model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926d50cb48b52befd6bb786ea68c67c11dfea30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->