### PR TITLE
fix(cli): restore transcript-style chat output

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,5 +1,5 @@
-// Ink TUI root: header, conversation, optional side column, status, approval
-// modal, and input bar. Tab / Shift-Tab cycles focus across subagent streams.
+// Ink TUI root: conversation, optional side column, status, approval modal,
+// and input bar. Tab / Shift-Tab cycles focus across subagent streams.
 
 import { Box, useInput, useWindowSize } from 'ink';
 
@@ -65,8 +65,8 @@ export function App(props: AppProps): React.JSX.Element {
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="row" flexGrow={1}>
-        <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Box flexDirection="column">
           <ConversationPane width={transcriptWidth} />
         </Box>
         {showSideColumn ? (

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -58,4 +58,9 @@ export function registerBuiltinSlashCommands(): void {
     name: 'resume',
     description: 'Resume a previous session',
   });
+  registerSlashCommand({
+    name: 'exit',
+    description: 'Exit the CLI session',
+    aliases: ['quit'],
+  });
 }

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -41,6 +41,15 @@ function TranscriptEntry({
     );
   }
 
+  if (entry.role === 'error') {
+    return (
+      <Box marginBottom={1} paddingX={1}>
+        <Text color="red">! </Text>
+        <Text color="red">{entry.text}</Text>
+      </Box>
+    );
+  }
+
   return (
     <Box marginBottom={1}>
       <Markdown content={entry.text} width={width} />
@@ -64,6 +73,30 @@ export interface ConversationPaneProps {
   readonly width?: number;
 }
 
+export function splitTranscriptEntries(
+  entries: readonly ConversationEntry[],
+  status: StreamStatus | undefined,
+): {
+  readonly finalized: ConversationEntry[];
+  readonly live: ConversationEntry | undefined;
+} {
+  const streamIsAppending = isAppending(status);
+  let live: ConversationEntry | undefined;
+  if (streamIsAppending) {
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index];
+      if (entry.role !== 'assistant' || entry.finalized) continue;
+      live = entry;
+      break;
+    }
+  }
+  const finalized = entries
+    .filter((entry) => entry !== live)
+    .map((entry) => ({ ...entry, finalized: true }));
+
+  return { finalized, live };
+}
+
 export function ConversationPane(
   props: ConversationPaneProps = {},
 ): React.JSX.Element {
@@ -71,25 +104,10 @@ export function ConversationPane(
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
-  const streamIsAppending = isAppending(slice?.status);
-
-  const finalized: ConversationEntry[] = [];
-  let live: ConversationEntry | undefined;
-  for (const entry of entries) {
-    if (
-      streamIsAppending &&
-      entry.role === 'assistant' &&
-      !entry.finalized &&
-      entry === entries.at(-1)
-    ) {
-      live = entry;
-    } else {
-      finalized.push({ ...entry, finalized: true });
-    }
-  }
+  const { finalized, live } = splitTranscriptEntries(entries, slice?.status);
 
   return (
-    <Box flexDirection="column" flexGrow={1}>
+    <Box flexDirection="column">
       <Static items={finalized}>
         {(entry) => (
           <TranscriptEntry key={entry.id} entry={entry} width={props.width} />

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -28,6 +28,7 @@ import { createCliRuntimeHost } from '../../runtime/runtimeHost';
 import { writeTextStderr } from '../../runtime/logSinks';
 import { App } from './App';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
+import { listSlashCommands, parseSlashInput } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
 import { clearApprovals } from './state/approvalQueue';
@@ -37,6 +38,12 @@ import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
+import {
+  appendAssistantTranscriptIfMissing,
+  appendLocalAssistantTranscript,
+  clearActiveTranscript,
+  moveLocalTranscriptToStream,
+} from './state/transcript';
 import { cleanupTerminalModes } from './terminalCleanup';
 
 export interface ChatResult {
@@ -56,6 +63,109 @@ interface TuiSession {
   runExitCode: CliExitCode;
   runCompleted: boolean;
   stopRequested: boolean;
+}
+
+interface SlashCommandContext {
+  readonly session: TuiSession;
+  readonly initialAgent: string;
+  readonly initialModel: string;
+  readonly interruptActive: () => void;
+  readonly requestInputExit: () => void;
+}
+
+async function handleTuiSlashCommand(
+  line: string,
+  context: SlashCommandContext,
+): Promise<boolean> {
+  const parsed = parseSlashInput(line);
+  if (!parsed) return false;
+
+  const command = parsed.name.toLowerCase();
+  const rest = parsed.remainder.trim();
+  switch (command) {
+    case 'help': {
+      const commands = listSlashCommands()
+        .map((cmd) => `/${cmd.name} - ${cmd.description}`)
+        .join('\n');
+      appendLocalAssistantTranscript(commands);
+      return true;
+    }
+    case 'clear':
+      clearActiveTranscript();
+      return true;
+    case 'exit':
+    case 'quit':
+      context.session.stopRequested = true;
+      context.interruptActive();
+      context.requestInputExit();
+      return true;
+    case 'agent':
+      if (context.session.runPromise) {
+        appendLocalAssistantTranscript(
+          'The agent is fixed for this chat session. Start a new chat to use a different agent.',
+        );
+      } else if (rest) {
+        cliState.sessionMeta.set({
+          ...cliState.sessionMeta.get(),
+          agent: rest,
+        });
+        appendLocalAssistantTranscript(`Agent set to ${rest}.`);
+      } else {
+        appendLocalAssistantTranscript('Usage: /agent <name>');
+      }
+      return true;
+    case 'model':
+      if (context.session.runPromise) {
+        appendLocalAssistantTranscript(
+          'The model is fixed for this chat session. Start a new chat to use a different model.',
+        );
+      } else if (rest) {
+        try {
+          await setCliHelperModel(rest);
+          cliState.sessionMeta.set({
+            ...cliState.sessionMeta.get(),
+            model: rest,
+          });
+          appendLocalAssistantTranscript(`Model set to ${rest}.`);
+        } catch (error: unknown) {
+          appendLocalAssistantTranscript(toErrorMessage(error));
+        }
+      } else {
+        appendLocalAssistantTranscript('Usage: /model <name>');
+      }
+      return true;
+    case 'status': {
+      const meta = cliState.sessionMeta.get();
+      const activeStreamId = cliState.activeStreamId.get();
+      const slice = activeStreamId
+        ? cliState.streams.get().get(activeStreamId)
+        : undefined;
+      appendLocalAssistantTranscript(
+        [
+          `agent: ${meta.agent || context.initialAgent}`,
+          `model: ${meta.model || context.initialModel}`,
+          `status: ${slice?.status ?? 'not started'}`,
+        ].join('\n'),
+      );
+      return true;
+    }
+    default: {
+      const registered = listSlashCommands().find(
+        (cmd) =>
+          cmd.name.toLowerCase() === command ||
+          cmd.aliases?.some((alias) => alias.toLowerCase() === command) ===
+            true,
+      );
+      if (registered) {
+        appendLocalAssistantTranscript(
+          `/${parsed.name} is registered but is not available in this CLI view yet.`,
+        );
+      } else {
+        appendLocalAssistantTranscript(`Unknown command: /${parsed.name}`);
+      }
+      return true;
+    }
+  }
 }
 
 export async function runChat(
@@ -125,6 +235,7 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
+  let requestInputExit: (() => void) | undefined;
 
   const interruptActive = (): void => {
     clearApprovals();
@@ -157,6 +268,7 @@ export async function runChat(
           enforceCategory: true,
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
+            moveLocalTranscriptToStream(resolvedStreamId);
             cliState.activeStreamId.set(resolvedStreamId);
             if (session.stopRequested) interruptActive();
           },
@@ -169,6 +281,13 @@ export async function runChat(
           session.runExitCode = CliExitCode.ApprovalDenied;
         } else {
           session.runExitCode = CliExitCode.AgentError;
+        }
+        if (result.category === AgentCategory.ToolUse) {
+          appendAssistantTranscriptIfMissing(
+            result.streamId,
+            result.lastResponse,
+            `final:${result.executionId}`,
+          );
         }
         notify({ kind: 'agentFinished' });
       })
@@ -187,6 +306,21 @@ export async function runChat(
   };
 
   const handleSubmit = (line: string): void => {
+    void handleSubmittedLine(line);
+  };
+
+  const handleSubmittedLine = async (line: string): Promise<void> => {
+    if (
+      await handleTuiSlashCommand(line, {
+        session,
+        initialAgent: agent,
+        initialModel: model,
+        interruptActive,
+        requestInputExit: () => requestInputExit?.(),
+      })
+    ) {
+      return;
+    }
     if (!session.runPromise) {
       startSession(line);
       return;
@@ -211,16 +345,10 @@ export async function runChat(
     });
   };
 
-  // alternateScreen (Ink 7.0+) parks rendering on the terminal's alt buffer:
-  // stray stderr writes from agent errors or approval prompts can't leak
-  // into main-screen scrollback, and exit restores the user's pre-launch
-  // terminal contents intact (no banner/conversation mixing with the shell
-  // prompt the way main-screen mode did).
   const ink = render(<App onSubmit={handleSubmit} history={inputHistory} />, {
     stdout: process.stdout,
     stderr: process.stderr,
     stdin: process.stdin,
-    alternateScreen: true,
   });
 
   let pendingExitTimer: ReturnType<typeof setTimeout> | undefined;
@@ -267,6 +395,11 @@ export async function runChat(
     session.stopRequested = true;
     interruptActive();
     exitNow(129);
+  };
+  requestInputExit = () => {
+    removeProcessHandlers();
+    clearPendingExit();
+    ink.unmount();
   };
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -20,11 +20,17 @@ import type {
 export interface ConversationEntry {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */
   readonly id: string;
-  readonly role: 'assistant' | 'user';
+  readonly role: 'assistant' | 'error' | 'user';
   /** Concatenated text for `MODEL_RESPONSE` entries. */
   readonly text: string;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */
   readonly finalized: boolean;
+  /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
+  readonly synthetic?: boolean;
+  /** Why the CLI synthesized this entry. */
+  readonly syntheticKind?: 'final' | 'local';
+  /** StreamLog head at the moment a synthetic entry was appended. */
+  readonly syntheticAfterSeq?: number;
 }
 
 export interface SessionMeta {
@@ -95,6 +101,8 @@ const ACTIVE_FORM = signal<ActiveSlashForm | undefined>(undefined);
 const SLASH_PALETTE_OPEN = signal<boolean>(false);
 
 const PENDING_EXIT_HINT = signal<boolean>(false);
+
+const RESET_HOOKS = new Set<() => void>();
 
 export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
@@ -181,4 +189,9 @@ export function resetCliState(): void {
   cliState.activeForm.set(undefined);
   cliState.slashPaletteOpen.set(false);
   cliState.pendingExitHint.set(false);
+  for (const resetHook of RESET_HOOKS) resetHook();
+}
+
+export function registerCliStateResetHook(resetHook: () => void): void {
+  RESET_HOOKS.add(resetHook);
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -9,13 +9,21 @@ import {
 } from '@shared/schemas';
 
 import { cliState, patchStream, type ConversationEntry } from './cliState';
+import { getTranscriptStartSeq } from './transcript';
 
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
+  MESSAGE_TYPES.ERROR,
   MESSAGE_TYPES.MODEL_RESPONSE,
   MESSAGE_TYPES.USER_MESSAGE,
 ]);
 
 const STREAM_SYNC_THROTTLE_MS = 200;
+
+type TranscriptCandidate = {
+  readonly rendered: ConversationEntry;
+  readonly sortSeq: number;
+  readonly tieBreak: number;
+};
 
 export function subscribeStreamLog(): () => void {
   const store = AgentLogger.getStreamLogStore();
@@ -43,23 +51,74 @@ export function syncStreamLog(streamId: StreamTabId): void {
   if (!log) return;
 
   const responses = log
-    .getRange(0)
+    .getRange(getTranscriptStartSeq(streamId))
     .filter((entry: StreamLogEntry) =>
       TRANSCRIPT_MESSAGE_TYPES.has(entry.messageType ?? ''),
     );
 
   patchStream(streamId, (slice) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
-    let changed = slice.entries.length !== responses.length;
-    const next = responses.map((entry: StreamLogEntry) => {
+    const syntheticEntries = slice.entries.filter((entry) => entry.synthetic);
+    const logEntries = responses.map((entry: StreamLogEntry) => {
       const text = entry.text ?? '';
       const role: ConversationEntry['role'] =
-        entry.messageType === MESSAGE_TYPES.USER_MESSAGE ? 'user' : 'assistant';
+        entry.messageType === MESSAGE_TYPES.USER_MESSAGE
+          ? 'user'
+          : entry.messageType === MESSAGE_TYPES.ERROR
+            ? 'error'
+            : 'assistant';
       const prev = existing.get(entry.id);
-      if (prev && prev.text === text && prev.role === role) return prev;
-      changed = true;
-      return { id: entry.id, role, text, finalized: role === 'user' };
+      const rendered =
+        prev && prev.text === text && prev.role === role
+          ? prev
+          : { id: entry.id, role, text, finalized: role !== 'assistant' };
+      return { entry, rendered };
     });
+    const logCandidates: TranscriptCandidate[] = logEntries.map(
+      ({ entry, rendered }) => ({
+        rendered,
+        sortSeq: entry.seqNo,
+        tieBreak: 0,
+      }),
+    );
+    const candidates: TranscriptCandidate[] = [...logCandidates];
+
+    for (const [index, entry] of syntheticEntries.entries()) {
+      if (entry.syntheticKind !== 'local') {
+        const duplicate = logCandidates.some(
+          (candidate) =>
+            candidate.rendered.role === entry.role &&
+            candidate.rendered.text.trim() === entry.text.trim(),
+        );
+        if (duplicate) continue;
+      }
+
+      candidates.push({
+        rendered: entry,
+        sortSeq: entry.syntheticAfterSeq ?? Number.POSITIVE_INFINITY,
+        tieBreak: index + 1,
+      });
+    }
+
+    const next = candidates
+      .sort(
+        (left, right) =>
+          left.sortSeq - right.sortSeq || left.tieBreak - right.tieBreak,
+      )
+      .map((candidate) => candidate.rendered);
+
+    const changed =
+      slice.entries.length !== next.length ||
+      slice.entries.some((entry, index) => {
+        const candidate = next[index];
+        return (
+          !candidate ||
+          entry.id !== candidate.id ||
+          entry.role !== candidate.role ||
+          entry.text !== candidate.text ||
+          entry.finalized !== candidate.finalized
+        );
+      });
     if (!changed) return slice;
     return { ...slice, entries: next };
   });

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -1,0 +1,115 @@
+import { AgentLogger } from '@logger/AgentLogger';
+import type { StreamTabId } from '@shared/schemas';
+
+import {
+  cliState,
+  patchStream,
+  removeStream,
+  registerCliStateResetHook,
+  type ConversationEntry,
+} from './cliState';
+
+export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;
+
+let localEntrySeq = 0;
+const clearedHeadByStream = new Map<StreamTabId, number>();
+
+function normalizeTranscriptText(text: string): string {
+  return text.trim();
+}
+
+export function appendAssistantTranscriptIfMissing(
+  streamId: StreamTabId,
+  text: string | undefined,
+  idPrefix = 'assistant',
+): void {
+  const normalized = normalizeTranscriptText(text ?? '');
+  if (!normalized) return;
+  const syntheticAfterSeq =
+    AgentLogger.getStreamLogStore().get(streamId)?.head ?? 0;
+
+  patchStream(streamId, (slice) => {
+    const entryId = `${idPrefix}:${streamId}`;
+    const alreadyRendered = slice.entries.some(
+      (entry) =>
+        entry.id === entryId ||
+        (!entry.synthetic &&
+          entry.role === 'assistant' &&
+          normalizeTranscriptText(entry.text) === normalized),
+    );
+    if (alreadyRendered) return slice;
+
+    const entry: ConversationEntry = {
+      id: entryId,
+      role: 'assistant',
+      text: normalized,
+      finalized: true,
+      synthetic: true,
+      syntheticKind: 'final',
+      syntheticAfterSeq,
+    };
+    return { ...slice, entries: [...slice.entries, entry] };
+  });
+}
+
+export function appendLocalAssistantTranscript(text: string): void {
+  const normalized = normalizeTranscriptText(text);
+  if (!normalized) return;
+
+  const streamId = cliState.activeStreamId.get() ?? CLI_LOCAL_STREAM_ID;
+  if (!cliState.activeStreamId.get()) cliState.activeStreamId.set(streamId);
+  const syntheticAfterSeq =
+    AgentLogger.getStreamLogStore().get(streamId)?.head ?? 0;
+
+  patchStream(streamId, (slice) => {
+    const entry: ConversationEntry = {
+      id: `local:${localEntrySeq++}:${streamId}:${slice.entries.length}`,
+      role: 'assistant',
+      text: normalized,
+      finalized: true,
+      synthetic: true,
+      syntheticKind: 'local',
+      syntheticAfterSeq,
+    };
+    return { ...slice, entries: [...slice.entries, entry] };
+  });
+}
+
+export function moveLocalTranscriptToStream(streamId: StreamTabId): void {
+  if (streamId === CLI_LOCAL_STREAM_ID) return;
+
+  const localSlice = cliState.streams.get().get(CLI_LOCAL_STREAM_ID);
+  if (!localSlice?.entries.length) return;
+
+  patchStream(streamId, (slice) => ({
+    ...slice,
+    entries: [...localSlice.entries, ...slice.entries],
+  }));
+  if (cliState.activeStreamId.get() === CLI_LOCAL_STREAM_ID) {
+    cliState.activeStreamId.set(streamId);
+  }
+  removeStream(CLI_LOCAL_STREAM_ID);
+}
+
+export function clearActiveTranscript(): void {
+  const activeStreamId = cliState.activeStreamId.get();
+  if (!activeStreamId) {
+    cliState.streams.set(new Map());
+    return;
+  }
+
+  const head = AgentLogger.getStreamLogStore().get(activeStreamId)?.head ?? 0;
+  clearedHeadByStream.set(activeStreamId, head);
+  patchStream(activeStreamId, (slice) => ({ ...slice, entries: [] }));
+}
+
+export function getTranscriptStartSeq(streamId: StreamTabId): number {
+  return clearedHeadByStream.get(streamId) ?? 0;
+}
+
+function resetTranscriptState(): void {
+  localEntrySeq = 0;
+  clearedHeadByStream.clear();
+}
+
+registerCliStateResetHook(resetTranscriptState);

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2,7 +2,13 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { StreamTabId } from '@shared/schemas';
+import { AgentLogger } from '@logger/AgentLogger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+import {
+  MESSAGE_TYPES,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import {
   cliState,
@@ -15,7 +21,17 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '../../../packages/cli/src/chat/tui/state/focusCycle';
+import { syncStreamLog } from '../../../packages/cli/src/chat/tui/state/subscribeStreamLog';
 import { wrapRuntimeHost } from '../../../packages/cli/src/chat/tui/state/subscribeRuntimeHost';
+import { splitTranscriptEntries } from '../../../packages/cli/src/chat/tui/panes/ConversationPane';
+import {
+  appendAssistantTranscriptIfMissing,
+  appendLocalAssistantTranscript,
+  CLI_LOCAL_STREAM_ID,
+  clearActiveTranscript,
+  getTranscriptStartSeq,
+  moveLocalTranscriptToStream,
+} from '../../../packages/cli/src/chat/tui/state/transcript';
 import type { CliRuntimeHost } from '../../../packages/cli/src/runtime/runtimeHost';
 
 const root = 'root' as StreamTabId;
@@ -55,6 +71,288 @@ describe('cliState Phase 4 fields', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     removeStream(root);
     expect(cliState.parentStream.get().has(child2)).toBe(false);
+  });
+});
+
+describe('CLI transcript state', () => {
+  it('mirrors error log entries into the transcript', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.error('Model request failed', {
+        messageType: MESSAGE_TYPES.ERROR,
+      });
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        role: 'error',
+        text: 'Model request failed',
+        finalized: true,
+      });
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('adds a final assistant response only when the stream log did not render it', () => {
+    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'assistant',
+      text: 'The answer is 2.',
+      finalized: true,
+    });
+  });
+
+  it('keeps repeated final responses from distinct turns visible', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
+
+      logger.info('second prompt', {
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+      });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:second');
+
+      logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'first prompt',
+        'Done.',
+        'second prompt',
+        'Done.',
+        'third prompt',
+      ]);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('does not duplicate a final response already present in the stream log', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('Done.', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual(['Done.']);
+      expect(entries[0]?.synthetic).toBeUndefined();
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('keeps repeated local slash-command responses visible', () => {
+    cliState.activeStreamId.set(root);
+
+    appendLocalAssistantTranscript('Available commands: /help');
+    appendLocalAssistantTranscript('Available commands: /help');
+
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'Available commands: /help',
+      'Available commands: /help',
+    ]);
+  });
+
+  it('keeps repeated local slash-command responses after stream-log syncs', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      cliState.activeStreamId.set(root);
+
+      appendLocalAssistantTranscript('Available commands: /help');
+      logger.info('partial response', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+      syncStreamLog(root);
+
+      appendLocalAssistantTranscript('Available commands: /help');
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(
+        entries
+          .filter((entry) => entry.syntheticKind === 'local')
+          .map((entry) => entry.text),
+      ).toEqual(['Available commands: /help', 'Available commands: /help']);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('keeps a model response live when local output follows it', () => {
+    const { finalized, live } = splitTranscriptEntries(
+      [
+        {
+          id: 'model-response',
+          role: 'assistant',
+          text: 'partial',
+          finalized: false,
+        },
+        {
+          id: 'local-help',
+          role: 'assistant',
+          text: 'Available commands: /help',
+          finalized: true,
+          synthetic: true,
+          syntheticKind: 'local',
+          syntheticAfterSeq: 1,
+        },
+      ],
+      STREAM_STATUS.RUNNING,
+    );
+
+    expect(live?.id).toBe('model-response');
+    expect(finalized.map((entry) => entry.id)).toEqual(['local-help']);
+  });
+
+  it('moves pre-session local slash-command output onto the resolved stream', () => {
+    appendLocalAssistantTranscript('Available commands: /help');
+
+    expect(
+      cliState.streams.get().get(CLI_LOCAL_STREAM_ID)?.entries,
+    ).toHaveLength(1);
+
+    moveLocalTranscriptToStream(root);
+
+    expect(cliState.streams.get().has(CLI_LOCAL_STREAM_ID)).toBe(false);
+    expect(cliState.activeStreamId.get()).toBe(root);
+    expect(
+      cliState.streams
+        .get()
+        .get(root)
+        ?.entries.map((entry) => entry.text),
+    ).toEqual(['Available commands: /help']);
+  });
+
+  it('preserves synthetic final responses across later log syncs', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+
+      logger.info('next prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        '1+1',
+        'The answer is 2.',
+        'next prompt',
+      ]);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('orders multiple synthetic responses relative to their stream-log anchors', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'first answer', 'final-1');
+
+      logger.info('second prompt', {
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+      });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'second answer', 'final-2');
+
+      logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'first prompt',
+        'first answer',
+        'second prompt',
+        'second answer',
+        'third prompt',
+      ]);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('does not replay cleared log entries on later syncs', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('old prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      cliState.activeStreamId.set(root);
+      clearActiveTranscript();
+
+      logger.info('new prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual(['new prompt']);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
+  it('resets cleared transcript cursors with cli state', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('old prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      cliState.activeStreamId.set(root);
+      clearActiveTranscript();
+      expect(getTranscriptStartSeq(root)).toBeGreaterThan(0);
+
+      resetCliState();
+
+      expect(getTranscriptStartSeq(root)).toBe(0);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes regressions in the latest CLI TUI where chat opened as a full-screen alternate buffer with large blank regions, and where a completed tool-use response could leave no visible assistant text if the stream log did not contain a model-response entry.

Changes:
- render the CLI chat in the normal terminal transcript instead of the alternate screen;
- stop the conversation pane from consuming the full terminal height when there is little content;
- mirror error log entries into the CLI transcript;
- append the final tool-use `lastResponse` when it was not already rendered from the stream log;
- handle basic slash commands (`/help`, `/clear`, `/agent`, `/model`, `/status`, `/exit`) in the TUI instead of sending them as model prompts.

## Validation

- `corepack pnpm --filter @texra/cli build`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/AnsiMarkdown.vitest.mts`
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings outside this change)
- `git diff --check`

## Manual check

Ran the built CLI in a pseudo-terminal. The patched CLI no longer emits the terminal alternate-screen enter sequence, `/help` renders in the transcript, and `/exit` exits the session cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors how the TUI builds/clears/augments transcript entries and adds in-TUI slash-command handling, which can affect what users see and how sessions exit, but doesn’t touch auth or data persistence.
> 
> **Overview**
> Restores a transcript-style CLI chat experience by removing alternate-screen/full-height layout behavior and preventing the conversation pane from consuming extra vertical space.
> 
> Improves transcript fidelity by (1) mirroring `ERROR` stream-log entries into the conversation, (2) preserving and ordering *synthetic* assistant entries (local slash-command output and missing final tool-use responses) alongside stream-log entries, and (3) adding `/clear` support via a per-stream “start seq” cursor so cleared output isn’t replayed on later log syncs.
> 
> Handles core slash commands directly in the TUI (`/help`, `/clear`, `/agent`, `/model`, `/status`, `/exit`/`/quit`) including clean in-app exit/unmount behavior, and adds comprehensive tests around transcript merging, deduplication, and clear semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d2b90ee90194e601b53fb8ad45fc7531a69aa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->