### PR TITLE
fix(workflow): name Pack and Clean inputs explicitly

### DIFF
--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -92,7 +92,7 @@ async function handleCleanMultiple(
   inputFile: string,
   agent: string,
   model: string,
-  outputFiles: string[] = [],
+  inputFiles: string[] = [],
 ): Promise<void> {
   const data = await parseWithErrorDisplay(
     CHANNEL,
@@ -102,13 +102,13 @@ async function handleCleanMultiple(
   );
   if (!data) return;
 
-  logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
+  logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
 
   const result = await runCleanMultiple(
     data.model,
     data.inputFile,
     data.agent,
-    outputFiles,
+    inputFiles,
   );
   showCleanResult(result, data.inputFile);
   emitClearMissingOutputs({
@@ -116,7 +116,7 @@ async function handleCleanMultiple(
       agent: data.agent,
       model: data.model,
       inputFile: data.inputFile,
-      outputFiles,
+      outputFiles: inputFiles,
     },
   });
 }

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -40,9 +40,9 @@ const PackConfigSchema = BasePackSchema.extend({
 
 const PackMultipleSchema = BasePackSchema.extend({
   inputFile: z.string().prefault(''),
-  outputFiles: z.array(z.string()).prefault([]),
-}).refine((d) => d.inputFile || d.outputFiles.length > 0, {
-  error: 'inputFile or outputFiles required',
+  inputFiles: z.array(z.string()).prefault([]),
+}).refine((d) => d.inputFile || d.inputFiles.length > 0, {
+  error: 'inputFile or inputFiles required',
 });
 
 function showPackResult(result: FileOpResult, inputFile: string): void {
@@ -177,20 +177,20 @@ async function handlePackMultiple(
   inputFile: string,
   agent: string,
   model: string,
-  outputFiles: string[] = [],
+  inputFiles: string[] = [],
 ): Promise<void> {
   return executePackOperation(
     PackMultipleSchema,
-    { inputFile, agent, model, outputFiles },
+    { inputFile, agent, model, inputFiles },
     'params',
     (data) =>
-      runPackMultiple(data.model, data.inputFile, data.agent, data.outputFiles),
+      runPackMultiple(data.model, data.inputFile, data.agent, data.inputFiles),
     (data) => ({
       streamConfig: {
         agent: data.agent,
         model: data.model,
         inputFile: data.inputFile,
-        outputFiles: data.outputFiles,
+        outputFiles: data.inputFiles,
       },
     }),
   );

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1291,9 +1291,8 @@ export class MainApp extends MainAppBase {
     const useMultiple = additionalInputFiles.length > 0;
     const command = this.getPackCleanCommand(action, useMultiple);
 
-    // Pack/clean's downstream `outputFiles` field is repurposed post-W4 as
-    // "additional input files to bundle with primaryInput" — there is no
-    // separate output-files picker anymore.
+    // Post-W4 there is no separate output-files picker. Pack/Clean operate on
+    // the selected input files and derived generated artifacts.
     postMessage(command, {
       inputFile: primaryInput,
       agent:
@@ -1301,7 +1300,7 @@ export class MainApp extends MainAppBase {
           ? this.toolUseAgent.get()
           : this.workflowAgent.get(),
       model: this.model.get(),
-      outputFiles: useMultiple ? additionalInputFiles : undefined,
+      inputFiles: useMultiple ? additionalInputFiles : undefined,
     });
 
     const actionLabel = capitalize(action);

--- a/packages/extension/src/webview/managers/ExecutionManager.ts
+++ b/packages/extension/src/webview/managers/ExecutionManager.ts
@@ -17,6 +17,7 @@ interface CommandMessage {
   editedFile?: string;
   agent?: string;
   model?: string;
+  inputFiles?: string[];
   outputFiles?: string[];
 }
 
@@ -72,18 +73,18 @@ export class ExecutionManager {
   }
 
   handleMultipleOperation(message: CommandMessage): void {
-    const outputFiles = message.outputFiles ?? [];
+    const inputFiles = message.inputFiles ?? [];
     const label = message.command.startsWith('pack') ? 'Packing' : 'Cleaning';
     logger.info(
       CHANNEL,
-      `${label} multiple files: ${message.inputFile}, ${outputFiles.join(', ')}`,
+      `${label} multiple files: ${message.inputFile}, ${inputFiles.join(', ')}`,
     );
     void vscode.commands.executeCommand(
       `texra.${message.command}`,
       message.inputFile,
       message.agent,
       message.model,
-      outputFiles,
+      inputFiles,
     );
   }
 }

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -192,10 +192,10 @@ export async function runPack(
   model: string,
   inputFile: string,
   agent: string,
-  outputFiles: string[] = [],
+  additionalInputFiles: string[] = [],
 ): Promise<FileOpResult> {
-  if (outputFiles.length > 0) {
-    return runPackMultiple(model, inputFile, agent, outputFiles);
+  if (additionalInputFiles.length > 0) {
+    return runPackMultiple(model, inputFile, agent, additionalInputFiles);
   }
   return runPackSingle(model, inputFile, agent);
 }

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -886,13 +886,13 @@ const CleanSingleMessageSchema = z.object({
 const PackMultipleMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.PACK_MULTIPLE),
   ...singleOperationFields,
-  outputFiles: z.array(z.string()).optional(),
+  inputFiles: z.array(z.string()).optional(),
 });
 
 const CleanMultipleMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE),
   ...singleOperationFields,
-  outputFiles: z.array(z.string()).optional(),
+  inputFiles: z.array(z.string()).optional(),
 });
 
 const HousekeepingMessages = [

--- a/src/test-kernel/schemas/MainViewHousekeeping.vitest.ts
+++ b/src/test-kernel/schemas/MainViewHousekeeping.vitest.ts
@@ -1,0 +1,22 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - schemas
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { MainViewInboundMessageSchema } from '@shared/schemas/mainView';
+
+describe('MainView housekeeping messages', () => {
+  it('uses inputFiles for Pack/Clean multiple payloads', () => {
+    const parsed = MainViewInboundMessageSchema.parse({
+      command: MAIN_VIEW_COMMANDS.PACK_MULTIPLE,
+      inputFile: 'main.tex',
+      inputFiles: ['chapter.tex'],
+      agent: 'correct',
+      model: 'gpt-5.4',
+    });
+
+    expect('inputFiles' in parsed ? parsed.inputFiles : undefined).toEqual([
+      'chapter.tex',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR removes the post-W4 ambiguity in the main-view Pack/Clean path.

- The webview now sends additional selected files as `inputFiles` for `packMultiple` and `cleanMultiple` messages.
- The inbound main-view schema and `ExecutionManager` forward those files under the same name.
- The extension command handlers and housekeeping wrapper now use `inputFiles` / `additionalInputFiles` for this path, so the code no longer describes selected inputs as `outputFiles`.
- Progress-view clearing still receives `outputFiles` internally because that API describes generated output tracking, not the main-view Pack/Clean payload.

This does not change the actual cleaning rule: Clean still deletes only generated-name artifacts derived from each selected input, not the selected source files themselves.

Closes #4092.
Closes #4093.

## Validation

- `corepack pnpm vitest run src/test-kernel/schemas/MainViewHousekeeping.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Pack/Clean multiple-file message/command payload shape (`outputFiles` -> `inputFiles`) across webview, schemas, and command handlers; risk is mainly integration regressions if any caller still sends the old field.
> 
> **Overview**
> **Removes ambiguity in main-view Pack/Clean multiple-file execution** by renaming the “extra selected files” field from `outputFiles` to `inputFiles` end-to-end (webview payloads, `MainViewInboundMessageSchema`, `ExecutionManager`, and the `packMultiple`/`cleanMultiple` command handlers).
> 
> Internally, progress-view clearing continues to use `outputFiles` in `streamConfig` (now populated from `inputFiles`) since that API still models generated output tracking. Adds a schema-level vitest to assert `PACK_MULTIPLE` payloads accept `inputFiles`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c283682863ceb9c14d69afc1feddf812549c40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->