### PR TITLE
feat(cli-tui): phase 5a — KeyHints + slash palette + input history

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -42,11 +42,8 @@ export function App(props: AppProps): React.JSX.Element {
       activeSlice.plan !== null
     : false;
 
-  // Ctrl-A / Ctrl-B focus cycle — runs at the App layer so the same chord
-  // lands no matter which pane the user just glanced at. The readline-style
-  // start-of-line / back-one-char binding of those chords inside the input
-  // bar lands in Phase 5 alongside the explicit focus-mode toggle; until
-  // then ink-text-input ignores ctrl chords anyway.
+  // Ctrl-A / Ctrl-B focus cycle runs at the App layer so the same chord
+  // lands no matter which pane currently has the user's attention.
   useInput((input, key) => {
     if (!key.ctrl) return;
     if (input === 'a') {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -14,10 +14,12 @@ import { currentApproval } from './state/approvalQueue';
 import { cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { useSignal } from './state/useSignal';
+import type { InputHistory } from './history/inputHistory';
 
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
   readonly inputDisabled?: boolean;
+  readonly history?: InputHistory;
 }
 
 export function App(props: AppProps): React.JSX.Element {
@@ -72,7 +74,11 @@ export function App(props: AppProps): React.JSX.Element {
       </Box>
       <StatusBar />
       <ApprovalModal pending={pending} />
-      <InputBar onSubmit={props.onSubmit} disabled={inputDisabled} />
+      <InputBar
+        onSubmit={props.onSubmit}
+        disabled={inputDisabled}
+        history={props.history}
+      />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -1,0 +1,85 @@
+// Slash command palette — pops up as the user types `/...` in the input bar.
+//
+// Phase 5 ships the inline-action shape only. Pick with arrow keys + Enter or
+// Tab to accept; Esc dismisses the palette without changing the input.
+
+import { Box, Text, useInput } from 'ink';
+import { useState, useEffect } from 'react';
+
+import { matchSlashCommands, type SlashCommand } from './slashRegistry';
+import { KeyHints } from '../ui/KeyHints';
+
+export interface SlashPaletteProps {
+  /** The current input value (excluding the leading `/`, after the slash). */
+  readonly query: string;
+  /** Accepted: caller should replace the input with the chosen command name. */
+  readonly onPick: (command: SlashCommand) => void;
+  readonly onCancel: () => void;
+}
+
+const MAX_VISIBLE = 8;
+
+export function SlashPalette(
+  props: SlashPaletteProps,
+): React.JSX.Element | null {
+  const matches = matchSlashCommands(props.query);
+  const [highlight, setHighlight] = useState(0);
+
+  // Whenever the match list resizes (user kept typing), clamp the cursor
+  // so it doesn't point past the end.
+  useEffect(() => {
+    if (highlight >= matches.length)
+      setHighlight(Math.max(0, matches.length - 1));
+  }, [matches.length, highlight]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      props.onCancel();
+      return;
+    }
+    if (key.upArrow) {
+      setHighlight((h) => (h <= 0 ? matches.length - 1 : h - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setHighlight((h) => (h + 1) % Math.max(matches.length, 1));
+      return;
+    }
+    if (key.return || key.tab || input === '\t') {
+      const chosen = matches[highlight];
+      if (chosen) props.onPick(chosen);
+    }
+  });
+
+  if (matches.length === 0) return null;
+  const visible = matches.slice(0, MAX_VISIBLE);
+  const truncated = matches.length - visible.length;
+
+  return (
+    <Box
+      borderStyle="single"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+    >
+      {visible.map((cmd, i) => (
+        <Box key={cmd.name}>
+          <Text color={i === highlight ? 'cyan' : undefined}>
+            {i === highlight ? '›' : ' '} /{cmd.name}
+          </Text>
+          <Text dimColor>{`  ${cmd.description}`}</Text>
+        </Box>
+      ))}
+      {truncated > 0 ? <Text dimColor>{`  … ${truncated} more`}</Text> : null}
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: 'Tab/Enter', action: 'accept' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -1,7 +1,4 @@
-// Slash command palette — pops up as the user types `/...` in the input bar.
-//
-// Phase 5 ships the inline-action shape only. Pick with arrow keys + Enter or
-// Tab to accept; Esc dismisses the palette without changing the input.
+// Slash command palette: pick with arrow keys + Enter or Tab; Esc dismisses it.
 
 import { Box, Text, useInput } from 'ink';
 import { useState, useEffect } from 'react';
@@ -24,35 +21,44 @@ export function SlashPalette(
 ): React.JSX.Element | null {
   const matches = matchSlashCommands(props.query);
   const [highlight, setHighlight] = useState(0);
+  const visible = matches.slice(0, MAX_VISIBLE);
+  const visibleCount = visible.length;
 
   // Whenever the match list resizes (user kept typing), clamp the cursor
   // so it doesn't point past the end.
   useEffect(() => {
-    if (highlight >= matches.length)
-      setHighlight(Math.max(0, matches.length - 1));
-  }, [matches.length, highlight]);
+    if (visibleCount === 0) {
+      if (highlight !== 0) setHighlight(0);
+      return;
+    }
+    if (highlight < 0 || highlight >= visibleCount) {
+      setHighlight(Math.min(Math.max(highlight, 0), visibleCount - 1));
+    }
+  }, [visibleCount, highlight]);
 
-  useInput((input, key) => {
-    if (key.escape) {
-      props.onCancel();
-      return;
-    }
-    if (key.upArrow) {
-      setHighlight((h) => (h <= 0 ? matches.length - 1 : h - 1));
-      return;
-    }
-    if (key.downArrow) {
-      setHighlight((h) => (h + 1) % Math.max(matches.length, 1));
-      return;
-    }
-    if (key.return || key.tab || input === '\t') {
-      const chosen = matches[highlight];
-      if (chosen) props.onPick(chosen);
-    }
-  });
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        props.onCancel();
+        return;
+      }
+      if (key.upArrow) {
+        setHighlight((h) => (h <= 0 ? visibleCount - 1 : h - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setHighlight((h) => (h + 1) % visibleCount);
+        return;
+      }
+      if (key.return || key.tab || input === '\t') {
+        const chosen = visible[highlight];
+        if (chosen) props.onPick(chosen);
+      }
+    },
+    { isActive: visibleCount > 0 },
+  );
 
-  if (matches.length === 0) return null;
-  const visible = matches.slice(0, MAX_VISIBLE);
+  if (visibleCount === 0) return null;
   const truncated = matches.length - visible.length;
 
   return (

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.ts
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.ts
@@ -1,0 +1,45 @@
+// Registers the slash commands the Phase 5 input palette surfaces. Each is
+// inline-only for now; structured-form variants (`/model`, `/status`,
+// `/agent`) land in the Phase 5 follow-up.
+//
+// Idempotent — `registerSlashCommand` overwrites by name.
+
+import { registerSlashCommand } from './slashRegistry';
+
+let installed = false;
+
+export function registerPhase5SlashCommands(): void {
+  if (installed) return;
+  installed = true;
+
+  registerSlashCommand({
+    name: 'help',
+    description: 'Show available slash commands',
+  });
+  registerSlashCommand({
+    name: 'clear',
+    description: 'Clear the screen (scrollback preserved)',
+  });
+  registerSlashCommand({
+    name: 'agent',
+    description: 'Switch the active agent — single-screen form in Phase 5b',
+  });
+  registerSlashCommand({
+    name: 'model',
+    description: 'Switch the active model — single-screen form in Phase 5b',
+  });
+  registerSlashCommand({
+    name: 'status',
+    description: 'Open the session status tabs — Phase 5b',
+  });
+  registerSlashCommand({
+    name: 'resume',
+    description: 'Resume a previous session — separate PRD',
+  });
+}
+
+/** Test seam — drops registered commands so vitests can re-register from
+ *  scratch without a hot-module reload. */
+export function _resetBuiltinSlashCommandsForTests(): void {
+  installed = false;
+}

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.ts
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.ts
@@ -1,6 +1,4 @@
-// Registers the slash commands the Phase 5 input palette surfaces. Each is
-// inline-only for now; structured-form variants (`/model`, `/status`,
-// `/agent`) land in the Phase 5 follow-up.
+// Registers the slash commands the input palette surfaces.
 //
 // Idempotent — `registerSlashCommand` overwrites by name.
 
@@ -8,7 +6,7 @@ import { registerSlashCommand } from './slashRegistry';
 
 let installed = false;
 
-export function registerPhase5SlashCommands(): void {
+export function registerBuiltinSlashCommands(): void {
   if (installed) return;
   installed = true;
 
@@ -22,24 +20,18 @@ export function registerPhase5SlashCommands(): void {
   });
   registerSlashCommand({
     name: 'agent',
-    description: 'Switch the active agent — single-screen form in Phase 5b',
+    description: 'Switch the active agent',
   });
   registerSlashCommand({
     name: 'model',
-    description: 'Switch the active model — single-screen form in Phase 5b',
+    description: 'Switch the active model',
   });
   registerSlashCommand({
     name: 'status',
-    description: 'Open the session status tabs — Phase 5b',
+    description: 'Open the session status tabs',
   });
   registerSlashCommand({
     name: 'resume',
     description: 'Resume a previous session — separate PRD',
   });
-}
-
-/** Test seam — drops registered commands so vitests can re-register from
- *  scratch without a hot-module reload. */
-export function _resetBuiltinSlashCommandsForTests(): void {
-  installed = false;
 }

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -1,0 +1,55 @@
+// In-tree slash command registry.
+//
+// Phase 5 ships an inline-action registry (just `name`, `description`,
+// `handler`); structured-form commands (`/model`, `/status`, `/agent`)
+// register via a `formComponent` field that lands in a follow-up PR per the
+// PRD's Phase-5 split note.
+
+export interface SlashCommand {
+  /** Command name without the leading `/`. */
+  readonly name: string;
+  readonly description: string;
+  /** Optional alias list for autocomplete (matches both `name` and aliases). */
+  readonly aliases?: readonly string[];
+  /**
+   * Fire-and-forget handler. Receives the raw remainder of the command line
+   * (everything after the command name + whitespace).
+   */
+  readonly handler?: (remainder: string) => void;
+}
+
+const COMMANDS = new Map<string, SlashCommand>();
+
+export function registerSlashCommand(command: SlashCommand): void {
+  COMMANDS.set(command.name, command);
+}
+
+export function unregisterSlashCommand(name: string): void {
+  COMMANDS.delete(name);
+}
+
+export function listSlashCommands(): readonly SlashCommand[] {
+  return [...COMMANDS.values()];
+}
+
+/** Returns the registered commands whose name or any alias starts with the
+ *  given prefix (case-insensitive). Ordered by registration. */
+export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
+  const lower = prefix.toLowerCase();
+  return listSlashCommands().filter((cmd) => {
+    if (cmd.name.toLowerCase().startsWith(lower)) return true;
+    return cmd.aliases?.some((a) => a.toLowerCase().startsWith(lower)) ?? false;
+  });
+}
+
+/** Parse a `"/cmd remainder"` input into `{ name, remainder }`. Returns
+ *  `undefined` if `text` doesn't begin with `/`. */
+export function parseSlashInput(
+  text: string,
+): { name: string; remainder: string } | undefined {
+  if (!text.startsWith('/')) return undefined;
+  const body = text.slice(1);
+  const ws = body.search(/\s/);
+  if (ws === -1) return { name: body, remainder: '' };
+  return { name: body.slice(0, ws), remainder: body.slice(ws + 1) };
+}

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -1,9 +1,4 @@
 // In-tree slash command registry.
-//
-// Phase 5 ships an inline-action registry (just `name`, `description`,
-// `handler`); structured-form commands (`/model`, `/status`, `/agent`)
-// register via a `formComponent` field that lands in a follow-up PR per the
-// PRD's Phase-5 split note.
 
 export interface SlashCommand {
   /** Command name without the leading `/`. */
@@ -32,8 +27,10 @@ export function listSlashCommands(): readonly SlashCommand[] {
   return [...COMMANDS.values()];
 }
 
-/** Returns the registered commands whose name or any alias starts with the
- *  given prefix (case-insensitive). Ordered by registration. */
+/**
+ * Returns registered commands whose name or an alias starts with `prefix`.
+ * Results are case-insensitive and preserve registration order.
+ */
 export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
   const lower = prefix.toLowerCase();
   return listSlashCommands().filter((cmd) => {
@@ -42,8 +39,10 @@ export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
   });
 }
 
-/** Parse a `"/cmd remainder"` input into `{ name, remainder }`. Returns
- *  `undefined` if `text` doesn't begin with `/`. */
+/**
+ * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
+ * Returns `undefined` if `text` does not begin with `/`.
+ */
 export function parseSlashInput(
   text: string,
 ): { name: string; remainder: string } | undefined {

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -1,0 +1,105 @@
+// Per-user input history persisted as JSONL under the global storage path.
+//
+// File format: one `{"t": <ms>, "v": "<line>"}` record per line. We avoid a
+// single-JSON-blob format so partial writes never corrupt the history; the
+// session reader skips malformed lines silently.
+
+// Local imports - filesystem
+import { GlobalStorageFS } from '@utils/files/storageFS';
+
+const HISTORY_DIR = 'tui';
+const HISTORY_PATH = `${HISTORY_DIR}/input-history.jsonl`;
+const MAX_LINES = 1000;
+const MAX_LINE_CHARS = 4000;
+
+interface HistoryRecord {
+  readonly t: number;
+  readonly v: string;
+}
+
+export interface InputHistory {
+  /** All distinct entries, most-recent last. */
+  all(): readonly string[];
+  /** Append a new entry. Duplicates of the most-recent entry are skipped. */
+  push(line: string): Promise<void>;
+  /** Reverse-incremental search: returns the most recent entry containing
+   *  `needle`, or undefined. */
+  reverseFind(
+    needle: string,
+    from?: number,
+  ): { value: string; index: number } | undefined;
+}
+
+function parseRecord(raw: string): HistoryRecord | undefined {
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (
+      typeof obj === 'object' &&
+      obj !== null &&
+      typeof (obj as { v?: unknown }).v === 'string'
+    ) {
+      const v = (obj as { v: string }).v;
+      const t = (obj as { t?: unknown }).t;
+      return { t: typeof t === 'number' ? t : 0, v };
+    }
+  } catch {
+    // ignore malformed line
+  }
+  return undefined;
+}
+
+function serializeRecords(entries: readonly string[]): string {
+  const now = Date.now();
+  return entries.map((v) => JSON.stringify({ t: now, v })).join('\n') + '\n';
+}
+
+export async function loadInputHistory(): Promise<InputHistory> {
+  let entries: string[] = [];
+  if (await GlobalStorageFS.exists(HISTORY_PATH)) {
+    const raw = await GlobalStorageFS.read(HISTORY_PATH);
+    for (const line of raw.split('\n')) {
+      const rec = parseRecord(line);
+      if (rec && rec.v.length > 0) entries.push(rec.v);
+    }
+  }
+  // Cap on load; older entries fall off when the ring is full.
+  if (entries.length > MAX_LINES) entries = entries.slice(-MAX_LINES);
+
+  return {
+    all() {
+      return entries;
+    },
+    async push(line: string) {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      const stored =
+        trimmed.length > MAX_LINE_CHARS
+          ? trimmed.slice(0, MAX_LINE_CHARS)
+          : trimmed;
+      if (entries.at(-1) === stored) return;
+      entries.push(stored);
+      await GlobalStorageFS.ensureDir(HISTORY_DIR);
+      if (entries.length > MAX_LINES) {
+        entries.splice(0, entries.length - MAX_LINES);
+        await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(entries));
+        return;
+      }
+      const record: HistoryRecord = { t: Date.now(), v: stored };
+      await GlobalStorageFS.appendFile(
+        HISTORY_PATH,
+        `${JSON.stringify(record)}\n`,
+      );
+    },
+    reverseFind(needle, from) {
+      if (!needle) return undefined;
+      const start = from === undefined ? entries.length - 1 : from - 1;
+      for (let i = start; i >= 0; i--) {
+        const value = entries[i];
+        if (value !== undefined && value.includes(needle)) {
+          return { value, index: i };
+        }
+      }
+      return undefined;
+    },
+  };
+}

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -1,7 +1,6 @@
 // Text input wrapping `ink-text-input`.
 //
-// Ctrl-J inserts a newline. Bracketed-paste detection lands fresh in
-// Phase 5 alongside the palette / @-mention overlays that consume it.
+// Ctrl-J inserts a newline.
 
 import { useInput } from 'ink';
 import TextInput from 'ink-text-input';

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -1,0 +1,79 @@
+// Ctrl-R reverse-incremental search popup.
+//
+// Mounts over the input bar (rendered above it). Each keystroke narrows the
+// most-recent match from the in-memory ring; Up cycles to the next older
+// match, Enter commits the selected line back into the input, Esc cancels.
+
+import { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+
+import type { InputHistory } from '../history/inputHistory';
+import { KeyHints } from '../ui/KeyHints';
+
+export interface ReverseSearchProps {
+  readonly history: InputHistory;
+  /** Commit the selected line — caller writes it into the input. */
+  readonly onCommit: (line: string) => void;
+  /** User hit Esc / Ctrl-G — close without committing. */
+  readonly onCancel: () => void;
+}
+
+export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+
+  const match = props.history.reverseFind(query, cursor);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      props.onCancel();
+      return;
+    }
+    if (key.upArrow || (key.ctrl && input === 'r')) {
+      // Step to the next older match.
+      if (!match) return;
+      const next = props.history.reverseFind(query, match.index);
+      if (next) setCursor(next.index + 1);
+      return;
+    }
+    if (key.downArrow) {
+      // Reset — start from the most-recent match again.
+      setCursor(undefined);
+    }
+  });
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="magenta"
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Box>
+        <Text color="magenta">(reverse-i-search)`</Text>
+        <TextInput
+          value={query}
+          onChange={(value) => {
+            setQuery(value);
+            setCursor(undefined);
+          }}
+          onSubmit={() => {
+            if (match) props.onCommit(match.value);
+            else props.onCancel();
+          }}
+        />
+        <Text color="magenta">`: </Text>
+        <Text>{match?.value ?? ''}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'Ctrl-R / ↑', action: 'older match' },
+            { key: '↓', action: 'reset' },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -30,7 +30,7 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
       props.onCancel();
       return;
     }
-    if (key.upArrow || (key.ctrl && input === 'r')) {
+    if (key.upArrow || (key.ctrl && input.toLowerCase() === 'r')) {
       // Step to the next older match.
       if (!match) return;
       const next = props.history.reverseFind(query, match.index);

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -4,6 +4,7 @@ import { ConfirmInput } from '@inkjs/ui';
 import type { AgentProposalPermission } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface AgentProposalProps {
   readonly payload: AgentProposalPermission;
@@ -25,10 +26,18 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
         <Text>{props.payload.instruction}</Text>
       </Box>
       <Box>
-        <Text dimColor>y approve · n reject · </Text>
         <ConfirmInput
           onConfirm={() => props.onDecide({ accepted: true })}
           onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: 'approve' },
+            { key: 'n', action: 'reject' },
+          ]}
+          confirmCancel={false}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -4,6 +4,7 @@ import { ConfirmInput } from '@inkjs/ui';
 import type { BashPermission } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface BashApprovalProps {
   readonly payload: BashPermission;
@@ -25,10 +26,18 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
         <Text>$ {props.payload.command}</Text>
       </Box>
       <Box>
-        <Text dimColor>y approve · n reject · </Text>
         <ConfirmInput
           onConfirm={() => props.onDecide({ accepted: true })}
           onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: 'approve' },
+            { key: 'n', action: 'reject' },
+          ]}
+          confirmCancel={false}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -6,6 +6,7 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import { buildHunks, DiffView, statsFromHunks } from '../render/DiffView';
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface EditApprovalProps {
   readonly request: ToolEditApprovalRequest;
@@ -47,10 +48,18 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
         <DiffView hunks={hunks} maxHunkLines={30} />
       </Box>
       <Box>
-        <Text dimColor>y approve · n reject · </Text>
         <ConfirmInput
           onConfirm={() => props.onDecide({ accepted: true })}
           onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: 'approve' },
