### PR TITLE
fix(cli): surface tool-use cycle errors in chat transcript

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -56,7 +56,7 @@ function LiveTranscriptEntry({
   readonly entry: ConversationEntry;
 }): React.JSX.Element {
   return (
-    <Box marginBottom={1}>
+    <Box>
       <Text>{entry.text}</Text>
     </Box>
   );
@@ -82,7 +82,14 @@ export function ConversationPane(
           <TranscriptEntry key={entry.id} entry={entry} width={props.width} />
         )}
       </Static>
-      {live ? <LiveTranscriptEntry entry={live} /> : null}
+      {/* Reserve a single line for the live region even when nothing is
+        * streaming. Ink renders Static items into scrollback above the
+        * live area, so toggling live presence between renders made the
+        * input bar appear to "shift down" by a line. A stable footer
+        * keeps the layout pinned. */}
+      <Box minHeight={1}>
+        {live ? <LiveTranscriptEntry entry={live} /> : null}
+      </Box>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -83,10 +83,10 @@ export function ConversationPane(
         )}
       </Static>
       {/* Reserve a single line for the live region even when nothing is
-        * streaming. Ink renders Static items into scrollback above the
-        * live area, so toggling live presence between renders made the
-        * input bar appear to "shift down" by a line. A stable footer
-        * keeps the layout pinned. */}
+       * streaming. Ink renders Static items into scrollback above the
+       * live area, so toggling live presence between renders made the
+       * input bar appear to "shift down" by a line. A stable footer
+       * keeps the layout pinned. */}
       <Box minHeight={1}>
         {live ? <LiveTranscriptEntry entry={live} /> : null}
       </Box>

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -35,12 +35,13 @@ import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
 import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
-import { subscribeStreamLog } from './state/subscribeStreamLog';
+import { subscribeStreamLog, syncStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
+  appendLocalErrorTranscript,
   clearActiveTranscript,
   moveLocalTranscriptToStream,
 } from './state/transcript';
@@ -282,6 +283,11 @@ export async function runChat(
         } else {
           session.runExitCode = CliExitCode.AgentError;
         }
