### PR TITLE
fix(cli): keep finalized turns in scrollback

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -11,19 +11,12 @@
 
 import { Box, Static, Text } from 'ink';
 
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
-
 import { Markdown } from '../render/Markdown';
 import { cliState, type ConversationEntry } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import { splitTranscriptEntries } from './transcriptEntries';
 
-function isAppending(status: StreamStatus | undefined): boolean {
-  return (
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING
-  );
-}
+export { splitTranscriptEntries } from './transcriptEntries';
 
 function TranscriptEntry({
   entry,
@@ -71,30 +64,6 @@ function LiveTranscriptEntry({
 
 export interface ConversationPaneProps {
   readonly width?: number;
-}
-
-export function splitTranscriptEntries(
-  entries: readonly ConversationEntry[],
-  status: StreamStatus | undefined,
-): {
-  readonly finalized: ConversationEntry[];
-  readonly live: ConversationEntry | undefined;
-} {
-  const streamIsAppending = isAppending(status);
-  let live: ConversationEntry | undefined;
-  if (streamIsAppending) {
-    for (let index = entries.length - 1; index >= 0; index -= 1) {
-      const entry = entries[index];
-      if (entry.role !== 'assistant' || entry.finalized) continue;
-      live = entry;
-      break;
-    }
-  }
-  const finalized = entries
-    .filter((entry) => entry !== live)
-    .map((entry) => ({ ...entry, finalized: true }));
-
-  return { finalized, live };
 }
 
 export function ConversationPane(

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,0 +1,37 @@
+import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+
+import type { ConversationEntry } from '../state/cliState';
+
+function isAppending(status: StreamStatus | undefined): boolean {
+  return (
+    status === STREAM_STATUS.INITIALIZING ||
+    status === STREAM_STATUS.RUNNING ||
+    status === STREAM_STATUS.RESUMING
+  );
+}
+
+function findLiveAssistantEntry(
+  entries: readonly ConversationEntry[],
+): ConversationEntry | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.role !== 'assistant' || entry.finalized) continue;
+    return entry;
+  }
+  return undefined;
+}
+
+export function splitTranscriptEntries(
+  entries: readonly ConversationEntry[],
+  status: StreamStatus | undefined,
+): {
+  readonly finalized: ConversationEntry[];
+  readonly live: ConversationEntry | undefined;
+} {
+  const live = isAppending(status)
+    ? findLiveAssistantEntry(entries)
+    : undefined;
+  const finalized = entries.filter((entry) => entry.finalized);
+
+  return { finalized, live };
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,13 +1,24 @@
 // Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
 
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 
 import { patchStream } from './cliState';
 import { syncStreamLog } from './subscribeStreamLog';
+import { finalizeAssistantTranscriptEntries } from './transcript';
+
+const FINAL_TRANSCRIPT_STATUSES: ReadonlySet<StreamStatus> = new Set([
+  STREAM_STATUS.ERROR,
+  STREAM_STATUS.STOPPED,
+  STREAM_STATUS.WAITING,
+]);
 
 export function subscribeStreamStatus(): () => void {
   return StreamStatusService.onDidChange((change) => {
     syncStreamLog(change.streamId);
+    if (FINAL_TRANSCRIPT_STATUSES.has(change.status)) {
+      finalizeAssistantTranscriptEntries(change.streamId);
+    }
     patchStream(change.streamId, (slice) => ({
       ...slice,
       status: change.status,

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -91,6 +91,20 @@ export function moveLocalTranscriptToStream(streamId: StreamTabId): void {
   removeStream(CLI_LOCAL_STREAM_ID);
 }
 
+export function finalizeAssistantTranscriptEntries(
+  streamId: StreamTabId,
+): void {
+  patchStream(streamId, (slice) => {
+    let changed = false;
+    const entries = slice.entries.map((entry) => {
+      if (entry.role !== 'assistant' || entry.finalized) return entry;
+      changed = true;
+      return { ...entry, finalized: true };
+    });
+    return changed ? { ...slice, entries } : slice;
+  });
+}
+
 export function clearActiveTranscript(): void {
   const activeStreamId = cliState.activeStreamId.get();
   if (!activeStreamId) {

--- a/src/test-kernel/cli/ConversationPane.vitest.ts
+++ b/src/test-kernel/cli/ConversationPane.vitest.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+import { splitTranscriptEntries } from '../../../packages/cli/src/chat/tui/panes/transcriptEntries';
+import {
+  cliState,
+  patchStream,
+  resetCliState,
+  type ConversationEntry,
+} from '../../../packages/cli/src/chat/tui/state/cliState';
+import { finalizeAssistantTranscriptEntries } from '../../../packages/cli/src/chat/tui/state/transcript';
+
+const STREAM_ID = 'cli-test-stream' as StreamTabId;
+
+function entry(
+  id: string,
+  role: ConversationEntry['role'],
+  text: string,
+  finalized: boolean,
+): ConversationEntry {
+  return { id, role, text, finalized };
+}
+
+describe('CLI conversation transcript splitting', () => {
+  it('keeps only explicit finalized entries in scrollback', () => {
+    const user = entry('u1', 'user', '1+1', true);
+    const assistant = entry('a1', 'assistant', '2', false);
+
+    const running = splitTranscriptEntries(
+      [user, assistant],
+      STREAM_STATUS.RUNNING,
+    );
+    expect(running.finalized).toEqual([user]);
+    expect(running.live).toBe(assistant);
+
+    const waitingBeforeFinalize = splitTranscriptEntries(
+      [user, assistant],
+      STREAM_STATUS.WAITING,
+    );
+    expect(waitingBeforeFinalize.finalized).toEqual([user]);
+    expect(waitingBeforeFinalize.live).toBeUndefined();
+  });
+
+  it('freezes assistant entries before they enter static scrollback', () => {
+    resetCliState();
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      entries: [
+        entry('u1', 'user', 'What is a tensor network?', true),
+        entry('a1', 'assistant', 'A structured decomposition.', false),
+      ],
+    }));
+
+    finalizeAssistantTranscriptEntries(STREAM_ID);
+
+    const slice = cliState.streams.get().get(STREAM_ID);
+    expect(slice?.entries.map((item) => item.finalized)).toEqual([true, true]);
+    const split = splitTranscriptEntries(
+      slice?.entries ?? [],
+      STREAM_STATUS.WAITING,
+    );
+    expect(split.finalized.map((item) => item.id)).toEqual(['u1', 'a1']);
+    expect(split.live).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- freezes assistant transcript entries when a CLI stream reaches a final/waiting state
- keeps the Ink Static region driven by explicit finalized entries rather than recomputing finalized turns during render
- extracts transcript splitting into a pure helper and adds CLI transcript tests

## Verification
- ../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- ../../node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json
- ../../node_modules/.bin/tsc --noEmit
- ../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- ../../node_modules/.bin/tsc --noEmit -p packages/extension/tsconfig.json
- node scripts/build-bundle.mjs (from packages/cli)
- npm run lint (passes with 15 pre-existing warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CLI transcript entries are finalized and displayed based on stream status; low blast radius but could regress scrollback/live rendering around status transitions.
> 
> **Overview**
> Fixes CLI transcript rendering so the Ink `Static` scrollback is driven only by entries explicitly marked `finalized`, avoiding re-computing/faking finalized turns during render.
> 
> Assistant entries are now *frozen* (marked `finalized`) when a stream transitions into terminal statuses (`WAITING`, `STOPPED`, `ERROR`) via `subscribeStreamStatus`, ensuring the last assistant turn moves from the live area into scrollback.
> 
> Extracts transcript splitting into a pure `splitTranscriptEntries` helper (`panes/transcriptEntries.ts`) and adds vitest coverage for the finalized/live split and the new finalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c6739127c3a34e21c4082cd198436788bd1c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->