### PR TITLE
chore(cli): simplify runtime layer

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -116,16 +116,10 @@ const agentsListCommand = defineCommand({
 async function listAgents(context: CliContext): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
   await loadAgents();
-  const agents = [
-    ...getVisibleAgents(AgentCategory.Workflow).map((agent) => ({
-      ...agent,
-      category: AgentCategory.Workflow,
-    })),
-    ...getVisibleAgents(AgentCategory.ToolUse).map((agent) => ({
-      ...agent,
-      category: AgentCategory.ToolUse,
-    })),
-  ];
+  const agents = [AgentCategory.Workflow, AgentCategory.ToolUse].flatMap(
+    (category) =>
+      getVisibleAgents(category).map((agent) => ({ ...agent, category })),
+  );
 
   if (context.outputFormat === 'json') {
     writeTextStdout(JSON.stringify(agents, null, 2));
@@ -695,12 +689,6 @@ function isCliError(error: unknown): error is Error & { code?: string } {
 }
 
 /**
- * Re-implement the surface citty's `runMain` provides — `--help` / `--version`
- * detection plus error handling around `runCommand` — so usage errors (missing
- * required flag, unknown subcommand, invalid enum value) preserve our
- * canonical `CliExitCode.Usage` (2) instead of citty's hard-coded `exit(1)`.
- */
-/**
  * Walk `rawArgs` positional-by-positional through the subcommand tree to find
  * the deepest matched command. Used to scope `--help` to the subcommand the
  * user typed rather than always showing root-level usage.
@@ -738,6 +726,12 @@ async function resolveDeepestSubCommand(
   return [cmd, parent];
 }
 
+/**
+ * Re-implement the surface citty's `runMain` provides — `--help` / `--version`
+ * detection plus error handling around `runCommand` — so usage errors (missing
+ * required flag, unknown subcommand, invalid enum value) preserve our
+ * canonical `CliExitCode.Usage` (2) instead of citty's hard-coded `exit(1)`.
+ */
 export async function runCli(
   argv?: readonly string[],
 ): Promise<{ exitCode: number }> {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -27,21 +27,18 @@ export interface ApprovalDecision {
   readonly userMessage?: string;
 }
 
-type ApprovalEvent =
-  | 'showBashPermission'
-  | 'showPlanApproval'
-  | 'showAgentProposal'
-  | 'showRetryRequest';
+const APPROVAL_EVENTS = [
+  'showBashPermission',
+  'showPlanApproval',
+  'showAgentProposal',
+  'showRetryRequest',
+] as const;
+type ApprovalEvent = (typeof APPROVAL_EVENTS)[number];
 
 function isApprovalEvent(
   event: keyof ProgressEventPayloads,
 ): event is ApprovalEvent {
-  return (
-    event === 'showBashPermission' ||
-    event === 'showPlanApproval' ||
-    event === 'showAgentProposal' ||
-    event === 'showRetryRequest'
-  );
+  return (APPROVAL_EVENTS as readonly string[]).includes(event);
 }
 
 const deniedApprovalContexts = new WeakSet<CliContext>();
@@ -209,6 +206,15 @@ function dispatchApprovalDecision<K extends ApprovalEvent>(
   }
 }
 
+function humanInputDenialFeedback(
+  context: CliContext,
+  yoloMessage: string,
+): string {
+  if (context.approvalPolicy === 'yolo') return yoloMessage;
+  markApprovalDenied(context);
+  return denyMessage(context.approvalPolicy);
+}
+
 function handleExternalInquiry(
   payload: ProgressEventPayloads['showExternalInquiry'],
   context: CliContext,
@@ -220,11 +226,10 @@ function handleExternalInquiry(
   }
 
   if (!approvalPromptAllowed(context)) {
-    const feedback =
-      context.approvalPolicy === 'yolo'
-        ? 'External inquiry requires human input; yolo mode cannot synthesize an external answer.'
-        : denyMessage(context.approvalPolicy);
-    if (context.approvalPolicy !== 'yolo') markApprovalDenied(context);
+    const feedback = humanInputDenialFeedback(
+      context,
+      'External inquiry requires human input; yolo mode cannot synthesize an external answer.',
+    );
     void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
     return;
   }
@@ -293,11 +298,10 @@ function handleUserQuestion(
   context: CliContext,
 ): void {
   if (!approvalPromptAllowed(context)) {
-    const feedback =
-      context.approvalPolicy === 'yolo'
-        ? 'User question requires human input; yolo mode cannot synthesize an answer.'
-        : denyMessage(context.approvalPolicy);
-    if (context.approvalPolicy !== 'yolo') markApprovalDenied(context);
+    const feedback = humanInputDenialFeedback(
+      context,
+      'User question requires human input; yolo mode cannot synthesize an answer.',
+    );
     void handleUserQuestionAction({
       requestId: payload.requestId,
       action: 'skip',

--- a/packages/cli/src/runtime/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approvalPolicy.ts
@@ -1,11 +1,2 @@
 export const CLI_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
-
-export function parseCliApprovalPolicy(
-  value: string | undefined,
-): CliApprovalPolicy | undefined {
-  if (value === undefined) return undefined;
-  return (CLI_APPROVAL_POLICIES as readonly string[]).includes(value)
-    ? (value as CliApprovalPolicy)
-    : undefined;
-}

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -85,10 +85,6 @@ export function readCliArgv(): string[] {
   return process.argv.slice(2);
 }
 
-function resolveCwdFlag(value: string | undefined, fallback: string): string {
-  return isNonEmptyString(value) ? path.resolve(value.trim()) : fallback;
-}
-
 let cachedVersion: Promise<string> | undefined;
 
 export function readCliVersion(): Promise<string> {
@@ -150,8 +146,11 @@ export async function buildCliContext(
   init: BuildCliContextInit,
 ): Promise<CliContext> {
   const ambient = init.ambient ?? readCliAmbientState();
+  const cwdFlag = init.globalArgs.cwd;
   return {
-    cwd: resolveCwdFlag(init.globalArgs.cwd, process.cwd()),
+    cwd: isNonEmptyString(cwdFlag)
+      ? path.resolve(cwdFlag.trim())
+      : process.cwd(),
     mode: cliMode(init.globalArgs, ambient),
     outputFormat: init.globalArgs.outputFormat,
     approvalPolicy: init.globalArgs.approvalPolicy,

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -41,20 +41,20 @@ let serverSideKeysInitialized = false;
 let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
 
+function logAt(
+  level: 'debug' | 'info' | 'warn',
+  channel: string,
+  message: string,
+): void {
+  if (quietPlatformLogs) return;
+  writeTextStderr(`[${level}] [${channel}] ${message}`);
+}
+
 const cliPlatformLog: LogBackend = {
   initialize() {},
-  debug: (channel, message) =>
-    quietPlatformLogs
-      ? undefined
-      : writeTextStderr(`[debug] [${channel}] ${message}`),
-  info: (channel, message) =>
-    quietPlatformLogs
-      ? undefined
-      : writeTextStderr(`[info] [${channel}] ${message}`),
-  warn: (channel, message) =>
-    quietPlatformLogs
-      ? undefined
-      : writeTextStderr(`[warn] [${channel}] ${message}`),
+  debug: (channel, message) => logAt('debug', channel, message),
+  info: (channel, message) => logAt('info', channel, message),
+  warn: (channel, message) => logAt('warn', channel, message),
   error: (channel, message) =>
     writeTextStderr(`[error] [${channel}] ${message}`),
 };
@@ -79,10 +79,9 @@ export async function initCliPlatform(
   );
 
   if (!tryPlatform()) {
-    const globalState = createMemoryStore();
     initPlatform({
       config: new MemoryConfigProvider(),
-      globalState,
+      globalState: createMemoryStore(),
       workspaceState: createMemoryStore(),
       log: cliPlatformLog,
       fs: nodeFilesystem,
@@ -94,32 +93,19 @@ export async function initCliPlatform(
       lifecycle: noopLifecycle,
       agentResume: { tryResumeStream: async () => false },
     });
+  }
+
+  if (!serverSideKeysInitialized) {
     initializeCliSupabaseAuth(cliPlatformLog);
     initializeServerSideKeyAccess(
-      {
-        state: globalState,
-        logger: cliPlatformLog,
-      },
-      getCliAuthProvider(),
-    );
-    serverSideKeysInitialized = true;
-  } else if (!serverSideKeysInitialized) {
-    initializeCliSupabaseAuth(cliPlatformLog);
-    initializeServerSideKeyAccess(
-      {
-        state: tryPlatform()?.globalState,
-        logger: cliPlatformLog,
-      },
+      { state: tryPlatform()?.globalState, logger: cliPlatformLog },
       getCliAuthProvider(),
     );
     serverSideKeysInitialized = true;
   }
 
-  if (await getCliAuthProvider().isAuthenticated()) {
-    await getServerSideKeyService().setUseIncludedModelAccess(true);
-  } else {
-    await getServerSideKeyService().setUseIncludedModelAccess(false);
-  }
+  const authed = await getCliAuthProvider().isAuthenticated();
+  await getServerSideKeyService().setUseIncludedModelAccess(authed);
   await setCliHelperModel(context.helperModel);
 
   if (bootstrappedResourcesPath !== context.resourcesPath) {

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -4,84 +4,43 @@ import { createInterface } from 'node:readline/promises';
 // Local imports - logger
 import type { LogRecord, LogSink } from '@logger/structuredLogger';
 
-let stdoutClosed = false;
-let stderrClosed = false;
+const closed = { stdout: false, stderr: false };
 
-function writeLine(
-  stream: NodeJS.WriteStream,
-  text: string,
-  streamClosed: () => boolean,
-  markClosed: () => void,
-): void {
-  if (streamClosed() || stream.destroyed) return;
-  const handleWriteError = (): void => {
-    // CLI output is best effort: throwing from an async write callback bypasses
-    // the command error boundary and can crash the process.
-    markClosed();
-  };
+type StreamKey = 'stdout' | 'stderr';
+
+// CLI output is best effort: throwing from an async write callback would bypass
+// the command error boundary and can crash the process.
+function writeRaw(key: StreamKey, text: string): void {
+  if (closed[key]) return;
+  const stream = process[key];
+  if (stream.destroyed) return;
   try {
-    stream.write(`${text}\n`, (error) => {
-      if (!error) return;
-      handleWriteError();
+    stream.write(text, (error) => {
+      if (error) closed[key] = true;
     });
   } catch {
-    handleWriteError();
+    closed[key] = true;
   }
 }
 
 export function writeNdjsonStdout(record: unknown): void {
-  writeLine(
-    process.stdout,
-    JSON.stringify(record),
-    () => stdoutClosed,
-    () => {
-      stdoutClosed = true;
-    },
-  );
+  writeRaw('stdout', `${JSON.stringify(record)}\n`);
 }
 
 export function writeTextStdout(text: string): void {
-  writeLine(
-    process.stdout,
-    text,
-    () => stdoutClosed,
-    () => {
-      stdoutClosed = true;
-    },
-  );
+  writeRaw('stdout', `${text}\n`);
 }
 
 export function writeRawStdout(text: string): void {
-  if (stdoutClosed || process.stdout.destroyed) return;
-  try {
-    process.stdout.write(text, (error) => {
-      if (error) stdoutClosed = true;
-    });
-  } catch {
-    stdoutClosed = true;
-  }
+  writeRaw('stdout', text);
 }
 
 export function writeRawStderr(text: string): void {
-  if (stderrClosed || process.stderr.destroyed) return;
-  try {
-    process.stderr.write(text, (error) => {
-      if (error) stderrClosed = true;
-    });
-  } catch {
-    stderrClosed = true;
-  }
+  writeRaw('stderr', text);
 }
 
 export function writeTextStderr(text: string): void {
-  writeLine(
-    process.stderr,
-    text,
-    () => stderrClosed,
-    () => {
-      stderrClosed = true;
-    },
-  );
+  writeRaw('stderr', `${text}\n`);
 }
 
 export async function askCliQuestion(question: string): Promise<string> {

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -21,10 +21,9 @@ export type CliRuntimeHost = AgentRuntimeHost & {
 };
 
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
-  const quietLogs = context.quietLogs ?? false;
   let sink: LogSink | undefined;
   let logger: Logger | undefined;
-  const ensureLogger = (): Logger => {
+  function ensureLogger(): Logger {
     if (logger) return logger;
     sink =
       context.outputFormat === 'ndjson'
@@ -32,7 +31,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         : new StderrTextSink();
     logger = createStructuredLogger(sink);
     return logger;
-  };
+  }
 
   return {
     emit(event, payload) {
@@ -48,14 +47,14 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         return;
       }
 
-      if (quietLogs && event !== 'requestShowError') return;
-
       if (event === 'requestShowError') {
         ensureLogger().error(
           (payload as ProgressEventPayloads['requestShowError']).message,
         );
         return;
       }
+
+      if (context.quietLogs) return;
 
       if (event === 'setTaskState') {
         const data = payload as ProgressEventPayloads['setTaskState'];


### PR DESCRIPTION
## Summary

Code-simplifier pass over the CLI runtime layer (added in cli-tui phases 0–6). No behavior changes; +74/-148 across 7 files.

- **logSinks**: collapse 5 stream writers onto a single `writeRaw(key, text)` over a `closed: { stdout, stderr }` map (drops ~40 lines of duplicated try/catch + flag glue).
- **initPlatform**: factor `logAt(level, channel, message)` shared by debug/info/warn arms of `cliPlatformLog`; merge duplicated Supabase + server-side-key init blocks; drop dead intermediate `const globalState`.
- **approvalAdapter**: replace 4-clause `isApprovalEvent` boolean chain with `APPROVAL_EVENTS` tuple + `.includes` (`ApprovalEvent` derived from the tuple); extract `humanInputDenialFeedback` to deduplicate yolo-vs-policy denial in `handleExternalInquiry` and `handleUserQuestion`.
- **approvalPolicy**: drop unused `parseCliApprovalPolicy` (zero callers anywhere in repo).
- **cliContext**: inline single-use `resolveCwdFlag`.
- **runtimeHost**: re-order `requestShowError` handling before the quiet-logs cutoff; drop `quietLogs` local shadow.
- **commands/root.ts**: `flatMap` over agent categories in `listAgents` instead of duplicated `.map(...)` per category; move misplaced JSDoc onto the function it describes.

No exported symbols changed.

## Test plan
- [x] \`npx tsc --noEmit -p packages/cli/tsconfig.json\` — clean
- [ ] CI green
- [ ] Smoke: \`texra chat\` boots and a slash command (e.g. \`/help\`, \`/login\`) round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on deduplicating CLI runtime/logging and approval-handling code; primary risk is subtle behavior changes in logging/quiet-mode and denial feedback strings/paths.
> 
> **Overview**
> **Simplifies the CLI runtime implementation without changing public APIs.**
> 
> Refactors CLI stream/log writing to a single best-effort `writeRaw` path, deduplicates platform log formatting and server-side key initialization in `initCliPlatform`, and cleans up approval-event handling by deriving `ApprovalEvent` from a constant list and centralizing human-input denial feedback.
> 
> Also removes the unused `parseCliApprovalPolicy`, inlines `cwd` flag resolution in `buildCliContext`, adjusts `runtimeHost` quiet-log gating so `requestShowError` is emitted before quiet suppression, and simplifies agent listing to a `flatMap` over categories while moving the `runCli` JSDoc to the correct location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d53a72bcb6e167823764873776ee735628165a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->