+            { key: 'n', action: 'reject' },
+          ]}
+          confirmCancel={false}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -5,6 +5,7 @@ import TextInput from 'ink-text-input';
 import type { ExternalInquiryPermission } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface ExternalInquiryProps {
   readonly payload: ExternalInquiryPermission;
@@ -61,7 +62,16 @@ export function ExternalInquiry(
           }}
         />
       </Box>
-      <Text dimColor>Enter answer · Ctrl-R reject with note · Esc skip</Text>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'Enter', action: 'submit answer' },
+            { key: 'Ctrl-R', action: 'reject with note' },
+            { key: 'Esc', action: 'skip' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -4,6 +4,7 @@ import { ConfirmInput } from '@inkjs/ui';
 import type { PlanApprovalPermission } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface PlanApprovalProps {
   readonly payload: PlanApprovalPermission;
@@ -39,10 +40,18 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
         ))}
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>y approve · n reject · </Text>
         <ConfirmInput
           onConfirm={() => props.onDecide({ accepted: true })}
           onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: 'approve' },
+            { key: 'n', action: 'reject' },
+          ]}
+          confirmCancel={false}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -4,6 +4,7 @@ import { ConfirmInput } from '@inkjs/ui';
 import type { RetryPermission } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface RetryRequestProps {
   readonly payload: RetryPermission;
@@ -27,10 +28,18 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
         <Text dimColor>{subject}</Text>
       </Box>
       <Box>
-        <Text dimColor>y retry · n give up · </Text>
         <ConfirmInput
           onConfirm={() => props.onDecide({ accepted: true })}
           onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: 'retry' },
