### PR TITLE
fix(settings): expand memory content preview

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -71,7 +71,7 @@ export class MemoryItem extends LitElement {
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-radius: var(--border-radius);
         margin: 0;
-        max-height: 120px;
+        max-height: clamp(220px, 45vh, 420px);
         overflow-y: auto;
       }
 


### PR DESCRIPTION
Closes #4059.

## Summary

- Increase the expanded memory contents preview from a fixed 120px cap to a responsive height range.
- Keep the preview scrollable so very long memory notes do not overtake the settings pane.

## Validation

- `../../node_modules/.bin/prettier --write packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts`
- `../../node_modules/.bin/eslint packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts`
- `../../node_modules/.bin/tsc --noEmit -p packages/extension/tsconfig.json`
- `VITE_WEBVIEW=settingsView ../../node_modules/.bin/vite build --mode development`

Note: the issue attachment URL returned `Not Found` in this environment, so the fix follows the issue text and the existing memory preview implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change to the settings webview that adjusts the memory preview container height; low risk aside from potential layout/scroll behavior differences across viewports.
> 
> **Overview**
> Updates the settings memory item expanded preview styling by replacing the fixed `max-height: 120px` with a responsive `clamp(220px, 45vh, 420px)` while keeping `overflow-y: auto`, allowing more content to be visible without the preview overtaking the pane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9d8a1bda3b6fd556d3f66c585d6abc1b87ff40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->