### PR TITLE
fix(anthropic): align compaction cache ttl

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -617,7 +617,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
       reservedCacheSlots += 1; // top-level automatic caching
       if (systemPrompt) reservedCacheSlots += 1; // system prompt breakpoint
     }
-    this.enforceCacheControlLimit(messages, reservedCacheSlots);
+
+    // Use 1-hour cache TTL for tool-use requests (which involve long-running
+    // tool execution cycles where 5-minute caches would frequently expire),
+    // and 5-minute TTL for simple non-tool requests.
+    const cacheControl = tools?.length
+      ? LONG_CACHE_CONTROL
+      : SHORT_CACHE_CONTROL;
+
+    this.enforceCacheControlLimit(messages, reservedCacheSlots, cacheControl);
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -627,13 +635,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (this.uploadedPdfPageCounts.size > 0) {
       this.pruneTrackedPdfPages(messages);
     }
-
-    // Use 1-hour cache TTL for tool-use requests (which involve long-running
-    // tool execution cycles where 5-minute caches would frequently expire),
-    // and 5-minute TTL for simple non-tool requests.
-    const cacheControl = tools?.length
-      ? LONG_CACHE_CONTROL
-      : SHORT_CACHE_CONTROL;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const options: MessageCreateParams = {
@@ -1064,6 +1065,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   private enforceCacheControlLimit(
     messages: MessageParam[],
     reservedSlots: number,
+    cacheControl: CacheControlEphemeral,
   ): void {
     if (!this.capabilities.supportsPromptCaching) {
       return;
@@ -1087,11 +1089,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // ContentBlockParam).
         const anyBlock = block as ContentBlockParam | BetaContentBlockParam;
 
-        // Compaction blocks keep their markers — track them for slot limiting
+        // Compaction blocks keep an explicit marker, but it must match the
+        // current request's top-level TTL so Anthropic sees monotone breakpoints.
         if (isCompactionCacheControlBlock(anyBlock)) {
-          if (anyBlock.cache_control) {
-            compactionBlocks.push(anyBlock);
-          }
+          anyBlock.cache_control = cacheControl;
+          compactionBlocks.push(anyBlock);
           continue;
         }
 

--- a/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
@@ -110,6 +110,14 @@ function betasFrom(call: unknown): string[] {
   return ((call as { betas?: string[] }).betas ?? []) as string[];
 }
 
+function firstCompactionCacheControlFrom(call: unknown): unknown {
+  const [firstMessage] = (call as { messages: MessageParam[] }).messages;
+  if (!Array.isArray(firstMessage.content)) {
+    return undefined;
+  }
+  return (firstMessage.content[0] as { cache_control?: unknown }).cache_control;
+}
+
 describe('Anthropic extended cache TTL beta', () => {
   it('adds the beta to create and token-count requests when tool-use uses a 1h cache TTL', async () => {
     const { client, createCalls, countCalls } = createClient();
@@ -138,7 +146,38 @@ describe('Anthropic extended cache TTL beta', () => {
     expect(betasFrom(countCalls[0])).not.toContain(EXTENDED_CACHE_TTL_BETA);
   });
 
-  it('adds the beta when a retained compaction block carries a 1h cache marker', async () => {
+  it('adds the beta when a retained compaction block uses a long-TTL request', async () => {
+    const { client, createCalls, countCalls } = createClient();
+    const messages: MessageParam[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'compaction',
+            content: '<summary>state</summary>',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ] as any,
+      },
+      ...structuredClone(USER_MESSAGES),
+    ];
+
+    await createHandler().createResponse({
+      client,
+      messages,
+      temperature: 0,
+      tools: [TOOL],
+    });
+
+    expect(betasFrom(createCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(betasFrom(countCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(firstCompactionCacheControlFrom(createCalls[0])).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+  });
+
+  it('normalizes retained compaction blocks to a short TTL for non-tool requests', async () => {
     const { client, createCalls, countCalls } = createClient();
     const messages: MessageParam[] = [
       {
@@ -160,7 +199,13 @@ describe('Anthropic extended cache TTL beta', () => {
       temperature: 0,
     });
 
-    expect(betasFrom(createCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
-    expect(betasFrom(countCalls[0])).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(firstCompactionCacheControlFrom(createCalls[0])).toEqual({
+      type: 'ephemeral',
+    });
+    expect(firstCompactionCacheControlFrom(countCalls[0])).toEqual({
+      type: 'ephemeral',
+    });
+    expect(betasFrom(createCalls[0])).not.toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(betasFrom(countCalls[0])).not.toContain(EXTENDED_CACHE_TTL_BETA);
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes a cache TTL ordering issue for Anthropic server-side compaction blocks. Retained compaction blocks previously kept a one-hour cache-control marker even when the next request was a simple non-tool request whose system prompt and top-level cache control used the default five-minute TTL. That can produce a non-monotone sequence of cache breakpoints and cause Anthropic to downgrade the compaction marker.

The handler now normalizes retained compaction block cache-control markers to the TTL selected for the current request. Tool-use requests keep one-hour compaction markers; non-tool requests use the short marker consistently.

Closes #4138.

## Verification

- corepack pnpm vitest run src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
- corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json
- npm run format
- npm run compile:fast
- npm run lint (passes with existing warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Anthropic request construction and cache-control handling; incorrect TTL normalization could change caching behavior or beta header selection for some conversations.
> 
> **Overview**
> Fixes Anthropic prompt-caching behavior by **forcing retained `compaction` blocks to use the current request’s `cache_control` TTL** (short for non-tool calls, long for tool-use) instead of preserving whatever TTL was saved in the conversation, avoiding non-monotone cache breakpoints.
> 
> Updates `enforceCacheControlLimit` to accept the selected `cache_control` and rewires request build order accordingly, and expands `AnthropicCacheBeta.vitest.ts` to assert both the `extended-cache-ttl` beta header and compaction-block TTL normalization for tool and non-tool requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5abc4dbbc5a5cc19acac05b862c3f44ed3f56fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->