### PR TITLE
fix(desktop): stream setup command output

### DIFF
--- a/packages/desktop/src/desktopSetupTerminalMessages.ts
+++ b/packages/desktop/src/desktopSetupTerminalMessages.ts
@@ -7,7 +7,7 @@ export const DESKTOP_SETUP_TERMINAL_COMMANDS = {
   CANCEL: 'desktop:setupTerminalCancel',
 } as const;
 
-export const DesktopSetupTerminalStatusSchema = z.enum([
+const DesktopSetupTerminalStatusSchema = z.enum([
   'running',
   'succeeded',
   'failed',
@@ -19,12 +19,8 @@ export type DesktopSetupTerminalStatus = z.infer<
   typeof DesktopSetupTerminalStatusSchema
 >;
 
-const DesktopSetupTerminalFinalStatusSchema = z.enum([
-  'succeeded',
-  'failed',
-  'timed-out',
-  'cancelled',
-]);
+const DesktopSetupTerminalFinalStatusSchema =
+  DesktopSetupTerminalStatusSchema.exclude(['running']);
 
 const DesktopSetupTerminalBaseSchema = z.object({
   runId: z.string().min(1),

--- a/packages/desktop/src/desktopSetupTerminalMessages.ts
+++ b/packages/desktop/src/desktopSetupTerminalMessages.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+
+export const DESKTOP_SETUP_TERMINAL_COMMANDS = {
+  SHOW: 'desktop:setupTerminalShow',
+  APPEND: 'desktop:setupTerminalAppend',
+  COMPLETE: 'desktop:setupTerminalComplete',
+  CANCEL: 'desktop:setupTerminalCancel',
+} as const;
+
+export const DesktopSetupTerminalStatusSchema = z.enum([
+  'running',
+  'succeeded',
+  'failed',
+  'timed-out',
+  'cancelled',
+]);
+
+export type DesktopSetupTerminalStatus = z.infer<
+  typeof DesktopSetupTerminalStatusSchema
+>;
+
+const DesktopSetupTerminalFinalStatusSchema = z.enum([
+  'succeeded',
+  'failed',
+  'timed-out',
+  'cancelled',
+]);
+
+const DesktopSetupTerminalBaseSchema = z.object({
+  runId: z.string().min(1),
+});
+
+export const DesktopSetupTerminalShowMessageSchema =
+  DesktopSetupTerminalBaseSchema.extend({
+    command: z.literal(DESKTOP_SETUP_TERMINAL_COMMANDS.SHOW),
+    title: z.string().min(1),
+    shellCommand: z.string().min(1),
+    cwd: z.string().min(1),
+  });
+
+export type DesktopSetupTerminalShowMessage = z.infer<
+  typeof DesktopSetupTerminalShowMessageSchema
+>;
+
+export const DesktopSetupTerminalAppendMessageSchema =
+  DesktopSetupTerminalBaseSchema.extend({
+    command: z.literal(DESKTOP_SETUP_TERMINAL_COMMANDS.APPEND),
+    stream: z.enum(['stdout', 'stderr']),
+    chunk: z.string(),
+  });
+
+export type DesktopSetupTerminalAppendMessage = z.infer<
+  typeof DesktopSetupTerminalAppendMessageSchema
+>;
+
+export const DesktopSetupTerminalCompleteMessageSchema =
+  DesktopSetupTerminalBaseSchema.extend({
+    command: z.literal(DESKTOP_SETUP_TERMINAL_COMMANDS.COMPLETE),
+    status: DesktopSetupTerminalFinalStatusSchema,
+    exitCode: z.int().nullish(),
+    output: z.string(),
+  });
+
+export type DesktopSetupTerminalCompleteMessage = z.infer<
+  typeof DesktopSetupTerminalCompleteMessageSchema
+>;
+
+export const DesktopSetupTerminalCancelMessageSchema =
+  DesktopSetupTerminalBaseSchema.extend({
+    command: z.literal(DESKTOP_SETUP_TERMINAL_COMMANDS.CANCEL),
+  });
+
+export type DesktopSetupTerminalCancelMessage = z.infer<
+  typeof DesktopSetupTerminalCancelMessageSchema
+>;
+
+export function buildDesktopSetupTerminalShowMessage(
+  payload: Omit<DesktopSetupTerminalShowMessage, 'command'>,
+): DesktopSetupTerminalShowMessage {
+  return {
+    command: DESKTOP_SETUP_TERMINAL_COMMANDS.SHOW,
+    ...payload,
+  };
+}
+
+export function buildDesktopSetupTerminalAppendMessage(
+  payload: Omit<DesktopSetupTerminalAppendMessage, 'command'>,
+): DesktopSetupTerminalAppendMessage {
+  return {
+    command: DESKTOP_SETUP_TERMINAL_COMMANDS.APPEND,
+    ...payload,
+  };
+}
+
+export function buildDesktopSetupTerminalCompleteMessage(
+  payload: Omit<DesktopSetupTerminalCompleteMessage, 'command'>,
+): DesktopSetupTerminalCompleteMessage {
+  return {
+    command: DESKTOP_SETUP_TERMINAL_COMMANDS.COMPLETE,
+    ...payload,
+  };
+}
+
+export function buildDesktopSetupTerminalCancelMessage(
+  runId: string,
+): DesktopSetupTerminalCancelMessage {
+  return {
+    command: DESKTOP_SETUP_TERMINAL_COMMANDS.CANCEL,
+    runId,
+  };
+}

--- a/packages/desktop/src/main/desktopTerminalRunner.ts
+++ b/packages/desktop/src/main/desktopTerminalRunner.ts
@@ -21,11 +21,12 @@ export function createDesktopTerminalRunner(
   return {
     async runCommand(request: TerminalRunRequest) {
       let output = '';
-      const appendOutput = (chunk: string) => {
+      const appendOutput = (stream: 'stdout' | 'stderr', chunk: string) => {
         output += chunk;
         if (output.length > RAW_OUTPUT_MAX_CHARS) {
           output = output.slice(-RAW_OUTPUT_MAX_CHARS);
         }
+        request.onOutput?.({ stream, chunk });
       };
       const result = await executeCommand(request.command, {
         cwd: request.cwd ?? options.cwd,
@@ -34,8 +35,9 @@ export function createDesktopTerminalRunner(
         channel: request.name,
         truncate: true,
         buffer: false,
-        onStdout: appendOutput,
-        onStderr: appendOutput,
+        signal: request.signal,
+        onStdout: (chunk) => appendOutput('stdout', chunk),
+        onStderr: (chunk) => appendOutput('stderr', chunk),
       });
       const bufferedOutput = [result.stdout, result.stderr]
         .filter(Boolean)
@@ -45,6 +47,7 @@ export function createDesktopTerminalRunner(
         exitCode: result.exitCode,
         output: tail(output || bufferedOutput),
         timedOut: result.timedOut ?? false,
+        cancelled: request.signal?.aborted ?? false,
       };
     },
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -56,7 +56,6 @@ import {
   buildDesktopSetupTerminalAppendMessage,
   buildDesktopSetupTerminalCompleteMessage,
   buildDesktopSetupTerminalShowMessage,
-  type DesktopSetupTerminalStatus,
 } from '../desktopSetupTerminalMessages.js';
 import {
   createDesktopAuthCallbackState,
@@ -323,7 +322,7 @@ function createWindow(options: {
     });
     activeSetupCommands.delete(runId);
 
-    const status: DesktopSetupTerminalStatus = result.cancelled
+    const status = result.cancelled
       ? 'cancelled'
       : result.timedOut
         ? 'timed-out'

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -197,6 +197,16 @@ async function showSetupCommandResult(
   }
 }
 
+function setupCommandExceptionResult(error: unknown): TerminalRunResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : 'Error';
+  return {
+    exitCode: undefined,
+    output: `${name}: ${message}`,
+    timedOut: false,
+  };
+}
+
 async function showSetupCommandOpenedInTerminal(
   window: BrowserWindow,
   command: string,
@@ -308,19 +318,25 @@ function createWindow(options: {
       }),
     );
 
-    const result = await setupTerminalRunner.runCommand({
-      name: 'TeXRA Setup',
-      command,
-      cwd: setupCommandCwd,
-      timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
-      signal: abortController.signal,
-      onOutput: ({ stream, chunk }) => {
-        postSetupTerminalMessage(
-          buildDesktopSetupTerminalAppendMessage({ runId, stream, chunk }),
-        );
-      },
-    });
-    activeSetupCommands.delete(runId);
+    let result: TerminalRunResult;
+    try {
+      result = await setupTerminalRunner.runCommand({
+        name: 'TeXRA Setup',
+        command,
+        cwd: setupCommandCwd,
+        timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
+        signal: abortController.signal,
+        onOutput: ({ stream, chunk }) => {
+          postSetupTerminalMessage(
+            buildDesktopSetupTerminalAppendMessage({ runId, stream, chunk }),
+          );
+        },
+      });
+    } catch (error: unknown) {
+      result = setupCommandExceptionResult(error);
+    } finally {
+      activeSetupCommands.delete(runId);
+    }
 
     const status = result.cancelled
       ? 'cancelled'

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -52,6 +52,13 @@ import {
 } from './desktopSetupTerminal.js';
 import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
 import {
+  DesktopSetupTerminalCancelMessageSchema,
+  buildDesktopSetupTerminalAppendMessage,
+  buildDesktopSetupTerminalCompleteMessage,
+  buildDesktopSetupTerminalShowMessage,
+  type DesktopSetupTerminalStatus,
+} from '../desktopSetupTerminalMessages.js';
+import {
   createDesktopAuthCallbackState,
   createDesktopAuthCoordinator,
   createDesktopSupabaseAuth,
@@ -280,8 +287,74 @@ function createWindow(options: {
   const setupTerminalRunner = createDesktopTerminalRunner({
     cwd: setupCommandCwd,
   });
+  let setupCommandCounter = 0;
+  const activeSetupCommands = new Map<string, AbortController>();
+  const postSetupTerminalMessage = (message: unknown): boolean => {
+    const ipc = ipcRef.current;
+    if (!ipc) return false;
+    if (window.isDestroyed() || window.webContents.isDestroyed()) return false;
+    ipc.postToRenderer(message);
+    return true;
+  };
+  const runSetupCommandInOverlay = async (command: string) => {
+    const runId = `setup-${Date.now()}-${++setupCommandCounter}`;
+    const abortController = new AbortController();
+    activeSetupCommands.set(runId, abortController);
+    const rendererReady = postSetupTerminalMessage(
+      buildDesktopSetupTerminalShowMessage({
+        runId,
+        title: 'TeXRA Setup',
+        shellCommand: command,
+        cwd: setupCommandCwd,
+      }),
+    );
+
+    const result = await setupTerminalRunner.runCommand({
+      name: 'TeXRA Setup',
+      command,
+      cwd: setupCommandCwd,
+      timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
+      signal: abortController.signal,
+      onOutput: ({ stream, chunk }) => {
+        postSetupTerminalMessage(
+          buildDesktopSetupTerminalAppendMessage({ runId, stream, chunk }),
+        );
+      },
+    });
+    activeSetupCommands.delete(runId);
+
+    const status: DesktopSetupTerminalStatus = result.cancelled
+      ? 'cancelled'
+      : result.timedOut
+        ? 'timed-out'
+        : result.exitCode === 0
+          ? 'succeeded'
+          : 'failed';
+    postSetupTerminalMessage(
+      buildDesktopSetupTerminalCompleteMessage({
+        runId,
+        status,
+        exitCode: result.exitCode ?? null,
+        output: result.output,
+      }),
+    );
+    if (!rendererReady) {
+      await showSetupCommandResult(window, command, result);
+    }
+  };
+  const setupTerminalIpc = {
+    handleMessage(message: { command: string } & Record<string, unknown>) {
+      const parsed = DesktopSetupTerminalCancelMessageSchema.safeParse(message);
+      if (!parsed.success) return false;
+      activeSetupCommands.get(parsed.data.runId)?.abort();
+      return true;
+    },
+  };
   const runSetupCommand = async (command: string) => {
-    if (process.platform === 'darwin') {
+    if (
+      process.platform === 'darwin' &&
+      setupCommandNeedsInteractiveTerminal(command)
+    ) {
       try {
         await openMacTerminalCommand(command, setupCommandCwd);
         await showSetupCommandOpenedInTerminal(window, command);
@@ -296,13 +369,7 @@ function createWindow(options: {
       return;
     }
 
-    const result = await setupTerminalRunner.runCommand({
-      name: 'TeXRA Setup',
-      command,
-      cwd: setupCommandCwd,
-      timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
-    });
-    await showSetupCommandResult(window, command, result);
+    await runSetupCommandInOverlay(command);
   };
   const previewHost = createDesktopPreviewHost({
     shell,
@@ -566,6 +633,7 @@ function createWindow(options: {
     settings: settingsIpc,
     progress: progressIpc,
     onboarding: onboardingIpc,
+    setupTerminal: setupTerminalIpc,
     logs: {
       readLog: () =>
         readDesktopLogSnapshot({ workspacePath: options.workspacePath }),

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -32,6 +32,7 @@ export interface DesktopMainViewIpcOptions {
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
   onboarding?: DesktopMessageHandler;
+  setupTerminal?: DesktopMessageHandler;
   logs?: DesktopLogIpcOptions;
   shellActions?: DesktopShellActions;
   modelListRefresh?: PromiseLike<void>;
@@ -94,6 +95,7 @@ export function installDesktopMainViewIpc(
     options.settings,
     options.progress,
     options.onboarding,
+    options.setupTerminal,
     viewState,
     logs,
     shell,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -104,7 +104,7 @@ import {
   type DesktopClosePdfMessage,
 } from '../desktopPdfMessages';
 import {
-  DESKTOP_SETUP_TERMINAL_COMMANDS,
+  buildDesktopSetupTerminalCancelMessage,
   DesktopSetupTerminalShowMessageSchema,
   DesktopSetupTerminalAppendMessageSchema,
   DesktopSetupTerminalCompleteMessageSchema,
@@ -980,9 +980,10 @@ function ensureSetupTerminalDialog(): WaDialog {
   const cancel = createSetupTerminalButton('xmark', 'Cancel');
   cancel.addEventListener('click', () => {
     if (setupTerminalActiveRunId) {
-      postMessage(DESKTOP_SETUP_TERMINAL_COMMANDS.CANCEL, {
-        runId: setupTerminalActiveRunId,
-      });
+      const { command, ...payload } = buildDesktopSetupTerminalCancelMessage(
+        setupTerminalActiveRunId,
+      );
+      postMessage(command, payload);
       setSetupTerminalStatus('cancelled');
     }
   });

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1061,7 +1061,9 @@ function completeSetupTerminalOverlay(
   payload: DesktopSetupTerminalCompleteMessage,
 ): void {
   if (payload.runId !== setupTerminalActiveRunId) return;
-  setupTerminalOutputText = payload.output || setupTerminalOutputText;
+  if (payload.output.length > setupTerminalOutputText.length) {
+    setupTerminalOutputText = payload.output;
+  }
   if (setupTerminalOutputElement) {
     setupTerminalOutputElement.textContent = setupTerminalOutputText;
     setupTerminalOutputElement.scrollTop =

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -60,6 +60,7 @@ import {
 } from '@shared/schemas/progressView';
 import type { DesktopThemeKind } from '@shared/constants/desktopTheme';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { copyTextToClipboard } from '@shared/utils/clipboard';
 import {
   applyHostBodyTheme,
   getWindowTargetOrigin,
@@ -970,11 +971,11 @@ function ensureSetupTerminalDialog(): WaDialog {
   actions.classList.add('desktop-setup-terminal-actions');
   const copyCommand = createSetupTerminalButton('copy', 'Copy command');
   copyCommand.addEventListener('click', () => {
-    void copyText(setupTerminalCommandText);
+    void copyTextToClipboard(setupTerminalCommandText);
   });
   const copyOutput = createSetupTerminalButton('copy', 'Copy output');
   copyOutput.addEventListener('click', () => {
-    void copyText(setupTerminalOutputText);
+    void copyTextToClipboard(setupTerminalOutputText);
   });
   setupTerminalCopyOutputButton = copyOutput;
   const cancel = createSetupTerminalButton('xmark', 'Cancel');
@@ -1013,11 +1014,6 @@ function createSetupTerminalButton(
   button.setAttribute('aria-label', label);
   render(html`${waIcon(icon)}<span>${label}</span>`, button);
   return button;
-}
-
-async function copyText(text: string): Promise<void> {
-  if (!text) return;
-  await navigator.clipboard?.writeText(text);
 }
 
 function openSetupTerminalOverlay(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -103,6 +103,16 @@ import {
   type DesktopShowPdfMessage,
   type DesktopClosePdfMessage,
 } from '../desktopPdfMessages';
+import {
+  DESKTOP_SETUP_TERMINAL_COMMANDS,
+  DesktopSetupTerminalShowMessageSchema,
+  DesktopSetupTerminalAppendMessageSchema,
+  DesktopSetupTerminalCompleteMessageSchema,
+  type DesktopSetupTerminalShowMessage,
+  type DesktopSetupTerminalAppendMessage,
+  type DesktopSetupTerminalCompleteMessage,
+  type DesktopSetupTerminalStatus,
+} from '../desktopSetupTerminalMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
 import { getRendererPlatform } from './rendererPlatform';
@@ -901,6 +911,195 @@ function closePdfOverlay(): void {
 }
 
 // =============================================================================
+// Setup command terminal overlay
+// =============================================================================
+
+const SETUP_TERMINAL_OUTPUT_LIMIT = 200_000;
+
+let setupTerminalDialog: WaDialog | null = null;
+let setupTerminalTitleElement: HTMLElement | null = null;
+let setupTerminalSubtitleElement: HTMLElement | null = null;
+let setupTerminalStatusElement: HTMLElement | null = null;
+let setupTerminalCommandElement: HTMLElement | null = null;
+let setupTerminalOutputElement: HTMLPreElement | null = null;
+let setupTerminalCancelButton: HTMLElement | null = null;
+let setupTerminalCopyOutputButton: HTMLElement | null = null;
+let setupTerminalActiveRunId: string | null = null;
+let setupTerminalCommandText = '';
+let setupTerminalOutputText = '';
+
+function ensureSetupTerminalDialog(): WaDialog {
+  if (setupTerminalDialog) return setupTerminalDialog;
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  dialog.classList.add('desktop-setup-terminal-overlay');
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = false;
+  dialog.setAttribute('aria-label', 'Setup command output');
+
+  const body = document.createElement('section');
+  body.classList.add('desktop-setup-terminal-body');
+
+  const header = document.createElement('header');
+  header.classList.add('desktop-setup-terminal-header');
+  const headerText = document.createElement('div');
+  headerText.classList.add('desktop-setup-terminal-heading');
+  const titleEl = document.createElement('h2');
+  titleEl.classList.add('desktop-setup-terminal-title');
+  titleEl.textContent = 'Setup';
+  setupTerminalTitleElement = titleEl;
+  const subtitleEl = document.createElement('p');
+  subtitleEl.classList.add('desktop-setup-terminal-subtitle');
+  setupTerminalSubtitleElement = subtitleEl;
+  headerText.append(titleEl, subtitleEl);
+
+  const statusEl = document.createElement('span');
+  statusEl.classList.add('desktop-setup-terminal-status');
+  setupTerminalStatusElement = statusEl;
+  header.append(headerText, statusEl);
+
+  const commandEl = document.createElement('code');
+  commandEl.classList.add('desktop-setup-terminal-command');
+  setupTerminalCommandElement = commandEl;
+
+  const outputEl = document.createElement('pre');
+  outputEl.classList.add('desktop-setup-terminal-output');
+  outputEl.textContent = '';
+  setupTerminalOutputElement = outputEl;
+
+  const actions = document.createElement('footer');
+  actions.classList.add('desktop-setup-terminal-actions');
+  const copyCommand = createSetupTerminalButton('copy', 'Copy command');
+  copyCommand.addEventListener('click', () => {
+    void copyText(setupTerminalCommandText);
+  });
+  const copyOutput = createSetupTerminalButton('copy', 'Copy output');
+  copyOutput.addEventListener('click', () => {
+    void copyText(setupTerminalOutputText);
+  });
+  setupTerminalCopyOutputButton = copyOutput;
+  const cancel = createSetupTerminalButton('xmark', 'Cancel');
+  cancel.addEventListener('click', () => {
+    if (setupTerminalActiveRunId) {
+      postMessage(DESKTOP_SETUP_TERMINAL_COMMANDS.CANCEL, {
+        runId: setupTerminalActiveRunId,
+      });
+      setSetupTerminalStatus('cancelled');
+    }
+  });
+  setupTerminalCancelButton = cancel;
+  const close = createSetupTerminalButton('xmark', 'Close');
+  close.addEventListener('click', () => {
+    dialog.open = false;
+  });
+  actions.append(copyCommand, copyOutput, cancel, close);
+
+  body.append(header, commandEl, outputEl, actions);
+  dialog.append(body);
+  appRoot.append(dialog);
+  setupTerminalDialog = dialog;
+  return dialog;
+}
+
+function createSetupTerminalButton(
+  icon: TeXRAIconName,
+  label: string,
+): HTMLElement {
+  const button = document.createElement('wa-button');
+  button.classList.add('desktop-setup-terminal-button');
+  button.setAttribute('appearance', 'outlined');
+  button.setAttribute('size', 'small');
+  button.setAttribute('title', label);
+  button.setAttribute('aria-label', label);
+  render(html`${waIcon(icon)}<span>${label}</span>`, button);
+  return button;
+}
+
+async function copyText(text: string): Promise<void> {
+  if (!text) return;
+  await navigator.clipboard?.writeText(text);
+}
+
+function openSetupTerminalOverlay(
+  payload: DesktopSetupTerminalShowMessage,
+): void {
+  const dialog = ensureSetupTerminalDialog();
+  setupTerminalActiveRunId = payload.runId;
+  setupTerminalCommandText = payload.shellCommand;
+  setupTerminalOutputText = '';
+  if (setupTerminalTitleElement) {
+    setupTerminalTitleElement.textContent = payload.title;
+  }
+  if (setupTerminalSubtitleElement) {
+    setupTerminalSubtitleElement.textContent = payload.cwd;
+  }
+  if (setupTerminalCommandElement) {
+    setupTerminalCommandElement.textContent = payload.shellCommand;
+  }
+  if (setupTerminalOutputElement) setupTerminalOutputElement.textContent = '';
+  setSetupTerminalStatus('running');
+  dialog.open = true;
+}
+
+function appendSetupTerminalOutput(
+  payload: DesktopSetupTerminalAppendMessage,
+): void {
+  if (payload.runId !== setupTerminalActiveRunId) return;
+  setupTerminalOutputText += payload.chunk;
+  if (setupTerminalOutputText.length > SETUP_TERMINAL_OUTPUT_LIMIT) {
+    setupTerminalOutputText = setupTerminalOutputText.slice(
+      -SETUP_TERMINAL_OUTPUT_LIMIT,
+    );
+  }
+  if (!setupTerminalOutputElement) return;
+  setupTerminalOutputElement.textContent = setupTerminalOutputText;
+  setupTerminalOutputElement.scrollTop =
+    setupTerminalOutputElement.scrollHeight;
+  setupTerminalCopyOutputButton?.toggleAttribute('disabled', false);
+}
+
+function completeSetupTerminalOverlay(
+  payload: DesktopSetupTerminalCompleteMessage,
+): void {
+  if (payload.runId !== setupTerminalActiveRunId) return;
+  setupTerminalOutputText = payload.output || setupTerminalOutputText;
+  if (setupTerminalOutputElement) {
+    setupTerminalOutputElement.textContent = setupTerminalOutputText;
+    setupTerminalOutputElement.scrollTop =
+      setupTerminalOutputElement.scrollHeight;
+  }
+  setSetupTerminalStatus(payload.status);
+  setupTerminalActiveRunId = null;
+}
+
+function setSetupTerminalStatus(status: DesktopSetupTerminalStatus): void {
+  if (setupTerminalStatusElement) {
+    setupTerminalStatusElement.textContent = formatSetupTerminalStatus(status);
+    setupTerminalStatusElement.dataset.status = status;
+  }
+  const running = status === 'running';
+  setupTerminalCancelButton?.toggleAttribute('disabled', !running);
+  setupTerminalCopyOutputButton?.toggleAttribute(
+    'disabled',
+    setupTerminalOutputText.length === 0,
+  );
+}
+
+function formatSetupTerminalStatus(status: DesktopSetupTerminalStatus): string {
+  switch (status) {
+    case 'running':
+      return 'Running';
+    case 'succeeded':
+      return 'Finished';
+    case 'failed':
+      return 'Failed';
+    case 'timed-out':
+      return 'Timed out';
+    case 'cancelled':
+      return 'Cancelled';
+  }
+}
+
+// =============================================================================
 // Onboarding + command palette
 // =============================================================================
 
@@ -1076,6 +1275,24 @@ window.addEventListener('message', (event) => {
   }
   if (isDesktopClosePdfMessage(event.data)) {
     closePdfOverlay();
+    return;
+  }
+  const setupTerminalShowParsed =
+    DesktopSetupTerminalShowMessageSchema.safeParse(event.data);
+  if (setupTerminalShowParsed.success) {
+    openSetupTerminalOverlay(setupTerminalShowParsed.data);
+    return;
+  }
+  const setupTerminalAppendParsed =
+    DesktopSetupTerminalAppendMessageSchema.safeParse(event.data);
+  if (setupTerminalAppendParsed.success) {
+    appendSetupTerminalOutput(setupTerminalAppendParsed.data);
+    return;
+  }
+  const setupTerminalCompleteParsed =
+    DesktopSetupTerminalCompleteMessageSchema.safeParse(event.data);
+  if (setupTerminalCompleteParsed.success) {
+    completeSetupTerminalOverlay(setupTerminalCompleteParsed.data);
     return;
   }
   // Progress view messages: dispatch directly into the shared messageDispatcher

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -447,6 +447,140 @@ wa-button.desktop-pdf-close::part(base) {
 }
 
 /* =====================================================================
+   Setup command terminal overlay (wa-dialog)
+   --------------------------------------------------------------------- */
+
+wa-dialog.desktop-setup-terminal-overlay {
+  --width: min(920px, calc(100vw - 48px));
+}
+
+wa-dialog.desktop-setup-terminal-overlay::part(dialog) {
+  width: min(920px, calc(100vw - 48px));
+  max-height: calc(100vh - 64px);
+  border-radius: var(--wa-border-radius-m, 3px);
+}
+
+wa-dialog.desktop-setup-terminal-overlay::part(body) {
+  padding: 0;
+  overflow: hidden;
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-body {
+  display: grid;
+  grid-template-rows: auto auto minmax(180px, 48vh) auto;
+  min-height: 0;
+  background: var(--wa-color-surface-default);
+  color: var(--wa-color-text-normal);
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--wa-space-m);
+  padding: var(--wa-space-m) var(--wa-space-l);
+  border-bottom: 1px solid var(--wa-color-surface-border);
+  background: var(--wa-color-surface-raised);
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-heading {
+  min-width: 0;
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-title {
+  margin: 0;
+  font-size: var(--wa-font-size-l);
+  font-weight: var(--wa-font-weight-semibold);
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-subtitle {
+  margin: var(--wa-space-2xs) 0 0;
+  overflow: hidden;
+  color: var(--wa-color-text-quiet);
+  font-family: var(--wa-font-family-code, monospace);
+  font-size: var(--wa-font-size-s);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-status {
+  flex: 0 0 auto;
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m, 3px);
+  padding: 2px 8px;
+  color: var(--wa-color-text-normal);
+  background: var(--wa-color-neutral-fill-quiet);
+  font-size: var(--wa-font-size-s);
+}
+
+wa-dialog.desktop-setup-terminal-overlay
+  .desktop-setup-terminal-status[data-status='succeeded'] {
+  border-color: var(--wa-color-success-border-quiet);
+  color: var(--wa-color-success-on-quiet);
+  background: var(--wa-color-success-fill-quiet);
+}
+
+wa-dialog.desktop-setup-terminal-overlay
+  .desktop-setup-terminal-status[data-status='failed'],
+wa-dialog.desktop-setup-terminal-overlay
+  .desktop-setup-terminal-status[data-status='timed-out'] {
+  border-color: var(--wa-color-danger-border-quiet);
+  color: var(--wa-color-danger-on-quiet);
+  background: var(--wa-color-danger-fill-quiet);
+}
+
+wa-dialog.desktop-setup-terminal-overlay
+  .desktop-setup-terminal-status[data-status='cancelled'] {
+  border-color: var(--wa-color-warning-border-quiet);
+  color: var(--wa-color-warning-on-quiet);
+  background: var(--wa-color-warning-fill-quiet);
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-command {
+  display: block;
+  overflow: auto;
+  padding: var(--wa-space-s) var(--wa-space-l);
+  border-bottom: 1px solid var(--wa-color-surface-border);
+  background: var(--wa-color-surface-lowered);
+  color: var(--wa-color-text-normal);
+  font-family: var(--wa-font-family-code, monospace);
+  font-size: var(--wa-font-size-s);
+  white-space: pre-wrap;
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-output {
+  margin: 0;
+  overflow: auto;
+  padding: var(--wa-space-m) var(--wa-space-l);
+  background: var(--wa-color-surface-default);
+  color: var(--wa-color-text-normal);
+  font-family: var(--wa-font-family-code, monospace);
+  font-size: var(--wa-font-size-s);
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+wa-dialog.desktop-setup-terminal-overlay .desktop-setup-terminal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--wa-space-xs);
+  padding: var(--wa-space-s) var(--wa-space-l);
+  border-top: 1px solid var(--wa-color-surface-border);
+  background: var(--wa-color-surface-raised);
+}
+
+wa-button.desktop-setup-terminal-button::part(base) {
+  min-height: 30px;
+  border-radius: var(--wa-border-radius-m, 3px);
+}
+
+wa-button.desktop-setup-terminal-button::part(label) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wa-space-2xs);
+}
+
+/* =====================================================================
    Logs drawer (wa-drawer)
    --------------------------------------------------------------------- */
 

--- a/src/hosts/terminalHost.ts
+++ b/src/hosts/terminalHost.ts
@@ -4,10 +4,19 @@ export interface TerminalOptions {
   env?: Record<string, string | undefined>;
 }
 
+export interface TerminalOutputChunk {
+  stream: 'stdout' | 'stderr';
+  chunk: string;
+}
+
 export interface TerminalRunRequest extends TerminalOptions {
   command: string;
   /** Hard cap on how long to wait for captured execution. */
   timeoutMs: number;
+  /** Cancels a captured command run. */
+  signal?: AbortSignal;
+  /** Streams command output while the process is still running. */
+  onOutput?: (chunk: TerminalOutputChunk) => void;
 }
 
 export interface TerminalRunResult {
@@ -16,6 +25,7 @@ export interface TerminalRunResult {
   /** ANSI-stripped, length-capped tail of command output when available. */
   output: string;
   timedOut: boolean;
+  cancelled?: boolean;
 }
 
 export interface TerminalHandle {

--- a/src/test-kernel/desktop/DesktopSetupTerminalMain.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSetupTerminalMain.vitest.mts
@@ -1,0 +1,23 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { repoPath } from './desktopTestPaths.mjs';
+
+function readDesktopMain(): string {
+  return readFileSync(repoPath('packages/desktop/src/main/index.ts'), 'utf8');
+}
+
+describe('desktop setup terminal main process', () => {
+  it('always cleans up captured setup commands and reports thrown failures', () => {
+    const desktopMain = readDesktopMain();
+
+    expect(desktopMain).toContain('setupCommandExceptionResult(error)');
+    expect(desktopMain).toContain('finally {');
+    expect(desktopMain).toContain('activeSetupCommands.delete(runId);');
+    expect(desktopMain).toContain('buildDesktopSetupTerminalCompleteMessage({');
+  });
+});

--- a/src/test-kernel/desktop/DesktopSetupTerminalMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSetupTerminalMessages.vitest.mts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+async function loadSetupTerminalMessages(): Promise<
+  typeof import('../../../packages/desktop/src/desktopSetupTerminalMessages')
+> {
+  return (await import(
+    moduleFileUrl(desktopSourcePath('desktopSetupTerminalMessages.ts'))
+  )) as typeof import('../../../packages/desktop/src/desktopSetupTerminalMessages');
+}
+
+describe('desktop setup terminal messages', () => {
+  it('round-trips show, append, complete, and cancel messages', async () => {
+    const {
+      DesktopSetupTerminalShowMessageSchema,
+      DesktopSetupTerminalAppendMessageSchema,
+      DesktopSetupTerminalCompleteMessageSchema,
+      DesktopSetupTerminalCancelMessageSchema,
+      buildDesktopSetupTerminalShowMessage,
+      buildDesktopSetupTerminalAppendMessage,
+      buildDesktopSetupTerminalCompleteMessage,
+      buildDesktopSetupTerminalCancelMessage,
+    } = await loadSetupTerminalMessages();
+
+    expect(
+      DesktopSetupTerminalShowMessageSchema.parse(
+        buildDesktopSetupTerminalShowMessage({
+          runId: 'run-1',
+          title: 'TeXRA Setup',
+          shellCommand: 'latexmk --version',
+          cwd: '/tmp/workspace',
+        }),
+      ),
+    ).toMatchObject({ command: 'desktop:setupTerminalShow' });
+
+    expect(
+      DesktopSetupTerminalAppendMessageSchema.parse(
+        buildDesktopSetupTerminalAppendMessage({
+          runId: 'run-1',
+          stream: 'stderr',
+          chunk: 'Installing',
+        }),
+      ),
+    ).toMatchObject({ command: 'desktop:setupTerminalAppend' });
+
+    expect(
+      DesktopSetupTerminalCompleteMessageSchema.parse(
+        buildDesktopSetupTerminalCompleteMessage({
+          runId: 'run-1',
+          status: 'succeeded',
+          exitCode: 0,
+          output: 'Done',
+        }),
+      ),
+    ).toMatchObject({ command: 'desktop:setupTerminalComplete' });
+
+    expect(
+      DesktopSetupTerminalCancelMessageSchema.parse(
+        buildDesktopSetupTerminalCancelMessage('run-1'),
+      ),
+    ).toMatchObject({ command: 'desktop:setupTerminalCancel' });
+  });
+
+  it('rejects running as a completion status', async () => {
+    const { DesktopSetupTerminalCompleteMessageSchema } =
+      await loadSetupTerminalMessages();
+    const result = DesktopSetupTerminalCompleteMessageSchema.safeParse({
+      command: 'desktop:setupTerminalComplete',
+      runId: 'run-1',
+      status: 'running',
+      exitCode: 0,
+      output: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/test-kernel/desktop/DesktopTerminalRunner.vitest.mts
+++ b/src/test-kernel/desktop/DesktopTerminalRunner.vitest.mts
@@ -14,10 +14,16 @@ interface DesktopTerminalRunnerModule {
       cwd?: string;
       env?: Record<string, string | undefined>;
       timeoutMs: number;
+      signal?: AbortSignal;
+      onOutput?: (chunk: {
+        stream: 'stdout' | 'stderr';
+        chunk: string;
+      }) => void;
     }): Promise<{
       exitCode: number | undefined;
       output: string;
       timedOut: boolean;
+      cancelled?: boolean;
     }>;
   };
 }
@@ -94,5 +100,49 @@ describe('desktop terminal runner', () => {
     expect(result.exitCode).toBe(0);
     expect(result.output.length).toBeLessThanOrEqual(12_000);
     expect(result.output.endsWith('tail')).toBe(true);
+  });
+
+  it('streams stdout and stderr chunks before completion', async () => {
+    const { createDesktopTerminalRunner } = await loadDesktopTerminalRunner();
+    const cwd = await mkdtemp(join(tmpdir(), 'texra-terminal-runner-'));
+    const runner = createDesktopTerminalRunner({ cwd });
+    const chunks: Array<{ stream: 'stdout' | 'stderr'; chunk: string }> = [];
+
+    const result = await runner.runCommand({
+      name: 'TeXRA Setup Stream Test',
+      command: nodeCommand(
+        "process.stdout.write('out'); process.stderr.write('err')",
+      ),
+      timeoutMs: 5_000,
+      onOutput: (chunk) => chunks.push(chunk),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(chunks).toEqual(
+      expect.arrayContaining([
+        { stream: 'stdout', chunk: 'out' },
+        { stream: 'stderr', chunk: 'err' },
+      ]),
+    );
+  });
+
+  it('cancels a running command with the supplied abort signal', async () => {
+    const { createDesktopTerminalRunner } = await loadDesktopTerminalRunner();
+    const cwd = await mkdtemp(join(tmpdir(), 'texra-terminal-runner-'));
+    const runner = createDesktopTerminalRunner({ cwd });
+    const controller = new AbortController();
+
+    const run = runner.runCommand({
+      name: 'TeXRA Setup Cancel Test',
+      command: nodeCommand('setTimeout(() => {}, 60_000)'),
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    const result = await run;
+    expect(result.cancelled).toBe(true);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.timedOut).toBe(false);
   });
 });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -237,6 +237,17 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toContain('logViewerTemplate');
   });
 
+  it('preserves streamed setup terminal output on completion', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain(
+      'payload.output.length > setupTerminalOutputText.length',
+    );
+    expect(rendererMain).not.toContain(
+      'payload.output || setupTerminalOutputText',
+    );
+  });
+
   it('does not import the deleted workspace-explorer surface', () => {
     const rendererMain = readRendererMain();
     expect(rendererMain).not.toContain('desktopWorkspaceExplorer');

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -206,11 +206,13 @@ export async function executeCommand(
 
           // Force-kill after FORCE_KILL_DELAY_MS if SIGTERM didn't work,
           // and destroy streams as a last resort to unblock `await subprocess`.
-          forceKillTimeoutId = setTimeout(() => {
-            signalProcessGroup(pid, 'SIGKILL');
-            shellSubprocess.stdout?.destroy();
-            shellSubprocess.stderr?.destroy();
-          }, FORCE_KILL_DELAY_MS);
+          if (forceKillTimeoutId === undefined) {
+            forceKillTimeoutId = setTimeout(() => {
+              signalProcessGroup(pid, 'SIGKILL');
+              shellSubprocess.stdout?.destroy();
+              shellSubprocess.stderr?.destroy();
+            }, FORCE_KILL_DELAY_MS);
+          }
         }, _shellTimeout);
       }
     }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -93,11 +93,17 @@ export async function executeCommand(
     onPid?: (pid: number) => void;
     /** Set to false to skip buffering stdout/stderr in memory (use with onStdout/onStderr). */
     buffer?: boolean;
+    /** Cancels the subprocess and its process group when possible. */
+    signal?: AbortSignal;
   } = {},
 ): Promise<ExecResult> {
   // Hoisted so the finally block can clear them on both success and error paths.
   let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  let signal: AbortSignal | undefined;
+  let subprocess: ResultPromise | undefined;
+  let commandCancelled = false;
 
   try {
     const workspacePath = options.cwd ?? WorkspaceFS.getPath();
@@ -131,8 +137,23 @@ export async function executeCommand(
 
     const logChannel = options.channel ?? CHANNEL;
 
-    let subprocess: ResultPromise;
     let shellTimedOut = false;
+    signal = options.signal;
+
+    const stopSubprocess = (force = false) => {
+      commandCancelled = commandCancelled || !force;
+      const pid = subprocess?.pid;
+      if (pid) {
+        signalProcessGroup(pid, force ? 'SIGKILL' : 'SIGTERM');
+      }
+      if (!force && forceKillTimeoutId === undefined) {
+        forceKillTimeoutId = setTimeout(() => {
+          stopSubprocess(true);
+          subprocess?.stdout?.destroy();
+          subprocess?.stderr?.destroy();
+        }, FORCE_KILL_DELAY_MS);
+      }
+    };
 
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
@@ -175,9 +196,10 @@ export async function executeCommand(
       if (subprocess.pid && options.onPid) options.onPid(subprocess.pid);
 
       if (_shellTimeout) {
+        const shellSubprocess = subprocess;
         shellTimeoutId = setTimeout(() => {
           shellTimedOut = true;
-          const pid = subprocess.pid;
+          const pid = shellSubprocess.pid;
           if (!pid) return;
 
           signalProcessGroup(pid, 'SIGTERM');
@@ -186,10 +208,22 @@ export async function executeCommand(
           // and destroy streams as a last resort to unblock `await subprocess`.
           forceKillTimeoutId = setTimeout(() => {
             signalProcessGroup(pid, 'SIGKILL');
-            subprocess.stdout?.destroy();
-            subprocess.stderr?.destroy();
+            shellSubprocess.stdout?.destroy();
+            shellSubprocess.stderr?.destroy();
           }, FORCE_KILL_DELAY_MS);
         }, _shellTimeout);
+      }
+    }
+
+    if (signal) {
+      abortListener = () => {
+        commandCancelled = true;
+        stopSubprocess();
+      };
+      if (signal.aborted) {
+        abortListener();
+      } else {
+        signal.addEventListener('abort', abortListener, { once: true });
       }
     }
 
@@ -209,7 +243,7 @@ export async function executeCommand(
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = result.exitCode ?? (commandCancelled ? 130 : 1);
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
 
     const normalizedStdout = normalizeOutput(stdout);
@@ -224,13 +258,23 @@ export async function executeCommand(
     }
 
     return {
-      success: exitCode === 0 && !timedOut,
+      success: exitCode === 0 && !timedOut && !commandCancelled,
       stdout: normalizedStdout,
       stderr: normalizedStderr,
       timedOut,
       exitCode,
     };
   } catch (err) {
+    if (commandCancelled) {
+      return {
+        success: false,
+        stdout: null,
+        stderr: 'Command cancelled',
+        timedOut: false,
+        exitCode: 130,
+      };
+    }
+
     logger.error(
       options.channel ?? CHANNEL,
       `Error executing command: ${toErrorMessage(err)}`,
@@ -249,5 +293,8 @@ export async function executeCommand(
   } finally {
     if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
     if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
+    if (signal && abortListener) {
+      signal.removeEventListener('abort', abortListener);
+    }
   }
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -141,7 +141,9 @@ export async function executeCommand(
     signal = options.signal;
 
     const stopSubprocess = (force = false) => {
-      commandCancelled = commandCancelled || !force;
+      if (!force) {
+        commandCancelled = true;
+      }
       const pid = subprocess?.pid;
       if (pid) {
         signalProcessGroup(pid, force ? 'SIGKILL' : 'SIGTERM');


### PR DESCRIPTION
## Summary
- Add a typed desktop setup-terminal message surface for command start, output chunks, completion, and cancellation.
- Run non-interactive desktop setup/tool install commands in an in-app output panel instead of waiting for a final modal result.
- Thread abort signals through the terminal runner and command executor so the panel can cancel a running setup process.

Closes #3808.

## Verification
- npm run format
- npm run typecheck
- npm run compile:fast
- npm run desktop:build
- npm run lint (passes with existing warnings)
- corepack pnpm exec vitest run src/test-kernel/desktop/DesktopTerminalRunner.vitest.mts src/test-kernel/desktop/DesktopSetupTerminalMessages.vitest.mts --testTimeout 20000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop main/renderer IPC plus subprocess execution (`executeCommand`) to add streaming and cancellation; mistakes could leave orphaned processes or regress setup/install flows across platforms.
> 
> **Overview**
> Adds a typed desktop setup-terminal message surface (`SHOW`/`APPEND`/`COMPLETE`/`CANCEL`) and wires a new setup-terminal overlay in the renderer to display live command output, status, and copy/cancel actions.
> 
> Updates the desktop main process to run non-interactive setup/install commands through this overlay, track active runs via `runId` + `AbortController`, and fall back to the old modal result when the renderer isn’t ready.
> 
> Extends the shared terminal execution path to support streaming output chunks and cancellation (plumbing `AbortSignal` through `TerminalRunRequest` → `createDesktopTerminalRunner` → `executeCommand`, with process-group termination and a cancelled exit code), and adds focused Vitest coverage for the new message schemas and runner behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd0abdbff96819adbcbdf7d866b7ee520bfd6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->