### PR TITLE
feat(cli-tui): phase 5b — /model structured form + form-mount surface

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -30,7 +30,9 @@ export function App(props: AppProps): React.JSX.Element {
   const pending = useSignal(currentApproval);
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
-  const inputDisabled = props.inputDisabled || pending !== undefined;
+  const activeForm = useSignal(cliState.activeForm);
+  const inputDisabled =
+    props.inputDisabled || pending !== undefined || activeForm !== undefined;
 
   // Hide the side column when both side panes would render empty —
   // otherwise the conversation loses 28 columns of width for nothing.
@@ -71,6 +73,9 @@ export function App(props: AppProps): React.JSX.Element {
       </Box>
       <StatusBar />
       <ApprovalModal pending={pending} />
+      {activeForm
+        ? activeForm.render(() => cliState.activeForm.set(undefined))
+        : null}
       <InputBar
         onSubmit={props.onSubmit}
         disabled={inputDisabled}

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.ts
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.ts
@@ -1,6 +1,8 @@
 // Registers the slash commands the input palette surfaces.
 //
-// Idempotent — `registerSlashCommand` overwrites by name.
+// Idempotent at the call-site granularity: the module-scope `installed`
+// flag short-circuits repeat invocations, so registrations that were
+// individually unregistered won't reappear without a process restart.
 
 import { registerSlashCommand } from './slashRegistry';
 
@@ -32,6 +34,12 @@ export function registerBuiltinSlashCommands(): void {
   });
   registerSlashCommand({
     name: 'resume',
-    description: 'Resume a previous session — separate PRD',
+    description: 'Resume a previous session',
   });
+}
+
+/** Test seam — drops registered commands so vitests can re-register from
+ *  scratch without a hot-module reload. */
+export function _resetBuiltinSlashCommandsForTests(): void {
+  installed = false;
 }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -4,7 +4,28 @@
 // flag short-circuits repeat invocations, so registrations that were
 // individually unregistered won't reappear without a process restart.
 
-import { registerSlashCommand } from './slashRegistry';
+import { ModelForm } from '../forms/ModelForm';
+import { cliState } from '../state/cliState';
+import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
+
+/** Adapter: wires the `/model` form's `(value)=>void` API into the generic
+ *  `SlashFormProps<unknown>` shape the registry expects. */
+function ModelFormAdapter(props: SlashFormProps): React.JSX.Element {
+  const current = cliState.sessionMeta.get().model;
+  return (
+    <ModelForm
+      currentModel={current}
+      onSelect={(value) => {
+        cliState.sessionMeta.set({
+          ...cliState.sessionMeta.get(),
+          model: value,
+        });
+        props.onDone(value);
+      }}
+      onCancel={() => props.onDone(undefined)}
+    />
+  );
+}
 
 let installed = false;
 
