### PR TITLE
feat(cli-tui): phase 4 — multi-agent panes + Ctrl-A/B focus cycle

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -26,7 +26,19 @@ export function App(props: AppProps): React.JSX.Element {
   // Single subscription site; pass the value down so ApprovalModal renders
   // off the same read and InputBar can stay mounted but disabled.
   const pending = useSignal(currentApproval);
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
   const inputDisabled = props.inputDisabled || pending !== undefined;
+
+  // Hide the side column when both side panes would render empty —
+  // otherwise the conversation loses 28 columns of width for nothing.
+  const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const showSideColumn = activeSlice
+    ? activeSlice.activeSubagents.length > 0 ||
+      activeSlice.activeProcesses.length > 0 ||
+      activeSlice.todos.length > 0 ||
+      activeSlice.plan !== null
+    : false;
 
   // Ctrl-A / Ctrl-B focus cycle — runs at the App layer so the same chord
   // lands no matter which pane the user just glanced at. The readline-style
@@ -51,10 +63,12 @@ export function App(props: AppProps): React.JSX.Element {
         <Box flexDirection="column" flexGrow={1}>
           <ConversationPane />
         </Box>
-        <Box flexDirection="column" minWidth={28}>
-          <SubagentList />
-          <TodosPlanPanel />
-        </Box>
+        {showSideColumn ? (
+          <Box flexDirection="column" minWidth={28}>
+            <SubagentList />
+            <TodosPlanPanel />
+          </Box>
+        ) : null}
       </Box>
       <StatusBar />
       <ApprovalModal pending={pending} />

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,13 +1,18 @@
-// Ink TUI root. Phase 1 skeleton + Phase 2 approval-modal overlay.
+// Ink TUI root. Phase 1 skeleton + Phase 2 approval-modal overlay + Phase 4
+// SubagentList / TodosPlanPanel side panels and Ctrl-A / Ctrl-B focus cycle.
 
-import { Box, useApp } from 'ink';
+import { Box, useApp, useInput } from 'ink';
 
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ConversationPane } from './panes/ConversationPane';
 import { Header } from './panes/Header';
 import { InputBar } from './panes/InputBar';
 import { StatusBar } from './panes/StatusBar';
+import { SubagentList } from './panes/SubagentList';
+import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
+import { cliState } from './state/cliState';
+import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { useSignal } from './state/useSignal';
 
 export interface AppProps {
@@ -21,17 +26,39 @@ export function App(props: AppProps): React.JSX.Element {
   // Single subscription site; pass the value down so ApprovalModal renders
   // off the same read and InputBar can stay mounted but disabled.
   const pending = useSignal(currentApproval);
+  const inputDisabled = props.inputDisabled || pending !== undefined;
+
+  // Ctrl-A / Ctrl-B focus cycle — runs at the App layer so the same chord
+  // lands no matter which pane the user just glanced at. The readline-style
+  // start-of-line / back-one-char binding of those chords inside the input
+  // bar lands in Phase 5 alongside the explicit focus-mode toggle; until
+  // then ink-text-input ignores ctrl chords anyway.
+  useInput((_input, key) => {
+    if (!key.ctrl) return;
+    if (_input === 'a') {
+      const next = nextFocusForward();
+      if (next) cliState.activeStreamId.set(next);
+    } else if (_input === 'b') {
+      const next = nextFocusBack();
+      if (next) cliState.activeStreamId.set(next);
+    }
+  });
 
   return (
     <Box flexDirection="column">
       <Header />
-      <ConversationPane />
+      <Box flexDirection="row" flexGrow={1}>
+        <Box flexDirection="column" flexGrow={1}>
+          <ConversationPane />
+        </Box>
+        <Box flexDirection="column" minWidth={28}>
+          <SubagentList />
+          <TodosPlanPanel />
+        </Box>
+      </Box>
       <StatusBar />
       <ApprovalModal pending={pending} />
-      <InputBar
-        onSubmit={props.onSubmit}
-        disabled={props.inputDisabled || pending !== undefined}
-      />
+      <InputBar onSubmit={props.onSubmit} disabled={inputDisabled} />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -45,12 +45,12 @@ export function App(props: AppProps): React.JSX.Element {
   // start-of-line / back-one-char binding of those chords inside the input
   // bar lands in Phase 5 alongside the explicit focus-mode toggle; until
   // then ink-text-input ignores ctrl chords anyway.
-  useInput((_input, key) => {
+  useInput((input, key) => {
     if (!key.ctrl) return;
-    if (_input === 'a') {
+    if (input === 'a') {
       const next = nextFocusForward();
       if (next) cliState.activeStreamId.set(next);
-    } else if (_input === 'b') {
+    } else if (input === 'b') {
       const next = nextFocusBack();
       if (next) cliState.activeStreamId.set(next);
     }

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -25,12 +25,25 @@ function statusLabel(status: string | undefined): string {
 export function StatusBar(): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
+  const bypass = useSignal(cliState.bypass);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const queued = slice?.queuedFollowUps ?? 0;
 
   return (
     <Box paddingX={1} justifyContent="space-between">
-      <Text dimColor>{statusLabel(slice?.status)}</Text>
+      <Box>
+        <Text dimColor>{statusLabel(slice?.status)}</Text>
+        {bypass.superYolo ? (
+          <Text color="red" bold>
+            {'  YOLO'}
+          </Text>
+        ) : null}
+        {bypass.toolEdit ? (
+          <Text color="yellow" bold>
+            {'  BYPASS'}
+          </Text>
+        ) : null}
+      </Box>
       {queued > 0 ? <Text dimColor>queued: {queued}</Text> : null}
     </Box>
   );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 
 import { STREAM_STATUS } from '@shared/schemas';
 
-import { cliState } from '../state/cliState';
+import { cliState, NO_BYPASS } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 
 function statusLabel(status: string | undefined): string {
@@ -25,9 +25,9 @@ function statusLabel(status: string | undefined): string {
 export function StatusBar(): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
-  const bypass = useSignal(cliState.bypass);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const queued = slice?.queuedFollowUps ?? 0;
+  const bypass = slice?.bypass ?? NO_BYPASS;
 
   return (
     <Box paddingX={1} justifyContent="space-between">

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -74,49 +74,31 @@ export function SubagentList(): React.JSX.Element | null {
   const { activeSubagents, activeProcesses, processOutput } = slice;
   if (activeSubagents.length === 0 && activeProcesses.length === 0) return null;
 
-  // Flatten + index up front so we don't mutate a counter inside JSX.
-  const rows: ReadonlyArray<{
-    section: 'subagent' | 'process';
-    child: ActiveChildInfo;
-    index: number;
-  }> = [
-    ...activeSubagents.map((child, i) => ({
-      section: 'subagent' as const,
-      child,
-      index: i,
-    })),
-    ...activeProcesses.map((child, i) => ({
-      section: 'process' as const,
-      child,
-      index: activeSubagents.length + i,
-    })),
-  ];
-
-  const subagentRows = rows.filter((r) => r.section === 'subagent');
-  const processRows = rows.filter((r) => r.section === 'process');
-
   return (
     <Box flexDirection="column" paddingX={1} marginBottom={1}>
-      {subagentRows.length > 0 ? (
+      {activeSubagents.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>
             Subagents
           </Text>
-          {subagentRows.map(({ child, index }) => (
-            <Row key={child.executionId} child={child} index={index} />
+          {activeSubagents.map((child, i) => (
+            <Row key={child.executionId} child={child} index={i} />
           ))}
         </Box>
       ) : null}
-      {processRows.length > 0 ? (
-        <Box flexDirection="column" marginTop={subagentRows.length > 0 ? 1 : 0}>
+      {activeProcesses.length > 0 ? (
+        <Box
+          flexDirection="column"
+          marginTop={activeSubagents.length > 0 ? 1 : 0}
+        >
           <Text bold dimColor>
             Processes
           </Text>
-          {processRows.map(({ child, index }) => (
+          {activeProcesses.map((child, i) => (
             <Row
               key={child.executionId}
               child={child}
-              index={index}
+              index={activeSubagents.length + i}
               tail={processOutput.get(child.executionId)}
             />
           ))}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -1,0 +1,72 @@
+// Lists active subagents + processes for the currently-focused stream.
+//
+// One row per `ActiveChildInfo`. Numeric key (1-9) on the left mirrors the
+// `0` / `1`–`9` jump shortcuts (see 30-reference.md § Keymap); the focus
+// cycle in `App.tsx` consumes the same ordering.
+
+import { Box, Text } from 'ink';
+
+import type { ActiveChildInfo } from '@shared/schemas';
+
+import { cliState } from '../state/cliState';
+import { useSignal } from '../state/useSignal';
+
+interface RowProps {
+  readonly child: ActiveChildInfo;
+  readonly index: number;
+}
+
+function statusColor(status: string | undefined): string | undefined {
+  if (!status) return 'green';
+  if (status === 'waiting' || status === 'idle') return 'yellow';
+  if (status === 'error' || status === 'stopped') return 'red';
+  return 'green';
+}
+
+function Row({ child, index }: RowProps): React.JSX.Element {
+  return (
+    <Box flexDirection="row">
+      <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
+      <Text color={statusColor(child.status)}>● </Text>
+      <Text>{child.agentName || child.toolName || child.executionId}</Text>
+      {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
+      {child.elapsed ? <Text dimColor>{` · ${child.elapsed}`}</Text> : null}
+    </Box>
+  );
+}
+
+export function SubagentList(): React.JSX.Element | null {
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  if (!slice) return null;
+  const subagents = slice.activeSubagents;
+  const processes = slice.activeProcesses;
+  if (subagents.length === 0 && processes.length === 0) return null;
+
+  let cursor = 0;
+  return (
+    <Box flexDirection="column" paddingX={1} marginBottom={1}>
+      {subagents.length > 0 ? (
+        <Box flexDirection="column">
+          <Text bold dimColor>
+            Subagents
+          </Text>
+          {subagents.map((child) => (
+            <Row key={child.executionId} child={child} index={cursor++} />
+          ))}
+        </Box>
+      ) : null}
+      {processes.length > 0 ? (
+        <Box flexDirection="column" marginTop={subagents.length > 0 ? 1 : 0}>
+          <Text bold dimColor>
+            Processes
+          </Text>
+          {processes.map((child) => (
+            <Row key={child.executionId} child={child} index={cursor++} />
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -1,20 +1,24 @@
-// Lists active subagents + processes for the currently-focused stream.
+// Lists active subagents + processes for the currently-focused stream and
+// tails the live stdout/stderr per process so the user can see what each
+// shell call is doing.
 //
-// One row per `ActiveChildInfo`. The leading numeric index is currently a
-// visual cue only — the `1`–`9` jump shortcuts land in Phase 5 alongside
-// the input-focus toggle.
+// The leading numeric index is currently a visual cue only — the `1`–`9`
+// jump shortcuts land in Phase 5 alongside the input-focus toggle.
 
 import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
 
-import { cliState } from '../state/cliState';
+import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
   readonly index: number;
+  readonly tail?: ProcessOutputTail;
 }
+
+const TAIL_LINES = 4;
 
 function statusColor(status: string | undefined): string | undefined {
   if (!status) return 'green';
@@ -23,14 +27,41 @@ function statusColor(status: string | undefined): string | undefined {
   return 'green';
 }
 
-function Row({ child, index }: RowProps): React.JSX.Element {
+/** Pull the last `TAIL_LINES` non-blank lines from the combined std streams.
+ *  The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
+ *  this is bounded work. */
+function lastLines(tail: ProcessOutputTail | undefined): string[] {
+  if (!tail) return [];
+  const combined = `${tail.stdout}\n${tail.stderr}`;
+  const lines = combined.split('\n');
+  const trimmed: string[] = [];
+  for (let i = lines.length - 1; i >= 0 && trimmed.length < TAIL_LINES; i--) {
+    const line = lines[i]?.trimEnd();
+    if (line) trimmed.unshift(line);
+  }
+  return trimmed;
+}
+
+function Row({ child, index, tail }: RowProps): React.JSX.Element {
+  const tailLines = lastLines(tail);
   return (
-    <Box flexDirection="row">
-      <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
-      <Text color={statusColor(child.status)}>● </Text>
-      <Text>{child.agentName || child.toolName || child.executionId}</Text>
-      {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
-      {child.elapsed ? <Text dimColor>{` · ${child.elapsed}`}</Text> : null}
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
+        <Text color={statusColor(child.status)}>● </Text>
+        <Text>{child.agentName || child.toolName || child.executionId}</Text>
+        {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
+        {child.elapsed ? <Text dimColor>{` · ${child.elapsed}`}</Text> : null}
+      </Box>
+      {tailLines.length > 0 ? (
+        <Box flexDirection="column" marginLeft={4}>
+          {tailLines.map((line, i) => (
+            <Text key={i} dimColor>
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
     </Box>
   );
 }
@@ -40,30 +71,54 @@ export function SubagentList(): React.JSX.Element | null {
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (!slice) return null;
-  const subagents = slice.activeSubagents;
-  const processes = slice.activeProcesses;
-  if (subagents.length === 0 && processes.length === 0) return null;
+  const { activeSubagents, activeProcesses, processOutput } = slice;
+  if (activeSubagents.length === 0 && activeProcesses.length === 0) return null;
 
-  let cursor = 0;
+  // Flatten + index up front so we don't mutate a counter inside JSX.
+  const rows: ReadonlyArray<{
+    section: 'subagent' | 'process';
+    child: ActiveChildInfo;
+    index: number;
+  }> = [
+    ...activeSubagents.map((child, i) => ({
+      section: 'subagent' as const,
+      child,
+      index: i,
+    })),
+    ...activeProcesses.map((child, i) => ({
+      section: 'process' as const,
+      child,
+      index: activeSubagents.length + i,
+    })),
+  ];
+
+  const subagentRows = rows.filter((r) => r.section === 'subagent');
+  const processRows = rows.filter((r) => r.section === 'process');
+
   return (
     <Box flexDirection="column" paddingX={1} marginBottom={1}>
-      {subagents.length > 0 ? (
+      {subagentRows.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>
             Subagents
           </Text>
-          {subagents.map((child) => (
-            <Row key={child.executionId} child={child} index={cursor++} />
+          {subagentRows.map(({ child, index }) => (
+            <Row key={child.executionId} child={child} index={index} />
           ))}
         </Box>
       ) : null}
-      {processes.length > 0 ? (
-        <Box flexDirection="column" marginTop={subagents.length > 0 ? 1 : 0}>
+      {processRows.length > 0 ? (
+        <Box flexDirection="column" marginTop={subagentRows.length > 0 ? 1 : 0}>
           <Text bold dimColor>
             Processes
           </Text>
-          {processes.map((child) => (
-            <Row key={child.executionId} child={child} index={cursor++} />
+          {processRows.map(({ child, index }) => (
+            <Row
+              key={child.executionId}
+              child={child}
+              index={index}
+              tail={processOutput.get(child.executionId)}
+            />
           ))}
         </Box>
       ) : null}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -1,8 +1,8 @@
 // Lists active subagents + processes for the currently-focused stream.
 //
-// One row per `ActiveChildInfo`. Numeric key (1-9) on the left mirrors the
-// `0` / `1`–`9` jump shortcuts (see 30-reference.md § Keymap); the focus
-// cycle in `App.tsx` consumes the same ordering.
+// One row per `ActiveChildInfo`. The leading numeric index is currently a
+// visual cue only — the `1`–`9` jump shortcuts land in Phase 5 alongside
+// the input-focus toggle.
 
 import { Box, Text } from 'ink';
 

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -1,0 +1,82 @@
+// Renders the active stream's todo checklist and (if present) the numbered
+// plan steps. Hidden when both lists are empty.
+
+import { Box, Text } from 'ink';
+
+import { TODO_STATUS, type TodoItem, type TodoStatus } from '@shared/schemas';
+
+import { cliState } from '../state/cliState';
+import { useSignal } from '../state/useSignal';
+
+function todoMarker(status: TodoStatus): string {
+  switch (status) {
+    case TODO_STATUS.COMPLETED:
+      return '☑';
+    case TODO_STATUS.IN_PROGRESS:
+      return '☐';
+    default:
+      return '□';
+  }
+}
+
+function todoColor(status: TodoStatus): string | undefined {
+  switch (status) {
+    case TODO_STATUS.COMPLETED:
+      return 'green';
+    case TODO_STATUS.IN_PROGRESS:
+      return 'cyan';
+    default:
+      return undefined;
+  }
+}
+
+function TodoRow({ todo }: { todo: TodoItem }): React.JSX.Element {
+  const label =
+    todo.status === TODO_STATUS.IN_PROGRESS ? todo.activeForm : todo.content;
+  return (
+    <Box>
+      <Text color={todoColor(todo.status)}>{todoMarker(todo.status)} </Text>
+      <Text dimColor={todo.status === TODO_STATUS.COMPLETED}>{label}</Text>
+    </Box>
+  );
+}
+
+export function TodosPlanPanel(): React.JSX.Element | null {
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  if (!slice) return null;
+  const { todos, plan } = slice;
+  if (todos.length === 0 && !plan) return null;
+
+  return (
+    <Box flexDirection="column" paddingX={1} marginBottom={1}>
+      {todos.length > 0 ? (
+        <Box flexDirection="column">
+          <Text bold dimColor>
+            Todos
+          </Text>
+          {todos.map((todo, i) => (
+            <TodoRow key={i} todo={todo} />
+          ))}
+        </Box>
+      ) : null}
+      {plan ? (
+        <Box flexDirection="column" marginTop={todos.length > 0 ? 1 : 0}>
+          <Text bold dimColor>
+            Plan
+          </Text>
+          <Text dimColor>{plan.summary}</Text>
+          {plan.steps.map((step, i) => (
+            <Box key={i}>
+              <Text color={todoColor(step.status)}>
+                {todoMarker(step.status)}{' '}
+              </Text>
+              <Text>{`${i + 1}. ${step.title}`}</Text>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -1,8 +1,9 @@
 // Signal-backed state for the CLI TUI. Mirrors the webview's `progressState`
 // shape — same primitives (`@lit-labs/signals`), same shape (one record per
 // stream + an `activeStreamId`) so future feature parity is a port, not a
-// rewrite. Phase 4 extends with subagent/process/todos/plan/process-output
-// fields plus the global bypass-state badges the StatusBar consumes.
+// rewrite. Phase 4 extends with per-stream subagent/process/todos/plan/
+// process-output fields plus the per-stream bypass-state badges the
+// StatusBar consumes.
 
 import { signal, type Signal } from '@lit-labs/signals';
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -1,15 +1,18 @@
 // Signal-backed state for the CLI TUI. Mirrors the webview's `progressState`
 // shape — same primitives (`@lit-labs/signals`), same shape (one record per
 // stream + an `activeStreamId`) so future feature parity is a port, not a
-// rewrite. Phase 1 only exposes the fields the header + conversation pane +
-// input bar actually consume; later phases extend.
+// rewrite. Phase 4 extends with subagent/process/todos/plan/process-output
+// fields plus the global bypass-state badges the StatusBar consumes.
 
 import { signal, type Signal } from '@lit-labs/signals';
 
 import type { StreamTabId } from '@shared/schemas';
 import type {
+  ActiveChildInfo,
   ConversationProgress,
+  Plan,
   StreamStatus,
+  TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
 
@@ -28,6 +31,11 @@ export interface SessionMeta {
   readonly cwd: string;
 }
 
+export interface ProcessOutputTail {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   readonly status: StreamStatus | undefined;
@@ -36,6 +44,18 @@ export interface StreamSlice {
   readonly conversation: ConversationProgress | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUps: number;
+  readonly activeSubagents: readonly ActiveChildInfo[];
+  readonly activeProcesses: readonly ActiveChildInfo[];
+  readonly todos: readonly TodoItem[];
+  readonly plan: Plan | null;
+  /** Tailed stdout/stderr per execution id; latest only — Phase 4 doesn't
+   *  buffer beyond a small per-line cap (see subscribeRuntimeHost). */
+  readonly processOutput: ReadonlyMap<string, ProcessOutputTail>;
+}
+
+export interface BypassState {
+  readonly toolEdit: boolean;
+  readonly superYolo: boolean;
 }
 
 const SESSION_META = signal<SessionMeta>({
@@ -48,10 +68,20 @@ const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
 
+/** child -> parent map populated from `setParentStream`. The focus cycle
+ *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
+const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
+
+const BYPASS_STATE = signal<BypassState>({ toolEdit: false, superYolo: false });
+
 export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
   streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
+  parentStream: PARENT_STREAM as Signal.State<
+    ReadonlyMap<StreamTabId, StreamTabId>
+  >,
+  bypass: BYPASS_STATE as Signal.State<BypassState>,
 };
 
 function emptySlice(streamId: StreamTabId): StreamSlice {
@@ -63,6 +93,11 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,
+    activeSubagents: [],
+    activeProcesses: [],
+    todos: [],
+    plan: null,
+    processOutput: new Map(),
   };
 }
 
@@ -88,6 +123,17 @@ export function patchStream(
   );
 }
 
+export function setParentStream(
+  childStreamId: StreamTabId,
+  parentStreamId: StreamTabId,
+): void {
+  const current = cliState.parentStream.get();
+  if (current.get(childStreamId) === parentStreamId) return;
+  const out = new Map(current);
+  out.set(childStreamId, parentStreamId);
+  cliState.parentStream.set(out);
+}
+
 export function removeStream(streamId: StreamTabId): void {
   const current = cliState.streams.get();
   if (!current.has(streamId)) return;
@@ -97,10 +143,23 @@ export function removeStream(streamId: StreamTabId): void {
   if (cliState.activeStreamId.get() === streamId) {
     cliState.activeStreamId.set(undefined);
   }
+  // Drop any parent-map edges that touched this stream so the focus cycle
+  // never lands on a stale id.
+  const parents = cliState.parentStream.get();
+  if (parents.has(streamId) || [...parents.values()].includes(streamId)) {
+    const nextParents = new Map(parents);
+    nextParents.delete(streamId);
+    for (const [child, parent] of nextParents) {
+      if (parent === streamId) nextParents.delete(child);
+    }
+    cliState.parentStream.set(nextParents);
+  }
 }
 
 export function resetCliState(): void {
   cliState.sessionMeta.set({ agent: '', model: '', cwd: '' });
   cliState.activeStreamId.set(undefined);
   cliState.streams.set(new Map());
+  cliState.parentStream.set(new Map());
+  cliState.bypass.set({ toolEdit: false, superYolo: false });
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -36,6 +36,11 @@ export interface ProcessOutputTail {
   readonly stderr: string;
 }
 
+export interface BypassState {
+  readonly toolEdit: boolean;
+  readonly superYolo: boolean;
+}
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   readonly status: StreamStatus | undefined;
@@ -48,14 +53,13 @@ export interface StreamSlice {
   readonly activeProcesses: readonly ActiveChildInfo[];
   readonly todos: readonly TodoItem[];
   readonly plan: Plan | null;
-  /** Tailed stdout/stderr per execution id; latest only — Phase 4 doesn't
-   *  buffer beyond a small per-line cap (see subscribeRuntimeHost). */
+  /** Tailed stdout/stderr per execution id; latest only — capped at
+   *  `PROCESS_TAIL_CHARS_MAX` in subscribeRuntimeHost. */
   readonly processOutput: ReadonlyMap<string, ProcessOutputTail>;
-}
-
-export interface BypassState {
-  readonly toolEdit: boolean;
-  readonly superYolo: boolean;
+  /** YOLO / BYPASS state is stream-scoped upstream (see
+   *  `permissionSlice.ts` in the extension), so concurrent parent/child
+   *  sessions can show distinct badges. */
+  readonly bypass: BypassState;
 }
 
 const SESSION_META = signal<SessionMeta>({
@@ -72,8 +76,6 @@ const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
  *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
 const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 
-const BYPASS_STATE = signal<BypassState>({ toolEdit: false, superYolo: false });
-
 export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
@@ -81,8 +83,9 @@ export const cliState = {
   parentStream: PARENT_STREAM as Signal.State<
     ReadonlyMap<StreamTabId, StreamTabId>
   >,
-  bypass: BYPASS_STATE as Signal.State<BypassState>,
 };
+
+export const NO_BYPASS: BypassState = { toolEdit: false, superYolo: false };
 
 function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
@@ -98,6 +101,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     todos: [],
     plan: null,
     processOutput: new Map(),
+    bypass: NO_BYPASS,
   };
 }
 
@@ -161,5 +165,4 @@ export function resetCliState(): void {
   cliState.activeStreamId.set(undefined);
   cliState.streams.set(new Map());
   cliState.parentStream.set(new Map());
-  cliState.bypass.set({ toolEdit: false, superYolo: false });
 }

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -1,9 +1,9 @@
 // Ctrl-A / Ctrl-B focus cycle.
 //
-// Ctrl-A advances forward through the focused stream's active subagents and
-// processes (in the order they're listed in the SubagentList pane). When at
-// the end of the list, it wraps back to the parent — keeping the cycle
-// closed even when no descendants exist (a noop).
+// Ctrl-A advances forward through the focused stream's *siblings* — the
+// active descendants of its parent (or, if the active stream is the parent,
+// its own descendants). When at the end of the list it wraps back to the
+// parent — keeping the cycle closed for both leaves and roots.
 //
 // Ctrl-B steps back to the parent if one is registered, otherwise stays put.
 //
@@ -14,34 +14,40 @@ import { type StreamTabId } from '@shared/schemas';
 
 import { cliState } from './cliState';
 
+function orderedDescendants(parent: StreamTabId): StreamTabId[] {
+  const slice = cliState.streams.get().get(parent);
+  if (!slice) return [];
+  const out: StreamTabId[] = [];
+  for (const child of slice.activeSubagents) {
+    if (child.childStreamId) out.push(child.childStreamId);
+  }
+  for (const proc of slice.activeProcesses) {
+    if (proc.childStreamId) out.push(proc.childStreamId);
+  }
+  return out;
+}
+
 /** Returns the next stream id the focus cycle should land on, or `undefined`
- *  if the cycle would not move (e.g. no descendants and no parent). The
- *  caller is responsible for assigning the result to
- *  `cliState.activeStreamId`. */
+ *  if the cycle would not move (no parent edges, no descendants). The caller
+ *  assigns the result to `cliState.activeStreamId`. */
 export function nextFocusForward(): StreamTabId | undefined {
   const activeId = cliState.activeStreamId.get();
   if (!activeId) return undefined;
-  const slice = cliState.streams.get().get(activeId);
-  // Missing slice means we landed on a child stream we haven't received any
-  // progress events for yet — treat it as a leaf so the cycle closes via
-  // the parent edge instead of stranding the focus.
-  const descendants: StreamTabId[] = [];
-  for (const child of slice?.activeSubagents ?? []) {
-    if (child.childStreamId) descendants.push(child.childStreamId);
+
+  // If we're sitting on a child stream, walk forward through the *parent's*
+  // ordered descendant list — so root → child1 → child2 → root closes the
+  // cycle even when child1/child2 are leaves themselves.
+  const parent = cliState.parentStream.get().get(activeId);
+  if (parent) {
+    const siblings = orderedDescendants(parent);
+    const idx = siblings.indexOf(activeId);
+    if (idx !== -1 && idx + 1 < siblings.length) return siblings[idx + 1];
+    return parent;
   }
-  for (const proc of slice?.activeProcesses ?? []) {
-    if (proc.childStreamId) descendants.push(proc.childStreamId);
-  }
-  if (descendants.length === 0) {
-    return cliState.parentStream.get().get(activeId);
-  }
-  // The active stream itself is the "start of the cycle"; advancing from it
-  // lands on the first descendant. If the active stream is already a
-  // descendant, advance through the list and wrap to the parent at the end.
-  const idx = descendants.indexOf(activeId);
-  if (idx === -1) return descendants[0];
-  if (idx + 1 < descendants.length) return descendants[idx + 1];
-  return cliState.parentStream.get().get(activeId) ?? descendants[0];
+
+  // We're at the root — drop into the first descendant.
+  const descendants = orderedDescendants(activeId);
+  return descendants[0];
 }
 
 /** Step up to the parent stream, if one is registered. */
@@ -49,23 +55,4 @@ export function nextFocusBack(): StreamTabId | undefined {
   const activeId = cliState.activeStreamId.get();
   if (!activeId) return undefined;
   return cliState.parentStream.get().get(activeId);
-}
-
-/** Returns the descendant at the given 1-based index for the active stream,
- *  combining subagents + processes in display order. Used by the `1`–`9`
- *  jump shortcuts. */
-export function descendantAt(index: number): StreamTabId | undefined {
-  if (index < 1) return undefined;
-  const activeId = cliState.activeStreamId.get();
-  if (!activeId) return undefined;
-  const slice = cliState.streams.get().get(activeId);
-  if (!slice) return undefined;
-  const ordered: StreamTabId[] = [];
-  for (const child of slice.activeSubagents) {
-    if (child.childStreamId) ordered.push(child.childStreamId);
-  }
-  for (const proc of slice.activeProcesses) {
-    if (proc.childStreamId) ordered.push(proc.childStreamId);
-  }
-  return ordered[index - 1];
 }

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -1,0 +1,71 @@
+// Ctrl-A / Ctrl-B focus cycle.
+//
+// Ctrl-A advances forward through the focused stream's active subagents and
+// processes (in the order they're listed in the SubagentList pane). When at
+// the end of the list, it wraps back to the parent — keeping the cycle
+// closed even when no descendants exist (a noop).
+//
+// Ctrl-B steps back to the parent if one is registered, otherwise stays put.
+//
+// We intentionally avoid `Ctrl-Shift-*` chords — many terminals collapse
+// shift over a letter to the unshifted Ctrl combo (see 10-architecture.md).
+
+import { type StreamTabId } from '@shared/schemas';
+
+import { cliState } from './cliState';
+
+/** Returns the next stream id the focus cycle should land on, or `undefined`
+ *  if the cycle would not move (e.g. no descendants and no parent). The
+ *  caller is responsible for assigning the result to
+ *  `cliState.activeStreamId`. */
+export function nextFocusForward(): StreamTabId | undefined {
+  const activeId = cliState.activeStreamId.get();
+  if (!activeId) return undefined;
+  const slice = cliState.streams.get().get(activeId);
+  // Missing slice means we landed on a child stream we haven't received any
+  // progress events for yet — treat it as a leaf so the cycle closes via
+  // the parent edge instead of stranding the focus.
+  const descendants: StreamTabId[] = [];
+  for (const child of slice?.activeSubagents ?? []) {
+    if (child.childStreamId) descendants.push(child.childStreamId);
+  }
+  for (const proc of slice?.activeProcesses ?? []) {
+    if (proc.childStreamId) descendants.push(proc.childStreamId);
+  }
+  if (descendants.length === 0) {
+    return cliState.parentStream.get().get(activeId);
+  }
+  // The active stream itself is the "start of the cycle"; advancing from it
+  // lands on the first descendant. If the active stream is already a
+  // descendant, advance through the list and wrap to the parent at the end.
+  const idx = descendants.indexOf(activeId);
+  if (idx === -1) return descendants[0];
+  if (idx + 1 < descendants.length) return descendants[idx + 1];
+  return cliState.parentStream.get().get(activeId) ?? descendants[0];
+}
+
+/** Step up to the parent stream, if one is registered. */
+export function nextFocusBack(): StreamTabId | undefined {
+  const activeId = cliState.activeStreamId.get();
+  if (!activeId) return undefined;
+  return cliState.parentStream.get().get(activeId);
+}
+
+/** Returns the descendant at the given 1-based index for the active stream,
+ *  combining subagents + processes in display order. Used by the `1`–`9`
+ *  jump shortcuts. */
+export function descendantAt(index: number): StreamTabId | undefined {
+  if (index < 1) return undefined;
+  const activeId = cliState.activeStreamId.get();
+  if (!activeId) return undefined;
+  const slice = cliState.streams.get().get(activeId);
+  if (!slice) return undefined;
+  const ordered: StreamTabId[] = [];
+  for (const child of slice.activeSubagents) {
+    if (child.childStreamId) ordered.push(child.childStreamId);
+  }
+  for (const proc of slice.activeProcesses) {
+    if (proc.childStreamId) ordered.push(proc.childStreamId);
+  }
+  return ordered[index - 1];
+}

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -14,6 +14,7 @@ import {
   patchStream,
   removeStream,
   setParentStream,
+  type ProcessOutputTail,
 } from './cliState';
 import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
@@ -81,10 +82,27 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateActiveProcesses': {
       const p = payload as ProgressEventPayloads['updateActiveProcesses'];
-      patchStream(p.parentStreamId, (s) => ({
-        ...s,
-        activeProcesses: p.processes,
-      }));
+      // Drop tails for executions that just left the active list — mirrors
+      // `pruneStaleOutputs` in the webview's streamMetaSlice so the map
+      // doesn't grow unboundedly for the lifetime of the parent stream.
+      const live = new Set(p.processes.map((c) => c.executionId));
+      patchStream(p.parentStreamId, (s) => {
+        let nextOutput = s.processOutput;
+        if (s.processOutput.size > 0) {
+          let mutated: Map<string, ProcessOutputTail> | undefined;
+          for (const id of s.processOutput.keys()) {
+            if (live.has(id)) continue;
+            if (!mutated) mutated = new Map(s.processOutput);
+            mutated.delete(id);
+          }
+          if (mutated) nextOutput = mutated;
+        }
+        return {
+          ...s,
+          activeProcesses: p.processes,
+          processOutput: nextOutput,
+        };
+      });
       return;
     }
     case 'updateProcessOutput': {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -21,16 +21,20 @@ type Emit = <K extends ProgressEvent>(
   payload: ProgressEventPayloads[K],
 ) => void;
 
-/** Cap on per-process tail bytes held in the signal map — beyond this we
- *  truncate at the head so the live pane never grows unbounded. Matches the
- *  PRD "Phase 4 doesn't buffer beyond a small per-line cap" guidance. */
-const PROCESS_TAIL_BYTES_MAX = 8 * 1024;
+/** Cap on per-process tail length held in the signal map (UTF-16 code
+ *  units, not bytes — markdown-it / ink work in JS strings). Beyond this we
+ *  truncate at the head so the live pane never grows unbounded. */
+const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
 
-function tailBytes(prev: string, next: string): string {
+function appendTail(prev: string, next: string): string {
   if (!next) return prev;
   const joined = `${prev}${next}`;
-  if (joined.length <= PROCESS_TAIL_BYTES_MAX) return joined;
-  return joined.slice(joined.length - PROCESS_TAIL_BYTES_MAX);
+  if (joined.length <= PROCESS_TAIL_CHARS_MAX) return joined;
+  let cut = joined.length - PROCESS_TAIL_CHARS_MAX;
+  // Don't slice in the middle of a surrogate pair.
+  const code = joined.charCodeAt(cut);
+  if (code >= 0xdc00 && code <= 0xdfff) cut += 1;
+  return joined.slice(cut);
 }
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
@@ -100,8 +104,8 @@ function applyToState<K extends ProgressEvent>(
           stderr: '',
         };
         const next = {
-          stdout: tailBytes(prev.stdout, p.stdout),
-          stderr: tailBytes(prev.stderr, p.stderr),
+          stdout: appendTail(prev.stdout, p.stdout),
+          stderr: appendTail(prev.stderr, p.stderr),
         };
         const map = new Map(s.processOutput);
         map.set(p.executionId, next);
@@ -122,18 +126,18 @@ function applyToState<K extends ProgressEvent>(
     case 'updateToolEditApprovalBypassState': {
       const p =
         payload as ProgressEventPayloads['updateToolEditApprovalBypassState'];
-      cliState.bypass.set({
-        ...cliState.bypass.get(),
-        toolEdit: p.bypassActive,
-      });
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        bypass: { ...s.bypass, toolEdit: p.bypassActive },
+      }));
       return;
     }
     case 'updateSuperYoloBypassState': {
       const p = payload as ProgressEventPayloads['updateSuperYoloBypassState'];
-      cliState.bypass.set({
-        ...cliState.bypass.get(),
-        superYolo: p.bypassActive,
-      });
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        bypass: { ...s.bypass, superYolo: p.bypassActive },
+      }));
       return;
     }
     case 'updateQueuedFollowUps': {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -2,11 +2,11 @@
 // still flowing through the original emitter. Approvals are intentionally
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { appendTail } from '@utils/strings/appendTail';
 
 import {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -1,19 +1,37 @@
 // Wrap a runtime host's `emit` so progress payloads patch `cliState` while
 // still flowing through the original emitter. Approvals are intentionally
-// not handled here — Phase 1 keeps them on the legacy adapter.
+// not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
 import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
-import { cliState, patchStream, removeStream } from './cliState';
+import {
+  cliState,
+  patchStream,
+  removeStream,
+  setParentStream,
+} from './cliState';
 import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
 type Emit = <K extends ProgressEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
 ) => void;
+
+/** Cap on per-process tail bytes held in the signal map — beyond this we
+ *  truncate at the head so the live pane never grows unbounded. Matches the
+ *  PRD "Phase 4 doesn't buffer beyond a small per-line cap" guidance. */
+const PROCESS_TAIL_BYTES_MAX = 8 * 1024;
+
+function tailBytes(prev: string, next: string): string {
+  if (!next) return prev;
+  const joined = `${prev}${next}`;
+  if (joined.length <= PROCESS_TAIL_BYTES_MAX) return joined;
+  return joined.slice(joined.length - PROCESS_TAIL_BYTES_MAX);
+}
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
@@ -35,6 +53,11 @@ function applyToState<K extends ProgressEvent>(
       cliState.activeStreamId.set(next ?? undefined);
       return;
     }
+    case 'setParentStream': {
+      const p = payload as ProgressEventPayloads['setParentStream'];
+      setParentStream(p.childStreamId, p.parentStreamId);
+      return;
+    }
     case 'removeStream':
       removeStream((payload as ProgressEventPayloads['removeStream']).streamId);
       return;
@@ -53,18 +76,77 @@ function applyToState<K extends ProgressEvent>(
       patchStream(p.streamId, (s) => ({ ...s, description: p.description }));
       return;
     }
+    case 'updateActiveSubagents': {
+      const p = payload as ProgressEventPayloads['updateActiveSubagents'];
+      patchStream(p.parentStreamId, (s) => ({
+        ...s,
+        activeSubagents: p.children,
+      }));
+      return;
+    }
+    case 'updateActiveProcesses': {
+      const p = payload as ProgressEventPayloads['updateActiveProcesses'];
+      patchStream(p.parentStreamId, (s) => ({
+        ...s,
+        activeProcesses: p.processes,
+      }));
+      return;
+    }
+    case 'updateProcessOutput': {
+      const p = payload as ProgressEventPayloads['updateProcessOutput'];
+      patchStream(p.parentStreamId, (s) => {
+        const prev = s.processOutput.get(p.executionId) ?? {
+          stdout: '',
+          stderr: '',
+        };
+        const next = {
+          stdout: tailBytes(prev.stdout, p.stdout),
+          stderr: tailBytes(prev.stderr, p.stderr),
+        };
+        const map = new Map(s.processOutput);
+        map.set(p.executionId, next);
+        return { ...s, processOutput: map };
+      });
+      return;
+    }
+    case 'updateTodos': {
+      const p = payload as ProgressEventPayloads['updateTodos'];
+      patchStream(p.streamId, (s) => ({ ...s, todos: p.todos }));
+      return;
+    }
+    case 'updatePlan': {
+      const p = payload as ProgressEventPayloads['updatePlan'];
+      patchStream(p.streamId, (s) => ({ ...s, plan: p.plan }));
+      return;
+    }
+    case 'updateToolEditApprovalBypassState': {
+      const p =
+        payload as ProgressEventPayloads['updateToolEditApprovalBypassState'];
+      cliState.bypass.set({
+        ...cliState.bypass.get(),
+        toolEdit: p.bypassActive,
+      });
+      return;
+    }
+    case 'updateSuperYoloBypassState': {
+      const p = payload as ProgressEventPayloads['updateSuperYoloBypassState'];
+      cliState.bypass.set({
+        ...cliState.bypass.get(),
+        superYolo: p.bypassActive,
+      });
+      return;
+    }
     case 'updateQueuedFollowUps': {
-      // `updateQueuedFollowUps` fires for both enqueue AND consume of the
-      // tool-use follow-up queue with no delta payload, so any local counter
-      // would drift one-way. Phase 1 leaves `queuedFollowUps` at its default
-      // (0); Phase 4 wires the StatusBar pill to the real queue length via
-      // `ToolUseFollowUpQueue.getAll(streamId).length` when the multi-agent
-      // surface lands.
+      // The event itself has no delta payload — re-read the queue directly so
+      // the StatusBar pill stays accurate after both enqueue and drain.
+      const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
+      const count = ToolUseFollowUpQueue.getAll(p.streamId).length;
+      patchStream(p.streamId, (s) =>
+        s.queuedFollowUps === count ? s : { ...s, queuedFollowUps: count },
+      );
       return;
     }
     default:
-      // Phase 1 only consumes the events the header/conversation/input row
-      // surfaces — later phases handle subagents/tools/approvals.
       return;
   }
 }

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -7,6 +7,7 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { appendTail } from '@utils/strings/appendTail';
 
 import {
   cliState,
@@ -22,20 +23,10 @@ type Emit = <K extends ProgressEvent>(
 ) => void;
 
 /** Cap on per-process tail length held in the signal map (UTF-16 code
- *  units, not bytes — markdown-it / ink work in JS strings). Beyond this we
- *  truncate at the head so the live pane never grows unbounded. */
-const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
-
-function appendTail(prev: string, next: string): string {
-  if (!next) return prev;
-  const joined = `${prev}${next}`;
-  if (joined.length <= PROCESS_TAIL_CHARS_MAX) return joined;
-  let cut = joined.length - PROCESS_TAIL_CHARS_MAX;
-  // Don't slice in the middle of a surrogate pair.
-  const code = joined.charCodeAt(cut);
-  if (code >= 0xdc00 && code <= 0xdfff) cut += 1;
-  return joined.slice(cut);
-}
+ *  units, not bytes — markdown-it / ink work in JS strings). Beyond this
+ *  we truncate at the head via the shared `appendTail` helper so the live
+ *  pane never grows unbounded. */
+export const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
@@ -104,8 +95,8 @@ function applyToState<K extends ProgressEvent>(
           stderr: '',
         };
         const next = {
-          stdout: appendTail(prev.stdout, p.stdout),
-          stderr: appendTail(prev.stderr, p.stderr),
+          stdout: appendTail(prev.stdout, p.stdout, PROCESS_TAIL_CHARS_MAX),
+          stderr: appendTail(prev.stderr, p.stderr, PROCESS_TAIL_CHARS_MAX),
         };
         const map = new Map(s.processOutput);
         map.set(p.executionId, next);

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -15,6 +15,8 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '../../../packages/cli/src/chat/tui/state/focusCycle';
+import { wrapRuntimeHost } from '../../../packages/cli/src/chat/tui/state/subscribeRuntimeHost';
+import type { CliRuntimeHost } from '../../../packages/cli/src/runtime/runtimeHost';
 
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;
@@ -53,6 +55,52 @@ describe('cliState Phase 4 fields', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     removeStream(root);
     expect(cliState.parentStream.get().has(child2)).toBe(false);
+  });
+});
+
+describe('subscribeRuntimeHost.updateActiveProcesses', () => {
+  function makeHost(): CliRuntimeHost {
+    return {
+      emit: () => {},
+      close: async () => {},
+    } as unknown as CliRuntimeHost;
+  }
+
+  it('prunes processOutput entries whose executionId left the active list', () => {
+    const wrapped = wrapRuntimeHost(makeHost());
+
+    // Seed: two live processes with tail output.
+    wrapped.emit('updateActiveProcesses', {
+      parentStreamId: root,
+      processes: [
+        { executionId: 'exec-a', agentName: 'bash' },
+        { executionId: 'exec-b', agentName: 'bash' },
+      ],
+    });
+    wrapped.emit('updateProcessOutput', {
+      parentStreamId: root,
+      executionId: 'exec-a',
+      stdout: 'A',
+      stderr: '',
+    });
+    wrapped.emit('updateProcessOutput', {
+      parentStreamId: root,
+      executionId: 'exec-b',
+      stdout: 'B',
+      stderr: '',
+    });
+    expect(cliState.streams.get().get(root)?.processOutput.size).toBe(2);
+
+    // exec-a finishes: its output buffer must be dropped on the next
+    // active-processes update.
+    wrapped.emit('updateActiveProcesses', {
+      parentStreamId: root,
+      processes: [{ executionId: 'exec-b', agentName: 'bash' }],
+    });
+    const out = cliState.streams.get().get(root)?.processOutput;
+    expect(out?.size).toBe(1);
+    expect(out?.has('exec-a')).toBe(false);
+    expect(out?.has('exec-b')).toBe(true);
   });
 });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2,6 +2,8 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { StreamTabId } from '@shared/schemas';
+
 import {
   cliState,
   patchStream,
@@ -13,7 +15,6 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '../../../packages/cli/src/chat/tui/state/focusCycle';
-import type { StreamTabId } from '@shared/schemas';
 
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1,16 +1,15 @@
-// Phase 4 state + focus-cycle smoke. We poke `cliState` directly and verify
-// the focus cycle helpers walk subagents/processes then return to the parent.
+// Phase 4 state + focus-cycle smoke.
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   cliState,
   patchStream,
+  removeStream,
   resetCliState,
   setParentStream,
 } from '../../../packages/cli/src/chat/tui/state/cliState';
 import {
-  descendantAt,
   nextFocusBack,
   nextFocusForward,
 } from '../../../packages/cli/src/chat/tui/state/focusCycle';
@@ -25,7 +24,7 @@ afterEach(() => {
 });
 
 describe('cliState Phase 4 fields', () => {
-  it('initialises every new slice with empty subagent/process/todo/plan defaults', () => {
+  it('initialises every new slice with empty subagent/process/todo/plan/bypass defaults', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     const slice = cliState.streams.get().get(root);
     expect(slice).toBeDefined();
@@ -34,20 +33,30 @@ describe('cliState Phase 4 fields', () => {
     expect(slice?.todos).toEqual([]);
     expect(slice?.plan).toBeNull();
     expect(slice?.processOutput.size).toBe(0);
+    expect(slice?.bypass).toEqual({ toolEdit: false, superYolo: false });
   });
 
-  it('tracks parent edges and drops them when a stream is removed', () => {
+  it('prunes parent edges when a stream is removed', () => {
     setParentStream(child1, root);
     setParentStream(child2, root);
     expect(cliState.parentStream.get().get(child1)).toBe(root);
     expect(cliState.parentStream.get().get(child2)).toBe(root);
-    patchStream(child1, (s) => s);
-    // removeStream is exercised indirectly via resetCliState in afterEach.
+
+    // Removing a child drops its own edge but leaves siblings intact.
+    patchStream(child1, (s) => ({ ...s, status: 'running' }));
+    removeStream(child1);
+    expect(cliState.parentStream.get().has(child1)).toBe(false);
+    expect(cliState.parentStream.get().get(child2)).toBe(root);
+
+    // Removing the parent prunes every edge that pointed at it.
+    patchStream(root, (s) => ({ ...s, status: 'running' }));
+    removeStream(root);
+    expect(cliState.parentStream.get().has(child2)).toBe(false);
   });
 });
 
 describe('focusCycle', () => {
-  it('advances Ctrl-A forward through descendants then wraps to parent', () => {
+  it('Ctrl-A cycles through siblings then wraps back to the parent', () => {
     cliState.activeStreamId.set(root);
     setParentStream(child1, root);
     setParentStream(child2, root);
@@ -60,12 +69,13 @@ describe('focusCycle', () => {
         { executionId: 'e2', agentName: 'b', childStreamId: child2 },
       ],
     }));
-    // From root → first descendant (subagent).
+    // root → first descendant.
     expect(nextFocusForward()).toBe(child1);
-    // child1 is a leaf in this fixture, so advancing from there returns to
-    // the parent (the cycle closes via the parent edge).
+    // child1 → next sibling resolved through the parent's descendant list.
     cliState.activeStreamId.set(child1);
-    patchStream(child1, (s) => s);
+    expect(nextFocusForward()).toBe(child2);
+    // child2 (last sibling) → wrap back to parent.
+    cliState.activeStreamId.set(child2);
     expect(nextFocusForward()).toBe(root);
   });
 
@@ -75,22 +85,5 @@ describe('focusCycle', () => {
     expect(nextFocusBack()).toBe(root);
     cliState.activeStreamId.set(root);
     expect(nextFocusBack()).toBeUndefined();
-  });
-
-  it('descendantAt resolves 1-based jump indices', () => {
-    cliState.activeStreamId.set(root);
-    patchStream(root, (s) => ({
-      ...s,
-      activeSubagents: [
-        { executionId: 'e1', agentName: 'a', childStreamId: child1 },
-      ],
-      activeProcesses: [
-        { executionId: 'e2', agentName: 'b', childStreamId: child2 },
-      ],
-    }));
-    expect(descendantAt(1)).toBe(child1);
-    expect(descendantAt(2)).toBe(child2);
-    expect(descendantAt(3)).toBeUndefined();
-    expect(descendantAt(0)).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1,0 +1,96 @@
+// Phase 4 state + focus-cycle smoke. We poke `cliState` directly and verify
+// the focus cycle helpers walk subagents/processes then return to the parent.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cliState,
+  patchStream,
+  resetCliState,
+  setParentStream,
+} from '../../../packages/cli/src/chat/tui/state/cliState';
+import {
+  descendantAt,
+  nextFocusBack,
+  nextFocusForward,
+} from '../../../packages/cli/src/chat/tui/state/focusCycle';
+import type { StreamTabId } from '@shared/schemas';
+
+const root = 'root' as StreamTabId;
+const child1 = 'child-1' as StreamTabId;
+const child2 = 'child-2' as StreamTabId;
+
+afterEach(() => {
+  resetCliState();
+});
+
+describe('cliState Phase 4 fields', () => {
+  it('initialises every new slice with empty subagent/process/todo/plan defaults', () => {
+    patchStream(root, (s) => ({ ...s, status: 'running' }));
+    const slice = cliState.streams.get().get(root);
+    expect(slice).toBeDefined();
+    expect(slice?.activeSubagents).toEqual([]);
+    expect(slice?.activeProcesses).toEqual([]);
+    expect(slice?.todos).toEqual([]);
+    expect(slice?.plan).toBeNull();
+    expect(slice?.processOutput.size).toBe(0);
+  });
+
+  it('tracks parent edges and drops them when a stream is removed', () => {
+    setParentStream(child1, root);
+    setParentStream(child2, root);
+    expect(cliState.parentStream.get().get(child1)).toBe(root);
+    expect(cliState.parentStream.get().get(child2)).toBe(root);
+    patchStream(child1, (s) => s);
+    // removeStream is exercised indirectly via resetCliState in afterEach.
+  });
+});
+
+describe('focusCycle', () => {
+  it('advances Ctrl-A forward through descendants then wraps to parent', () => {
+    cliState.activeStreamId.set(root);
+    setParentStream(child1, root);
+    setParentStream(child2, root);
+    patchStream(root, (s) => ({
+      ...s,
+      activeSubagents: [
+        { executionId: 'e1', agentName: 'a', childStreamId: child1 },
+      ],
+      activeProcesses: [
+        { executionId: 'e2', agentName: 'b', childStreamId: child2 },
+      ],
+    }));
+    // From root → first descendant (subagent).
+    expect(nextFocusForward()).toBe(child1);
+    // child1 is a leaf in this fixture, so advancing from there returns to
+    // the parent (the cycle closes via the parent edge).
+    cliState.activeStreamId.set(child1);
+    patchStream(child1, (s) => s);
+    expect(nextFocusForward()).toBe(root);
+  });
+
+  it('Ctrl-B returns to the parent and bottoms out at root', () => {
+    setParentStream(child1, root);
+    cliState.activeStreamId.set(child1);
+    expect(nextFocusBack()).toBe(root);
+    cliState.activeStreamId.set(root);
+    expect(nextFocusBack()).toBeUndefined();
+  });
+
+  it('descendantAt resolves 1-based jump indices', () => {
+    cliState.activeStreamId.set(root);
+    patchStream(root, (s) => ({
+      ...s,
+      activeSubagents: [
+        { executionId: 'e1', agentName: 'a', childStreamId: child1 },
+      ],
+      activeProcesses: [
+        { executionId: 'e2', agentName: 'b', childStreamId: child2 },
+      ],
+    }));
+    expect(descendantAt(1)).toBe(child1);
+    expect(descendantAt(2)).toBe(child2);
+    expect(descendantAt(3)).toBeUndefined();
+    expect(descendantAt(0)).toBeUndefined();
+  });
+});

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -17,15 +17,14 @@ describe('appendTail', () => {
   });
 
   it('does not split surrogate pairs at the truncation boundary', () => {
-    // "𐍈" (U+10348) is a 4-byte char = 2 UTF-16 code units (D800 DF48).
-    const prefix = 'X'.repeat(10);
-    const chunk = '𐍈Y';
-    // Total length = 10 + 2 + 1 = 13. maxChars = 4 ⇒ slice from index 9.
-    // Index 9 is the low surrogate — appendTail must advance to 10 so the
-    // pair stays intact (we lose the codepoint rather than yielding a lone
-    // low surrogate).
-    const out = appendTail(prefix, chunk, 4);
-    expect(out.length).toBeLessThanOrEqual(4);
-    expect(out.charCodeAt(0)).toBeLessThan(0xdc00);
+    // "𐍈" (U+10348) is encoded as two UTF-16 code units: high D800, low DF48.
+    // joined = "𐍈Y" (length 3); maxChars = 2 ⇒ cut at index 1, which is the
+    // *low* surrogate of the pair. Without the surrogate-aware fix the slice
+    // would yield a lone low surrogate ("\uDF48Y"); with the fix the cut
+    // advances past it and we drop the whole codepoint.
+    const out = appendTail('', '𐍈Y', 2);
+    expect(out).toBe('Y');
+    // Defense against accidental re-introduction of the dangling low surrogate.
+    expect(out.charCodeAt(0)).toBeLessThan(0xd800);
   });
 });

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { appendTail } from '../../utils/strings/appendTail';
+import { appendTail } from '@utils/strings/appendTail';
 
 describe('appendTail', () => {
   it('returns the current string when the chunk is empty', () => {

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendTail } from '../../utils/strings/appendTail';
+
+describe('appendTail', () => {
+  it('returns the current string when the chunk is empty', () => {
+    expect(appendTail('abc', '', 10)).toBe('abc');
+  });
+
+  it('concatenates when within budget', () => {
+    expect(appendTail('abc', 'def', 10)).toBe('abcdef');
+  });
+
+  it('truncates at the head when over budget', () => {
+    // joined = "0123456789abc" (13 chars), keep last 5 → "89abc".
+    expect(appendTail('0123456789', 'abc', 5)).toBe('89abc');
+  });
+
+  it('does not split surrogate pairs at the truncation boundary', () => {
+    // "𐍈" (U+10348) is a 4-byte char = 2 UTF-16 code units (D800 DF48).
+    const prefix = 'X'.repeat(10);
+    const chunk = '𐍈Y';
+    // Total length = 10 + 2 + 1 = 13. maxChars = 4 ⇒ slice from index 9.
+    // Index 9 is the low surrogate — appendTail must advance to 10 so the
+    // pair stays intact (we lose the codepoint rather than yielding a lone
+    // low surrogate).
+    const out = appendTail(prefix, chunk, 4);
+    expect(out.length).toBeLessThanOrEqual(4);
+    expect(out.charCodeAt(0)).toBeLessThan(0xdc00);
+  });
+});

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -34,6 +34,7 @@ import {
 import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { appendTail } from '@utils/strings/appendTail';
 import { executeCommand, signalProcessGroup } from '@utils/system/execUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -74,14 +75,6 @@ export type BashInput = z.infer<typeof BashInputSchema>;
 
 function usesShellLevelBackgrounding(command: string): boolean {
   return SHELL_BACKGROUNDING_PATTERN.test(command);
-}
-
-function appendTail(current: string, chunk: string, maxChars: number): string {
-  if (!chunk) return current;
-  const combined = current + chunk;
-  return combined.length > maxChars
-    ? combined.slice(combined.length - maxChars)
-    : combined;
 }
 
 class BashBackgroundSession implements IInterruptible {

--- a/src/utils/strings/appendTail.ts
+++ b/src/utils/strings/appendTail.ts
@@ -1,0 +1,19 @@
+// Append `chunk` to `current` and keep at most `maxChars` UTF-16 code units,
+// truncating at the head. Used by the bash background tail and the CLI TUI
+// process-output buffer; consolidated here to avoid drift.
+
+export function appendTail(
+  current: string,
+  chunk: string,
+  maxChars: number,
+): string {
+  if (!chunk) return current;
+  const combined = current + chunk;
+  if (combined.length <= maxChars) return combined;
+  let cut = combined.length - maxChars;
+  // Don't slice in the middle of a surrogate pair — the low half (DC00..DFFF)
+  // alone is a ?-rendering invalid code point.
+  const code = combined.charCodeAt(cut);
+  if (code >= 0xdc00 && code <= 0xdfff) cut += 1;
+  return combined.slice(cut);
+}


### PR DESCRIPTION
Phase 4 of `docs/prd/cli-tui-ink/`. Wires the multi-agent surface: subagent/process panels, todo + plan side panel, status-bar badges, and Ctrl-A/B focus traversal.

## Summary

**State (`cliState.ts`)**

- `StreamSlice` carries `activeSubagents`, `activeProcesses`, `todos`, `plan`, and a `processOutput` tail map (capped at 8 KB per execution to keep the live pane bounded).
- New top-level `parentStream` signal (child → parent edges) so the focus cycle never strands on a child without a way back, and a `bypass` signal feeding the StatusBar badges.

**Subscriptions (`subscribeRuntimeHost.ts`)**

- Routes `updateActiveSubagents` / `updateActiveProcesses` / `updateTodos` / `updatePlan` / `updateProcessOutput` / `setParentStream` into the new signals.
- Routes `updateToolEditApprovalBypassState` and `updateSuperYoloBypassState` into the bypass signal.
- `updateQueuedFollowUps` now reads the real length from `ToolUseFollowUpQueue.getAll(streamId)` instead of being a stub.

**UI**

- `<SubagentList>` — subagent + process rows with status colour and elapsed time.
- `<TodosPlanPanel>` — todo checklist (☐ pending / ☐ in-progress / ☑ completed) and numbered plan steps with the plan summary line.
- `<StatusBar>` — appends YOLO / BYPASS / queued badges.
- `App` layout splits into a `flexGrow` conversation column and a `minWidth=28` side column for the new panes.

**Focus cycle (`state/focusCycle.ts`)**

- `Ctrl-A` walks active descendants (subagents then processes), wraps to parent at the end or when the focused stream has no descendants.
- `Ctrl-B` steps back to the parent; bottoms out cleanly when no parent is recorded.
- Per the PRD note, readline-style start-of-line / back-one-char bindings inside the input bar land in Phase 5 alongside the explicit focus-mode toggle. `ink-text-input` ignores ctrl chords today, so the global handler doesn't collide.

**Out of scope**

- The PRD's "runtime patch for `detachActiveChildren`" sits outside this PR per the architecture doc.

## Test plan

- [x] `npm run typecheck` green (full workspace).
- [x] `npm run test:kernel -- src/test-kernel/cli/` — 30/30 pass including the 5 new vitests covering slice defaults, parent-edge tracking, forward/back walk, leaf wrap, and 1-based jump indexing.
- [ ] Manual: run `texra chat --tui`, spawn a subagent or process, verify the side panel populates and Ctrl-A/Ctrl-B navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands CLI TUI state/event handling (new per-stream fields, process output buffering/pruning, and focus navigation), which could cause UI/state regressions or memory growth if tails/pruning are incorrect.
> 
> **Overview**
> Adds Phase 4 multi-agent UI to the CLI Ink TUI: the main `App` now conditionally renders a right-side column with `SubagentList` (active subagents/processes + tailed stdout/stderr) and `TodosPlanPanel` (todos + plan summary/steps), and wires global `Ctrl-A`/`Ctrl-B` input to cycle focus between parent/child streams.
> 
> Extends `cliState` and `subscribeRuntimeHost` to track and update per-stream subagents, processes, todos, plan, per-process output tails (capped + pruned), parent-stream relationships for focus traversal, bypass flags surfaced as `YOLO`/`BYPASS` badges in `StatusBar`, and makes `queuedFollowUps` reflect the real `ToolUseFollowUpQueue` length.
> 
> Extracts a shared `appendTail` utility (surrogate-pair safe truncation) and updates `bash` background output tailing to use it, with new kernel tests covering state defaults, focus cycle behavior, output pruning, and `appendTail` truncation semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fd6cc6bf2a9630d97b578482730927ec35daad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->