### PR TITLE
refactor(auth): extract createHostAuthCoordinator shared by cli/desktop/extension

### DIFF
--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -9,10 +9,7 @@ import {
 
 // Local imports - auth
 import { AUTH_CALLBACK_TIMEOUT_MS, DEFAULT_OAUTH_PROVIDER } from '@auth/config';
-import {
-  createSupabaseAuthCoordinator,
-  createSupabaseSessionStorage,
-} from '@auth/SupabaseAuthCoordinator';
+import { createHostAuthCoordinator } from '@auth/createHostAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   type SupabaseSession,
@@ -80,8 +77,8 @@ function getCliSupabaseAuthCoordinator(): SupabaseSessionCoordinator {
 
 export function initializeCliSupabaseAuth(log?: LogBackend): void {
   activeAuthLog = log ?? activeAuthLog;
-  coordinator ??= createSupabaseAuthCoordinator({
-    storage: createSupabaseSessionStorage(getCliSecrets()),
+  coordinator ??= createHostAuthCoordinator({
+    secrets: getCliSecrets(),
     log: deferredAuthLog,
   });
 }

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -7,10 +7,7 @@ import {
   toRemoteAgentProfileData,
 } from '@agent/index';
 import { DEFAULT_OAUTH_PROVIDER, getAuthCallbackUri } from '@auth/config';
-import {
-  createSupabaseAuthCoordinator,
-  createSupabaseSessionStorage,
-} from '@auth/SupabaseAuthCoordinator';
+import { createHostAuthCoordinator } from '@auth/createHostAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   type SupabaseCallbackResult,
@@ -261,8 +258,8 @@ export function createDesktopSupabaseAuth(
 export function createDesktopAuthCoordinator(
   options: Pick<DesktopSupabaseAuthOptions, 'secrets' | 'log'>,
 ): DesktopAuthCoordinator {
-  return createSupabaseAuthCoordinator({
-    storage: createSupabaseSessionStorage(options.secrets),
+  return createHostAuthCoordinator({
+    secrets: options.secrets,
     log: createSessionLog(options.log),
   });
 }

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -12,11 +12,8 @@ import {
   isOAuthProvider,
   type OAuthProvider,
 } from './config';
-import {
-  DEFAULT_AUTH_EDGE_FUNCTION_TIMEOUT_MS,
-  createSupabaseAuthCoordinator,
-  createSupabaseSessionStorage,
-} from './SupabaseAuthCoordinator';
+import { DEFAULT_AUTH_EDGE_FUNCTION_TIMEOUT_MS } from './SupabaseAuthCoordinator';
+import { createHostAuthCoordinator } from './createHostAuthCoordinator';
 import { getServerSideKeyService } from './serverKeys';
 import {
   fetchWithTimeout,
@@ -56,12 +53,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private isProcessingCallback = false;
 
   constructor(private context: vscode.ExtensionContext) {
-    this.sessionCoordinator = createSupabaseAuthCoordinator({
-      storage: createSupabaseSessionStorage({
+    this.sessionCoordinator = createHostAuthCoordinator({
+      secrets: {
         get: (key) => Promise.resolve(context.secrets.get(key)),
         set: (key, value) => Promise.resolve(context.secrets.store(key, value)),
         delete: (key) => Promise.resolve(context.secrets.delete(key)),
-      }),
+      },
       whenReady: async () => {
         if (!this.uriHandler) {
           throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);

--- a/src/auth/createHostAuthCoordinator.ts
+++ b/src/auth/createHostAuthCoordinator.ts
@@ -1,0 +1,42 @@
+import {
+  createSupabaseAuthCoordinator,
+  createSupabaseSessionStorage,
+  type SupabaseSecretStore,
+} from './SupabaseAuthCoordinator';
+import type {
+  SupabaseSessionCoordinator,
+  SupabaseSessionLog,
+} from './SupabaseSession';
+
+export interface HostAuthCoordinatorInit {
+  /**
+   * Secret storage backing the persisted Supabase session.
+   * VS Code passes a `context.secrets`-backed adapter; CLI and Electron pass
+   * their `PlatformSecrets` implementation directly.
+   */
+  readonly secrets: SupabaseSecretStore;
+  /** Optional structured log sink for the session coordinator. */
+  readonly log?: SupabaseSessionLog;
+  /**
+   * Optional gate the coordinator awaits before processing OAuth callbacks.
+   * The VS Code host uses this to ensure the URI handler is installed.
+   */
+  readonly whenReady?: () => Promise<void>;
+}
+
+/**
+ * Shared host wiring for the Supabase session coordinator.
+ *
+ * All three TeXRA hosts (CLI, Electron, VS Code extension) build the same
+ * coordinator from a secret store + log; this helper centralises that
+ * construction so host-specific files only deal with their OAuth glue.
+ */
+export function createHostAuthCoordinator(
+  init: HostAuthCoordinatorInit,
+): SupabaseSessionCoordinator {
+  return createSupabaseAuthCoordinator({
+    storage: createSupabaseSessionStorage(init.secrets),
+    log: init.log,
+    whenReady: init.whenReady,
+  });
+}

--- a/src/auth/createHostAuthCoordinator.ts
+++ b/src/auth/createHostAuthCoordinator.ts
@@ -9,28 +9,15 @@ import type {
 } from './SupabaseSession';
 
 export interface HostAuthCoordinatorInit {
-  /**
-   * Secret storage backing the persisted Supabase session.
-   * VS Code passes a `context.secrets`-backed adapter; CLI and Electron pass
-   * their `PlatformSecrets` implementation directly.
-   */
   readonly secrets: SupabaseSecretStore;
-  /** Optional structured log sink for the session coordinator. */
   readonly log?: SupabaseSessionLog;
   /**
-   * Optional gate the coordinator awaits before processing OAuth callbacks.
-   * The VS Code host uses this to ensure the URI handler is installed.
+   * Gate the coordinator awaits before processing OAuth callbacks. The VS
+   * Code host uses this to ensure the URI handler is installed first.
    */
   readonly whenReady?: () => Promise<void>;
 }
 
-/**
- * Shared host wiring for the Supabase session coordinator.
- *
- * All three TeXRA hosts (CLI, Electron, VS Code extension) build the same
- * coordinator from a secret store + log; this helper centralises that
- * construction so host-specific files only deal with their OAuth glue.
- */
 export function createHostAuthCoordinator(
   init: HostAuthCoordinatorInit,
 ): SupabaseSessionCoordinator {


### PR DESCRIPTION
## Summary

Lift the shared Supabase auth coordinator setup from CLI, Desktop, and VS Code extension into `src/auth/createHostAuthCoordinator.ts`. Cross-package consolidation identified in a research pass that compared the three hosts' wiring layers (the only other real win in that pass landed separately as the temp-file manager refactor).

All three hosts previously inlined the same boilerplate:
\`\`\`ts
createSupabaseAuthCoordinator({
  storage: createSupabaseSessionStorage(secrets),
  log,
  whenReady,
});
\`\`\`
Now they call \`createHostAuthCoordinator({ secrets, log, whenReady })\` and the inner wrapping is in one place.

**Intentionally NOT lifted:**
- \`SupabaseClient.setTokenExpiry()\` — each host wires this at a different lifecycle point.
- \`getServerSideKeyService().clearAllCaches()\` / \`setUseIncludedModelAccess()\` — host-specific in timing (CLI ties to sign-in; Desktop to sign-out + callback; Extension to \`storeSession\` / \`removeSession\`). Pulling these would force a contrived event-callback API.
- Host-specific OAuth glue (loopback HTTP server, Electron protocol router, VS Code AuthenticationProvider).

## Commits
- \`cedcf9596\` — extract the helper, migrate 3 hosts. Net -22 / +53 (helper file).
- followup — /simplify pass trimmed WHAT-comments on the new \`HostAuthCoordinatorInit\` JSDoc.

## Test plan
- [x] \`npx tsc --noEmit -p packages/cli/tsconfig.json\` — error count unchanged vs baseline (pre-existing TUI/ink/citty module-resolution noise only).
- [x] \`npx tsc --noEmit -p packages/extension/tsconfig.json\` — error count unchanged (pre-existing OpenRouter SDK noise only).
- [x] Root \`npx tsc --noEmit\` — error count unchanged.
- [ ] CI green
- [ ] Smoke: \`texra login github\` on CLI; sign-in / sign-out on Desktop; sign-in on VS Code extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-behavior refactor but it changes auth coordinator initialization across CLI, Desktop, and the VS Code extension; a miswired secrets/log/whenReady parameter would break sign-in or session persistence in multiple hosts.
> 
> **Overview**
> Consolidates the repeated Supabase auth coordinator wiring used by the CLI, Desktop app, and VS Code extension into a new helper, `src/auth/createHostAuthCoordinator.ts`.
> 
> Each host now calls `createHostAuthCoordinator({ secrets, log, whenReady })` instead of inlining `createSupabaseAuthCoordinator` + `createSupabaseSessionStorage`, keeping host-specific auth flow logic unchanged while centralizing session storage setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18f1b55392fb4057151ab633b960eac14743097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->