### PR TITLE
chore(cli-tui): simplify render & modal components

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,7 +1,7 @@
 // Ink TUI root. Phase 1 skeleton + Phase 2 approval-modal overlay + Phase 4
 // SubagentList / TodosPlanPanel side panels and Ctrl-A / Ctrl-B focus cycle.
 
-import { Box, useApp, useInput } from 'ink';
+import { Box, useInput } from 'ink';
 
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ConversationPane } from './panes/ConversationPane';
@@ -23,8 +23,6 @@ export interface AppProps {
 }
 
 export function App(props: AppProps): React.JSX.Element {
-  const { exit } = useApp();
-  void exit;
   // Single subscription site; pass the value down so ApprovalModal renders
   // off the same read and InputBar can stay mounted but disabled.
   const pending = useSignal(currentApproval);
@@ -37,12 +35,12 @@ export function App(props: AppProps): React.JSX.Element {
   // Hide the side column when both side panes would render empty —
   // otherwise the conversation loses 28 columns of width for nothing.
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const showSideColumn = activeSlice
-    ? activeSlice.activeSubagents.length > 0 ||
+  const showSideColumn =
+    activeSlice !== undefined &&
+    (activeSlice.activeSubagents.length > 0 ||
       activeSlice.activeProcesses.length > 0 ||
       activeSlice.todos.length > 0 ||
-      activeSlice.plan !== null
-    : false;
+      activeSlice.plan !== null);
 
   // Ctrl-A / Ctrl-B focus cycle runs at the App layer so the same chord
   // lands no matter which pane currently has the user's attention.

--- a/packages/cli/src/chat/tui/forms/ModelForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelForm.tsx
@@ -1,11 +1,8 @@
 // Single-screen `/model` form. Renders the resolved model list with
 // availability status, lets the user pick a new active model with arrow
-// keys + Enter, and writes the choice back into `cliState.sessionMeta`
-// alongside the existing CLI helper-model wiring.
-//
-// Phase 5b ships the *picker* surface; ramping the new selection through
-// `setCliHelperModel` for follow-up turns is a downstream concern handled
-// by the caller's `onPick` (see `App.tsx` → `applyModelSelection`).
+// keys + Enter, and forwards the choice to `onSelect`. Ramping the new
+// selection through `setCliHelperModel` is a downstream concern handled
+// by the caller (see `commands/registerBuiltins.tsx`).
 
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
@@ -21,6 +18,34 @@ export interface ModelFormProps {
   readonly currentModel: string;
   readonly onSelect: (value: string) => void;
   readonly onCancel: () => void;
+}
+
+interface ModelFrameProps {
+  readonly color: string;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}
+
+function ModelFrame(props: ModelFrameProps): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={props.color}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={props.color}>
+        {props.title}
+      </Text>
+      {props.children}
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[{ key: 'Esc', action: 'cancel' }]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
 }
 
 export function ModelForm(props: ModelFormProps): React.JSX.Element {
@@ -54,44 +79,16 @@ export function ModelForm(props: ModelFormProps): React.JSX.Element {
 
   if (loading) {
     return (
-      <Box
-        borderStyle="round"
-        borderColor="cyan"
-        flexDirection="column"
-        paddingX={1}
-      >
-        <Text bold color="cyan">
-          /model
-        </Text>
+      <ModelFrame color="cyan" title="/model">
         <Text dimColor>Loading model registry…</Text>
-        <Box marginTop={1}>
-          <KeyHints
-            hints={[{ key: 'Esc', action: 'cancel' }]}
-            confirmCancel={false}
-          />
-        </Box>
-      </Box>
+      </ModelFrame>
     );
   }
   if (error) {
     return (
-      <Box
-        borderStyle="round"
-        borderColor="red"
-        flexDirection="column"
-        paddingX={1}
-      >
-        <Text bold color="red">
-          /model — error
-        </Text>
+      <ModelFrame color="red" title="/model — error">
         <Text>{error}</Text>
-        <Box marginTop={1}>
-          <KeyHints
-            hints={[{ key: 'Esc', action: 'cancel' }]}
-            confirmCancel={false}
-          />
-        </Box>
-      </Box>
+      </ModelFrame>
     );
   }
 

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from 'ink';
-import { ConfirmInput } from '@inkjs/ui';
 
 import type { AgentProposalPermission } from '@shared/schemas';
 
+import { ConfirmCard } from './ConfirmCard';
 import type { ApprovalDecision } from '../state/approvalQueue';
-import { KeyHints } from '../ui/KeyHints';
 
 export interface AgentProposalProps {
   readonly payload: AgentProposalPermission;
@@ -13,33 +12,15 @@ export interface AgentProposalProps {
 
 export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   return (
-    <Box
+    <ConfirmCard
       borderStyle="double"
-      borderColor="magenta"
-      flexDirection="column"
-      paddingX={1}
+      color="magenta"
+      title={`Spawn ${props.payload.agent}?`}
+      onDecide={props.onDecide}
     >
-      <Text bold color="magenta">
-        Spawn {props.payload.agent}?
-      </Text>
       <Box marginY={1}>
         <Text>{props.payload.instruction}</Text>
       </Box>
-      <Box>
-        <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
-        />
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'y', action: 'approve' },
-            { key: 'n', action: 'reject' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from 'ink';
-import { ConfirmInput } from '@inkjs/ui';
 
 import type { BashPermission } from '@shared/schemas';
 
+import { ConfirmCard } from './ConfirmCard';
 import type { ApprovalDecision } from '../state/approvalQueue';
-import { KeyHints } from '../ui/KeyHints';
 
 export interface BashApprovalProps {
   readonly payload: BashPermission;
@@ -13,33 +12,15 @@ export interface BashApprovalProps {
 
 export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   return (
-    <Box
+    <ConfirmCard
       borderStyle="double"
-      borderColor="yellow"
-      flexDirection="column"
-      paddingX={1}
+      color="yellow"
+      title="Run bash command?"
+      onDecide={props.onDecide}
     >
-      <Text bold color="yellow">
-        Run bash command?
-      </Text>
       <Box marginY={1}>
         <Text>$ {props.payload.command}</Text>
       </Box>
-      <Box>
-        <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
-        />
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'y', action: 'approve' },
-            { key: 'n', action: 'reject' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -1,0 +1,49 @@
+// Shared scaffolding for y/n approval modals — bordered frame, colored
+// title, padded body slot, ConfirmInput, and `y / n` KeyHints footer.
+
+import { Box, Text } from 'ink';
+import { ConfirmInput } from '@inkjs/ui';
+
+import type { ApprovalDecision } from '../state/approvalQueue';
+import { KeyHints } from '../ui/KeyHints';
+
+export interface ConfirmCardProps {
+  readonly borderStyle: 'single' | 'double';
+  readonly color: string;
+  readonly title: string;
+  readonly approveLabel?: string;
+  readonly rejectLabel?: string;
+  readonly children: React.ReactNode;
+  readonly onDecide: (decision: ApprovalDecision) => void;
+}
+
+export function ConfirmCard(props: ConfirmCardProps): React.JSX.Element {
+  return (
+    <Box
+      borderStyle={props.borderStyle}
+      borderColor={props.color}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={props.color}>
+        {props.title}
+      </Text>
+      {props.children}
+      <Box>
+        <ConfirmInput
+          onConfirm={() => props.onDecide({ accepted: true })}
+          onCancel={() => props.onDecide({ accepted: false })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'y', action: props.approveLabel ?? 'approve' },
+            { key: 'n', action: props.rejectLabel ?? 'reject' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -1,14 +1,14 @@
 // Shared scaffolding for y/n approval modals — bordered frame, colored
 // title, padded body slot, ConfirmInput, and `y / n` KeyHints footer.
 
-import { Box, Text } from 'ink';
+import { Box, Text, type BoxProps } from 'ink';
 import { ConfirmInput } from '@inkjs/ui';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
 import { KeyHints } from '../ui/KeyHints';
 
 export interface ConfirmCardProps {
-  readonly borderStyle: 'single' | 'double';
+  readonly borderStyle: BoxProps['borderStyle'];
   readonly color: string;
   readonly title: string;
   readonly approveLabel?: string;

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -17,29 +17,37 @@ export interface ConfirmCardProps {
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
-export function ConfirmCard(props: ConfirmCardProps): React.JSX.Element {
+export function ConfirmCard({
+  borderStyle,
+  color,
+  title,
+  approveLabel = 'approve',
+  rejectLabel = 'reject',
+  children,
+  onDecide,
+}: ConfirmCardProps): React.JSX.Element {
   return (
     <Box
-      borderStyle={props.borderStyle}
-      borderColor={props.color}
+      borderStyle={borderStyle}
+      borderColor={color}
       flexDirection="column"
       paddingX={1}
     >
-      <Text bold color={props.color}>
-        {props.title}
+      <Text bold color={color}>
+        {title}
       </Text>
-      {props.children}
+      {children}
       <Box>
         <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
+          onConfirm={() => onDecide({ accepted: true })}
+          onCancel={() => onDecide({ accepted: false })}
         />
       </Box>
       <Box marginTop={1}>
         <KeyHints
           hints={[
-            { key: 'y', action: props.approveLabel ?? 'approve' },
-            { key: 'n', action: props.rejectLabel ?? 'reject' },
+            { key: 'y', action: approveLabel },
+            { key: 'n', action: rejectLabel },
           ]}
           confirmCancel={false}
         />

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from 'react';
 import { Box, Text } from 'ink';
-import { ConfirmInput } from '@inkjs/ui';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
+import { ConfirmCard } from './ConfirmCard';
 import { buildHunks, DiffView, statsFromHunks } from '../render/DiffView';
 import type { ApprovalDecision } from '../state/approvalQueue';
-import { KeyHints } from '../ui/KeyHints';
 
 export interface EditApprovalProps {
   readonly request: ToolEditApprovalRequest;
@@ -31,15 +30,12 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const stats = useMemo(() => statsFromHunks(hunks), [hunks]);
 
   return (
-    <Box
+    <ConfirmCard
       borderStyle="double"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
+      color="cyan"
+      title={`Apply edit to ${props.request.path}?`}
+      onDecide={props.onDecide}
     >
-      <Text bold color="cyan">
-        Apply edit to {props.request.path}?
-      </Text>
       <Text dimColor>
         +{stats.added} / −{stats.removed} · {stats.hunks} hunks · source:{' '}
         {props.request.sourceTool}
@@ -47,21 +43,6 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       <Box marginY={1} flexDirection="column">
         <DiffView hunks={hunks} maxHunkLines={30} />
       </Box>
-      <Box>
-        <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
-        />
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'y', action: 'approve' },
-            { key: 'n', action: 'reject' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from 'ink';
-import { ConfirmInput } from '@inkjs/ui';
 
 import type { RetryPermission } from '@shared/schemas';
 
+import { ConfirmCard } from './ConfirmCard';
 import type { ApprovalDecision } from '../state/approvalQueue';
-import { KeyHints } from '../ui/KeyHints';
 
 export interface RetryRequestProps {
   readonly payload: RetryPermission;
@@ -13,35 +12,18 @@ export interface RetryRequestProps {
 
 export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const subject = props.payload.errorMessage ?? props.payload.operation;
-
   return (
-    <Box
+    <ConfirmCard
       borderStyle="single"
-      borderColor="yellow"
-      flexDirection="column"
-      paddingX={1}
+      color="yellow"
+      title="Retry the failed call?"
+      approveLabel="retry"
+      rejectLabel="give up"
+      onDecide={props.onDecide}
     >
-      <Text bold color="yellow">
-        Retry the failed call?
-      </Text>
       <Box marginY={1}>
         <Text dimColor>{subject}</Text>
       </Box>
-      <Box>
-        <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
-        />
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'y', action: 'retry' },
-            { key: 'n', action: 'give up' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -31,14 +31,11 @@ function statusColor(status: string | undefined): string | undefined {
  *  this is bounded work. */
 function lastLines(tail: ProcessOutputTail | undefined): string[] {
   if (!tail) return [];
-  const combined = `${tail.stdout}\n${tail.stderr}`;
-  const lines = combined.split('\n');
-  const trimmed: string[] = [];
-  for (let i = lines.length - 1; i >= 0 && trimmed.length < TAIL_LINES; i--) {
-    const line = lines[i]?.trimEnd();
-    if (line) trimmed.unshift(line);
-  }
-  return trimmed;
+  const nonBlank = `${tail.stdout}\n${tail.stderr}`
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+  return nonBlank.slice(-TAIL_LINES);
 }
 
 function Row({ child, index, tail }: RowProps): React.JSX.Element {

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -69,15 +69,43 @@ function configureAnsi(md: MarkdownItInstance): void {
     )}`;
   };
 
-  const headingOpen: RenderRule = (tokens, idx) => {
+  r.heading_open = (tokens, idx) => {
     const level = Number(tokens[idx]?.tag?.slice(1) ?? 1);
     const marker = '#'.repeat(level);
     const start = quoteDepth === 0 ? '\n' : quoteBlockStart(tokens, idx);
     return `${start}${pico.bold(pico.cyan(`${marker} `))}`;
   };
-  const codeInline: RenderRule = (tokens, idx) =>
+  r.heading_close = () => '\n';
+
+  r.paragraph_open = (tokens, idx) => {
+    if (quoteDepth === 0) return '';
+    // markdown-it fires custom rules even for `hidden` paragraph tokens
+    // (only the default `renderToken` short-circuits on hidden). Tight
+    // lists inside blockquotes (`> - a\n> - b`) emit such hidden
+    // paragraphs right after `list_item_open` — re-prefixing here would
+    // inject the gutter after the bullet marker. The bullet rule already
+    // sits inside the blockquote run, so the gutter is intact.
+    if (tokens[idx]?.hidden) return '';
+    const prev = tokens[idx - 1]?.type;
+    if (prev === 'blockquote_open' || prev === 'list_item_open') return '';
+    return quotePrefix();
+  };
+  r.paragraph_close = (tokens, idx) => {
+    if (tokens[idx]?.hidden) return '\n';
+    if (tokens[idx + 1]?.type === 'blockquote_close') return '\n';
+    return quoteDepth > 0 ? `\n${quotePrefix()}\n` : '\n\n';
+  };
+
+  r.strong_open = () => sgr(1);
+  r.strong_close = () => sgr(22);
+  r.em_open = () => sgr(3);
+  r.em_close = () => sgr(23);
+  r.s_open = () => sgr(9);
+  r.s_close = () => sgr(29);
+
+  r.code_inline = (tokens, idx) =>
     pico.cyan(`\`${tokens[idx]?.content ?? ''}\``);
-  const fence: RenderRule = (tokens, idx) => {
+  r.fence = (tokens, idx) => {
     const token = tokens[idx];
     if (!token) return '';
     const langName = token.info.trim().split(/\s+/)[0] ?? '';
@@ -90,70 +118,28 @@ function configureAnsi(md: MarkdownItInstance): void {
       body || pico.gray(token.content.replace(/\n+$/, '')),
     )}\n\n`;
   };
-  const codeBlock: RenderRule = (tokens, idx) =>
+  r.code_block = (tokens, idx) =>
     `${withQuoteGutter(
       tokens,
       idx,
       pico.gray(tokens[idx]?.content.replace(/\n+$/, '') ?? ''),
     )}\n\n`;
-  const listItemOpen: RenderRule = (tokens, idx) => {
-    const token = tokens[idx];
-    const marker = token?.info ? `${token.info}${token.markup || '.'}` : '•';
-    // The first item in a list inherits the blockquote gutter from
-    // `blockquote_open`; continuation items follow a `list_item_close → \n`
-    // and need the gutter re-injected so the second bullet doesn't render
-    // at column 0.
-    const prev = tokens[idx - 1]?.type;
-    const fresh = prev === 'bullet_list_open' || prev === 'ordered_list_open';
-    return `${fresh ? '' : quotePrefix()}  ${pico.dim(marker)} `;
-  };
-  const paragraphOpen: RenderRule = (tokens, idx) => {
-    if (quoteDepth === 0) return '';
-    const token = tokens[idx];
-    // markdown-it fires custom rules even for `hidden` paragraph tokens
-    // (only the default `renderToken` short-circuits on hidden). Tight
-    // lists inside blockquotes (`> - a\n> - b`) emit such hidden
-    // paragraphs right after `list_item_open` — re-prefixing here would
-    // inject the gutter after the bullet marker. The bullet rule already
-    // sits inside the blockquote run, so the gutter is intact.
-    if (token?.hidden) return '';
-    const prev = tokens[idx - 1]?.type;
-    if (prev === 'blockquote_open' || prev === 'list_item_open') return '';
-    return quotePrefix();
-  };
-  const paragraphClose: RenderRule = (tokens, idx) => {
-    if (tokens[idx]?.hidden) return '\n';
-    if (tokens[idx + 1]?.type === 'blockquote_close') return '\n';
-    return quoteDepth > 0 ? `\n${quotePrefix()}\n` : '\n\n';
-  };
-  const textRule: RenderRule = (tokens, idx) => tokens[idx]?.content ?? '';
-  const image: RenderRule = (tokens, idx) => {
-    const alt = tokens[idx]?.content ?? '';
-    return pico.dim(`[image: ${alt}]`);
-  };
-
-  r.heading_open = headingOpen;
-  r.heading_close = () => '\n';
-
-  r.paragraph_open = paragraphOpen;
-  r.paragraph_close = paragraphClose;
-
-  r.strong_open = () => sgr(1);
-  r.strong_close = () => sgr(22);
-  r.em_open = () => sgr(3);
-  r.em_close = () => sgr(23);
-  r.s_open = () => sgr(9);
-  r.s_close = () => sgr(29);
-
-  r.code_inline = codeInline;
-  r.fence = fence;
-  r.code_block = codeBlock;
 
   r.bullet_list_open = () => '';
   r.bullet_list_close = () => '';
   r.ordered_list_open = () => '';
   r.ordered_list_close = () => '';
-  r.list_item_open = listItemOpen;
+  // The first item in a list inherits the blockquote gutter from
+  // `blockquote_open`; continuation items follow a `list_item_close → \n`
+  // and need the gutter re-injected so the second bullet doesn't render
+  // at column 0.
+  r.list_item_open = (tokens, idx) => {
+    const token = tokens[idx];
+    const marker = token?.info ? `${token.info}${token.markup || '.'}` : '•';
+    const prev = tokens[idx - 1]?.type;
+    const fresh = prev === 'bullet_list_open' || prev === 'ordered_list_open';
+    return `${fresh ? '' : quotePrefix()}  ${pico.dim(marker)} `;
+  };
   r.list_item_close = () => '';
 
   r.blockquote_open = (tokens, idx) => {
@@ -181,8 +167,8 @@ function configureAnsi(md: MarkdownItInstance): void {
   r.hardbreak = () => `\n${quotePrefix()}`;
 
   // markdown-it default `text` rule escapes HTML; we want raw text.
-  r.text = textRule;
-  r.image = image;
+  r.text = (tokens, idx) => tokens[idx]?.content ?? '';
+  r.image = (tokens, idx) => pico.dim(`[image: ${tokens[idx]?.content ?? ''}]`);
 
   const render = md.renderer.render.bind(md.renderer);
   md.renderer.render = (tokens, options, env) => {

--- a/packages/cli/src/chat/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/chat/tui/ui/KeyHints.tsx
@@ -24,29 +24,22 @@ export interface KeyHintsProps {
 
 const SEP = ' · ';
 
-function Hint({ hint }: { hint: KeyHint }): React.JSX.Element {
-  return (
-    <Text dimColor>
-      <Text bold>{hint.key}</Text> {hint.action}
-    </Text>
-  );
-}
+const DEFAULT_TAIL: readonly KeyHint[] = [
+  { key: 'Enter', action: 'confirm' },
+  { key: 'Esc', action: 'cancel' },
+];
 
 export function KeyHints(props: KeyHintsProps): React.JSX.Element {
-  const tail: KeyHint[] =
+  const all =
     props.confirmCancel === false
-      ? []
-      : [
-          { key: 'Enter', action: 'confirm' },
-          { key: 'Esc', action: 'cancel' },
-        ];
-  const all = [...props.hints, ...tail];
+      ? props.hints
+      : [...props.hints, ...DEFAULT_TAIL];
   return (
     <Box>
       {all.map((hint, i) => (
-        <Text key={i}>
-          {i > 0 ? <Text dimColor>{SEP}</Text> : null}
-          <Hint hint={hint} />
+        <Text key={i} dimColor>
+          {i > 0 ? SEP : ''}
+          <Text bold>{hint.key}</Text> {hint.action}
         </Text>
       ))}
     </Box>


### PR DESCRIPTION
## Summary

Code-simplifier pass over the Ink TUI render & component layer (built across cli-tui phases 1–6). No observable UI change; +121/-225 across 10 files (1 new shared helper).

- **modals**: extract shared \`ConfirmCard\` (bordered Box + colored title + \`ConfirmInput\` + y/n \`KeyHints\` footer) used by \`BashApproval\`, \`AgentProposal\`, \`RetryRequest\`, and \`EditApproval\`. \`PlanApproval\` and \`ApprovalModal\` intentionally untouched (their layout doesn't fit the y/n confirm pattern). \`ExternalInquiry\` left alone (uses a text input, not confirm).
- **App.tsx**: drop dead \`useApp()\` import + \`void exit;\` discard (no exit handler wired here); collapse \`showSideColumn\` from a ternary-always-returning-boolean to a single boolean expression.
- **ModelForm**: extract local \`ModelFrame\` for the duplicated loading/error scaffolding; fix stale comment pointing at a removed \`applyModelSelection\` symbol.
- **KeyHints**: inline the single-use \`Hint\` sub-component into the \`.map\`; lift \`DEFAULT_TAIL\` (the \`Enter confirm · Esc cancel\` pair) to a module-level constant.
- **SubagentList.lastLines**: replace the reverse-loop with \`split → map(trimEnd) → filter → slice(-N)\`.
- **ansiMarkdown**: inline the once-used named \`RenderRule\` constants (\`headingOpen\`, \`codeInline\`, \`fence\`, \`codeBlock\`, \`listItemOpen\`, \`paragraphOpen\`, \`paragraphClose\`, \`textRule\`, \`image\`) directly into the \`r.*\` assignments. The non-obvious "why" comments (\`paragraph_open\` hidden-token rule, \`list_item_open\` continuation gutter) are preserved.

No exported prop contracts changed (\`AppProps\`, \`BashApprovalProps\`, \`AgentProposalProps\`, \`RetryRequestProps\`, \`EditApprovalProps\`, \`ModelFormProps\`, \`KeyHintsProps\` unchanged).

## Test plan
- [x] \`npx vitest run src/test-kernel/cli/\` — 34/34 pass
- [ ] CI green
- [ ] Smoke: open TUI (\`texra chat\` in TTY), trigger each modal type (bash, edit, plan, retry, agent-proposal) and confirm visual layout matches main
- [ ] Smoke: \`/model\` form loading + error states render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on UI scaffolding (Ink TUI) with minimal logic changes; main risk is small layout/interaction regressions in approval modals and markdown rendering.
> 
> **Overview**
> Simplifies the CLI TUI component layer by extracting a shared `ConfirmCard` for y/n-style approval modals and migrating `BashApproval`, `AgentProposal`, `EditApproval`, and `RetryRequest` to use it.
> 
> Cleans up and de-duplicates UI scaffolding elsewhere: removes dead `useApp()` usage and simplifies `showSideColumn` gating in `App`, factors a shared `ModelFrame` for `/model` loading/error states, and streamlines `KeyHints` rendering.
> 
> Applies small internal refactors with intended no-behavior-change outcomes, including simplifying `SubagentList` tail extraction and inlining renderer rule functions in `render/ansiMarkdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d1b8ef088c654cec0aea50c6a5ec43e1ad0ef49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->