### PR TITLE
fix(latex): surface compiled workflow PDFs

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -578,7 +578,7 @@ export class FileList extends LitElement {
     basePath: string,
     previousPath: string | undefined,
   ): TemplateResult | typeof nothing {
-    if (!previousPath) return nothing;
+    if (!previousPath || previousPath === basePath) return nothing;
 
     return renderFileActionButton({
       icon: 'diff-added',

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -830,6 +830,14 @@ export class LaTeXTab extends LitElement {
         min: LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min,
       })}
       ${this.renderBooleanSetting({
+        field: 'workflowAutoOpenPdf',
+        label: 'Open compiled PDF or log',
+        description:
+          'After auto-compile finishes, open the latest PDF on success or the truncated LaTeX log on failure.',
+        defaultValue: LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
+        currentValue: cv.workflowAutoOpenPdf,
+      })}
+      ${this.renderBooleanSetting({
         field: 'latexdiffBetweenRounds',
         label: 'Generate diffs between consecutive rounds',
         description:
@@ -886,6 +894,7 @@ export class LaTeXTab extends LitElement {
   private renderBooleanSetting(opts: {
     field:
       | 'workflowAutoCompile'
+      | 'workflowAutoOpenPdf'
       | 'latexdiffBetweenRounds'
       | 'latexdiffChangesOnly';
     label: string;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,5 +1,6 @@
 import { Node } from '@agent/node';
 import type { RoundFileMapping } from '@agent/output/types';
+import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import {
   hasCompileFailures,
@@ -18,8 +19,11 @@ import {
   type RoundSummary,
 } from '@agent/output/roundSummary';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { getWorkspaceState } from '@agent/core/stateStore';
 import { toErrorMessage } from '@common/errors';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type { CompileFailure, RoundOutput } from '@shared/schemas';
+import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import type { AgentFileLocation, FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 
@@ -39,6 +43,7 @@ interface OutputExecResult {
   roundOutput: RoundOutput;
   summary: RoundSummary;
   compileFailures: CompileFailure[];
+  compiledArtifacts: CompiledPdfArtifact[];
   emitCompileFailures: boolean;
 }
 
@@ -88,6 +93,7 @@ export class OutputNode<C = unknown> extends Node<
 
     let mapping: RoundFileMapping | undefined;
     let compileFailures: CompileFailure[] = [];
+    const compiledArtifacts: CompiledPdfArtifact[] = [];
     let emitCompileFailures = false;
 
     // Only process if turn ended (model completed response)
@@ -122,13 +128,15 @@ export class OutputNode<C = unknown> extends Node<
 
         await tryOperation(
           'Latexdiff',
-          () =>
-            this.handleLatexdiff(
+          async () => {
+            const diffArtifacts = await this.handleLatexdiff(
               currentRound,
               diffBaseFiles,
               mapping!,
               diffManager,
-            ),
+            );
+            compiledArtifacts.push(...diffArtifacts);
+          },
           logger,
         );
 
@@ -139,10 +147,12 @@ export class OutputNode<C = unknown> extends Node<
               outputState,
               currentRound,
             );
-            compileFailures = await runCompileCheck(
+            const compileResult = await runCompileCheck(
               this.services,
               currentRound,
             );
+            compileFailures = compileResult.failures;
+            compiledArtifacts.push(...compileResult.artifacts);
             setCompileFailures(outputState, currentRound, compileFailures);
             emitCompileFailures =
               compileFailures.length > 0 || hadCompileFailures;
@@ -174,7 +184,13 @@ export class OutputNode<C = unknown> extends Node<
       { isRewrite: setting.isRewrite },
     );
 
-    return { roundOutput, summary, compileFailures, emitCompileFailures };
+    return {
+      roundOutput,
+      summary,
+      compileFailures,
+      compiledArtifacts,
+      emitCompileFailures,
+    };
   }
 
   async execFallback(
@@ -221,6 +237,7 @@ export class OutputNode<C = unknown> extends Node<
       },
       summary,
       compileFailures: [],
+      compiledArtifacts: [],
       emitCompileFailures: false,
     };
   }
@@ -250,6 +267,24 @@ export class OutputNode<C = unknown> extends Node<
     // Open files that haven't been opened yet
     for (const location of summary.filesToOpen) {
       runtimeHost.emit('requestOpenFile', { location, preserveFocus: true });
+    }
+
+    if (endTurn && shouldAutoOpenPdfOrLog()) {
+      if (execRes.compileFailures.length > 0) {
+        for (const failure of execRes.compileFailures) {
+          runtimeHost.emit('requestOpenFile', {
+            location: failure.log,
+            preserveFocus: true,
+          });
+        }
+      } else {
+        for (const artifact of execRes.compiledArtifacts) {
+          runtimeHost.emit('requestOpenFile', {
+            location: artifact.latestPdf,
+            preserveFocus: true,
+          });
+        }
+      }
     }
 
     // Validate expected outputs if turn ended
@@ -292,17 +327,24 @@ export class OutputNode<C = unknown> extends Node<
     baseFiles: FileLocation[],
     mapping: RoundFileMapping,
     diffManager: LatexDiffManager,
-  ): Promise<void> {
+  ): Promise<CompiledPdfArtifact[]> {
     const { logger } = this.services;
 
     const existingBase = await Promise.all(
-      baseFiles.map((f) => flexibleFS.exists(f)),
+      baseFiles.map((base) => flexibleFS.exists(base)),
     );
     if (!existingBase.some(Boolean)) {
       logger.debug('No base files found for latexdiff');
-      return;
+      return [];
     }
 
-    await diffManager.handleLatexdiffofOutput(currentRound, mapping);
+    return diffManager.handleLatexdiffofOutput(currentRound, mapping);
   }
+}
+
+function shouldAutoOpenPdfOrLog(): boolean {
+  return getWorkspaceState().get<boolean>(
+    WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
+    LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
+  );
 }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -10,6 +10,7 @@ import { LaTeXdiffResult, LaTeXdiffService } from '@latex/latexdiff';
 import { AgentLogger, type AgentLogStage } from '@logger/AgentLogger';
 import {
   type DiffResult,
+  type ExecutionId,
   MESSAGE_TYPES,
   type OutputFileInfo,
 } from '@shared/schemas';
@@ -17,7 +18,6 @@ import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_RANGES,
 } from '@shared/constants/latex';
-import type { ExecutionId } from '@shared/schemas';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -29,6 +29,10 @@ import {
 import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
 
+import {
+  publishCompiledPdfArtifact,
+  type CompiledPdfArtifact,
+} from './compiledPdfArtifacts';
 import type { RoundFileMapping } from './types';
 
 interface DiffOutputDirectory {
@@ -108,27 +112,28 @@ export class LatexDiffManager {
     currRound: number,
     mapping: RoundFileMapping,
     stage?: AgentLogStage,
-  ): Promise<void> {
+  ): Promise<CompiledPdfArtifact[]> {
     const execute = () => this.performLatexdiffOperations(currRound, mapping);
     try {
-      await (stage ? stage.within(execute) : execute());
+      return await (stage ? stage.within(execute) : execute());
     } catch (err) {
       this.logger.error(
         `Error during latexdiff processing: ${toErrorMessage(err)}`,
         { messageType: MESSAGE_TYPES.INTERNAL },
       );
+      return [];
     }
   }
 
   private async performLatexdiffOperations(
     currRound: number,
     mapping: RoundFileMapping,
-  ): Promise<void> {
+  ): Promise<CompiledPdfArtifact[]> {
     if (!(await checkToolInstalled('latexdiff'))) {
       this.logger.warn(
         'Skipping latexdiff operations - latexdiff not installed',
       );
-      return;
+      return [];
     }
 
     const outputFiles = this.getOutputFiles()[currRound] ?? [];
@@ -136,7 +141,7 @@ export class LatexDiffManager {
       this.logger.warn(
         `No output files found for round ${currRound}, skipping latexdiff operations`,
       );
-      return;
+      return [];
     }
 
     // Ensure round-dir has symlinks to all mirrored deps so latexdiff's
@@ -157,6 +162,7 @@ export class LatexDiffManager {
     );
 
     const aggregated: DiffResult[] = [];
+    const artifacts: CompiledPdfArtifact[] = [];
 
     if (this.agentSetting.isRewrite) {
       const basePairs = [...mapping.baseToOutput.entries()];
@@ -178,9 +184,13 @@ export class LatexDiffManager {
               { cwd, outputDirectory: diffDirectory?.absolutePath },
             ),
           label: 'round-diff',
+          pdfStemSuffix: '-diff',
           diffDirectory,
         });
-        if (result) aggregated.push(result);
+        if (result) {
+          aggregated.push(result.diffResult);
+          if (result.artifact) artifacts.push(result.artifact);
+        }
       }
     }
 
@@ -215,9 +225,13 @@ export class LatexDiffManager {
               },
             ),
           label: 'between-rounds-diff',
+          pdfStemSuffix: '-round-diff',
           diffDirectory,
         });
