### PR TITLE
refactor(tools/approval): extract shared temp-file manager for desktop + extension

### DIFF
--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -12,6 +12,7 @@ import {
   runLatexdiff,
   type LatexPreviewEntry,
 } from '@tools/approval/latexPreview';
+import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -151,13 +152,12 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   ): Promise<DesktopPendingToolEditApproval> {
     const tempRoot = this.options.tempRoot ?? tmpdir();
     const tempDir = await mkdtemp(path.join(tempRoot, 'texra-tool-edit-'));
-    const ext = path.extname(request.path) || '.txt';
-    const originalPath = path.join(tempDir, `${randomUUID()}-original${ext}`);
-    const proposedPath = path.join(tempDir, `${randomUUID()}-proposed${ext}`);
-    await Promise.all([
-      writeFile(originalPath, request.originalContent, 'utf8'),
-      writeFile(proposedPath, request.proposedContent, 'utf8'),
-    ]);
+    const { originalPath, proposedPath } = await writeApprovalTempFiles({
+      directory: tempDir,
+      targetPath: request.path,
+      originalContent: request.originalContent,
+      proposedContent: request.proposedContent,
+    });
 
     return {
       requestId,

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -8,7 +8,6 @@
  * approval/rejection via the progress view.
  */
 
-import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
@@ -29,6 +28,10 @@ import {
   previewProposedLatex,
   runLatexdiff,
 } from '@tools/approval/latexPreview';
+import {
+  writeApprovalTempFiles,
+  type ApprovalTempFiles,
+} from '@tools/approval/tempFileManager';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -87,21 +90,27 @@ async function ensureStorageDir(): Promise<string> {
   return dir;
 }
 
-async function createTempFile(
-  side: 'original' | 'proposed',
+async function stageApprovalSources(
   targetPath: string,
-  content: string,
-): Promise<DiffSource> {
-  const dir = await ensureStorageDir();
-  const ext = path.extname(targetPath) || '.txt';
-  const fileName = `${randomUUID()}-${side}${ext}`;
-  const filePath = path.join(dir, fileName);
-  await fs.writeFile(filePath, content, 'utf8');
-  return { filePath };
-}
-
-async function cleanupTempFile(source: DiffSource): Promise<void> {
-  await fs.unlink(source.filePath).catch(() => {});
+  originalContent: string,
+  proposedContent: string,
+): Promise<{
+  original: DiffSource;
+  proposed: DiffSource;
+  cleanup: ApprovalTempFiles['cleanup'];
+}> {
+  const directory = await ensureStorageDir();
+  const staged = await writeApprovalTempFiles({
+    directory,
+    targetPath,
+    originalContent,
+    proposedContent,
+  });
+  return {
+    original: { filePath: staged.originalPath },
+    proposed: { filePath: staged.proposedPath },
+    cleanup: staged.cleanup,
+  };
 }
 
 async function revealFirstChangedLine(
@@ -167,16 +176,11 @@ async function nativeRequestApproval(
 
   approvalCounter += 1;
   const requestId = `approval-${Date.now().toString(36)}-${approvalCounter}`;
-  const originalSource = await createTempFile(
-    'original',
-    filePath,
-    originalContent,
-  );
-  const proposedSource = await createTempFile(
-    'proposed',
-    filePath,
-    proposedContent,
-  );
+  const {
+    original: originalSource,
+    proposed: proposedSource,
+    cleanup: cleanupApprovalSources,
+  } = await stageApprovalSources(filePath, originalContent, proposedContent);
 
   const description = vscode.workspace.asRelativePath(
     WorkspaceFS.fullPath(filePath),
@@ -282,8 +286,7 @@ async function nativeRequestApproval(
     if (diffSession) {
       await diffViewHost.closeDiff(diffSession);
     }
-    await cleanupTempFile(originalSource);
-    await cleanupTempFile(proposedSource);
+    await cleanupApprovalSources();
 
     // Clean up any workspace temp files created by preview/latexdiff (parallel for performance)
     if (entry?.workspaceTempCleanup.length) {

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -28,10 +28,7 @@ import {
   previewProposedLatex,
   runLatexdiff,
 } from '@tools/approval/latexPreview';
-import {
-  writeApprovalTempFiles,
-  type ApprovalTempFiles,
-} from '@tools/approval/tempFileManager';
+import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -88,29 +85,6 @@ async function ensureStorageDir(): Promise<string> {
   const dir = getStorageDir();
   await fs.mkdir(dir, { recursive: true });
   return dir;
-}
-
-async function stageApprovalSources(
-  targetPath: string,
-  originalContent: string,
-  proposedContent: string,
-): Promise<{
-  original: DiffSource;
-  proposed: DiffSource;
-  cleanup: ApprovalTempFiles['cleanup'];
-}> {
-  const directory = await ensureStorageDir();
-  const staged = await writeApprovalTempFiles({
-    directory,
-    targetPath,
-    originalContent,
-    proposedContent,
-  });
-  return {
-    original: { filePath: staged.originalPath },
-    proposed: { filePath: staged.proposedPath },
-    cleanup: staged.cleanup,
-  };
 }
 
 async function revealFirstChangedLine(
@@ -176,11 +150,19 @@ async function nativeRequestApproval(
 
   approvalCounter += 1;
   const requestId = `approval-${Date.now().toString(36)}-${approvalCounter}`;
+  const directory = await ensureStorageDir();
   const {
-    original: originalSource,
-    proposed: proposedSource,
+    originalPath,
+    proposedPath,
     cleanup: cleanupApprovalSources,
-  } = await stageApprovalSources(filePath, originalContent, proposedContent);
+  } = await writeApprovalTempFiles({
+    directory,
+    targetPath: filePath,
+    originalContent,
+    proposedContent,
+  });
+  const originalSource: DiffSource = { filePath: originalPath };
+  const proposedSource: DiffSource = { filePath: proposedPath };
 
   const description = vscode.workspace.asRelativePath(
     WorkspaceFS.fullPath(filePath),

--- a/src/tools/approval/tempFileManager.ts
+++ b/src/tools/approval/tempFileManager.ts
@@ -36,18 +36,14 @@ export interface ApprovalTempFiles {
 }
 
 export interface WriteApprovalTempFilesInput {
-  /** Pre-existing directory the caller owns (mkdtemp result, storage dir, etc.). */
   readonly directory: string;
-  /** Target file path (used to pick the extension shown in the diff view). */
+  /** Seeds the file extension shown in the diff view; not a write target. */
   readonly targetPath: string;
   readonly originalContent: string;
   readonly proposedContent: string;
 }
 
 /**
- * Materialize the original/proposed pair into `directory` and return
- * the resulting paths plus a per-file cleanup closure.
- *
  * File names use a per-side UUID so reusing a shared directory across
  * concurrent requests cannot collide.
  */

--- a/src/tools/approval/tempFileManager.ts
+++ b/src/tools/approval/tempFileManager.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared temp-file manager for tool edit approval flows.
+ *
+ * Desktop and Extension both materialize the original and proposed file
+ * contents on disk so a host-specific diff view (Electron IPC, vscode.diff)
+ * can read them. This module owns the file naming and write/cleanup
+ * mechanics; each host owns its directory-lifecycle strategy:
+ *
+ *   - Desktop creates a fresh per-request directory via `mkdtemp` and
+ *     deletes the whole directory at the end.
+ *   - Extension reuses a persistent storage directory and unlinks the
+ *     individual files (via the returned `cleanup`) once done.
+ *
+ * Why `node:fs/promises` instead of `platform().fs`:
+ * the diff editor reads these files outside the platform abstraction, and
+ * Extension intentionally bypasses BaseFS normalization so the diff view
+ * sees raw bytes. Going through `platform().fs.writeFile` would route
+ * through a Uint8Array conversion that's a needless detour for this use,
+ * and `platform()` may not be initialized in every host that wants to
+ * stage diff inputs.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { unlink, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface ApprovalTempFiles {
+  readonly originalPath: string;
+  readonly proposedPath: string;
+  /**
+   * Removes the two written files. Idempotent and silent on ENOENT —
+   * callers that manage an enclosing directory (e.g. Desktop's mkdtemp)
+   * can still rm-rf the dir afterwards without seeing errors here.
+   */
+  readonly cleanup: () => Promise<void>;
+}
+
+export interface WriteApprovalTempFilesInput {
+  /** Pre-existing directory the caller owns (mkdtemp result, storage dir, etc.). */
+  readonly directory: string;
+  /** Target file path (used to pick the extension shown in the diff view). */
+  readonly targetPath: string;
+  readonly originalContent: string;
+  readonly proposedContent: string;
+}
+
+/**
+ * Materialize the original/proposed pair into `directory` and return
+ * the resulting paths plus a per-file cleanup closure.
+ *
+ * File names use a per-side UUID so reusing a shared directory across
+ * concurrent requests cannot collide.
+ */
+export async function writeApprovalTempFiles(
+  input: WriteApprovalTempFilesInput,
+): Promise<ApprovalTempFiles> {
+  const { directory, targetPath, originalContent, proposedContent } = input;
+  const ext = path.extname(targetPath) || '.txt';
+  const originalPath = path.join(directory, `${randomUUID()}-original${ext}`);
+  const proposedPath = path.join(directory, `${randomUUID()}-proposed${ext}`);
+
+  await Promise.all([
+    writeFile(originalPath, originalContent, 'utf8'),
+    writeFile(proposedPath, proposedContent, 'utf8'),
+  ]);
+
+  return {
+    originalPath,
+    proposedPath,
+    cleanup: async () => {
+      await Promise.all([
+        unlink(originalPath).catch(() => undefined),
+        unlink(proposedPath).catch(() => undefined),
+      ]);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Lift the shared temp-file mechanics from Desktop's and Extension's tool-edit approval handlers into \`src/tools/approval/tempFileManager.ts\`. Cross-package consolidation identified in a research pass; this is the second of two wins (the first was the auth coordinator helper in a parallel PR).

Both Desktop and Extension materialize the original and proposed file contents on disk so a host-specific diff view (Electron IPC, \`vscode.diff\`) can read them. The file naming + write/cleanup mechanics were duplicated:

- Desktop wrote \`\${uuid}-original\${ext}\` / \`\${uuid}-proposed\${ext}\` into a per-request \`mkdtemp\` directory.
- Extension wrote the same shape into a persistent shared storage directory.

The new helper takes a caller-owned directory and the two contents, returns the two paths + a per-file cleanup closure. Each host keeps its own directory-lifecycle strategy (mkdtemp + rm-rf vs persistent + per-file unlink). CLI doesn't stage diff temp files, so it's unaffected.

## Design notes
- The helper uses \`node:fs/promises\` directly rather than \`platform().fs\`: Extension intentionally bypasses BaseFS line-ending normalization so the diff view sees raw bytes, and \`platform()\` is not guaranteed initialized for every host that stages diff inputs. Documented in the module header.
- Per-side UUID names mean a shared storage directory can host concurrent approvals without collision.

## Commits
- \`765ee9c25\` — extract the helper, migrate 2 hosts. Net +80 lines total (helper file has cleanup closure + type defs + module header that didn't exist inline before).
- \`e8963df46\` — /simplify follow-up: inline the single-use \`stageApprovalSources\` wrapper in \`nativeToolEditApproval.ts\` (CLAUDE.md two-layer factory anti-pattern); trim WHAT comments on the new types. Net -22 lines.

## Test plan
- [x] \`npx tsc --noEmit -p packages/desktop/tsconfig.json\` — clean.
- [x] \`npx tsc --noEmit -p packages/extension/tsconfig.json\` — error count unchanged vs baseline (pre-existing OpenRouter SDK noise only).
- [ ] CI green
- [ ] Smoke: trigger a tool edit on Desktop and Extension, accept + reject + open-diff flows
- [ ] Smoke: confirm temp files are cleaned up (Desktop's mkdtemp rm-rf; Extension's per-file unlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes temp-file creation/cleanup for approval diffs; main risk is incorrect temp file lifecycle leading to leaked files or broken diff previews on Desktop/VS Code.
> 
> **Overview**
> Refactors tool-edit approval flows to **share temp file staging logic** between Desktop and the VS Code extension via new `src/tools/approval/tempFileManager.ts`.
> 
> Desktop and Extension now call `writeApprovalTempFiles()` to write the original/proposed contents with consistent UUID-based naming and to handle per-file cleanup (Extension unlinks the files; Desktop still deletes the whole per-request temp directory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8963df46bd0180a7cc2e28b7c57090ef39fd0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->