### PR TITLE
fix(anthropic): send extended cache ttl beta

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -190,6 +190,7 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 const COMPACTION_BETA: AnthropicBeta = 'compact-2026-01-12';
+const EXTENDED_CACHE_TTL_BETA: AnthropicBeta = 'extended-cache-ttl-2025-04-11';
 
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
 const OPUS_47_FULLNAME = 'claude-opus-4-7';
@@ -237,6 +238,14 @@ const LONG_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
   ttl: '1h',
 };
+
+function isLongCacheControl(cacheControl: unknown): boolean {
+  if (!cacheControl || typeof cacheControl !== 'object') {
+    return false;
+  }
+  const marker = cacheControl as Partial<CacheControlEphemeral>;
+  return marker.type === 'ephemeral' && marker.ttl === '1h';
+}
 
 // Cache creation cost multipliers relative to base input price, by TTL.
 const CACHE_CREATION_COST_MULTIPLIER_5M = 1.25;
@@ -393,6 +402,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
+  private hasLongCacheControlMarker(messages: MessageParam[]): boolean {
+    return messages.some((message) => {
+      if (!Array.isArray(message.content)) {
+        return false;
+      }
+      return message.content.some((block) =>
+        isLongCacheControl(
+          (block as { cache_control?: unknown }).cache_control,
+        ),
+      );
+    });
+  }
+
   /**
    * Sets up context management configuration for Anthropic's server-side editing.
    * Must be called before token counting so estimate options match create options.
@@ -534,11 +556,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Strip betas that only apply to message creation (e.g., output length)
     // while keeping context headers needed for accurate token counting.
-    const countTokenBetas = options?.betas?.filter(
-      (beta) => beta === CONTEXT_MANAGEMENT_BETA || beta === COMPACTION_BETA,
+    const countTokenBetas = new Set(
+      options?.betas?.filter(
+        (beta) =>
+          beta === CONTEXT_MANAGEMENT_BETA ||
+          beta === COMPACTION_BETA ||
+          beta === EXTENDED_CACHE_TTL_BETA,
+      ),
     );
-    if (countTokenBetas?.length) {
-      countTokensParams.betas = countTokenBetas;
+    if (this.hasLongCacheControlMarker(messages)) {
+      countTokenBetas.add(EXTENDED_CACHE_TTL_BETA);
+    }
+    if (countTokenBetas.size > 0) {
+      countTokensParams.betas = [...countTokenBetas];
     }
 
     const responseTokenCount =
@@ -632,6 +662,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
         cache_control: cacheControl,
       }),
     };
+
+    if (
+      supportsCache &&
+      (isLongCacheControl(cacheControl) ||
+        this.hasLongCacheControlMarker(messages))
+    ) {
+      this.ensureBeta(options, EXTENDED_CACHE_TTL_BETA);
+    }
 
     if (tools?.length) {
       options.tools = toAnthropicTools(tools, {

--- a/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
@@ -1,0 +1,166 @@
+// Third-party imports
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent model handlers
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+// Type imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ToolDefinition } from '@model';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
+
+const EXTENDED_CACHE_TTL_BETA = 'extended-cache-ttl-2025-04-11';
+
+function createHandler(): ModelHandlerAnthropic {
+  const handler = new ModelHandlerAnthropic({
+    name: 'test-anthropic',
+    label: 'Test Anthropic',
+    fullName: 'claude-test',
+    shortName: 'claude-test',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsPromptCaching: true,
+      supportsTokenCounting: true,
+      supportsReasoning: false,
+    },
+    openRouterOnly: false,
+  });
+
+  handler.setLogger({
+    streamId: 'test',
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fileList: vi.fn(),
+    withCurrentGroup: vi.fn(() => undefined),
+    runWithinCurrentGroup: vi.fn(async (fn: () => unknown) => fn()),
+    runWithGroup: vi.fn(
+      async (_groupId: string | undefined, fn: () => unknown) => fn(),
+    ),
+  } as unknown as AgentLogger);
+  (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
+    false;
+  return handler;
+}
+
+function createClient() {
+  const createCalls: unknown[] = [];
+  const countCalls: unknown[] = [];
+  const client = {
+    beta: {
+      messages: {
+        countTokens: vi.fn(async (params: unknown) => {
+          countCalls.push(params);
+          return { input_tokens: 10 };
+        }),
+        create: vi.fn(async (params: unknown) => {
+          createCalls.push(params);
+          return {
+            id: 'msg',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-test',
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          };
+        }),
+      },
+    },
+  };
+
+  return {
+    client: client as unknown as Anthropic,
+    createCalls,
+    countCalls,
+  };
+}
+
+const USER_MESSAGES: MessageParam[] = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'hello', citations: null }],
+  },
+];
+
+const TOOL: ToolDefinition = {
+  name: 'lookup',
+  description: 'Look up a value',
+  parameters: {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+function betasFrom(call: unknown): string[] {
+  return ((call as { betas?: string[] }).betas ?? []) as string[];
+}
+
+describe('Anthropic extended cache TTL beta', () => {
+  it('adds the beta to create and token-count requests when tool-use uses a 1h cache TTL', async () => {
+    const { client, createCalls, countCalls } = createClient();
+
+    await createHandler().createResponse({
+      client,
+      messages: structuredClone(USER_MESSAGES),
+      temperature: 0,
+      tools: [TOOL],
+    });
+
+    expect(betasFrom(createCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(betasFrom(countCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+  });
+
+  it('does not add the beta to simple 5-minute cache requests', async () => {
+    const { client, createCalls, countCalls } = createClient();
+
+    await createHandler().createResponse({
+      client,
+      messages: structuredClone(USER_MESSAGES),
+      temperature: 0,
+    });
+
+    expect(betasFrom(createCalls[0])).not.toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(betasFrom(countCalls[0])).not.toContain(EXTENDED_CACHE_TTL_BETA);
+  });
+
+  it('adds the beta when a retained compaction block carries a 1h cache marker', async () => {
+    const { client, createCalls, countCalls } = createClient();
+    const messages: MessageParam[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'compaction',
+            content: '<summary>state</summary>',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ] as any,
+      },
+      ...structuredClone(USER_MESSAGES),
+    ];
+
+    await createHandler().createResponse({
+      client,
+      messages,
+      temperature: 0,
+    });
+
+    expect(betasFrom(createCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(betasFrom(countCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the Anthropic extended-cache beta header whenever TeXRA sends a one-hour ephemeral cache-control marker. The dynamic cache TTL work introduced 1h cache markers for tool-use and retained compaction blocks; without the corresponding beta header, Anthropic rejects those requests.

The change keeps beta handling local to the Anthropic model handler:

- defines the extended-cache-ttl-2025-04-11 beta constant next to the other Anthropic beta headers
- adds the beta to message-creation requests when the request-level cache control or retained message blocks use a 1h TTL
- preserves or derives the same beta for token-count requests, so estimates use the same cache-control features as creation requests
- adds focused tests for long-TTL tool-use requests, short 5-minute requests, and retained compaction blocks

Closes #4137.

## Verification

- corepack pnpm vitest run src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts
- corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json
- npm run format
- npm run compile:fast
- npm run lint (passes with existing warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Anthropic request construction and token-counting options; incorrect beta/header handling could still cause 400s or mismatched token estimates, but the change is narrowly scoped and covered by targeted tests.
> 
> **Overview**
> Ensures Anthropic requests include the `extended-cache-ttl-2025-04-11` beta header whenever a **1-hour `ephemeral` cache TTL** is used (either via top-level `cache_control` for tool-use or via retained message blocks such as compaction markers).
> 
> Updates token counting to mirror creation-time betas by detecting long-TTL cache markers in messages and propagating the same beta to `countTokens` calls, and adds vitest coverage for tool-use (1h), non-tool (5m), and retained compaction scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90f3e6e72bbaf7a092ca8f6853b53d86001a142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->