### PR TITLE
feat(inquiry): show transcript and persist drafts

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -31,8 +31,10 @@ import { AGENT_CATEGORY } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
 import {
+  getOpenTurnDraft,
   listThreadsByStatus,
   listOpenThreads,
+  manifestToTranscript,
   readExternalInquiryThread,
 } from '@tools/inquiry/externalInquiryStorage';
 
@@ -443,6 +445,8 @@ export class ProgressViewProvider
           suggestSearch: lastTurn.suggestSearch ?? undefined,
           attachFiles: lastTurn.attachFiles ?? undefined,
           sessionLinks: collectKnownSessionLinks(manifest),
+          draft: getOpenTurnDraft(manifest),
+          transcript: manifestToTranscript(manifest),
           allowBypass: false,
           streamId: manifest.parentStreamId,
         });

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -432,7 +432,9 @@ export class ProgressViewProvider
 
     for (const summary of open) {
       try {
-        const manifest = await readExternalInquiryThread(summary.threadId);
+        const manifest = await readExternalInquiryThread(summary.threadId, {
+          hydrate: true,
+        });
         if (!manifest || manifest.status !== 'open') continue;
         if (!manifest.parentStreamId) continue;
         const lastTurn = manifest.turns.at(-1);

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -22,12 +22,18 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+import { postMessage } from '@shared/hostBridge';
+import type {
+  ExternalInquiryPermission,
+  InquiryDraft,
+  InquiryTranscriptTurn,
+} from '@shared/schemas';
 import {
   commonViewStyles,
   designTokens,
   requestPanelStyles,
 } from '@shared/styles';
-import type { ExternalInquiryPermission } from '@shared/schemas';
 import { CopyButtonController } from '@shared/controllers/CopyButtonController';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
@@ -36,18 +42,19 @@ import { ProgressEvents } from '../events';
 
 // ── Draft persistence ──
 
-interface InquiryDraft {
-  answerText: string;
-  sessionLinksText: string;
-}
-
 const DRAFT_CACHE_CAP = 50;
+const DRAFT_SAVE_DELAY_MS = 400;
 const draftCache = new Map<string, InquiryDraft>();
 const resolvedIds = new Set<string>();
 const INQUIRY_SUBMIT_ACTION = 'submit';
 
 function getRequestId(permission: { data: unknown }): string {
   return (permission.data as ExternalInquiryPermission).requestId;
+}
+
+function getThreadId(permission: { data: unknown }): string {
+  const data = permission.data as ExternalInquiryPermission;
+  return data.threadId ?? data.requestId;
 }
 
 function safeHttpUrl(link: string): string | undefined {
@@ -83,35 +90,46 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
 
   private copyController = new CopyButtonController(this);
   private draftRestored = false;
+  private draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
 
   // ── Lifecycle ──
 
   override disconnectedCallback(): void {
-    this.saveDraft();
+    this.flushDraft();
     super.disconnectedCallback();
   }
 
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
+    if (changed.has('permission')) {
+      this.draftRestored = false;
+    }
     // Restore draft once on first update (avoids the extra render from connectedCallback).
     if (!this.draftRestored) {
       this.draftRestored = true;
-      const draft = draftCache.get(getRequestId(this.permission));
+      const data = this.permission.data as ExternalInquiryPermission;
+      const draft = draftCache.get(getRequestId(this.permission)) ?? data.draft;
       if (draft) {
-        this.answerText = draft.answerText;
-        this.sessionLinksText = draft.sessionLinksText;
+        this.answerText = draft.answer;
+        this.sessionLinksText = draft.sessionLinks;
       }
     }
   }
 
-  private saveDraft(): void {
+  private currentDraft(): InquiryDraft | null {
+    if (!this.answerText && !this.sessionLinksText) return null;
+    return {
+      answer: this.answerText,
+      sessionLinks: this.sessionLinksText,
+    };
+  }
+
+  private saveDraft(options: { persist: boolean }): void {
     const id = getRequestId(this.permission);
     if (resolvedIds.has(id)) return;
-    if (this.answerText || this.sessionLinksText) {
-      draftCache.set(id, {
-        answerText: this.answerText,
-        sessionLinksText: this.sessionLinksText,
-      });
+    const draft = this.currentDraft();
+    if (draft) {
+      draftCache.set(id, draft);
       if (draftCache.size > DRAFT_CACHE_CAP) {
         const oldest = draftCache.keys().next().value;
         if (oldest !== undefined) draftCache.delete(oldest);
@@ -119,6 +137,32 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     } else {
       draftCache.delete(id);
     }
+    if (options.persist) {
+      postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+        action: 'draft',
+        threadId: getThreadId(this.permission),
+        draft,
+      });
+    }
+  }
+
+  private scheduleDraftSave(): void {
+    this.saveDraft({ persist: false });
+    if (this.draftSaveTimer) {
+      clearTimeout(this.draftSaveTimer);
+    }
+    this.draftSaveTimer = setTimeout(() => {
+      this.draftSaveTimer = undefined;
+      this.saveDraft({ persist: true });
+    }, DRAFT_SAVE_DELAY_MS);
+  }
+
+  private flushDraft(): void {
+    if (this.draftSaveTimer) {
+      clearTimeout(this.draftSaveTimer);
+      this.draftSaveTimer = undefined;
+    }
+    this.saveDraft({ persist: true });
   }
 
   override handleKeyboardShortcut(key: string): boolean {
@@ -157,6 +201,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
         <div class="external-inquiry-request__details">
           ${this.renderHeader(data)}
           ${data.context ? this.renderContext(data.context) : nothing}
+          ${this.renderTranscript(data.transcript ?? [])}
           ${this.renderQuestion(data.question)}
           ${data.suggestSearch ? this.renderSearchHint() : nothing}
           ${data.attachFiles?.length
@@ -186,6 +231,63 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   private renderContext(context: string): TemplateResult {
     return html`
       <div class="external-inquiry-request__context">${context}</div>
+    `;
+  }
+
+  private renderTranscript(
+    transcript: InquiryTranscriptTurn[],
+  ): TemplateResult | typeof nothing {
+    const answeredTurns = transcript.filter((turn) => turn.answer);
+    if (answeredTurns.length === 0) return nothing;
+
+    return html`
+      <details class="external-inquiry-request__transcript">
+        <summary class="external-inquiry-request__transcript-summary">
+          <wa-icon library="texra" name="history" aria-hidden="true"></wa-icon>
+          Conversation transcript (${answeredTurns.length})
+        </summary>
+        <div class="external-inquiry-request__transcript-turns">
+          ${repeat(
+            answeredTurns,
+            (turn) => turn.turnIndex,
+            (turn) => this.renderTranscriptTurn(turn),
+          )}
+        </div>
+      </details>
+    `;
+  }
+
+  private renderTranscriptTurn(turn: InquiryTranscriptTurn): TemplateResult {
+    return html`
+      <section class="external-inquiry-request__transcript-turn">
+        <div class="external-inquiry-request__transcript-turn-header">
+          Turn ${turn.turnIndex}
+        </div>
+        ${turn.context
+          ? html`
+              <div class="external-inquiry-request__transcript-context">
+                ${turn.context}
+              </div>
+            `
+          : nothing}
+        <div class="external-inquiry-request__transcript-label">Q</div>
+        <div class="external-inquiry-request__transcript-text">
+          ${turn.question}
+        </div>
+        <div class="external-inquiry-request__transcript-label">A</div>
+        <div class="external-inquiry-request__transcript-text">
+          ${turn.answer}
+        </div>
+        ${turn.sessionLinks?.length
+          ? html`
+              <div class="external-inquiry-request__transcript-links">
+                ${turn.sessionLinks.map((link) =>
+                  this.renderKnownSessionLink(link),
+                )}
+              </div>
+            `
+          : nothing}
+      </section>
     `;
   }
 
@@ -361,10 +463,12 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
 
   private handleAnswerInput(e: Event): void {
     this.answerText = (e.target as HTMLTextAreaElement).value;
+    this.scheduleDraftSave();
   }
 
   private handleSessionLinksInput(e: Event): void {
     this.sessionLinksText = (e.target as HTMLTextAreaElement).value;
+    this.scheduleDraftSave();
   }
 
   private handleKeyDown(e: KeyboardEvent): void {

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -39,6 +39,7 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { ProgressEvents } from '../events';
+import type { PermissionState } from './PermissionCard';
 
 // ── Draft persistence ──
 
@@ -47,6 +48,16 @@ const DRAFT_SAVE_DELAY_MS = 400;
 const draftCache = new Map<string, InquiryDraft>();
 const resolvedIds = new Set<string>();
 const INQUIRY_SUBMIT_ACTION = 'submit';
+
+interface InquiryPermissionIds {
+  requestId: string;
+  threadId: string;
+}
+
+interface PendingDraftSave extends InquiryPermissionIds {
+  draft: InquiryDraft | null;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 function getRequestId(permission: { data: unknown }): string {
   return (permission.data as ExternalInquiryPermission).requestId;
@@ -90,7 +101,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
 
   private copyController = new CopyButtonController(this);
   private draftRestored = false;
-  private draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
+  private pendingDraftSave: PendingDraftSave | undefined;
 
   // ── Lifecycle ──
 
@@ -102,6 +113,12 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
     if (changed.has('permission')) {
+      const previousPermission = changed.get('permission') as
+        | PermissionState
+        | undefined;
+      if (previousPermission) this.flushDraft(previousPermission);
+      this.answerText = '';
+      this.sessionLinksText = '';
       this.draftRestored = false;
     }
     // Restore draft once on first update (avoids the extra render from connectedCallback).
@@ -124,45 +141,79 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     };
   }
 
-  private saveDraft(options: { persist: boolean }): void {
-    const id = getRequestId(this.permission);
-    if (resolvedIds.has(id)) return;
-    const draft = this.currentDraft();
+  private getPermissionIds(
+    permission: { data: unknown } = this.permission,
+  ): InquiryPermissionIds {
+    return {
+      requestId: getRequestId(permission),
+      threadId: getThreadId(permission),
+    };
+  }
+
+  private writeDraft(
+    ids: InquiryPermissionIds,
+    draft: InquiryDraft | null,
+    options: { persist: boolean },
+  ): void {
+    if (resolvedIds.has(ids.requestId)) return;
     if (draft) {
-      draftCache.set(id, draft);
+      draftCache.set(ids.requestId, draft);
       if (draftCache.size > DRAFT_CACHE_CAP) {
         const oldest = draftCache.keys().next().value;
         if (oldest !== undefined) draftCache.delete(oldest);
       }
     } else {
-      draftCache.delete(id);
+      draftCache.delete(ids.requestId);
     }
     if (options.persist) {
       postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
         action: 'draft',
-        threadId: getThreadId(this.permission),
+        threadId: ids.threadId,
         draft,
       });
     }
   }
 
-  private scheduleDraftSave(): void {
-    this.saveDraft({ persist: false });
-    if (this.draftSaveTimer) {
-      clearTimeout(this.draftSaveTimer);
-    }
-    this.draftSaveTimer = setTimeout(() => {
-      this.draftSaveTimer = undefined;
-      this.saveDraft({ persist: true });
-    }, DRAFT_SAVE_DELAY_MS);
+  private clearPendingDraftSave(): void {
+    if (!this.pendingDraftSave) return;
+    clearTimeout(this.pendingDraftSave.timer);
+    this.pendingDraftSave = undefined;
   }
 
-  private flushDraft(): void {
-    if (this.draftSaveTimer) {
-      clearTimeout(this.draftSaveTimer);
-      this.draftSaveTimer = undefined;
+  private scheduleDraftSave(): void {
+    const ids = this.getPermissionIds();
+    const draft = this.currentDraft();
+    this.writeDraft(ids, draft, { persist: false });
+    this.clearPendingDraftSave();
+    const timer = setTimeout(() => {
+      const pending = this.pendingDraftSave;
+      this.pendingDraftSave = undefined;
+      if (!pending) return;
+      const currentIds = this.getPermissionIds();
+      if (
+        currentIds.requestId !== pending.requestId ||
+        currentIds.threadId !== pending.threadId
+      ) {
+        return;
+      }
+      this.writeDraft(pending, pending.draft, { persist: true });
+    }, DRAFT_SAVE_DELAY_MS);
+    this.pendingDraftSave = { ...ids, draft, timer };
+  }
+
+  private flushDraft(permission: { data: unknown } = this.permission): void {
+    const ids = this.getPermissionIds(permission);
+    const pending = this.pendingDraftSave;
+    if (
+      pending &&
+      pending.requestId === ids.requestId &&
+      pending.threadId === ids.threadId
+    ) {
+      this.clearPendingDraftSave();
+      this.writeDraft(ids, pending.draft, { persist: true });
+      return;
     }
-    this.saveDraft({ persist: true });
+    this.writeDraft(ids, this.currentDraft(), { persist: true });
   }
 
   override handleKeyboardShortcut(key: string): boolean {

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -100,3 +100,14 @@ export const InquiryDraftSchema = z.object({
   sessionLinks: z.string(),
 });
 export type InquiryDraft = z.infer<typeof InquiryDraftSchema>;
+
+export const InquiryTranscriptTurnSchema = z.object({
+  turnIndex: z.int().positive(),
+  timestamp: z.string().min(1),
+  question: z.string(),
+  context: z.string().nullish(),
+  answer: z.string().nullish(),
+  answeredAt: z.string().nullish(),
+  sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
+});
+export type InquiryTranscriptTurn = z.infer<typeof InquiryTranscriptTurnSchema>;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -21,6 +21,7 @@ import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
+  InquiryDraftSchema,
   InquiryThreadUpdatedEventSchema,
 } from './inquiry';
 import {
@@ -698,13 +699,7 @@ const ExternalInquiryActionMessageSchema = z
     answer: z.string().min(1).optional(),
     sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
     feedback: z.string().optional(),
-    draft: z
-      .object({
-        answer: z.string(),
-        sessionLinks: z.string(),
-      })
-      .nullable()
-      .optional(),
+    draft: InquiryDraftSchema.nullable().optional(),
   })
   .superRefine((message, ctx) => {
     if (message.action === 'submit' && !message.answer) {

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -111,6 +111,8 @@ export type AgentProposalPermission = z.infer<
 // ============================================================================
 
 import {
+  InquiryDraftSchema,
+  InquiryTranscriptTurnSchema,
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
 } from './inquiry';
@@ -122,6 +124,8 @@ export const ExternalInquiryPermissionSchema = PermissionBaseSchema.extend({
   suggestSearch: z.boolean().nullish(),
   attachFiles: z.array(z.string()).nullish(),
   sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
+  draft: InquiryDraftSchema.nullish(),
+  transcript: z.array(InquiryTranscriptTurnSchema).nullish(),
 });
 export type ExternalInquiryPermission = z.infer<
   typeof ExternalInquiryPermissionSchema

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -656,6 +656,72 @@ export const requestPanelStyles: CSSResult = css`
     border-top: var(--border-thin) solid var(--wa-color-surface-border);
   }
 
+  .external-inquiry-request__transcript {
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    border-radius: var(--border-radius);
+    background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.05));
+  }
+
+  .external-inquiry-request__transcript-summary {
+    display: flex;
+    align-items: center;
+    gap: ${sp.small};
+    padding: ${sp.small} ${sp.medium};
+    cursor: pointer;
+    color: var(--wa-color-text-normal);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .external-inquiry-request__transcript-turns {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.medium};
+    max-height: min(28vh, 18rem);
+    overflow-y: auto;
+    padding: ${sp.medium};
+    border-top: var(--border-thin) solid var(--wa-color-surface-border);
+    scrollbar-gutter: stable;
+  }
+
+  .external-inquiry-request__transcript-turn {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.small};
+  }
+
+  .external-inquiry-request__transcript-turn
+    + .external-inquiry-request__transcript-turn {
+    padding-top: ${sp.medium};
+    border-top: var(--border-thin) solid var(--wa-color-surface-border);
+  }
+
+  .external-inquiry-request__transcript-turn-header,
+  .external-inquiry-request__transcript-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .external-inquiry-request__transcript-context {
+    font-size: var(--font-size-sm);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .external-inquiry-request__transcript-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--wa-color-text-normal);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
+  .external-inquiry-request__transcript-links {
+    display: flex;
+    flex-direction: column;
+    gap: ${sp.tiny};
+  }
+
   .external-inquiry-request__search-hint {
     display: flex;
     align-items: center;

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -230,6 +230,13 @@ describe('InquiryStorage', () => {
     await platform.fs.createDirectory(
       `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0011`,
     );
+    await platform.fs.createDirectory(
+      `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0011/t1`,
+    );
+    await platform.fs.writeFile(
+      `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0011/t1/answer.txt`,
+      Buffer.from('Legacy A', 'utf8'),
+    );
     await platform.fs.writeFile(
       `${platform.storage.getGlobalStoragePath()}/${path}`,
       Buffer.from(JSON.stringify(legacy), 'utf8'),
@@ -239,5 +246,12 @@ describe('InquiryStorage', () => {
     expect(manifest).not.toBeNull();
     expect(manifest!.status).toBe('answered');
     expect(manifest!.parentStreamId).toBeNull();
+
+    const hydrated = await readExternalInquiryThread('ei_aabbccdd0011', {
+      hydrate: true,
+    });
+    expect(manifestToTranscript(hydrated!)).toMatchObject([
+      { turnIndex: 1, question: 'Legacy Q', answer: 'Legacy A' },
+    ]);
   });
 });

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -7,16 +7,19 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import type { StreamTabId } from '@shared/schemas';
+import { ToolError } from '@tools/result';
 import {
+  getOpenTurnDraft,
   listOpenThreads,
   listOpenThreadsForStream,
   listThreadsByStatus,
   markDropped,
+  manifestToTranscript,
+  persistOpenTurnDraft,
   readExternalInquiryThread,
   recordAnswerForOpenTurn,
   recordOpenQuestion,
 } from '@tools/inquiry/externalInquiryStorage';
-import { ToolError } from '@tools/result';
 
 import type { Platform } from '@platform/platform';
 
@@ -113,6 +116,38 @@ describe('InquiryStorage', () => {
     expect(followUp.manifest.status).toBe('open');
     expect(followUp.manifest.turns).toHaveLength(2);
     expect(followUp.turn.question).toBe('Q2 (follow-up)');
+  });
+
+  it('persists open-turn drafts and exposes transcript turns', async () => {
+    const t = await recordOpenQuestion({
+      parentStreamId: STREAM_A,
+      question: 'Q1',
+    });
+    await recordAnswerForOpenTurn({ threadId: t.threadId, answer: 'A1' });
+    await recordOpenQuestion({
+      threadId: t.threadId,
+      parentStreamId: STREAM_A,
+      question: 'Q2',
+    });
+
+    await persistOpenTurnDraft({
+      threadId: t.threadId,
+      draft: {
+        answer: 'partial answer',
+        sessionLinks: 'https://chat.example/thread',
+      },
+    });
+
+    const manifest = await readExternalInquiryThread(t.threadId);
+    expect(manifest).not.toBeNull();
+    expect(getOpenTurnDraft(manifest!)).toEqual({
+      answer: 'partial answer',
+      sessionLinks: 'https://chat.example/thread',
+    });
+    expect(manifestToTranscript(manifest!)).toMatchObject([
+      { turnIndex: 1, question: 'Q1', answer: 'A1' },
+      { turnIndex: 2, question: 'Q2', answer: undefined },
+    ]);
   });
 
   it('updates parentStreamId on cross-stream follow-up', async () => {

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -338,6 +338,10 @@ export class ExternalInquiryTool extends defineTool({
       suggestSearch: input.suggestSearch ?? undefined,
       attachFiles: input.attachFiles ?? undefined,
     });
+    const manifest =
+      (await readExternalInquiryThread(persisted.threadId, {
+        hydrate: true,
+      })) ?? persisted.manifest;
 
     // Mirror to execution so the agent can read prior turns via the executions tool.
     if (executionId) {
@@ -362,9 +366,9 @@ export class ExternalInquiryTool extends defineTool({
       context: input.context ?? undefined,
       suggestSearch: input.suggestSearch ?? undefined,
       attachFiles: input.attachFiles ?? undefined,
-      sessionLinks: collectKnownSessionLinks(persisted.manifest),
-      draft: getOpenTurnDraft(persisted.manifest),
-      transcript: manifestToTranscript(persisted.manifest),
+      sessionLinks: collectKnownSessionLinks(manifest),
+      draft: getOpenTurnDraft(manifest),
+      transcript: manifestToTranscript(manifest),
       allowBypass: false,
       streamId,
     });

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -34,8 +34,10 @@ import { collectKnownSessionLinks } from './externalInquiryResultFormatter';
 import {
   ensureExternalInquiryThreadMirror,
   getThreadSummary,
+  getOpenTurnDraft,
   listThreadsByStatus,
   markDropped,
+  manifestToTranscript,
   readExternalInquiryThread,
   recordAnswerForOpenTurn,
   recordOpenQuestion,
@@ -361,6 +363,8 @@ export class ExternalInquiryTool extends defineTool({
       suggestSearch: input.suggestSearch ?? undefined,
       attachFiles: input.attachFiles ?? undefined,
       sessionLinks: collectKnownSessionLinks(persisted.manifest),
+      draft: getOpenTurnDraft(persisted.manifest),
+      transcript: manifestToTranscript(persisted.manifest),
       allowBypass: false,
       streamId,
     });

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -9,6 +9,7 @@ import {
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
   InquiryDraftSchema,
+  type InquiryTranscriptTurn,
   StreamTabIdSchema,
   type ExternalInquiryThreadId,
   type ExternalInquiryThreadSummary,
@@ -448,7 +449,8 @@ export async function recordAnswerForOpenTurn(params: {
     if (existing.status !== 'open') return null;
     if (existing.turns.length === 0) return null;
 
-    const lastTurn = existing.turns[existing.turns.length - 1];
+    const lastTurn = existing.turns.at(-1);
+    if (!lastTurn) return null;
     if (lastTurn.answer) return null;
 
     const timestamp = new Date().toISOString();
@@ -542,7 +544,8 @@ export async function persistOpenTurnDraft(params: {
     if (!existing || existing.status !== 'open' || existing.turns.length === 0)
       return;
 
-    const lastTurn = existing.turns[existing.turns.length - 1];
+    const lastTurn = existing.turns.at(-1);
+    if (!lastTurn) return;
     if (lastTurn.answer) return;
 
     const nextTurn: ExternalInquiryTurnRecord = {
@@ -557,6 +560,29 @@ export async function persistOpenTurnDraft(params: {
 
     await writeThreadManifest(nextManifest);
   });
+}
+
+export function getOpenTurnDraft(
+  manifest: ExternalInquiryThreadManifest,
+): InquiryDraft | undefined {
+  if (manifest.status !== 'open') return undefined;
+  const lastTurn = manifest.turns.at(-1);
+  if (!lastTurn || lastTurn.answer) return undefined;
+  return lastTurn.draft ?? undefined;
+}
+
+export function manifestToTranscript(
+  manifest: ExternalInquiryThreadManifest,
+): InquiryTranscriptTurn[] {
+  return manifest.turns.map((turn) => ({
+    turnIndex: turn.turnIndex,
+    timestamp: turn.timestamp,
+    question: turn.question,
+    context: turn.context ?? undefined,
+    answer: turn.answer ?? undefined,
+    answeredAt: turn.answeredAt ?? undefined,
+    sessionLinks: turn.sessionLinks ?? undefined,
+  }));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes #4101.

Adds manifest-backed UI state for external inquiry threads:

- shows prior answered turns in the external inquiry panel as a compact conversation transcript
- carries the open-turn draft from the manifest into replayed inquiry panels after reload
- debounces answer/session-link draft edits back into the existing manifest `draft` field
- keeps transcript/draft payloads derived from the inquiry manifest so `inquiry read`, replay, and the panel share the same source of truth

## Validation

- `npm run format`
- `npx vitest run src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts src/test-kernel/tools/InquiryContinuation.vitest.ts src/test-kernel/progressView/InquiryPanelState.vitest.ts`
- `CI=true npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings outside this change)

## Notes

The first sandboxed `typecheck` attempt failed while pnpm was restoring packages because DNS access to the npm registry was blocked. I restored dependencies with `corepack pnpm install` using approved network access, then reran the checks successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes external inquiry persistence and host↔webview messaging, adding debounced draft writes to on-disk manifests and new payload fields that affect reload/hydration behavior.
> 
> **Overview**
> Adds **manifest-backed external inquiry UI state** by sending the current open-turn `draft` and a derived `transcript` with each `showExternalInquiry`, including during progress-view hydration after reload.
> 
> Updates `ExternalInquiryPanel` to render a collapsible transcript of prior answered turns and to **debounce draft edits** (answer + session links) back to the host via a new `EXTERNAL_INQUIRY_ACTION` `draft` message; drafts are flushed on unmount/permission changes and restored from either in-memory cache or the manifest-provided `draft`.
> 
> Extends shared schemas with `InquiryTranscriptTurn` and reuses `InquiryDraftSchema` across messages, and adds storage helpers (`getOpenTurnDraft`, `manifestToTranscript`) plus tests covering draft persistence and transcript/hydration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06f1d615239aedcb8b8662480b85e69cea16e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->