### PR TITLE
feat(cli-tui): phase 1 — Ink skeleton + signals + p-queue follow-ups

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,12 @@
   },
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
+    "@lit-labs/signals": "^0.3.0",
     "@texra/core": "workspace:*",
     "citty": "^0.2.2",
     "ink": "^6.8.0",
+    "ink-text-input": "^6.0.0",
+    "p-queue": "^9.2.0",
     "picocolors": "^1.1.1",
     "react": "^19.0.0",
     "string-width": "^8.0.0",

--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 
 import { chmod } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
 
 import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
+
+const reactDevtoolsStub = fileURLToPath(
+  new URL('./react-devtools-core-stub.mjs', import.meta.url),
+);
 
 const outfile = 'dist/bin/texra.js';
 
@@ -14,6 +19,14 @@ await build({
   format: 'esm',
   target: 'node20',
   external: ['fsevents'],
+  alias: {
+    // Ink statically imports `react-devtools-core` from its `devtools.js`,
+    // which is only reached when `process.env.DEV === 'true'`. We never
+    // attach to React DevTools from the production CLI, so alias the import
+    // to a no-op stub. Avoids pulling the (heavy) real package into the
+    // bundle while keeping ink's dynamic-import path resolvable.
+    'react-devtools-core': reactDevtoolsStub,
+  },
   outfile,
   // The React Compiler runs as a Babel pre-pass scoped to .tsx files under
   // packages/cli/src/chat/tui/. Confirmed addition is only

--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -17,15 +17,22 @@ const processInputPatterns = [
 
 const processInputAllowedFiles = new Set([
   'packages/cli/src/runtime/cliContext.ts',
+  // Ink needs the actual `process.stdin` stream object to wire its raw-mode
+  // input pipeline; this file is the TUI I/O boundary.
+  'packages/cli/src/chat/tui/runChatTui.tsx',
 ]);
 
 const processTerminalInputAllowedFiles = new Set([
   'packages/cli/src/runtime/cliContext.ts',
+  'packages/cli/src/chat/tui/runChatTui.tsx',
 ]);
 
 const processOutputAllowedFiles = new Set([
   'packages/cli/src/bin/texra.ts',
   'packages/cli/src/runtime/logSinks.ts',
+  // Ink mounts onto real `process.stdout`/`process.stderr` streams; the rest
+  // of the TUI must keep going through logSinks.
+  'packages/cli/src/chat/tui/runChatTui.tsx',
 ]);
 
 const processOutputPatterns = [

--- a/packages/cli/scripts/react-devtools-core-stub.mjs
+++ b/packages/cli/scripts/react-devtools-core-stub.mjs
@@ -1,0 +1,10 @@
+// No-op stub for `react-devtools-core`. Ink imports this package only when
+// `DEV=true` to attach to a running React DevTools session — irrelevant for
+// production CLI bundles. We alias to this file at build time (see
+// build-bundle.mjs) so esbuild can resolve the static import without the
+// real (heavy) devtools dep being installed.
+const noop = () => {};
+export default {
+  initialize: noop,
+  connectToDevTools: noop,
+};

--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -1,4 +1,5 @@
-// Local imports - CLI commands
+import { toErrorMessage } from '@common/errors/errorMessage';
+
 import { runCli } from '../commands/root';
 import { CliExitCode } from '../runtime/exitCodes';
 import { writeTextStderr } from '../runtime/logSinks';
@@ -7,7 +8,6 @@ try {
   const result = await runCli();
   process.exitCode = result.exitCode;
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  writeTextStderr(`TeXRA CLI failed: ${message}`);
+  writeTextStderr(`TeXRA CLI failed: ${toErrorMessage(error)}`);
   process.exitCode = CliExitCode.AgentError;
 }

--- a/packages/cli/src/chat/runChat.ts
+++ b/packages/cli/src/chat/runChat.ts
@@ -361,7 +361,7 @@ export async function runChat(
         }
       })
       .catch((error) => {
-        renderer.error(error instanceof Error ? error.message : String(error));
+        renderer.error(toErrorMessage(error));
         closeReader();
       });
   };
@@ -473,7 +473,7 @@ export async function runChat(
         }
         if (
           !responsePrinter.didPrint() &&
-          result.category === 'toolUse' &&
+          result.category === AgentCategory.ToolUse &&
           result.lastResponse
         ) {
           writeTextStdout(result.lastResponse);
@@ -484,9 +484,7 @@ export async function runChat(
           ? CliExitCode.Success
           : CliExitCode.AgentError;
         if (!session.stopRequested) {
-          renderer.error(
-            error instanceof Error ? error.message : String(error),
-          );
+          renderer.error(toErrorMessage(error));
         }
       })
       .finally(() => {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -2,14 +2,12 @@
 // over the cliState signals. Approvals + tool cards + subagents + markdown
 // + slash forms land in Phases 2–5.
 
-import { useEffect } from 'react';
 import { Box, useApp } from 'ink';
 
 import { ConversationPane } from './panes/ConversationPane';
 import { Header } from './panes/Header';
 import { InputBar } from './panes/InputBar';
 import { StatusBar } from './panes/StatusBar';
-import { makeFrameLogger } from './render/frameTelemetry';
 
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
@@ -18,15 +16,8 @@ export interface AppProps {
 
 export function App(props: AppProps): React.JSX.Element {
   const { exit } = useApp();
-  useEffect(() => {
-    const onFrame = makeFrameLogger();
-    const tick = (): void => onFrame(Date.now());
-    const interval = setInterval(tick, 16);
-    return () => clearInterval(interval);
-  }, []);
-
-  // Surface Ctrl-D as exit when input is empty — handled higher up in
-  // runChat (via `requestChatExit`); we keep `exit` reachable for that path.
+  // `exit` is reachable for future approval-modal / Ctrl-D handlers that
+  // unmount via React; runChatTui currently drives lifecycle externally.
   void exit;
 
   return (

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,9 +1,40 @@
-// Smoke target for the React Compiler Babel pre-pass
-// (scripts/smoke-react-compiler.mjs). Not on any runtime path yet.
+// Phase 1 Ink skeleton — Header + ConversationPane + StatusBar + InputBar
+// over the cliState signals. Approvals + tool cards + subagents + markdown
+// + slash forms land in Phases 2–5.
 
-import { Text } from 'ink';
-import type { ReactElement } from 'react';
+import { useEffect } from 'react';
+import { Box, useApp } from 'ink';
 
-export function App(): ReactElement {
-  return <Text>TeXRA TUI scaffold ready (Phase 1+).</Text>;
+import { ConversationPane } from './panes/ConversationPane';
+import { Header } from './panes/Header';
+import { InputBar } from './panes/InputBar';
+import { StatusBar } from './panes/StatusBar';
+import { makeFrameLogger } from './render/frameTelemetry';
+
+export interface AppProps {
+  readonly onSubmit: (line: string) => void;
+  readonly inputDisabled?: boolean;
+}
+
+export function App(props: AppProps): React.JSX.Element {
+  const { exit } = useApp();
+  useEffect(() => {
+    const onFrame = makeFrameLogger();
+    const tick = (): void => onFrame(Date.now());
+    const interval = setInterval(tick, 16);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Surface Ctrl-D as exit when input is empty — handled higher up in
+  // runChat (via `requestChatExit`); we keep `exit` reachable for that path.
+  void exit;
+
+  return (
+    <Box flexDirection="column">
+      <Header />
+      <ConversationPane />
+      <StatusBar />
+      <InputBar onSubmit={props.onSubmit} disabled={props.inputDisabled} />
+    </Box>
+  );
 }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -1,0 +1,98 @@
+// Paste-aware text input wrapping `ink-text-input` per
+// docs/prd/cli-tui-ink/10-architecture.md (Input component).
+//
+// Adds three things on top of the upstream:
+//   1. Paste-aware submit — Enter inside a bracketed paste is a newline,
+//      not "submit". Without this, pasting a 50-line LaTeX block fires
+//      50 submissions (success criterion 3 in the PRD).
+//   2. Horizontal viewport sliding — when value > terminal width, scroll
+//      the visible window so the caret stays visible.
+//   3. Declared cursor — surface the cursor position so callers (overlay
+//      menus, IME) can place auxiliary chrome.
+//
+// Ctrl-J is mapped to literal newline so users have an explicit
+// newline shortcut (also kills the `/multi` ceremony from the legacy CLI).
+
+import { useCallback, useMemo, useState } from 'react';
+import { Box, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+
+import { usePasteHandler } from './usePasteHandler';
+
+export interface BaseTextInputProps {
+  readonly value: string;
+  readonly placeholder?: string;
+  readonly focus?: boolean;
+  /** Submit handler — only fires when the user actually presses Enter outside a paste. */
+  readonly onSubmit: (value: string) => void;
+  readonly onChange: (value: string) => void;
+  /** Width hint from the parent layout; used to drive horizontal viewport. */
+  readonly width?: number;
+}
+
+export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
+  const { isPasted, currentPaste } = usePasteHandler();
+  const [cursorOffset, setCursorOffset] = useState(0);
+
+  const handleChange = useCallback(
+    (next: string) => {
+      props.onChange(next);
+      setCursorOffset(next.length);
+    },
+    [props],
+  );
+
+  const handleSubmit = useCallback(
+    (next: string) => {
+      // Suppress Enter-as-submit while a paste is mid-flight. The paste
+      // handler clears `isPasted` on the next microtask, so legitimate
+      // submits right after a paste still go through.
+      if (isPasted) {
+        const withNewline = `${next}\n${currentPaste}`;
+        props.onChange(withNewline);
+        return;
+      }
+      props.onSubmit(next);
+    },
+    [isPasted, currentPaste, props],
+  );
+
+  // Ctrl-J = literal newline. Ink's `useInput` fires *before* TextInput
+  // sees the keypress, so intercepting Ctrl-J here lets us splice a `\n`
+  // into the value without TextInput interpreting it as submit.
+  useInput((_input, key) => {
+    if (props.focus === false) return;
+    if (key.ctrl && _input === 'j') {
+      props.onChange(`${props.value}\n`);
+    }
+  });
+
+  // Horizontal viewport: only show the trailing slice that fits in `width`,
+  // anchored on the cursor. The viewport offset is exposed for overlay
+  // positioning (currently unused; reserved for Phase 5 palette / @-mention
+  // overlays).
+  const viewport = useMemo(() => {
+    if (props.width === undefined) {
+      return { value: props.value, offset: 0 };
+    }
+    const cap = Math.max(1, props.width - 1);
+    if (props.value.length <= cap) {
+      return { value: props.value, offset: 0 };
+    }
+    const start = Math.max(0, cursorOffset - cap);
+    return { value: props.value.slice(start), offset: start };
+  }, [props.value, props.width, cursorOffset]);
+
+  return (
+    <Box>
+      <TextInput
+        value={viewport.value}
+        placeholder={props.placeholder}
+        focus={props.focus ?? true}
+        showCursor
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+      />
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -1,19 +1,20 @@
 // Paste-aware text input wrapping `ink-text-input` per
 // docs/prd/cli-tui-ink/10-architecture.md (Input component).
 //
-// Adds three things on top of the upstream:
-//   1. Paste-aware submit — Enter inside a bracketed paste is a newline,
-//      not "submit". Without this, pasting a 50-line LaTeX block fires
-//      50 submissions (success criterion 3 in the PRD).
-//   2. Horizontal viewport sliding — when value > terminal width, scroll
-//      the visible window so the caret stays visible.
-//   3. Declared cursor — surface the cursor position so callers (overlay
-//      menus, IME) can place auxiliary chrome.
+// Phase 1 ships the paste-aware Enter behaviour and the Ctrl-J → newline
+// shortcut. The full horizontal-viewport implementation (PRD: "viewport
+// offsets exposed for overlay positioning") is deferred to Phase 5 alongside
+// the palette / @-mention overlays — slicing `props.value` before handing it
+// to a controlled `ink-text-input` drops characters once the value exceeds
+// the viewport width, because the input's `onChange` returns the modified
+// *slice* and `handleChange` writes that back as the full draft.
 //
-// Ctrl-J is mapped to literal newline so users have an explicit
-// newline shortcut (also kills the `/multi` ceremony from the legacy CLI).
+// Until Phase 5 lands a proper viewport↔full-string reconciliation, Phase 1
+// passes the full value through. Long lines wrap visually (ink's default
+// `<TextInput>` does not horizontally scroll); paste-aware submit still
+// fires correctly.
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback } from 'react';
 import { Box, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 
@@ -26,21 +27,10 @@ export interface BaseTextInputProps {
   /** Submit handler — only fires when the user actually presses Enter outside a paste. */
   readonly onSubmit: (value: string) => void;
   readonly onChange: (value: string) => void;
-  /** Width hint from the parent layout; used to drive horizontal viewport. */
-  readonly width?: number;
 }
 
 export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   const { isPasted, currentPaste } = usePasteHandler();
-  const [cursorOffset, setCursorOffset] = useState(0);
-
-  const handleChange = useCallback(
-    (next: string) => {
-      props.onChange(next);
-      setCursorOffset(next.length);
-    },
-    [props],
-  );
 
   const handleSubmit = useCallback(
     (next: string) => {
@@ -48,8 +38,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       // handler clears `isPasted` on the next microtask, so legitimate
       // submits right after a paste still go through.
       if (isPasted) {
-        const withNewline = `${next}\n${currentPaste}`;
-        props.onChange(withNewline);
+        props.onChange(`${next}\n${currentPaste}`);
         return;
       }
       props.onSubmit(next);
@@ -60,37 +49,21 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   // Ctrl-J = literal newline. Ink's `useInput` fires *before* TextInput
   // sees the keypress, so intercepting Ctrl-J here lets us splice a `\n`
   // into the value without TextInput interpreting it as submit.
-  useInput((_input, key) => {
+  useInput((input, key) => {
     if (props.focus === false) return;
-    if (key.ctrl && _input === 'j') {
+    if (key.ctrl && input === 'j') {
       props.onChange(`${props.value}\n`);
     }
   });
 
-  // Horizontal viewport: only show the trailing slice that fits in `width`,
-  // anchored on the cursor. The viewport offset is exposed for overlay
-  // positioning (currently unused; reserved for Phase 5 palette / @-mention
-  // overlays).
-  const viewport = useMemo(() => {
-    if (props.width === undefined) {
-      return { value: props.value, offset: 0 };
-    }
-    const cap = Math.max(1, props.width - 1);
-    if (props.value.length <= cap) {
-      return { value: props.value, offset: 0 };
-    }
-    const start = Math.max(0, cursorOffset - cap);
-    return { value: props.value.slice(start), offset: start };
-  }, [props.value, props.width, cursorOffset]);
-
   return (
     <Box>
       <TextInput
-        value={viewport.value}
+        value={props.value}
         placeholder={props.placeholder}
         focus={props.focus ?? true}
         showCursor
-        onChange={handleChange}
+        onChange={props.onChange}
         onSubmit={handleSubmit}
       />
     </Box>

--- a/packages/cli/src/chat/tui/input/usePasteHandler.tsx
+++ b/packages/cli/src/chat/tui/input/usePasteHandler.tsx
@@ -1,10 +1,15 @@
 // Bracketed-paste detection per
 // docs/prd/cli-tui-ink/10-architecture.md (Input component).
 //
-// Reads `CSI 200 ~` / `CSI 201 ~` from raw stdin and exposes an
-// `isPasted` flag plus a `currentPaste` buffer. Consumers (BaseTextInput,
+// Reads `CSI 200 ~` / `CSI 201 ~` from raw stdin and exposes an `isPasted`
+// flag plus a `currentPaste` buffer. Consumers (BaseTextInput, future
 // attachment paste) read these to decide whether `Enter` is "submit" or
 // "newline".
+//
+// We attach an additional `data` listener to `stdin`. Ink's `useInput` has
+// already put stdin into raw mode for the rendered tree, so we don't touch
+// raw-mode state here — letting Ink own that lifecycle avoids the race
+// where two consumers fight over the raw-mode toggle.
 
 import { useEffect, useState } from 'react';
 import { useStdin } from 'ink';
@@ -16,21 +21,15 @@ interface PasteState {
 
 const INITIAL: PasteState = { isPasted: false, currentPaste: '' };
 
-const PASTE_START = '[200~';
-const PASTE_END = '[201~';
+const PASTE_START = '\u001B[200~';
+const PASTE_END = '\u001B[201~';
 
-/**
- * Track bracketed-paste boundaries. Returns the current paste state plus a
- * `handleInput` helper consumers can call with raw chunks (when ink's
- * `useInput` path isn't sufficient).
- */
 export function usePasteHandler(): PasteState {
-  const { stdin, isRawModeSupported, setRawMode } = useStdin();
+  const { stdin, isRawModeSupported } = useStdin();
   const [state, setState] = useState<PasteState>(INITIAL);
 
   useEffect(() => {
     if (!stdin || !isRawModeSupported) return;
-    setRawMode(true);
 
     let inPaste = false;
     let pasteBuffer = '';
@@ -59,7 +58,7 @@ export function usePasteHandler(): PasteState {
         const finalPaste = pasteBuffer;
         pasteBuffer = '';
         setState({ isPasted: true, currentPaste: finalPaste });
-        // Snap back to non-paste mode for the next render so Enter goes
+        // Snap back to non-paste mode on the next microtask so Enter goes
         // back to "submit" after the paste fully lands.
         queueMicrotask(() => setState(INITIAL));
       }
@@ -69,7 +68,7 @@ export function usePasteHandler(): PasteState {
     return () => {
       stdin.off('data', onData);
     };
-  }, [stdin, isRawModeSupported, setRawMode]);
+  }, [stdin, isRawModeSupported]);
 
   return state;
 }

--- a/packages/cli/src/chat/tui/input/usePasteHandler.tsx
+++ b/packages/cli/src/chat/tui/input/usePasteHandler.tsx
@@ -1,0 +1,75 @@
+// Bracketed-paste detection per
+// docs/prd/cli-tui-ink/10-architecture.md (Input component).
+//
+// Reads `CSI 200 ~` / `CSI 201 ~` from raw stdin and exposes an
+// `isPasted` flag plus a `currentPaste` buffer. Consumers (BaseTextInput,
+// attachment paste) read these to decide whether `Enter` is "submit" or
+// "newline".
+
+import { useEffect, useState } from 'react';
+import { useStdin } from 'ink';
+
+interface PasteState {
+  readonly isPasted: boolean;
+  readonly currentPaste: string;
+}
+
+const INITIAL: PasteState = { isPasted: false, currentPaste: '' };
+
+const PASTE_START = '[200~';
+const PASTE_END = '[201~';
+
+/**
+ * Track bracketed-paste boundaries. Returns the current paste state plus a
+ * `handleInput` helper consumers can call with raw chunks (when ink's
+ * `useInput` path isn't sufficient).
+ */
+export function usePasteHandler(): PasteState {
+  const { stdin, isRawModeSupported, setRawMode } = useStdin();
+  const [state, setState] = useState<PasteState>(INITIAL);
+
+  useEffect(() => {
+    if (!stdin || !isRawModeSupported) return;
+    setRawMode(true);
+
+    let inPaste = false;
+    let pasteBuffer = '';
+
+    const onData = (chunk: Buffer | string): void => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      let cursor = 0;
+      while (cursor < text.length) {
+        if (!inPaste) {
+          const start = text.indexOf(PASTE_START, cursor);
+          if (start === -1) return;
+          inPaste = true;
+          cursor = start + PASTE_START.length;
+          pasteBuffer = '';
+          continue;
+        }
+        const end = text.indexOf(PASTE_END, cursor);
+        if (end === -1) {
+          pasteBuffer += text.slice(cursor);
+          setState({ isPasted: true, currentPaste: pasteBuffer });
+          return;
+        }
+        pasteBuffer += text.slice(cursor, end);
+        inPaste = false;
+        cursor = end + PASTE_END.length;
+        const finalPaste = pasteBuffer;
+        pasteBuffer = '';
+        setState({ isPasted: true, currentPaste: finalPaste });
+        // Snap back to non-paste mode for the next render so Enter goes
+        // back to "submit" after the paste fully lands.
+        queueMicrotask(() => setState(INITIAL));
+      }
+    };
+
+    stdin.on('data', onData);
+    return () => {
+      stdin.off('data', onData);
+    };
+  }, [stdin, isRawModeSupported, setRawMode]);
+
+  return state;
+}

--- a/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
+++ b/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
@@ -1,0 +1,62 @@
+// Terminal notification dispatcher per
+// docs/prd/cli-tui-ink/10-architecture.md (Terminal notifications).
+//
+// Phase 1 ships `agentFinished` + `approvalNeeded`; progress (OSC 9;4) lands
+// in Phase 4 when long-running activity surfaces.
+//
+// Each emission is capability-gated by the `terminalCapabilities` signal:
+// terminals that didn't acknowledge OSC support during DA1 discovery get the
+// fallback `BEL` only, not full OSC sequences (silent terminals on macOS
+// Terminal in particular gain nothing from OSC 9 / 99 and may even garble).
+//
+// Multiplexer-aware DCS wrapping for tmux/screen is deferred per
+// docs/prd/cli-tui-ink/30-reference.md#16-risks (R9).
+
+import { writeRawStdout } from '../../../runtime/logSinks';
+import { terminalCapabilities } from '../state/terminalCapabilities';
+
+export type NotificationKind = 'agentFinished' | 'approvalNeeded';
+
+export interface NotifyInit {
+  readonly kind: NotificationKind;
+  readonly title?: string;
+  readonly body?: string;
+}
+
+const BEL = '';
+const ESC = '';
+
+function osc9(message: string): string {
+  return `${ESC}]9;${message}${BEL}`;
+}
+
+function osc99(message: string): string {
+  // OSC 99 ; <kv> ; <body> ST — Kitty's notification protocol.
+  return `${ESC}]99;;${message}${ESC}\\`;
+}
+
+export function notify(init: NotifyInit): void {
+  const caps = terminalCapabilities.get();
+  const message = formatMessage(init);
+  if (caps.oscColorReports) {
+    // OSC-capable terminal — use the structured notification protocol.
+    writeRawStdout(osc99(message));
+    writeRawStdout(osc9(message));
+    return;
+  }
+  writeRawStdout(BEL);
+}
+
+function formatMessage(init: NotifyInit): string {
+  if (init.title && init.body) return `${init.title}: ${init.body}`;
+  return init.title ?? init.body ?? defaultMessageFor(init.kind);
+}
+
+function defaultMessageFor(kind: NotificationKind): string {
+  switch (kind) {
+    case 'agentFinished':
+      return 'TeXRA agent finished';
+    case 'approvalNeeded':
+      return 'TeXRA approval needed';
+  }
+}

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -1,0 +1,51 @@
+// Conversation pane — Phase 1 renders MODEL_RESPONSE entries only.
+//
+// Finalized entries are committed to ink's `<Static>` region so they survive
+// re-renders and stay in scrollback. The in-flight entry (last one when the
+// stream is still streaming) renders in a live `<Box>` above the input bar.
+//
+// Tool cards, multi-agent stripes, and approval modals all land in later
+// phases.
+
+import { Box, Static, Text } from 'ink';
+
+import { cliState, type ConversationEntry } from '../state/cliState';
+import { useSignal } from '../state/useSignal';
+
+function isStreaming(entry: ConversationEntry): boolean {
+  return !entry.finalized;
+}
+
+export function ConversationPane(): React.JSX.Element {
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const entries = slice?.entries ?? [];
+
+  const finalized: ConversationEntry[] = [];
+  let live: ConversationEntry | undefined;
+  for (const entry of entries) {
+    if (isStreaming(entry) && entry === entries.at(-1)) {
+      live = entry;
+    } else {
+      finalized.push({ ...entry, finalized: true });
+    }
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Static items={finalized}>
+        {(entry) => (
+          <Box key={entry.id} marginBottom={1}>
+            <Text>{entry.text}</Text>
+          </Box>
+        )}
+      </Static>
+      {live ? (
+        <Box marginBottom={1}>
+          <Text>{live.text}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/Header.tsx
+++ b/packages/cli/src/chat/tui/panes/Header.tsx
@@ -1,0 +1,47 @@
+import { Box, Text } from 'ink';
+
+import { cliState } from '../state/cliState';
+import { useSignal } from '../state/useSignal';
+
+function formatNumber(n: number | undefined): string {
+  if (n === undefined) return '—';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatCost(cost: number | undefined): string {
+  if (cost === undefined) return '—';
+  return `$${cost.toFixed(4)}`;
+}
+
+export function Header(): React.JSX.Element {
+  const meta = useSignal(cliState.sessionMeta);
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+
+  return (
+    <Box borderStyle="round" paddingX={1} flexDirection="column">
+      <Box justifyContent="space-between">
+        <Text>
+          <Text bold>TeXRA</Text>
+          <Text dimColor> · </Text>
+          <Text>{meta.agent || '—'}</Text>
+          <Text dimColor> · </Text>
+          <Text>{meta.model || '—'}</Text>
+        </Text>
+        <Text dimColor>{slice?.description ?? meta.cwd}</Text>
+      </Box>
+      {slice?.usage ? (
+        <Box>
+          <Text dimColor>
+            in {formatNumber(slice.usage.inputTokens)} · out{' '}
+            {formatNumber(slice.usage.outputTokens)} · cost{' '}
+            {formatCost(slice.usage.cost)}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+import { Box, Text, useStdout } from 'ink';
+
+import { BaseTextInput } from '../input/BaseTextInput';
+
+export interface InputBarProps {
+  /** Forwarded to BaseTextInput; called only on real (non-paste) Enter. */
+  readonly onSubmit: (value: string) => void;
+  /** Disable the input while an approval modal is owning the screen. */
+  readonly disabled?: boolean;
+  /** Prompt prefix (e.g. `>`). */
+  readonly prompt?: string;
+}
+
+export function InputBar(props: InputBarProps): React.JSX.Element {
+  const { stdout } = useStdout();
+  const [value, setValue] = useState('');
+
+  const handleSubmit = useCallback(
+    (submitted: string) => {
+      const trimmed = submitted.trim();
+      if (trimmed.length === 0) return;
+      setValue('');
+      props.onSubmit(trimmed);
+    },
+    [props],
+  );
+
+  return (
+    <Box borderStyle="round" paddingX={1}>
+      <Text>{props.prompt ?? '>'} </Text>
+      <BaseTextInput
+        value={value}
+        focus={!props.disabled}
+        onChange={setValue}
+        onSubmit={handleSubmit}
+        width={Math.max(20, (stdout?.columns ?? 80) - 4)}
+      />
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { Box, Text } from 'ink';
 
 import { BaseTextInput } from '../input/BaseTextInput';
 
@@ -13,7 +13,6 @@ export interface InputBarProps {
 }
 
 export function InputBar(props: InputBarProps): React.JSX.Element {
-  const { stdout } = useStdout();
   const [value, setValue] = useState('');
 
   const handleSubmit = useCallback(
@@ -34,7 +33,6 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         focus={!props.disabled}
         onChange={setValue}
         onSubmit={handleSubmit}
-        width={Math.max(20, (stdout?.columns ?? 80) - 4)}
       />
     </Box>
   );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,0 +1,37 @@
+import { Box, Text } from 'ink';
+
+import { STREAM_STATUS } from '@shared/schemas';
+
+import { cliState } from '../state/cliState';
+import { useSignal } from '../state/useSignal';
+
+function statusLabel(status: string | undefined): string {
+  switch (status) {
+    case STREAM_STATUS.INITIALIZING:
+      return 'starting…';
+    case STREAM_STATUS.RUNNING:
+      return 'running';
+    case STREAM_STATUS.WAITING:
+      return 'idle';
+    case STREAM_STATUS.STOPPED:
+      return 'stopped';
+    case STREAM_STATUS.READY:
+      return 'ready';
+    default:
+      return status ?? '—';
+  }
+}
+
+export function StatusBar(): React.JSX.Element {
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const queued = slice?.queuedFollowUps ?? 0;
+
+  return (
+    <Box paddingX={1} justifyContent="space-between">
+      <Text dimColor>{statusLabel(slice?.status)}</Text>
+      {queued > 0 ? <Text dimColor>queued: {queued}</Text> : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/render/frameTelemetry.ts
+++ b/packages/cli/src/chat/tui/render/frameTelemetry.ts
@@ -1,0 +1,63 @@
+// Ink frame timings + SIGWINCH coalescing (R13).
+//
+// Subscribes via ink's `onFrame` hook. Emits per-phase timings to the
+// platform logger at trace level so post-launch jank is debuggable without
+// re-instrumenting. Resize bursts are coalesced via a microtask gate so a
+// drag along the window edge doesn't tear `<Static>` content.
+
+import { tryPlatform } from '@platform/platform';
+
+interface FrameSample {
+  readonly renderMs: number;
+  readonly diffMs: number;
+  readonly writeMs: number;
+  readonly yogaLayoutMs: number;
+}
+
+let resizeQueued = false;
+
+/**
+ * Coalesce a SIGWINCH callback so multiple resize events inside the same
+ * microtask collapse into one. The actual resize handler (re-measure stdout,
+ * trigger Ink re-render) runs once on the next microtask drain.
+ */
+export function coalesceResize(handler: () => void): () => void {
+  return () => {
+    if (resizeQueued) return;
+    resizeQueued = true;
+    queueMicrotask(() => {
+      resizeQueued = false;
+      handler();
+    });
+  };
+}
+
+export function logFrameSample(sample: FrameSample): void {
+  const log = tryPlatform()?.log;
+  if (!log) return;
+  log.debug(
+    'cli-tui',
+    `frame render=${sample.renderMs.toFixed(2)} diff=${sample.diffMs.toFixed(2)} write=${sample.writeMs.toFixed(2)} yoga=${sample.yogaLayoutMs.toFixed(2)}`,
+  );
+}
+
+/**
+ * Track Date.now() between Ink's `onFrame` events. Ink doesn't break out
+ * the render → diff → write → yoga phases yet; this scaffold logs the
+ * total inter-frame delta so the line-by-line breakdown can land when ink
+ * exposes them.
+ */
+export function makeFrameLogger(): (now: number) => void {
+  let last = 0;
+  return (now: number) => {
+    if (last !== 0) {
+      logFrameSample({
+        renderMs: now - last,
+        diffMs: 0,
+        writeMs: 0,
+        yogaLayoutMs: 0,
+      });
+    }
+    last = now;
+  };
+}

--- a/packages/cli/src/chat/tui/render/frameTelemetry.ts
+++ b/packages/cli/src/chat/tui/render/frameTelemetry.ts
@@ -1,63 +1,34 @@
-// Ink frame timings + SIGWINCH coalescing (R13).
+// Frame telemetry stub.
 //
-// Subscribes via ink's `onFrame` hook. Emits per-phase timings to the
-// platform logger at trace level so post-launch jank is debuggable without
-// re-instrumenting. Resize bursts are coalesced via a microtask gate so a
-// drag along the window edge doesn't tear `<Static>` content.
+// Phase 1 reserves the shape but doesn't wire anything to a render loop —
+// Ink doesn't expose a per-frame callback we can subscribe to outside of
+// internal devtools paths, and a `setInterval`-driven timer (the first
+// draft) was firing 60×/s regardless of actual paint activity. The proper
+// hook lands when Phase 4 picks up Ink's frame events (or we patch
+// `node_modules/.pnpm/ink*/node_modules/ink/build/render-node-to-output.js`
+// behind a build switch).
+//
+// SIGWINCH coalescing (R13) lands alongside the multi-agent / resize work
+// in Phase 4. The earlier draft of `coalesceResize` had no callers and
+// shared module-level state across them — deleted rather than left as dead
+// code.
 
 import { tryPlatform } from '@platform/platform';
 
+import { cliEnvValue } from '../../../runtime/cliContext';
+
 interface FrameSample {
   readonly renderMs: number;
-  readonly diffMs: number;
-  readonly writeMs: number;
-  readonly yogaLayoutMs: number;
 }
 
-let resizeQueued = false;
-
-/**
- * Coalesce a SIGWINCH callback so multiple resize events inside the same
- * microtask collapse into one. The actual resize handler (re-measure stdout,
- * trigger Ink re-render) runs once on the next microtask drain.
- */
-export function coalesceResize(handler: () => void): () => void {
-  return () => {
-    if (resizeQueued) return;
-    resizeQueued = true;
-    queueMicrotask(() => {
-      resizeQueued = false;
-      handler();
-    });
-  };
-}
+const TELEMETRY_ENABLED = cliEnvValue('TEXRA_TUI_FRAME_TELEMETRY') === '1';
 
 export function logFrameSample(sample: FrameSample): void {
-  const log = tryPlatform()?.log;
-  if (!log) return;
-  log.debug(
+  if (!TELEMETRY_ENABLED) return;
+  // `LogBackend` has `debug` as its lowest level — there's no `trace`. We
+  // gate behind `TEXRA_TUI_FRAME_TELEMETRY=1` to keep normal runs quiet.
+  tryPlatform()?.log.debug(
     'cli-tui',
-    `frame render=${sample.renderMs.toFixed(2)} diff=${sample.diffMs.toFixed(2)} write=${sample.writeMs.toFixed(2)} yoga=${sample.yogaLayoutMs.toFixed(2)}`,
+    `frame render=${sample.renderMs.toFixed(2)}`,
   );
-}
-
-/**
- * Track Date.now() between Ink's `onFrame` events. Ink doesn't break out
- * the render → diff → write → yoga phases yet; this scaffold logs the
- * total inter-frame delta so the line-by-line breakdown can land when ink
- * exposes them.
- */
-export function makeFrameLogger(): (now: number) => void {
-  let last = 0;
-  return (now: number) => {
-    if (last !== 0) {
-      logFrameSample({
-        renderMs: now - last,
-        diffMs: 0,
-        writeMs: 0,
-        yogaLayoutMs: 0,
-      });
-    }
-    last = now;
-  };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1,0 +1,227 @@
+// Ink-mounted chat session per docs/prd/cli-tui-ink (Phase 1).
+//
+// This is the new TUI entry that the `--tui` flag mounts; the legacy
+// `runChat.ts` path is still the default until Phase 6. We intentionally
+// share as much as possible with the legacy path — platform init, default
+// resolution, approval handlers, the agent runtime host — and only swap the
+// rendering surface (Ink) and the follow-up queue (p-queue, replacing the
+// hand-rolled promise chain).
+//
+// Approvals stay on the legacy adapter for Phase 1 per the PRD; the
+// approval dispatcher only lights up in Phase 2.
+
+import { render } from 'ink';
+import PQueue from 'p-queue';
+
+import { loadAgents } from '@agent/index';
+import { type AgentConfigPayload } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { interruptActiveChildren } from '@agent/runtime/executionRegistry';
+import { executeAgent } from '@agent/runtime/executeAgent';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import { toErrorMessage } from '@common/errors/errorMessage';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+import { type CliContext } from '../../runtime/cliContext';
+import {
+  hasCliApprovalDenied,
+  installCliApprovalHandlers,
+} from '../../runtime/approvalAdapter';
+import { resolveChatDefaults } from '../../runtime/chatDefaults';
+import { CliExitCode } from '../../runtime/exitCodes';
+import { initCliPlatform, setCliHelperModel } from '../../runtime/initPlatform';
+import { createCliRuntimeHost } from '../../runtime/runtimeHost';
+import { writeTextStderr } from '../../runtime/logSinks';
+import { type ChatResult, type RunChatInit } from '../runChat';
+import { App } from './App';
+import { notify } from './notifications/terminalNotifier';
+import { cliState, resetCliState } from './state/cliState';
+import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
+import { subscribeStreamLog } from './state/subscribeStreamLog';
+import { subscribeStreamStatus } from './state/subscribeStreamStatus';
+import { discoverTerminalCapabilities } from './state/terminalCapabilities';
+
+interface TuiSession {
+  streamId: StreamTabId | undefined;
+  runPromise: Promise<void> | undefined;
+  runExitCode: CliExitCode;
+  runCompleted: boolean;
+  stopRequested: boolean;
+}
+
+export async function runChatTui(
+  context: CliContext,
+  init: RunChatInit,
+): Promise<ChatResult> {
+  if (context.mode === 'headless') {
+    writeTextStderr(
+      'texra chat --tui requires an interactive terminal. Did you mean texra run?',
+    );
+    return { exitCode: CliExitCode.Usage };
+  }
+
+  // Streaming-text fallback per docs/prd/cli-tui-ink/20-implementation §13:
+  // when stdout is piped but stdin is TTY, Ink chrome can't render usefully —
+  // delegate back to the legacy plain renderer so `texra chat --tui | tee` and
+  // similar shapes keep working. Phase 4 lifts this into a dedicated mode
+  // that still flows through the React tree but writes plain ANSI to stdout.
+  if (!process.stdout.isTTY) {
+    const { runChat } = await import('../runChat');
+    return runChat(context, init);
+  }
+
+  await initCliPlatform({ ...context, quietLogs: true });
+  const defaults = await resolveChatDefaults({
+    cwd: context.cwd,
+    agentOverride: init.agentOverride,
+    modelOverride: init.modelOverride,
+  });
+  const { agent, model } = defaults;
+  await setCliHelperModel(model);
+
+  cliState.sessionMeta.set({ agent, model, cwd: context.cwd });
+
+  const sessionContext: CliContext = {
+    ...context,
+    helperModel: model,
+    quietLogs: true,
+  };
+  installCliApprovalHandlers(sessionContext);
+  await loadAgents();
+
+  // DA1 sentinel discovery happens in the background — capability-gated
+  // notifications fall back to BEL until it completes (~250ms typical).
+  void discoverTerminalCapabilities({
+    stdin: process.stdin,
+    stdout: process.stdout,
+  });
+
+  const disposers: Array<() => void> = [];
+  disposers.push(subscribeStreamLog());
+  disposers.push(subscribeStreamStatus());
+
+  const session: TuiSession = {
+    streamId: undefined,
+    runPromise: undefined,
+    runExitCode: CliExitCode.Success,
+    runCompleted: false,
+    stopRequested: false,
+  };
+
+  const followUpQueue = new PQueue({ concurrency: 1 });
+
+  const interruptActive = (): void => {
+    if (!session.streamId) return;
+    interruptActiveChildren(session.streamId);
+    getInterruptible(session.streamId)?.interrupt();
+  };
+
+  const startSession = (instruction: string): void => {
+    const config: AgentConfigPayload = {
+      agent,
+      model,
+      instruction,
+      agentCategory: AgentCategory.ToolUse,
+      workingDirectory: context.cwd,
+    };
+    const runtimeHost = createCliRuntimeHost(sessionContext);
+    const wrapped = wrapRuntimeHost(runtimeHost);
+
+    session.runPromise = executeAgent(config, undefined, {
+      runtimeHost: wrapped,
+      enforceCategory: true,
+      onStreamResolved: (resolvedStreamId) => {
+        session.streamId = resolvedStreamId;
+        cliState.activeStreamId.set(resolvedStreamId);
+        if (session.stopRequested) interruptActive();
+      },
+    })
+      .then((result) => {
+        if (session.stopRequested || result.status !== 'error') {
+          session.runExitCode = CliExitCode.Success;
+        } else if (hasCliApprovalDenied(sessionContext)) {
+          session.runExitCode = CliExitCode.ApprovalDenied;
+        } else {
+          session.runExitCode = CliExitCode.AgentError;
+        }
+        notify({ kind: 'agentFinished' });
+      })
+      .catch((error: unknown) => {
+        if (!session.stopRequested) {
+          writeTextStderr(toErrorMessage(error));
+        }
+        session.runExitCode = session.stopRequested
+          ? CliExitCode.Success
+          : CliExitCode.AgentError;
+      })
+      .finally(() => {
+        session.runCompleted = true;
+        void runtimeHost.close();
+      });
+  };
+
+  const handleSubmit = (line: string): void => {
+    if (!session.runPromise) {
+      startSession(line);
+      return;
+    }
+    void followUpQueue.add(async () => {
+      if (!session.streamId || session.stopRequested) return;
+      const result = await sendFollowUp(session.streamId, line);
+      if (result.status === 'no_session') {
+        session.stopRequested = true;
+      }
+    });
+  };
+
+  const ink = render(<App onSubmit={handleSubmit} />, {
+    stdout: process.stdout,
+    stderr: process.stderr,
+    stdin: process.stdin,
+  });
+
+  // Bridge SIGINT to a graceful interrupt (first tap) / process exit (second tap).
+  let sigintCount = 0;
+  const handleSigint = (): void => {
+    sigintCount += 1;
+    if (sigintCount >= 2) {
+      process.kill(process.pid, 'SIGINT');
+      return;
+    }
+    session.stopRequested = true;
+    interruptActive();
+  };
+  process.on('SIGINT', handleSigint);
+
+  // Auto-prompt when the active stream goes WAITING so the UI clearly
+  // signals "your turn." Combined with the StatusBar pill, this replaces
+  // the legacy reader.prompt() ergonomics.
+  disposers.push(
+    StreamStatusService.onDidChange((change) => {
+      if (
+        change.streamId === session.streamId &&
+        change.status === STREAM_STATUS.WAITING &&
+        !session.stopRequested
+      ) {
+        notify({ kind: 'agentFinished' });
+      }
+    }),
+  );
+
+  try {
+    await ink.waitUntilExit();
+  } finally {
+    process.off('SIGINT', handleSigint);
+    for (const dispose of disposers) dispose();
+    await followUpQueue.onIdle();
+    if (session.runPromise && !session.runCompleted) {
+      session.stopRequested = true;
+      interruptActive();
+    }
+    await session.runPromise;
+    resetCliState();
+  }
+  return { exitCode: session.runExitCode };
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -91,9 +91,12 @@ export async function runChatTui(
   installCliApprovalHandlers(sessionContext);
   await loadAgents();
 
-  // DA1 sentinel discovery happens in the background — capability-gated
-  // notifications fall back to BEL until it completes (~250ms typical).
-  void discoverTerminalCapabilities({
+  // DA1 sentinel discovery runs *before* Ink mounts so it owns the raw-mode
+  // toggle exclusively — interleaving with Ink's own raw-mode lifecycle (set
+  // when `useInput` mounts) caused capability discovery to flip raw mode off
+  // ~250ms in, breaking input. Capability-gated notifications fall back to
+  // BEL during this window (~250ms typical, hard 250ms cap on no DA1 reply).
+  await discoverTerminalCapabilities({
     stdin: process.stdin,
     stdout: process.stdout,
   });
@@ -167,7 +170,18 @@ export async function runChatTui(
       startSession(line);
       return;
     }
+    // PRD success criterion: follow-ups must not be silently dropped when the
+    // user submits before `onStreamResolved` populates `session.streamId`.
+    // p-queue serializes work but doesn't have an "await predicate" primitive,
+    // so the task itself waits for the stream id via a tiny poll loop.
     void followUpQueue.add(async () => {
+      while (
+        session.streamId === undefined &&
+        !session.stopRequested &&
+        !session.runCompleted
+      ) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      }
       if (!session.streamId || session.stopRequested) return;
       const result = await sendFollowUp(session.streamId, line);
       if (result.status === 'no_session') {
@@ -182,13 +196,17 @@ export async function runChatTui(
     stdin: process.stdin,
   });
 
-  // Bridge SIGINT to a graceful interrupt (first tap) / process exit (second tap).
+  // Bridge SIGINT to a graceful interrupt (first tap) / process exit
+  // (second tap). We detach the handler before exiting on the second tap so
+  // Node's default termination path runs — re-`process.kill`-ing while the
+  // listener is still installed would re-enter `handleSigint` and loop.
   let sigintCount = 0;
   const handleSigint = (): void => {
     sigintCount += 1;
     if (sigintCount >= 2) {
-      process.kill(process.pid, 'SIGINT');
-      return;
+      process.off('SIGINT', handleSigint);
+      ink.unmount();
+      process.exit(130);
     }
     session.stopRequested = true;
     interruptActive();

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -1,0 +1,106 @@
+// Signal-backed state for the CLI TUI. Mirrors the webview's `progressState`
+// shape — same primitives (`@lit-labs/signals`), same shape (one record per
+// stream + an `activeStreamId`) so future feature parity is a port, not a
+// rewrite. Phase 1 only exposes the fields the header + conversation pane +
+// input bar actually consume; later phases extend.
+
+import { signal, type Signal } from '@lit-labs/signals';
+
+import type { StreamTabId } from '@shared/schemas';
+import type {
+  ConversationProgress,
+  StreamStatus,
+  TokenUsageStats,
+} from '@shared/schemas';
+
+export interface ConversationEntry {
+  /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */
+  readonly id: string;
+  /** Concatenated text for `MODEL_RESPONSE` entries. */
+  readonly text: string;
+  /** True once the stream transitions to `WAITING`/`COMPLETED`. */
+  readonly finalized: boolean;
+}
+
+export interface SessionMeta {
+  readonly agent: string;
+  readonly model: string;
+  readonly cwd: string;
+}
+
+export interface StreamSlice {
+  readonly streamId: StreamTabId;
+  readonly status: StreamStatus | undefined;
+  readonly description: string | undefined;
+  readonly usage: TokenUsageStats | undefined;
+  readonly conversation: ConversationProgress | undefined;
+  readonly entries: readonly ConversationEntry[];
+  readonly queuedFollowUps: number;
+}
+
+const SESSION_META = signal<SessionMeta>({
+  agent: '',
+  model: '',
+  cwd: '',
+});
+
+const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
+
+const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
+
+export const cliState = {
+  sessionMeta: SESSION_META as Signal.State<SessionMeta>,
+  activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
+  streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
+};
+
+function emptySlice(streamId: StreamTabId): StreamSlice {
+  return {
+    streamId,
+    status: undefined,
+    description: undefined,
+    usage: undefined,
+    conversation: undefined,
+    entries: [],
+    queuedFollowUps: 0,
+  };
+}
+
+function withSliceUpdate(
+  current: ReadonlyMap<StreamTabId, StreamSlice>,
+  streamId: StreamTabId,
+  update: (slice: StreamSlice) => StreamSlice,
+): ReadonlyMap<StreamTabId, StreamSlice> {
+  const slice = current.get(streamId) ?? emptySlice(streamId);
+  const next = update(slice);
+  if (next === slice) return current;
+  const out = new Map(current);
+  out.set(streamId, next);
+  return out;
+}
+
+export function patchStream(
+  streamId: StreamTabId,
+  update: (slice: StreamSlice) => StreamSlice,
+): void {
+  cliState.streams.set(
+    withSliceUpdate(cliState.streams.get(), streamId, update),
+  );
+}
+
+export function removeStream(streamId: StreamTabId): void {
+  const current = cliState.streams.get();
+  if (!current.has(streamId)) return;
+  const out = new Map(current);
+  out.delete(streamId);
+  cliState.streams.set(out);
+  if (cliState.activeStreamId.get() === streamId) {
+    cliState.activeStreamId.set(undefined);
+  }
+}
+
+export function resetCliState(): void {
+  cliState.sessionMeta.set({ agent: '', model: '', cwd: '' });
+  cliState.activeStreamId.set(undefined);
+  cliState.streams.set(new Map());
+}

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -7,9 +7,8 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 
-import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
-
 import { cliState, patchStream, removeStream } from './cliState';
+import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
 type Emit = <K extends ProgressEvent>(
   event: K,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -1,0 +1,72 @@
+// Wrap a runtime host's `emit` so progress payloads patch `cliState` while
+// still flowing through the original emitter. Approvals are intentionally
+// not handled here — Phase 1 keeps them on the legacy adapter.
+
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+
+import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
+
+import { cliState, patchStream, removeStream } from './cliState';
+
+type Emit = <K extends ProgressEvent>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+) => void;
+
+export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
+  const original = host.emit;
+  const emit: Emit = (event, payload) => {
+    applyToState(event, payload);
+    return original(event, payload);
+  };
+  return { ...host, emit };
+}
+
+function applyToState<K extends ProgressEvent>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+): void {
+  switch (event) {
+    case 'setActiveStream': {
+      const next = (payload as ProgressEventPayloads['setActiveStream'])
+        .streamId;
+      cliState.activeStreamId.set(next ?? undefined);
+      return;
+    }
+    case 'removeStream':
+      removeStream((payload as ProgressEventPayloads['removeStream']).streamId);
+      return;
+    case 'updateStreamUsage': {
+      const p = payload as ProgressEventPayloads['updateStreamUsage'];
+      patchStream(p.streamId, (s) => ({ ...s, usage: p.usage }));
+      return;
+    }
+    case 'updateConversationProgress': {
+      const p = payload as ProgressEventPayloads['updateConversationProgress'];
+      patchStream(p.streamId, (s) => ({ ...s, conversation: p.progress }));
+      return;
+    }
+    case 'updateStreamDescription': {
+      const p = payload as ProgressEventPayloads['updateStreamDescription'];
+      patchStream(p.streamId, (s) => ({ ...s, description: p.description }));
+      return;
+    }
+    case 'updateQueuedFollowUps': {
+      const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        // We only get a "something queued" pulse — bump by one and let the
+        // consumer (StatusBar / InputBar pill) reset on submit.
+        queuedFollowUps: s.queuedFollowUps + 1,
+      }));
+      return;
+    }
+    default:
+      // Phase 1 only consumes the events the header/conversation/input row
+      // surfaces — later phases handle subagents/tools/approvals.
+      return;
+  }
+}

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -55,13 +55,12 @@ function applyToState<K extends ProgressEvent>(
       return;
     }
     case 'updateQueuedFollowUps': {
-      const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        // We only get a "something queued" pulse — bump by one and let the
-        // consumer (StatusBar / InputBar pill) reset on submit.
-        queuedFollowUps: s.queuedFollowUps + 1,
-      }));
+      // `updateQueuedFollowUps` fires for both enqueue AND consume of the
+      // tool-use follow-up queue with no delta payload, so any local counter
+      // would drift one-way. Phase 1 leaves `queuedFollowUps` at its default
+      // (0); Phase 4 wires the StatusBar pill to the real queue length via
+      // `ToolUseFollowUpQueue.getAll(streamId).length` when the multi-agent
+      // surface lands.
       return;
     }
     default:

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -1,0 +1,49 @@
+// Mirror StreamLogStore `MODEL_RESPONSE` deltas into `cliState.streams[].entries`.
+// Phase 1 only renders model responses; tool/approval entries land later.
+
+import { AgentLogger } from '@logger/AgentLogger';
+import {
+  MESSAGE_TYPES,
+  type StreamLogEntry,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { cliState, patchStream } from './cliState';
+
+export function subscribeStreamLog(): () => void {
+  const store = AgentLogger.getStreamLogStore();
+  return store.onChange((streamId) => syncStream(streamId));
+}
+
+function syncStream(streamId: StreamTabId): void {
+  const store = AgentLogger.getStreamLogStore();
+  const log = store.get(streamId);
+  if (!log) return;
+
+  const responses = log
+    .getRange(0)
+    .filter(
+      (entry: StreamLogEntry) =>
+        entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+
+  patchStream(streamId, (slice) => {
+    const existing = new Map(slice.entries.map((e) => [e.id, e]));
+    let changed = slice.entries.length !== responses.length;
+    const next = responses.map((entry: StreamLogEntry) => {
+      const text = entry.text ?? '';
+      const prev = existing.get(entry.id);
+      if (prev && prev.text === text) return prev;
+      changed = true;
+      return { id: entry.id, text, finalized: false };
+    });
+    if (!changed) return slice;
+    return { ...slice, entries: next };
+  });
+
+  // Surface stream as active if we don't already have one — handles bare
+  // `texra chat` where setActiveStream is the first signal the runtime emits.
+  if (!cliState.activeStreamId.get()) {
+    cliState.activeStreamId.set(streamId);
+  }
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,0 +1,14 @@
+// Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
+
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+
+import { patchStream } from './cliState';
+
+export function subscribeStreamStatus(): () => void {
+  return StreamStatusService.onDidChange((change) => {
+    patchStream(change.streamId, (slice) => ({
+      ...slice,
+      status: change.status,
+    }));
+  });
+}

--- a/packages/cli/src/chat/tui/state/terminalCapabilities.ts
+++ b/packages/cli/src/chat/tui/state/terminalCapabilities.ts
@@ -56,6 +56,10 @@ const QUERIES = {
 const DA1_SENTINEL = '[c';
 
 // Response markers we look for in the read buffer (before the DA1 reply).
+// The `\x1b` (ESC) is mandatory in every CSI/OSC reply — that's exactly
+// what `no-control-regex` flags; the rule is paranoid for terminal-protocol
+// patterns. Suppression is scoped to this block.
+/* eslint-disable no-control-regex */
 const RESPONSE_MARKERS = {
   // Kitty keyboard: `CSI ? <flags> u`
   kittyKeyboard: /\[\?[\d;]*u/,
@@ -69,6 +73,7 @@ const RESPONSE_MARKERS = {
 
 // DA1 response: `CSI ? <attrs> c`
 const DA1_RESPONSE = /\[\?[\d;]*c/;
+/* eslint-enable no-control-regex */
 
 export interface DiscoveryStreams {
   readonly stdin: NodeJS.ReadStream;

--- a/packages/cli/src/chat/tui/state/terminalCapabilities.ts
+++ b/packages/cli/src/chat/tui/state/terminalCapabilities.ts
@@ -3,8 +3,9 @@
 // We write a batch of capability queries (Kitty keyboard protocol, DECRQM
 // for grapheme cluster mode, DECRQM for bracketed paste, OSC color reads)
 // followed by `CSI c` (Device Attributes 1). Every terminal answers DA1, so
-// any feature whose reply lands before the DA1 response is supported, and
-// anything missing isn't — no timeouts, no false negatives.
+// any feature whose reply lands before the DA1 response is supported.
+// There are no *per-capability* timeouts — only an outer 250ms safeguard for
+// terminals that fail to answer DA1 at all, so startup never blocks.
 //
 // Pattern adapted from Claude Code's `src/ink/terminal-querier.ts` per
 // docs/prd/cli-tui-ink/10-architecture.md (Terminal capability discovery).

--- a/packages/cli/src/chat/tui/state/terminalCapabilities.ts
+++ b/packages/cli/src/chat/tui/state/terminalCapabilities.ts
@@ -1,0 +1,137 @@
+// Terminal feature discovery via the DA1-sentinel pattern.
+//
+// We write a batch of capability queries (Kitty keyboard protocol, DECRQM
+// for grapheme cluster mode, DECRQM for bracketed paste, OSC color reads)
+// followed by `CSI c` (Device Attributes 1). Every terminal answers DA1, so
+// any feature whose reply lands before the DA1 response is supported, and
+// anything missing isn't — no timeouts, no false negatives.
+//
+// Pattern adapted from Claude Code's `src/ink/terminal-querier.ts` per
+// docs/prd/cli-tui-ink/10-architecture.md (Terminal capability discovery).
+//
+// This module is the source of truth for the `terminalCapabilities` signal
+// consumed by the notifier (capability-gating OSC 9 / 99 / BEL) and future
+// input-layer features (Kitty keyboard, bracketed paste).
+
+import { signal, type Signal } from '@lit-labs/signals';
+
+export interface TerminalCapabilities {
+  /** Kitty keyboard progressive enhancement protocol (`CSI ? u`). */
+  readonly kittyKeyboard: boolean;
+  /** Grapheme cluster mode (DECRQM mode 2027). */
+  readonly graphemeClusters: boolean;
+  /** Bracketed paste mode (DECRQM mode 2004). */
+  readonly bracketedPaste: boolean;
+  /** OSC 4 (color table) is honored — proxy for OSC-family support. */
+  readonly oscColorReports: boolean;
+  /** Discovery actually ran (false when stdin/stdout isn't a TTY). */
+  readonly discovered: boolean;
+}
+
+const NONE: TerminalCapabilities = {
+  kittyKeyboard: false,
+  graphemeClusters: false,
+  bracketedPaste: false,
+  oscColorReports: false,
+  discovered: false,
+};
+
+const CAPS = signal<TerminalCapabilities>(NONE);
+
+export const terminalCapabilities = CAPS as Signal.State<TerminalCapabilities>;
+
+// Queries to write — each must produce a response before DA1 if supported.
+// The order matches the response order so we can scan for response markers.
+const QUERIES = {
+  kittyKeyboard: '[?u',
+  graphemeClusters: '[?2027$p',
+  bracketedPaste: '[?2004$p',
+  oscColorReports: ']4;0;?',
+} as const satisfies Record<
+  keyof Omit<TerminalCapabilities, 'discovered'>,
+  string
+>;
+
+const DA1_SENTINEL = '[c';
+
+// Response markers we look for in the read buffer (before the DA1 reply).
+const RESPONSE_MARKERS = {
+  // Kitty keyboard: `CSI ? <flags> u`
+  kittyKeyboard: /\[\?[\d;]*u/,
+  // DECRPM grapheme clusters: `CSI ? 2027 ; <value> $ y`
+  graphemeClusters: /\[\?2027;[01]\$y/,
+  // DECRPM bracketed paste: `CSI ? 2004 ; <value> $ y`
+  bracketedPaste: /\[\?2004;[01]\$y/,
+  // OSC 4 color: `OSC 4 ; <index> ; rgb:... BEL` (or ST)
+  oscColorReports: /\]4;0;rgb:/,
+} as const satisfies Record<keyof typeof QUERIES, RegExp>;
+
+// DA1 response: `CSI ? <attrs> c`
+const DA1_RESPONSE = /\[\?[\d;]*c/;
+
+export interface DiscoveryStreams {
+  readonly stdin: NodeJS.ReadStream;
+  readonly stdout: NodeJS.WriteStream;
+}
+
+/**
+ * Run terminal capability discovery once at startup. Returns the resolved
+ * capabilities; also publishes to the `terminalCapabilities` signal so
+ * consumers can read it lazily.
+ *
+ * Times out after ~250ms. A terminal that fails to answer DA1 is a serious
+ * outlier; we degrade to "no advanced features" rather than block startup.
+ */
+export async function discoverTerminalCapabilities(
+  streams: DiscoveryStreams,
+): Promise<TerminalCapabilities> {
+  if (!streams.stdin.isTTY || !streams.stdout.isTTY) {
+    CAPS.set(NONE);
+    return NONE;
+  }
+
+  const queryString = Object.values(QUERIES).join('') + DA1_SENTINEL;
+
+  const wasRaw = streams.stdin.isRaw;
+  streams.stdin.setRawMode?.(true);
+  streams.stdin.resume();
+
+  const result = await new Promise<string>((resolve) => {
+    let buffer = '';
+    let settled = false;
+    const onData = (chunk: Buffer): void => {
+      if (settled) return;
+      buffer += chunk.toString('utf8');
+      if (DA1_RESPONSE.test(buffer)) {
+        settled = true;
+        cleanup();
+        resolve(buffer);
+      }
+    };
+    const onTimeout = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(buffer);
+    };
+    const timer = setTimeout(onTimeout, 250);
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      streams.stdin.off('data', onData);
+    };
+    streams.stdin.on('data', onData);
+    streams.stdout.write(queryString);
+  });
+
+  if (!wasRaw) streams.stdin.setRawMode?.(false);
+
+  const caps: TerminalCapabilities = {
+    discovered: true,
+    kittyKeyboard: RESPONSE_MARKERS.kittyKeyboard.test(result),
+    graphemeClusters: RESPONSE_MARKERS.graphemeClusters.test(result),
+    bracketedPaste: RESPONSE_MARKERS.bracketedPaste.test(result),
+    oscColorReports: RESPONSE_MARKERS.oscColorReports.test(result),
+  };
+  CAPS.set(caps);
+  return caps;
+}

--- a/packages/cli/src/chat/tui/state/useSignal.ts
+++ b/packages/cli/src/chat/tui/state/useSignal.ts
@@ -1,0 +1,29 @@
+// React bridge for `@lit-labs/signals` via `useSyncExternalStore`. Mirrors
+// the primitive the webview's `progressState` uses so the CLI host can read
+// the same signals without pulling in a second state-management library.
+
+import { useSyncExternalStore } from 'react';
+import { Signal } from '@lit-labs/signals';
+
+type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
+
+/**
+ * Subscribe a React component to a `@lit-labs/signals` state/computed signal.
+ *
+ * `Signal.subtle.Watcher` fires exactly once per change and must be re-armed
+ * in the notify callback — the wrapper does that here so consumers see every
+ * update.
+ */
+export function useSignal<T>(signal: ReadableSignal<T>): T {
+  return useSyncExternalStore(
+    (notify) => {
+      const watcher = new Signal.subtle.Watcher(() => {
+        notify();
+        watcher.watch();
+      });
+      watcher.watch(signal);
+      return () => watcher.unwatch(signal);
+    },
+    () => signal.get(),
+  );
+}

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -545,15 +545,27 @@ const chatCommand = defineCommand({
       default: 'minimal',
       description: 'Tool/progress rows: grouped, minimal, or hidden',
     },
+    tui: {
+      type: 'boolean',
+      description:
+        'Opt into the Ink-based TUI (preview; defaults off until Phase 6).',
+    },
   },
   async run(ctx) {
     const context = await contextFromArgs(ctx.args);
-    const { runChat } = await import('../chat/runChat');
-    const result = await runChat(context, {
+    const init = {
       agentOverride: optString(ctx.args.agent),
       modelOverride: optString(ctx.args.model),
       toolDisplay: ctx.args['tool-display'],
-    });
+    };
+    if (ctx.args.tui === true) {
+      const { runChatTui } = await import('../chat/tui/runChatTui');
+      const result = await runChatTui(context, init);
+      setExitCode(result.exitCode);
+      return;
+    }
+    const { runChat } = await import('../chat/runChat');
+    const result = await runChat(context, init);
     setExitCode(result.exitCode);
   },
 });

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -18,13 +18,17 @@ import { isNonEmptyString } from '@utils/core/stringCore';
 import {
   buildCliContext,
   CliUsageError,
+  CLI_OUTPUT_FORMATS,
   readCliAmbientState,
   readCliArgv,
   readCliVersion,
   type CliContext,
   type CliOutputFormat,
 } from '../runtime/cliContext';
-import type { CliApprovalPolicy } from '../runtime/approvalPolicy';
+import {
+  CLI_APPROVAL_POLICIES,
+  type CliApprovalPolicy,
+} from '../runtime/approvalPolicy';
 import {
   hasCliApprovalDenied,
   installCliApprovalHandlers,
@@ -88,12 +92,12 @@ const GLOBAL_ARGS: {
   cwd: { type: 'string' },
   'output-format': {
     type: 'enum',
-    options: ['text', 'json', 'ndjson'],
+    options: [...CLI_OUTPUT_FORMATS],
     default: 'text',
   },
   'approval-policy': {
     type: 'enum',
-    options: ['never', 'ask', 'yolo'],
+    options: [...CLI_APPROVAL_POLICIES],
     default: 'never',
   },
 };
@@ -113,11 +117,11 @@ async function listAgents(context: CliContext): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
   await loadAgents();
   const agents = [
-    ...getVisibleAgents('workflow').map((agent) => ({
+    ...getVisibleAgents(AgentCategory.Workflow).map((agent) => ({
       ...agent,
       category: AgentCategory.Workflow,
     })),
-    ...getVisibleAgents('toolUse').map((agent) => ({
+    ...getVisibleAgents(AgentCategory.ToolUse).map((agent) => ({
       ...agent,
       category: AgentCategory.ToolUse,
     })),
@@ -435,7 +439,7 @@ async function resolveWorkflowOutput(
   copiedOutput: string | undefined;
   displayResult: ExecuteAgentResult;
 }> {
-  if (!outputFile || result.category !== 'workflow') {
+  if (!outputFile || result.category !== AgentCategory.Workflow) {
     return { copiedOutput: undefined, displayResult: result };
   }
 
@@ -511,7 +515,7 @@ async function runWorkflowAgent(
       ts: new Date().toISOString(),
       result: displayResult,
     });
-  } else if (result.category === 'workflow') {
+  } else if (result.category === AgentCategory.Workflow) {
     const finalOutput = result.outputs.at(-1);
     writeTextStdout(
       copiedOutput ??
@@ -557,7 +561,6 @@ const chatCommand = defineCommand({
 const helpCommand = defineCommand({
   meta: { name: 'help', description: 'Show TeXRA CLI usage' },
   async run() {
-    const { showUsage } = await import('citty');
     await showUsage(rootCommand);
   },
 });

--- a/packages/cli/src/runtime/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approvalPolicy.ts
@@ -4,6 +4,8 @@ export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
 export function parseCliApprovalPolicy(
   value: string | undefined,
 ): CliApprovalPolicy | undefined {
-  if (value === 'never' || value === 'ask' || value === 'yolo') return value;
-  return undefined;
+  if (value === undefined) return undefined;
+  return (CLI_APPROVAL_POLICIES as readonly string[]).includes(value)
+    ? (value as CliApprovalPolicy)
+    : undefined;
 }

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -8,7 +8,9 @@ import { isNonEmptyString } from '@utils/core/stringCore';
 import { type CliApprovalPolicy } from './approvalPolicy';
 
 export type CliMode = 'headless' | 'interactive';
-export type CliOutputFormat = 'text' | 'json' | 'ndjson';
+
+export const CLI_OUTPUT_FORMATS = ['text', 'json', 'ndjson'] as const;
+export type CliOutputFormat = (typeof CLI_OUTPUT_FORMATS)[number];
 
 export interface CliPromptRequest {
   readonly kind: 'approval' | 'externalInquiry';
@@ -119,8 +121,9 @@ export interface CliGlobalArgs {
 }
 
 function cliMode(globalArgs: CliGlobalArgs, ambient: CliAmbientState): CliMode {
-  // Headless gate (narrowed per PRD 13): --print/-p, CI, or stdin non-TTY.
-  // Piping stdout or stderr alone no longer forces headless.
+  // Headless trigger: explicit --print/-p, CI=1, or stdin non-TTY. Piping
+  // stdout or stderr alone does NOT force headless — that's the gap the new
+  // Ink streaming-text fallback fills.
   const headless =
     globalArgs.print === true || ambient.isCi || !ambient.stdinIsTty;
   return headless ? 'headless' : 'interactive';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@inkjs/ui':
         specifier: ^2.0.0
         version: 2.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.6))
+      '@lit-labs/signals':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@texra/core':
         specifier: workspace:*
         version: link:../core
@@ -333,6 +336,12 @@ importers:
       ink:
         specifier: ^6.8.0
         version: 6.8.0(@types/react@19.2.14)(react@19.2.6)
+      ink-text-input:
+        specifier: ^6.0.0
+        version: 6.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      p-queue:
+        specifier: ^9.2.0
+        version: 9.2.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -3546,6 +3555,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -4085,6 +4097,13 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink-text-input@6.0.0:
+    resolution: {integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
+      react: '>=18'
 
   ink@6.8.0:
     resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
@@ -5057,9 +5076,17 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  p-queue@9.2.0:
+    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
+    engines: {node: '>=20'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -9955,6 +9982,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.4: {}
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
@@ -10584,6 +10613,13 @@ snapshots:
 
   ini@1.3.8:
     optional: true
+
+  ink-text-input@6.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+    dependencies:
+      chalk: 5.6.2
+      ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      type-fest: 4.41.0
 
   ink@6.8.0(@types/react@19.2.14)(react@19.2.6):
     dependencies:
@@ -11564,10 +11600,17 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  p-queue@9.2.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "target": "ES2022",
+    "jsx": "react-jsx",
     "lib": ["ES2023", "DOM"],
     "experimentalDecorators": true,
     "useDefineForClassFields": false,


### PR DESCRIPTION
Second of six sequential PRs implementing the Ink-based TUI defined in [`docs/prd/cli-tui-ink`](docs/prd/cli-tui-ink/README.md). Default still routes to the legacy plain renderer; the new path is opt-in via `texra chat --tui`.

## Summary

- New entry point: `texra chat --tui` mounts the Ink TUI; without the flag the legacy renderer is unchanged.
- Signals-backed state via `@lit-labs/signals` (same primitive the webview's `progressState` uses) + a 10-line `useSyncExternalStore` bridge — no second state library.
- Skeleton render tree: `Header` (agent / model / usage), `ConversationPane` (`<Static>` for finalized turns + live `<Box>` for in-flight), `StatusBar` (status + queued pill), `InputBar` (paste-aware `BaseTextInput`).
- `BaseTextInput` wraps `ink-text-input` with paste-aware Enter (`CSI 200 ~` / `CSI 201 ~` parsing), horizontal viewport sliding, Ctrl-J newline. Pasting 50 lines fires **one** submit, not 50 (PRD success criterion 3).
- DA1-sentinel terminal capability discovery (Kitty keyboard, DECRQM 2027 grapheme clusters, bracketed paste, OSC color reads). Capability signal feeds the notifier.
- Terminal notifier (OSC 99 / OSC 9 / BEL) for `agentFinished` + `approvalNeeded`, capability-gated.
- Frame telemetry on Ink's `onFrame` (trace level) + `coalesceResize` for SIGWINCH bursts.
- `p-queue` replaces the hand-rolled `followUpFlush` promise chain in the new path.
- Streaming-text fallback: `texra chat --tui` with stdout piped (stdin TTY) delegates to the legacy renderer so `texra chat --tui | tee` keeps working (PRD § 13).

## What's deliberately not in this PR

- **Approvals** — still on the legacy adapter; the typed `Promise<Decision>` dispatcher lands in Phase 2.
- **Tool cards**, **multi-agent stripes**, **markdown / code highlighting** — Phases 2–3.
- **Slash palette**, **`@` mentions**, **transcript search**, **structured forms** — Phase 5.
- **Replacing the legacy renderer as the default** — Phase 6.

## Files added

`packages/cli/src/chat/tui/`:
- `state/{useSignal,cliState,subscribeRuntimeHost,subscribeStreamLog,subscribeStreamStatus,terminalCapabilities}.ts`
- `panes/{Header,ConversationPane,StatusBar,InputBar}.tsx`
- `input/{BaseTextInput,usePasteHandler}.tsx`
- `notifications/terminalNotifier.ts`
- `render/frameTelemetry.ts`
- `App.tsx`, `runChatTui.tsx`

`packages/cli/scripts/`:
- `react-devtools-core-stub.mjs` (aliased in `build-bundle.mjs` so Ink's conditional devtools import doesn't fail bundle resolution).

Deps added: `@lit-labs/signals`, `ink-text-input`, `p-queue`.

## Includes a follow-up /simplify cleanup commit (`2c3507df5`)

Carries over the round-2 review findings from PR #4074 that weren't already merged: derive `CliOutputFormat` from a `CLI_OUTPUT_FORMATS` tuple, use `CLI_APPROVAL_POLICIES` everywhere, use `AgentCategory` enum in the remaining 5 sites, use `toErrorMessage` instead of inline `error instanceof Error ? ...` triads, drop the dynamic `await import('citty')` inside `helpCommand`, replace the PRD-13 comment reference with a durable explanation.

## Test plan

- [x] `pnpm --filter @texra/cli run build` green (typecheck, host-import check, react-compiler smoke, bundle).
- [x] `texra chat --help` lists the new `--tui` flag.
- [x] `texra chat --tui --print` exits `2` with "requires interactive terminal".
- [x] `texra chat --tui </dev/null` rejects with the headless message.
- [ ] In a real terminal: `texra chat --tui` mounts the Ink TUI and accepts a user message (manual verification — interactive).
- [ ] In a real terminal: `texra chat --tui | tee log.txt` falls back to the streaming-text path (no Ink chrome in the tee output) — manual.
- [ ] Phase-2 reviews will pick up any remaining Phase-1 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive `texra chat --tui` execution path with raw-stdin handling, terminal capability probing, and a new follow-up queue; while opt-in, it touches runtime/chat execution flow and terminal I/O which can be brittle across environments.
> 
> **Overview**
> Adds an opt-in Ink-based chat UI behind `texra chat --tui`, including a minimal render tree (header/conversation/status/input) driven by new `@lit-labs/signals` state mirrored from runtime stream log/status events.
> 
> Introduces paste-aware input (`ink-text-input` + bracketed-paste parsing), terminal capability discovery (DA1-sentinel) and capability-gated notifications (OSC 9/99 with BEL fallback), and replaces the TUI follow-up submission chain with a serialized `p-queue`.
> 
> Updates CLI/build plumbing: aliases Ink’s `react-devtools-core` import to a no-op stub during bundling, loosens the host-import guard to allow direct `process.stdin/stdout/stderr` use in `runChatTui`, adds shared constants for output/approval enums, and standardizes error formatting via `toErrorMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de111b15e9ff0f781321ffed5d6a57a433f704c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->