### PR TITLE
refactor(agents): skip prefills for reasoning models and drop vestigial YAML prefills

### DIFF
--- a/packages/extension/resources/agents/correct.yaml
+++ b/packages/extension/resources/agents/correct.yaml
@@ -6,8 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   rounds: 1
-  prefills:
-    - "Here are the revised \\LaTeX documents. <documents>"
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/merge.yaml
+++ b/packages/extension/resources/agents/merge.yaml
@@ -6,8 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   rounds: 1
-  prefills:
-    - '<documents>'
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/ocr.yaml
+++ b/packages/extension/resources/agents/ocr.yaml
@@ -7,9 +7,6 @@ settings:
   endTag: </documents>
   defaultOutputFiles:
     - ocr_result.tex
-  prefills:
-    - "Here is the \\LaTeX OCR output. <documents>"
-    - ''
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/transcribe_audio.yaml
+++ b/packages/extension/resources/agents/transcribe_audio.yaml
@@ -7,9 +7,6 @@ settings:
   endTag: </documents>
   defaultOutputFiles:
     - transcript.tex
-  prefills:
-    - 'Here is the audio transcript. <documents>'
-    - ''
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/write/paper2poster.yaml
+++ b/packages/extension/resources/agents/write/paper2poster.yaml
@@ -6,9 +6,6 @@ settings:
   isRewrite: False
   defaultOutputFiles:
     - poster.tex
-  prefills:
-    - 'Here is the Beamer poster. <documents>'
-    - ''
   requiredFilesInternal:
     TEMPLATE_POSTER: template_poster.tex
     TEMPLATE_POSTER_STYLE: beamercolorthemempi.sty

--- a/packages/extension/resources/agents/write/paper2slide.yaml
+++ b/packages/extension/resources/agents/write/paper2slide.yaml
@@ -5,9 +5,6 @@ settings:
   endTag: </documents>
   defaultOutputFiles:
     - slides.tex
-  prefills:
-    - 'Here is the Beamer presentation. <documents>'
-    - ''
   requiredFilesInternal:
     TEMPLATE_SLIDE: template_slide.tex
 

--- a/packages/extension/resources/docs/agent-creation/execution_and_testing.md
+++ b/packages/extension/resources/docs/agent-creation/execution_and_testing.md
@@ -12,9 +12,9 @@ working-directory fields), resolves the YAML, and dispatches one of two
 flow shapes:
 
 - **Workflow flow** for `agentCategory: workflow`. Fixed rounds, each round
-  consumes paired `prefills[i]` / `userRequest[i]`. Operates on `inputFiles`
-  (or the active editor selection). Emits LaTeX output files per `documentTag`
-  / `defaultOutputFiles`.
+  consumes `userRequest[i]`. Operates on `inputFiles` (or the active editor
+  selection). Emits LaTeX output files per `documentTag` /
+  `defaultOutputFiles`.
 - **Tool-use flow** for `agentCategory: toolUse`. Multi-step loop invoking
   declared tools. May WAIT for interim follow-ups, spawn subagents via
   `delegate_workflow` / `delegate_agent`, and resume.

--- a/packages/extension/resources/docs/agent-creation/workflow_schema.md
+++ b/packages/extension/resources/docs/agent-creation/workflow_schema.md
@@ -18,9 +18,6 @@ settings:
   temperature: 0.1 # 0.1 for editing, 0.5-0.8 for creative tasks
   documentTag: documents
   endTag: '</documents>'
-  prefills: # MUST have exactly `rounds` entries
-    - '<scratchpad>'
-    - '<scratchpad>'
 
 prompts:
   systemPrompt: |
@@ -40,8 +37,11 @@ prompts:
 
 ## Critical rules
 
