### PR TITLE
fix: render proposal instructions as markdown

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -6,6 +6,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -28,6 +29,7 @@ import {
   type WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { postMessage } from '@shared/hostBridge';
+import { markdownStyles } from '@shared/styles/markdownStyles';
 import {
   renderAgentOptions,
   renderModelOptions,
@@ -43,6 +45,7 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { processMarkdownContent } from '../formatters/markdownRenderer';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { PermissionState } from './PermissionCard';
 
@@ -57,6 +60,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   static override styles = [
     designTokens,
     commonViewStyles,
+    markdownStyles,
     requestPanelStyles,
     selectStyles,
   ];
@@ -164,7 +168,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                   >${data.model}</span
                 >`}
           </div>
-          <div class="workflow-proposal__instruction">${data.instruction}</div>
+          ${this.renderInstruction(data.instruction)}
           ${isWorkflow ? this.renderExtractFlags(data) : nothing}
           ${this.renderProposalFiles(data)}
         </div>
@@ -196,6 +200,13 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   // ===========================================================================
   // Proposal-specific rendering
   // ===========================================================================
+
+  private renderInstruction(instruction: string): TemplateResult {
+    const markdownHtml = processMarkdownContent(instruction);
+    return html`<div class="workflow-proposal__instruction markdown-content">
+      ${unsafeHTML(markdownHtml)}
+    </div>`;
+  }
 
   private renderWorkingDirectory(
     data: AgentProposalPermission,

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -460,12 +460,15 @@ export const requestPanelStyles: CSSResult = css`
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
     word-break: break-word;
-    white-space: pre-wrap;
     max-height: 12em;
     overflow-y: auto;
     line-height: var(--line-height-normal);
     padding: ${sp.small} 0;
     border-bottom: var(--border-thin) solid var(--wa-color-surface-border);
+  }
+
+  .workflow-proposal__instruction pre {
+    white-space: pre-wrap;
   }
 
   .workflow-proposal__extract-flags {

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { repoPath } from '../desktop/desktopTestPaths.mjs';
+
+function readSource(relativePath: string): string {
+  return readFileSync(repoPath(relativePath), 'utf8');
+}
+
+describe('ProposalRequestPanel', () => {
+  it('renders proposal instructions through the progress markdown renderer', () => {
+    const source = readSource(
+      'packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts',
+    );
+
+    expect(source).toContain('processMarkdownContent(instruction)');
+    expect(source).toContain('unsafeHTML(markdownHtml)');
+    expect(source).toContain('markdown-content');
+  });
+});


### PR DESCRIPTION
Fixes #4065

## Summary

Render agent proposal instructions through the progress view Markdown renderer instead of showing the raw instruction string. This gives proposal text the same Markdown, code, link, and math rendering behavior used elsewhere in the progress view while preserving escaping through the existing renderer.

## Validation

- `../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/progressView/ProposalRequestPanel.vitest.mts src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts`
- `../../node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts src/shared/styles/requestPanelStyles.ts src/test-kernel/progressView/ProposalRequestPanel.vitest.mts`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (passes with one pre-existing import-order warning in `packages/extension/src/extension.ts`)

`npm run compile:fast` could not run from the temporary worktree because pnpm tried to purge the symlinked `node_modules` and aborted in non-TTY mode (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces `unsafeHTML` rendering for proposal instructions; while it routes through the shared Markdown renderer with `html:false`, any renderer changes/regressions could impact XSS safety and display correctness.
> 
> **Overview**
> Proposal instructions in `ProposalRequestPanel` are now rendered as Markdown by passing `instruction` through `processMarkdownContent` and injecting the result with `unsafeHTML`, bringing code/math/link formatting in line with the rest of the progress view.
> 
> Styling is updated to include `markdownStyles` and adjust whitespace handling so `<pre>` blocks wrap, and a small Vitest test asserts the panel uses the Markdown rendering path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a571fe5b4277911eb3b389f512551b2e7a25af06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->