### PR TITLE
fix(progress): declutter stream tab metadata

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -2,14 +2,12 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
 // Local imports
 import {
   STREAM_STATUS,
-  type ConversationProgress,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -29,10 +27,6 @@ import './WorktreeChip';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import {
-  renderProgressBadgeContent,
-  getProgressBadgeTitle,
-} from '../formatters/progressBadgeFormatter';
 import { layoutStyles } from '../styles/logStyles';
 import {
   ACTIVE_STREAM_STATUSES,
@@ -364,19 +358,6 @@ export class StreamTab extends LitElement {
         transform: rotate(90deg);
       }
 
-      .progress-badge-inline {
-        font-size: var(--font-size-xs);
-        padding: var(--wa-space-3xs) var(--wa-space-2xs);
-        border-radius: var(--border-radius-small);
-        background-color: color-mix(
-          in srgb,
-          var(--color-text-secondary) 10%,
-          transparent
-        );
-        white-space: nowrap;
-        flex-shrink: 0;
-      }
-
       .worktree-chip-row {
         display: flex;
         align-items: center;
@@ -399,9 +380,6 @@ export class StreamTab extends LitElement {
   @property({ type: Number }) childCount = 0;
   /** Whether the child list is expanded. */
   @property({ type: Boolean, reflect: true }) expanded = false;
-  /** Progress data (conversation turns, tool calls). */
-  @property({ attribute: false }) progress: ConversationProgress | undefined =
-    undefined;
 
   // Cached derived values — only recomputed when inputs change
   private _cachedInfo: StreamTabInfo | null = null;
@@ -504,7 +482,6 @@ export class StreamTab extends LitElement {
                   <span class="model"
                     >${stream.modelLabel ?? stream.model ?? ''}</span
                   >
-                  ${this.renderProgressBadge()}
                   <wa-icon
                     library="texra"
                     name=${agentDecorator.icon}
@@ -542,16 +519,6 @@ export class StreamTab extends LitElement {
         </wa-button>
       </div>
     `;
-  }
-
-  private renderProgressBadge(): TemplateResult | typeof nothing {
-    if (!this.progress?.conversationTurns) return nothing;
-    return html`<span
-      class="progress-badge-inline"
-      title=${ifDefined(getProgressBadgeTitle(this.progress))}
-    >
-      ${renderProgressBadgeContent(this.progress)}
-    </span>`;
   }
 }
 
@@ -753,11 +720,6 @@ export class StreamTabs extends LitElement {
     return this.streamStates.get(name)?.lastTimestamp;
   }
 
-  private getProgress(name: StreamTabId): ConversationProgress | undefined {
-    const state = this.streamStates.get(name);
-    return state?.conversationProgress;
-  }
-
   /**
    * Classify an entire child branch, not just the direct row. Results are
    * memoized for each reactive update so deep child trees are traversed once
@@ -824,7 +786,6 @@ export class StreamTabs extends LitElement {
         .compact=${options.compact}
         .status=${this.getStatus(stream.name)}
         .lastTimestamp=${this.getTimestamp(stream.name)}
-        .progress=${this.getProgress(stream.name)}
         ?active=${stream.name === this.activeStreamId}
         .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}
         .childCount=${childCount}

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -4,7 +4,7 @@ import type { ConversationProgress } from '@shared/schemas';
 
 /**
  * Render progress badge with conversation turns and tool call count.
- * Used by StreamHeader (wa-tag variant) and StreamTabs (inline span variant).
+ * Used by StreamHeader.
  */
 export function renderProgressBadgeContent(
   progress: ConversationProgress | undefined,


### PR DESCRIPTION
Closes #4083.

## Summary

- Remove the conversation turn/tool-call badge from stream tab rows so the side rail tab header has less competing metadata.
- Keep the existing progress badge in the main stream header, where there is enough horizontal space for this detail.
- Update the progress badge formatter comment so its remaining use is accurate.

## Validation

- `../../node_modules/.bin/prettier --write packages/extension/src/progressView/frontend/components/StreamTabs.ts packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts`
- `../../node_modules/.bin/eslint packages/extension/src/progressView/frontend/components/StreamTabs.ts packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts`
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit -p packages/extension/tsconfig.json`
- `VITE_WEBVIEW=progressView ../../node_modules/.bin/vite build --mode development`

Note: `npm run typecheck` and `npm run compile:fast` could not complete in this symlinked worktree because pnpm attempted to purge/reinstall `node_modules` and then hit the sandboxed network. The equivalent direct TypeScript and touched-webview Vite checks above passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI decluttering change that removes progress metadata from the stream side-rail tabs without altering stream state or backend logic.
> 
> **Overview**
> Removes the inline conversation-turn/tool-call progress badge from `StreamTabs` tab rows (including its styling, `ConversationProgress` wiring, and related imports) to reduce metadata clutter in the side rail.
> 
> Updates `progressBadgeFormatter` documentation to reflect that the formatter is now only used by `StreamHeader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bc50d53f94f2e05819e8b85c386602ad788e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->