-- `prefills` and `userRequest` MUST both have the same number of entries as
-  `rounds`. Round 1 → one entry each; round 2 → two entries each.
+- `userRequest` MUST have the same number of entries as `rounds`. Round 1
+  → one entry; round 2 → two entries.
+- Do NOT emit `prefills`. The field is deprecated --- reasoning models
+  ignore it at runtime, and other models do fine when the userRequest
+  spells out the expected `<documents>...</documents>` wrapper.
 - Always include `{{ INSTRUCTION }}` somewhere so user instructions pass
   through.
 - System prompts should use LaTeX formatting (`\begin{itemize}`,
@@ -119,9 +119,6 @@ settings:
   agentCategory: workflow
   documentTag: documents
   endTag: '</documents>'
-  prefills:
-    - '<scratchpad>'
-    - '<scratchpad>'
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/templates/agentCreatorWorkflow.yaml
+++ b/packages/extension/resources/templates/agentCreatorWorkflow.yaml
@@ -26,9 +26,9 @@ prompts:
       - temperature: low (0.1) for editing/correction tasks, higher (0.5-0.8) for creative/generation tasks.
       - rounds: 1 for simple single-pass tasks, 2 for tasks that benefit from reflection.
     - userRequest is an array with exactly as many entries as rounds (1 or 2).
-    - prefills is OPTIONAL. Omit it unless the agent should skip preamble and force
-      the response to start with a specific token (e.g., - "<documents>").
-      If you do include prefills, the array length MUST equal the number of rounds.
+    - Do NOT emit `prefills`. The field is deprecated --- reasoning models
+      ignore it at runtime, and other models do fine when the userRequest
+      spells out the expected `<documents>...</documents>` wrapper.
     - Fields with defaults can be omitted if the default value is acceptable.
     Respond only with the YAML wrapped in <yaml> tags.
 
@@ -120,8 +120,7 @@ prompts:
     IMPORTANT REMINDERS:
     - The documentTag in prompts must match the settings.documentTag.
     - userRequest must be an array with exactly as many entries as rounds (1 or 2).
-    - Omit prefills by default; only add it (with one entry per round) when the agent should
-      skip preamble and force the response to start with a specific token like "<documents>".
+    - Do NOT emit `prefills` --- the field is deprecated and reasoning models ignore it.
     - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
     - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.
 

--- a/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
@@ -10,10 +10,10 @@ settings:
   isRewrite: true
   documentTag: documents
   endTag: </documents>
-  # Optional: `prefills` can force the assistant turn to start with a specific
-  # token (e.g., - "<documents>") for agents that should skip preamble
-  # and jump straight to output. Most workflow agents do not need this --- modern
-  # thinking-capable models reason natively before producing the final output.
+  # `prefills` is deprecated and almost never needed. Reasoning-capable
+  # models ignore it at runtime, and other models do fine when the
+  # userRequest spells out the expected `<documents>...</documents>`
+  # wrapper. Omit it.
 
 # --- Agent Prompts ---
 prompts:

--- a/packages/extension/resources/tool_use_agents/creator.yaml
+++ b/packages/extension/resources/tool_use_agents/creator.yaml
@@ -128,8 +128,9 @@ prompts:
     - Agent names: lowercase, underscores or dashes only.
     - Keep prompts focused. Write precisely what the agent needs for its
       specific purpose — do not pad with boilerplate.
-    - For workflow agents, `prefills` and `userRequest` must have the same
-      number of entries as `rounds`.
+    - For workflow agents, `userRequest` must have the same number of
+      entries as `rounds`. Do NOT emit `prefills` --- the field is
+      deprecated and ignored by reasoning models.
     - For tool-use agents, `userRequest` must be a single string that
       contains {% raw %}`{{ INSTRUCTION }}`{% endraw %}.
     - Agents can inherit from existing agents via `inherits: parent_name`.

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -55,7 +55,16 @@ export class PrepareContextNode<C = unknown> extends Node<
       );
     }
 
