### PR TITLE
fix(agent): allow follow-up after resumable errors

### DIFF
--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
+import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   sendFollowUp,
@@ -25,8 +26,11 @@ async function lazyDetectWaitingStatus(
   streamId: StreamTabId,
 ): Promise<boolean> {
   const currentStatus = StreamStatusService.get(streamId);
-  if (currentStatus) {
-    return currentStatus === STREAM_STATUS.WAITING;
+  if (currentStatus === STREAM_STATUS.WAITING) {
+    return true;
+  }
+  if (!shouldProbePersistedFlowForFollowUp(currentStatus)) {
+    return false;
   }
   if (inFlightDetections.has(streamId)) {
     return false;

--- a/src/agent/runtime/followUpResumeDetection.ts
+++ b/src/agent/runtime/followUpResumeDetection.ts
@@ -1,0 +1,12 @@
+import { isInFlightStatus } from '@common/constants/streamStatus';
+import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+
+/**
+ * Return true when a follow-up should check persistent flow state before
+ * declaring that no session can continue.
+ */
+export function shouldProbePersistedFlowForFollowUp(
+  status: StreamStatus | undefined,
+): boolean {
+  return status !== STREAM_STATUS.READY && !isInFlightStatus(status);
+}

--- a/src/test-kernel/agent/FollowUpResumeDetection.vitest.mts
+++ b/src/test-kernel/agent/FollowUpResumeDetection.vitest.mts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
+import { STREAM_STATUS } from '@shared/schemas';
+
+describe('shouldProbePersistedFlowForFollowUp', () => {
+  it('probes when no in-memory status is available', () => {
+    expect(shouldProbePersistedFlowForFollowUp(undefined)).toBe(true);
+  });
+
+  it('probes terminal statuses that may still have a persisted flow record', () => {
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.ERROR)).toBe(true);
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.STOPPED)).toBe(
+      true,
+    );
+  });
+
+  it('does not probe the explicit ready status', () => {
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.READY)).toBe(
+      false,
+    );
+  });
+
+  it('does not probe active or already waiting statuses', () => {
+    expect(
+      shouldProbePersistedFlowForFollowUp(STREAM_STATUS.INITIALIZING),
+    ).toBe(false);
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.RUNNING)).toBe(
+      false,
+    );
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.RESUMING)).toBe(
+      false,
+    );
+    expect(shouldProbePersistedFlowForFollowUp(STREAM_STATUS.WAITING)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4090.

Workflow runs can preserve a persisted flow record after a provider-side failure, including empty API responses. The follow-up command previously treated an in-memory `ERROR` status as terminal and never checked that persisted flow record, so users could not continue the same stream.

This PR makes follow-up resume detection probe persisted flow records for inactive terminal statuses before declaring that no session can continue. Active and already-waiting streams keep their existing behavior.

## Validation

- `npm run format`
- `npx vitest run src/test-kernel/agent/FollowUpResumeDetection.vitest.mts`
- `git diff --check`
- `CI=true npm run typecheck`
- `npm run lint` (passes with the existing 9 warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up resume detection logic to query persisted flow state for some terminal/unknown statuses, which can alter when streams are treated as resumable. Risk is moderate because it impacts session/stream lifecycle behavior, but is narrowly scoped and covered by new unit tests.
> 
> **Overview**
> Follow-up handling now **probes persisted flow records** when the stream is in an inactive/terminal (or unknown) state, instead of treating any cached non-waiting status as definitive.
> 
> This introduces `shouldProbePersistedFlowForFollowUp()` and updates `lazyDetectWaitingStatus` to skip probing only for *in-flight* statuses and explicit `READY`, enabling follow-ups to continue after provider-side failures that left a resumable persisted flow. A Vitest suite validates the probe/no-probe status matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab734f34d2aeac7e8c46e6ef103537d89957638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->