### PR TITLE
fix(latex): keep latexdiff artifacts in run storage

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -570,15 +570,6 @@ export class FileList extends LitElement {
         file: filePath,
         base: basePath,
       })}
-      ${renderFileActionButton({
-        icon: 'diff-single',
-        label: 'LaTeXdiff',
-        title: 'LaTeXdiff',
-        className: 'diff-btn',
-        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
-        file: filePath,
-        base: basePath,
-      })}
     `;
   }
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -17,6 +17,7 @@ import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_RANGES,
 } from '@shared/constants/latex';
+import type { ExecutionId } from '@shared/schemas';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -29,6 +30,12 @@ import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
 
 import type { RoundFileMapping } from './types';
+
+interface DiffOutputDirectory {
+  absolutePath: string;
+  relativePath: string;
+  executionId: ExecutionId;
+}
 
 export class LatexDiffManager {
   private readonly latexdiffService: LaTeXdiffService;
@@ -135,6 +142,8 @@ export class LatexDiffManager {
     // Ensure round-dir has symlinks to all mirrored deps so latexdiff's
     // relative \input{} resolution works when its cwd is runDir/r{round}.
     await this.fileService.ensureMirroredInRoundDir(currRound);
+    await this.fileService.ensureMirroredInDiffRoundDir(currRound);
+    const diffDirectory = this.getDiffOutputDirectory(currRound);
 
     const outputByPath = new Map(
       outputFiles.map((f) => [getComparablePath(f.location), f]),
@@ -166,9 +175,10 @@ export class LatexDiffManager {
               revised,
               currRound,
               undefined,
-              { cwd },
+              { cwd, outputDirectory: diffDirectory?.absolutePath },
             ),
           label: 'round-diff',
+          diffDirectory,
         });
         if (result) aggregated.push(result);
       }
@@ -201,9 +211,11 @@ export class LatexDiffManager {
               undefined,
               {
                 cwd,
+                outputDirectory: diffDirectory?.absolutePath,
               },
             ),
           label: 'between-rounds-diff',
+          diffDirectory,
         });
         if (result) aggregated.push(result);
       }
@@ -250,6 +262,7 @@ export class LatexDiffManager {
       cwd: string,
     ) => Promise<LaTeXdiffResult>;
     label: string;
+    diffDirectory: DiffOutputDirectory | null;
   }): Promise<DiffResult | null> {
     const {
       outputPath,
@@ -259,6 +272,7 @@ export class LatexDiffManager {
       baseRound,
       runDiff,
       label,
+      diffDirectory,
     } = params;
 
     const revisedFile = outputByPath.get(outputPath);
@@ -279,6 +293,7 @@ export class LatexDiffManager {
     const diffLocation = await this.compileDiffIfSuccessful(
       result,
       baseLocation,
+      diffDirectory,
     );
 
     const revisedWithLineage: OutputFileInfo = {
@@ -303,19 +318,16 @@ export class LatexDiffManager {
   private async compileDiffIfSuccessful(
     result: LaTeXdiffResult,
     referenceLocation: FileLocation,
+    diffDirectory: DiffOutputDirectory | null,
   ): Promise<FileLocation | null> {
     if (!result.success || !result.diffFileName) {
       return null;
     }
 
-    // LaTeXdiffService writes the diff next to the reference's absolutePath.
-    // We must therefore describe the diff with a FileLocation of the same
-    // kind as `referenceLocation`, otherwise rewrite runs (base = workspace
-    // original) would try to compile a diff that lives in run storage — a
-    // file that was never written there.
-    const diffLocation = this.buildSiblingDiffLocation(
+    const diffLocation = this.buildDiffLocation(
       referenceLocation,
       result.diffFileName,
+      diffDirectory,
     );
 
     const buildDir = path.join(
@@ -341,16 +353,25 @@ export class LatexDiffManager {
   }
 
   /**
-   * Describe the diff file that LaTeXdiffService wrote next to
-   * `reference.absolutePath`. The returned FileLocation must share the
-   * reference's kind — otherwise rewrite runs (base = workspace original)
-   * would try to compile a diff that lives in run storage while the file
-   * was actually written into the workspace.
+   * Describe the diff file that LaTeXdiffService wrote. Workflow runs pass a
+   * run-storage output directory so the generated `.tex` and build artifacts
+   * stay out of the user's workspace. Older callers that do not have run
+   * storage keep the historical sibling placement.
    */
-  private buildSiblingDiffLocation(
+  private buildDiffLocation(
     reference: FileLocation,
     diffFileName: string,
+    diffDirectory: DiffOutputDirectory | null,
   ): FileLocation {
+    if (diffDirectory) {
+      const absolutePath = path.join(diffDirectory.absolutePath, diffFileName);
+      return createRunStorageLocation(
+        absolutePath,
+        path.join(diffDirectory.relativePath, diffFileName),
+        diffDirectory.executionId,
+      );
+    }
+
     const siblingAbsolute = path.join(
       path.dirname(reference.absolutePath),
       diffFileName,
@@ -371,5 +392,19 @@ export class LatexDiffManager {
       );
     }
     return createExternalLocation(siblingAbsolute);
+  }
+
+  private getDiffOutputDirectory(round: number): DiffOutputDirectory | null {
+    const { executionId, runDirectory } = this.fileService.metadata;
+    if (!executionId || !runDirectory) {
+      return null;
+    }
+
+    const relativePath = path.join('diff', `r${round}`);
+    return {
+      absolutePath: path.join(runDirectory, relativePath),
+      relativePath,
+      executionId,
+    };
   }
 }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -90,7 +90,7 @@ export class LaTeXdiffService {
     suffix = '_diff',
     runIndent = true,
     mathMarkup?: MathMarkupOption,
-    options?: { cwd?: string; subtype?: string },
+    options?: { cwd?: string; subtype?: string; outputDirectory?: string },
   ): Promise<LaTeXdiffResult> {
     try {
       const inputFile = inputLocation.absolutePath;
@@ -122,7 +122,9 @@ export class LaTeXdiffService {
       }
 
       const diffFileName = generateDiffFileName(inputFile, editedFile, suffix);
-      const outputPath = path.join(path.dirname(inputFile), diffFileName);
+      const outputDirectory =
+        options?.outputDirectory ?? path.dirname(inputFile);
+      const outputPath = path.join(outputDirectory, diffFileName);
 
       logger.debug(
         this.channel,
@@ -145,6 +147,7 @@ export class LaTeXdiffService {
       }
 
       // Write and process output
+      await flexibleFS.ensureDir(pathToLocation(outputDirectory));
       const outputLocation = pathToLocation(outputPath);
       await flexibleFS.write(outputLocation, result.stdout);
       await this.fileProcessor.processDiffFile(outputLocation);
@@ -287,7 +290,7 @@ export class LaTeXdiffService {
     outputLocation: FileLocation,
     round: number,
     mathMarkup?: MathMarkupOption,
-    options?: { cwd?: string },
+    options?: { cwd?: string; outputDirectory?: string },
   ): Promise<LaTeXdiffResult> {
     try {
       const [baseExists, outputExists] = await Promise.all([
@@ -318,7 +321,7 @@ export class LaTeXdiffService {
     firstLocation: FileLocation,
     secondLocation: FileLocation,
     mathMarkup?: MathMarkupOption,
-    options?: { cwd?: string },
+    options?: { cwd?: string; outputDirectory?: string },
   ): Promise<LaTeXdiffResult> {
     try {
       const [firstExists, secondExists] = await Promise.all([

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -1,0 +1,148 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMemoryStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { createWorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  createExternalLocation,
+  createWorkspaceLocation,
+  getRunDir,
+  TaskRunFileService,
+} from '@utils/files';
+
+const mocks = vi.hoisted(() => ({
+  executeCommand: vi.fn(),
+}));
+
+vi.mock('@utils/system', () => ({
+  executeCommand: mocks.executeCommand,
+}));
+
+vi.mock('@agent/core/stateStore', () => ({
+  getWorkspaceState: () => ({
+    get: <T>(_key: unknown, fallback: T) => fallback,
+  }),
+  tryGetWorkspaceState: () => ({
+    get: <T>(_key: unknown, fallback: T) => fallback,
+  }),
+}));
+
+vi.mock('@agent/core/config', () => ({
+  getConfig: <T>(_key: string, fallback: T) => fallback,
+}));
+
+describe('LaTeXdiffService shadow output', () => {
+  const tempDirs: string[] = [];
+
+  async function makeTempDir(prefix: string): Promise<string> {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  async function installNodeBackedPlatform(
+    workspaceDir: string,
+    storageRoot: string,
+  ): Promise<void> {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {
+          workspacePath: workspaceDir,
+        },
+        {
+          fs: nodeFilesystem,
+          workspace: createNodeWorkspace(() => workspaceDir),
+          storage: createWorkspaceStorageProvider(storageRoot, workspaceDir),
+          globalState: createMemoryStore(),
+          workspaceState: createMemoryStore(),
+        },
+      ),
+    );
+  }
+
+  beforeEach(() => {
+    mocks.executeCommand.mockResolvedValue({
+      success: true,
+      stdout:
+        '\\documentclass{article}\n\\begin{document}\nchanged\n\\end{document}\n',
+      stderr: '',
+    });
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('writes generated diff sources to the requested output directory', async () => {
+    const { LaTeXdiffService } = await import('@latex/latexdiff');
+    const tempDir = await makeTempDir('texra-latexdiff-');
+    const sourceDir = path.join(tempDir, 'workspace');
+    const shadowDir = path.join(tempDir, 'executions', 'run-1', 'diff', 'r1');
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      path.join(sourceDir, 'base.tex'),
+      '\\documentclass{article}\n\\begin{document}\nold\n\\end{document}\n',
+    );
+    await writeFile(
+      path.join(sourceDir, 'revised.tex'),
+      '\\documentclass{article}\n\\begin{document}\nnew\n\\end{document}\n',
+    );
+    await installNodeBackedPlatform(sourceDir, path.join(tempDir, 'storage'));
+
+    const service = new LaTeXdiffService('test');
+    const result = await service.runDiff(
+      createExternalLocation(path.join(sourceDir, 'base.tex')),
+      createExternalLocation(path.join(sourceDir, 'revised.tex')),
+      '_diff',
+      false,
+      undefined,
+      { outputDirectory: shadowDir },
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(result.diffFileName).toBe('revised_diff.tex');
+    await expect(
+      readFile(path.join(shadowDir, 'revised_diff.tex'), 'utf8'),
+    ).resolves.toContain('changed');
+    await expect(
+      readFile(path.join(sourceDir, 'revised_diff.tex'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('mirrors workspace dependencies into diff round storage', async () => {
+    const tempDir = await makeTempDir('texra-diff-mirror-');
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const storageRoot = path.join(tempDir, 'storage');
+    const dependencyPath = path.join(workspaceDir, 'refs', 'macros.sty');
+    await mkdir(path.dirname(dependencyPath), { recursive: true });
+    await writeFile(dependencyPath, '\\newcommand{\\RR}{\\mathbb{R}}\n');
+
+    await installNodeBackedPlatform(workspaceDir, storageRoot);
+
+    const fileService = new TaskRunFileService('run-1');
+    await fileService.mirrorWorkspaceFile(
+      createWorkspaceLocation(dependencyPath, 'refs/macros.sty'),
+    );
+
+    await fileService.ensureMirroredInDiffRoundDir(2);
+
+    await expect(
+      readFile(
+        path.join(getRunDir('run-1'), 'diff', 'r2', 'refs', 'macros.sty'),
+        'utf8',
+      ),
+    ).resolves.toBe('\\newcommand{\\RR}{\\mathbb{R}}\n');
+  });
+});

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -451,12 +451,32 @@ export class TaskRunFileService {
    *     revised content.
    */
   public async ensureMirroredInRoundDir(round: number): Promise<void> {
+    await this.ensureMirroredInRunSubdir(`r${round}`, {
+      protectPrimaryOutput: true,
+    });
+  }
+
+  /**
+   * Ensure mirrored workspace dependencies are also reachable from
+   * `<runDir>/diff/r{round}/...`, where workflow latexdiff sources and build
+   * artifacts live.
+   */
+  public async ensureMirroredInDiffRoundDir(round: number): Promise<void> {
+    await this.ensureMirroredInRunSubdir(path.join('diff', `r${round}`), {
+      protectPrimaryOutput: false,
+    });
+  }
+
+  private async ensureMirroredInRunSubdir(
+    relativeDirectory: string,
+    options: { protectPrimaryOutput: boolean },
+  ): Promise<void> {
     const executionId = this.metadata.executionId;
     if (!executionId || this.mirroredDependencies.size === 0) {
       return;
     }
 
-    const roundSegment = `r${round}`;
+    const destinationSegment = relativeDirectory;
     const runDir = getRunDir(executionId);
 
     await Promise.all(
@@ -468,10 +488,14 @@ export class TaskRunFileService {
         // round's result. Skip these — the dependency is still reachable at
         // `r{round}/../<relativePath>`, i.e. `<runDir>/<relativePath>`.
         const { dir: depDir, name: depName } = path.parse(relativePath);
-        if (depDir === '' && depName === WORKFLOW_OUTPUT_BASENAME) {
+        if (
+          options.protectPrimaryOutput &&
+          depDir === '' &&
+          depName === WORKFLOW_OUTPUT_BASENAME
+        ) {
           logger.debug(
             CHANNEL,
-            `Skipping round-dir mirror of ${relativePath}: would clobber primary output in ${roundSegment}`,
+            `Skipping run-dir mirror of ${relativePath}: would clobber primary output in ${destinationSegment}`,
           );
           return;
         }
@@ -479,7 +503,7 @@ export class TaskRunFileService {
         const sourceAbsolute = path.join(runDir, relativePath);
         const destinationAbsolute = path.join(
           runDir,
-          roundSegment,
+          destinationSegment,
           relativePath,
         );
 
@@ -493,7 +517,7 @@ export class TaskRunFileService {
           if (!stat.isSymbolicLink()) {
             logger.debug(
               CHANNEL,
-              `Skipping round-dir mirror of ${relativePath}: destination in ${roundSegment} is an existing real file (likely an extracted output)`,
+              `Skipping run-dir mirror of ${relativePath}: destination in ${destinationSegment} is an existing real file`,
             );
             return;
           }
@@ -516,7 +540,7 @@ export class TaskRunFileService {
         } catch (error) {
           logger.debug(
             CHANNEL,
-            `Unable to mirror ${relativePath} into ${roundSegment}: ${toErrorMessage(error)}`,
+            `Unable to mirror ${relativePath} into ${destinationSegment}: ${toErrorMessage(error)}`,
           );
         }
       }),


### PR DESCRIPTION
## Summary

Refs #3234, Phase 2.

- write generated latexdiff source files into the task-run shadow directory at `<runDir>/diff/r<round>/...` instead of next to workspace sources
- compile generated diff PDFs from that shadow directory, so auxiliary build artifacts remain in run storage
- mirror workspace dependencies into each diff round directory so `\input`, `.sty`, `.cls`, and related paths still resolve
- remove the redundant row-level LaTeXdiff action from generated-file rows; the row keeps compare, accept, merge, and previous-round compare actions

## Validation

- `../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts src/test-kernel/latex/LatexdiffBibQuality.vitest.ts`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (passes with 18 existing warnings)
- direct extension compile-fast steps: `node scripts/clean-extension-dist.mjs`, `node esbuild.config.mjs`, and Vite builds for `progressView`, `settingsView`, and `webview`

Note: `npm run compile:fast` itself could not run in this linked worktree because pnpm attempted to purge the symlinked `node_modules` directory without a TTY. The underlying extension compile steps were run directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where LaTeX diff sources and PDFs are written and how dependencies are mirrored, which can break latexdiff/compile paths in workflow runs if directory metadata or symlinks are wrong.
> 
> **Overview**
> Moves workflow `latexdiff` output (generated `.tex` + compiled PDF build artifacts) into per-run shadow storage under `runDir/diff/r{round}` instead of writing next to workspace sources.
> 
> Plumbs an optional `outputDirectory` through `LaTeXdiffService` and `LatexDiffManager`, adds mirroring of workspace dependencies into the diff round directory, and adds test coverage for both behaviors.
> 
> Removes the per-file “LaTeXdiff” action button from the Progress View generated-files list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb3936878d66946fae2900f202754ac7ac6c6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->