### PR TITLE
chore(desktop): simplify main-process wiring

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -358,6 +358,11 @@ export class DesktopProgressBridge {
   dispose(): void {
     this.toolEditApprovals.dispose();
     this.unsubscribe();
+    this.clearAllStreamMaps();
+    this.workflowFileActions.clearAllBackups();
+  }
+
+  private clearAllStreamMaps(): void {
     this.agentProposals.clear();
     this.cursors.clear();
     this.taskStates.clear();
@@ -370,10 +375,7 @@ export class DesktopProgressBridge {
     this.creationTimestamps.clear();
     this.conversationProgress.clear();
     this.streamBadges.clear();
-    // Bot review (#3819) caught the omission — `deleteAllStreams()`
-    // already clears `restoredStreams`; `dispose()` should match.
     this.restoredStreams.clear();
-    this.workflowFileActions.clearAllBackups();
   }
 
   private send(message: ProgressViewOutboundMessage): void {
@@ -1040,18 +1042,7 @@ export class DesktopProgressBridge {
     }
 
     await this.streamLogs.clear();
-    this.cursors.clear();
-    this.taskStates.clear();
-    this.outputFiles.clear();
-    this.statuses.clear();
-    this.categories.clear();
-    this.executionIds.clear();
-    this.agentProposals.clear();
-    this.descriptions.clear();
-    this.parentStreams.clear();
-    this.creationTimestamps.clear();
-    this.conversationProgress.clear();
-    this.streamBadges.clear();
+    this.clearAllStreamMaps();
     this.workflowFileActions.clearAllBackups();
     this.activeStream = '';
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
@@ -1212,9 +1203,8 @@ export class DesktopProgressBridge {
       runtimeHost: this.runtimeHost,
       openWorkflowOutput: async (result) => {
         const output = result.outputs.at(-1);
-        if (output) {
-          await this.options.openPath?.(output.absolutePath);
-        }
+        if (!output) return;
+        await this.options.openPath?.(output.absolutePath);
       },
     });
   }
@@ -1265,10 +1255,7 @@ export class DesktopProgressBridge {
     );
     const targetExists =
       isNewFile && (await fileExists(targetLocation.absolutePath));
-    let action: string;
-    if (targetExists) action = 'overwrite existing';
-    else if (isNewFile) action = 'create';
-    else action = 'overwrite';
+    const action = getAcceptAction(isNewFile, targetExists);
     const extensionNote = isNewFile
       ? `Extensions differ (${path.extname(baseFile).toLowerCase()} vs ${path.extname(editedFile).toLowerCase()}). `
       : '';
@@ -1389,6 +1376,12 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function getAcceptAction(isNewFile: boolean, targetExists: boolean): string {
+  if (targetExists) return 'overwrite existing';
+  if (isNewFile) return 'create';
+  return 'overwrite';
 }
 
 export function createDesktopAgentExecution(

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -57,18 +57,10 @@ export function createDesktopDiffHost(
       readFile(proposed.filePath, 'utf8'),
     ]);
 
-    // Prefer the in-app overlay when wired. Falling back to the external
-    // editor is intentional for headless tests + the audit-item-C escape
-    // hatch (`forceExternal`). Wrap the post in try/catch and respect a
-    // `false` return value from `postToRenderer` so we transparently
-    // fall back when the IPC bridge isn't reachable yet (startup race)
-    // or the BrowserWindow has been destroyed (Copilot/Cursor review
-    // on #3815 — silent overlay failure was the only previous failure
-    // mode).
+    // Prefer the in-app overlay when wired. A `false` return value or
+    // a thrown error opts into the external-editor fallback (covers the
+    // startup IPC race, destroyed BrowserWindow, and `forceExternal`).
     if (options.postToRenderer && !options.forceExternal) {
-      // Pick a language hint from the proposed file extension; the
-      // proposed path is the one the user is reviewing for acceptance,
-      // so its extension wins over the (possibly stale) original.
       let posted = false;
       try {
         const result = options.postToRenderer(
@@ -81,8 +73,6 @@ export function createDesktopDiffHost(
             proposedPath: proposed.filePath,
           }),
         );
-        // `void` (the common case) is treated as success; explicit
-        // `false` opts into the external-editor fallback.
         posted = result !== false;
       } catch (error) {
         console.error(
@@ -91,11 +81,9 @@ export function createDesktopDiffHost(
         );
       }
       if (posted) return { original, proposed, title };
-      // fall through to the external-editor flow below.
     }
 
-    // External-editor fallback: keep the previous behaviour — write a
-    // unified patch file to a tmp dir and hand off via `openPath`.
+    // External-editor fallback: write a unified patch file and open it.
     const patch =
       computeUserPatch(originalContent, proposedContent) ??
       `No textual changes for ${path.basename(proposed.filePath)}.\n`;

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -89,11 +89,7 @@ export function createDesktopFileSelection(
 ): DesktopFileSelection {
   const getWorkspacePath =
     options.getWorkspacePath ?? (() => platform().workspace.getWorkspacePath());
-  const onError =
-    options.onError ??
-    ((error) => {
-      console.error(error);
-    });
+  const onError = options.onError ?? defaultOnError;
 
   function runAsync(work: Promise<void>): void {
     void work.catch(onError);
@@ -102,12 +98,12 @@ export function createDesktopFileSelection(
   function postFileList(
     fileType: keyof typeof SET_COMMAND_BY_FILE_TYPE,
     files: string[],
-    additionalPayload: Record<string, unknown> = {},
+    preserveBaseFile = false,
   ) {
     options.postToRenderer({
       command: SET_COMMAND_BY_FILE_TYPE[fileType],
       files,
-      ...additionalPayload,
+      ...(preserveBaseFile && { preserveBaseFile: true }),
     });
   }
 
@@ -127,16 +123,10 @@ export function createDesktopFileSelection(
 
   async function requestSingleFileList(
     fileType: keyof typeof SET_COMMAND_BY_FILE_TYPE,
-    listOptions: { preserveBaseFile?: boolean } = {},
+    preserveBaseFile = false,
   ) {
-    const files = await list(
-      fileType === 'base' ? 'input' : (fileType as ListableFileType),
-    );
-    postFileList(
-      fileType,
-      files,
-      listOptions.preserveBaseFile ? { preserveBaseFile: true } : {},
-    );
+    const files = await list(fileType === 'base' ? 'input' : fileType);
+    postFileList(fileType, files, preserveBaseFile);
   }
 
   // Multi-list categories (input/context/media) are user-owned and only
@@ -144,7 +134,7 @@ export function createDesktopFileSelection(
   // the still-single-slot base-file dropdown and the empty-workspace banner.
   async function refreshDiskBackedDropdowns() {
     const inputFiles = await list('input');
-    postFileList('base', inputFiles, { preserveBaseFile: true });
+    postFileList('base', inputFiles, true);
     options.postToRenderer({
       command:
         inputFiles.length === 0
@@ -233,9 +223,7 @@ export function createDesktopFileSelection(
         return true;
       case MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE:
         runAsync(
-          requestSingleFileList('base', {
-            preserveBaseFile: message.preserveBaseFile === true,
-          }),
+          requestSingleFileList('base', message.preserveBaseFile === true),
         );
         return true;
       case MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES:
@@ -254,4 +242,8 @@ export function createDesktopFileSelection(
   }
 
   return { handleMessage };
+}
+
+function defaultOnError(error: unknown): void {
+  console.error(error);
 }

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -100,13 +100,9 @@ export function createDesktopGitHost(
       if (!workspace) {
         return { commits: [], isGitRepo: false };
       }
-      // Bot review (#3817) flagged that the prior `existsSync('.git')` probe
-      // wrongly reports `false` when the user opens a subdirectory inside a
-      // repo (`.git` only exists at the repo root). Use `git rev-parse
-      // --is-inside-work-tree` instead — that's also what handles the
-      // `.git`-as-pointer-file case for worktrees and submodules. The cost
-      // is one extra `git` invocation up front but the call is fast (<10ms
-      // typical) so we eat it for correctness.
+      // Use `git rev-parse --is-inside-work-tree` instead of `existsSync('.git')`
+      // — the latter wrongly reports `false` from subdirectories and misses
+      // worktrees/submodules where `.git` is a pointer file (bot review #3817).
       try {
         const { stdout } = await execFileAsync(
           'git',
@@ -117,10 +113,8 @@ export function createDesktopGitHost(
           return { commits: [], isGitRepo: false };
         }
       } catch {
-        // `git` missing from PATH, not a repo, or rev-parse failed for any
-        // other reason — treat as "not a repo". Avoid surfacing this via
-        // `onError` because it's the steady-state for any non-git workspace
-        // and would spam logs.
+        // Missing git, not a repo, etc. Don't surface via `onError` — this
+        // is the steady-state for any non-git workspace.
         return { commits: [], isGitRepo: false };
       }
 
@@ -128,10 +122,7 @@ export function createDesktopGitHost(
         const { stdout } = await execFileAsync(
           'git',
           [
-            // `--no-pager` is portable across platforms (no dependency on
-            // `cat` being on PATH, which broke on Windows per #3817).
-            // `execFile` already runs git non-tty so a pager wouldn't
-            // normally engage, but we pin it explicitly anyway.
+            // `--no-pager` is portable; Windows lacks `cat` on PATH (#3817).
             '--no-pager',
             'log',
             '-n',
@@ -146,11 +137,8 @@ export function createDesktopGitHost(
         );
         return { commits: parseCommitLog(stdout), isGitRepo: true };
       } catch (error) {
-        // `git` missing from PATH, not a repo, or any other failure -> empty
-        // list. We still report `isGitRepo: true` because the rev-parse
-        // probe already passed; surfacing "no commits yet" is more accurate
-        // than pretending the user is outside a repo and would otherwise
-        // mask legitimate empty-repo states.
+        // rev-parse already passed, so we know it's a repo — report
+        // isGitRepo:true with an empty list so empty-repo states stay honest.
         options.onError?.(error);
         return { commits: [], isGitRepo: true };
       }

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -25,10 +25,9 @@ export function isDesktopCommandMessage(
 export function createDesktopErrorReporter(
   onError?: (error: unknown) => void,
 ): (error: unknown) => void {
-  return (
-    onError ??
-    ((error) => {
-      console.error(error);
-    })
-  );
+  return onError ?? defaultReportError;
+}
+
+function defaultReportError(error: unknown): void {
+  console.error(error);
 }

--- a/packages/desktop/src/main/desktopMainViewStartup.ts
+++ b/packages/desktop/src/main/desktopMainViewStartup.ts
@@ -15,6 +15,10 @@ import {
 } from './desktopIpcTypes.js';
 import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
 
+async function defaultGetAuthStatus(): Promise<MainViewAuthStatus> {
+  return { authenticated: false };
+}
+
 export interface DesktopMainViewStartupOptions {
   renderer: DesktopRenderer;
   modelListRefresh?: PromiseLike<void>;
@@ -42,7 +46,7 @@ export function createDesktopMainViewStartup({
       ]);
       return { agentOptions, modelOptions };
     },
-    getAuthStatus: getAuthStatus ?? (async () => ({ authenticated: false })),
+    getAuthStatus: getAuthStatus ?? defaultGetAuthStatus,
   });
 
   async function postStartupMessages(): Promise<void> {

--- a/packages/desktop/src/main/desktopModelListRefresh.ts
+++ b/packages/desktop/src/main/desktopModelListRefresh.ts
@@ -8,17 +8,16 @@ export interface DesktopModelListRefreshOptions {
   onError?: (error: unknown) => void;
 }
 
-export function refreshDesktopModelListStateIfNeeded({
+export async function refreshDesktopModelListStateIfNeeded({
   globalState = platform().globalState,
   onError,
 }: DesktopModelListRefreshOptions = {}): Promise<void> {
-  return refreshModelListStateIfNeeded(globalState)
-    .then((result) => {
-      if (result.added.length > 0 || result.removed.length > 0) {
-        invalidateModelOptionsCache();
-      }
-    })
-    .catch((error: unknown) => {
-      onError?.(error);
-    });
+  try {
+    const result = await refreshModelListStateIfNeeded(globalState);
+    if (result.added.length > 0 || result.removed.length > 0) {
+      invalidateModelOptionsCache();
+    }
+  } catch (error) {
+    onError?.(error);
+  }
 }

--- a/packages/desktop/src/main/desktopNavigationPolicy.ts
+++ b/packages/desktop/src/main/desktopNavigationPolicy.ts
@@ -40,8 +40,7 @@ export function installDesktopNavigationPolicy(
   webContents: WebContents,
   options: DesktopNavigationPolicyOptions = {},
 ): void {
-  const reportAsyncError =
-    options.onAsyncError ?? ((error) => console.error(error));
+  const reportAsyncError = options.onAsyncError ?? defaultReportError;
 
   webContents.setWindowOpenHandler(({ url }) => {
     routeOrDeny(url, reportAsyncError);
@@ -61,4 +60,8 @@ export function installDesktopNavigationPolicy(
   webContents.on('will-attach-webview', (event) => {
     event.preventDefault();
   });
+}
+
+function defaultReportError(error: unknown): void {
+  console.error(error);
 }

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -96,20 +96,15 @@ export function createDesktopPreviewHost(
     }
   }
 
-  // Try to render the PDF inside the desktop via the wa-dialog overlay.
-  // Returns `true` when the renderer accepted the IPC, `false` when we
-  // should fall back to the external viewer. Mirrors the diff host's
-  // contract: a `false` return value or a thrown error opts into
-  // `shell.openPath`. Bot review on #3815 explicitly required not
-  // silently swallowing IPC failures.
+  // Try to render the PDF in the wa-dialog overlay. Returns `false` (so
+  // the caller falls back to `shell.openPath`) when the renderer rejects
+  // or throws — mirrors the diff host's contract.
   function tryShowPdfInRenderer(pdfPath: string, title: string): boolean {
     if (!options.postToRenderer || options.forceExternal) return false;
     try {
       const result = options.postToRenderer(
         buildDesktopShowPdfMessage({ title, pdfPath }),
       );
-      // `void` (the common case) is treated as success; explicit
-      // `false` opts into the external-viewer fallback.
       return result !== false;
     } catch (error) {
       console.error(
@@ -152,12 +147,9 @@ export function createDesktopPreviewHost(
     }
 
     // Confirm the PDF is on disk before rendering it (the iframe will
-    // happily load nothing and present a blank surface otherwise).
+    // load nothing and present a blank surface otherwise).
     await ensurePathExists(pdfPath);
 
-    // Prefer the in-app overlay (audit item B / trajectory #17).
-    // External-viewer fallback covers headless tests and the
-    // `forceExternal` escape hatch.
     if (tryShowPdfInRenderer(pdfPath, path.basename(pdfPath))) return;
 
     await openPath(pdfPath);

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -30,10 +30,7 @@ export function createDesktopProgressIpc(
 ): DesktopProgressIpc {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
   const onUnsupportedCommand =
-    options.onUnsupportedCommand ??
-    ((message) => {
-      console.warn(`Unsupported desktop Progress command: ${message.command}`);
-    });
+    options.onUnsupportedCommand ?? defaultUnsupportedCommand;
 
   function runAsync(work: Promise<unknown>): void {
     void work.catch(reportAsyncError);
@@ -145,4 +142,8 @@ export function createDesktopProgressIpc(
       }
     },
   };
+}
+
+function defaultUnsupportedCommand(message: ProgressViewInboundMessage): void {
+  console.warn(`Unsupported desktop Progress command: ${message.command}`);
 }

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -190,25 +190,24 @@ export function installDesktopProtocolCallbackLifecycle(
 }
 
 function normalizeProtocolPath(url: URL): string {
-  const rawPath =
-    url.pathname && url.pathname !== '/'
-      ? url.pathname
-      : url.hostname
-        ? `/${url.hostname}`
-        : '';
+  const rawPath = getRawProtocolPath(url);
   return rawPath.length > 1 && rawPath.endsWith('/')
     ? rawPath.slice(0, -1)
     : rawPath;
 }
 
+function getRawProtocolPath(url: URL): string {
+  if (url.pathname && url.pathname !== '/') return url.pathname;
+  if (url.hostname) return `/${url.hostname}`;
+  return '';
+}
+
 function registerProtocolClient(options: InstallDesktopProtocolOptions): void {
-  const { app } = options;
-  const didRegister =
-    app.isPackaged || !options.execPath || !options.devAppArg
-      ? app.setAsDefaultProtocolClient(TEXRA_PROTOCOL)
-      : app.setAsDefaultProtocolClient(TEXRA_PROTOCOL, options.execPath, [
-          options.devAppArg,
-        ]);
+  const { app, execPath, devAppArg } = options;
+  const useDevArgs = !app.isPackaged && execPath && devAppArg;
+  const didRegister = useDevArgs
+    ? app.setAsDefaultProtocolClient(TEXRA_PROTOCOL, execPath, [devAppArg])
+    : app.setAsDefaultProtocolClient(TEXRA_PROTOCOL);
 
   if (!didRegister) {
     options.log?.warn?.(`Failed to register ${TEXRA_PROTOCOL}:// handler`);

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -230,11 +230,7 @@ export function createDesktopSettingsIpc(
 ): DesktopSettingsIpc {
   const workspaceState = options.workspaceState ?? platform().workspaceState;
   const globalState = options.globalState ?? platform().globalState;
-  const onError =
-    options.onError ??
-    ((error) => {
-      console.error(error);
-    });
+  const onError = options.onError ?? defaultOnError;
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
@@ -359,7 +355,7 @@ export function createDesktopSettingsIpc(
     loadMemoryItems,
     loadMemoryPreview,
     isMemoryEnabled: () =>
-      globalState.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true) ?? true,
+      globalState.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true),
     setMemoryEnabled: async (enabled) => {
       await globalState.update(GlobalStateKey.MEMORY_ENABLED, enabled);
     },
@@ -718,37 +714,37 @@ export function createDesktopSettingsIpc(
         workspaceState.get<string>(
           WorkspaceStateKey.CODEX_SANDBOX_MODE,
           'workspace-write',
-        ) ?? 'workspace-write',
+        ),
       ),
       codexReasoningEffort: parseCodexReasoningEffort(
         workspaceState.get<string>(
           WorkspaceStateKey.CODEX_REASONING_EFFORT,
           'high',
-        ) ?? 'high',
+        ),
       ),
       codexApprovalPolicy: parseCodexApprovalPolicy(
         workspaceState.get<string>(
           WorkspaceStateKey.CODEX_APPROVAL_POLICY,
           'never',
-        ) ?? 'never',
+        ),
       ),
       claudeAgentModel: parseClaudeAgentModel(
         workspaceState.get<string>(
           WorkspaceStateKey.CLAUDE_AGENT_MODEL,
           CLAUDE_AGENT_DEFAULT_MODEL,
-        ) ?? CLAUDE_AGENT_DEFAULT_MODEL,
+        ),
       ),
       claudeAgentPermissionMode: parseClaudeAgentPermissionMode(
         workspaceState.get<string>(
           WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
           'acceptEdits',
-        ) ?? 'acceptEdits',
+        ),
       ),
       claudeAgentEffort: parseClaudeAgentEffort(
         workspaceState.get<string>(
           WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
           'high',
-        ) ?? 'high',
+        ),
       ),
     });
   }
@@ -1538,4 +1534,8 @@ export function createDesktopSettingsIpc(
       }
     },
   };
+}
+
+function defaultOnError(error: unknown): void {
+  console.error(error);
 }

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -170,48 +170,34 @@ export function createDesktopShellActions(
     openWorkspaceFolder,
     resetMainView,
     sendRecentCommits: () => {
-      // Prefer the real git host when wired (closes audit item A from
-      // `docs/dev/standalone-trajectory-audit.md`). Falls back to the
-      // synchronous `.git` probe so the boolean stays honest even when no
-      // git host is supplied (e.g. in tests, or before the host is wired).
-      const getRecentCommits = options.getRecentCommits;
+      const postReply = (commits: string[], isGitRepo: boolean) => {
+        renderer.postToRenderer({
+          command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+          commits,
+          isGitRepo,
+        });
+      };
+      const { getRecentCommits } = options;
       if (getRecentCommits) {
         void getRecentCommits()
-          .then(({ commits, isGitRepo }) => {
-            renderer.postToRenderer({
-              command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-              commits,
-              isGitRepo,
-            });
-          })
+          .then(({ commits, isGitRepo }) => postReply(commits, isGitRepo))
           .catch((error) => {
-            // The git host already swallows expected errors; reaching this
-            // catch implies a programmer bug. Surface the error so it gets
-            // logged, but still send a conservative reply so the launcher
-            // banner doesn't hang waiting for a response.
+            // The git host swallows expected errors; reaching this catch
+            // is a programmer bug. Log and send a conservative reply so
+            // the launcher banner doesn't hang.
             reportAsyncError(error);
-            renderer.postToRenderer({
-              command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-              commits: [],
-              isGitRepo: false,
-            });
+            postReply([], false);
           });
         return;
       }
-      // No git host: best-effort `isGitRepo` boolean, empty commit list.
+      // No git host wired (tests / pre-init): best-effort isGitRepo probe.
       let isGitRepo = false;
       try {
         isGitRepo = options.isWorkspaceGitRepo?.() ?? false;
       } catch (error) {
-        // Probe failures should never break the IPC reply — fall back
-        // to the conservative "not a repo" answer.
         reportAsyncError(error);
       }
-      renderer.postToRenderer({
-        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-        commits: [],
-        isGitRepo,
-      });
+      postReply([], isGitRepo);
     },
     showRoute: postRoute,
     showSettings: postSettingsRoute,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -67,15 +67,12 @@ export function installDesktopMainViewIpc(
     debugMode: options.debugMode,
     getTheme: options.getTheme,
   });
-  const shell =
+  const shell = createDesktopShellIpc(
+    bridge,
     options.shellActions == null
-      ? createDesktopShellIpc(bridge, {
-          onAsyncError: options.onAsyncError,
-        })
-      : createDesktopShellIpc(bridge, {
-          actions: options.shellActions,
-          onAsyncError: options.onAsyncError,
-        });
+      ? { onAsyncError: options.onAsyncError }
+      : { actions: options.shellActions, onAsyncError: options.onAsyncError },
+  );
   const execution = createDesktopExecutionIpc({
     executeAgent: options.executeAgent,
     onAsyncError: options.onAsyncError,


### PR DESCRIPTION
## Summary

Code-simplifier pass over \`packages/desktop/src/main/\` (Electron main-process wiring). 14 files, net **−59 LOC**. No IPC channel names, payload schemas, or public exports changed.

### Recurring patterns extracted
- **\`defaultReportError\` / \`defaultOnError\` / \`defaultUnsupportedCommand\` / \`defaultGetAuthStatus\`** — module-level helpers replacing inline arrows that defaulted dependency-injected error/auth callbacks. Applied across \`desktopIpcTypes\`, \`desktopNavigationPolicy\`, \`desktopFileSelection\`, \`desktopSettingsIpc\`, \`desktopMainViewStartup\`, \`desktopProgressIpc\`.
- **Trimmed multi-paragraph review-history comments** (\`desktopDiffHost\`, \`desktopPreviewHost\`, \`desktopGitHost\`) to the load-bearing WHY (e.g., #3817 portability rationale, \`existsSync('.git')\` subdirectory bug, in-app-overlay fallback contract).

### Per-file
- **\`desktopFileSelection.ts\`** — collapsed \`postFileList\`'s open \`additionalPayload: Record<string, unknown>\` to the only key ever used (\`preserveBaseFile: boolean\`); flattened \`requestSingleFileList(fileType, {preserveBaseFile?})\` to \`(fileType, preserveBaseFile?)\`; removed needless \`as ListableFileType\` cast (TS narrowing already handles it).
- **\`desktopSettingsIpc.ts\`** — dropped 7 redundant \`?? defaultValue\` chains after \`StateStore.get<T>(KEY, default)\` (the platform contract returns \`T\`, not \`T | undefined\`, when a default is supplied).
- **\`mainViewIpc.ts\`** — collapsed the two-branch \`createDesktopShellIpc()\` invocation into one call with a ternary options object.
- **\`desktopShellIpc.ts\`** — extracted \`postReply\` inside \`sendRecentCommits\` so the host-wired and probe-fallback paths share one \`renderer.postToRenderer({...})\` call shape (was 3 duplicated blocks).
- **\`desktopProtocolCallbacks.ts\`** — split nested ternary in \`normalizeProtocolPath\` into a named \`getRawProtocolPath\` helper (per CLAUDE.md "avoid nested ternaries"); flattened \`registerProtocolClient\`'s 4-condition ternary into a single \`useDevArgs\` boolean.
- **\`desktopAgentExecution.ts\`** — extracted \`clearAllStreamMaps\` shared by \`dispose()\` and \`deleteAllStreams()\` (was 14-line duplicate); extracted module-level \`getAcceptAction(isNewFile, targetExists)\` for the action label (replaces \`let action; if/else if/else\`); simplified \`openWorkflowOutput\`'s nested branch to early return.
- **\`desktopModelListRefresh.ts\`** — rewrote a \`.then(...).catch(...)\` chain as \`async/await\` + \`try/catch\` for readability.

### Out of scope
- \`desktopSupabaseAuth.ts\`, \`desktopToolEditApproval.ts\` (just landed via consolidation PRs #4120/#4121).
- \`packages/desktop/src/main/platform/*\`, \`index.ts\`, preload/renderer (separate concerns).
- \`bootstrap.ts\`, \`desktopMenu.ts\`, \`desktopOnboardingIpc.ts\`, \`desktopViewStateIpc.ts\`, \`desktopSetupTerminal.ts\`, \`desktopTerminalRunner.ts\`, \`desktopPrompt.ts\`, \`desktopCrashReporting.ts\`, \`desktopStreamSnapshot.ts\`, \`desktopAppLog.ts\`, \`desktopLogIpc.ts\`, \`desktopLogRedaction.ts\`, \`desktopExecutionIpc.ts\`, \`hostBridge.ts\`, \`fatalStartupError.ts\` — already clean; further changes risked harming clarity or touching test contracts (e.g. \`installDesktopAppLog\`'s return value is asserted in \`DesktopAppLog.vitest.mts\`).

## Test plan
- [x] \`npx tsc --noEmit -p packages/desktop/tsconfig.main.json\` — only the pre-existing \`electron\` type-lib error remains; no new errors introduced.
- [ ] CI green
- [ ] Smoke: boot desktop, exercise file selection + git recent-commits + settings tab + protocol callback flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactors and small logic extractions across Electron main-process IPC/hosts, but it touches stream cleanup and git/protocol handling paths where regressions could impact state reset or startup flows.
> 
> **Overview**
> **Refactors Electron main-process wiring to reduce duplication and clarify fallbacks** without changing IPC command names or payload schemas.
> 
> Stream lifecycle cleanup is consolidated in `DesktopProgressBridge` by extracting `clearAllStreamMaps()` and reusing it for both `dispose()` and `deleteAllStreams()` (plus ensuring workflow file backups are cleared in both). Several IPC/host modules replace inline default callbacks with shared helpers (e.g. default error reporters, unsupported-command handler, and auth status provider) and simplify option plumbing.
> 
> A few targeted logic simplifications accompany the cleanup: `desktopFileSelection` narrows the base-file refresh payload to a `preserveBaseFile` flag, `desktopModelListRefresh` switches to `async/await` with `try/catch`, `desktopProtocolCallbacks` removes nested ternaries in protocol parsing/registration, and diff/PDF overlay hosts keep the explicit “return false/throw → external fallback” behavior while trimming/comment-tightening. `desktopShellIpc` also deduplicates the recent-commits reply path and `mainViewIpc` collapses shell IPC construction into a single call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910e77cc8ee581c0473dcf1318b9a06de17cd4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->