### PR TITLE
feat(progress): show inquiry threads in background tasks

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -31,6 +31,7 @@ import { AGENT_CATEGORY } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
 import {
+  listThreadsByStatus,
   listOpenThreads,
   readExternalInquiryThread,
 } from '@tools/inquiry/externalInquiryStorage';
@@ -41,6 +42,8 @@ import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { ProgressViewState } from './state/ProgressViewState';
 
 import type { MainViewProvider } from '../MainViewProvider';
+
+const MAX_INQUIRY_THREAD_HYDRATION = 100;
 
 /**
  * Orchestrates the progress view webview with exclusive rendering:
@@ -384,8 +387,25 @@ export class ProgressViewProvider
     // extension reload — ApprovalRequestHandler.pending is in-memory and
     // empty at construction. Fire-and-forget: the replay below covers
     // anything already in-memory; this fills in the durable rows.
+    void this.syncInquiryThreads();
     void this.hydrateOpenInquiries();
     this.replayPendingPrompts();
+  }
+
+  private async syncInquiryThreads(): Promise<void> {
+    if (!this.webviewUpdater.isAvailable()) return;
+
+    try {
+      const threads = await listThreadsByStatus({
+        status: 'any',
+        scope: 'all',
+        limit: MAX_INQUIRY_THREAD_HYDRATION,
+      });
+      this.webviewUpdater.syncInquiryThreads(threads);
+    } catch {
+      // A damaged manifest should not prevent the progress view from
+      // showing streams or replaying pending request panels.
+    }
   }
 
   /**

--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -118,6 +118,11 @@ export class ProgressEventHandler {
             );
           }
         },
+        inquiryThreadUpdated: (_, thread) => {
+          if (this.webviewUpdater.isAvailable()) {
+            this.webviewUpdater.updateInquiryThread(thread);
+          }
+        },
         updateStreamDescription: (_, { streamId, description }) => {
           this.state.meta.setDescription(streamId, description);
           if (this.webviewUpdater.isAvailable()) {

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -25,14 +25,20 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
-import { STREAM_STATUS, type ActiveChildInfo } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type ActiveChildInfo,
+  type InquiryThreadUpdatedEvent,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { ProgressEvents } from '../events';
 
 // Local imports - contexts
 import {
   EMPTY_PROCESS_OUTPUTS,
+  EMPTY_INQUIRY_THREADS,
   EMPTY_STREAM_BY_ID,
+  inquiryThreadsContext,
   processOutputContext,
   streamByIdContext,
   type ProcessOutputMap,
@@ -97,6 +103,10 @@ export class BackgroundTasksPanel extends LitElement {
         color: var(--color-info);
       }
 
+      .task-icon--inquiry {
+        color: var(--wa-color-brand-fill-loud);
+      }
+
       .task-name {
         flex: 0 1 auto;
         max-width: min(14rem, 40%);
@@ -129,6 +139,13 @@ export class BackgroundTasksPanel extends LitElement {
 
       .task-elapsed {
         flex-shrink: 0;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+      }
+
+      .inquiry-id {
+        flex: 0 0 auto;
+        font-family: var(--wa-font-family-code);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
       }
@@ -218,12 +235,19 @@ export class BackgroundTasksPanel extends LitElement {
   @state()
   private streamById: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
+  @consume({ context: inquiryThreadsContext, subscribe: true })
+  @state()
+  private inquiries: InquiryThreadUpdatedEvent[] = EMPTY_INQUIRY_THREADS;
+
   /** Track previous active count to detect transitions. */
   private prevActiveCount = 0;
 
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
-    const active = this.activeProcesses.length + this.activeSubagents.length;
+    const active =
+      this.activeProcesses.length +
+      this.activeSubagents.length +
+      this.inquiries.filter((thread) => thread.status === 'open').length;
     // Auto-open when tasks appear (0 → N), auto-close when all finish (N → 0)
     if (this.prevActiveCount === 0 && active > 0) {
       this.open = true;
@@ -236,7 +260,7 @@ export class BackgroundTasksPanel extends LitElement {
   override render(): TemplateResult | typeof nothing {
     const active = this.activeProcesses.length + this.activeSubagents.length;
     const finished = this.finishedProcessCount + this.finishedSubagentCount;
-    if (active + finished === 0) return nothing;
+    if (active + finished + this.inquiries.length === 0) return nothing;
 
     return html`
       <wa-details
@@ -257,8 +281,80 @@ export class BackgroundTasksPanel extends LitElement {
             this.finishedSubagentCount,
             'subagent',
           )}
+          ${this.renderInquirySection()}
         </div>
       </wa-details>
+    `;
+  }
+
+  private renderInquirySection(): TemplateResult | typeof nothing {
+    if (this.inquiries.length === 0) return nothing;
+
+    const openCount = this.inquiries.filter((t) => t.status === 'open').length;
+    const answeredCount = this.inquiries.filter(
+      (t) => t.status === 'answered',
+    ).length;
+    const droppedCount = this.inquiries.filter(
+      (t) => t.status === 'dropped',
+    ).length;
+
+    return html`
+      <details open>
+        <summary class="section-label">
+          <wa-icon
+            library="texra"
+            name="chevron-right"
+            class="toggle-icon"
+            aria-hidden="true"
+          ></wa-icon>
+          <wa-icon library="texra" name="comments" aria-hidden="true"></wa-icon>
+          <span
+            >Inquiries${openCount
+              ? html` &middot; ${openCount} open`
+              : nothing}${answeredCount
+              ? html` &middot; ${answeredCount} answered`
+              : nothing}${droppedCount
+              ? html` &middot; ${droppedCount} dropped`
+              : nothing}</span
+          >
+        </summary>
+        <div class="section-content">
+          ${repeat(
+            this.inquiries,
+            (thread) => thread.threadId,
+            (thread) => this.renderInquiryItem(thread),
+          )}
+        </div>
+      </details>
+    `;
+  }
+
+  private renderInquiryItem(thread: InquiryThreadUpdatedEvent): TemplateResult {
+    const preview = thread.lastQuestionPreview || '(empty question)';
+    return html`
+      <div class="task-item">
+        <div class="task-header">
+          <wa-icon
+            library="texra"
+            name="circle-question"
+            aria-hidden="true"
+            class="task-icon task-icon--inquiry"
+          ></wa-icon>
+          <span class="inquiry-id" title=${thread.threadId}
+            >${thread.threadId}</span
+          >
+          <span class="task-description" title=${preview}>${preview}</span>
+          <span class="task-elapsed" title=${thread.lastActivityIso}
+            >${formatInquiryActivity(thread.lastActivityIso)}</span
+          >
+          <wa-tag
+            class="task-status"
+            variant=${inquiryStatusVariant(thread.status)}
+            size="small"
+            >${thread.status}</wa-tag
+          >
+        </div>
+      </div>
     `;
   }
 
@@ -439,6 +535,28 @@ function isWaiting(child: ActiveChildInfo): boolean {
     child.status === STREAM_STATUS.WAITING ||
     child.status === STREAM_STATUS.READY
   );
+}
+
+function inquiryStatusVariant(
+  status: InquiryThreadUpdatedEvent['status'],
+): 'warning' | 'success' | 'neutral' {
+  if (status === 'open') return 'warning';
+  if (status === 'answered') return 'success';
+  return 'neutral';
+}
+
+function formatInquiryActivity(iso: string): string {
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) return '';
+
+  const elapsedMs = Date.now() - time;
+  if (elapsedMs < 60_000) return 'now';
+  if (elapsedMs < 3_600_000) return `${Math.floor(elapsedMs / 60_000)}m`;
+  if (elapsedMs < 86_400_000) return `${Math.floor(elapsedMs / 3_600_000)}h`;
+  return new Date(time).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
 }
 
 declare global {

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -6,11 +6,13 @@ import { provide } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
 
 // Local imports - shared
+import type { InquiryThreadUpdatedEvent } from '@shared/schemas';
 import { SignalWatcher } from '@shared/signals';
 import { isProcessAgent } from '@shared/streams/agentKind';
 
 // Local imports - progress view
 import {
+  activeInquiries$,
   activeProcessOutputs$,
   logContext$,
   permissions$,
@@ -18,10 +20,12 @@ import {
   streamContext$,
 } from '../progressState';
 import {
+  EMPTY_INQUIRY_THREADS,
   EMPTY_LOG_CONTEXT,
   EMPTY_PROCESS_OUTPUTS,
   EMPTY_STREAM_BY_ID,
   EMPTY_STREAM_CONTEXT,
+  inquiryThreadsContext,
   permissionsContext,
   processOutputContext,
   streamByIdContext,
@@ -79,6 +83,11 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   @state()
   private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
+  @provide({ context: inquiryThreadsContext })
+  @state()
+  private inquiryThreadsContextValue: InquiryThreadUpdatedEvent[] =
+    EMPTY_INQUIRY_THREADS;
+
   /** Sync signal-computed values into @provide/@state context properties. */
   protected override willUpdate(): void {
     this.streamContextValue = streamContext$.get();
@@ -86,6 +95,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
     this.permissionsContextValue = permissions$.get();
     this.processOutputContextValue = activeProcessOutputs$.get();
     this.streamByIdContextValue = streamById$.get();
+    this.inquiryThreadsContextValue = activeInquiries$.get();
   }
 
   override render(): TemplateResult {

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -10,6 +10,7 @@ import { createContext } from '@lit/context';
 // Local imports - progress view
 import type {
   LogMessageData,
+  InquiryThreadUpdatedEvent,
   StreamStatus,
   StreamTabId,
   StreamTabInfo,
@@ -105,6 +106,12 @@ export const EMPTY_PROCESS_OUTPUTS: ProcessOutputMap = new Map();
 
 export const processOutputContext = createContext<ProcessOutputMap>(
   'progress-process-outputs',
+);
+
+export const EMPTY_INQUIRY_THREADS: InquiryThreadUpdatedEvent[] = [];
+
+export const inquiryThreadsContext = createContext<InquiryThreadUpdatedEvent[]>(
+  'progress-inquiry-threads',
 );
 
 /**

--- a/packages/extension/src/progressView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/progressView/frontend/messageDispatcher.ts
@@ -21,6 +21,7 @@ import { taskHandlers } from './slices/taskSlice';
 import { runTrackingHandlers } from './slices/runTrackingSlice';
 import { permissionHandlers } from './slices/permissionSlice';
 import { followUpHandlers } from './slices/followUpSlice';
+import { inquiryHandlers } from './slices/inquirySlice';
 import { syncHandlers } from './slices/syncSlice';
 import { uiHandlers } from './slices/uiSlice';
 
@@ -71,6 +72,7 @@ const handlers: HandlerRegistry = {
   ...runTrackingHandlers,
   ...permissionHandlers,
   ...followUpHandlers,
+  ...inquiryHandlers,
   ...syncHandlers,
   ...uiHandlers,
 };

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -19,6 +19,7 @@ import { Signal, signal, select, combine } from '@shared/signals';
 import {
   createStreamState,
   type ProgressViewPlacement,
+  type InquiryThreadUpdatedEvent,
   type StreamTabId,
   type StreamTabInfo,
   type TaskGroup,
@@ -50,6 +51,9 @@ import type { PermissionState } from './components/PermissionCard';
 
 /** Stable empty array for activeTaskGroups$ default (avoids new [] per read). */
 const EMPTY_TASK_GROUPS: TaskGroup[] = [];
+
+/** Stable empty array for activeInquiries$ default. */
+const EMPTY_INQUIRIES: InquiryThreadUpdatedEvent[] = [];
 
 /** Stable empty map returned when no parent has active children. */
 const EMPTY_CHILD_MAP: Map<StreamTabId, StreamTabInfo[]> = new Map();
@@ -84,6 +88,7 @@ export const streamStates$ = select(appState, (s) => s.streamStates);
 export const streamLogs$ = select(appState, (s) => s.streamLogs);
 export const activeStreamId$ = select(appState, (s) => s.activeStreamId);
 export const processOutputs$ = select(appState, (s) => s.processOutputs);
+export const inquiries$ = select(appState, (s) => s.inquiries);
 export const followupOptions$ = select(
   appState,
   (s) => s.followupOptionsByStream,
@@ -231,6 +236,18 @@ export const activeProcessOutputs$ = new Signal.Computed(
 export const activeTaskGroups$ = new Signal.Computed(
   () => activeStreamState$.get()?.taskGroups ?? EMPTY_TASK_GROUPS,
 );
+
+/** Inquiry threads whose latest parent stream is the active stream. */
+export const activeInquiries$ = new Signal.Computed(() => {
+  const activeStreamId = activeStreamId$.get();
+  if (!activeStreamId) return EMPTY_INQUIRIES;
+  const threads = [...inquiries$.get().values()]
+    .filter((thread) => thread.parentStreamId === activeStreamId)
+    .sort(
+      (a, b) => Date.parse(b.lastActivityIso) - Date.parse(a.lastActivityIso),
+    );
+  return threads.length > 0 ? threads : EMPTY_INQUIRIES;
+});
 
 export const activeIsToolUse$ = new Signal.Computed(() => {
   const state = activeStreamState$.get();

--- a/packages/extension/src/progressView/frontend/slices/inquirySlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/inquirySlice.ts
@@ -1,0 +1,29 @@
+import { create } from 'mutative';
+
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+import type { HandlerRegistry } from '../messageDispatcher';
+
+export const inquiryHandlers: HandlerRegistry = {
+  [PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS]: (data, ctx) => {
+    ctx.setState((prev) =>
+      create(prev, (draft) => {
+        draft.inquiries.clear();
+        for (const thread of data.threads) {
+          if (thread.parentStreamId == null) continue;
+          draft.inquiries.set(thread.threadId, thread);
+        }
+      }),
+    );
+  },
+
+  [PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD]: (data, ctx) => {
+    if (data.thread.parentStreamId == null) return;
+
+    ctx.setState((prev) =>
+      create(prev, (draft) => {
+        draft.inquiries.set(data.thread.threadId, data.thread);
+      }),
+    );
+  },
+};

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -10,6 +10,8 @@ import {
   type StreamTabInfo,
   type StreamTabId,
   type SetFollowupOptionsMessage,
+  type InquiryThreadUpdatedEvent,
+  type ExternalInquiryThreadId,
 } from '@shared/schemas';
 import type { ProcessOutputMap } from './contexts/streamContexts';
 
@@ -77,6 +79,8 @@ export interface ProgressState {
   processOutputs: Map<StreamTabId, ProcessOutputMap>;
   /** Workflow-result follow-up option data, keyed per stream. */
   followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
+  /** Durable external inquiry thread summaries, keyed by thread id. */
+  inquiries: Map<ExternalInquiryThreadId, InquiryThreadUpdatedEvent>;
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */
@@ -95,6 +99,7 @@ export function createInitialState(): ProgressState {
     streamLogs: new Map(),
     processOutputs: new Map(),
     followupOptionsByStream: new Map(),
+    inquiries: new Map(),
   };
 }
 

--- a/packages/extension/src/progressView/managers/WebviewUpdater.ts
+++ b/packages/extension/src/progressView/managers/WebviewUpdater.ts
@@ -14,6 +14,7 @@ import type {
   ContextStateData,
   OutputFileInfo,
   CompileFailure,
+  InquiryThreadUpdatedEvent,
   PermissionPayload,
   ProgressPermissionKind,
   ProgressViewPlacement,
@@ -314,6 +315,20 @@ export class WebviewUpdater {
       executionId,
       stdout,
       stderr,
+    });
+  }
+
+  syncInquiryThreads(threads: InquiryThreadUpdatedEvent[]): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS,
+      threads,
+    });
+  }
+
+  updateInquiryThread(thread: InquiryThreadUpdatedEvent): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD,
+      thread,
     });
   }
 

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -23,6 +23,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   UPDATE_STREAM_BADGES: 'updateStreamBadges',
   UPDATE_STREAM_DESCRIPTION: 'updateStreamDescription',
   UPDATE_PROCESS_OUTPUT: 'updateProcessOutput',
+  SYNC_INQUIRY_THREADS: 'syncInquiryThreads',
+  UPDATE_INQUIRY_THREAD: 'updateInquiryThread',
   UPDATE_PARENT_STREAM: 'updateParentStream',
   UPDATE_FILES: 'updateFiles',
   UPDATE_MISSING_OUTPUTS: 'updateMissingOutputs',

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -11,6 +11,7 @@ import {
   createDispatcher,
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
+import { OdysseyStatusSchema } from '@tools/odyssey/odysseyMeta';
 
 import { AgentCategorySchema } from './agent';
 import { StreamTabIdSchema } from './identifiers';
@@ -20,6 +21,7 @@ import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
+  InquiryThreadUpdatedEventSchema,
 } from './inquiry';
 import {
   AgentProposalSchema,
@@ -35,7 +37,6 @@ import {
   UserQuestionPermissionSchema,
 } from './prompts';
 import { StreamStatusSchema, StreamTabInfoSchema } from './stream';
-import { OdysseyStatusSchema } from '@tools/odyssey/odysseyMeta';
 import {
   ActiveChildInfoSchema,
   ConversationProgressSchema,
@@ -337,6 +338,16 @@ export const UpdateRecordingMessageSchema = z.object({
   error: z.string().optional(),
 });
 
+export const SyncInquiryThreadsMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS),
+  threads: z.array(InquiryThreadUpdatedEventSchema),
+});
+
+export const UpdateInquiryThreadMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD),
+  thread: InquiryThreadUpdatedEventSchema,
+});
+
 export const SyncStreamContentMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
   stream: z.union([StreamTabIdSchema, z.literal('')]),