+            { key: 'n', action: 'give up' },
+          ]}
+          confirmCancel={false}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -4,7 +4,7 @@ import { Box, Text, useInput } from 'ink';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { SlashPalette } from '../commands/SlashPalette';
-import { parseSlashInput } from '../commands/slashRegistry';
+import { matchSlashCommands, parseSlashInput } from '../commands/slashRegistry';
 import type { InputHistory } from '../history/inputHistory';
 
 export interface InputBarProps {
@@ -19,15 +19,16 @@ export interface InputBarProps {
 }
 
 export function InputBar(props: InputBarProps): React.JSX.Element {
+  const { disabled, history, onSubmit, prompt } = props;
   const [value, setValue] = useState('');
   const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
-  const historyRef = useRef(props.history);
-  historyRef.current = props.history;
+  const historyRef = useRef(history);
+  historyRef.current = history;
 
   // Listen for Ctrl-R *outside* the text input — Ink emits the keystroke
   // to every `useInput` consumer, but ink-text-input ignores ctrl chords.
   useInput((input, key) => {
-    if (props.disabled) return;
+    if (disabled) return;
     if (key.ctrl && input.toLowerCase() === 'r' && historyRef.current) {
       setReverseSearchOpen(true);
     }
@@ -39,22 +40,30 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       if (trimmed.length === 0) return;
       setValue('');
       void historyRef.current?.push(trimmed);
-      props.onSubmit(trimmed);
+      onSubmit(trimmed);
     },
-    [props],
+    [onSubmit],
   );
 
   // Slash palette pops up while typing /…
   const parsed = parseSlashInput(value);
+  const isTypingSlashCommandName =
+    parsed !== undefined && !/\s/.test(value.slice(1));
+  const hasPaletteMatches =
+    parsed !== undefined && matchSlashCommands(parsed.name).length > 0;
   const showPalette =
-    parsed !== undefined && !reverseSearchOpen && !props.disabled;
+    parsed !== undefined &&
+    isTypingSlashCommandName &&
+    hasPaletteMatches &&
+    !reverseSearchOpen &&
+    !disabled;
 
   useEffect(() => {
     // Auto-close the reverse-search overlay when the input is disabled —
     // an approval modal taking focus shouldn't trap the user in the
     // search prompt.
-    if (props.disabled && reverseSearchOpen) setReverseSearchOpen(false);
-  }, [props.disabled, reverseSearchOpen]);
+    if (disabled && reverseSearchOpen) setReverseSearchOpen(false);
+  }, [disabled, reverseSearchOpen]);
 
   return (
     <Box flexDirection="column">
@@ -63,7 +72,9 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           query={parsed.name}
           onPick={(cmd) =>
             setValue(
-              `/${cmd.name}${parsed.remainder ? ` ${parsed.remainder}` : ' '}`,
+              `/${cmd.name}${
+                parsed.remainder ? ` ${parsed.remainder.trimStart()}` : ' '
+              }`,
             )
           }
           onCancel={() => {
@@ -83,12 +94,12 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         />
       ) : null}
       <Box borderStyle="round" paddingX={1}>
-        <Text>{props.prompt ?? '>'} </Text>
+        <Text>{prompt ?? '>'} </Text>
         <BaseTextInput
           value={value}
-          focus={!props.disabled && !reverseSearchOpen}
+          focus={!disabled && !reverseSearchOpen}
           onChange={setValue}
-          onSubmit={handleSubmit}
+          onSubmit={showPalette ? () => undefined : handleSubmit}
         />
       </Box>
     </Box>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useState } from 'react';
