### PR TITLE
fix(executions): show bash runs as processes

### DIFF
--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -1,11 +1,17 @@
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
+// Local imports - storage
+import type { ExecutionListingEntry } from '@agent/storage';
+
 // Local imports - schemas
 import { STATUS_DISPLAY, TODO_STATUS } from '@shared/schemas';
 
 // Local imports - tools
-import { formatTodoSection } from '@tools/executionFormatters';
+import {
+  formatListingLine,
+  formatTodoSection,
+} from '@tools/executionFormatters';
 import { formatSubagentProgress } from '@tools/subagentResults';
 
 describe('tool status formatting', () => {
@@ -45,6 +51,23 @@ describe('tool status formatting', () => {
     );
     expect(progress).toContain(
       `  ${STATUS_DISPLAY[TODO_STATUS.PENDING].icon} Write response`,
+    );
+  });
+
+  it('renders bash execution history as a process without a model', () => {
+    const entry: ExecutionListingEntry = {
+      id: '16c0f3f748e4',
+      timestamp: '2026-05-15T23:42:06.000Z',
+      parentExecutionId: 'fcf5150d37c6',
+      agent: 'bash',
+      model: 'gemini31p',
+      agentConfig: null,
+      category: 'toolUse',
+      terminalStatus: 'completed',
+    };
+
+    expect(formatListingLine(entry)).toBe(
+      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
     );
   });
 });

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -58,6 +58,7 @@ import {
   formatTodoSection,
   getAvailablePaths,
   getExecutionStatusInfo,
+  resolveExecutionDisplayCategory,
 } from './executionFormatters';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
@@ -86,6 +87,9 @@ const WORKFLOW_ONLY_FIELDS = new Set([
 
 /** Config fields only relevant to toolUse agents — hidden for workflow. */
 const TOOL_USE_ONLY_FIELDS = new Set(['toolConfig']);
+
+/** Synthetic process configs carry agent-only defaults that are not meaningful. */
+const PROCESS_HIDDEN_FIELDS = new Set(['model', 'agentCategory', 'toolConfig']);
 
 /**
  * Listen for follow-up messages on the current stream and abort the given
@@ -503,13 +507,18 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       };
     }
 
-    const category = meta?.category ?? config?.agentCategory;
+    const category = resolveExecutionDisplayCategory(
+      config?.agent,
+      meta?.category ?? config?.agentCategory,
+    );
     const info = getExecutionStatusInfo(executionId, meta?.terminalStatus);
     const lines = [
       `Execution: ${executionId}`,
       `Agent: ${config?.agent ?? 'unknown'}`,
       ...(category ? [`Category: ${category}`] : []),
-      `Model: ${config?.model ?? 'default'}`,
+      ...(category === 'process'
+        ? []
+        : [`Model: ${config?.model ?? 'default'}`]),
       `Timestamp: ${meta?.timestamp ?? 'unknown'}`,
       `Status: ${formatStatusInfo(info)}`,
     ];
@@ -727,12 +736,17 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     }
 
     // Filter out fields irrelevant to this agent's category
-    const { agentCategory } = config;
-    if (agentCategory) {
+    const category = resolveExecutionDisplayCategory(
+      config.agent,
+      config.agentCategory,
+    );
+    if (category) {
       const excludeSet =
-        agentCategory === 'toolUse'
-          ? WORKFLOW_ONLY_FIELDS
-          : TOOL_USE_ONLY_FIELDS;
+        category === 'process'
+          ? PROCESS_HIDDEN_FIELDS
+          : category === 'toolUse'
+            ? WORKFLOW_ONLY_FIELDS
+            : TOOL_USE_ONLY_FIELDS;
       const filtered = Object.fromEntries(
         Object.entries(config).filter(([key]) => !excludeSet.has(key)),
       );

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -222,7 +222,7 @@ export class BashTool extends defineTool({
       syntheticConfig,
       'bash',
       parentExecutionId,
-      'toolUse',
+      'process',
     );
 
     const { childStreamId, logger } = createChildStream(

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -10,6 +10,14 @@ import {
   TODO_STATUS,
   type TodoStatus,
 } from '@shared/schemas';
+import { isProcessAgent } from '@shared/streams/agentKind';
+
+export function resolveExecutionDisplayCategory(
+  agent: string | undefined,
+  category: string | undefined,
+): string | undefined {
+  return isProcessAgent(agent) ? 'process' : category;
+}
 
 /** Return paths available for a given agent category. */
 export function getAvailablePaths(
@@ -68,12 +76,14 @@ export function formatProgressLine(
 export function formatListingLine(entry: ExecutionListingEntry): string {
   const ts = entry.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
   const info = getExecutionStatusInfo(entry.id, entry.terminalStatus);
-  const categoryTag = entry.category ? `  ${entry.category}` : '';
+  const category = resolveExecutionDisplayCategory(entry.agent, entry.category);
+  const categoryTag = category ? `  ${category}` : '';
+  const modelTag = category === 'process' ? '' : `  ${entry.model}`;
   const parentSuffix = entry.parentExecutionId
     ? `  parent=${entry.parentExecutionId}`
     : '';
   const descSuffix = entry.description ? `  — ${entry.description}` : '';
-  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
+  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}${modelTag}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
 }
 
 function getTodoStatusIcon(status: string | undefined): string {


### PR DESCRIPTION
## Summary

- Store new background bash executions with the `process` category instead of `toolUse`.
- Normalize bash execution-history display to `process`, including older persisted entries that still carry `toolUse` metadata.
- Hide model-only fields from bash process listings, summaries, and config output.

Closes #4107.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/ToolStatusFormatting.vitest.ts`
- `corepack pnpm run typecheck`
- `npm run format`
- `npm run lint` (passes with 15 pre-existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to execution-history categorization/formatting for `bash` runs and filtering of displayed config fields, without impacting execution semantics or security-sensitive logic.
> 
> **Overview**
> Normalizes background `bash` executions to display as **`process`** runs (including older stored entries), and omits misleading model info for these process entries.
> 
> Updates `executions` summary/config output to use a new `resolveExecutionDisplayCategory()` helper and hides synthetic process-only config fields; adds a focused Vitest to ensure `formatListingLine()` renders `bash` history as `process` with no model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0deba0df3fed01ebc24f9f8b7d64d3b918eb3dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->