-    const prefill = await promptBuilder.buildPrefill(currentRound);
+    // Reasoning models produce their own preamble through extended thinking,
+    // so any configured prefill would force an unnecessary surface-level
+    // continuation. Skip it for those models regardless of YAML configuration.
+    const prefill = modelHandler.capabilities.supportsReasoning
+      ? ''
+      : await promptBuilder.buildPrefill(currentRound);
+
+    if (modelHandler.capabilities.supportsReasoning) {
+      logger.debug('Reasoning-capable model detected; skipping prefill');
+    }
 
     logger.debug(
       `Prepared ${isFirstRound ? 'first' : `round ${currentRound}`} context with ${messages.length} messages`,

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -58,12 +58,11 @@ export class PrepareContextNode<C = unknown> extends Node<
     // Reasoning models produce their own preamble through extended thinking,
     // so any configured prefill would force an unnecessary surface-level
     // continuation. Skip it for those models regardless of YAML configuration.
-    const prefill = modelHandler.capabilities.supportsReasoning
-      ? ''
-      : await promptBuilder.buildPrefill(currentRound);
-
+    let prefill = '';
     if (modelHandler.capabilities.supportsReasoning) {
       logger.debug('Reasoning-capable model detected; skipping prefill');
+    } else {
+      prefill = await promptBuilder.buildPrefill(currentRound);
     }
 
     logger.debug(

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1118,6 +1118,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       );
       workspaceState.assembly.accumulatedOutput = prefill;
 
+      if (prefill.length === 0) {
+        this.logger.debug(
+          'No prefill provided; skipping pseudo-prefill instruction',
+        );
+        return [false, messages];
+      }
+
       // Add pseudo-prefill instruction to user message
       // (Google's Chat API requires alternating user/model turns)
       const lastMessage = messages.at(-1);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1125,6 +1125,12 @@ export class ModelHandlerOpenAI<
     let endTurn = false;
 
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
+      if (prefill.length === 0) {
+        this.logger.debug(
+          'No prefill provided; skipping pseudo-prefill instruction',
+        );
+        return [endTurn, messages];
+      }
       const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
       const lastMessage = messages.at(-1);
       if (lastMessage && Array.isArray(lastMessage.content)) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2470,6 +2470,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     let endTurn = false;
 
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
+      if (prefill.length === 0) {
+        this.logger.debug(
+          'No prefill provided; skipping pseudo-prefill instruction',
+        );
+        return [endTurn, messages];
+      }
       const pseudoPrefill = `Organize your response with xml tags. Start your response with:\n${prefill}`;
       const lastMessage = messages.at(-1);
       if (lastMessage) {

--- a/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
@@ -1008,6 +1008,12 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     prefill: string,
   ): Promise<[boolean, ChatMessages[]]> {
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
+      if (prefill.length === 0) {
+        this.logger.debug(
+          'No prefill provided; skipping pseudo-prefill instruction',
+        );
+        return [false, messages];
+      }
       const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
       const lastMessage = messages.at(-1);
       if (lastMessage && Array.isArray(lastMessage.content)) {

--- a/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
@@ -1,0 +1,206 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Third-party imports
+import { createPartFromText, type Content } from '@google/genai';
+import { describe, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory, AgentSettingSchema } from '@agent/core/AgentDataclass';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
+import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/modelHandlerOpenRouterNative';
+
+// Local imports - logger
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - utils
+import type { FileLocation } from '@utils/files';
+
+// Type imports
+import type { ChatMessages } from '@openrouter/sdk/models';
+
+type LoggerStub = Partial<AgentLogger> & {
+  streamId: string;
+};
+
+function createLoggerStub(): LoggerStub {
+  return {
+    streamId: 'test-channel',
+    debug: () => {
+      /* no-op for tests */
+    },
+    info: () => {
+      /* no-op for tests */
+    },
+    warn: () => {
+      /* no-op for tests */
+    },
+    error: () => {
+      /* no-op for tests */
+    },
+    withCurrentGroup: () => undefined,
+    runWithinCurrentGroup: async (fn: () => any) => fn(),
+    runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+  };
+}
+
+function buildConfig(
+  provider: ModelProvider,
+  overrides: Partial<ModelConfig> = {},
+): ModelConfig {
+  return {
+    name: 'test-model',
+    label: 'Test Model',
+    fullName: 'test-model',
+    shortName: 'test-model',
+    provider,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: false,
+      supportsVision: false,
+      ...(overrides.capabilities ?? {}),
+    },
+    openRouterOnly: false,
+    ...overrides,
+  };
+}
+
+function createAgentSetting() {
+  return AgentSettingSchema.parse({
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'documents',
+    endTag: '</documents>',
+  });
+}
+
+async function withMissingOutput<T>(
+  test: (outputLocation: FileLocation) => Promise<T>,
+): Promise<T> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-prefill-'));
+  try {
+    return await test({
+      kind: 'external',
+      absolutePath: path.join(tempDir, 'r0', 'output.xml'),
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe('model handler empty prefill behavior', () => {
+  it('OpenAI chat preserves user content when prefill is empty', async () => {
+    await withMissingOutput(async (outputLocation) => {
+      const handler = new ModelHandlerOpenAI(buildConfig(ModelProvider.OPENAI));
+      handler.setLogger(createLoggerStub() as unknown as AgentLogger);
+      const messages = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        },
+      ];
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          createAgentSetting(),
+          messages,
+          AgentWorkspaceState.create(),
+          outputLocation,
+          '',
+        );
+
+      assert.equal(isComplete, false);
+      assert.deepEqual(updatedMessages, [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        },
+      ]);
+    });
+  });
+
+  it('Google GenAI preserves user parts when prefill is empty', async () => {
+    await withMissingOutput(async (outputLocation) => {
+      const handler = new ModelHandlerGoogleGenAI(
+        buildConfig(ModelProvider.GOOGLE),
+      );
+      handler.setLogger(createLoggerStub() as unknown as AgentLogger);
+      const messages: Content[] = [
+        {
+          role: 'user',
+          parts: [createPartFromText('revise the document')],
+        },
+      ];
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          createAgentSetting(),
+          messages,
+          workspaceState,
+          outputLocation,
+          '',
+        );
+
+      assert.equal(isComplete, false);
+      assert.deepEqual(updatedMessages, [
+        {
+          role: 'user',
+          parts: [createPartFromText('revise the document')],
+        },
+      ]);
+      assert.equal(workspaceState.assembly.accumulatedOutput, '');
+    });
+  });
+
+  it('OpenRouter native preserves user content when prefill is empty', async () => {
+    await withMissingOutput(async (outputLocation) => {
+      const handler = new ModelHandlerOpenRouterNative(
+        buildConfig(ModelProvider.OPENAI, {
+          openrouterFullName: 'openai/test-model',
+        }),
+      );
+      handler.setLogger(createLoggerStub() as unknown as AgentLogger);
+      const messages: ChatMessages[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        },
+      ];
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          createAgentSetting(),
+          messages,
+          AgentWorkspaceState.create(),
+          outputLocation,
+          '',
+        );
+
+      assert.equal(isComplete, false);
+      assert.deepEqual(updatedMessages, [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        },
+      ]);
+    });
+  });
+});

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
@@ -1,5 +1,8 @@
 // Standard library imports
 import { strict as assert } from 'assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import {
