### PR TITLE
chore(cli-tui): simplify state layer

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -118,26 +118,17 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
   };
 }
 
-function withSliceUpdate(
-  current: ReadonlyMap<StreamTabId, StreamSlice>,
-  streamId: StreamTabId,
-  update: (slice: StreamSlice) => StreamSlice,
-): ReadonlyMap<StreamTabId, StreamSlice> {
-  const slice = current.get(streamId) ?? emptySlice(streamId);
-  const next = update(slice);
-  if (next === slice) return current;
-  const out = new Map(current);
-  out.set(streamId, next);
-  return out;
-}
-
 export function patchStream(
   streamId: StreamTabId,
   update: (slice: StreamSlice) => StreamSlice,
 ): void {
-  cliState.streams.set(
-    withSliceUpdate(cliState.streams.get(), streamId, update),
-  );
+  const current = cliState.streams.get();
+  const slice = current.get(streamId) ?? emptySlice(streamId);
+  const next = update(slice);
+  if (next === slice) return;
+  const out = new Map(current);
+  out.set(streamId, next);
+  cliState.streams.set(out);
 }
 
 export function setParentStream(
@@ -163,14 +154,13 @@ export function removeStream(streamId: StreamTabId): void {
   // Drop any parent-map edges that touched this stream so the focus cycle
   // never lands on a stale id.
   const parents = cliState.parentStream.get();
-  if (parents.has(streamId) || [...parents.values()].includes(streamId)) {
-    const nextParents = new Map(parents);
-    nextParents.delete(streamId);
-    for (const [child, parent] of nextParents) {
-      if (parent === streamId) nextParents.delete(child);
-    }
-    cliState.parentStream.set(nextParents);
+  let nextParents: Map<StreamTabId, StreamTabId> | undefined;
+  for (const [child, parent] of parents) {
+    if (child !== streamId && parent !== streamId) continue;
+    if (!nextParents) nextParents = new Map(parents);
+    nextParents.delete(child);
   }
+  if (nextParents) cliState.parentStream.set(nextParents);
 }
 
 export function resetCliState(): void {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -34,7 +34,6 @@ import {
   denyMessage,
   immediateDecision,
   markApprovalDenied,
-  type ApprovalDecision as PolicyDecision,
 } from '../../../runtime/approvalAdapter';
 import { assertNever } from '../assertNever';
 import { enqueueApproval, type ApprovalDecision } from './approvalQueue';
@@ -45,13 +44,19 @@ type Emit = <K extends ProgressEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
 ) => void;
-type ApprovalEvent =
-  | 'showBashPermission'
-  | 'showPlanApproval'
-  | 'showAgentProposal'
-  | 'showRetryRequest'
-  | 'showExternalInquiry'
-  | 'showUserQuestion';
+
+const APPROVAL_EVENTS = [
+  'showBashPermission',
+  'showPlanApproval',
+  'showAgentProposal',
+  'showRetryRequest',
+  'showExternalInquiry',
+  'showUserQuestion',
+] as const;
+
+type ApprovalEvent = (typeof APPROVAL_EVENTS)[number];
+
+const APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(APPROVAL_EVENTS);
 
 /**
  * Install the typed approval pipeline. Returns an `unbind` callback that
@@ -81,14 +86,11 @@ export function installTuiApprovals(
   }) as Emit;
 
   setToolEditApprovalHandler(async (request) => {
-    const policy = immediateDecision(context);
-    if (policy) {
-      return policy.accepted
-        ? { accepted: true, appliedContent: request.proposedContent }
-        : { accepted: false, userMessage: policy.userMessage };
+    let decision = immediateDecision(context);
+    if (!decision) {
+      decision = await enqueueApproval({ kind: 'toolEdit', request });
+      markIfRejected(context, decision);
     }
-    const decision = await enqueueApproval({ kind: 'toolEdit', request });
-    markIfRejected(context, decision);
     return decision.accepted
       ? { accepted: true, appliedContent: request.proposedContent }
       : { accepted: false, userMessage: decision.userMessage };
@@ -100,17 +102,8 @@ export function installTuiApprovals(
   };
 }
 
-const APPROVAL_EVENTS = new Set<ApprovalEvent>([
-  'showBashPermission',
-  'showPlanApproval',
-  'showAgentProposal',
-  'showRetryRequest',
-  'showExternalInquiry',
-  'showUserQuestion',
-]);
-
 function isApprovalEvent(event: ProgressEvent): event is ApprovalEvent {
-  return APPROVAL_EVENTS.has(event as ApprovalEvent);
+  return APPROVAL_EVENT_SET.has(event);
 }
 
 function routeApproval(
@@ -122,45 +115,33 @@ function routeApproval(
     case 'showBashPermission':
       routeWithPolicy(
         context,
-        dispatchBash,
+        'bash',
         payload as ProgressEventPayloads['showBashPermission'],
-        (p) => ({
-          kind: 'bash',
-          payload: p,
-        }),
+        dispatchBash,
       );
       return;
     case 'showPlanApproval':
       routeWithPolicy(
         context,
-        dispatchPlan,
+        'plan',
         payload as ProgressEventPayloads['showPlanApproval'],
-        (p) => ({
-          kind: 'plan',
-          payload: p,
-        }),
+        dispatchPlan,
       );
       return;
     case 'showAgentProposal':
       routeWithPolicy(
         context,
-        dispatchProposal,
+        'proposal',
         payload as ProgressEventPayloads['showAgentProposal'],
-        (p) => ({
-          kind: 'proposal',
-          payload: p,
-        }),
+        dispatchProposal,
       );
       return;
     case 'showRetryRequest':
       routeWithPolicy(
         context,
-        dispatchRetry,
+        'retry',
         payload as ProgressEventPayloads['showRetryRequest'],
-        (p) => ({
-          kind: 'retry',
-          payload: p,
-        }),
+        dispatchRetry,
       );
       return;
     case 'showExternalInquiry':
@@ -183,18 +164,24 @@ function routeApproval(
   }
 }
 
-function routeWithPolicy<P>(
+function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   context: CliContext,
-  dispatch: (payload: P, decision: ApprovalDecision) => void,
+  kind: K,
   payload: P,
-  toQueuePayload: (p: P) => Parameters<typeof enqueueApproval>[0],
+  dispatch: (payload: P, decision: ApprovalDecision) => void,
 ): void {
-  const policy: PolicyDecision | undefined = immediateDecision(context);
+  const policy = immediateDecision(context);
   if (policy) {
     dispatch(payload, policy);
     return;
   }
-  void enqueueApproval(toQueuePayload(payload)).then((decision) => {
+  // The Extract<...> cast narrows the queue payload to the kind we picked;
+  // each dispatcher already trusts its payload shape via its own signature.
+  const queuePayload = { kind, payload } as Extract<
+    Parameters<typeof enqueueApproval>[0],
+    { kind: K }
+  >;
+  void enqueueApproval(queuePayload).then((decision) => {
     markIfRejected(context, decision);
     dispatch(payload, decision);
   });
@@ -294,15 +281,20 @@ function handleUserQuestion(
   payload: ProgressEventPayloads['showUserQuestion'],
   context: CliContext,
 ): void {
-  const policy = immediateDecision(context);
-  const feedback = policy
-    ? context.approvalPolicy === 'yolo'
-      ? 'User question requires human input; yolo mode cannot synthesize an answer.'
-      : denyMessage(context.approvalPolicy)
-    : 'User questions are not yet supported in the CLI TUI.';
+  const feedback = userQuestionFeedback(context);
   void handleUserQuestionAction({
     requestId: payload.requestId,
     action: 'skip',
     feedback,
   });
+}
+
+function userQuestionFeedback(context: CliContext): string {
+  if (!immediateDecision(context)) {
+    return 'User questions are not yet supported in the CLI TUI.';
+  }
+  if (context.approvalPolicy === 'yolo') {
+    return 'User question requires human input; yolo mode cannot synthesize an answer.';
+  }
+  return denyMessage(context.approvalPolicy);
 }

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -87,20 +87,16 @@ function applyToState<K extends ProgressEvent>(
       // doesn't grow unboundedly for the lifetime of the parent stream.
       const live = new Set(p.processes.map((c) => c.executionId));
       patchStream(p.parentStreamId, (s) => {
-        let nextOutput = s.processOutput;
-        if (s.processOutput.size > 0) {
-          let mutated: Map<string, ProcessOutputTail> | undefined;
-          for (const id of s.processOutput.keys()) {
-            if (live.has(id)) continue;
-            if (!mutated) mutated = new Map(s.processOutput);
-            mutated.delete(id);
-          }
-          if (mutated) nextOutput = mutated;
+        let pruned: Map<string, ProcessOutputTail> | undefined;
+        for (const id of s.processOutput.keys()) {
+          if (live.has(id)) continue;
+          pruned ??= new Map(s.processOutput);
+          pruned.delete(id);
         }
         return {
           ...s,
           activeProcesses: p.processes,
-          processOutput: nextOutput,
+          processOutput: pruned ?? s.processOutput,
         };
       });
       return;


### PR DESCRIPTION
## Summary

Code-simplifier pass over the CLI Ink TUI state/subscription layer (built across cli-tui phases 1–5). No subscription contracts, signal shapes, or exported APIs changed; +65/-87 across 3 files.

This is the fourth and last of the four-area CLI simplification sweep (after #4109 runtime, #4110 chat orchestration, #4111 render & modals). The original parallel run lost this work without committing; this re-run lands the same wins.

- **cliState**: inline single-use \`withSliceUpdate\` into \`patchStream\` (the only caller). Replace the two-pass \`removeStream\` parent-map cleanup (\`parents.has(id) || [...parents.values()].includes(id)\` followed by nested loops) with a single forward iteration that builds the new map lazily only when there's actually an edge to drop.
- **subscribeApprovals**:
  - Drop unused \`PolicyDecision\` import alias (never referenced after switching to the inferred return type of \`immediateDecision\`).
  - Single source of truth for \`APPROVAL_EVENTS\` (was duplicated between a string-literal \`ApprovalEvent\` union AND a \`new Set<ApprovalEvent>([...])\` instantiation).
  - Flatten \`routeWithPolicy\` from \`(context, dispatch, payload, toQueuePayload)\` to \`(context, kind, payload, dispatch)\` — each call site loses its \`(p) => ({ kind: 'bash', payload: p })\` closure builder. \`Extract<...>\` narrows the queue payload to the picked kind.
  - Collapse \`setToolEditApprovalHandler\`'s split policy/enqueue paths into a single decision-then-return shape.
  - Extract \`userQuestionFeedback\` from the nested ternary in \`handleUserQuestion\`.
- **subscribeRuntimeHost**: clean up \`updateActiveProcesses\`'s prune loop — drop the redundant \`s.processOutput.size > 0\` guard (the loop is a no-op on an empty map anyway), rename \`mutated\` to \`pruned\`, use \`??=\` for the copy-on-first-write step.

## Test plan
- [ ] CI green (typecheck + format + vitest cli kernel)
- [ ] Smoke: open TUI, trigger each approval kind (bash/plan/agent/retry/external inquiry/user question) and confirm queue + immediate-policy paths still route correctly
- [ ] Smoke: kill a subprocess while a parent stream is active and confirm the process-output map prunes without UI glitches
- [ ] Smoke: close a subagent stream and confirm parent-map edges are cleaned up (no stale focus cycle targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of CLI TUI state/approval plumbing; behavior should be unchanged but small mistakes could surface as missed approvals or stale stream focus cleanup.
> 
> **Overview**
> Simplifies the CLI Ink TUI state/subscription layer without changing event contracts or exported APIs.
> 
> In `cliState`, inlines the single-use stream update helper into `patchStream` and streamlines `removeStream` parent-edge cleanup to a single lazy copy-on-write pass.
> 
> In approvals, centralizes approval-event constants, simplifies `routeWithPolicy`/tool-edit decision flow, and extracts user-question feedback generation into a helper. Runtime-host subscription pruning for `updateActiveProcesses` is also tightened to lazily clone `processOutput` only when entries are actually removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51946337bef4f15aa6b6b608b4194fbea780876f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->