### PR TITLE
fix: compact retry details and select menus

### DIFF
--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -155,7 +155,7 @@ const SUPER_YOLO_TOGGLE_BUTTON = Object.freeze({
 
 const COMPACT_RESPONSE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.COMPACT_RESPONSE_BTN,
-  icon: 'fold',
+  icon: 'compress',
   command: PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE,
   title:
     'Compact conversation context (summarize history to reduce token usage)',

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -340,6 +340,16 @@ export const requestPanelStyles: CSSResult = css`
     font-size: var(--font-size-xs);
   }
 
+  .retry-request__error-details::part(header) {
+    min-height: 28px;
+    padding: ${sp.small} ${sp.large};
+    color: var(--wa-color-text-quiet);
+  }
+
+  .retry-request__error-details::part(content) {
+    padding: 0 ${sp.large} ${sp.large};
+  }
+
   .retry-request__error-summary {
     cursor: pointer;
     color: var(--wa-color-text-quiet);

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -33,6 +33,19 @@ export const compactFormControlStyles: CSSResult = css`
     margin-inline-start: var(--wa-space-3xs);
   }
 
+  wa-select::part(listbox) {
+    padding-block: var(--wa-space-3xs);
+    border-radius: var(--border-radius);
+    box-shadow: var(--wa-shadow-s, var(--wa-shadow-m));
+  }
+
+  wa-select wa-option::part(base) {
+    min-height: 22px;
+    padding: 2px 8px 2px 4px;
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
   wa-input {
     font-size: var(--font-size-sm);
   }

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -42,6 +42,8 @@ import { faCodeCompare } from '@fortawesome/free-solid-svg-icons/faCodeCompare';
 import { faCodeMerge } from '@fortawesome/free-solid-svg-icons/faCodeMerge';
 import { faComment } from '@fortawesome/free-solid-svg-icons/faComment';
 import { faComments } from '@fortawesome/free-solid-svg-icons/faComments';
+import { faCompass } from '@fortawesome/free-solid-svg-icons/faCompass';
+import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faCube } from '@fortawesome/free-solid-svg-icons/faCube';
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase';
@@ -179,6 +181,8 @@ const icons = {
   'code-merge': faCodeMerge,
   comment: faComment,
   comments: faComments,
+  compass: faCompass,
+  compress: faCompress,
   copy: faCopy,
   cube: faCube,
   database: faDatabase,
@@ -283,7 +287,7 @@ const CODICON_ALIASES = {
   error: 'circle-exclamation',
   'file-media': 'image',
   files: 'copy',
-  fold: 'chevron-up',
+  fold: 'compress',
   'folder-library': 'folder-tree',
   'folder-opened': 'folder-open',
   github: 'code-branch',

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -1,0 +1,37 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readRequestPanelStyles(): string {
+  return readFileSync(
+    resolve(REPO_ROOT, 'src/shared/styles/requestPanelStyles.ts'),
+    'utf8',
+  );
+}
+
+describe('request panel styles', () => {
+  it('keeps retry error details headers compact', () => {
+    const source = readRequestPanelStyles();
+    const headerStart = source.indexOf(
+      '.retry-request__error-details::part(header)',
+    );
+    const contentStart = source.indexOf(
+      '.retry-request__error-details::part(content)',
+    );
+    const headerRule = source.slice(headerStart, contentStart);
+
+    expect(headerStart).toBeGreaterThanOrEqual(0);
+    expect(contentStart).toBeGreaterThan(headerStart);
+    expect(headerRule).toContain('min-height: 28px');
+    expect(headerRule).toContain('padding: ${sp.small} ${sp.large}');
+  });
+});

--- a/src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts
+++ b/src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts
@@ -1,0 +1,33 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readSource(path: string): string {
+  return readFileSync(resolve(REPO_ROOT, path), 'utf8');
+}
+
+describe('progress toolbar icon consistency', () => {
+  it('uses registered and semantically specific icons for Odyssey and compaction', () => {
+    const constants = readSource(
+      'packages/extension/src/progressView/frontend/constants.ts',
+    );
+    const iconRegistry = readSource('src/shared/wa/webAwesomeIcons.ts');
+
+    expect(constants).toContain("icon: 'compass'");
+    expect(iconRegistry).toContain('compass: faCompass');
+
+    expect(constants).toContain("icon: 'compress'");
+    expect(iconRegistry).toContain('compress: faCompress');
+    expect(iconRegistry).toContain("fold: 'compress'");
+    expect(iconRegistry).not.toContain("fold: 'chevron-up'");
+  });
+});

--- a/src/test-kernel/webview/SelectStyles.vitest.mts
+++ b/src/test-kernel/webview/SelectStyles.vitest.mts
@@ -1,0 +1,35 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readSelectStyles(): string {
+  return readFileSync(resolve(REPO_ROOT, 'src/shared/styles/selectStyles.ts'), {
+    encoding: 'utf8',
+  });
+}
+
+describe('shared select styles', () => {
+  it('keeps Web Awesome select menus at IDE density', () => {
+    const source = readSelectStyles();
+    const listboxStart = source.indexOf('wa-select::part(listbox)');
+    const optionStart = source.indexOf('wa-select wa-option::part(base)');
+    const inputStart = source.indexOf('wa-input {');
+    const menuRules = source.slice(listboxStart, inputStart);
+
+    expect(listboxStart).toBeGreaterThanOrEqual(0);
+    expect(optionStart).toBeGreaterThan(listboxStart);
+    expect(inputStart).toBeGreaterThan(optionStart);
+    expect(menuRules).toContain('padding-block: var(--wa-space-3xs)');
+    expect(menuRules).toContain('min-height: 22px');
+    expect(menuRules).toContain('padding: 2px 8px 2px 4px');
+  });
+});


### PR DESCRIPTION
## Summary

This tightens several progress and launcher controls that looked too heavy after the Web Awesome migration.

- Makes the retry request "Error details" accordion header compact instead of inheriting the large default Web Awesome details header.
- Registers the missing `compass` icon so the Odyssey toolbar button renders correctly.
- Uses a `compress` icon for context compaction rather than the ambiguous chevron-like `fold` alias, and maps the old `fold` alias to the same glyph for consistency.
- Reduces Web Awesome select menu density so agent/model and file selectors are closer to the previous VS Code-style dropdowns.

Fixes #4075

## Validation

- `../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts src/test-kernel/webview/SelectStyles.vitest.mts`
- `../../node_modules/.bin/eslint src/shared/styles/requestPanelStyles.ts src/shared/styles/selectStyles.ts src/shared/wa/webAwesomeIcons.ts packages/extension/src/progressView/frontend/constants.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts src/test-kernel/webview/SelectStyles.vitest.mts`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adjusts CSS styling and icon mappings, plus adds snapshot-like Vitest checks to prevent regressions.
> 
> **Overview**
> Tightens Web Awesome UI density and visual consistency in the progress/request views.
> 
> Updates the progress toolbar to use `compress` for context compaction and ensures the Odyssey button icon (`compass`) is registered; also remaps the legacy `fold` alias to the same `compress` glyph for consistency.
> 
> Refines styling for retry error details by explicitly compacting the `::part(header)`/`::part(content)` spacing, and reduces `wa-select` menu/listbox + option padding/height to better match IDE-density controls. Adds Vitest coverage to assert these CSS/icon invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0de021f4d4886e3eea359282d317f2d859d7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->