@@ -9,10 +12,14 @@ import {
 } from 'llm-zoo';
 
 // Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory, AgentSettingSchema } from '@agent/core/AgentDataclass';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
 
 // Type imports
 import type { AgentLogger } from '@logger/AgentLogger';
+import { pathToLocation } from '@utils/files';
 import type { ResponseInputItem } from 'openai/resources/responses/responses';
 
 type LoggerStub = Partial<AgentLogger> & {
@@ -220,5 +227,49 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.deepEqual(requests[2].input, rebuiltMessages);
     assert.equal(tokenCountCalls, 3);
     assert.equal(requests[2].max_output_tokens, 99990);
+  });
+});
+
+describe('ModelHandlerOpenAIResponse.initializeOutputAndPrefill', () => {
+  it('skips pseudo-prefill instruction when prefill is empty', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'openai-response-prefill-empty-'),
+    );
+    const outputPath = path.join(tempDir, 'r0', 'output.xml');
+
+    try {
+      const handler = createHandler();
+      const agentSetting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'documents',
+        endTag: '</documents>',
+      });
+      const userMessage: ResponseInputItem = {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'revise the document' }],
+      } as ResponseInputItem;
+      const messages: ResponseInputItem[] = [userMessage];
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          agentSetting,
+          messages,
+          workspaceState,
+          pathToLocation(outputPath),
+          '',
+        );
+
+      assert.equal(isComplete, false);
+      assert.equal(updatedMessages.length, 1);
+      const onlyContent = (updatedMessages[0] as any).content;
+      assert.deepEqual(onlyContent, [
+        { type: 'input_text', text: 'revise the document' },
+      ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Reasoning-capable models produce their own preamble through extended
thinking, so any configured prefill is pure noise. PrepareContextNode
now forces an empty prefill whenever the active model handler reports
supportsReasoning, and the OpenAI / OpenAI Responses / Google GenAI /
OpenRouter handlers stop emitting their degenerate
"Start your response with:\n" pseudo-prefill when prefill is empty
(matching Anthropic's existing empty-prefill behavior).

Removes the now-vestigial `prefills:` block from the six built-in
workflow agents (ocr, correct, merge, transcribe_audio, paper2slide,
paper2poster) -- every one of their userRequest prompts already
instructs the model to wrap its output in <documents>...</documents>.

Updates the workflow template, agent-creator guidance, and
agent-creation docs to discourage `prefills` going forward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message/prefill handling across multiple model handlers and the workflow reflection flow, which can affect output formatting/continuation behavior across providers. Added tests reduce regression risk but behavior changes apply broadly to workflow runs.
> 
> **Overview**
> **Removes reliance on workflow `prefills` and prevents noisy pseudo-prefill prompts.** The reflection flow now forces `prefill` to empty for reasoning-capable models (`supportsReasoning`), ignoring any YAML-configured prefills.
> 
> Model handlers (OpenAI Chat, OpenAI Responses, Google GenAI, OpenRouter native) now *skip injecting* the "Start your response with…" pseudo-prefill instruction when `prefill` is empty, aligning behavior across providers.
> 
> Built-in workflow agent YAMLs drop their `prefills:` blocks, and agent-creation templates/docs are updated to mark `prefills` as deprecated and to require only `userRequest` to match `rounds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf1731201f967bbab728b3d93acec128602016b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->