@@ -27,6 +48,7 @@ export function registerBuiltinSlashCommands(): void {
   registerSlashCommand({
     name: 'model',
     description: 'Switch the active model',
+    formComponent: ModelFormAdapter,
   });
   registerSlashCommand({
     name: 'status',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -59,9 +59,3 @@ export function registerBuiltinSlashCommands(): void {
     description: 'Resume a previous session',
   });
 }
-
-/** Test seam — drops registered commands so vitests can re-register from
- *  scratch without a hot-module reload. */
-export function _resetBuiltinSlashCommandsForTests(): void {
-  installed = false;
-}

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -1,5 +1,13 @@
 // In-tree slash command registry.
 
+/** A structured-form component renders inline when the user picks a slash
+ *  command that declares one (e.g. `/model`). Calls `onDone(result)` to
+ *  commit the user's selection or `onDone(undefined)` on cancel. */
+export interface SlashFormProps<T = unknown> {
+  readonly onDone: (result: T | undefined) => void;
+  readonly remainder: string;
+}
+
 export interface SlashCommand {
   /** Command name without the leading `/`. */
   readonly name: string;
@@ -11,6 +19,11 @@ export interface SlashCommand {
    * (everything after the command name + whitespace).
    */
   readonly handler?: (remainder: string) => void;
+  /**
+   * Optional structured-form renderer. When present, picking the command
+   * mounts this component instead of routing through `handler` / the input.
+   */
+  readonly formComponent?: React.ComponentType<SlashFormProps>;
 }
 
 const COMMANDS = new Map<string, SlashCommand>();

--- a/packages/cli/src/chat/tui/forms/ModelForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelForm.tsx
@@ -7,7 +7,7 @@
 // `setCliHelperModel` for follow-up turns is a downstream concern handled
 // by the caller's `onPick` (see `App.tsx` → `applyModelSelection`).
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
 import { Select } from '../ui/Select';
@@ -27,6 +27,12 @@ export function ModelForm(props: ModelFormProps): React.JSX.Element {
   const [models, setModels] = useState<readonly CliModelAccess[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>(undefined);
+
+  useInput((_input, key) => {
+    if ((loading || error) && key.escape) {
+      props.onCancel();
+    }
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -58,6 +64,12 @@ export function ModelForm(props: ModelFormProps): React.JSX.Element {
           /model
         </Text>
         <Text dimColor>Loading model registry…</Text>
+        <Box marginTop={1}>
+          <KeyHints
+            hints={[{ key: 'Esc', action: 'cancel' }]}
+            confirmCancel={false}
+          />
+        </Box>
       </Box>
     );
   }
@@ -74,7 +86,10 @@ export function ModelForm(props: ModelFormProps): React.JSX.Element {
         </Text>
         <Text>{error}</Text>
         <Box marginTop={1}>
-          <KeyHints hints={[]} />
+          <KeyHints
+            hints={[{ key: 'Esc', action: 'cancel' }]}
+            confirmCancel={false}
+          />
         </Box>
       </Box>
     );

--- a/packages/cli/src/chat/tui/forms/ModelForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelForm.tsx
@@ -1,0 +1,119 @@
+// Single-screen `/model` form. Renders the resolved model list with
+// availability status, lets the user pick a new active model with arrow
+// keys + Enter, and writes the choice back into `cliState.sessionMeta`
+// alongside the existing CLI helper-model wiring.
+//
+// Phase 5b ships the *picker* surface; ramping the new selection through
+// `setCliHelperModel` for follow-up turns is a downstream concern handled
+// by the caller's `onPick` (see `App.tsx` → `applyModelSelection`).
+
+import { Box, Text } from 'ink';
+import { useEffect, useState } from 'react';
+
+import { Select } from '../ui/Select';
+import { KeyHints } from '../ui/KeyHints';
+import {
+  getCliModelAccessList,
+  type CliModelAccess,
+} from '../../../runtime/modelAccess';
+
+export interface ModelFormProps {
+  readonly currentModel: string;
+  readonly onSelect: (value: string) => void;
+  readonly onCancel: () => void;
+}
+
+export function ModelForm(props: ModelFormProps): React.JSX.Element {
+  const [models, setModels] = useState<readonly CliModelAccess[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getCliModelAccessList()
+      .then((list) => {
+        if (cancelled) return;
+        setModels(list);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor="cyan"
+        flexDirection="column"
+        paddingX={1}
+      >
+        <Text bold color="cyan">
+          /model
+        </Text>
+        <Text dimColor>Loading model registry…</Text>
+      </Box>
+    );
+  }
+  if (error) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor="red"
+        flexDirection="column"
+        paddingX={1}
+      >
+        <Text bold color="red">
+          /model — error
+        </Text>
+        <Text>{error}</Text>
+        <Box marginTop={1}>
+          <KeyHints hints={[]} />
+        </Box>
+      </Box>
+    );
+  }
+
+  const items = models.map((m) => ({
+    value: m.model.value,
+    label: m.model.label || m.model.value,
+    description: m.status,
+    disabled: !m.available,
+  }));
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        /model
+      </Text>
+      <Text dimColor>Pick a model. ✓ marks the current selection.</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Select
+          items={items}
+          activeValue={props.currentModel}
+          onSelect={props.onSelect}
+          onCancel={props.onCancel}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: '1-9', action: 'jump' },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -48,22 +48,34 @@ function parseRecord(raw: string): HistoryRecord | undefined {
   return undefined;
 }
 
-function serializeRecords(entries: readonly string[]): string {
-  const now = Date.now();
-  return entries.map((v) => JSON.stringify({ t: now, v })).join('\n') + '\n';
+/** Serialise the in-memory ring back to JSONL. Records keep their original
+ *  timestamp so a compaction doesn't collapse the entire history to "now"
+ *  in case anything ever reads the file externally. */
+function serializeRecords(records: readonly HistoryRecord[]): string {
+  return records.map((r) => JSON.stringify(r)).join('\n') + '\n';
 }
 
 export async function loadInputHistory(): Promise<InputHistory> {
-  let entries: string[] = [];
+  // Each record keeps its original timestamp so compactions don't rewrite
+  // every entry's `t` to `now`.
+  let records: HistoryRecord[] = [];
   if (await GlobalStorageFS.exists(HISTORY_PATH)) {
-    const raw = await GlobalStorageFS.read(HISTORY_PATH);
-    for (const line of raw.split('\n')) {
-      const rec = parseRecord(line);
-      if (rec && rec.v.length > 0) entries.push(rec.v);
+    try {
+      const raw = await GlobalStorageFS.read(HISTORY_PATH);
+      for (const line of raw.split('\n')) {
+        const rec = parseRecord(line);
+        if (rec && rec.v.length > 0) records.push(rec);
+      }
+    } catch {
+      // A read failure (EIO, permission, race-after-exists) must not block
+      // the TUI from mounting — the user can still type, just without
+      // history this session.
+      records = [];
     }
   }
   // Cap on load; older entries fall off when the ring is full.
-  if (entries.length > MAX_LINES) entries = entries.slice(-MAX_LINES);
+  if (records.length > MAX_LINES) records = records.slice(-MAX_LINES);
+  let entries = records.map((r) => r.v);
 
   return {
     all() {
@@ -77,14 +89,17 @@ export async function loadInputHistory(): Promise<InputHistory> {
           ? trimmed.slice(0, MAX_LINE_CHARS)
           : trimmed;
       if (entries.at(-1) === stored) return;
+      const record: HistoryRecord = { t: Date.now(), v: stored };
       entries.push(stored);
+      records.push(record);
       await GlobalStorageFS.ensureDir(HISTORY_DIR);
       if (entries.length > MAX_LINES) {
-        entries.splice(0, entries.length - MAX_LINES);
-        await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(entries));
+        const drop = entries.length - MAX_LINES;
+        entries.splice(0, drop);
+        records.splice(0, drop);
+        await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(records));
         return;
       }
-      const record: HistoryRecord = { t: Date.now(), v: stored };
       await GlobalStorageFS.appendFile(
         HISTORY_PATH,
         `${JSON.stringify(record)}\n`,

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -75,7 +75,7 @@ export async function loadInputHistory(): Promise<InputHistory> {
   }
   // Cap on load; older entries fall off when the ring is full.
   if (records.length > MAX_LINES) records = records.slice(-MAX_LINES);
-  let entries = records.map((r) => r.v);
+  const entries = records.map((r) => r.v);
 
   return {
     all() {

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -15,7 +15,8 @@ export interface ReverseSearchProps {
   readonly history: InputHistory;
   /** Commit the selected line — caller writes it into the input. */
   readonly onCommit: (line: string) => void;
-  /** User hit Esc / Ctrl-G — close without committing. */
+  /** User hit Esc (or Ctrl-G, which Ink reports as Ctrl-G → wired below) —
+   *  close without committing. */
   readonly onCancel: () => void;
 }
 
@@ -26,7 +27,7 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
   const match = props.history.reverseFind(query, cursor);
 
   useInput((input, key) => {
-    if (key.escape) {
+    if (key.escape || (key.ctrl && input.toLowerCase() === 'g')) {
       props.onCancel();
       return;
     }

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -39,7 +39,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       const trimmed = submitted.trim();
       if (trimmed.length === 0) return;
       setValue('');
-      void historyRef.current?.push(trimmed);
+      // Persisting history is best-effort — a disk failure (read-only fs,
+      // ENOSPC) must not block the submit. Surface the failure to stderr
+      // so it isn't completely silent.
+      historyRef.current?.push(trimmed).catch((err: unknown) => {
+        process.stderr.write(
+          `texra: failed to persist input history: ${String(err)}\n`,
+        );
+      });
       onSubmit(trimmed);
     },
     [onSubmit],

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -6,6 +6,8 @@ import { ReverseSearch } from '../input/ReverseSearch';
 import { SlashPalette } from '../commands/SlashPalette';
 import { matchSlashCommands, parseSlashInput } from '../commands/slashRegistry';
 import type { InputHistory } from '../history/inputHistory';
+import { writeTextStderr } from '../../../runtime/logSinks';
+import { cliState } from '../state/cliState';
 
 export interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter. */
@@ -40,11 +42,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       if (trimmed.length === 0) return;
       setValue('');
       // Persisting history is best-effort — a disk failure (read-only fs,
-      // ENOSPC) must not block the submit. Surface the failure to stderr
-      // so it isn't completely silent.
+      // ENOSPC) must not block the submit. Surface the failure through the
+      // shared log sink so it isn't completely silent.
       historyRef.current?.push(trimmed).catch((err: unknown) => {
-        process.stderr.write(
-          `texra: failed to persist input history: ${String(err)}\n`,
+        writeTextStderr(
+          `texra: failed to persist input history: ${String(err)}`,
         );
       });
       onSubmit(trimmed);
@@ -77,13 +79,29 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       {showPalette ? (
         <SlashPalette
           query={parsed.name}
-          onPick={(cmd) =>
+          onPick={(cmd) => {
+            if (cmd.formComponent) {
+              // Structured forms own the screen — clear the input and let
+              // the active-form signal mount the component (see App.tsx).
+              const Form = cmd.formComponent;
+              setValue('');
+              cliState.activeForm.set({
+                commandName: cmd.name,
+                render: (close) => (
+                  <Form
+                    remainder={parsed.remainder.trimStart()}
+                    onDone={() => close()}
+                  />
+                ),
+              });
+              return;
+            }
             setValue(
               `/${cmd.name}${
                 parsed.remainder ? ` ${parsed.remainder.trimStart()}` : ' '
               }`,
-            )
-          }
+            );
+          }}
           onCancel={() => {
             /* Esc clears the slash — caller can re-open by typing again. */
             setValue('');

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -44,7 +44,8 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       // Persisting history is best-effort — a disk failure (read-only fs,
       // ENOSPC) must not block the submit. Surface the failure through the
       // shared log sink so it isn't completely silent.
-      historyRef.current?.push(trimmed).catch((err: unknown) => {
+      const historyPersist = historyRef.current?.push(trimmed);
+      historyPersist?.catch((err: unknown) => {
         writeTextStderr(
           `texra: failed to persist input history: ${String(err)}`,
         );

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -77,6 +77,17 @@ const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
  *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
 const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 
+/** Active inline slash form, or `undefined` when the chat input owns the
+ *  screen. The form's `onDone` clears this slot. Kept opaque (the form
+ *  carries its own state) so the registry stays declarative. */
+export interface ActiveSlashForm {
+  /** The slash command that mounted the form (for the header strip). */
+  readonly commandName: string;
+  /** Render the form body. Receives the close callback. */
+  readonly render: (onDone: () => void) => React.ReactNode;
+}
+const ACTIVE_FORM = signal<ActiveSlashForm | undefined>(undefined);
+
 export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
@@ -84,6 +95,7 @@ export const cliState = {
   parentStream: PARENT_STREAM as Signal.State<
     ReadonlyMap<StreamTabId, StreamTabId>
   >,
+  activeForm: ACTIVE_FORM as Signal.State<ActiveSlashForm | undefined>,
 };
 
 export const NO_BYPASS: BypassState = { toolEdit: false, superYolo: false };
@@ -166,4 +178,5 @@ export function resetCliState(): void {
   cliState.activeStreamId.set(undefined);
   cliState.streams.set(new Map());
   cliState.parentStream.set(new Map());
+  cliState.activeForm.set(undefined);
 }

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -8,7 +8,7 @@
 // receive a 1-based numeric prefix so digit shortcuts can jump directly.
 
 import { Box, Text, useInput } from 'ink';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface SelectItem<T> {
   readonly value: T;
@@ -27,14 +27,24 @@ export interface SelectProps<T> {
   readonly initialIndex?: number;
 }
 
+function clampIndex(index: number, length: number): number {
+  if (length <= 0) return 0;
+  return Math.min(Math.max(index, 0), length - 1);
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
-  const initial =
-    props.initialIndex ??
-    Math.max(
-      0,
-      props.items.findIndex((it) => it.value === props.activeValue),
-    );
+  const activeIndex = props.items.findIndex(
+    (it) => it.value === props.activeValue,
+  );
+  const initial = clampIndex(
+    props.initialIndex ?? (activeIndex >= 0 ? activeIndex : 0),
+    props.items.length,
+  );
   const [highlight, setHighlight] = useState(initial);
+
+  useEffect(() => {
+    setHighlight((h) => clampIndex(h, props.items.length));
+  }, [props.items.length]);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -42,11 +52,15 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       return;
     }
     if (key.upArrow) {
-      setHighlight((h) => (h <= 0 ? props.items.length - 1 : h - 1));
+      setHighlight((h) =>
+        clampIndex(h <= 0 ? props.items.length - 1 : h - 1, props.items.length),
+      );
       return;
     }
     if (key.downArrow) {
-      setHighlight((h) => (h + 1) % props.items.length);
+      setHighlight((h) =>
+        props.items.length === 0 ? 0 : (h + 1) % props.items.length,
+      );
       return;
     }
     if (key.return) {

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -1,0 +1,95 @@
+// Numbered select primitive for slash forms + future palettes.
+//
+// Renders each item with a `›` pointer on the focused row (Ink figures.pointer
+// equivalent in plain ASCII) and a `✓` on the currently-active value per
+// docs/prd/cli-tui-ink/10-architecture.md § Intuitiveness conventions.
+//
+// `↑/↓` walks the rows, Enter calls `onSelect`, Esc calls `onCancel`. Items
+// receive a 1-based numeric prefix so digit shortcuts can jump directly.
+
+import { Box, Text, useInput } from 'ink';
+import { useState } from 'react';
+
+export interface SelectItem<T> {
+  readonly value: T;
+  readonly label: string;
+  readonly description?: string;
+  readonly disabled?: boolean;
+}
+
+export interface SelectProps<T> {
+  readonly items: ReadonlyArray<SelectItem<T>>;
+  /** Value currently active in the system (rendered with a tick). */
+  readonly activeValue?: T;
+  readonly onSelect: (value: T) => void;
+  readonly onCancel: () => void;
+  /** Focus the Nth item on mount (defaults to the active value's index, or 0). */
+  readonly initialIndex?: number;
+}
+
+export function Select<T>(props: SelectProps<T>): React.JSX.Element {
+  const initial =
+    props.initialIndex ??
+    Math.max(
+      0,
+      props.items.findIndex((it) => it.value === props.activeValue),
+    );
+  const [highlight, setHighlight] = useState(initial);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      props.onCancel();
+      return;
+    }
+    if (key.upArrow) {
+      setHighlight((h) => (h <= 0 ? props.items.length - 1 : h - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setHighlight((h) => (h + 1) % props.items.length);
+      return;
+    }
+    if (key.return) {
+      const choice = props.items[highlight];
+      if (choice && !choice.disabled) props.onSelect(choice.value);
+      return;
+    }
+    // 1-9 digit jumps for direct selection.
+    const digit = Number(input);
+    if (Number.isInteger(digit) && digit >= 1 && digit <= 9) {
+      const idx = digit - 1;
+      if (idx < props.items.length) {
+        const choice = props.items[idx];
+        if (choice && !choice.disabled) {
+          setHighlight(idx);
+          props.onSelect(choice.value);
+        }
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {props.items.map((item, i) => {
+        const focused = i === highlight;
+        const active = item.value === props.activeValue;
+        const pointer = focused ? '›' : ' ';
+        const tick = active ? '✓' : ' ';
+        const numeric = i < 9 ? `${i + 1}.` : '  ';
+        return (
+          <Box key={String(item.value)}>
+            <Text color={focused ? 'cyan' : undefined}>
+              {pointer} {tick} {numeric}{' '}
+            </Text>
+            <Text color={focused ? 'cyan' : undefined} dimColor={item.disabled}>
+              {item.label}
+            </Text>
+            {item.description ? (
+              <Text dimColor>{` — ${item.description}`}</Text>
+            ) : null}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
Phase 5b builds on the Phase 5a foundation, landing the structured-form architecture and the first form (`/model`). Also folds in the Phase 5a review cleanup that landed after #4103 merged.

## Summary

**Cherry-picked from Phase 5a follow-up (`4d256eb`)**

- `inputHistory.loadInputHistory` wraps the JSONL read in try/catch.
- Compactions preserve each entry's original timestamp.
- `/resume` description drops the roadmap framing.
- `ReverseSearch` wires Ctrl-G as the documented secondary cancel.
- `InputBar` surfaces history persist failures through the log sink.

**Form-mount surface (this commit)**

- `slashRegistry.SlashCommand` grows an optional `formComponent` field with `SlashFormProps<{onDone, remainder}>`.
- `cliState.activeForm` signal holds the currently-mounted form's `commandName` + render thunk.
- `App.tsx` mounts the active form above the input bar and disables typing while a form owns the screen.
- `SlashPalette.onPick` dispatches form-bearing commands through the `activeForm` signal instead of inserting the command into the input.

**Primitives**

- `ui/Select.tsx` — numbered select with `›` pointer + `✓` tick, 1-9 direct jumps, Enter/Esc.
- `forms/ModelForm.tsx` — loads the resolved model registry, picks an active model, writes selection back into `cliState.sessionMeta`.

**Out of scope (Phase 5 remainders)**

- `Ctrl-P` full palette (`fzf-for-js` cross-section search).
- Image-paste attachments.
- `@` file picker.
- `Ctrl-F` transcript search.
- `Ctrl-O` expand affordance for truncated content.
- Tabbed-form scaffold for `/status` (single-screen first).

## Test plan

- [x] `npm run typecheck` green.
- [x] `npm run test:kernel -- src/test-kernel/cli/` — 34/34 pass.
- [x] `pnpm --filter @texra/cli build` green (CLI architecture check + bundle).
- [ ] Manual: `texra chat --tui`, type `/m`, pick `/model` from the palette, navigate the list with ↑/↓, hit Enter, verify the header reflects the new model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces new TUI state and input-routing for slash commands, which could affect chat input focus/disable behavior and command handling. Changes are UI-scoped with limited data impact (session meta + local history persistence).
> 
> **Overview**
> Adds **structured-form support for slash commands**: `SlashCommand` can now declare a `formComponent`, `InputBar` mounts these via a new `cliState.activeForm` signal (instead of inserting text), and `App` renders the active form overlay while disabling normal input.
> 
> Introduces the first form, **`/model`**, including a reusable numbered `Select` UI and a `ModelForm` that loads available models and updates `cliState.sessionMeta.model` on selection.
> 
> Includes related robustness tweaks: input history loading is wrapped in try/catch and compaction preserves timestamps; history write failures are logged; reverse search adds Ctrl-G cancel; and builtin command metadata is updated (notably `/resume` and `/model` now wired to the form).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161ae2213ffd11a6a1125eaca7831c49ca61c49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->