-import { Box, Text } from 'ink';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
 
 import { BaseTextInput } from '../input/BaseTextInput';
+import { ReverseSearch } from '../input/ReverseSearch';
+import { SlashPalette } from '../commands/SlashPalette';
+import { parseSlashInput } from '../commands/slashRegistry';
+import type { InputHistory } from '../history/inputHistory';
 
 export interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter. */
@@ -10,30 +14,83 @@ export interface InputBarProps {
   readonly disabled?: boolean;
   /** Prompt prefix (e.g. `>`). */
   readonly prompt?: string;
+  /** Persistent input history (optional — undefined disables Ctrl-R). */
+  readonly history?: InputHistory;
 }
 
 export function InputBar(props: InputBarProps): React.JSX.Element {
   const [value, setValue] = useState('');
+  const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
+  const historyRef = useRef(props.history);
+  historyRef.current = props.history;
+
+  // Listen for Ctrl-R *outside* the text input — Ink emits the keystroke
+  // to every `useInput` consumer, but ink-text-input ignores ctrl chords.
+  useInput((input, key) => {
+    if (props.disabled) return;
+    if (key.ctrl && input.toLowerCase() === 'r' && historyRef.current) {
+      setReverseSearchOpen(true);
+    }
+  });
 
   const handleSubmit = useCallback(
     (submitted: string) => {
       const trimmed = submitted.trim();
       if (trimmed.length === 0) return;
       setValue('');
+      void historyRef.current?.push(trimmed);
       props.onSubmit(trimmed);
     },
     [props],
   );
 
+  // Slash palette pops up while typing /…
+  const parsed = parseSlashInput(value);
+  const showPalette =
+    parsed !== undefined && !reverseSearchOpen && !props.disabled;
+
+  useEffect(() => {
+    // Auto-close the reverse-search overlay when the input is disabled —
+    // an approval modal taking focus shouldn't trap the user in the
+    // search prompt.
+    if (props.disabled && reverseSearchOpen) setReverseSearchOpen(false);
+  }, [props.disabled, reverseSearchOpen]);
+
   return (
-    <Box borderStyle="round" paddingX={1}>
-      <Text>{props.prompt ?? '>'} </Text>
-      <BaseTextInput
-        value={value}
-        focus={!props.disabled}
-        onChange={setValue}
-        onSubmit={handleSubmit}
-      />
+    <Box flexDirection="column">
+      {showPalette ? (
+        <SlashPalette
+          query={parsed.name}
+          onPick={(cmd) =>
+            setValue(
+              `/${cmd.name}${parsed.remainder ? ` ${parsed.remainder}` : ' '}`,
+            )
+          }
+          onCancel={() => {
+            /* Esc clears the slash — caller can re-open by typing again. */
+            setValue('');
+          }}
+        />
+      ) : null}
+      {reverseSearchOpen && historyRef.current ? (
+        <ReverseSearch
+          history={historyRef.current}
+          onCommit={(line) => {
+            setValue(line);
+            setReverseSearchOpen(false);
+          }}
+          onCancel={() => setReverseSearchOpen(false)}
+        />
+      ) : null}
+      <Box borderStyle="round" paddingX={1}>
+        <Text>{props.prompt ?? '>'} </Text>
+        <BaseTextInput
+          value={value}
+          focus={!props.disabled && !reverseSearchOpen}
+          onChange={setValue}
+          onSubmit={handleSubmit}
+        />
+      </Box>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -2,8 +2,7 @@
 // tails the live stdout/stderr per process so the user can see what each
 // shell call is doing.
 //
-// The leading numeric index is currently a visual cue only — the `1`–`9`
-// jump shortcuts land in Phase 5 alongside the input-focus toggle.
+// The leading numeric index is currently a visual cue only.
 
 import { Box, Text } from 'ink';
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -29,6 +29,8 @@ import { createCliRuntimeHost } from '../../runtime/runtimeHost';
 import { writeTextStderr } from '../../runtime/logSinks';
 import { type ChatResult, type RunChatInit } from '../runChat';
 import { App } from './App';
+import { registerPhase5SlashCommands } from './commands/registerBuiltins';
+import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
@@ -88,6 +90,10 @@ export async function runChatTui(
   // through the original resolvers (see state/subscribeApprovals.ts).
   // The legacy adapter only stays on the `!--tui` path now.
   await loadAgents();
+
+  const inputHistory = await loadInputHistory();
+  // Pre-register the slash commands the input palette uses.
+  registerPhase5SlashCommands();
 
   // DA1 sentinel discovery runs *before* Ink mounts so it owns the raw-mode
   // toggle exclusively — interleaving with Ink's own raw-mode lifecycle (set
@@ -191,7 +197,7 @@ export async function runChatTui(
     });
   };
 
-  const ink = render(<App onSubmit={handleSubmit} />, {
+  const ink = render(<App onSubmit={handleSubmit} history={inputHistory} />, {
     stdout: process.stdout,
     stderr: process.stderr,
     stdin: process.stdin,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -29,7 +29,7 @@ import { createCliRuntimeHost } from '../../runtime/runtimeHost';
 import { writeTextStderr } from '../../runtime/logSinks';
 import { type ChatResult, type RunChatInit } from '../runChat';
 import { App } from './App';
-import { registerPhase5SlashCommands } from './commands/registerBuiltins';
+import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
 import { clearApprovals } from './state/approvalQueue';
@@ -93,7 +93,7 @@ export async function runChatTui(
 
   const inputHistory = await loadInputHistory();
   // Pre-register the slash commands the input palette uses.
-  registerPhase5SlashCommands();
+  registerBuiltinSlashCommands();
 
   // DA1 sentinel discovery runs *before* Ink mounts so it owns the raw-mode
   // toggle exclusively — interleaving with Ink's own raw-mode lifecycle (set

--- a/packages/cli/src/chat/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/chat/tui/ui/KeyHints.tsx
@@ -1,0 +1,54 @@
+// Shared footer-strip for every modal / form / palette / approval card.
+//
+// Per docs/prd/cli-tui-ink/10-architecture.md § Intuitiveness conventions:
+// each row carries scope-specific keys first, navigation in the middle, and
+// `Enter confirm · Esc cancel` last. Ad-hoc footer text is a review-blocker.
+
+import { Box, Text } from 'ink';
+
+export interface KeyHint {
+  /** Key glyph (e.g. `Enter`, `Ctrl-R`, `↑/↓`). */
+  readonly key: string;
+  /** What the key does (e.g. `confirm`, `cancel`, `cycle`). */
+  readonly action: string;
+}
+
+export interface KeyHintsProps {
+  /** Scope-specific keys (rendered first). */
+  readonly hints: readonly KeyHint[];
+  /** Append the canonical `Enter confirm · Esc cancel` pair when true.
+   *  Modals override to `false` when their primary affordance is different
+   *  (e.g. a `y / n` prompt). */
+  readonly confirmCancel?: boolean;
+}
+
+const SEP = ' · ';
+
+function Hint({ hint }: { hint: KeyHint }): React.JSX.Element {
+  return (
+    <Text dimColor>
+      <Text bold>{hint.key}</Text> {hint.action}
+    </Text>
+  );
+}
+
+export function KeyHints(props: KeyHintsProps): React.JSX.Element {
+  const tail: KeyHint[] =
+    props.confirmCancel === false
+      ? []
+      : [
+          { key: 'Enter', action: 'confirm' },
+          { key: 'Esc', action: 'cancel' },
+        ];
+  const all = [...props.hints, ...tail];
+  return (
+    <Box>
+      {all.map((hint, i) => (
+        <Text key={i}>
+          {i > 0 ? <Text dimColor>{SEP}</Text> : null}
+          <Hint hint={hint} />
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -1,4 +1,4 @@
-// Phase 5 slash command registry + parse helpers.
+// Slash command registry and parse helpers.
 
 import { afterEach, describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -1,0 +1,61 @@
+// Phase 5 slash command registry + parse helpers.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  listSlashCommands,
+  matchSlashCommands,
+  parseSlashInput,
+  registerSlashCommand,
+  unregisterSlashCommand,
+} from '../../../packages/cli/src/chat/tui/commands/slashRegistry';
+
+afterEach(() => {
+  for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
+});
+
+describe('slashRegistry', () => {
+  it('matches by name prefix case-insensitively', () => {
+    registerSlashCommand({ name: 'model', description: 'pick a model' });
+    registerSlashCommand({ name: 'agent', description: 'pick an agent' });
+    registerSlashCommand({ name: 'merge', description: 'merge outputs' });
+    expect(matchSlashCommands('m').map((c) => c.name)).toEqual([
+      'model',
+      'merge',
+    ]);
+    expect(matchSlashCommands('Mo').map((c) => c.name)).toEqual(['model']);
+    expect(matchSlashCommands('').map((c) => c.name)).toEqual([
+      'model',
+      'agent',
+      'merge',
+    ]);
+  });
+
+  it('matches aliases alongside the canonical name', () => {
+    registerSlashCommand({
+      name: 'help',
+      description: 'show help',
+      aliases: ['h', 'usage'],
+    });
+    expect(matchSlashCommands('h').map((c) => c.name)).toEqual(['help']);
+    expect(matchSlashCommands('us').map((c) => c.name)).toEqual(['help']);
+  });
+});
+
+describe('parseSlashInput', () => {
+  it('returns undefined for non-slash input', () => {
+    expect(parseSlashInput('hello world')).toBeUndefined();
+  });
+
+  it('splits the command name from its remainder', () => {
+    expect(parseSlashInput('/model anthropic claude')).toEqual({
+      name: 'model',
+      remainder: 'anthropic claude',
+    });
+    expect(parseSlashInput('/help')).toEqual({ name: 'help', remainder: '' });
+    expect(parseSlashInput('/agent  reasoner')).toEqual({
+      name: 'agent',
+      remainder: ' reasoner',
+    });
+  });
+});


### PR DESCRIPTION
First slice of Phase 5 (Ergonomics). Lands the foundation pieces — shared `<KeyHints>`, persistent input history with Ctrl-R reverse search, and the `/` slash-command palette — so subsequent slices can build on the conventions instead of inventing their own.

## Scope

**Shipped**

- **Shared `<KeyHints>`** (`tui/ui/KeyHints.tsx`): single footer-strip used by every modal/palette per [§ Intuitiveness conventions](../docs/prd/cli-tui-ink/10-architecture.md#intuitiveness-conventions). All six approval modals now render through it; ad-hoc footer text — the review-blocker the PRD calls out — is gone.
- **Input history** (`tui/history/inputHistory.ts`): JSONL persistence under `storage/tui/input-history.jsonl` (cap 1000 entries × 4 KB lines, dedup against previous entry). Exposes `all()` / `push()` / `reverseFind()`.
- **Reverse search** (`tui/input/ReverseSearch.tsx`): `Ctrl-R` pops it open; each keystroke narrows the most-recent match, `↑` cycles older, Enter commits the value back into the input.
- **Slash palette** (`tui/commands/SlashPalette.tsx` + `slashRegistry.ts`): pops up as the user types `/…`; `↑/↓` navigates, `Tab` / `Enter` accepts. Built-in commands cover `/help /clear /agent /model /status /resume`.

**Deferred to Phase 5b** (per the architecture doc's recommended split)

- Structured slash forms (`/model` single-screen, `/status` tabbed scaffold, `/agent` reuses primitives).
- `Ctrl-P` full palette (`fzf-for-js` across slash commands / agents / models / attachments / files).
- Image-paste attachments wired through `BaseTextInput` + `cliState.attachments`.
- `@` file picker.
- `Ctrl-F` transcript search.
- `Ctrl-O` expand affordance for truncated content.

## Test plan

- [x] `npm run typecheck` green.
- [x] `npm run test:kernel -- src/test-kernel/cli/` — 34/34 pass, including the 4 new vitests covering registry prefix + alias match and `parseSlashInput` semantics.
- [ ] Manual: run `texra chat --tui`, type `/he`, verify the palette filters to `/help`; Ctrl-R, type a substring, verify the most-recent match surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core TUI input handling by adding new overlays (slash palette, Ctrl-R reverse search) and persistent history writes, which could introduce keybinding/focus regressions or filesystem edge cases.
> 
> **Overview**
> Adds *ergonomics primitives* to the CLI TUI: a shared `KeyHints` footer component and updates all approval modals to use it instead of ad-hoc hint text.
> 
> Extends the input bar with a `/` slash-command autocomplete palette (backed by a new in-tree `slashRegistry` plus builtin registrations) and introduces persisted JSONL input history with `Ctrl-R` reverse incremental search; `runChatTui` now loads history/registers builtins and passes history into `App`/`InputBar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cbfda9f4adbf0f46897d10fbee69fc6e984cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->