### PR TITLE
fix: handle bash backgrounding and keychain denials

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -596,6 +596,9 @@ function createWindow(options: {
     agentExecution.dispose();
     desktopAuth.dispose();
   });
+  window.webContents.once('did-finish-load', () => {
+    void options.initializeCrashReporting();
+  });
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);
@@ -662,7 +665,6 @@ if (protocolLifecycle.shouldContinue) {
         })();
         await crashReportingInitialization;
       };
-      await initializeCrashReporting();
       const authCoordinator = createDesktopAuthCoordinator({
         secrets: platform().secrets,
         log: console,

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -56,6 +56,7 @@ function isStoredSecret(value: unknown): value is StoredSecret {
 export class ElectronSecrets implements PlatformSecrets {
   private warnedAboutBasicText = false;
   private warnedAboutKeychainDenied = false;
+  private keychainDecryptUnavailable = false;
 
   constructor(
     private readonly store: JsonStore,
@@ -76,11 +77,14 @@ export class ElectronSecrets implements PlatformSecrets {
       return undefined;
     }
 
+    if (this.keychainDecryptUnavailable) return undefined;
+
     const stored = this.store.get<unknown>(key);
     if (!isStoredSecret(stored)) return undefined;
     try {
       return safeStorage.decryptString(Buffer.from(stored.value, 'base64'));
     } catch (error) {
+      this.keychainDecryptUnavailable = true;
       // The macOS keychain (and Linux libsecret/KWallet) can reject decrypts
       // when the user denies the OS prompt or the entry encryption key has
       // been rotated. Treat this as "no saved secret" so the rest of the

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -93,9 +93,11 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     const electron = (await import('electron')) as unknown as {
       safeStorage: { decryptString: (value: Buffer) => string };
     };
-    vi.spyOn(electron.safeStorage, 'decryptString').mockImplementation(() => {
-      throw new Error('denied');
-    });
+    const decryptSpy = vi
+      .spyOn(electron.safeStorage, 'decryptString')
+      .mockImplementation(() => {
+        throw new Error('denied');
+      });
     const { ElectronSecrets } = await loadElectronSecrets();
     const warnings: string[] = [];
     const fakeStore = {
@@ -116,6 +118,7 @@ describe('ElectronSecrets keychain-denial bootstrap recovery', () => {
     await secrets.get('c');
 
     expect(warnings).toHaveLength(1);
+    expect(decryptSpy).toHaveBeenCalledOnce();
   });
 });
 
@@ -265,5 +268,7 @@ describe('desktop main process keychain access', () => {
     );
     expect(source).not.toContain('prewarmElectronKeychain');
     expect(source).not.toContain('safeStorage.encryptString');
+    expect(source).not.toContain('await initializeCrashReporting();');
+    expect(source).toContain("webContents.once('did-finish-load'");
   });
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -105,4 +105,47 @@ describe('BashTool error feedback', () => {
     expect(toolResult?.output).toContain('stderr failure details');
     expect(toolResult?.output).toContain('stdout failure guidance');
   });
+
+  it('rejects shell-level backgrounding before command execution', async () => {
+    vi.spyOn(agentConfig, 'getConfig').mockImplementation(
+      <T>(key: string, defaultValue?: T): T => {
+        if (key === BASH_APPROVAL_CONFIG_KEY) return false as T;
+        return defaultValue as T;
+      },
+    );
+    const executeSpy = vi.spyOn(execUtils, 'executeCommand');
+
+    const result = await new BashTool().call({
+      command:
+        'nohup python verify_residual_order.py > verify_residual_order_run.log 2>&1 &\necho "PID: $!"',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('shell-level backgrounding');
+    expect(result.error).toContain('run_in_background: true');
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not reject ampersands in later shell command segments', async () => {
+    vi.spyOn(agentConfig, 'getConfig').mockImplementation(
+      <T>(key: string, defaultValue?: T): T => {
+        if (key === BASH_APPROVAL_CONFIG_KEY) return false as T;
+        return defaultValue as T;
+      },
+    );
+    const executeSpy = vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: true,
+      stdout: 'done',
+      stderr: '',
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    const result = await new BashTool().call({
+      command: 'nohup longtask; echo done &',
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(executeSpy).toHaveBeenCalledOnce();
+  });
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -46,6 +46,11 @@ const BASH_TIMEOUT_MS = 120_000; // 120 s
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */
 const BACKGROUND_LOG_CAP_CHARS = 200_000;
+const SHELL_BACKGROUNDING_PATTERN =
+  /(?:^|[\s;])nohup\b[^\n;]*(?<![>&])&(?![>&])/;
+const SHELL_BACKGROUNDING_MESSAGE =
+  'This command uses shell-level backgrounding (`nohup ... &`) inside a foreground bash tool call. ' +
+  'Do not emulate background execution inside the shell; call the bash tool again with `run_in_background: true` and the command without `nohup` or a trailing `&`.';
 
 const BashInputSchema = z.strictObject({
   command: z.string(),
@@ -66,6 +71,10 @@ const BashInputSchema = z.strictObject({
 });
 
 export type BashInput = z.infer<typeof BashInputSchema>;
+
+function usesShellLevelBackgrounding(command: string): boolean {
+  return SHELL_BACKGROUNDING_PATTERN.test(command);
+}
 
 function appendTail(current: string, chunk: string, maxChars: number): string {
   if (!chunk) return current;
@@ -102,6 +111,13 @@ export class BashTool extends defineTool({
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {
+    if (
+      !input.run_in_background &&
+      usesShellLevelBackgrounding(input.command)
+    ) {
+      throw new ToolError(SHELL_BACKGROUNDING_MESSAGE);
+    }
+
     // Request approval before executing the command
     const approval = await requestBashApproval({ command: input.command });
 
@@ -160,7 +176,8 @@ export class BashTool extends defineTool({
       parts.push(
         `To fix, either:\n` +
           `- Increase the timeout parameter up to 600s (600000ms): { "timeout": 600000 }\n` +
-          `- Set run_in_background: true to execute asynchronously: { "run_in_background": true }`,
+          `- Set run_in_background: true to execute asynchronously: { "run_in_background": true }\n` +
+          `Do not use shell-level backgrounding such as \`nohup ... &\` inside a foreground call.`,
       );
       throw new ToolError(parts.join('\n'));
     }


### PR DESCRIPTION
## Summary

This addresses two small follow-up issues from the current queue.

- Rejects `nohup ... &` shell-level backgrounding inside foreground bash tool calls before execution, and tells the model to retry with `run_in_background: true` instead. The timeout guidance now repeats the same instruction so long-running work is less likely to be retried as shell backgrounding.
- After one Electron safeStorage decrypt failure, treats saved secrets as unavailable for the rest of that desktop session. This prevents repeated OS keychain prompts after the user denies or cannot satisfy the first prompt.
- Adds regression coverage for both the model-visible bash feedback path and the one-prompt keychain-denial behavior.

Fixes #4078
Fixes #4079

## Validation

- `../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/tools/BashToolErrorFeedback.vitest.ts src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts`
- `../../node_modules/.bin/eslint src/tools/bash.ts src/test-kernel/tools/BashToolErrorFeedback.vitest.ts packages/desktop/src/main/platform/electronSecrets.ts src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- `npm run lint` (completed with 0 errors and one unrelated pre-existing import-order warning in `packages/extension/src/extension.ts`)

`npm run compile:fast` could not be run from this temporary worktree: pnpm tried to manage the symlinked `node_modules` directory and aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. The earlier attempt without the symlink tried to fetch packages and failed under the network sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command execution validation in `BashTool` and alters Electron startup/secret handling; mistakes could block legitimate commands or hide persisted secrets/crash reporting during a session.
> 
> **Overview**
> Prevents foreground `bash` tool calls from running `nohup ... &` by detecting shell-level backgrounding and failing fast with guidance to retry using `run_in_background: true`; timeout error guidance now repeats the same instruction. Adds regression tests to ensure backgrounding is rejected only when it’s the `nohup ... &` pattern and that execution is not invoked.
> 
> Improves desktop startup robustness by deferring crash reporting initialization until the window finishes loading, and by latching `ElectronSecrets` into a “decrypt unavailable” state after the first `safeStorage.decryptString` failure so subsequent secret reads return `undefined` without repeated prompts/warnings; tests updated to assert the single-decrypt behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3862615e0751e66efc94c3f8bbf7954fe4244a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->