### PR TITLE
chore(agent): simplify shared runtime + eventBus

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -374,8 +374,7 @@ function compensateFailedActivation(args: {
 export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
-  const { configPayload } = input;
-  const { runtimeHost } = input;
+  const { configPayload, runtimeHost } = input;
   const executionId = input.executionId ?? generateExecutionId();
   if (
     !input.streamTabIdOverride &&

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -1,14 +1,9 @@
 /**
- * Promise-based coordinator for agent proposals (workflow and tool-use).
+ * Promise-based coordinator for workflow and tool-use agent proposals.
  *
- * Handles both:
- * - Workflow agents (document processing with file I/O)
- * - Tool-use agents (interactive assistants with tools)
- *
- * Flow:
- * 1. Tool calls `waitForProposal()` - returns Promise, emits 'showAgentProposal'
- * 2. User approves/rejects/sets up → resolves Promise with corresponding action
- * 3. On resolution → emits 'resolveAgentProposal' to dismiss UI
+ * 1. Tool calls `waitForProposal()` → returns Promise, emits 'showAgentProposal'.
+ * 2. User approves/rejects/sets up → resolves Promise with the corresponding action.
+ * 3. On resolution → emits 'resolveAgentProposal' to dismiss UI.
  */
 
 import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -18,11 +13,6 @@ import {
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
 
-// ============================================================================
-// Types
-// ============================================================================
-
-/** Result of an agent proposal (workflow or tool-use). */
 export type ProposalResult =
   | { action: 'approve'; model?: string; agent?: string }
   | { action: 'reject'; feedback?: string }
@@ -32,21 +22,15 @@ export type ProposalResult =
 export interface ProposalRequestOptions {
   proposalId: string;
   proposal: AgentProposal;
-  /** Timeout in milliseconds (default: wait indefinitely) */
+  /** Timeout in milliseconds (default: wait indefinitely). */
   timeoutMs?: number;
 }
 
-/** Payload for show event */
 interface ProposalShowPayload extends Record<string, unknown> {
   proposalId: string;
   streamId: string;
 }
 
-// ============================================================================
-// Coordinator Implementation
-// ============================================================================
-
-/** Manages pending agent proposals (workflow and tool-use). */
 export class AgentProposalCoordinator extends BasePromiseCoordinator<
   ProposalResult,
   ProposalShowPayload
@@ -61,17 +45,13 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
     return { action: 'reject' };
   }
 
-  /** Wait for user action on a proposal. Uses different signature from base class. */
   waitForProposal(
     streamId: string,
     options: ProposalRequestOptions,
   ): Promise<ProposalResult> {
     const { proposalId, proposal, timeoutMs } = options;
 
-    // Request host to show progress view so user sees the proposal
     this.runtimeHost.emit('requestEnsureProgressView', {});
-
-    // Activate the stream that needs approval so user sees the prompt immediately
     this.runtimeHost.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
@@ -82,11 +62,6 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
   }
 }
 
-// ============================================================================
-// Singleton Export
-// ============================================================================
-
-/** Singleton coordinator instance. */
 export const proposalCoordinator = new AgentProposalCoordinator(
   getDefaultAgentRuntimeHost,
 );

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -1,30 +1,17 @@
 /**
- * Generic promise-based coordinator for user interaction flows.
+ * Generic promise-based coordinator for user-interaction flows
+ * (retry requests, agent proposals, plan approvals, ...).
  *
- * Provides a reusable pattern for:
- * - Retry requests (after API failures)
- * - Agent proposals (workflow/tool-use delegation)
- * - Future interactive flows
- *
- * Architecture:
- * - Single Map tracks all pending requests by ID
- * - Promise-based: callers await a Promise that resolves on user action
- * - Two states: pending (waiting) or resolved (done)
- *
- * Flow:
- * 1. Caller invokes waitForUserAction() → returns Promise, emits show event
- * 2. User acts → appropriate method resolves Promise with result
- * 3. On resolution → emits resolve event to dismiss UI, defers cleanup
+ * Each request is keyed by a string id. waitForUserAction() returns a Promise
+ * that resolves when a corresponding resolveRequest()/clearRequest() runs.
+ * Replacing a still-pending id auto-rejects the previous waiter with
+ * getDefaultCancelResult().
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
-// ============================================================================
-// Types
-// ============================================================================
-
-/** Base result type - subclasses extend with specific actions */
+/** Base result type — subclasses extend with specific actions. */
 interface BaseResult {
   action: string;
   feedback?: string;
@@ -40,7 +27,6 @@ function toRuntimeHostProvider(
   return typeof runtimeHost === 'function' ? runtimeHost : () => runtimeHost;
 }
 
-/** Internal state: pending (waiting for user) or resolved (done) */
 type RequestState<TResult> =
   | {
       status: 'pending';
@@ -50,24 +36,15 @@ type RequestState<TResult> =
     }
   | { status: 'resolved' };
 
-/** Configuration for coordinator behavior */
 export interface CoordinatorConfig {
-  /** Event name emitted to show UI (e.g., 'showRetryRequest') */
+  /** Event name emitted to show UI (e.g. 'showRetryRequest'). */
   showEventName: keyof ProgressEventPayloads;
-  /** Event name emitted to resolve/hide UI (e.g., 'resolveRetryRequest') */
+  /** Event name emitted to resolve/hide UI (e.g. 'resolveRetryRequest'). */
   resolveEventName: keyof ProgressEventPayloads;
-  /** Field name for ID in resolve event payload (e.g., 'streamId', 'proposalId') */
+  /** Field name for the id in the resolve event payload (e.g. 'streamId', 'proposalId'). */
   idFieldName: string;
 }
 
-// ============================================================================
-// Base Coordinator Implementation
-// ============================================================================
-
-/**
- * Generic coordinator for promise-based user interaction flows.
- * Subclasses provide specific result types and event configurations.
- */
 export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
@@ -82,25 +59,21 @@ export abstract class BasePromiseCoordinator<
     return this.getRuntimeHost();
   }
 
-  /** Single source of truth for all pending requests */
   protected readonly requests = new Map<string, RequestState<TResult>>();
 
-  /** Configuration for this coordinator */
   protected abstract readonly config: CoordinatorConfig;
 
-  /**
-   * Get the default result for cancelled/replaced requests.
-   * Subclasses override to provide appropriate default (e.g., { action: 'cancel' }).
-   */
+  /** Result used when a pending request is cancelled or replaced. */
   protected abstract getDefaultCancelResult(): TResult;
 
+  /** Result used on timeout (defaults to `{ action: 'timeout' }`). */
+  protected getTimeoutResult(): TResult {
+    return { action: 'timeout' } as TResult;
+  }
+
   /**
-   * Wait for user action. Emits show event and returns Promise.
-   *
-   * @param id - Unique identifier for this request
-   * @param payload - Data to emit with show event
-   * @param options - Optional timeout configuration
-   * @returns Promise that resolves with user's action
+   * Wait for user action. Emits the show event and returns a Promise that
+   * resolves once the user (or timeout) decides.
    */
   waitForUserAction(
     id: string,
@@ -109,7 +82,6 @@ export abstract class BasePromiseCoordinator<
   ): Promise<TResult> {
     const runtimeHost = this.runtimeHost;
 
-    // Cancel any existing pending request for this ID
     const existing = this.requests.get(id);
     if (existing?.status === 'pending') {
       clearTimeout(existing.timeoutId);
@@ -136,29 +108,15 @@ export abstract class BasePromiseCoordinator<
         timeoutId,
       });
 
-      // Emit show event (cast needed for generic base class)
       runtimeHost.emit(this.config.showEventName, payload as any);
     });
   }
 
