### PR TITLE
fix(settings): move reliability controls to models tab

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -166,7 +166,7 @@ import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 type MessageFor<C extends SettingsViewInboundMessage['command']> =
   SettingsMessageFor<C>;
 
-/** Reliability settings surfaced in the Multi-Agent tab. */
+/** Reliability settings surfaced in the Models tab. */
 const RELIABILITY_SETTINGS: (Omit<NumberVscodeSetting, 'value'> & {
   defaultValue: number;
 })[] = [

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -275,7 +275,7 @@ export class SettingsApp extends SettingsAppBase {
   // Agent teams state
   private readonly customPresets = signal<AgentModePreset[]>([]);
 
-  // Multi-agent coordination / reliability state
+  // Multi-agent coordination state
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
   private readonly allowOrchestratorKill = signal(true);
   private readonly detachSubagentsOnStop = signal(false);
@@ -1035,6 +1035,7 @@ export class SettingsApp extends SettingsAppBase {
               .providerKeyStatuses=${this.providerKeyStatuses.get()}
               .globalStreamingDefault=${this.globalStreamingDefault.get()}
               .modelSelectionItems=${this.modelSelectionItems.get()}
+              .reliabilitySettings=${this.reliabilitySettings.get()}
               .helperModel=${this.helperModel.get()}
               .preferShortModelNames=${this.preferShortModelNames.get()}
               @profile-api-access-mode=${this.handleApiAccessMode}
@@ -1081,7 +1082,6 @@ export class SettingsApp extends SettingsAppBase {
 
           <wa-tab-panel name="multi-agent">
             <multi-agent-tab
-              .reliabilitySettings=${this.reliabilitySettings.get()}
               .customPresets=${this.customPresets.get()}
               .allowOrchestratorKill=${this.allowOrchestratorKill.get()}
               .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
@@ -1094,7 +1094,6 @@ export class SettingsApp extends SettingsAppBase {
               @worktree-support-toggle=${this.handleWorktreeSupportToggle}
               @nested-delegation-max-depth-change=${this
                 .handleNestedDelegationMaxDepthChange}
-              @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}
             ></multi-agent-tab>

--- a/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
@@ -1,0 +1,133 @@
+/** Numeric reliability controls for long-running model sessions. */
+
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { commonViewStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared utilities
+import { createEvent } from '@shared/utils/events';
+
+// Local imports - shared schemas
+import type { NumberVscodeSetting } from '@shared/schemas/settingsViewMessages';
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+
+function clampSetting(value: number, min?: number, max?: number): number {
+  let result = value;
+  if (min != null) result = Math.max(min, result);
+  if (max != null) result = Math.min(max, result);
+  return result;
+}
+
+@customElement('reliability-settings-section')
+export class ReliabilitySettingsSection extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .setting-block {
+        padding: var(--wa-space-xs);
+        background-color: var(--wa-color-neutral-fill-quiet);
+        border-radius: var(--border-radius);
+      }
+
+      .setting-description {
+        margin: var(--wa-space-2xs) 0 var(--wa-space-xs) 0;
+        font-size: var(--font-size-sm);
+      }
+
+      .setting-row {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-2xs) 0;
+      }
+
+      .setting-row label {
+        min-width: 140px;
+        font-size: var(--font-size-sm);
+        color: var(--wa-color-text-normal);
+      }
+
+      .setting-input {
+        width: 80px;
+      }
+
+      .setting-unit {
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+      }
+
+      .setting-help {
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-xs);
+        margin: 0;
+        padding-left: calc(140px + var(--wa-space-xs));
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) settings: NumberVscodeSetting[] = [];
+
+  private handleSettingChange(
+    setting: NumberVscodeSetting,
+    input: WaInput,
+  ): void {
+    const parsed = Number(input.value);
+    if (Number.isNaN(parsed)) {
+      input.value = String(setting.value);
+      return;
+    }
+    const value = clampSetting(parsed, setting.min, setting.max);
+    if (value !== parsed) input.value = String(value);
+    this.dispatchEvent(
+      createEvent('provider-vscode-setting-set', { key: setting.key, value }),
+    );
+  }
+
+  private renderSetting(setting: NumberVscodeSetting): TemplateResult {
+    return html`
+      <div class="setting-row">
+        <label>${setting.label}</label>
+        <wa-input
+          class="setting-input"
+          type="number"
+          .value=${String(setting.value)}
+          min=${setting.min ?? nothing}
+          max=${setting.max ?? nothing}
+          @change=${(event: Event) =>
+            this.handleSettingChange(setting, event.target as WaInput)}
+        ></wa-input>
+        ${setting.unit
+          ? html`<span class="setting-unit">${setting.unit}</span>`
+          : nothing}
+      </div>
+      <p class="setting-help">${setting.description}</p>
+    `;
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (this.settings.length === 0) return nothing;
+    return html`
+      <h3>Reliability</h3>
+      <p class="text-secondary setting-description">
+        Tweak how long model sessions handle retries and context limits.
+      </p>
+      <div class="setting-block">
+        ${this.settings.map((setting) => this.renderSetting(setting))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'reliability-settings-section': ReliabilitySettingsSection;
+  }
+}

--- a/packages/extension/src/settingsView/frontend/components/profile/events.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/events.ts
@@ -30,7 +30,7 @@ export const ProviderKeyEvents = {
     createEvent('provider-endpoint-set', detail),
   setGlobalStreaming: (detail: { enabled: boolean }) =>
     createEvent('provider-global-streaming-set', detail),
-  setVscodeSetting: (detail: { key: string; value: boolean }) =>
+  setVscodeSetting: (detail: { key: string; value: boolean | number }) =>
     createEvent('provider-vscode-setting-set', detail),
   openUrl: (detail: { url: string }) =>
     createEvent('provider-open-url', detail),

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -11,14 +11,16 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas
 import type {
-  ProviderKeyStatus,
   ModelSelectionItem,
+  NumberVscodeSetting,
+  ProviderKeyStatus,
 } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/ApiAccessSection';
 import '../components/profile/ProviderKeyList';
 import '../components/profile/ModelSelectionList';
+import '../components/profile/ReliabilitySettingsSection';
 
 @customElement('models-tab')
 export class ModelsTab extends LitElement {
@@ -41,6 +43,8 @@ export class ModelsTab extends LitElement {
   @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
   @property({ attribute: false }) globalStreamingDefault = true;
   @property({ attribute: false }) modelSelectionItems: ModelSelectionItem[] =
+    [];
+  @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
   @property({ attribute: false }) helperModel = '';
   @property({ type: Boolean }) preferShortModelNames = false;
@@ -124,6 +128,9 @@ export class ModelsTab extends LitElement {
           .providerKeyStatuses=${this.providerKeyStatuses}
           .preferShortModelNames=${this.preferShortModelNames}
         ></model-selection-list>
+        <reliability-settings-section
+          .settings=${this.reliabilitySettings}
+        ></reliability-settings-section>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -1,4 +1,4 @@
-/** Multi-agent teams, coordination toggles, and reliability tuning. */
+/** Multi-agent teams and coordination toggles. */
 
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
@@ -20,20 +20,12 @@ import {
   AGENT_MODE_PRESETS,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
-import type { NumberVscodeSetting } from '@shared/schemas/settingsViewMessages';
 import {
   NESTED_DELEGATION_DEPTH_RANGE,
   clampNestedDelegationDepth,
 } from '@shared/constants/delegationPolicy';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-
-function clampSetting(value: number, min?: number, max?: number): number {
-  let result = value;
-  if (min != null) result = Math.max(min, result);
-  if (max != null) result = Math.min(max, result);
-  return result;
-}
 
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
@@ -205,30 +197,24 @@ export class MultiAgentTab extends LitElement {
         display: inline-flex;
       }
 
-      /* Reliability settings */
-      .reliability-row {
+      .numeric-setting-row {
         display: flex;
         align-items: center;
         gap: var(--wa-space-xs);
         padding: var(--wa-space-2xs) 0;
       }
 
-      .reliability-row label {
+      .numeric-setting-row label {
         min-width: 140px;
         font-size: var(--font-size-sm);
         color: var(--wa-color-text-normal);
       }
 
-      .reliability-input {
+      .numeric-setting-input {
         width: 80px;
       }
 
-      .reliability-unit {
-        color: var(--color-text-secondary);
-        font-size: var(--font-size-sm);
-      }
-
-      .reliability-description {
+      .numeric-setting-description {
         color: var(--color-text-secondary);
         font-size: var(--font-size-xs);
         margin: 0;
@@ -242,8 +228,6 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) worktreeSupport = false;
   @property({ attribute: false }) nestedDelegationMaxDepth =
     NESTED_DELEGATION_DEPTH_RANGE.default;
-  @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
-    [];
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
   @state() private activePresetId: string | null = null;
 
@@ -278,22 +262,6 @@ export class MultiAgentTab extends LitElement {
     event.stopPropagation();
     this.dispatchEvent(
       createEvent('delete-agent-mode-preset', { presetId: preset.id }),
-    );
-  }
-
-  private handleReliabilityChange(
-    setting: NumberVscodeSetting,
-    input: WaInput,
-  ): void {
-    const parsed = Number(input.value);
-    if (Number.isNaN(parsed)) {
-      input.value = String(setting.value);
-      return;
-    }
-    const value = clampSetting(parsed, setting.min, setting.max);
-    if (value !== parsed) input.value = String(value);
-    this.dispatchEvent(
-      createEvent('reliability-setting-change', { key: setting.key, value }),
     );
   }
 
@@ -377,29 +345,6 @@ export class MultiAgentTab extends LitElement {
             </button>`
           : nothing}
       </div>
-    `;
-  }
-
-  private renderReliabilitySetting(
-    setting: NumberVscodeSetting,
-  ): TemplateResult {
-    return html`
-      <div class="reliability-row">
-        <label>${setting.label}</label>
-        <wa-input
-          class="reliability-input"
-          type="number"
-          .value=${String(setting.value)}
-          min=${setting.min ?? nothing}
-          max=${setting.max ?? nothing}
-          @change=${(e: Event) =>
-            this.handleReliabilityChange(setting, e.target as WaInput)}
-        ></wa-input>
-        ${setting.unit
-          ? html`<span class="reliability-unit">${setting.unit}</span>`
-          : nothing}
-      </div>
-      <p class="reliability-description">${setting.description}</p>
     `;
   }
 
@@ -516,10 +461,10 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <div class="reliability-row">
+          <div class="numeric-setting-row">
             <label>Max delegation depth</label>
             <wa-input
-              class="reliability-input"
+              class="numeric-setting-input"
               type="number"
               .value=${String(this.nestedDelegationMaxDepth)}
               min=${NESTED_DELEGATION_DEPTH_RANGE.min}
@@ -528,27 +473,13 @@ export class MultiAgentTab extends LitElement {
                 this.handleNestedDelegationMaxDepthChange(e.target as WaInput)}
             ></wa-input>
           </div>
-          <p class="reliability-description">
+          <p class="numeric-setting-description">
             Depth 1 (default): only the top-level orchestrator may delegate;
             subagents cannot delegate further. Depth 2 lets a sub-orchestrator
             delegate once more (orchestrator → sub-orchestrator → leaf). Higher
             values allow deeper chains.
           </p>
         </div>
-
-        ${this.reliabilitySettings.length > 0
-          ? html`
-              <h3>Reliability</h3>
-              <p class="text-secondary setting-description">
-                Tweak how long sessions handle retries and context limits.
-              </p>
-              <div class="setting-block">
-                ${this.reliabilitySettings.map((s) =>
-                  this.renderReliabilitySetting(s),
-                )}
-              </div>
-            `
-          : nothing}
       </div>
     `;
   }

--- a/src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts
+++ b/src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts
@@ -1,0 +1,98 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+const reliabilitySettings = [
+  {
+    key: 'texra.model.compactionThresholdPercent',
+    label: 'Compaction threshold',
+    description: 'Context window percentage to trigger compaction.',
+    value: 75,
+    min: 0,
+    max: 100,
+    unit: '%',
+  },
+  {
+    key: 'texra.model.retry.maxAttempts',
+    label: 'Retry attempts',
+    description: 'Automatic retry attempts before manual retry.',
+    value: 0,
+    min: 0,
+  },
+];
+
+type LitTestElement = HTMLElement & {
+  updateComplete: Promise<unknown>;
+};
+
+type ModelsTabElement = LitTestElement & {
+  reliabilitySettings: typeof reliabilitySettings;
+};
+
+describe('settings reliability placement', () => {
+  useLitComponentTestDom(async () => {
+    await import('@settingsView/frontend/tabs/ModelsTab');
+    await import('@settingsView/frontend/tabs/MultiAgentTab');
+  });
+
+  it('shows reliability settings at the bottom of the Models tab', async () => {
+    const tab = document.createElement('models-tab') as ModelsTabElement;
+    tab.reliabilitySettings = reliabilitySettings;
+    document.body.append(tab);
+
+    await tab.updateComplete;
+    const section = tab.shadowRoot?.querySelector(
+      'reliability-settings-section',
+    ) as LitTestElement | null;
+
+    expect(section).not.toBeNull();
+    await section?.updateComplete;
+    expect(section?.shadowRoot?.textContent).toContain('Reliability');
+    expect(section?.shadowRoot?.textContent).toContain('Retry attempts');
+  });
+
+  it('does not render model reliability controls in Multi-Agent', async () => {
+    const tab = document.createElement('multi-agent-tab') as LitTestElement;
+    document.body.append(tab);
+
+    await tab.updateComplete;
+
+    expect(tab.shadowRoot?.textContent).not.toContain('Compaction threshold');
+    expect(tab.shadowRoot?.textContent).not.toContain('Retry attempts');
+  });
+
+  it('emits numeric reliability changes through the existing VS Code setting event', async () => {
+    const tab = document.createElement('models-tab') as ModelsTabElement;
+    tab.reliabilitySettings = reliabilitySettings;
+    document.body.append(tab);
+    await tab.updateComplete;
+
+    const events: unknown[] = [];
+    tab.addEventListener('provider-vscode-setting-set', (event) => {
+      events.push((event as CustomEvent).detail);
+    });
+
+    const section = tab.shadowRoot?.querySelector(
+      'reliability-settings-section',
+    ) as LitTestElement | null;
+    await section?.updateComplete;
+
+    const input = section?.shadowRoot?.querySelector('wa-input') as
+      | (HTMLElement & { value: string })
+      | null;
+    expect(input).not.toBeNull();
+    input!.value = '101';
+    input!.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+
+    expect(events).toEqual([
+      {
+        key: 'texra.model.compactionThresholdPercent',
+        value: 100,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Moves reliability tuning controls out of Multi-Agent and to the bottom of the Models tab.
- Factors the numeric reliability controls into a dedicated `ReliabilitySettingsSection` component.
- Keeps the existing VS Code setting write path so reliability values still persist through the same settings handler.

Closes #4060.

## Validation

- `corepack pnpm vitest run src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts`
- `npm run typecheck`
- `npm run format`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes where reliability settings are rendered and how numeric values are emitted/persisted via the shared `provider-vscode-setting-set` pathway; regressions would affect user configuration UX and settings writes.
> 
> **Overview**
> Moves the **model reliability tuning controls** out of the `Multi-Agent` tab and renders them at the bottom of the `Models` tab.
> 
> Factors the numeric inputs into a new `reliability-settings-section` component that clamps values and emits updates via the existing `provider-vscode-setting-set` event (expanded to support `number`), and removes the now-duplicated reliability UI/event wiring from `MultiAgentTab`.
> 
> Adds a Vitest coverage check to ensure the controls appear only in `Models`, and that changes dispatch the expected numeric VS Code setting update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57a6156d10012a9dcd62ee6c228ef9c954f09fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->