### PR TITLE
fix(desktop): unblock universal macOS build after claude-agent-sdk add

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -33,7 +33,7 @@ extraResources:
 mac:
   category: public.app-category.productivity
   icon: build/icon.icns
-  x64ArchFiles: '**/app.asar.unpacked/node_modules/@openai/codex-*/vendor/**'
+  x64ArchFiles: '**/app.asar.unpacked/node_modules/{@openai/codex-*/vendor,@anthropic-ai/claude-agent-sdk-*}/**'
   target:
     - target: dmg
       arch:

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -258,7 +258,7 @@ async function exists(path) {
   }
 }
 
-async function readDirNames(path) {
+export async function readDirNames(path) {
   try {
     return await readdir(path);
   } catch (error) {

--- a/scripts/prune-desktop-codex-payload.mjs
+++ b/scripts/prune-desktop-codex-payload.mjs
@@ -1,3 +1,5 @@
+import { readdir, rm } from 'node:fs/promises';
+import { join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
@@ -33,19 +35,88 @@ export default async function pruneDesktopCodexPayload(context) {
         ', ',
       )}`,
     );
+  } else {
+    console.log(
+      `Codex CLI payload pruning removed unused packages: ${describeBundledCodexPackages(
+        pruned.map(({ platformKey, pkg, path }) => ({
+          platformKey,
+          pkg,
+          locations: [path],
+          sizeBytes: 0,
+        })),
+      )}`,
+    );
+  }
+
+  await pruneClaudeAgentSdkPackages(resourcesDir, expectedPlatformKeys);
+}
+
+async function pruneClaudeAgentSdkPackages(resourcesDir, expectedPlatformKeys) {
+  const unpackedRoot = join(resourcesDir, 'app.asar.unpacked');
+  const expected = new Set(
+    expectedPlatformKeys.flatMap((key) =>
+      key.startsWith('linux-') ? [key, `${key}-musl`] : [key],
+    ),
+  );
+  const removed = [];
+
+  for (const root of [
+    join(unpackedRoot, 'node_modules', '@anthropic-ai'),
+    join(unpackedRoot, 'node_modules', '.pnpm'),
+  ]) {
+    const entries = await safeReaddir(root);
+    for (const entry of entries) {
+      const matched = matchClaudeAgentSdkEntry(entry);
+      if (matched == null) continue;
+      if (expected.has(matched)) continue;
+
+      const target = join(root, entry);
+      await rm(target, { recursive: true, force: true });
+      removed.push(relative(unpackedRoot, target));
+    }
+  }
+
+  if (removed.length === 0) {
+    console.log(
+      `claude-agent-sdk payload pruning kept expected packages: ${[...expected].join(', ')}`,
+    );
     return;
   }
 
   console.log(
-    `Codex CLI payload pruning removed unused packages: ${describeBundledCodexPackages(
-      pruned.map(({ platformKey, pkg, path }) => ({
-        platformKey,
-        pkg,
-        locations: [path],
-        sizeBytes: 0,
-      })),
-    )}`,
+    `claude-agent-sdk payload pruning removed unused packages: ${removed.join(', ')}`,
   );
+}
+
+const claudeAgentSdkPlatformKeys = [
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64-musl',
+  'linux-x64-musl',
+  'linux-arm64',
+  'linux-x64',
+  'win32-arm64',
+  'win32-x64',
+];
+
+function matchClaudeAgentSdkEntry(entry) {
+  for (const platformKey of claudeAgentSdkPlatformKeys) {
+    const directName = `claude-agent-sdk-${platformKey}`;
+    if (entry === directName) return platformKey;
+    if (entry.includes(`@anthropic-ai+claude-agent-sdk-${platformKey}@`)) {
+      return platformKey;
+    }
+  }
+  return null;
+}
+
+async function safeReaddir(path) {
+  try {
+    return await readdir(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/prune-desktop-codex-payload.mjs
+++ b/scripts/prune-desktop-codex-payload.mjs
@@ -1,4 +1,4 @@
-import { readdir, rm } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -7,6 +7,7 @@ import {
   describeBundledCodexPackages,
   inferCodexPlatformKeys,
   pruneBundledCodexPackages,
+  readDirNames,
   resourcesDirForElectronBuilderContext,
 } from './desktop-codex-payload.mjs';
 
@@ -64,7 +65,7 @@ async function pruneClaudeAgentSdkPackages(resourcesDir, expectedPlatformKeys) {
     join(unpackedRoot, 'node_modules', '@anthropic-ai'),
     join(unpackedRoot, 'node_modules', '.pnpm'),
   ]) {
-    const entries = await safeReaddir(root);
+    const entries = await readDirNames(root);
     for (const entry of entries) {
       const matched = matchClaudeAgentSdkEntry(entry);
       if (matched == null) continue;
@@ -108,15 +109,6 @@ function matchClaudeAgentSdkEntry(entry) {
     }
   }
   return null;
-}
-
-async function safeReaddir(path) {
-  try {
-    return await readdir(path);
-  } catch (error) {
-    if (error?.code === 'ENOENT') return [];
-    throw error;
-  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary

`npm run desktop:package:dist` failed after the upgrade to `@anthropic-ai/claude-agent-sdk` 0.3.x (PR #4066) brought in arch-specific optional packages. The universal merger errored because `@anthropic-ai/claude-agent-sdk-darwin-arm64/claude` is bytewise identical in both the x64 and arm64 temp builds (pnpm hoists every optional arch package into both trees) and wasn't covered by the existing `x64ArchFiles` rule.

- Extend the electron-builder `x64ArchFiles` glob to also accept `@anthropic-ai/claude-agent-sdk-*` paths.
- Extend the existing Codex `afterPack` pruner with a parallel pass that removes wrong-arch `@anthropic-ai/claude-agent-sdk-*` packages from each temp build, mirroring the Codex pattern (covers both `node_modules/@anthropic-ai/<pkg>` aliases and `node_modules/.pnpm/@anthropic-ai+<pkg>@...` store entries).

## Test plan

- [x] `npm run build:fast` — produces `releases/texra-0.37.8.vsix`.
- [x] `corepack pnpm --filter @texra/cli build` — CLI bundle succeeds.
- [x] `npm run desktop:package:dist` end-to-end — produces `TeXRA-0.37.8-mac-universal.dmg` (499 MB) and `.zip` (483 MB) with no universal-merge errors.
- [ ] Smoke-launch the produced `.app` on both arm64 and x64 macs (universal binary).
- [ ] Confirm `claude-agent-sdk` runtime dispatches to the matching arch's `claude` binary on each host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop packaging/universal-merge behavior by adjusting `x64ArchFiles` and deleting arch-specific `claude-agent-sdk` directories during `afterPack`, which could impact bundled dependencies if the matching patterns are wrong.
> 
> **Overview**
> Fixes macOS universal desktop packaging after introducing arch-specific `@anthropic-ai/claude-agent-sdk` optional dependencies.
> 
> Updates electron-builder config to treat `@anthropic-ai/claude-agent-sdk-*` as `x64ArchFiles`, and extends the `afterPack` pruning hook to remove non-target-arch `claude-agent-sdk` packages (both `node_modules/@anthropic-ai` aliases and `.pnpm` store entries). Also exports `readDirNames` from `desktop-codex-payload.mjs` for reuse by the new pruner pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4096d5f515ac2e46809a6f3a96804475bf5229bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->