### PR TITLE
fix: start compact response immediately

### DIFF
--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -2,15 +2,16 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import {
-  getInterruptible,
-  getToolUseFlowContext,
-} from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   detachActiveChildren,
   interruptActiveChildren,
 } from '@agent/runtime/executionRegistry';
+import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  getInterruptible,
+  getToolUseFlowContext,
+} from '@agent/toolUse/ToolUseAgentRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { STREAM_STATUS } from '@shared/schemas';
@@ -46,8 +47,9 @@ export async function compactResponse(streamId: StreamTabId): Promise<void> {
     return;
   }
 
-  flowContext.modelHandler.requestCompaction();
+  flowContext.requestImmediateCompaction();
+  notifyFollowUpSent(streamId, flowContext.runtimeHost);
   await vscode.window.showInformationMessage(
-    'Context compaction requested. The conversation will be compacted on the next API call.',
+    'Context compaction requested. The agent will process it on the next model call.',
   );
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -211,23 +211,33 @@ class ToolUsePrepNode<C> extends BaseNode<
   CycleParams,
   ToolUseCycleServices<C>
 > {
-  async prep(
-    _shared: ToolUseCycleShared,
-  ): Promise<{ interrupted: boolean; queuedFollowUp: string | null }> {
+  async prep(_shared: ToolUseCycleShared): Promise<{
+    interrupted: boolean;
+    queuedFollowUp: string | null;
+    synthetic: boolean;
+  }> {
     const interrupted = this.services.checkInterruption();
 
     if (!this.services.session?.hasQueuedFollowUp()) {
-      return { interrupted, queuedFollowUp: null };
+      return { interrupted, queuedFollowUp: null, synthetic: false };
     }
 
     // Drain without waiting (we know there's something queued)
-    const items = await this.services.session.waitForFollowUp(() => false);
-    return { interrupted, queuedFollowUp: items?.join('\n\n') ?? null };
+    const batch = await this.services.session.waitForFollowUp(() => false);
+    return {
+      interrupted,
+      queuedFollowUp: batch?.items.join('\n\n') ?? null,
+      synthetic: batch?.synthetic ?? false,
+    };
   }
 
   async post(
     shared: ToolUseCycleShared,
-    prepRes: { interrupted: boolean; queuedFollowUp: string | null },
+    prepRes: {
+      interrupted: boolean;
+      queuedFollowUp: string | null;
+      synthetic: boolean;
+    },
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
       shared.shouldStop = true;
@@ -239,13 +249,17 @@ class ToolUsePrepNode<C> extends BaseNode<
     // This ensures user's message typed during tool execution is seen
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUp) {
-      this.services.logger.userMessage(prepRes.queuedFollowUp);
+      if (!prepRes.synthetic) {
+        this.services.logger.userMessage(prepRes.queuedFollowUp);
+      }
       shared.messages =
         await this.services.modelHandler.createUserFollowUpMessages(
           shared.messages,
           prepRes.queuedFollowUp,
         );
-      this.services.onFollowUpConsumed?.();
+      if (!prepRes.synthetic) {
+        this.services.onFollowUpConsumed?.();
+      }
     }
 
     resetCycleState(shared, [

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -1,20 +1,31 @@
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueueBatch } from '@agent/toolUse/FollowUpQueue';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface IToolUseSession {
   appendFollowUp(text: string): void;
+  appendSyntheticFollowUp(text: string): void;
   hasQueuedFollowUp(): boolean;
   /** Wait for the next follow-up items. Returns null if interrupted. */
-  waitForFollowUp(checkInterruption: () => boolean): Promise<string[] | null>;
+  waitForFollowUp(
+    checkInterruption: () => boolean,
+  ): Promise<FollowUpQueueBatch | null>;
 }
 
 export class ToolUseSessionLifecycle implements IToolUseSession {
   private readonly followUps = ToolUseFollowUpQueue.acquire(this.streamTabId);
+  private syntheticFollowUpPending = false;
 
   constructor(private readonly streamTabId: StreamTabId) {}
 
   appendFollowUp(text: string): void {
     this.followUps.enqueue(text);
+  }
+
+  appendSyntheticFollowUp(text: string): void {
+    if (this.syntheticFollowUpPending) return;
+    this.syntheticFollowUpPending = true;
+    this.followUps.enqueueSynthetic(text);
   }
 
   hasQueuedFollowUp(): boolean {
@@ -23,11 +34,16 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
 
   async waitForFollowUp(
     checkInterruption: () => boolean,
-  ): Promise<string[] | null> {
-    return this.followUps.waitAndDrainAll(checkInterruption);
+  ): Promise<FollowUpQueueBatch | null> {
+    const batch = await this.followUps.waitAndDrainAll(checkInterruption);
+    if (batch?.synthetic) {
+      this.syntheticFollowUpPending = false;
+    }
+    return batch;
   }
 
   interrupt(): void {
+    this.syntheticFollowUpPending = false;
     this.followUps.dispose();
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -92,12 +92,16 @@ export class ToolUseWaitNode<C> extends Node<
       });
     }
 
-    const items = await session.waitForFollowUp(checkInterruption);
-    if (!items || checkInterruption()) {
+    const batch = await session.waitForFollowUp(checkInterruption);
+    if (!batch || checkInterruption()) {
       return { kind: 'stop' };
     }
 
-    return { kind: 'continue', followUp: items.join('\n\n') };
+    return {
+      kind: 'continue',
+      followUp: batch.items.join('\n\n'),
+      synthetic: batch.synthetic,
+    };
   }
 
   async execFallback(

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -77,9 +77,13 @@ export interface ToolUseFlowContext {
   readonly modelHandler: ToolUseServices['modelHandler'];
   readonly runtimeHost: ToolUseServices['runtimeHost'];
   interrupt(): void;
+  requestImmediateCompaction(): void;
 }
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
+
+const IMMEDIATE_COMPACTION_FOLLOW_UP =
+  'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
 
 function resolveTools(
   tools: AgentToolUseSetting['tools'],
@@ -181,6 +185,14 @@ export async function runToolUseFlow<C = unknown>(
       clearRetryRequest(streamId);
       clearPlanApprovalForStream(streamId);
       sessionLifecycle.interrupt();
+    },
+    requestImmediateCompaction(): void {
+      input.modelHandler.requestCompaction();
+      if (!sessionLifecycle.hasQueuedFollowUp()) {
+        sessionLifecycle.appendSyntheticFollowUp(
+          IMMEDIATE_COMPACTION_FOLLOW_UP,
+        );
+      }
     },
   };
 

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -5,11 +5,29 @@
  * toolUse modules, allowing it to be imported without circular dependency issues.
  */
 
+interface FollowUpQueueItem {
+  readonly text: string;
+  readonly synthetic: boolean;
+}
+
+export interface FollowUpQueueBatch {
+  readonly items: string[];
+  readonly synthetic: boolean;
+}
+
 export class FollowUpQueue {
-  private readonly queued: string[] = [];
-  private resolver: ((value: string | null) => void) | null = null;
+  private readonly queued: FollowUpQueueItem[] = [];
+  private resolver: ((value: FollowUpQueueItem | null) => void) | null = null;
 
   enqueue(value: string): void {
+    this.enqueueItem({ text: value, synthetic: false });
+  }
+
+  enqueueSynthetic(value: string): void {
+    this.enqueueItem({ text: value, synthetic: true });
+  }
+
+  private enqueueItem(value: FollowUpQueueItem): void {
     if (this.resolver) {
       const resolve = this.resolver;
       this.resolver = null;
@@ -24,31 +42,49 @@ export class FollowUpQueue {
   }
 
   drain(): string[] {
-    return this.queued.splice(0);
+    return this.queued
+      .splice(0)
+      .filter((item) => !item.synthetic)
+      .map((item) => item.text);
   }
 
-  waitForNext(checkInterruption: () => boolean): Promise<string | null> {
+  waitForNext(
+    checkInterruption: () => boolean,
+  ): Promise<FollowUpQueueItem | null> {
     if (this.queued.length > 0) {
       return Promise.resolve(this.queued.shift()!);
     }
     if (checkInterruption()) {
       return Promise.resolve(null);
     }
-    return new Promise<string | null>((resolve) => {
+    return new Promise<FollowUpQueueItem | null>((resolve) => {
       this.resolver = resolve;
     });
   }
 
   /**
-   * Wait for at least one item, then drain all available.
+   * Wait for at least one item, then drain one batch.
+   * Synthetic items are returned as a single-item batch; visible batches stop
+   * at the next synthetic boundary so hidden maintenance turns do not merge
+   * with user text.
    * Returns null if interrupted.
    */
   async waitAndDrainAll(
     checkInterruption: () => boolean,
-  ): Promise<string[] | null> {
+  ): Promise<FollowUpQueueBatch | null> {
     const first = await this.waitForNext(checkInterruption);
     if (first === null) return null;
-    return [first, ...this.drain()];
+    if (first.synthetic) {
+      return { items: [first.text], synthetic: true };
+    }
+
+    const items = [first.text];
+    while (true) {
+      const next = this.queued[0];
+      if (!next || next.synthetic) break;
+      items.push(this.queued.shift()!.text);
+    }
+    return { items, synthetic: false };
   }
 
   cancelWait(): void {
@@ -64,6 +100,8 @@ export class FollowUpQueue {
 
   /** Get a copy of all queued items for display purposes. */
   getAll(): string[] {
-    return [...this.queued];
+    return this.queued
+      .filter((item) => !item.synthetic)
+      .map((item) => item.text);
   }
 }

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -12,6 +12,7 @@
 
 import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { AgentLogger } from '@logger/AgentLogger';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
@@ -40,7 +41,10 @@ export function onFollowUpSent(
   };
 }
 
-function notifyFollowUpSent(streamId: StreamTabId): void {
+export function notifyFollowUpSent(
+  streamId: StreamTabId,
+  runtimeHost?: AgentRuntimeHost,
+): void {
   for (const observer of followUpSentObservers) {
     try {
       observer(streamId);
@@ -50,6 +54,7 @@ function notifyFollowUpSent(streamId: StreamTabId): void {
       );
     }
   }
+  runtimeHost?.emit('followUpSent', { streamId });
 }
 
 /**
@@ -70,9 +75,7 @@ export async function sendFollowUp(
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
     flowContext.session.appendFollowUp(text);
-    notifyFollowUpSent(streamId);
-    // Notify blocking tools (e.g. ExecutionsTool wait) so they can abort early
-    flowContext.runtimeHost.emit('followUpSent', { streamId });
+    notifyFollowUpSent(streamId, flowContext.runtimeHost);
     return { status: 'sent' };
   }
 

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -1,0 +1,77 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
+import { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
+import type { StreamTabId } from '@shared/schemas';
+
+describe('FollowUpQueue', () => {
+  it('batches visible follow-ups for normal user input', async () => {
+    const queue = new FollowUpQueue();
+
+    queue.enqueue('first');
+    queue.enqueue('second');
+
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: ['first', 'second'],
+      synthetic: false,
+    });
+  });
+
+  it('keeps synthetic follow-ups out of visible queue state', async () => {
+    const queue = new FollowUpQueue();
+
+    queue.enqueueSynthetic('compact now');
+    queue.enqueue('user text');
+
+    expect(queue.getAll()).toEqual(['user text']);
+
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: ['compact now'],
+      synthetic: true,
+    });
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: ['user text'],
+      synthetic: false,
+    });
+  });
+
+  it('coalesces duplicate synthetic session follow-ups', async () => {
+    const session = new ToolUseSessionLifecycle(
+      'stream:synthetic-coalesce' as StreamTabId,
+    );
+
+    try {
+      session.appendSyntheticFollowUp('compact now');
+      session.appendSyntheticFollowUp('compact again');
+
+      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
+        items: ['compact now'],
+        synthetic: true,
+      });
+      expect(session.hasQueuedFollowUp()).toBe(false);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('allows synthetic session follow-ups after an interrupt clears the queue', async () => {
+    const session = new ToolUseSessionLifecycle(
+      'stream:synthetic-interrupt' as StreamTabId,
+    );
+
+    try {
+      session.appendSyntheticFollowUp('compact before interrupt');
+      session.interrupt();
+      session.appendSyntheticFollowUp('compact after interrupt');
+
+      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
+        items: ['compact after interrupt'],
+        synthetic: true,
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+});

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -561,7 +561,7 @@ function startClaudeAgentLoop(params: {
         );
         if (!messages || session.isInterrupted()) break;
 
-        const prompt = messages.join('\n\n');
+        const prompt = messages.items.join('\n\n');
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
           runtimeHost,
         });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -574,7 +574,7 @@ function startCodexLoop(params: {
         );
         if (!messages || session.isInterrupted()) break;
 
-        const prompt = messages.join('\n\n');
+        const prompt = messages.items.join('\n\n');
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
           runtimeHost,
         });


### PR DESCRIPTION
## Summary

Fixes #4142.

This changes manual context compaction from a deferred flag into an immediate internal continuation for active tool-use sessions. When the compact button is clicked, the flow now requests compaction and wakes the waiting session with a hidden synthetic follow-up, so the next model call starts at once instead of waiting for another user message.

The synthetic follow-up is kept out of the visible queued-message state and is not logged as a user message. Ordinary follow-ups retain the existing batching behavior.

## Verification

- npm run format
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors, existing 15 warnings)
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-use session control flow and follow-up queue semantics (introducing hidden synthetic messages) to trigger immediate continuations; bugs here could cause missed/extra turns or confusing UI state around follow-ups/compaction.
> 
> **Overview**
> Manual context compaction is changed from a deferred flag into an **immediate continuation** for active tool-use sessions: `compactResponse` now calls `flowContext.requestImmediateCompaction()` and explicitly notifies follow-up listeners to wake any waiters.
> 
> The follow-up queue is extended to support **synthetic (hidden) follow-ups** via `FollowUpQueueBatch` (`items` + `synthetic`), with batching that stops at synthetic boundaries and excludes synthetic entries from `getAll()`/`drain()`. Tool-use flow nodes (`ToolUseWaitNode`, `ToolUseCycleFlow` prep) propagate the `synthetic` flag so synthetic messages are not logged as user text and do not trigger `onFollowUpConsumed`.
> 
> `runToolUseFlow` adds `requestImmediateCompaction()` which requests compaction and, when idle, injects a one-time synthetic follow-up to start the next model call immediately. Related tools (`claudeAgent`, `codex`) are updated for the new queue batch shape, and new Vitest coverage validates batching, hidden synthetic behavior, and coalescing/reset of synthetic follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e12279d23fb245f2d4cef89543fdeffee7dee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->