### PR TITLE
chore(extension): simplify frontend utility layer

### DIFF
--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -62,10 +62,10 @@ async function handleShowAgentConfigBanner(
   });
 }
 
-function handleRequestShowError(
-  payload: ProgressEventPayloads['requestShowError'],
-): void {
-  vscode.window.showErrorMessage(payload.message);
+function handleRequestShowError({
+  message,
+}: ProgressEventPayloads['requestShowError']): void {
+  void vscode.window.showErrorMessage(message);
 }
 
 async function handleRequestEnsureProgressView(

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -68,12 +68,6 @@ function buildDiagnostic(
   return diag;
 }
 
-function keepToolDiagnostics(
-  diagnostics: readonly vscode.Diagnostic[],
-): vscode.Diagnostic[] {
-  return diagnostics.filter((diag) => diag.code === CODE_TOOL);
-}
-
 async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
   const activeCollection = collection;
   if (!activeCollection) return;
@@ -95,8 +89,8 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
 
   const annotations = parseCriticismAnnotations(text);
   const uri = vscode.Uri.file(absolutePath);
-  const manualDiagnostics = keepToolDiagnostics(
-    activeCollection.get(uri) ?? [],
+  const manualDiagnostics = (activeCollection.get(uri) ?? []).filter(
+    (diag) => diag.code === CODE_TOOL,
   );
 
   if (annotations.length === 0) {

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -26,9 +26,7 @@ import type {
 } from '@tools/lean/leanTypes';
 import { WorkspaceFS } from '@utils/files';
 
-// ============================================================================
-// Types
-// ============================================================================
+type LspHover = import('vscode-languageserver-protocol').Hover;
 
 /**
  * Duck-typed FileUri compatible with the Lean 4 extension's ExtUri.
@@ -90,10 +88,6 @@ interface Lean4ExtensionApi {
   lean4EnabledFeatures: Promise<Lean4EnabledFeatures>;
 }
 
-// ============================================================================
-// Helpers to convert vscode.Diagnostic → LeanDiagnostic
-// ============================================================================
-
 function toLeanDiagnostic(d: vscode.Diagnostic): LeanDiagnostic {
   return {
     severity: d.severity,
@@ -109,14 +103,6 @@ function toLeanDiagnostic(d: vscode.Diagnostic): LeanDiagnostic {
   };
 }
 
-function toLeanDiagnostics(diagnostics: vscode.Diagnostic[]): LeanDiagnostic[] {
-  return diagnostics.map(toLeanDiagnostic);
-}
-
-// ============================================================================
-// Diagnostics
-// ============================================================================
-
 /**
  * Get diagnostics for a Lean file using VS Code's diagnostics API.
  * This returns diagnostics from the Lean 4 extension's LSP.
@@ -125,11 +111,11 @@ export function getDiagnostics(filePath: string): LeanDiagnostic[] {
   const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
   const directLookup = vscode.languages.getDiagnostics(uri);
   if (directLookup.length > 0) {
-    return toLeanDiagnostics(directLookup);
+    return directLookup.map(toLeanDiagnostic);
   }
 
   // Fallback: search by path in case URI format differs
-  return toLeanDiagnostics(findDiagnosticsByPath(uri.fsPath));
+  return findDiagnosticsByPath(uri.fsPath).map(toLeanDiagnostic);
 }
 
 /** Find diagnostics by matching file path (case-insensitive). */
@@ -161,10 +147,6 @@ export async function executeFileCommand(
     return false;
   }
 }
-
-// ============================================================================
-// LSP Requests (via Lean 4 Extension API)
-// ============================================================================
 
 const LEAN4_EXTENSION_ID = 'leanprover.lean4';
 
@@ -314,18 +296,14 @@ export async function getHoverInfo(
   filePath: string,
   line: number,
   column: number,
-): Promise<LspResult<import('vscode-languageserver-protocol').Hover>> {
-  return sendPositionRequest<import('vscode-languageserver-protocol').Hover>(
+): Promise<LspResult<LspHover>> {
+  return sendPositionRequest<LspHover>(
     filePath,
     line,
     column,
     'textDocument/hover',
   );
 }
-
-// ============================================================================
-// VS Code Wrappers
-// ============================================================================
 
 /**
  * Open a Lean file, wait for diagnostics, and return them.

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -37,11 +37,6 @@ export class SecretManager {
     await this.storage.delete(key);
   }
 
-  /**
-   * Backed by the canonical `API_PROVIDERS` constant in `@model/apiProviders`
-   * (which is itself the typed alias for `@shared/constants/apiKeyProviders`).
-   * Kept here for callers that already use `SecretManager.API_PROVIDERS`.
-   */
   public static readonly API_PROVIDERS = API_PROVIDERS;
 
   public static readonly GITHUB_TOKEN_KEY = 'github.token';

--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -27,7 +27,6 @@ const READER_DRAIN_MS = 250;
 export async function runTerminalCommand(
   args: TerminalRunRequest,
 ): Promise<TerminalRunResult> {
-  const { name, command, timeoutMs } = args;
   const terminal = revealTerminal(args);
   const integration = await waitForShellIntegration(
     terminal,
@@ -35,11 +34,11 @@ export async function runTerminalCommand(
   );
 
   if (!integration) {
-    terminal.sendText(command, true);
+    terminal.sendText(args.command, true);
     return { exitCode: undefined, output: '', timedOut: false };
   }
 
-  return captureExecution(integration, command, timeoutMs);
+  return captureExecution(integration, args.command, args.timeoutMs);
 }
 
 /**

--- a/packages/extension/src/frontend/ui/dialogs.ts
+++ b/packages/extension/src/frontend/ui/dialogs.ts
@@ -85,7 +85,6 @@ export interface FileSelectionResult {
 export async function selectFileFromWorkspace(
   options: FileDialogOptions,
 ): Promise<FileSelectionResult | null> {
-  // selectFile handles workspace check internally via computeDefaultUri
   const relativePath = await selectFile(options);
   if (!relativePath) return null;
 

--- a/packages/extension/src/frontend/ui/instruction.ts
+++ b/packages/extension/src/frontend/ui/instruction.ts
@@ -22,7 +22,6 @@ export async function showInstructionWithSuppress(
 ): Promise<void> {
   const stateKey = `${INSTRUCTION_PREFIX}${key}`;
 
-  // Check if user previously dismissed this instruction
   if (showSuppress && globalSM.get<boolean>(stateKey)) {
     return;
   }

--- a/packages/extension/src/frontend/vscode/vscodeConfig.ts
+++ b/packages/extension/src/frontend/vscode/vscodeConfig.ts
@@ -93,7 +93,6 @@ export class VscodeConfigProvider implements ConfigProvider {
     const inspection = configKeys(key)
       .map((item) => inspectKey<T>(item))
       .find((item) => item !== undefined);
-
     return normalizeInspection(inspection, this.get<T>(key));
   }
 

--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -41,11 +41,8 @@ export class VscodeFileSystem implements FileSystemProvider {
   }
 
   async readDirectory(target: string): Promise<[string, number][]> {
-    const entries = await vscode.workspace.fs.readDirectory(
-      vscode.Uri.file(target),
-    );
-    // vscode.FileType values are numerically compatible with our FileType
-    return entries;
+    // vscode.FileType values are numerically compatible with our FileType.
+    return vscode.workspace.fs.readDirectory(vscode.Uri.file(target));
   }
 
   async copy(


### PR DESCRIPTION
## Summary

Code-simplifier pass over \`packages/extension/src/frontend/\` (host-allowed VS Code utilities). No API changes; net −40 LOC across 9 files.

- **agentEventListeners.ts**: \`handleRequestShowError\` destructures \`message\` directly; \`void\` the discarded \`showErrorMessage\` promise.
- **latex/inlineCriticism.ts**: inline single-use \`keepToolDiagnostics\` (3-line filter at the call site).
- **lean/VscodeIntegration.ts**: drop 4 ASCII section-divider banners; inline single-use \`toLeanDiagnostics\` wrapper; hoist duplicated \`import('vscode-languageserver-protocol').Hover\` into an \`LspHover\` type alias.
- **secretManager.ts**: drop stale 4-line JSDoc claiming \`API_PROVIDERS\` was "kept for callers using \`SecretManager.API_PROVIDERS\`" — that field is in active use throughout the package.
- **setupTerminalRunner.ts**: drop unused \`name\` binding from top-level destructure in \`runTerminalCommand\`.
- **ui/dialogs.ts, ui/instruction.ts, vscode/vscodeConfig.ts, vscode/vscodeFileSystem.ts**: small dead-code / stale-comment cleanups, redundant intermediate variables collapsed.

## Out of scope (deliberate skips)
- \`setup.ts\` (~525 LOC): every comment carries non-obvious WHY (LATEX_CONFIG_VERSION migration footguns, \`inspect()\` vs \`get()\` source detection). No simplification wins without losing intent.
- \`agents/AgentDirectoryManager.ts\` (~485 LOC): the recursive watcher rebuild has subtle ordering invariants the comments capture.
- \`audio.ts\`: \`context\` param unused but the commands layer (\`RecordingManager.ts\`) passes \`this.context\` — out of scope per task instructions.
- \`latex/openBuild.ts\`: \`%DOC%\`/\`%DIR%\` placeholder ordering carries a non-obvious WHY.

## Test plan
- [x] \`npx tsc --noEmit -p packages/extension/tsconfig.json\` — error count unchanged vs baseline (pre-existing OpenRouter SDK noise only).
- [ ] CI green
- [ ] Smoke: open extension, trigger an agent run, confirm event listener errors still surface via showErrorMessage; trigger a LaTeX criticism flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor-only changes: small inlining/cleanup in VS Code frontend utilities with no behavior changes intended, aside from explicitly discarding a few returned promises.
> 
> **Overview**
> Simplifies several `@frontend/` VS Code utility modules by removing single-use helpers/section banners, inlining trivial filters/mappers, and collapsing redundant intermediates (net small LOC reduction).
> 
> Minor call-site cleanups include destructuring payload fields (e.g., `handleRequestShowError`), explicitly `void`ing UI promises, using a shared `LspHover` type alias in Lean integration, and trimming stale comments in `SecretManager`, dialog/instruction helpers, config inspection, and filesystem `readDirectory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fda26a1078e124366d9bc1c5885984bae233641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->