### PR TITLE
feat(cli): add header banner and reorganize chat TUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ scripts/Heap-20260221T154935.heapsnapshot
 scripts/analyze_heap.py
 .claude/projects
 .claude/worktrees
+.worktrees/
 
 # Playwright e2e: per-run artifacts (screenshots baselines under
 # tests/e2e/__screenshots__/ ARE committed — only the run output is ignored).

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -76,7 +76,6 @@ export function App(props: AppProps): React.JSX.Element {
           </Box>
         ) : null}
       </Box>
-      <StatusBar />
       <ApprovalModal pending={pending} />
       {activeForm
         ? activeForm.render(() => cliState.activeForm.set(undefined))
@@ -86,6 +85,7 @@ export function App(props: AppProps): React.JSX.Element {
         disabled={inputDisabled}
         history={props.history}
       />
+      <StatusBar />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
+++ b/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
@@ -1,0 +1,101 @@
+// Banner printed at the very top of a chat session.
+//
+// Ink only supports one `<Static>` per app (the ConversationPane already
+// owns it for the transcript), so we can't render the banner through Ink
+// — a second Static would be silently dropped. Instead we write the
+// banner directly to stdout *before* Ink mounts, which places it in the
+// real terminal scrollback above the live region.
+//
+// The pixel art mirrors the TeXRA logo: a two-lobed brain (purple) with
+// the integral and sigma glyphs inside, and four orange neuron terminals
+// dangling underneath. Kept to four rows so it doesn't dominate the
+// screen on tall sessions.
+
+import os from 'node:os';
+
+import pc from 'picocolors';
+
+type Color = 'magenta' | 'cyan' | 'yellow' | 'white' | 'dim';
+interface Segment {
+  readonly text: string;
+  readonly color?: Color;
+  readonly bold?: boolean;
+}
+
+function paint(seg: Segment): string {
+  let out = seg.text;
+  switch (seg.color) {
+    case 'magenta':
+      out = pc.magenta(out);
+      break;
+    case 'cyan':
+      out = pc.cyan(out);
+      break;
+    case 'yellow':
+      out = pc.yellow(out);
+      break;
+    case 'white':
+      out = pc.white(out);
+      break;
+    case 'dim':
+      out = pc.dim(out);
+      break;
+    case undefined:
+      break;
+  }
+  if (seg.bold) out = pc.bold(out);
+  return out;
+}
+
+function row(...segments: Segment[]): string {
+  return segments.map(paint).join('');
+}
+
+// 4-row brain mascot, oval/circular silhouette: narrow crown,
+// widest in the middle, narrow chin. ∫ and Σ read as two "eyes"
+// in the hemispheres, a centered fissure (│) splits the lobes,
+// and a tiny yellow smile (◡) sits underneath.
+const LOGO_ROWS: string[] = [
+  row({ text: '   ╭─╮', color: 'magenta' }),
+  row(
+    { text: '  ╱', color: 'magenta' },
+    { text: '∫', color: 'white', bold: true },
+    { text: '│', color: 'magenta' },
+    { text: 'Σ', color: 'white', bold: true },
+    { text: '╲', color: 'magenta' },
+  ),
+  row(
+    { text: '  ╲ ', color: 'magenta' },
+    { text: '◡', color: 'yellow' },
+    { text: ' ╱', color: 'magenta' },
+  ),
+  row({ text: '   ╰─╯', color: 'magenta' }),
+];
+
+function shortenCwd(cwd: string): string {
+  const home = os.homedir();
+  if (cwd === home) return '~';
+  if (cwd.startsWith(`${home}/`)) return `~/${cwd.slice(home.length + 1)}`;
+  return cwd;
+}
+
+export interface HeaderBannerInfo {
+  readonly version: string;
+  readonly agent: string;
+  readonly model: string;
+  readonly cwd: string;
+}
+
+export function printHeaderBanner(info: HeaderBannerInfo): void {
+  const rightLines = [
+    `${pc.bold('TeXRA')} ${pc.dim(`v${info.version}`)}`,
+    `${pc.cyan(info.agent || 'chat')} ${pc.dim('·')} ${info.model || '—'}`,
+    pc.dim(shortenCwd(info.cwd)),
+    '',
+  ];
+  const gutter = '   ';
+  const lines = LOGO_ROWS.map(
+    (logoLine, idx) => `${logoLine}${gutter}${rightLines[idx] ?? ''}`,
+  );
+  process.stdout.write(`\n${lines.join('\n')}\n\n`);
+}

--- a/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
+++ b/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
@@ -6,12 +6,12 @@
 // banner directly to stdout *before* Ink mounts, which places it in the
 // real terminal scrollback above the live region.
 //
-// The pixel art mirrors the TeXRA logo: a two-lobed brain (purple) with
-// the integral and sigma glyphs inside, and four orange neuron terminals
-// dangling underneath. Kept to four rows so it doesn't dominate the
-// screen on tall sessions.
+// The pixel art is a rounded brain mascot with ∫ and Σ in the two
+// hemispheres and a small smile underneath. Kept to four rows so it
+// doesn't dominate the screen on tall sessions.
 
 import os from 'node:os';
+import path from 'node:path';
 
 import pc from 'picocolors';
 
@@ -47,15 +47,27 @@ function paint(seg: Segment): string {
   return out;
 }
 
-function row(...segments: Segment[]): string {
-  return segments.map(paint).join('');
+interface LogoRow {
+  readonly text: string;
+  readonly width: number;
+}
+
+// Visible width = sum of raw segment lengths (all glyphs in the logo
+// are single-cell BMP characters, so `.length` matches column count).
+// Reported alongside the ANSI-painted text so `printHeaderBanner` can
+// right-pad rows to a uniform width without trying to strip the ANSI.
+function row(...segments: Segment[]): LogoRow {
+  return {
+    text: segments.map(paint).join(''),
+    width: segments.reduce((sum, s) => sum + s.text.length, 0),
+  };
 }
 
 // 4-row brain mascot, oval/circular silhouette: narrow crown,
 // widest in the middle, narrow chin. ∫ and Σ read as two "eyes"
 // in the hemispheres, a centered fissure (│) splits the lobes,
 // and a tiny yellow smile (◡) sits underneath.
-const LOGO_ROWS: string[] = [
+const LOGO_ROWS: readonly LogoRow[] = [
   row({ text: '   ╭─╮', color: 'magenta' }),
   row(
     { text: '  ╱', color: 'magenta' },
@@ -75,7 +87,12 @@ const LOGO_ROWS: string[] = [
 function shortenCwd(cwd: string): string {
   const home = os.homedir();
   if (cwd === home) return '~';
-  if (cwd.startsWith(`${home}/`)) return `~/${cwd.slice(home.length + 1)}`;
+  // path.sep keeps the tilde shortening working on Windows, where
+  // os.homedir() returns a backslash-separated path.
+  const sep = path.sep;
+  if (cwd.startsWith(`${home}${sep}`)) {
+    return `~${sep}${cwd.slice(home.length + sep.length)}`;
+  }
   return cwd;
 }
 
@@ -94,8 +111,10 @@ export function printHeaderBanner(info: HeaderBannerInfo): void {
     '',
   ];
   const gutter = '   ';
-  const lines = LOGO_ROWS.map(
-    (logoLine, idx) => `${logoLine}${gutter}${rightLines[idx] ?? ''}`,
-  );
+  const maxLogoWidth = Math.max(...LOGO_ROWS.map((r) => r.width));
+  const lines = LOGO_ROWS.map((r, idx) => {
+    const pad = ' '.repeat(maxLogoWidth - r.width);
+    return `${r.text}${pad}${gutter}${rightLines[idx] ?? ''}`;
+  });
   process.stdout.write(`\n${lines.join('\n')}\n\n`);
 }

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -127,7 +127,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           onCancel={() => setReverseSearchOpen(false)}
         />
       ) : null}
-      <Box paddingX={1}>
+      <Box borderStyle="round" borderColor="gray" paddingX={1}>
         <Text color="cyan">{prompt ?? '›'} </Text>
         <BaseTextInput
           value={value}

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -45,12 +45,6 @@ export function StatusBar(): React.JSX.Element {
         ) : (
           <Text dimColor>{statusLabel(slice?.status)}</Text>
         )}
-        {slice?.description ? (
-          <>
-            <Text dimColor>·</Text>
-            <Text dimColor>{slice.description}</Text>
-          </>
-        ) : null}
         {bypass.superYolo ? <Badge color="red">YOLO</Badge> : null}
         {bypass.toolEdit ? <Badge color="yellow">BYPASS</Badge> : null}
       </Box>

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -19,7 +19,7 @@ import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
-import { type CliContext } from '../../runtime/cliContext';
+import { type CliContext, readCliVersion } from '../../runtime/cliContext';
 import { hasCliApprovalDenied } from '../../runtime/approvalAdapter';
 import { resolveChatDefaults } from '../../runtime/chatDefaults';
 import { CliExitCode } from '../../runtime/exitCodes';
@@ -27,6 +27,7 @@ import { initCliPlatform, setCliHelperModel } from '../../runtime/initPlatform';
 import { createCliRuntimeHost } from '../../runtime/runtimeHost';
 import { writeTextStderr } from '../../runtime/logSinks';
 import { App } from './App';
+import { printHeaderBanner } from './panes/HeaderBanner';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { listSlashCommands, parseSlashInput } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
@@ -354,6 +355,8 @@ export async function runChat(
     });
   };
 
+  const version = await readCliVersion();
+  printHeaderBanner({ version, agent, model, cwd: context.cwd });
   const ink = render(<App onSubmit={handleSubmit} history={inputHistory} />, {
     stdout: process.stdout,
     stderr: process.stderr,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -52,7 +52,6 @@ export interface BypassState {
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   readonly status: StreamStatus | undefined;
-  readonly description: string | undefined;
   readonly usage: TokenUsageStats | undefined;
   readonly conversation: ConversationProgress | undefined;
   readonly entries: readonly ConversationEntry[];
@@ -122,7 +121,6 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
     status: undefined,
-    description: undefined,
     usage: undefined,
     conversation: undefined,
     entries: [],

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -67,11 +67,11 @@ function applyToState<K extends ProgressEvent>(
       patchStream(p.streamId, (s) => ({ ...s, conversation: p.progress }));
       return;
     }
-    case 'updateStreamDescription': {
-      const p = payload as ProgressEventPayloads['updateStreamDescription'];
-      patchStream(p.streamId, (s) => ({ ...s, description: p.description }));
+    case 'updateStreamDescription':
+      // The CLI TUI dropped its status-bar description display, so this
+      // event has no consumer here. Ignored to avoid an unused per-turn
+      // write. The progress view (VS Code / desktop) still handles it.
       return;
-    }
     case 'updateActiveSubagents': {
       const p = payload as ProgressEventPayloads['updateActiveSubagents'];
       patchStream(p.parentStreamId, (s) => ({


### PR DESCRIPTION
## Summary

- Adds a one-shot TeXRA header banner at the top of `texra chat` (pixel brain with ∫/Σ, version, `agent · model`, cwd). Printed to stdout before Ink mounts so it stays in real terminal scrollback — same pattern Claude Code uses.
- Wraps the input row in a rounded border and moves the status pill (`◆ agent · model · status`) underneath the input.
- Drops the per-stream `description` from the main-session status bar so stale text like `Calculating 1+1` doesn't carry over between turns.

## Why a stdout printer instead of an Ink `<Static>` component

Ink (7.0.3) only supports one `<Static>` per app; the conversation pane already owns it for transcript entries, so a second Static (e.g. for a header component) is silently dropped. Writing the banner to stdout before `ink.render()` puts it in the terminal scrollback above the live region without competing for the Static slot.

## Visual

```
   ╭─╮       TeXRA v0.37.8
  ╱∫│Σ╲      chat · deepseekT
  ╲ ◡ ╱      ~/Local/AI-Projects/coauthor
   ╰─╯

  <transcript>

 ╭─────────────────╮
 │ › your input    │
 ╰─────────────────╯
 ◆ chat · deepseekT · idle
```

## Test plan

- [ ] `node packages/cli/dist/bin/texra.js --model=deepseekT` in an interactive terminal — banner appears at top with magenta brain, white ∫/Σ, yellow smile.
- [ ] Submit a few prompts — status pill stays clean (no leftover description), input box keeps its rounded border, status sits below the input.
- [ ] Resize the terminal — layout doesn't regress (Ink owns the live region; banner remains in scrollback).
- [ ] `texra run` / piped stdout still skipped from chat (existing `--print`/non-TTY guards untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to the interactive CLI TUI (stdout banner printing and layout tweaks) with minimal impact beyond presentation.
> 
> **Overview**
> Adds a one-time `texra chat` header banner printed to stdout before Ink mounts (logo + version, `agent · model`, and shortened cwd) via new `HeaderBanner` and `readCliVersion()` usage.
> 
> Reorganizes the TUI layout by moving `StatusBar` below the input, styling `InputBar` with a rounded border, and removing the per-stream `description` field/display (and ignoring `updateStreamDescription` events to avoid redundant state writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586b952622ce86db679e427fd2f44e425518ac88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->