### PR TITLE
feat: add host-backed open_pdf tool

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -83,6 +83,7 @@ import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { interruptAllCodexSessions } from '@tools/codex';
 import { interruptAllClaudeAgentSessions } from '@tools/claudeAgent';
 import { setExtensionChecker } from '@tools/externalToolDefs';
+import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
 import {
@@ -355,6 +356,16 @@ export async function activate(context: vscode.ExtensionContext) {
   initializeNativeToolEditApproval(context, extensionAgentRuntimeHost);
   setLeanVscodeServices(leanVscodeIntegration);
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
+  setOpenPdfOpener(async ({ location, preserveFocus }) => {
+    await vscode.commands.executeCommand(
+      'vscode.open',
+      vscode.Uri.file(location.absolutePath),
+      {
+        viewColumn: vscode.ViewColumn.Beside,
+        preserveFocus,
+      } satisfies vscode.TextDocumentShowOptions,
+    );
+  });
   setToolMissingHandler(async (message, openDocsCommand) => {
     const actions = openDocsCommand ? ['View Installation Guide'] : [];
     const choice = await vscode.window.showErrorMessage(message, ...actions);

--- a/src/test-kernel/tools/OpenPdfTool.vitest.ts
+++ b/src/test-kernel/tools/OpenPdfTool.vitest.ts
@@ -1,0 +1,173 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - tests
+import { createFakePlatform } from '@test/support/FakePlatform';
+
+// Local imports - runtime
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
+// Local imports - tools
+import {
+  OpenPdfTool,
+  setOpenPdfOpener,
+  type OpenPdfRequest,
+} from '@tools/OpenPdfTool';
+
+describe('OpenPdfTool', () => {
+  beforeEach(async () => {
+    await installPlatform(
+      createFakePlatform({
+        workspacePath: '/workspace',
+        storagePath: '/storage',
+        files: {
+          '/workspace/paper.pdf': '%PDF-1.4\n',
+          '/workspace/figures/result.pdf': '%PDF-1.4\n',
+          '/run/paper.pdf': '%PDF-1.4\n',
+          '/storage/executions/run-1/output.pdf': '%PDF-1.4\n',
+          '/workspace/paper.tex': '\\documentclass{article}',
+        },
+      }),
+    );
+    setOpenPdfOpener(undefined);
+  });
+
+  it('reports that PDF opening is unavailable when no host callback is registered', async () => {
+    const tool = new OpenPdfTool();
+
+    const result = await tool.call({ path: 'paper.tex' });
+
+    expect(result).toMatchObject({
+      isError: true,
+      error: expect.stringContaining('open_pdf is not available'),
+    });
+  });
+
+  it('opens an existing PDF through the registered host callback', async () => {
+    const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
+    openPdf.mockResolvedValue(undefined);
+    setOpenPdfOpener(openPdf);
+    const tool = new OpenPdfTool();
+
+    const result = await tool.call({
+      path: 'figures/result.pdf',
+      preserve_focus: true,
+    });
+
+    expect(result).toMatchObject({
+      summary: 'Opened PDF: figures/result.pdf',
+      output: 'Opened PDF: figures/result.pdf',
+    });
+    expect(openPdf).toHaveBeenCalledWith({
+      location: {
+        kind: 'workspace',
+        absolutePath: '/workspace/figures/result.pdf',
+        relativePath: 'figures/result.pdf',
+      },
+      preserveFocus: true,
+    });
+  });
+
+  it('allows absolute paths inside active run storage', async () => {
+    const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
+    openPdf.mockResolvedValue(undefined);
+    setOpenPdfOpener(openPdf);
+    const tool = new OpenPdfTool();
+
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: createRuntimeHost(),
+        executionId: 'run-1',
+      }),
+      () =>
+        tool.call({
+          path: '/storage/executions/run-1/output.pdf',
+          preserve_focus: true,
+        }),
+    );
+
+    expect(result).toMatchObject({
+      summary: 'Opened PDF: output.pdf',
+      output: 'Opened PDF: output.pdf',
+    });
+    expect(openPdf).toHaveBeenCalledWith({
+      location: {
+        kind: 'runStorage',
+        absolutePath: '/storage/executions/run-1/output.pdf',
+        relativePath: 'output.pdf',
+        executionId: 'run-1',
+      },
+      preserveFocus: true,
+    });
+  });
+
+  it('does not parse working_directory before checking absolute run-storage paths', async () => {
+    const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
+    openPdf.mockResolvedValue(undefined);
+    setOpenPdfOpener(openPdf);
+    const tool = new OpenPdfTool();
+
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: createRuntimeHost(),
+        executionId: 'run-1',
+        workingDirectory: 'relative-path',
+      }),
+      () => tool.call({ path: '/storage/executions/run-1/output.pdf' }),
+    );
+
+    expect(result).toMatchObject({
+      summary: 'Opened PDF: output.pdf',
+      output: 'Opened PDF: output.pdf',
+    });
+    expect(openPdf).toHaveBeenCalledOnce();
+  });
+
+  it('rejects arbitrary absolute paths outside the allowed roots', async () => {
+    const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
+    setOpenPdfOpener(openPdf);
+    const tool = new OpenPdfTool();
+
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: createRuntimeHost(),
+        workingDirectory: '/workspace',
+      }),
+      () => tool.call({ path: '/run/paper.pdf' }),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      error: expect.stringContaining(
+        'Path must stay within the working directory',
+      ),
+    });
+    expect(openPdf).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-PDF files before invoking the host callback', async () => {
+    const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
+    setOpenPdfOpener(openPdf);
+    const tool = new OpenPdfTool();
+
+    const result = await tool.call({ path: 'paper.tex' });
+
+    expect(result).toMatchObject({
+      isError: true,
+      error: expect.stringContaining('open_pdf only opens PDF files'),
+    });
+    expect(openPdf).not.toHaveBeenCalled();
+  });
+});
+
+async function installPlatform(
+  platform: ReturnType<typeof createFakePlatform>,
+) {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(platform);
+}
+
+function createRuntimeHost(): AgentRuntimeHost {
+  return { emit: vi.fn() };
+}

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -1,0 +1,134 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - runtime
+import { tryUseRunContext } from '@agent/runtime/RunContext';
+
+// Type imports
+import type { FileLocation } from '@shared/schemas';
+
+// Local imports - tools
+import {
+  currentToolRoot,
+  resolveWorkspaceRelativePath,
+} from '@tools/pathResolution';
+import { ToolError, type ToolResult } from '@tools/result';
+
+// Local imports - utilities
+import {
+  AbsoluteFS,
+  createRunStorageLocation,
+  getRunDir,
+  pathToLocation,
+} from '@utils/files';
+
+// Local file imports
+import { defineTool } from './core/define';
+
+export interface OpenPdfRequest {
+  readonly location: FileLocation;
+  readonly preserveFocus: boolean;
+}
+
+export type OpenPdfOpener = (request: OpenPdfRequest) => Promise<void> | void;
+
+let openPdfOpener: OpenPdfOpener | undefined;
+
+/** Register the host-specific PDF opener. Leave unset in non-UI hosts. */
+export function setOpenPdfOpener(opener: OpenPdfOpener | undefined): void {
+  openPdfOpener = opener;
+}
+
+const OpenPdfInputSchema = z.strictObject({
+  path: z.string().describe('Path to the PDF file to open.'),
+  preserve_focus: z
+    .boolean()
+    .nullish()
+    .describe('Whether the editor should preserve focus after opening.'),
+});
+
+export type OpenPdfInput = z.infer<typeof OpenPdfInputSchema>;
+
+export class OpenPdfTool extends defineTool({
+  name: 'open_pdf',
+  description:
+    'Open a PDF file in the host PDF viewer. The tool accepts workspace-relative paths, working-directory-relative paths, and absolute run-storage paths.',
+  schema: OpenPdfInputSchema,
+}) {
+  protected async execute(input: OpenPdfInput): Promise<ToolResult> {
+    if (!openPdfOpener) {
+      return {
+        isError: true,
+        error:
+          'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
+      };
+    }
+
+    const location = resolvePdfLocation(input.path);
+    const displayPath = displayPdfLocation(location);
+
+    if (path.extname(location.absolutePath).toLowerCase() !== '.pdf') {
+      throw new ToolError(`open_pdf only opens PDF files: ${displayPath}`);
+    }
+    if (!(await AbsoluteFS.isFile(location.absolutePath))) {
+      throw new ToolError(`PDF file not found: ${displayPath}`);
+    }
+
+    await openPdfOpener({
+      location,
+      preserveFocus: input.preserve_focus ?? false,
+    });
+
+    return {
+      summary: `Opened PDF: ${displayPath}`,
+      output: `Opened PDF: ${displayPath}`,
+    };
+  }
+}
+
+function resolvePdfLocation(rawPath: string): FileLocation {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    throw new ToolError('path is required.');
+  }
+
+  const runStorageLocation = resolveRunStorageLocation(trimmed);
+  if (runStorageLocation) {
+    return runStorageLocation;
+  }
+
+  const root = currentToolRoot();
+  const resolved = resolveWorkspaceRelativePath(trimmed, root);
+  return pathToLocation(resolved.absolute);
+}
+
+function resolveRunStorageLocation(rawPath: string): FileLocation | undefined {
+  if (!path.isAbsolute(rawPath)) return undefined;
+
+  const executionId = tryUseRunContext()?.executionId;
+  if (!executionId) return undefined;
+
+  const runDirectory = getRunDir(executionId);
+  const relativePath = path
+    .relative(runDirectory, rawPath)
+    .replaceAll('\\', '/');
+  if (
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath) ||
+    relativePath === ''
+  ) {
+    return undefined;
+  }
+
+  return createRunStorageLocation(rawPath, relativePath, executionId);
+}
+
+function displayPdfLocation(location: FileLocation): string {
+  if (location.kind === 'workspace' || location.kind === 'runStorage') {
+    return location.relativePath;
+  }
+  return location.absolutePath;
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -35,6 +35,7 @@ import { PlanTool } from './plan/PlanTool';
 import { TodoWriteTool } from './todo/TodoTool';
 import { MemoryTool } from './memory/MemoryTool';
 import { OdysseyTool } from './odyssey';
+import { OpenPdfTool } from './OpenPdfTool';
 import {
   ZoteroAddTool,
   ZoteroCollectionsTool,
@@ -114,6 +115,7 @@ function createDefaultTools() {
     plan: new PlanTool(),
     memory: new MemoryTool(),
     odyssey: new OdysseyTool(),
+    open_pdf: new OpenPdfTool(),
     lean_diagnostics: new LeanDiagnosticsTool(),
     lean_file: new LeanFileTool(),
     lean_project: new LeanProjectTool(),


### PR DESCRIPTION
## Summary

- Add a host-neutral open_pdf tool for #3234 Phase 5.
- Resolve workspace-relative, working-directory-relative, and absolute run-storage PDF paths.
- Register the VS Code extension opener callback at activation using vscode.open.
- Keep non-UI hosts structured: the tool reports that PDF opening is unavailable instead of importing VS Code.

## Notes

This implements the tool substrate only. It does not expose open_pdf to latexFixer; PRD section 10 recommends keeping PDF opening orchestrator-driven until there is a clear use case.

Refs #3234.

## Verification

- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/OpenPdfTool.vitest.ts
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors, existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new tool that opens local files via a host callback and adds new path-resolution logic (including absolute run-storage handling), which could impact safety/UX if validation is wrong.
> 
> **Overview**
> Adds a new host-neutral `open_pdf` tool that resolves workspace/working-directory relative paths and (when in an active run) allows absolute paths under the run’s storage directory, then validates the target is an existing `.pdf` before invoking a host-provided opener.
> 
> Wires the VS Code extension to register the opener on activation via `vscode.open` (beside the current editor, optional focus preservation), registers `open_pdf` in the default tool registry, and adds Vitest coverage for availability, path-allowlisting, and file-type checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d139f07968fe52ed6173b2ac4e302fba426f7dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->