### PR TITLE
fix(cli): render markdown headings and wrap ansi output

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,7 +1,7 @@
 // Ink TUI root: header, conversation, optional side column, status, approval
 // modal, and input bar. Tab / Shift-Tab cycles focus across subagent streams.
 
-import { Box, useInput } from 'ink';
+import { Box, useInput, useWindowSize } from 'ink';
 
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ConversationPane } from './panes/ConversationPane';
@@ -14,6 +14,9 @@ import { cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { useSignal } from './state/useSignal';
 import type { InputHistory } from './history/inputHistory';
+
+const SIDE_COLUMN_WIDTH = 28;
+const MIN_TRANSCRIPT_WIDTH = 20;
 
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
@@ -29,6 +32,7 @@ export function App(props: AppProps): React.JSX.Element {
   const streams = useSignal(cliState.streams);
   const activeForm = useSignal(cliState.activeForm);
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
+  const { columns } = useWindowSize();
   const inputDisabled =
     props.inputDisabled || pending !== undefined || activeForm !== undefined;
 
@@ -41,6 +45,10 @@ export function App(props: AppProps): React.JSX.Element {
       activeSlice.activeProcesses.length > 0 ||
       activeSlice.todos.length > 0 ||
       activeSlice.plan !== null);
+  const transcriptWidth = Math.max(
+    MIN_TRANSCRIPT_WIDTH,
+    columns - (showSideColumn ? SIDE_COLUMN_WIDTH : 0),
+  );
 
   // Tab / Shift-Tab cycles stream focus at the App layer. Stand down while a
   // modal/form is up (they own input) or the slash palette is open (Tab there
@@ -59,10 +67,10 @@ export function App(props: AppProps): React.JSX.Element {
     <Box flexDirection="column">
       <Box flexDirection="row" flexGrow={1}>
         <Box flexDirection="column" flexGrow={1}>
-          <ConversationPane />
+          <ConversationPane width={transcriptWidth} />
         </Box>
         {showSideColumn ? (
-          <Box flexDirection="column" minWidth={28}>
+          <Box flexDirection="column" minWidth={SIDE_COLUMN_WIDTH}>
             <SubagentList />
             <TodosPlanPanel />
           </Box>

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
@@ -7,12 +7,18 @@ import { ConfirmCard } from './ConfirmCard';
 import { buildHunks, DiffView, statsFromHunks } from '../render/DiffView';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
+const EDIT_DIFF_PADDING = 6;
+const MIN_EDIT_DIFF_WIDTH = 20;
+
 export interface EditApprovalProps {
   readonly request: ToolEditApprovalRequest;
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {
+  const { columns } = useWindowSize();
+  const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
+
   // Single diff pass shared between the summary line and the inline view.
   const hunks = useMemo(
     () =>
@@ -41,7 +47,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
         {props.request.sourceTool}
       </Text>
       <Box marginY={1} flexDirection="column">
-        <DiffView hunks={hunks} maxHunkLines={30} />
+        <DiffView hunks={hunks} maxHunkLines={30} width={diffWidth} />
       </Box>
     </ConfirmCard>
   );

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -27,8 +27,10 @@ function isAppending(status: StreamStatus | undefined): boolean {
 
 function TranscriptEntry({
   entry,
+  width,
 }: {
   readonly entry: ConversationEntry;
+  readonly width?: number;
 }): React.JSX.Element {
   if (entry.role === 'user') {
     return (
@@ -41,7 +43,7 @@ function TranscriptEntry({
 
   return (
     <Box marginBottom={1}>
-      <Markdown content={entry.text} />
+      <Markdown content={entry.text} width={width} />
     </Box>
   );
 }
@@ -58,7 +60,13 @@ function LiveTranscriptEntry({
   );
 }
 
-export function ConversationPane(): React.JSX.Element {
+export interface ConversationPaneProps {
+  readonly width?: number;
+}
+
+export function ConversationPane(
+  props: ConversationPaneProps = {},
+): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
@@ -83,7 +91,9 @@ export function ConversationPane(): React.JSX.Element {
   return (
     <Box flexDirection="column" flexGrow={1}>
       <Static items={finalized}>
-        {(entry) => <TranscriptEntry key={entry.id} entry={entry} />}
+        {(entry) => (
+          <TranscriptEntry key={entry.id} entry={entry} width={props.width} />
+        )}
       </Static>
       {live ? <LiveTranscriptEntry entry={live} /> : null}
     </Box>

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -7,6 +7,8 @@
 import { Box, Text } from 'ink';
 import { structuredPatch, type StructuredPatchHunk } from 'diff';
 
+import { wrapAnsiToWidth } from './ansiWrap';
+
 export type Hunk = StructuredPatchHunk;
 
 export interface DiffStats {
@@ -16,6 +18,8 @@ export interface DiffStats {
 }
 
 const NO_NEWLINE_MARKER = '\\';
+const MIN_DIFF_WIDTH = 20;
+const DEFAULT_DIFF_WIDTH = 74;
 
 /** Compute hunks once; callers reuse for both stats and the renderer. */
 export function buildHunks(
@@ -45,10 +49,12 @@ export interface DiffViewProps {
   readonly hunks: readonly Hunk[];
   /** Maximum context lines per hunk before truncating; 0 = no truncation. */
   readonly maxHunkLines?: number;
+  readonly width?: number;
 }
 
 export function DiffView(props: DiffViewProps): React.JSX.Element {
   const max = props.maxHunkLines ?? 0;
+  const width = Math.max(MIN_DIFF_WIDTH, props.width ?? DEFAULT_DIFF_WIDTH);
 
   return (
     <Box flexDirection="column">
@@ -63,9 +69,9 @@ export function DiffView(props: DiffViewProps): React.JSX.Element {
         const hunkHeader = `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
         return (
           <Box key={`${hi}-${hunk.oldStart}`} flexDirection="column">
-            <Text dimColor>{hunkHeader}</Text>
+            <Text dimColor>{wrapAnsiToWidth(hunkHeader, width)}</Text>
             {visible.map((line, li) => (
-              <DiffLine key={li} line={line} />
+              <DiffLine key={li} line={line} width={width} />
             ))}
             {remaining > 0 ? (
               <Text dimColor>… {remaining} more lines</Text>
@@ -77,9 +83,16 @@ export function DiffView(props: DiffViewProps): React.JSX.Element {
   );
 }
 
-function DiffLine({ line }: { line: string }): React.JSX.Element {
+function DiffLine({
+  line,
+  width,
+}: {
+  readonly line: string;
+  readonly width: number;
+}): React.JSX.Element {
+  const wrapped = wrapAnsiToWidth(line, width);
   const marker = line[0];
-  if (marker === '+') return <Text color="green">{line}</Text>;
-  if (marker === '-') return <Text color="red">{line}</Text>;
-  return <Text dimColor>{line}</Text>;
+  if (marker === '+') return <Text color="green">{wrapped}</Text>;
+  if (marker === '-') return <Text color="red">{wrapped}</Text>;
+  return <Text dimColor>{wrapped}</Text>;
 }

--- a/packages/cli/src/chat/tui/render/Markdown.tsx
+++ b/packages/cli/src/chat/tui/render/Markdown.tsx
@@ -9,12 +9,13 @@ import { renderAnsiMarkdown } from './ansiMarkdown';
 
 export interface MarkdownProps {
   readonly content: string;
+  readonly width?: number;
 }
 
 export function Markdown(props: MarkdownProps): React.JSX.Element {
   // `renderAnsiMarkdown` trims trailing newlines so Ink doesn't add a blank
   // line at the bottom of each conversation entry; the parent
   // `<Box marginBottom={1}>` already provides separation between entries.
-  const rendered = renderAnsiMarkdown(props.content);
+  const rendered = renderAnsiMarkdown(props.content, { width: props.width });
   return <Text>{rendered}</Text>;
 }

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -19,6 +19,8 @@ import {
   type MarkdownProcessor,
 } from '@shared/markdown';
 
+import { wrapAnsiToWidth } from './ansiWrap';
+
 import type { RenderRule } from 'markdown-it/lib/renderer.mjs';
 
 /** SGR open/close codes wrapped through String.fromCharCode so the ESC byte
@@ -42,6 +44,7 @@ function highlightForTui(code: string, lang: string): string {
 function configureAnsi(md: MarkdownItInstance): void {
   const r = md.renderer.rules;
   let quoteDepth = 0;
+  let headingDepth = 0;
 
   const quotePrefix = (): string =>
     quoteDepth > 0 ? pico.dim('│ '.repeat(quoteDepth)) : '';
@@ -70,12 +73,14 @@ function configureAnsi(md: MarkdownItInstance): void {
   };
 
   r.heading_open = (tokens, idx) => {
-    const level = Number(tokens[idx]?.tag?.slice(1) ?? 1);
-    const marker = '#'.repeat(level);
+    headingDepth += 1;
     const start = quoteDepth === 0 ? '\n' : quoteBlockStart(tokens, idx);
-    return `${start}${pico.bold(pico.cyan(`${marker} `))}`;
+    return start;
   };
-  r.heading_close = () => '\n';
+  r.heading_close = () => {
+    headingDepth = Math.max(0, headingDepth - 1);
+    return '\n';
+  };
 
   r.paragraph_open = (tokens, idx) => {
     if (quoteDepth === 0) return '';
@@ -103,8 +108,13 @@ function configureAnsi(md: MarkdownItInstance): void {
   r.s_open = () => sgr(9);
   r.s_close = () => sgr(29);
 
-  r.code_inline = (tokens, idx) =>
-    pico.cyan(`\`${tokens[idx]?.content ?? ''}\``);
+  const styleHeadingText = (text: string): string =>
+    headingDepth > 0 ? pico.bold(pico.cyan(text)) : text;
+
+  r.code_inline = (tokens, idx) => {
+    const code = `\`${tokens[idx]?.content ?? ''}\``;
+    return headingDepth > 0 ? styleHeadingText(code) : pico.cyan(code);
+  };
   r.fence = (tokens, idx) => {
     const token = tokens[idx];
     if (!token) return '';
@@ -167,16 +177,18 @@ function configureAnsi(md: MarkdownItInstance): void {
   r.hardbreak = () => `\n${quotePrefix()}`;
 
   // markdown-it default `text` rule escapes HTML; we want raw text.
-  r.text = (tokens, idx) => tokens[idx]?.content ?? '';
+  r.text = (tokens, idx) => styleHeadingText(tokens[idx]?.content ?? '');
   r.image = (tokens, idx) => pico.dim(`[image: ${tokens[idx]?.content ?? ''}]`);
 
   const render = md.renderer.render.bind(md.renderer);
   md.renderer.render = (tokens, options, env) => {
     quoteDepth = 0;
+    headingDepth = 0;
     try {
       return render(tokens, options, env);
     } finally {
       quoteDepth = 0;
+      headingDepth = 0;
     }
   };
 }
@@ -187,12 +199,19 @@ function formatAnsiLatexReference(refType: string, label: string): string {
 
 let cachedProcessor: MarkdownProcessor | null = null;
 
+export interface RenderAnsiMarkdownOptions {
+  readonly width?: number;
+}
+
 /**
  * Render markdown to an ANSI-coloured string suitable for an Ink `<Text>`.
  * Uses a per-host LRU cache so streaming deltas don't re-render the entire
  * message body each frame.
  */
-export function renderAnsiMarkdown(content: string): string {
+export function renderAnsiMarkdown(
+  content: string,
+  options: RenderAnsiMarkdownOptions = {},
+): string {
   if (!cachedProcessor) {
     const renderer = createMarkdownRenderer({
       highlight: highlightForTui,
@@ -203,7 +222,9 @@ export function renderAnsiMarkdown(content: string): string {
       formatLatexReference: formatAnsiLatexReference,
     });
   }
-  return cachedProcessor(content).trimEnd();
+  return wrapAnsiToWidth(cachedProcessor(content), options.width, {
+    preserveMarkdownPrefix: true,
+  }).trimEnd();
 }
 
 /** Test seam: drop the cached processor so tests can re-init cleanly. */

--- a/packages/cli/src/chat/tui/render/ansiWrap.ts
+++ b/packages/cli/src/chat/tui/render/ansiWrap.ts
@@ -1,0 +1,146 @@
+import wrapAnsi from 'wrap-ansi';
+
+const MIN_WRAP_WIDTH = 1;
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+
+export interface WrapAnsiOptions {
+  readonly preserveMarkdownPrefix?: boolean;
+}
+
+function normalizedWidth(width: number | undefined): number | undefined {
+  if (width == null || !Number.isFinite(width)) return undefined;
+  return Math.max(MIN_WRAP_WIDTH, Math.floor(width));
+}
+
+function ansiEscapeEnd(text: string, index: number): number {
+  if (text[index] !== ESC) return index;
+  const next = text[index + 1];
+  if (next === '[') {
+    let end = index + 2;
+    while (end < text.length && !/[@-~]/.test(text[end] ?? '')) end += 1;
+    return Math.min(end + 1, text.length);
+  }
+  if (next === ']') {
+    const belEnd = text.indexOf(BEL, index + 2);
+    const stEnd = text.indexOf(`${ESC}\\`, index + 2);
+    if (belEnd === -1 && stEnd === -1) return text.length;
+    if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
+    return stEnd + 2;
+  }
+  return Math.min(index + 2, text.length);
+}
+
+function stripAnsiForPrefix(text: string): string {
+  let plain = '';
+  for (let i = 0; i < text.length; ) {
+    if (text[i] === ESC) {
+      i = ansiEscapeEnd(text, i);
+    } else {
+      plain += text[i];
+      i += 1;
+    }
+  }
+  return plain;
+}
+
+function splitRawAtVisiblePrefix(
+  line: string,
+  visiblePrefixLength: number,
+): { prefix: string; rest: string } {
+  let visible = 0;
+  let index = 0;
+  while (index < line.length && visible < visiblePrefixLength) {
+    if (line[index] === ESC) {
+      index = ansiEscapeEnd(line, index);
+    } else {
+      visible += 1;
+      index += 1;
+    }
+  }
+  while (line[index] === ESC) index = ansiEscapeEnd(line, index);
+  return {
+    prefix: line.slice(0, index),
+    rest: line.slice(index),
+  };
+}
+
+function markdownContinuationPrefix(line: string):
+  | {
+      firstPrefix: string;
+      continuationPrefix: string;
+      content: string;
+      width: number;
+    }
+  | undefined {
+  const plain = stripAnsiForPrefix(line);
+  const list = plain.match(/^((?:│ )*)( {2}(?:•|\d+[.)]) )/);
+  if (list) {
+    const quote = list[1] ?? '';
+    const marker = list[2] ?? '';
+    const first = splitRawAtVisiblePrefix(line, quote.length + marker.length);
+    const quotePrefix =
+      quote.length > 0
+        ? splitRawAtVisiblePrefix(line, quote.length).prefix
+        : '';
+    return {
+      firstPrefix: first.prefix,
+      continuationPrefix: `${quotePrefix}${' '.repeat(marker.length)}`,
+      content: first.rest,
+      width: quote.length + marker.length,
+    };
+  }
+
+  const quote = plain.match(/^((?:│ )+)/);
+  if (quote) {
+    const prefixWidth = quote[1]?.length ?? 0;
+    const first = splitRawAtVisiblePrefix(line, prefixWidth);
+    return {
+      firstPrefix: first.prefix,
+      continuationPrefix: first.prefix,
+      content: first.rest,
+      width: prefixWidth,
+    };
+  }
+
+  return undefined;
+}
+
+function wrapMarkdownPrefixedLine(line: string, columns: number): string {
+  const prefix = markdownContinuationPrefix(line);
+  if (!prefix) return wrapLine(line, columns);
+  const contentWidth = Math.max(MIN_WRAP_WIDTH, columns - prefix.width);
+  const wrapped = wrapLine(prefix.content, contentWidth).split('\n');
+  return wrapped
+    .map((part, index) =>
+      index === 0
+        ? `${prefix.firstPrefix}${part}`
+        : `${prefix.continuationPrefix}${part}`,
+    )
+    .join('\n');
+}
+
+function wrapLine(line: string, columns: number): string {
+  return wrapAnsi(line, columns, {
+    hard: true,
+    trim: false,
+  });
+}
+
+export function wrapAnsiToWidth(
+  text: string,
+  width?: number,
+  options: WrapAnsiOptions = {},
+): string {
+  const columns = normalizedWidth(width);
+  if (columns == null) return text;
+
+  return text
+    .split('\n')
+    .map((line) =>
+      options.preserveMarkdownPrefix
+        ? wrapMarkdownPrefixedLine(line, columns)
+        : wrapLine(line, columns),
+    )
+    .join('\n');
+}

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -13,6 +13,29 @@ import {
   _resetAnsiMarkdownForTests,
   renderAnsiMarkdown,
 } from '../../../packages/cli/src/chat/tui/render/ansiMarkdown';
+import { wrapAnsiToWidth } from '../../../packages/cli/src/chat/tui/render/ansiWrap';
+
+function displayWidthForTest(line: string): number {
+  let width = 0;
+  for (const char of line) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (
+      (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0x1f300 && codePoint <= 0x1faff)
+    ) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}
 
 describe('renderAnsiMarkdown', () => {
   it('renders plain prose with no HTML escapes', () => {
@@ -75,7 +98,7 @@ describe('renderAnsiMarkdown', () => {
       '> # Heading\n>\n> ```ts\n> const x = 1;\n> const y = 2;\n> ```\n>\n> ---',
     );
     const plain = stripAnsi(out);
-    expect(plain).toContain('│ # Heading');
+    expect(plain).toContain('│ Heading');
     expect(plain).toContain('│ const x = 1;');
     expect(plain).toContain('│ const y = 2;');
     expect(plain).toContain('│ ─');
@@ -88,10 +111,93 @@ describe('renderAnsiMarkdown', () => {
     expect(stripAnsi(out)).toContain('2) two');
   });
 
+  it('renders headings without visible Markdown markers', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      '## What is a Tensor Network?\n\n### Core objects',
+    );
+    const plain = stripAnsi(out);
+    expect(plain).toContain('What is a Tensor Network?');
+    expect(plain).toContain('Core objects');
+    expect(plain).not.toContain('## What');
+    expect(plain).not.toContain('### Core');
+  });
+
   it('separates consecutive paragraphs visually', () => {
     _resetAnsiMarkdownForTests();
     const out = renderAnsiMarkdown('First paragraph.\n\nSecond paragraph.');
     expect(stripAnsi(out)).toContain('First paragraph.\n\nSecond paragraph.');
+  });
+
+  it('wraps rendered markdown at display-cell boundaries', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown('你好🙂abcdef', { width: 6 });
+    const lines = stripAnsi(out).split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it('keeps blockquote gutters on wrapped continuation lines', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown('> abcdef ghijkl mnopqr', { width: 10 });
+    const plain = stripAnsi(out);
+    const lines = plain.split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line).toMatch(/^│ /);
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('keeps list indentation on wrapped continuation lines', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown('- abcdef ghijkl mnopqr', { width: 10 });
+    const plain = stripAnsi(out);
+    const lines = plain.split('\n');
+    expect(lines[0]).toMatch(/^ {2}• /);
+    expect(lines.slice(1).every((line) => line.startsWith('    '))).toBe(true);
+    for (const line of lines) {
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('styles heading text across inline code boundaries', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown('## Use `git` correctly');
+    const plain = stripAnsi(out);
+    expect(plain).toContain('Use `git` correctly');
+    expect(plain).not.toContain('## Use');
+  });
+
+  it('keeps OSC hyperlinks balanced when wrapping ANSI text', () => {
+    const esc = String.fromCharCode(27);
+    const bel = String.fromCharCode(7);
+    const open = `${esc}]8;;https://example.com${esc}\\`;
+    const close = `${esc}]8;;${esc}\\`;
+    const closeWithBel = `${esc}]8;;${bel}`;
+    const out = wrapAnsiToWidth(`${open}hello world${close}`, 5);
+    const plain = stripAnsi(out);
+    expect(plain.replaceAll('\n', '')).toBe('hello world');
+    for (const line of plain.split('\n')) {
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(5);
+    }
+    const openCount = out.split(`${esc}]8;;https://example.com`).length - 1;
+    const closeCount =
+      out.split(close).length - 1 + (out.split(closeWithBel).length - 1);
+    expect(openCount).toBe(closeCount);
+    expect(out).toContain(open);
+    expect(out).toContain(close);
+  });
+
+  it('wraps diff lines with the same ANSI-aware width helper', () => {
+    const out = wrapAnsiToWidth('+你好🙂abcdef', 6);
+    const lines = stripAnsi(out).split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(6);
+    }
   });
 
   it('memoises identical inputs (second call hits the cache)', () => {


### PR DESCRIPTION
## Summary

This PR fixes two CLI TUI rendering defects:

- Markdown headings now render as styled terminal headings instead of visible `##` / `###` source markers.
- Finalized CLI Markdown and edit diff lines are wrapped with an ANSI-aware helper so narrow terminals handle styled spans, OSC hyperlinks, CJK text, emoji, and combining-width text more reliably.

The terminal width is injected from the Ink boundary (`App` and `EditApproval`) instead of reading process state inside render helpers.

Closes #4117.
Closes #4114.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AnsiMarkdown.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes in core TUI rendering and new ANSI-wrapping logic that affects transcript and diff display across terminal sizes and character widths.
> 
> **Overview**
> Improves CLI TUI rendering to be *terminal-width aware*: `App` and `EditApproval` now measure `useWindowSize()` and pass explicit widths down to the conversation transcript and edit diff views.
> 
> Markdown output is updated to (a) render headings as styled text without showing `##`/`###` markers and (b) wrap finalized markdown and diff lines using a new ANSI-aware `wrapAnsiToWidth` helper that preserves blockquote/list prefixes and handles OSC hyperlinks and wide characters. Tests are expanded to cover heading rendering and width-wrapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045c9b2741758c6e57ad4eff93604cddf37fe0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->