### PR TITLE
refactor(auth): hide Supabase coordinator helpers

### DIFF
--- a/src/auth/SupabaseAuthCoordinator.ts
+++ b/src/auth/SupabaseAuthCoordinator.ts
@@ -22,14 +22,14 @@ export interface SupabaseSecretStore {
   delete(key: string): Promise<void>;
 }
 
-export interface SupabaseAuthCoordinatorOptions {
+interface SupabaseAuthCoordinatorOptions {
   storage: SupabaseSessionStorage;
   whenReady?: () => Promise<void>;
   log?: SupabaseSessionLog;
   edgeFunctionTimeoutMs?: number;
 }
 
-export function createSupabaseSessionStorage(
+function createSupabaseSessionStorage(
   secrets: SupabaseSecretStore,
   sessionKey = SUPABASE_SESSION_KEY,
 ): SupabaseSessionStorage {
@@ -40,7 +40,7 @@ export function createSupabaseSessionStorage(
   };
 }
 
-export function createSupabaseAuthCoordinator(
+function createSupabaseAuthCoordinator(
   options: SupabaseAuthCoordinatorOptions,
 ): SupabaseSessionCoordinator {
   try {
@@ -65,4 +65,24 @@ export function createSupabaseAuthCoordinator(
   });
   SupabaseClient.setAuthProvider(coordinator);
   return coordinator;
+}
+
+export interface HostAuthCoordinatorInit {
+  readonly secrets: SupabaseSecretStore;
+  readonly log?: SupabaseSessionLog;
+  /**
+   * Gate the coordinator awaits before processing OAuth callbacks. The VS
+   * Code host uses this to ensure the URI handler is installed first.
+   */
+  readonly whenReady?: () => Promise<void>;
+}
+
+export function createHostAuthCoordinator(
+  init: HostAuthCoordinatorInit,
+): SupabaseSessionCoordinator {
+  return createSupabaseAuthCoordinator({
+    storage: createSupabaseSessionStorage(init.secrets),
+    log: init.log,
+    whenReady: init.whenReady,
+  });
 }

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { SupabaseClient } from './SupabaseClient';
@@ -52,13 +53,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   /** Flag to prevent race conditions between OAuth and magic link handlers */
   private isProcessingCallback = false;
 
-  constructor(private context: vscode.ExtensionContext) {
+  constructor(_context: vscode.ExtensionContext) {
     this.sessionCoordinator = createHostAuthCoordinator({
-      secrets: {
-        get: (key) => Promise.resolve(context.secrets.get(key)),
-        set: (key, value) => Promise.resolve(context.secrets.store(key, value)),
-        delete: (key) => Promise.resolve(context.secrets.delete(key)),
-      },
+      secrets: platform().secrets,
       whenReady: async () => {
         if (!this.uriHandler) {
           throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);

--- a/src/auth/createHostAuthCoordinator.ts
+++ b/src/auth/createHostAuthCoordinator.ts
@@ -1,29 +1,4 @@
-import {
-  createSupabaseAuthCoordinator,
-  createSupabaseSessionStorage,
-  type SupabaseSecretStore,
+export {
+  createHostAuthCoordinator,
+  type HostAuthCoordinatorInit,
 } from './SupabaseAuthCoordinator';
-import type {
-  SupabaseSessionCoordinator,
-  SupabaseSessionLog,
-} from './SupabaseSession';
-
-export interface HostAuthCoordinatorInit {
-  readonly secrets: SupabaseSecretStore;
-  readonly log?: SupabaseSessionLog;
-  /**
-   * Gate the coordinator awaits before processing OAuth callbacks. The VS
-   * Code host uses this to ensure the URI handler is installed first.
-   */
-  readonly whenReady?: () => Promise<void>;
-}
-
-export function createHostAuthCoordinator(
-  init: HostAuthCoordinatorInit,
-): SupabaseSessionCoordinator {
-  return createSupabaseAuthCoordinator({
-    storage: createSupabaseSessionStorage(init.secrets),
-    log: init.log,
-    whenReady: init.whenReady,
-  });
-}


### PR DESCRIPTION
## Summary

Fixes #4124.
Fixes #4125.

This PR keeps `createHostAuthCoordinator` as the host-facing auth coordinator entry point while making the lower-level Supabase coordinator helpers module-private:

- makes `SupabaseAuthCoordinatorOptions`, `createSupabaseSessionStorage`, and `createSupabaseAuthCoordinator` private to `SupabaseAuthCoordinator.ts`;
- preserves the existing `src/auth/createHostAuthCoordinator.ts` import path as a small re-export shim;
- reuses the initialized platform secrets in `SupabaseAuthProvider` instead of rebuilding the VS Code secrets adapter inline.

## Validation

- `corepack pnpm run typecheck`
- `npm run format`
- `npm run lint` (passes with existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly changes module visibility and wiring for secret storage; main risk is an export/import mismatch breaking host auth initialization at runtime or build time.
> 
> **Overview**
> Refactors Supabase auth coordinator setup so only the host-facing `createHostAuthCoordinator` (and `HostAuthCoordinatorInit`) remain exported, while `SupabaseAuthCoordinatorOptions`, `createSupabaseSessionStorage`, and `createSupabaseAuthCoordinator` become module-private in `SupabaseAuthCoordinator.ts`.
> 
> Updates `SupabaseAuthProvider` to use the shared `platform().secrets` implementation instead of constructing a VS Code secrets adapter inline, and turns `createHostAuthCoordinator.ts` into a small re-export shim to preserve the existing import path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1e7903b8132d656c8184a6f822b9ab2dfd9cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->