+        // Pull any final MODEL_RESPONSE chunks out of the AgentLogger
+        // buffer before falling back to `result.lastResponse`. Without
+        // this, a reply that finalized between sync ticks would never
+        // hit the transcript.
+        if (result.streamId) syncStreamLog(result.streamId);
         if (result.category === AgentCategory.ToolUse) {
           appendAssistantTranscriptIfMissing(
             result.streamId,
@@ -293,7 +299,10 @@ export async function runChat(
       })
       .catch((error: unknown) => {
         if (!session.stopRequested) {
-          writeTextStderr(toErrorMessage(error));
+          // Ink owns stdout while the TUI is mounted, so writing to
+          // stderr disappears under the alternate screen. Surface the
+          // failure inline so the user sees why the agent stopped.
+          appendLocalErrorTranscript(toErrorMessage(error));
         }
         session.runExitCode = session.stopRequested
           ? CliExitCode.Success

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -17,7 +17,11 @@ const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.USER_MESSAGE,
 ]);
 
-const STREAM_SYNC_THROTTLE_MS = 200;
+// Coalesce bursts into a single render without visibly delaying the
+// first paint. 200ms looks like a hang on short replies (an entire reply
+// can land before the first sync fires); one animation frame is enough
+// to batch chunks and keeps the transcript feeling live.
+const STREAM_SYNC_THROTTLE_MS = 16;
 
 type TranscriptCandidate = {
   readonly rendered: ConversationEntry;
@@ -46,6 +50,12 @@ export function subscribeStreamLog(): () => void {
 }
 
 export function syncStreamLog(streamId: StreamTabId): void {
+  // AgentLogger throttles MODEL_RESPONSE chunks into the store via a 50ms
+  // timer. If we read before that timer fires (e.g. the stream finalized
+  // between two TUI sync ticks), the assistant text is still sitting in
+  // an in-memory buffer and never reaches the transcript. Force any
+  // pending flushers to materialize before we read.
+  AgentLogger.flushPendingStreamUpdates();
   const store = AgentLogger.getStreamLogStore();
   const log = store.get(streamId);
   if (!log) return;

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -53,6 +53,17 @@ export function appendAssistantTranscriptIfMissing(
 }
 
 export function appendLocalAssistantTranscript(text: string): void {
+  appendLocalTranscriptEntry('assistant', text);
+}
+
+export function appendLocalErrorTranscript(text: string): void {
+  appendLocalTranscriptEntry('error', text);
+}
+
+function appendLocalTranscriptEntry(
+  role: 'assistant' | 'error',
+  text: string,
+): void {
   const normalized = normalizeTranscriptText(text);
   if (!normalized) return;
 
@@ -64,7 +75,7 @@ export function appendLocalAssistantTranscript(text: string): void {
   patchStream(streamId, (slice) => {
     const entry: ConversationEntry = {
       id: `local:${localEntrySeq++}:${streamId}:${slice.entries.length}`,
-      role: 'assistant',
+      role,
       text: normalized,
       finalized: true,
       synthetic: true,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -7,6 +7,7 @@ import {
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { formatProviderHttpError } from '@common/errors';
+import { MESSAGE_TYPES } from '@shared/schemas';
 
 import {
   type ToolUseRunShared,
@@ -179,6 +180,13 @@ export class ToolUseCycleNode<C> extends Node<
           message: execRes.message,
           userRetryable: execRes.userRetryable ?? false,
         };
+        // Surface the failure in the transcript. Without this the WaitNode
+        // resets lastError when the user sends a follow-up (see
+        // ToolUseWaitNode.post), so a recurring failure (e.g. missing API
+        // key) leaves the agent stuck in "idle" with no visible reason.
+        this.services.logger.error(execRes.message, {
+          messageType: MESSAGE_TYPES.ERROR,
+        });
         break;
       case 'cancelled':
         shared.userCancelledRetry = true;

--- a/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
@@ -3,10 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUseCycleNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseCycleNode';
-import type { CyclePrepResult } from '@agent/implementations/flows/tooluse/nodes/types';
+import type {
+  CyclePrepResult,
+  ToolUseRunShared,
+} from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import type { Plan, TodoItem } from '@shared/schemas';
+import { MESSAGE_TYPES, type Plan, type TodoItem } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
 const todo: TodoItem = {
@@ -74,5 +78,30 @@ describe('tool-use progress events', () => {
         },
       },
     ]);
+  });
+
+  it('logs failed cycle outcomes as transcript errors', async () => {
+    const workspaceState = AgentWorkspaceState.create();
+    const prepRes = createPrepResult(workspaceState);
+    const shared: Partial<ToolUseRunShared> = {};
+    const error = vi.fn();
+    const node = new ToolUseCycleNode().setServices({
+      logger: { error },
+    } as unknown as ToolUseServices);
+
+    const transition = await node.post(shared as ToolUseRunShared, prepRes, {
+      outcome: 'failed',
+      message: 'Model claude-opus-4-7 not found',
+      userRetryable: false,
+    });
+
+    expect(transition).toBe(FlowTransition.DEFAULT);
+    expect(shared.lastError).toEqual({
+      message: 'Model claude-opus-4-7 not found',
+      userRetryable: false,
+    });
+    expect(error).toHaveBeenCalledWith('Model claude-opus-4-7 not found', {
+      messageType: MESSAGE_TYPES.ERROR,
+    });
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -27,6 +27,7 @@ import { splitTranscriptEntries } from '../../../packages/cli/src/chat/tui/panes
 import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
+  appendLocalErrorTranscript,
   CLI_LOCAL_STREAM_ID,
   clearActiveTranscript,
   getTranscriptStartSeq,
@@ -176,6 +177,43 @@ describe('CLI transcript state', () => {
       'Available commands: /help',
       'Available commands: /help',
     ]);
+  });
+
+  it('adds local runtime errors to the transcript', () => {
+    cliState.activeStreamId.set(root);
+
+    appendLocalErrorTranscript('Model claude-opus-4-7 not found');
+
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'error',
+      text: 'Model claude-opus-4-7 not found',
+      finalized: true,
+      synthetic: true,
+      syntheticKind: 'local',
+    });
+  });
+
+  it('flushes pending model-response chunks before transcript sync', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      const stream = logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE);
+      stream.append('A short final answer.');
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'A short final answer.',
+      ]);
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
   });
 
   it('keeps repeated local slash-command responses after stream-log syncs', () => {


### PR DESCRIPTION
## Summary

The CLI chat TUI showed the user's prompts but neither model responses nor any error feedback, leaving the agent stuck in `idle` with an empty transcript. Two root causes plus three adjacent fixes:

**Root cause** — `ToolUseCycleNode.post` stored cycle failures in `shared.lastError` but never logged them. `ToolUseWaitNode.post` then cleared `lastError` when the user sent a follow-up, so a recurring failure (missing API key, auth error, etc.) was silently invisible. Fixed by writing the failure message into the StreamLogStore as a `MESSAGE_TYPES.ERROR` entry — the TUI already renders ERROR entries as red lines via the existing `TranscriptEntry` path.

**Adjacent fixes** uncovered while diagnosing:

- `subscribeStreamLog`: sync throttle dropped 200ms → 16ms, and `AgentLogger.flushPendingStreamUpdates()` is now called before reading the store. Short replies that finalized between sync ticks could otherwise stay buffered in AgentLogger's 50ms throttle and never reach the transcript.
- `runChatTui`: agent errors routed through `appendLocalErrorTranscript` instead of `writeTextStderr` (Ink owns stdout/stderr while mounted, so stderr writes are invisible). Force a `syncStreamLog(streamId)` after `executeAgent` resolves so the final assistant chunk lands before the `appendAssistantTranscriptIfMissing` fallback runs.
- `transcript`: factored shared `appendLocalTranscriptEntry` helper, added `appendLocalErrorTranscript`.
- `ConversationPane`: wrap the live region in `<Box minHeight={1}>` so toggling live presence between renders no longer shifts the input bar down by a row.

## Test plan

- [x] Build clean (`pnpm --filter @texra/cli build`)
- [x] `texra chat --model=<model>` with no API key configured → red error line appears in the transcript instead of silent idle.
- [x] `texra chat --model=<model>` with valid auth → model response renders, no layout shift on first/last token.
- [x] User submits a second prompt after a cycle failure → both prompts and the error remain visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CLI TUI transcript plumbing and stream-log syncing; while behavior is well-scoped, timing/throttling changes and forced flushes could affect ordering or duplication of transcript entries.
> 
> **Overview**
> Fixes missing/hidden feedback in `texra chat` by ensuring **tool-use cycle failures are logged as `MESSAGE_TYPES.ERROR`** and therefore rendered in the TUI transcript.
> 
> Improves transcript reliability by **syncing any buffered model-response chunks on agent completion** (`syncStreamLog` now forces `AgentLogger.flushPendingStreamUpdates()`), lowering stream-log sync throttling to ~1 frame, and routing uncaught runtime errors into the transcript via `appendLocalErrorTranscript` instead of `stderr`.
> 
> Stabilizes the conversation layout by reserving a persistent one-line live region (`minHeight={1}`) to prevent the input bar from shifting when streaming starts/stops, and adds/updates tests covering the new error logging and flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161699e775ba8a5a00d7fded6802e970e92c52b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->