-  /**
-   * Get timeout result. Override if different from cancel.
-   */
-  protected getTimeoutResult(): TResult {
-    return { action: 'timeout' } as TResult;
-  }
-
-  /**
-   * Check if a request is pending.
-   */
   hasPendingRequest(id: string): boolean {
     return this.getPendingRequest(id) !== null;
   }
 
-  /**
-   * Clear a pending request without user action.
-   * Used for cleanup when flow is cancelled externally.
-   */
+  /** Clear a pending request without user action (external cancellation). */
   clearRequest(id: string): void {
     const req = this.getPendingRequest(id);
     if (!req) return;
@@ -168,22 +126,12 @@ export abstract class BasePromiseCoordinator<
     this.cleanup(id, req.runtimeHost);
   }
 
-  /**
-   * Clear every pending request owned by this coordinator.
-   */
   clearAll(): void {
     for (const id of this.requests.keys()) {
       this.clearRequest(id);
     }
   }
 
-  // ==========================================================================
-  // Protected helpers for subclasses
-  // ==========================================================================
-
-  /**
-   * Get a pending request if it exists.
-   */
   protected getPendingRequest(
     id: string,
   ): (RequestState<TResult> & { status: 'pending' }) | null {
@@ -191,9 +139,6 @@ export abstract class BasePromiseCoordinator<
     return req?.status === 'pending' ? req : null;
   }
 
-  /**
-   * Resolve a pending request with a result.
-   */
   resolveRequest(id: string, result: TResult): boolean {
     const req = this.getPendingRequest(id);
     if (!req) return false;
@@ -204,18 +149,15 @@ export abstract class BasePromiseCoordinator<
     return true;
   }
 