@@ -427,6 +438,8 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     OdysseyActiveUpdatedMessageSchema,
     UpdateFollowUpTextMessageSchema,
     UpdateRecordingMessageSchema,
+    SyncInquiryThreadsMessageSchema,
+    UpdateInquiryThreadMessageSchema,
     SetPlacementMessageSchema,
     ProgressSetThemeMessageSchema,
     ProgressDeleteStreamMessageSchema,

--- a/src/test-kernel/progressView/InquiryPanelState.vitest.ts
+++ b/src/test-kernel/progressView/InquiryPanelState.vitest.ts
@@ -1,0 +1,156 @@
+// Third-party imports
+import { create } from 'mutative';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - common webview
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - progress view frontend
+import { inquiryHandlers } from '@progressView/frontend/slices/inquirySlice';
+import {
+  createInitialState,
+  type ProgressState,
+  type StreamLogs,
+} from '@progressView/frontend/store';
+import type { MessageHandlerContext } from '@progressView/frontend/messageDispatcher';
+
+// Local imports - shared schemas
+import type {
+  ExternalInquiryThreadId,
+  InquiryThreadUpdatedEvent,
+  ProgressViewOutboundMessage,
+  StreamTabId,
+} from '@shared/schemas';
+
+function createContext(initialState: ProgressState): {
+  ctx: MessageHandlerContext;
+  getState: () => ProgressState;
+} {
+  let state = initialState;
+  const ctx: MessageHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    },
+    setStreamState: (streamId, updater) => {
+      const current = state.streamStates.get(streamId);
+      if (!current) return;
+      const updated = updater(current);
+      if (updated === current) return;
+      state = create(state, (draft) => {
+        draft.streamStates.set(streamId, updated);
+      });
+    },
+    setStreamLogs: (
+      _streamId,
+      _updater: (prev: StreamLogs) => StreamLogs,
+    ) => {},
+    savePrefs: () => {},
+    getPermissions: () => [],
+    setPermissions: () => {},
+    setPlacement: () => {},
+  };
+  return { ctx, getState: () => state };
+}
+
+function thread(
+  threadId: string,
+  parentStreamId: string | null,
+  status: InquiryThreadUpdatedEvent['status'],
+): InquiryThreadUpdatedEvent {
+  return {
+    threadId: threadId as ExternalInquiryThreadId,
+    parentStreamId: parentStreamId as StreamTabId | null,
+    status,
+    lastQuestionPreview: `Question for ${threadId}`,
+    lastActivityIso: '2026-05-16T12:00:00.000Z',
+    turnCount: 1,
+  };
+}
+
+function dispatch(
+  message: ProgressViewOutboundMessage,
+  ctx: MessageHandlerContext,
+) {
+  const handler = inquiryHandlers[message.command];
+  expect(handler).toBeDefined();
+  handler?.(message as never, ctx);
+}
+
+describe('inquiry panel frontend state', () => {
+  it('hydrates durable inquiry summaries', () => {
+    const { ctx, getState } = createContext(createInitialState());
+
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS,
+        threads: [
+          thread('ei_aabbccdd0011', 'stream-a', 'open'),
+          thread('ei_aabbccdd0012', 'stream-a', 'answered'),
+        ],
+      },
+      ctx,
+    );
+
+    expect(getState().inquiries.size).toBe(2);
+    expect(getState().inquiries.get('ei_aabbccdd0011')).toMatchObject({
+      status: 'open',
+      parentStreamId: 'stream-a',
+    });
+  });
+
+  it('does not retain ownerless thread summaries in panel state', () => {
+    const { ctx, getState } = createContext(createInitialState());
+
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS,
+        threads: [
+          thread('ei_aabbccdd0011', null, 'answered'),
+          thread('ei_aabbccdd0012', 'stream-a', 'open'),
+        ],
+      },
+      ctx,
+    );
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD,
+        thread: thread('ei_aabbccdd0013', null, 'answered'),
+      },
+      ctx,
+    );
+
+    expect(getState().inquiries.has('ei_aabbccdd0011')).toBe(false);
+    expect(getState().inquiries.has('ei_aabbccdd0012')).toBe(true);
+    expect(getState().inquiries.has('ei_aabbccdd0013')).toBe(false);
+  });
+
+  it('replaces stale hydrated summaries and accepts incremental updates', () => {
+    const state = createInitialState();
+    state.inquiries.set(
+      'ei_stale000000' as ExternalInquiryThreadId,
+      thread('ei_stale000000', 'stream-a', 'open'),
+    );
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS,
+        threads: [thread('ei_aabbccdd0011', 'stream-a', 'open')],
+      },
+      ctx,
+    );
+    dispatch(
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD,
+        thread: thread('ei_aabbccdd0011', 'stream-a', 'answered'),
+      },
+      ctx,
+    );
+
+    expect(getState().inquiries.has('ei_stale000000')).toBe(false);
+    expect(getState().inquiries.get('ei_aabbccdd0011')?.status).toBe(
+      'answered',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4100.

This PR adds durable external inquiry thread summaries to the Progress view state and renders them in the Background Tasks panel for the stream that owns the thread. The panel now shows open, answered, and dropped inquiry threads after reload, alongside existing process and subagent background activity.

## Changes

- Adds typed progress-view messages for syncing all inquiry thread summaries and incrementally updating one thread.
- Hydrates persisted inquiry summaries from external inquiry storage when the progress webview becomes ready.
- Stores inquiry summaries in frontend progress state and filters them to the active stream.
- Adds an Inquiries section to the Background Tasks panel with status, last activity, and question preview.
- Covers frontend inquiry state hydration and incremental updates with a Vitest suite.

## Verification

- npx vitest run src/test-kernel/progressView/InquiryPanelState.vitest.ts src/test-kernel/progressView/ProcessOutputState.vitest.ts
- npm run format
- CI=true npm run typecheck
- npm run compile:fast
- npm run lint (passes with existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new progress-view message types and state hydration paths that run on webview ready/reload, which could affect rendering/perf or message ordering if manifests are large or malformed (though errors are swallowed).
> 
> **Overview**
> Adds durable external inquiry thread *summaries* to the Progress view so they can be displayed alongside processes/subagents in the **Background Tasks** panel.
> 
> On webview readiness, the extension now fetches and syncs up to `MAX_INQUIRY_THREAD_HYDRATION` inquiry threads from storage (`listThreadsByStatus`) and then incrementally pushes updates on `inquiryThreadUpdated` events via new outbound commands `syncInquiryThreads` / `updateInquiryThread`. The frontend stores these threads in progress state (`inquiries`), derives active-stream inquiries (`activeInquiries$`), provides them via a new Lit context, and renders an **Inquiries** section with status/counts, last-activity formatting, and question preview; includes Vitest coverage for hydration/update behavior and dropping ownerless threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814be0a633e8ab458e0978915a17b2445091ef5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->