-        if (result) aggregated.push(result);
+        if (result) {
+          aggregated.push(result.diffResult);
+          if (result.artifact) artifacts.push(result.artifact);
+        }
       }
     } else if (!generateBetweenRoundDiffs) {
       this.logger.debug(
@@ -230,6 +244,8 @@ export class LatexDiffManager {
     } else {
       this.logger.debug('No latexdiff results to report');
     }
+
+    return artifacts;
   }
 
   private logPairMatches(
@@ -262,8 +278,12 @@ export class LatexDiffManager {
       cwd: string,
     ) => Promise<LaTeXdiffResult>;
     label: string;
+    pdfStemSuffix: string;
     diffDirectory: DiffOutputDirectory | null;
-  }): Promise<DiffResult | null> {
+  }): Promise<{
+    diffResult: DiffResult;
+    artifact: CompiledPdfArtifact | null;
+  } | null> {
     const {
       outputPath,
       baseLocation,
@@ -272,6 +292,7 @@ export class LatexDiffManager {
       baseRound,
       runDiff,
       label,
+      pdfStemSuffix,
       diffDirectory,
     } = params;
 
@@ -290,11 +311,15 @@ export class LatexDiffManager {
     const result = await runDiff(baseLocation, revisedFile.location, cwd);
     this.logLatexdiffResult(result, label);
 
-    const diffLocation = await this.compileDiffIfSuccessful(
+    const compiled = await this.compileDiffIfSuccessful(
       result,
       baseLocation,
       diffDirectory,
+      revisedFile.round,
+      revisedFile.location,
+      pdfStemSuffix,
     );
+    const diffLocation = compiled?.diffLocation ?? null;
 
     const revisedWithLineage: OutputFileInfo = {
       ...revisedFile,
@@ -306,12 +331,15 @@ export class LatexDiffManager {
     };
 
     return {
-      baseLocation,
-      baseRound,
-      revised: revisedWithLineage,
-      diffLocation,
-      status: result.success ? 'success' : 'error',
-      message: result.success ? undefined : result.message,
+      diffResult: {
+        baseLocation,
+        baseRound,
+        revised: revisedWithLineage,
+        diffLocation,
+        status: result.success ? 'success' : 'error',
+        message: result.success ? undefined : result.message,
+      },
+      artifact: compiled?.artifact ?? null,
     };
   }
 
@@ -319,7 +347,13 @@ export class LatexDiffManager {
     result: LaTeXdiffResult,
     referenceLocation: FileLocation,
     diffDirectory: DiffOutputDirectory | null,
-  ): Promise<FileLocation | null> {
+    round: number,
+    sourceLocation: FileLocation,
+    pdfStemSuffix: string,
+  ): Promise<{
+    diffLocation: FileLocation;
+    artifact: CompiledPdfArtifact | null;
+  } | null> {
     if (!result.success || !result.diffFileName) {
       return null;
     }
@@ -343,13 +377,35 @@ export class LatexDiffManager {
         LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs,
       ),
     );
-    await compileLatex2Pdf(diffLocation, {
+    const ok = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,
       timeout: timeoutMs,
     });
 
-    return diffLocation;
+    if (!ok) {
+      return { diffLocation, artifact: null };
+    }
+
+    const { executionId, runDirectory } = this.fileService.metadata;
+    const compiledPdfPath = path.join(
+      buildDir,
+      `${path.basename(diffLocation.absolutePath).replace(/\.tex$/i, '')}.pdf`,
+    );
+    const artifact =
+      executionId && runDirectory
+        ? await publishCompiledPdfArtifact({
+            runDirectory,
+            executionId,
+            round,
+            displayName: path.basename(diffLocation.absolutePath),
+            source: sourceLocation,
+            compiledPdfPath,
+            pdfStemSuffix,
+          })
+        : null;
+
+    return { diffLocation, artifact };
   }
 
   /**

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -19,6 +19,10 @@ import {
   type TaskRunFileService,
 } from '@utils/files';
 
+import {
+  publishCompiledPdfArtifact,
+  type CompiledPdfArtifact,
+} from './compiledPdfArtifacts';
 import { getOutputFilesByRound, type OutputState } from './outputState';
 
 export interface CompileCheckContext {
@@ -30,6 +34,11 @@ export interface CompileCheckContext {
 
 const LOG_TAIL_LINES = 200;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
+
+export interface CompileCheckResult {
+  failures: CompileFailure[];
+  artifacts: CompiledPdfArtifact[];
+}
 
 /**
  * Return a human-readable display name for an output file in compile messages.
@@ -57,26 +66,26 @@ function getCompileDisplayName(file: OutputFileInfo): string {
 export async function runCompileCheck(
   ctx: CompileCheckContext,
   currentRound: number,
-): Promise<CompileFailure[]> {
+): Promise<CompileCheckResult> {
   if (
     !getWorkspaceState().get<boolean>(
       WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
       LATEX_CONFIG_DEFAULTS.workflowAutoCompile,
     )
   ) {
-    return [];
+    return { failures: [], artifacts: [] };
   }
 
   const runDirectory = ctx.fileService.metadata.runDirectory;
   if (!runDirectory) {
     ctx.logger.debug('Compile check skipped: no run directory');
-    return [];
+    return { failures: [], artifacts: [] };
   }
 
   const texOutputs = (
     getOutputFilesByRound(ctx.outputState)[currentRound] ?? []
   ).filter((f) => f.location.absolutePath.toLowerCase().endsWith('.tex'));
-  if (texOutputs.length === 0) return [];
+  if (texOutputs.length === 0) return { failures: [], artifacts: [] };
 
   // Skip gracefully when no LaTeX toolchain is installed so the run doesn't
   // leave stray `compile/<name>.log` artifacts that the orchestrator would
@@ -85,7 +94,7 @@ export async function runCompileCheck(
     ctx.logger.debug(
       'Compile check skipped: neither latexmk nor pdflatex is installed',
     );
-    return [];
+    return { failures: [], artifacts: [] };
   }
 
   const timeoutMs = Math.max(
@@ -100,11 +109,12 @@ export async function runCompileCheck(
   // the build succeeded.
   const compileRoot = path.join(runDirectory, 'compile');
   const failures: CompileFailure[] = [];
+  const artifacts: CompiledPdfArtifact[] = [];
 
   for (const outputFile of texOutputs) {
     const displayName = getCompileDisplayName(outputFile);
     try {
-      const failure = await compileOne(
+      const result = await compileOne(
         ctx,
         outputFile,
         currentRound,
@@ -115,7 +125,8 @@ export async function runCompileCheck(
           timeoutMs,
         },
       );
-      if (failure) failures.push(failure);
+      if (result.failure) failures.push(result.failure);
+      if (result.artifact) artifacts.push(result.artifact);
     } catch (err) {
       ctx.logger.warn(
         `Compile check: ${displayName} skipped — ${toErrorMessage(err)}`,
@@ -123,7 +134,7 @@ export async function runCompileCheck(
     }
   }
 
-  return failures;
+  return { failures, artifacts };
 }
 
 interface PerFileOptions {
@@ -138,7 +149,10 @@ async function compileOne(
   currentRound: number,
   displayName: string,
   opts: PerFileOptions,
-): Promise<CompileFailure | null> {
+): Promise<{
+  failure: CompileFailure | null;
+  artifact: CompiledPdfArtifact | null;
+}> {
   // compiledBasename is the actual on-disk filename LaTeX engines use when
   // naming their .log; it may differ from displayName when file.source is set.
   const compiledBasename = path.basename(outputFile.location.absolutePath);
@@ -174,7 +188,7 @@ async function compileOne(
     ctx.logger.debug(
       `Compile check: ${displayName} has no \\documentclass, skipping`,
     );
-    return null;
+    return { failure: null, artifact: null };
   }
 
   // execa's timeout option kills the child process on expiry, so we don't
@@ -187,7 +201,28 @@ async function compileOne(
 
   if (ok) {
     ctx.logger.debug(`Compile check: ${displayName} built successfully`);
-    return null;
+    const executionId = ctx.fileService.metadata.executionId;
+    const compiledPdfPath = path.join(
+      buildDir,
+      `${compiledBasename.replace(/\.tex$/i, '')}.pdf`,
+    );
+    const artifact = executionId
+      ? await publishCompiledPdfArtifact({
+          runDirectory: opts.runDirectory,
+          executionId,
+          round: currentRound,
+          displayName,
+          source: outputFile.location,
+          compiledPdfPath,
+        })
+      : null;
+
+    if (artifact) {
+      ctx.logger.debug(
+        `Compile check: ${displayName} PDF persisted at ${artifact.latestPdf.relativePath}`,
+      );
+    }
+    return { failure: null, artifact };
   }
 
   const tail = await readLogTail(buildDir, compiledBasename);
@@ -208,11 +243,14 @@ async function compileOne(
       )
     : logDest;
   return {
-    round: currentRound,
-    displayName,
-    output: outputFile.location,
-    log: logLocation,
-    logRelativePath,
+    failure: {
+      round: currentRound,
+      displayName,
+      output: outputFile.location,
+      log: logLocation,
+      logRelativePath,
+    },
+    artifact: null,
   };
 }
 

--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -1,0 +1,131 @@
+// Standard library imports
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+// Local imports - shared schemas
+import type { ExecutionId, FileLocation } from '@shared/schemas';
+
+// Local imports - file utilities
+import {
+  createRunStorageLocation,
+  getComparablePath,
+  type RunStorageFileLocation,
+} from '@utils/files';
+
+export interface CompiledPdfArtifact {
+  round: number;
+  displayName: string;
+  source: FileLocation;
+  pdf: RunStorageFileLocation;
+  latestPdf: RunStorageFileLocation;
+}
+
+export interface PublishCompiledPdfOptions {
+  runDirectory: string;
+  executionId: ExecutionId;
+  round: number;
+  displayName: string;
+  source: FileLocation;
+  compiledPdfPath: string;
+  pdfStemSuffix?: string;
+  outputPdfName?: string;
+}
+
+function normalizePdfRelativePath(pdfPath: string): string {
+  const parts = pdfPath
+    .replaceAll('\\', '/')
+    .split('/')
+    .filter((part) => part && part !== '.' && part !== '..');
+  const normalized = parts.length > 0 ? parts.join('/') : 'output.pdf';
+  return normalized.toLowerCase().endsWith('.pdf')
+    ? normalized
+    : `${normalized}.pdf`;
+}
+
+function stripRoundPrefix(relativePath: string, round: number): string {
+  const roundPrefix = `r${round}/`;
+  return relativePath.startsWith(roundPrefix)
+    ? relativePath.slice(roundPrefix.length)
+    : relativePath;
+}
+
+function toPdfRelativePath(options: PublishCompiledPdfOptions): string {
+  if (options.outputPdfName) {
+    return normalizePdfRelativePath(options.outputPdfName);
+  }
+
+  const comparablePath =
+    options.source.kind === 'external'
+      ? path.basename(options.displayName)
+      : stripRoundPrefix(getComparablePath(options.source), options.round);
+  const parsed = path.parse(comparablePath || options.displayName);
+  const stem = parsed.name || path.basename(options.displayName, parsed.ext);
+  const directory = parsed.dir;
+  const pdfStem = `${stem || 'output'}${options.pdfStemSuffix ?? ''}`;
+  return normalizePdfRelativePath(path.join(directory, `${pdfStem}.pdf`));
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function linkOrCopyFile(
+  source: string,
+  destination: string,
+): Promise<void> {
+  await ensureParentDir(destination);
+  await fs.rm(destination, { force: true, recursive: true });
+
+  try {
+    await fs.symlink(source, destination);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (
+      err.code &&
+      ['EPERM', 'EACCES', 'EINVAL', 'ENOTSUP'].includes(err.code)
+    ) {
+      await fs.copyFile(source, destination);
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function publishCompiledPdfArtifact(
+  options: PublishCompiledPdfOptions,
+): Promise<CompiledPdfArtifact | null> {
+  const stats = await fs.stat(options.compiledPdfPath).catch(() => null);
+  if (!stats?.isFile()) return null;
+
+  const pdfRelativePath = toPdfRelativePath(options);
+  const roundRelativePath = path.join(
+    'output',
+    `r${options.round}`,
+    pdfRelativePath,
+  );
+  const latestRelativePath = path.join('output', 'latest', pdfRelativePath);
+  const roundAbsolutePath = path.join(options.runDirectory, roundRelativePath);
+  const latestAbsolutePath = path.join(
+    options.runDirectory,
+    latestRelativePath,
+  );
+
+  await linkOrCopyFile(options.compiledPdfPath, roundAbsolutePath);
+  await linkOrCopyFile(roundAbsolutePath, latestAbsolutePath);
+
+  return {
+    round: options.round,
+    displayName: options.displayName,
+    source: options.source,
+    pdf: createRunStorageLocation(
+      roundAbsolutePath,
+      roundRelativePath,
+      options.executionId,
+    ),
+    latestPdf: createRunStorageLocation(
+      latestAbsolutePath,
+      latestRelativePath,
+      options.executionId,
+    ),
+  };
+}

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -60,6 +60,7 @@ export enum WorkspaceStateKey {
   // LaTeX/compile/diff settings (migrated from VS Code config)
   WORKFLOW_AUTO_COMPILE = 'texra.workflow.autoCompileAfterOutput',
   WORKFLOW_AUTO_COMPILE_TIMEOUT_MS = 'texra.workflow.autoCompileTimeoutMs',
+  WORKFLOW_AUTO_OPEN_PDF = 'texra.workflow.autoOpenPdf',
   LATEXDIFF_BETWEEN_ROUNDS = 'texra.latexdiff.generateBetweenRoundDiffs',
   LATEXDIFF_TIMEOUT_MS = 'texra.latexdiff.timeoutMs',
   LATEXDIFF_MATH_MARKUP = 'texra.latexdiff.mathMarkup',

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -110,7 +110,6 @@ export class ProgressWorkflowFileActionsController {
       return;
     }
 
-    await this.deps.host.latexdiffFile(previousFile, file);
     await this.deps.host.compareFiles(previousFile, file);
   }
 

--- a/src/shared/constants/latex.ts
+++ b/src/shared/constants/latex.ts
@@ -451,6 +451,7 @@ export type LatexFormatterValue = (typeof LATEX_FORMATTER_VALUES)[number];
 export const LATEX_CONFIG_DEFAULTS = {
   workflowAutoCompile: true,
   workflowAutoCompileTimeoutMs: 120000,
+  workflowAutoOpenPdf: true,
   latexdiffBetweenRounds: false,
   latexdiffTimeoutMs: 10000,
   latexdiffMathMarkup: 'coarse' as LatexdiffMathMarkupValue,
@@ -473,6 +474,7 @@ export const LATEX_FIELD_TO_KEY = {
   workflowAutoCompile: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
   workflowAutoCompileTimeoutMs:
     WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+  workflowAutoOpenPdf: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
   latexdiffBetweenRounds: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
   latexdiffTimeoutMs: WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
   latexdiffMathMarkup: WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -543,6 +543,7 @@ export const LatexConfigValuesSchema = z.object({
     .int()
     .min(LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min)
     .optional(),
+  workflowAutoOpenPdf: z.boolean().optional(),
   latexdiffBetweenRounds: z.boolean().optional(),
   latexdiffTimeoutMs: z
     .int()

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -1,0 +1,222 @@
+// Standard library imports
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - agent output
+import { publishCompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
+
+// Local imports - file utilities
+import { createExternalLocation, createRunStorageLocation } from '@utils/files';
+
+describe('compiled PDF artifacts', () => {
+  const tempDirs: string[] = [];
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'texra-pdf-artifact-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('publishes per-round and latest stable PDF paths', async () => {
+    const runDirectory = await makeTempDir();
+    const buildDir = path.join(runDirectory, 'compile', 'build', 'r2', 'paper');
+    const compiledPdfPath = path.join(buildDir, 'paper.pdf');
+    await mkdir(buildDir, { recursive: true });
+    await writeFile(compiledPdfPath, 'pdf bytes');
+
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'abc123',
+      round: 2,
+      displayName: 'paper.tex',
+      source: createExternalLocation(
+        path.join(runDirectory, 'r2', 'paper.tex'),
+      ),
+      compiledPdfPath,
+    });
+
+    expect(artifact?.pdf.relativePath).toBe('output/r2/paper.pdf');
+    expect(artifact?.latestPdf.relativePath).toBe('output/latest/paper.pdf');
+    await expect(
+      readFile(path.join(runDirectory, 'output', 'r2', 'paper.pdf'), 'utf8'),
+    ).resolves.toBe('pdf bytes');
+    await expect(
+      readFile(
+        path.join(runDirectory, 'output', 'latest', 'paper.pdf'),
+        'utf8',
+      ),
+    ).resolves.toBe('pdf bytes');
+  });
+
+  it('allows callers to publish diff PDFs with canonical names', async () => {
+    const runDirectory = await makeTempDir();
+    const buildDir = path.join(runDirectory, 'diff', 'r1', 'build');
+    const compiledPdfPath = path.join(buildDir, 'output-diff.pdf');
+    await mkdir(buildDir, { recursive: true });
+    await writeFile(compiledPdfPath, 'diff pdf');
+
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'def456',
+      round: 1,
+      displayName: 'chapter-diff.pdf',
+      source: createExternalLocation(path.join(runDirectory, 'diff.tex')),
+      compiledPdfPath,
+      outputPdfName: 'chapter-diff.pdf',
+    });
+
+    expect(artifact?.pdf.relativePath).toBe('output/r1/chapter-diff.pdf');
+    expect(artifact?.latestPdf.relativePath).toBe(
+      'output/latest/chapter-diff.pdf',
+    );
+  });
+
+  it('derives diff PDF names from the same source path rule', async () => {
+    const runDirectory = await makeTempDir();
+    const buildDir = path.join(runDirectory, 'diff', 'r4', 'build');
+    const compiledPdfPath = path.join(buildDir, 'latexdiff-output.pdf');
+    await mkdir(buildDir, { recursive: true });
+    await writeFile(compiledPdfPath, 'diff pdf');
+
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'suffix123',
+      round: 4,
+      displayName: 'latexdiff-output.tex',
+      source: createRunStorageLocation(
+        path.join(runDirectory, 'r4', 'sections', 'main.tex'),
+        path.join('r4', 'sections', 'main.tex'),
+        'suffix123',
+      ),
+      compiledPdfPath,
+      pdfStemSuffix: '-diff',
+    });
+
+    expect(artifact?.pdf.relativePath).toBe('output/r4/sections/main-diff.pdf');
+    expect(artifact?.latestPdf.relativePath).toBe(
+      'output/latest/sections/main-diff.pdf',
+    );
+  });
+
+  it('keeps distinct diff kinds for the same revised source', async () => {
+    const runDirectory = await makeTempDir();
+    const buildDir = path.join(runDirectory, 'diff', 'r5', 'build');
+    const baseDiffPdfPath = path.join(buildDir, 'base.pdf');
+    const roundDiffPdfPath = path.join(buildDir, 'round.pdf');
+    const source = createRunStorageLocation(
+      path.join(runDirectory, 'r5', 'sections', 'main.tex'),
+      path.join('r5', 'sections', 'main.tex'),
+      'kind123',
+    );
+    await mkdir(buildDir, { recursive: true });
+    await writeFile(baseDiffPdfPath, 'base diff');
+    await writeFile(roundDiffPdfPath, 'round diff');
+
+    const baseDiff = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'kind123',
+      round: 5,
+      displayName: 'base-diff.tex',
+      source,
+      compiledPdfPath: baseDiffPdfPath,
+      pdfStemSuffix: '-diff',
+    });
+    const roundDiff = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'kind123',
+      round: 5,
+      displayName: 'round-diff.tex',
+      source,
+      compiledPdfPath: roundDiffPdfPath,
+      pdfStemSuffix: '-round-diff',
+    });
+
+    expect(baseDiff?.pdf.relativePath).toBe('output/r5/sections/main-diff.pdf');
+    expect(roundDiff?.pdf.relativePath).toBe(
+      'output/r5/sections/main-round-diff.pdf',
+    );
+    await expect(
+      readFile(
+        path.join(runDirectory, 'output', 'r5', 'sections', 'main-diff.pdf'),
+        'utf8',
+      ),
+    ).resolves.toBe('base diff');
+    await expect(
+      readFile(
+        path.join(
+          runDirectory,
+          'output',
+          'r5',
+          'sections',
+          'main-round-diff.pdf',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe('round diff');
+  });
+
+  it('preserves source subdirectories for duplicate basenames', async () => {
+    const runDirectory = await makeTempDir();
+    const buildDir = path.join(runDirectory, 'compile', 'build', 'r3');
+    const firstPdfPath = path.join(buildDir, 'ch1-main', 'main.pdf');
+    const secondPdfPath = path.join(buildDir, 'ch2-main', 'main.pdf');
+    await mkdir(path.dirname(firstPdfPath), { recursive: true });
+    await mkdir(path.dirname(secondPdfPath), { recursive: true });
+    await writeFile(firstPdfPath, 'chapter 1');
+    await writeFile(secondPdfPath, 'chapter 2');
+
+    const first = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'dup123',
+      round: 3,
+      displayName: 'main.tex',
+      source: createRunStorageLocation(
+        path.join(runDirectory, 'r3', 'ch1', 'main.tex'),
+        path.join('r3', 'ch1', 'main.tex'),
+        'dup123',
+      ),
+      compiledPdfPath: firstPdfPath,
+    });
+    const second = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'dup123',
+      round: 3,
+      displayName: 'main.tex',
+      source: createRunStorageLocation(
+        path.join(runDirectory, 'r3', 'ch2', 'main.tex'),
+        path.join('r3', 'ch2', 'main.tex'),
+        'dup123',
+      ),
+      compiledPdfPath: secondPdfPath,
+    });
+
+    expect(first?.pdf.relativePath).toBe('output/r3/ch1/main.pdf');
+    expect(second?.pdf.relativePath).toBe('output/r3/ch2/main.pdf');
+    expect(first?.latestPdf.relativePath).toBe('output/latest/ch1/main.pdf');
+    expect(second?.latestPdf.relativePath).toBe('output/latest/ch2/main.pdf');
+    await expect(
+      readFile(
+        path.join(runDirectory, 'output', 'r3', 'ch1', 'main.pdf'),
+        'utf8',
+      ),
+    ).resolves.toBe('chapter 1');
+    await expect(
+      readFile(
+        path.join(runDirectory, 'output', 'r3', 'ch2', 'main.pdf'),
+        'utf8',
+      ),
+    ).resolves.toBe('chapter 2');
+  });
+});

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -81,6 +81,7 @@ describe('output progress events', () => {
           endTurn: false,
         },
         compileFailures: [],
+        compiledArtifacts: [],
         emitCompileFailures: false,
       },
     );

--- a/src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - controllers
+import {
+  ProgressWorkflowFileActionsController,
+  type ProgressWorkflowFileActionsControllerDeps,
+} from '@controllers/progressView/ProgressWorkflowFileActionsController';
+
+function createDeps(
+  overrides: Partial<ProgressWorkflowFileActionsControllerDeps['host']>,
+): ProgressWorkflowFileActionsControllerDeps {
+  return {
+    state: {
+      getActiveStream: () => '',
+      getExecutionId: () => undefined,
+      getOutputFiles: () => new Map(),
+    },
+    host: {
+      compareFiles: async () => {},
+      acceptEditedFile: async () => {},
+      mergeFile: async () => {},
+      latexdiffFile: async () => {},
+      openDirectory: async () => {},
+      openLabel: async () => true,
+      readFile: async () => '',
+      showInfo: async () => {},
+      showError: async () => {},
+      ...overrides,
+    },
+    sendFollowUp: async () => {},
+  };
+}
+
+describe('ProgressWorkflowFileActionsController', () => {
+  it('compares previous output without also running latexdiff', async () => {
+    const compared: Array<[string, string]> = [];
+    const latexdiffs: Array<[string, string]> = [];
+    const deps = createDeps({
+      compareFiles: async (baseFile, editedFile) => {
+        compared.push([baseFile, editedFile]);
+      },
+      latexdiffFile: async (baseFile, editedFile) => {
+        latexdiffs.push([baseFile, editedFile]);
+      },
+    });
+    const controller = new ProgressWorkflowFileActionsController(deps);
+
+    await controller.comparePrevious(
+      '/workspace/output-r1.tex',
+      '/workspace/original.tex',
+      '/workspace/output-r0.tex',
+    );
+
+    expect(compared).toEqual([
+      ['/workspace/output-r0.tex', '/workspace/output-r1.tex'],
+    ]);
+    expect(latexdiffs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Persist successful workflow compile PDFs under task-run storage at `output/rN/` and `output/latest/`.
- Persist compiled LaTeXdiff PDFs with stable `*-diff.pdf` names when diff compilation succeeds.
- Add a LaTeX setting to open the latest compiled PDF on success, or the compile log on failure.
- Remove duplicated previous-round action behavior so compare-with-previous no longer also runs LaTeXdiff, and hide the previous-round diff button when it would compare the same base file.

## Validation

- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `../../node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- desktop typechecks: `tsconfig.json`, `tsconfig.main.json`, `tsconfig.preload.json`, `tsconfig.renderer.json`
- `../../node_modules/.bin/vitest run --config vitest.config.mjs` (736 tests)
- `node --max-old-space-size=4096 ../../node_modules/eslint/bin/eslint.js src packages/extension/src packages/desktop/src packages/cli/src` (no errors; existing warnings remain)
- direct fast extension build: esbuild plus Vite builds for progressView, settingsView, and webview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow output processing to persist compiled PDFs/diff PDFs into run storage and optionally auto-open artifacts/logs, which could affect post-round side effects and filesystem behavior. Risk is moderated by being additive and covered by new tests, but it touches core output/compile/diff flows.
> 
> **Overview**
> **Surfaces compiled LaTeX outputs as stable run-storage artifacts.** Successful workflow compile checks now publish PDFs into task-run storage under `output/rN/` and `output/latest/`, and `latexdiff` builds also publish their compiled PDFs with stable suffixes (e.g. `*-diff.pdf`, `*-round-diff.pdf`) when compilation succeeds.
> 
> **Adds a new user setting to auto-open results.** Introduces `workflowAutoOpenPdf` (default on) and wires it through settings schema/UI and workspace state; when enabled, the workflow opens the latest compiled PDF(s) on success or the compile log(s) on failure at end-of-turn.
> 
> **Cleans up progress view actions.** Removes the duplicate behavior where “compare with previous” also ran `latexdiff`, and hides the previous-round compare button when it would compare against the same base file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d983856a501205f07bb7dc153c5019ec8df577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->