-  /**
-   * Clean up state and emit resolution event.
-   */
   private cleanup(id: string, runtimeHost: AgentRuntimeHost): void {
     this.requests.set(id, { status: 'resolved' });
 
-    // Emit resolve event (cast needed for generic base class)
     runtimeHost.emit(this.config.resolveEventName, {
       [this.config.idFieldName]: id,
     } as any);
 
-    // Defer Map deletion to avoid blocking current execution
+    // Defer Map deletion so callers re-entering this method (e.g. resolving
+    // and then immediately re-checking pending state) see the resolved entry.
     setImmediate(() => {
       if (this.requests.get(id)?.status === 'resolved') {
         this.requests.delete(id);

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -2,8 +2,7 @@
  * Polymorphic execution handles.
  *
  * Replaces data-oriented maps with handles that know how to report status,
- * interrupt/kill, and describe themselves. Eliminates the multi-registry
- * cascade in getExecutionStatusInfo and handleKill.
+ * interrupt/kill, and describe themselves.
  */
 
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
@@ -16,11 +15,6 @@ import {
 } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
 
-// ============================================================================
-// Status types
-// ============================================================================
-
-/** Resolved status for display purposes. */
 export interface ExecutionStatusInfo {
   status: string;
   elapsed: string | null;
@@ -41,10 +35,6 @@ const PROCESSING_STATUSES: ReadonlySet<string> = new Set([
   STREAM_STATUS.RESUMING,
 ]);
 
-// ============================================================================
-// Handle interface
-// ============================================================================
-
 export interface ExecutionHandle {
   readonly executionId: string;
   readonly parentStreamId: StreamTabId;
@@ -53,27 +43,18 @@ export interface ExecutionHandle {
   readonly startedAt: number;
   readonly runtimeHost: AgentRuntimeHost;
 
-  /** Get current status without probing multiple registries. */
   getStatus(): ExecutionStatusInfo;
 
-  /** Interrupt or kill. Returns true if successful. */
+  /** Interrupt or kill. Returns true if the call had an effect. */
   terminate(): boolean;
 
-  /** Round progress (if applicable). */
   getProgress(): { currentRound?: number; totalRounds?: number };
 
-  /** Update round progress. */
   updateProgress(update: { currentRound?: number; totalRounds?: number }): void;
 }
 
-// ============================================================================
-// AgentExecutionHandle — for workflow and toolUse subagents
-// ============================================================================
-
 /**
  * Handle for agent-based executions (workflow or toolUse subagents).
- * Absorbs the per-entry role of the former subagentLineage module.
- *
  * When `parentStreamId` differs from `childStreamId`, the handle represents
  * a subagent whose parent is an orchestrator.
  */
@@ -139,13 +120,9 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 }
 
-// ============================================================================
-// ProcessExecutionHandle — for background bash
-// ============================================================================
-
 /**
  * Handle for background bash processes.
- * No childStreamId — processes don't have their own stream.
+ * No `childStreamId` — processes don't have their own stream.
  */
 export class ProcessExecutionHandle implements ExecutionHandle {
   readonly category = 'process' as const;
@@ -166,7 +143,6 @@ export class ProcessExecutionHandle implements ExecutionHandle {
   ) {}
 
   getStatus(): ExecutionStatusInfo {
-    // If handle exists in registry → running
     return {
       status: STREAM_STATUS.RUNNING,
       elapsed: formatDuration(Date.now() - this.startedAt),
@@ -182,13 +158,9 @@ export class ProcessExecutionHandle implements ExecutionHandle {
   }
 
   updateProgress(): void {
-    // Processes don't have round progress
+    // Processes don't have round progress.
   }
 }
-
-// ============================================================================
-// Subagent lineage helpers
-// ============================================================================
 
 /** True when the handle is a child of parentStreamId (not the parent itself). */
 function isChildOf(
@@ -205,9 +177,9 @@ function isChildOf(
 }
 
 /**
- * Interrupt all active subagents of a parent stream.
- * Called before interrupting the parent so subagents stop
- * promptly instead of running to completion.
+ * Interrupt all active subagents of a parent stream. Called before
+ * interrupting the parent so subagents stop promptly instead of running to
+ * completion.
  */
 export function interruptActiveChildren(
   parentStreamId: StreamTabId,
@@ -220,7 +192,7 @@ export function interruptActiveChildren(
   }
 }
 
-/** Collect {executionId, agentName} for handles matching a class under a parent stream. */
+/** Collect {executionId, agentName, ...} for handles matching a class under a parent stream. */
 export function collectChildSummary(
   parentStreamId: StreamTabId,
   handles: Iterable<ExecutionHandle>,

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -1,10 +1,9 @@
 /**
  * Promise-based coordinator for plan approval gates.
  *
- * Flow:
- * 1. PlanTool calls `waitForApproval()` - returns Promise, emits 'showPlanApproval'
- * 2. User approves/rejects → resolves Promise with corresponding action
- * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI
+ * 1. PlanTool calls `waitForApproval()` → returns Promise, emits 'showPlanApproval'.
+ * 2. User approves/rejects → resolves Promise with the corresponding action.
+ * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI.
  */
 
 import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -14,11 +13,6 @@ import {
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
 
-// ============================================================================
-// Types
-// ============================================================================
-
-/** Result of a plan approval request. */
 export type PlanApprovalResult =
   | { action: 'approve' }
   | { action: 'reject'; feedback?: string }
@@ -27,22 +21,16 @@ export type PlanApprovalResult =
 export interface PlanApprovalRequestOptions {
   approvalId: string;
   plan: Plan;
-  /** Timeout in milliseconds (default: wait indefinitely) */
+  /** Timeout in milliseconds (default: wait indefinitely). */
   timeoutMs?: number;
 }
 
-/** Payload for show event */
 interface PlanApprovalShowPayload extends Record<string, unknown> {
   approvalId: string;
   streamId: string;
   plan: Plan;
 }
 
-// ============================================================================
-// Coordinator Implementation
-// ============================================================================
-
-/** Manages pending plan approval requests. */
 export class PlanApprovalCoordinator extends BasePromiseCoordinator<
   PlanApprovalResult,
   PlanApprovalShowPayload
@@ -61,21 +49,16 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
     return { action: 'reject' };
   }
 
-  /** Wait for user action on a plan. */
   waitForApproval(
     streamId: string,
     options: PlanApprovalRequestOptions,
   ): Promise<PlanApprovalResult> {
     const { approvalId, plan, timeoutMs } = options;
 
-    // Track bidirectional mapping for cleanup
     this.streamApprovalMap.set(streamId, approvalId);
     this.approvalStreamMap.set(approvalId, streamId);
 
-    // Request host to show progress view so user sees the approval prompt
     this.runtimeHost.emit('requestEnsureProgressView', {});
-
-    // Activate the stream that needs approval so user sees the prompt immediately
     this.runtimeHost.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
@@ -85,43 +68,30 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
     );
   }
 
-  /** Override to clean up stream mapping on normal resolution. */
+  private dropMappingByApprovalId(approvalId: string): void {
+    const streamId = this.approvalStreamMap.get(approvalId);
+    if (!streamId) return;
+    this.streamApprovalMap.delete(streamId);
+    this.approvalStreamMap.delete(approvalId);
+  }
+
   override resolveRequest(id: string, result: PlanApprovalResult): boolean {
-    const streamId = this.approvalStreamMap.get(id);
-    if (streamId) {
-      this.streamApprovalMap.delete(streamId);
-      this.approvalStreamMap.delete(id);
-    }
+    this.dropMappingByApprovalId(id);
     return super.resolveRequest(id, result);
   }
 
-  /** Override to clean up stream mapping on external cancellation. */
   override clearRequest(id: string): void {
-    const streamId = this.approvalStreamMap.get(id);
-    if (streamId) {
-      this.streamApprovalMap.delete(streamId);
-      this.approvalStreamMap.delete(id);
-    }
+    this.dropMappingByApprovalId(id);
     super.clearRequest(id);
   }
 
-  /**
-   * Clear any pending plan approval for the given stream.
-   * Used for cleanup when flows are interrupted or streams are deleted.
-   */
+  /** Clear any pending plan approval for the given stream. */
   clearForStream(streamId: string): void {
     const approvalId = this.streamApprovalMap.get(streamId);
-    if (approvalId) {
-      this.clearRequest(approvalId);
-    }
+    if (approvalId) this.clearRequest(approvalId);
   }
 }
 
-// ============================================================================
-// Singleton Export
-// ============================================================================
-
-/** Singleton coordinator instance. */
 export const planApprovalCoordinator = new PlanApprovalCoordinator(
   getDefaultAgentRuntimeHost,
 );

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -1,13 +1,9 @@
-// Node imports
 import * as fs from 'fs';
 
-// Third-party imports
 import pMap from 'p-map';
 
-// Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
 
-// Local imports - runtime
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ProcessExecutionHandle } from './ExecutionHandle';
 

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -1,12 +1,11 @@
 /**
- * RetryRequestCoordinator - Promise-based coordinator for manual retry handling.
+ * Promise-based coordinator for manual retry handling.
  *
- * Flow:
- * 1. Agent calls `waitForUserAction()` - returns Promise, emits 'showRetryRequest'
- * 2. User clicks retry → `triggerRetry()` → resolves Promise with 'retry'
- * 3. Or: User cancels → `cancelRetry()` → resolves Promise with 'cancel'
- * 4. Or: Timeout → auto-resolves Promise with 'timeout'
- * 5. On resolution → emits 'resolveRetryRequest' to dismiss UI
+ * 1. Agent calls `waitForRetry()` → returns Promise, emits 'showRetryRequest'.
+ * 2. User clicks retry → `triggerRetry()` → resolves Promise with 'retry'.
+ *    Or:    User cancels → `cancelRetry()` → resolves Promise with 'cancel'.
+ *    Or:    Timeout → auto-resolves Promise with 'timeout'.
+ * 3. On resolution → emits 'resolveRetryRequest' to dismiss UI.
  */
 
 import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -17,34 +16,26 @@ import {
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
 
-/**
- * Result of a retry request. Discriminated union for type-safe handling.
- * Includes optional feedback for user guidance on retry.
- */
 export type RetryResult =
   | { action: 'retry'; feedback?: string }
   | { action: 'cancel' }
   | { action: 'timeout' };
 
-/**
- * Options for initiating a retry request.
- */
 export interface RetryRequestOptions {
-  /** Name of the operation that failed (e.g., "Model invocation") */
+  /** Name of the operation that failed (e.g. "Model invocation"). */
   operation: string;
-  /** Error message to display to user */
+  /** Error message to display to the user. */
   errorMessage?: string;
-  /** Model name for context */
+  /** Model name for context. */
   model?: string;
-  /** Logger for debug messages */
+  /** Logger for debug messages. */
   logger: AgentLogger;
-  /** Timeout in milliseconds (defaults to wait indefinitely) */
+  /** Timeout in milliseconds (default: wait indefinitely). */
   timeoutMs?: number;
-  /** Structured error details for expandable display */
+  /** Structured error details for expandable display. */
   errorDetails?: ProviderErrorPartial;
 }
 
-/** Payload for show event */
 interface RetryShowPayload extends Record<string, unknown> {
   streamId: string;
   operation: string;
@@ -53,10 +44,6 @@ interface RetryShowPayload extends Record<string, unknown> {
   errorDetails?: ProviderErrorPartial;
 }
 
-/**
- * Manages pending retry requests.
- * Extends BasePromiseCoordinator with retry-specific behavior.
- */
 export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
   RetryResult,
   RetryShowPayload
@@ -67,26 +54,20 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
     idFieldName: 'streamId',
   };
 
-  /** Track logger per request for debug messages */
+  /** Per-stream logger captured during waitForRetry, consulted by trigger/cancel. */
   private readonly loggers = new Map<string, AgentLogger>();
 
   protected getDefaultCancelResult(): RetryResult {
     return { action: 'cancel' };
   }
 
-  /**
-   * Wait for user action on a retry request.
-   */
   waitForRetry(
     streamId: string,
     options: RetryRequestOptions,
   ): Promise<RetryResult> {
     const { logger, operation, errorMessage, model, timeoutMs, errorDetails } =
       options;
-
-    // Store logger for this request
     this.loggers.set(streamId, logger);
-
     logger.debug(
       `Waiting for manual retry: ${errorMessage ?? 'unknown error'}`,
     );
@@ -108,35 +89,20 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
     );
   }
 
-  /**
-   * Trigger a retry for a stream. Called when user clicks the retry button.
-   * @param streamId - The stream to retry
-   * @param feedback - Optional feedback from user
-   * @returns true if retry was triggered, false if no pending request
-   */
+  /** Resolve with 'retry'. Returns true if a pending request was resolved. */
   triggerRetry(streamId: string, feedback?: string): boolean {
-    const logger = this.loggers.get(streamId);
-    logger?.debug('Retry requested');
+    this.loggers.get(streamId)?.debug('Retry requested');
     this.loggers.delete(streamId);
     return this.resolveRequest(streamId, { action: 'retry', feedback });
   }
 
-  /**
-   * Cancel a retry for a stream. Called when user clicks the cancel button.
-   * @param streamId - The stream to cancel
-   * @returns true if cancelled, false if no pending request
-   */
+  /** Resolve with 'cancel'. Returns true if a pending request was resolved. */
   cancelRetry(streamId: string): boolean {
-    const logger = this.loggers.get(streamId);
-    logger?.debug('Retry cancelled');
+    this.loggers.get(streamId)?.debug('Retry cancelled');
     this.loggers.delete(streamId);
     return this.resolveRequest(streamId, { action: 'cancel' });
   }
 
-  /**
-   * Clear a pending retry request.
-   * Overrides base to clean up logger.
-   */
   override clearRequest(streamId: string): void {
     this.loggers.delete(streamId);
     super.clearRequest(streamId);

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,11 +1,8 @@
-// Third-party imports
 import { AsyncLocalStorage } from 'async_hooks';
 
-// Local imports - shared schemas
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
-// Local imports - runtime
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentProposalCoordinator } from './AgentProposalCoordinator';
 import type { PlanApprovalCoordinator } from './PlanApprovalCoordinator';

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -33,45 +33,25 @@ import {
 
 const logger = new AgentLogger('SessionResumeRetrieval');
 
-// =============================================================================
-// Types - Zod schemas as single source of truth
-// =============================================================================
-
-/**
- * Schema for tool-use session resume data.
- * Contains full snapshot with messages, state slices, etc.
- */
+/** Tool-use session resume data: full snapshot with messages, state slices. */
 const ToolUseResumeDataSchema = z.object({
   type: z.literal('toolUse'),
   snapshot: ToolUseSessionSnapshotSchema,
 });
 
-/**
- * Schema for workflow session resume data.
- * Contains minimal data - flow reads persisted state via executionId.
- */
+/** Workflow session resume data: minimal — flow reads persisted state via executionId. */
 const WorkflowResumeDataSchema = z.object({
   type: z.literal('workflow'),
   agentConfig: AgentConfigSchema,
   executionId: ExecutionIdSchema,
 });
 
-/** Resume data for tool-use sessions - derived from schema. */
 type ToolUseResumeData = z.infer<typeof ToolUseResumeDataSchema>;
-
-/** Resume data for workflow sessions - derived from schema. */
 type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
 
-/** Discriminated union of session resume data. */
 export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 
-// =============================================================================
-// Schema for Tool-Use Flow Record Validation
-// =============================================================================
-
-/**
- * State slices schema (shared between flat and legacy formats).
- */
+/** State slices schema (shared between flat and legacy formats). */
 const StateSlicesSchema = z.object({
   runStateSnapshot: AgentRunStateSnapshotSchema,
   workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
@@ -118,10 +98,6 @@ const WorkflowFlowRecordStateSchema = z.object({
   totalRounds: z.int().nonnegative(),
 });
 
-// =============================================================================
-// Public API
-// =============================================================================
-
 /**
  * Retrieve resume data for a WAITING session.
  *
@@ -151,14 +127,7 @@ export async function retrieveSessionResumeData(
   return null;
 }
 
-// =============================================================================
-// Internal Helpers
-// =============================================================================
-
-/**
- * Read flow record from execution store.
- * Returns the flow record if found and valid, null otherwise.
- */
+/** Read a flow record from the execution store. Returns null if absent or invalid. */
 async function readFlowRecord(
   executionId: ExecutionId,
   agentType: 'tool-use' | 'workflow',

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,11 +1,8 @@
-// Standard library imports
 import * as path from 'path';
 
-// Third-party imports
 import deepmerge from 'deepmerge';
 import * as yaml from 'yaml';
 
-// Local imports - agent components
 import {
   resolveAgent,
   type AgentSource,
@@ -23,8 +20,6 @@ import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import * as logger from '@agent/core/logger';
 import { toErrorMessage } from '@common/errors';
 import { resolveToolDefinitions } from '@tools/registry';
-
-// Internal imports
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'agentLoad';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -254,18 +254,23 @@ function buildStoppedFlowResult(
   };
 }
 
-function buildFallbackNotification(config: AgentConfig) {
+function buildFallbackNotification(config: AgentConfig): {
+  agentName: string;
+  modelName: string;
+  inputName: string;
+  outputInfo: string;
+} {
   const primaryInput = config.inputFiles[0];
   const inputName = primaryInput
     ? path.basename(primaryInput)
     : 'selected input';
-  const { outputFiles = [] } = config;
-  const outputInfo =
-    outputFiles.length > 1
-      ? `to ${outputFiles.length} files`
-      : outputFiles[0]
-        ? `to ${path.basename(outputFiles[0])}`
-        : '';
+  const outputFiles = config.outputFiles ?? [];
+  let outputInfo = '';
+  if (outputFiles.length > 1) {
+    outputInfo = `to ${outputFiles.length} files`;
+  } else if (outputFiles[0]) {
+    outputInfo = `to ${path.basename(outputFiles[0])}`;
+  }
   return {
     agentName: config.agent,
     modelName: config.model,
@@ -273,10 +278,6 @@ function buildFallbackNotification(config: AgentConfig) {
     outputInfo,
   };
 }
-
-// ============================================================================
-// Public Entry Points
-// ============================================================================
 
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -1,8 +1,8 @@
 /**
  * Handle-based execution registry.
  *
- * Manages ExecutionHandle instances, providing registration, lookup,
- * change notification, and subagent lineage tracking in a single module.
+ * Manages ExecutionHandle instances and provides registration, lookup, change
+ * notification, and subagent lineage tracking in a single module.
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -31,45 +31,36 @@ export {
 
 const registry = new Map<string, ExecutionHandle>();
 const changeCallbacks = new Map<string, Array<() => void>>();
-// Persistent listeners — stay attached across notifications (unlike one-shot
+// Persistent listeners stay attached across notifications (unlike one-shot
 // waiters in `changeCallbacks`). Used by the executions subscribe action.
 const persistentListeners = new Map<
   string,
   Set<(handle: ExecutionHandle | undefined) => void>
 >();
 
-// Notify waiters and refresh UI badges when stream status changes (e.g. RUNNING → WAITING).
-// Without this, waitForExecutionChange only resolves on progress/kill/untrack,
-// and the background tasks panel would show stale running/waiting badges.
+// Notify waiters and refresh UI badges when stream status changes
+// (e.g. RUNNING → WAITING). Without this, waitForExecutionChange only resolves
+// on progress/kill/untrack, and the background-tasks panel shows stale badges.
 StreamStatusService.onDidChange(({ streamId }) => {
   for (const [executionId, handle] of registry) {
     if (
       handle instanceof AgentExecutionHandle &&
       handle.childStreamId === streamId
     ) {
-      const runtimeHost = handle.runtimeHost;
       notifyWaiters(executionId);
-      // Re-emit badge update so the parent's background tasks panel
-      // reflects the new status (e.g. running → waiting).
       if (handle.parentStreamId !== handle.childStreamId) {
-        emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
+        emitActiveSubagentsUpdate(handle.parentStreamId, handle.runtimeHost);
       }
       break;
     }
   }
 });
 
-// ============================================================================
-// Core registry operations
-// ============================================================================
-
 /** Register an execution handle. */
 export function trackExecution(handle: ExecutionHandle): void {
   registry.set(handle.executionId, handle);
-  const runtimeHost = handle.runtimeHost;
+  const { runtimeHost } = handle;
 
-  // Emit subagent UI update and parent linkage only for actual subagents
-  // (where parentStreamId differs from childStreamId)
   if (handle instanceof AgentExecutionHandle) {
     if (handle.parentStreamId !== handle.childStreamId) {
       emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
@@ -78,10 +69,7 @@ export function trackExecution(handle: ExecutionHandle): void {
         parentStreamId: handle.parentStreamId,
       });
     }
-  }
-
-  // Emit process badge update for background bash processes
-  if (handle instanceof ProcessExecutionHandle) {
+  } else if (handle instanceof ProcessExecutionHandle) {
     registerProcessOutput(handle, runtimeHost);
     emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
   }
@@ -93,20 +81,19 @@ export function untrackExecution(executionId: string): void {
   registry.delete(executionId);
   notifyWaiters(executionId);
   if (!handle) return;
-  const runtimeHost = handle.runtimeHost;
+  const { runtimeHost } = handle;
 
-  // Emit subagent UI update on removal (only for actual subagents)
   if (
     handle instanceof AgentExecutionHandle &&
     handle.parentStreamId !== handle.childStreamId
   ) {
     emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
+    return;
   }
 
-  // Emit process badge update on removal and flush final output.
-  // The final read must complete before the badge update, because the
-  // badge handler prunes output entries for processes no longer active.
   if (handle instanceof ProcessExecutionHandle) {
+    // The final read must complete before the badge update, because the
+    // badge handler prunes output entries for processes no longer active.
     const finalize = (): void => {
       unregisterProcessOutput(executionId);
       emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
@@ -119,12 +106,11 @@ export function untrackExecution(executionId: string): void {
   }
 }
 
-/** Get a handle by execution ID. */
 export function getHandle(executionId: string): ExecutionHandle | undefined {
   return registry.get(executionId);
 }
 
-/** Terminate an execution via its handle. Returns true if successful. */
+/** Terminate an execution via its handle. Returns true on success. */
 export function killExecution(executionId: string): boolean {
   const handle = registry.get(executionId);
   if (!handle) return false;
@@ -135,15 +121,14 @@ export function killExecution(executionId: string): boolean {
   return result;
 }
 
-/** All currently tracked (active) execution IDs. */
 export function getActiveExecutionIds(): string[] {
   return [...registry.keys()];
 }
 
 /**
- * Kill only background OS processes (bash, codex) without touching agent stream status.
- * Agent executions are left in RUNNING so the restart recovery logic can restore
- * them to WAITING (resumable) if a flow record exists.
+ * Kill only background OS processes (bash, codex) without touching agent
+ * stream status. Agent executions are left in RUNNING so restart recovery can
+ * restore them to WAITING (resumable) if a flow record exists.
  */
 export function killBackgroundProcesses(): void {
   for (const [executionId, handle] of registry) {
@@ -153,7 +138,6 @@ export function killBackgroundProcesses(): void {
   }
 }
 
-/** Delegate progress update to the handle. */
 export function updateExecutionProgress(
   executionId: string,
   update: { currentRound?: number; totalRounds?: number },
@@ -163,10 +147,6 @@ export function updateExecutionProgress(
   handle.updateProgress(update);
   notifyWaiters(executionId);
 }
-
-// ============================================================================
-// Blocking wait
-// ============================================================================
 
 /**
  * Wait for any change on an execution: status transition, progress update,
@@ -192,8 +172,7 @@ export function waitForExecutionChange(
 
 /**
  * Wait for any of the given executions to change.
- * Resolves with the execution ID that changed first (or '' on abort).
- * Pass an AbortSignal to clean up callbacks if the caller times out.
+ * Resolves with the execution id that changed first (or '' on abort).
  */
 export function waitForAnyExecutionChange(
   executionIds: string[],
@@ -232,15 +211,7 @@ export function waitForAnyExecutionChange(
   });
 }
 
-// ============================================================================
-// Subagent lineage
-// ============================================================================
-
-/**
- * Interrupt all active subagents of a parent stream.
- * Called before interrupting the parent so subagents stop
- * promptly instead of running to completion.
- */
+/** Interrupt all active subagents of a parent stream. */
 export function interruptActiveChildren(parentStreamId: StreamTabId): void {
   interruptChildren(parentStreamId, registry.values());
 }
@@ -248,7 +219,8 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
 /**
  * Detach all active subagents from a parent, promoting them to top-level.
  * Subagents continue running independently and deliver results via the
- * follow-up queue. Called when stopping an orchestrator without killing children.
+ * follow-up queue. Called when stopping an orchestrator without killing
+ * children.
  */
 export function detachActiveChildren(
   parentStreamId: StreamTabId,
@@ -287,35 +259,31 @@ export function getActiveChildren(parentStreamId: StreamTabId): {
   };
 }
 
-/** Emit the current active subagent list for a parent to the progress UI. */
 function emitActiveSubagentsUpdate(
   parentStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  const children = collectChildSummary(
-    parentStreamId,
-    registry.values(),
-    AgentExecutionHandle,
-  );
   runtimeHost.emit('updateActiveSubagents', {
     parentStreamId,
-    children,
+    children: collectChildSummary(
+      parentStreamId,
+      registry.values(),
+      AgentExecutionHandle,
+    ),
   });
 }
 
-/** Emit the current active processes list for a parent to the progress UI. */
 function emitActiveProcessesUpdate(
   parentStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  const processes = collectChildSummary(
-    parentStreamId,
-    registry.values(),
-    ProcessExecutionHandle,
-  );
   runtimeHost.emit('updateActiveProcesses', {
     parentStreamId,
-    processes,
+    processes: collectChildSummary(
+      parentStreamId,
+      registry.values(),
+      ProcessExecutionHandle,
+    ),
   });
 }
 
@@ -342,8 +310,7 @@ function notifyWaiters(executionId: string): void {
   if (!listeners && !callbacks) return;
 
   // Persistent listeners fire first and stay attached so subscribers keep
-  // receiving every transition (status, progress, untrack) until they
-  // dispose themselves.
+  // receiving every transition until they dispose themselves.
   if (listeners) {
     const handle = registry.get(executionId);
     // Iterate a snapshot so a listener disposing itself mid-fire is safe.
@@ -356,20 +323,18 @@ function notifyWaiters(executionId: string): void {
   }
 
   // Backstop against listener leaks: if the execution is no longer tracked,
-  // any still-registered persistent listener is firing into the void. The
-  // binder's listener self-disposes on untrack, but a third-party caller
-  // that forgets the disposer would otherwise leak indefinitely.
+  // any still-registered persistent listener is firing into the void.
   if (!registry.has(executionId)) {
     persistentListeners.delete(executionId);
   }
 }
 
 /**
- * Add a persistent listener invoked on every change to `executionId`
- * (status transition, progress update, kill, untrack). Returns a disposer.
+ * Add a persistent listener invoked on every change to `executionId` (status
+ * transition, progress update, kill, untrack). Returns a disposer.
  *
- * The callback receives the current `ExecutionHandle`, or `undefined` once
- * the execution has been untracked (terminal event).
+ * The callback receives the current `ExecutionHandle`, or `undefined` once the
+ * execution has been untracked (terminal event).
  */
 export function addExecutionListener(
   executionId: string,

--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -9,7 +9,7 @@ import { AbsoluteFS } from '@utils/files';
 const nunjucksEnv = nunjucks.configure({ autoescape: false });
 
 let extensionPath: string | null = null;
-let cachedTemplate: string | null = null;
+let templatePromise: Promise<string> | null = null;
 
 const PolishYamlSchema = z.object({
   prompts: z.object({ userRequest: z.string() }),
@@ -23,8 +23,8 @@ export function initializePolishModel(extPath: string): void {
   extensionPath = extPath;
 }
 
-async function loadPromptTemplate(): Promise<string> {
-  if (cachedTemplate) return cachedTemplate;
+function loadPromptTemplate(): Promise<string> {
+  if (templatePromise) return templatePromise;
   if (!extensionPath) {
     throw new Error(
       'Polish model not initialized. Call initializePolishModel() first.',
@@ -36,10 +36,11 @@ async function loadPromptTemplate(): Promise<string> {
     'templates',
     'instructionPolish.yaml',
   );
-  const content = await AbsoluteFS.read(yamlPath);
-  const parsed = PolishYamlSchema.parse(yaml.parse(content));
-  cachedTemplate = parsed.prompts.userRequest;
-  return cachedTemplate;
+  templatePromise = (async () => {
+    const content = await AbsoluteFS.read(yamlPath);
+    return PolishYamlSchema.parse(yaml.parse(content)).prompts.userRequest;
+  })();
+  return templatePromise;
 }
 
 /**

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -1,4 +1,3 @@
-// Local imports - runtime
 import {
   proposalCoordinator,
   type ProposalRequestOptions,

--- a/src/agent/runtime/runExecutionRequest.ts
+++ b/src/agent/runtime/runExecutionRequest.ts
@@ -1,4 +1,3 @@
-// Local imports - agent
 import { registerExecution } from '@agent/storage';
 
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -283,16 +283,14 @@ class ProgressEventBus implements ProgressEventBusLike {
     listener: (payload: ProgressEventPayloads[K]) => void,
     options?: { signal?: AbortSignal },
   ): () => void {
-    if (options?.signal?.aborted) {
-      return () => {};
-    }
+    if (options?.signal?.aborted) return () => {};
 
     this.emitter.on(event, listener);
-
-    const cleanup = () => this.emitter.off(event, listener);
+    const cleanup = (): void => {
+      this.emitter.off(event, listener);
+    };
     options?.signal?.addEventListener('abort', cleanup, { once: true });
 
-    // Replay buffered events for this event type and remove them (single pass)
     const remaining: typeof this.buffer = [];
     for (const item of this.buffer) {
       if (item.event === event) {

--- a/src/eventBus/index.ts
+++ b/src/eventBus/index.ts
@@ -1,11 +1,3 @@
-/**
- * Event bus barrel export.
- *
- * Public API:
- * - `bus`: Singleton event bus instance for emitting/subscribing to events
- * - `ProgressEventPayloads`: Type map of event names to payload types
- * - `ProgressEventBusLike`: Interface for dependency injection in event handlers
- */
 export {
   bus,
   type ProgressEventBusLike,


### PR DESCRIPTION
## Summary

Code-simplifier pass over host-neutral \`src/agent/runtime/\` (~4500 LOC) + \`src/eventBus/\` (~320 LOC). 17 files, **net −264 LOC** (133 added / 397 removed). Includes one real bug fix in \`polishModel.ts\` template caching. Public contracts (\`AgentRuntimeHost\`, \`ProgressEventPayloads\`, \`executeAgent\` signature) untouched.

### Bug fix
- **\`polishModel.ts\`** — cache the template **promise** (not the resolved string) so concurrent first-callers share one \`fs\` read + Zod parse instead of racing. Was a real, observable race on cold-cache concurrent calls.

### Coordinators
- **\`BasePromiseCoordinator.ts\`** / **\`AgentProposalCoordinator.ts\`** / **\`RetryRequestCoordinator.ts\`** — stripped section divider banners, consolidated headers, rewrote outdated header in RetryRequest (was referring to retired \`waitForUserAction\` instead of \`waitForRetry\`). Preserved the load-bearing \`setImmediate\` cleanup rationale.
- **\`PlanApprovalCoordinator.ts\`** — extracted \`dropMappingByApprovalId()\` to deduplicate the bidirectional-map cleanup between \`resolveRequest\` and \`clearRequest\`.

### Execution registry
- **\`ExecutionHandle.ts\`** — stripped section dividers.
- **\`executionRegistry.ts\`** — stripped dividers; destructured \`runtimeHost\` once per branch; collapsed the agent vs. process \`untrackExecution\` branches into a single early-returning if/else.

### Launch / orchestration
- **\`executeAgent.ts\`** — rewrote \`buildFallbackNotification\` with an \`if/else\` chain (the original nested ternary violated CLAUDE.md "avoid nested ternaries"); added explicit return type.
- **\`AgentLaunchContext.ts\`** — merged two consecutive destructurings of \`input\` into one.

### eventBus
- **\`ProgressEventBus.ts\`** — tightened \`on()\`: collapsed aborted-signal early return, named cleanup as a \`void\` function, removed superfluous "single pass" comment.

### Comment-only cleanups (banner-style dividers)
\`agentLoad.ts\`, \`ProcessOutputPoller.ts\`, \`RunContext.ts\`, \`runCoordinators.ts\`, \`runExecutionRequest.ts\`, \`SessionResumeRetrieval.ts\` — removed redundant \`// Standard library imports\` / \`// Third-party imports\` / \`// Local imports — ...\` banner comments.

### What was preserved
All load-bearing WHY comments: saga-style compensation in \`AgentLaunchContext\`, listener-leak backstop and badge-flush ordering in \`executionRegistry\`, TOCTOU re-check in \`ExecutionSubscriptionBinder\`, fail-closed sentinel in \`delegationPolicy\`.

### Out of scope / deferred
- \`runCoordinators.ts\`'s ref-counting legacy-singleton fallback (256-line bridge with dedicated tests in \`runCoordinators.vitest.ts\` for the fallback path). Worth a separate, dedicated PR.
- \`ExecutionSubscriptionBinder.ts\`, \`delegationPolicy.ts\`, \`sessionDescription.ts\`, \`helperModel.ts\`, \`ModelFactory.ts\`, \`idleContinuation.ts\`, \`StreamStatusService.ts\`, \`RunStorageService.ts\`, \`toolInjection.ts\`, \`InterruptManager.ts\`, \`AgentFlowResult.ts\`, \`followUpResumeDetection.ts\`, \`reasoningEffort.ts\` — reviewed but already concise.

## Test plan
- [x] \`npx tsc --noEmit\` — clean for runtime/eventBus.
- [x] \`npx vitest run src/test-kernel/agent/runtime/\` — 12/12 pass across 5 files.
- [ ] CI green
- [ ] Smoke: trigger an agent run; confirm progress events still fire; trigger a plan-approval cycle to exercise the \`PlanApprovalCoordinator\` cleanup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly comment/structure cleanup and small refactors in runtime coordinators/registry/event bus, with one behavioral fix to cache the `polishModel` template load Promise for concurrent callers. Risk is low but touches user-interaction gating (approval/proposal/retry) and process tracking paths.
> 
> **Overview**
> Simplifies the shared agent runtime by tightening and de-duplicating coordinator/registry code (proposal/plan approval/retry coordinators, `BasePromiseCoordinator`, and `executionRegistry`) without changing public contracts.
> 
> Includes a **real bug fix** in `polishModel.ts`: caches the in-flight template-load *Promise* so concurrent first calls share a single file read/parse instead of racing.
> 
> Makes a few small behavioral-neutral cleanups: clearer `buildFallbackNotification` logic in `executeAgent`, minor event-bus `on()` cleanup, and widespread removal of banner-style comments/section dividers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57768d42349fb2eea9025b91ba62fcd2c10d2434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->