### PR TITLE
fix: simplify launcher file panels

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,7 +6,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { html, nothing, render, type TemplateResult } from 'lit';
+import { html, render, type TemplateResult } from 'lit';
 import { create as mutate } from 'mutative';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
@@ -231,20 +231,6 @@ function emptyWorkspaceTemplate(): TemplateResult {
   `;
 }
 
-function emptyStreamsTemplate(): TemplateResult {
-  return html`
-    <section class="desktop-empty-streams" aria-label="First run suggestions">
-      <div class="desktop-empty-streams-copy">
-        <h2>Start from the launcher</h2>
-        <p>Choose files and an agent above before the first run.</p>
-        <p class="desktop-empty-streams-example">
-          Try: <q>polish the abstract</q>
-        </p>
-      </div>
-    </section>
-  `;
-}
-
 // =============================================================================
 // Progress message + event wiring (without mounting <progress-app>)
 // =============================================================================
@@ -305,15 +291,27 @@ const CHROME_ICON_BUTTONS: ReadonlyArray<ChromeIconButtonSpec> = [
   { key: 'logs', icon: 'file-lines', label: 'Logs', onClick: openLogsDrawer },
 ] as const;
 
+function getWorkspaceDirectoryLabel(workspacePath: string | undefined): string {
+  if (!workspacePath) return 'No folder';
+
+  const normalized = workspacePath.replaceAll('\\', '/');
+  const trimmed = normalized.replace(/\/+$/, '');
+  if (!trimmed) return normalized.startsWith('/') ? '/' : workspacePath;
+  return trimmed.split('/').at(-1) || trimmed;
+}
+
 function shellTemplate(): TemplateResult {
   const activeId = activeStreamId$.get();
   const hasStreams = hasAnyStreams$.get();
   const showConversation = activeId != null && hasStreams;
-  const showLauncherEmptyState = hasWorkspace && !hasStreams;
+  const workspacePath = window.texraDesktop?.workspacePath;
+  const workspaceDirectoryLabel = getWorkspaceDirectoryLabel(workspacePath);
   return html`
     <section class="desktop-shell">
       <nav class="desktop-nav" aria-label="Desktop chrome">
-        <span class="desktop-brand">TeXRA</span>
+        <span class="desktop-workspace-directory" title=${workspacePath ?? ''}>
+          ${workspaceDirectoryLabel}
+        </span>
         <wa-button
           class="desktop-icon-button"
           appearance="plain"
@@ -392,13 +390,8 @@ function shellTemplate(): TemplateResult {
           >
             ${hasWorkspace
               ? html`
-                  <section
-                    class=${showLauncherEmptyState
-                      ? 'desktop-launcher-surface desktop-launcher-surface--empty'
-                      : 'desktop-launcher-surface'}
-                  >
+                  <section class="desktop-launcher-surface">
                     ${mainView}
-                    ${showLauncherEmptyState ? emptyStreamsTemplate() : nothing}
                   </section>
                 `
               : noWorkspacePlaceholder}

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -33,13 +33,17 @@ body {
   background: var(--wa-color-surface-lowered);
 }
 
-.desktop-brand {
+.desktop-workspace-directory {
+  flex: 0 1 40ch;
   margin-right: 12px;
+  min-width: 0;
+  max-width: clamp(12ch, 24vw, 40ch);
   color: var(--wa-color-text-normal);
   font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Custom elements need an explicit `[hidden]` rule — the user-agent
@@ -211,10 +215,6 @@ wa-button.desktop-rail-settings::part(base) {
   min-width: 0;
   min-height: 0;
   height: 100%;
-}
-
-.desktop-launcher-surface--empty {
-  grid-template-rows: minmax(0, 1fr) auto;
 }
 
 .desktop-launcher-surface > main-app {
@@ -580,35 +580,6 @@ wa-input.desktop-command-palette-input::part(base) {
   flex-wrap: wrap;
   justify-content: center;
   gap: var(--wa-space-s);
-}
-
-.desktop-empty-streams {
-  padding: var(--wa-space-s) var(--wa-space-l);
-  border-top: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-lowered);
-}
-
-.desktop-empty-streams-copy {
-  min-width: 0;
-}
-
-.desktop-empty-streams-copy h2 {
-  margin: 0 0 var(--wa-space-2xs);
-  color: var(--wa-color-text-normal);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.desktop-empty-streams-copy p {
-  margin: 0;
-  color: var(--wa-color-text-quiet);
-  font-size: 12px;
-  line-height: 1.4;
-}
-
-.desktop-empty-streams-copy .desktop-empty-streams-example {
-  margin-top: var(--wa-space-2xs);
-  color: var(--wa-color-text-normal);
 }
 
 .desktop-bootstrap-fallback {

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -106,15 +106,14 @@ async function setSettingsTab(tabIndex: number): Promise<void> {
  */
 test('first launch shows a usable launcher chrome', async () => {
   await setRoute('main');
-  // The chrome brand and command palette button must be reachable from the user.
-  // The brand label is styled uppercase via CSS, but the underlying text
-  // node is "TeXRA". Match case-insensitively so a future style flip won't
-  // destabilise the test.
-  const brand = await launched.page
-    .locator('.desktop-brand')
+  // The workspace directory and command palette button must be reachable.
+  const workspaceDirectory =
+    launched.workspacePath.split(/[\\/]/).at(-1) ?? launched.workspacePath;
+  const directoryLabel = await launched.page
+    .locator('.desktop-workspace-directory')
     .first()
     .innerText();
-  expect(brand.toLowerCase()).toContain('texra');
+  expect(directoryLabel).toContain(workspaceDirectory);
   await expect(launched.page.locator('.desktop-command-button')).toBeVisible();
   await expect(launched.page.locator('.desktop-folder-button')).toHaveCount(0);
   // The main view itself either renders <main-app> or the no-workspace empty
@@ -241,7 +240,9 @@ test('rapid settings-tab switching does not crash the renderer', async () => {
     await setSettingsTab(idx);
   }
   // The chrome must still be alive after the burst.
-  await expect(launched.page.locator('.desktop-brand')).toBeVisible();
+  await expect(
+    launched.page.locator('.desktop-workspace-directory'),
+  ).toBeVisible();
 });
 
 /**

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -25,7 +25,6 @@ import {
   type SingleFiles,
   type FileOptions,
   type MultiFiles,
-  type MultiFilesVisible,
   type CheckboxValues,
   type ActionDetail,
   type AgentChangeDetail,
@@ -87,7 +86,6 @@ import {
   DEFAULT_SINGLE_FILES,
   DEFAULT_FILE_OPTIONS,
   DEFAULT_MULTI_FILES,
-  DEFAULT_MULTI_FILES_VISIBLE,
   DEFAULT_CHECKBOX_VALUES,
   FILE_UPDATE_COMMANDS,
   MULTI_FILE_COMMAND_TO_KEY,
@@ -153,9 +151,6 @@ export class MainApp extends MainAppBase {
     ...DEFAULT_FILE_OPTIONS,
   });
   private readonly multiFiles = signal<MultiFiles>({ ...DEFAULT_MULTI_FILES });
-  private readonly multiFilesVisible = signal<MultiFilesVisible>({
-    ...DEFAULT_MULTI_FILES_VISIBLE,
-  });
   private readonly outputFilesActive = signal(DEFAULT_STATE.outputFilesActive);
   private readonly latexdiffsVisible = signal(DEFAULT_STATE.latexdiffsVisible);
   private readonly checkboxValues = signal<CheckboxValues>({
@@ -198,7 +193,6 @@ export class MainApp extends MainAppBase {
       singleFiles: this.singleFiles.get(),
       fileOptions: this.fileOptions.get(),
       multiFiles: this.multiFiles.get(),
-      multiFilesVisible: this.multiFilesVisible.get(),
       outputFilesActive: this.outputFilesActive.get(),
     }),
   );
@@ -384,7 +378,6 @@ export class MainApp extends MainAppBase {
 
     const sf = this.singleFiles.get();
     const mf = this.multiFiles.get();
-    const mv = this.multiFilesVisible.get();
     const cv = this.checkboxValues.get();
 
     const persisted: MainViewPersistedState = {
@@ -402,10 +395,6 @@ export class MainApp extends MainAppBase {
       contextFiles: mf.contextFiles,
       mediaFiles: mf.mediaFiles,
       outputFiles: [],
-      inputFilesVisible: mv.inputFiles,
-      contextFilesVisible: mv.contextFiles,
-      mediaFilesVisible: mv.mediaFiles,
-      outputFilesVisible: false,
       outputFilesActive: false,
       latexdiffsVisible: this.latexdiffsVisible.get(),
       autoExtractFigure: cv.autoExtractFigure,
@@ -439,12 +428,6 @@ export class MainApp extends MainAppBase {
       contextFiles: state.contextFiles,
       mediaFiles: state.mediaFiles,
       outputFiles: [],
-    });
-    this.multiFilesVisible.set({
-      inputFiles: state.inputFilesVisible,
-      contextFiles: state.contextFilesVisible,
-      mediaFiles: state.mediaFilesVisible,
-      outputFiles: false,
     });
     this.outputFilesActive.set(false);
     this.latexdiffsVisible.set(state.latexdiffsVisible);
@@ -649,10 +632,6 @@ export class MainApp extends MainAppBase {
     if (!listId) return;
 
     this.multiFiles.set({ ...this.multiFiles.get(), [listId]: files });
-    this.multiFilesVisible.set({
-      ...this.multiFilesVisible.get(),
-      [listId]: files.length > 0,
-    });
     if (listId === ELEMENT_IDS.OUTPUT_FILES) {
       this.outputFilesActive.set(false);
     }
@@ -669,10 +648,6 @@ export class MainApp extends MainAppBase {
     this.multiFiles.set({
       ...mf,
       mediaFiles: [...existing, file],
-    });
-    this.multiFilesVisible.set({
-      ...this.multiFilesVisible.get(),
-      mediaFiles: true,
     });
     this.saveState();
   }
@@ -711,10 +686,6 @@ export class MainApp extends MainAppBase {
       const mf = this.multiFiles.get();
       const existing = mf[listId] ?? [];
       const next = [filePath, ...existing.filter((f) => f !== filePath)];
-      this.multiFilesVisible.set({
-        ...this.multiFilesVisible.get(),
-        [listId]: true,
-      });
       this.updateMultiFiles(listId, next);
       return;
     }
@@ -768,10 +739,6 @@ export class MainApp extends MainAppBase {
     const existing = mf[listId] ?? [];
     const merged = this.mergeUnique(existing, filesToAdd);
     this.multiFiles.set({ ...mf, [listId]: merged });
-    this.multiFilesVisible.set({
-      ...this.multiFilesVisible.get(),
-      [listId]: true,
-    });
     this.saveState();
   }
 
@@ -888,17 +855,6 @@ export class MainApp extends MainAppBase {
         }),
       ) as MultiFiles,
     );
-
-    this.multiFilesVisible.set(
-      Object.fromEntries(
-        MULTIPLE_DOCUMENT_FILE_TYPES.map((type) => {
-          const key = `${type}Files` as keyof MultiFilesVisible;
-          const visible =
-            state[`${key}Visible` as keyof MainViewPersistedState];
-          return [key, Boolean(visible)];
-        }),
-      ) as MultiFilesVisible,
-    );
   }
 
   private clearForNewSession(): void {
@@ -916,12 +872,6 @@ export class MainApp extends MainAppBase {
         contextFiles: [],
         mediaFiles: [],
         outputFiles: [],
-      });
-      this.multiFilesVisible.set({
-        inputFiles: false,
-        contextFiles: false,
-        mediaFiles: false,
-        outputFiles: false,
       });
       if (defaults.checkboxOverrides) {
         this.checkboxValues.set({
@@ -944,27 +894,11 @@ export class MainApp extends MainAppBase {
     return MULTI_FILE_COMMAND_TO_KEY[command];
   }
 
-  private toggleListVisibility(listId: keyof MultiFiles): void {
-    const visible = !this.multiFilesVisible.get()[listId];
-    this.multiFilesVisible.set({
-      ...this.multiFilesVisible.get(),
-      [listId]: visible,
-    });
-    if (listId === ELEMENT_IDS.OUTPUT_FILES) {
-      this.outputFilesActive.set(false);
-    }
-    this.saveState();
-  }
-
   private handleRemoveFile(listId: keyof MultiFiles, file: string): void {
     const files = (this.multiFiles.get()[listId] ?? []).filter(
       (f: string) => f !== file,
     );
     if (files.length === 0) {
-      this.multiFilesVisible.set({
-        ...this.multiFilesVisible.get(),
-        [listId]: false,
-      });
       if (listId === ELEMENT_IDS.OUTPUT_FILES) {
         this.outputFilesActive.set(false);
       }
@@ -1021,10 +955,6 @@ export class MainApp extends MainAppBase {
 
   private handleEmptyFiles(type: MultipleDocumentFileType): void {
     const listId = `${type}Files`;
-    this.multiFilesVisible.set({
-      ...this.multiFilesVisible.get(),
-      [listId]: false,
-    });
     if (type === 'output') {
       this.outputFilesActive.set(false);
     }
@@ -1052,10 +982,6 @@ export class MainApp extends MainAppBase {
     this.refreshInstructionPlaceholder(false);
     if (parsed === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive.set(false);
-      this.multiFilesVisible.set({
-        ...this.multiFilesVisible.get(),
-        outputFiles: false,
-      });
       this.updateMultiFiles('outputFiles', []);
     }
     this.saveState();
@@ -1442,12 +1368,6 @@ export class MainApp extends MainAppBase {
 
   private handleLatexdiffEmptyFile(e: CustomEvent<FileActionDetail>): void {
     this.handleEmptyFile(e.detail.type);
-  }
-
-  private handleComponentToggleList(
-    e: CustomEvent<MultipleFilesActionDetail>,
-  ): void {
-    this.toggleListVisibility(e.detail.listId as keyof MultiFiles);
   }
 
   private handleComponentAddOpenedFiles(
@@ -1888,7 +1808,6 @@ export class MainApp extends MainAppBase {
                       (config) => html`
                         <file-select-group
                           .config=${config}
-                          @toggle-list=${this.handleComponentToggleList}
                           @add-opened-files=${this
                             .handleComponentAddOpenedFiles}
                           @empty-files=${this.handleComponentEmptyFiles}

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -77,23 +77,14 @@ export class FileSelectGroup extends LitElement {
       ),
   );
 
-  /** Track previous expanded state to detect visibility changes */
-  private wasExpanded = false;
-
   protected override updated(changedProps: Map<string, unknown>): void {
-    const isExpanded = this.currentListVisible;
-    if (changedProps.has('config') || (isExpanded && !this.wasExpanded)) {
+    if (changedProps.has('config')) {
       this.sortableController.reinitialize();
     }
-    this.wasExpanded = isExpanded;
   }
 
   private get listId(): string {
     return `${this.config.type}Files`;
-  }
-
-  private handleToggleList(): void {
-    this.dispatchEvent(MainViewEvents.toggleList({ listId: this.listId }));
   }
 
   private handleAddOpenedFiles(): void {
@@ -172,12 +163,6 @@ export class FileSelectGroup extends LitElement {
     const key =
       `${this.config.type}Files` as keyof FileStateContextValue['multiFiles'];
     return this.fileState?.multiFiles[key] ?? [];
-  }
-
-  private get currentListVisible(): boolean {
-    const key =
-      `${this.config.type}Files` as keyof FileStateContextValue['multiFilesVisible'];
-    return this.fileState?.multiFilesVisible[key] ?? false;
   }
 
   private get isFileInputDisabled(): boolean {
@@ -341,8 +326,6 @@ export class FileSelectGroup extends LitElement {
 
   override render(): TemplateResult {
     const { config } = this;
-    const toggleId = `toggle${config.type[0].toUpperCase()}${config.type.slice(1)}Files`;
-    const chevronName = this.currentListVisible ? 'chevron-up' : 'chevron-down';
 
     return html`
       <div
@@ -350,7 +333,6 @@ export class FileSelectGroup extends LitElement {
           'file-select': true,
           'drop-active': this.isDragActive,
         })}
-        data-expanded=${String(this.currentListVisible)}
         @dragenter=${this.handleDragEnter}
         @dragover=${this.handleDragOver}
         @dragleave=${this.handleDragLeave}
@@ -375,16 +357,6 @@ export class FileSelectGroup extends LitElement {
               : nothing}
           </div>
           <div class="file-select-actions">
-            <button
-              id=${toggleId}
-              class="toggle-icon"
-              title=${config.toggleTitle}
-              type="button"
-              aria-label=${config.toggleTitle}
-              @click=${this.handleToggleList}
-            >
-              ${waIcon(chevronName)}
-            </button>
             ${renderIconActionButton({
               id: `addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,
@@ -414,20 +386,13 @@ export class FileSelectGroup extends LitElement {
             })}
           </div>
         </div>
-        ${this.currentListVisible
-          ? html`
-              <div
-                id="${this.listId}Container"
-                class="multiple-files-container"
-              >
-                <div class="multiple-files-content">
-                  <div id=${this.listId} class="multiple-files-list">
-                    ${this.renderFileList()}
-                  </div>
-                </div>
-              </div>
-            `
-          : nothing}
+        <div id="${this.listId}Container" class="multiple-files-container">
+          <div class="multiple-files-content">
+            <div id=${this.listId} class="multiple-files-list">
+              ${this.renderFileList()}
+            </div>
+          </div>
+        </div>
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -40,9 +40,6 @@ export const MainViewEvents = {
 
   emptyFile: (detail: FileActionDetail) => createEvent('empty-file', detail),
 
-  toggleList: (detail: MultipleFilesActionDetail) =>
-    createEvent('toggle-list', detail),
-
   addOpenedFiles: (detail: MultipleFilesTypeActionDetail) =>
     createEvent('add-opened-files', detail),
 

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -14,7 +14,6 @@ import {
   type SingleFiles,
   type FileOptions,
   type MultiFiles,
-  type MultiFilesVisible,
 } from '@shared/schemas';
 
 import {
@@ -49,14 +48,6 @@ export const DEFAULT_MULTI_FILES: MultiFiles = {
   contextFiles: [],
   mediaFiles: [],
   outputFiles: [],
-};
-
-/** Default multi-files visibility state (typed) */
-export const DEFAULT_MULTI_FILES_VISIBLE: MultiFilesVisible = {
-  inputFiles: false,
-  contextFiles: false,
-  mediaFiles: false,
-  outputFiles: false,
 };
 
 /** Default checkbox values (typed) */
@@ -125,7 +116,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     type: 'input',
     label: 'Input',
     icon: 'file-code',
-    toggleTitle: 'Show or hide additional input files',
     addOpenedLabel: 'Add opened files as input',
     emptyListLabel: 'Clear all input files',
     selectListLabel: 'Add input files',
@@ -137,7 +127,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     type: 'context',
     label: 'Context',
     icon: 'book',
-    toggleTitle: 'Show or hide additional context files',
     addOpenedLabel: 'Add opened files as context',
     emptyListLabel: 'Clear all context files',
     selectListLabel: 'Add context files',
@@ -149,7 +138,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     type: 'media',
     label: 'Media',
     icon: 'device-camera-video',
-    toggleTitle: 'Show or hide additional media files',
     addOpenedLabel: 'Add opened files as media',
     emptyListLabel: 'Clear all media files',
     selectListLabel: 'Add media files',

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -29,10 +29,6 @@ export const fileSelectLayoutStyles = css`
     margin-bottom: var(--wa-space-3xs);
   }
 
-  .file-select:has(.optional-label) {
-    margin-bottom: var(--wa-space-3xs);
-  }
-
   .file-select-header {
     display: flex;
     justify-content: space-between;
@@ -42,14 +38,6 @@ export const fileSelectLayoutStyles = css`
     line-height: var(--line-height-normal);
     gap: var(--wa-space-2xs);
     min-height: 22px;
-  }
-
-  /* When the inline wa-select collapses (no current file, list closed),
-     drop the header's bottom margin so the slot becomes a single 22px row
-     instead of leaving a wasted gap above the next slot. */
-  .file-select:not([data-expanded='true']):not([data-has-current='true'])
-    .file-select-header {
-    margin-bottom: 0;
   }
 
   .file-select-header > wa-button {
@@ -129,14 +117,6 @@ export const fileSelectLayoutStyles = css`
   .file-select wa-select {
     width: 100%;
   }
-
-  /* Hide the inline wa-select when there's no current selection AND the list
-     isn't expanded — saves a wasted row showing "None". The select still
-     surfaces as soon as the user expands, picks a current file, or starts
-     filtering. The list-management buttons (add-opened, clear-list, add)
-     stay visible at all times so they remain reachable in one click — the
-     user complained that hiding them behind the chevron made the launcher
-     feel "minimized too much". */
 `;
 
 /** Toggle icon and optional label styles. */
@@ -170,11 +150,6 @@ export const toggleStyles = css`
     outline: var(--border-thin) solid var(--wa-color-focus);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
-  }
-
-  .file-select[data-expanded='true'] .optional-label,
-  .file-select[data-expanded='true'] .toggle-icon {
-    color: var(--wa-color-text-normal);
   }
 `;
 

--- a/src/controllers/mainView/MainViewStateRestoreController.ts
+++ b/src/controllers/mainView/MainViewStateRestoreController.ts
@@ -21,7 +21,6 @@ export function buildMainViewState(
   const { agentConfig } = taskState;
   const isToolUse = isToolUseTaskState(taskState);
   const isWorkflow = isWorkflowTaskState(taskState);
-  const activeFiles = isWorkflow ? taskState.activeFiles : undefined;
   const toolConfig = agentConfig.toolConfig ?? {};
 
   // Resolve agent name to full key (e.g., "criticize" -> "builtIn:criticize").
@@ -44,11 +43,7 @@ export function buildMainViewState(
     contextFiles: agentConfig.contextFiles,
     mediaFiles: agentConfig.mediaFiles,
     outputFiles: agentConfig.outputFiles,
-    inputFilesVisible: activeFiles?.input,
-    contextFilesVisible: activeFiles?.context,
-    mediaFilesVisible: activeFiles?.media,
-    outputFilesVisible: activeFiles?.output,
-    outputFilesActive: activeFiles?.output,
+    outputFilesActive: isWorkflow ? taskState.activeFiles?.output : undefined,
     autoExtractFigure: toolConfig.autoExtractFigure,
     autoExtractTikzFigure: toolConfig.autoExtractTikzFigure,
     autoCompileInputPdf: toolConfig.autoCompileInputPdf,

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -123,70 +123,13 @@ const MainViewPersistedStateBaseSchema = UIFileFieldsSchema.merge(
   workflowInstruction: z.string().prefault(''),
   toolUseInstruction: z.string().prefault(''),
   baseFile: z.string().prefault(''),
-  inputFilesVisible: z.boolean().prefault(false),
-  contextFilesVisible: z.boolean().prefault(false),
-  mediaFilesVisible: z.boolean().prefault(false),
-  outputFilesVisible: z.boolean().prefault(false),
   outputFilesActive: z.boolean().prefault(false),
   latexdiffsVisible: z.boolean().prefault(false),
   openedFiles: z.array(z.string()).nullish(),
 });
 
-// Layer the visibility-key migration on top of the shared file-field
-// migration so MainView and AgentConfig stay in sync without duplicating
-// the file-slot logic.
-function migrateLegacyMainViewState(input: unknown): unknown {
-  const original =
-    typeof input === 'object' && input !== null && !Array.isArray(input)
-      ? (input as Record<string, unknown>)
-      : {};
-  const migrated = migrateLegacyContextFileFields(input);
-  if (
-    typeof migrated !== 'object' ||
-    migrated === null ||
-    Array.isArray(migrated)
-  ) {
-    return migrated;
-  }
-  const obj = migrated as Record<string, unknown>;
-  for (const [single, multi, visible] of [
-    ['inputFile', 'inputFiles', 'inputFilesVisible'],
-    ['contextFile', 'contextFiles', 'contextFilesVisible'],
-    ['mediaFile', 'mediaFiles', 'mediaFilesVisible'],
-  ] as const) {
-    if (
-      obj[visible] === undefined &&
-      original[single] !== undefined &&
-      Array.isArray(obj[multi]) &&
-      obj[multi].length > 0
-    ) {
-      obj[visible] = true;
-    }
-  }
-  if (
-    obj.contextFilesVisible === undefined &&
-    (original.referenceFile !== undefined ||
-      original.referenceFiles !== undefined ||
-      original.auxiliaryFile !== undefined ||
-      original.auxiliaryFiles !== undefined) &&
-    Array.isArray(obj.contextFiles) &&
-    obj.contextFiles.length > 0
-  ) {
-    obj.contextFilesVisible = true;
-  }
-  if (
-    obj.contextFilesVisible === undefined &&
-    (obj.referenceFilesVisible || obj.auxiliaryFilesVisible)
-  ) {
-    obj.contextFilesVisible = true;
-  }
-  delete obj.referenceFilesVisible;
-  delete obj.auxiliaryFilesVisible;
-  return obj;
-}
-
 export const MainViewPersistedStateSchema = z.preprocess(
-  migrateLegacyMainViewState,
+  migrateLegacyContextFileFields,
   MainViewPersistedStateBaseSchema,
 );
 export type MainViewPersistedState = z.infer<
@@ -229,7 +172,6 @@ export const FileSelectConfigSchema = z.object({
   type: DocumentFileTypeSchema,
   label: z.string(),
   icon: z.string(),
-  toggleTitle: z.string(),
   addOpenedLabel: z.string(),
   emptyListLabel: z.string(),
   selectListLabel: z.string(),
@@ -263,21 +205,12 @@ export const MultiFilesSchema = z.object({
 });
 export type MultiFiles = z.infer<typeof MultiFilesSchema>;
 
-export const MultiFilesVisibleSchema = z.object({
-  inputFiles: z.boolean(),
-  contextFiles: z.boolean(),
-  mediaFiles: z.boolean(),
-  outputFiles: z.boolean(),
-});
-export type MultiFilesVisible = z.infer<typeof MultiFilesVisibleSchema>;
-
 export const FileStateContextSchema = z.object({
   sessionType: SessionTypeSchema,
   checkboxValues: CheckboxValuesSchema,
   singleFiles: SingleFilesSchema,
   fileOptions: FileOptionsSchema,
   multiFiles: MultiFilesSchema,
-  multiFilesVisible: MultiFilesVisibleSchema,
   outputFilesActive: z.boolean(),
 });
 export type FileStateContextValue = z.infer<typeof FileStateContextSchema>;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -790,7 +790,6 @@ describe('DesktopProgressBridge', () => {
             instruction: 'Check this draft.',
             inputFiles: ['main.tex', 'appendix.tex'],
             outputFiles: ['main.review.tex'],
-            outputFilesVisible: true,
           }),
         }),
       ]);

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -90,7 +90,7 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     );
   });
 
-  it('renders concise empty-state guidance for first launch and no sessions', () => {
+  it('renders workspace setup without a second first-run panel', () => {
     const rendererMain = readRendererMain();
     const styles = readRendererStyles();
 
@@ -98,13 +98,31 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toContain(
       'Run workflow or tool-use agents with the chosen model.',
     );
-    expect(rendererMain).toContain('desktop-empty-streams');
-    expect(rendererMain).toContain('Try: <q>polish the abstract</q>');
+    expect(rendererMain).not.toContain('desktop-empty-streams');
+    expect(rendererMain).not.toContain('Try: <q>polish the abstract</q>');
     expect(rendererMain).toContain('openCommandPalette');
     expect(rendererMain).not.toContain('SETTINGS_TAB.MODELS');
     expect(rendererMain).not.toContain('SETTINGS_TAB.AGENTS');
-    expect(styles).toContain('.desktop-launcher-surface--empty');
-    expect(styles).not.toContain('.desktop-empty-streams-actions');
+    expect(styles).not.toContain('.desktop-launcher-surface--empty');
+    expect(styles).not.toContain('.desktop-empty-streams');
+  });
+
+  it('shows the workspace directory in the chrome instead of a product label', () => {
+    const rendererMain = readRendererMain();
+    const styles = readRendererStyles();
+
+    expect(rendererMain).toContain('getWorkspaceDirectoryLabel');
+    expect(rendererMain).toContain('window.texraDesktop?.workspacePath');
+    expect(rendererMain).toContain(
+      "if (!trimmed) return normalized.startsWith('/') ? '/' : workspacePath;",
+    );
+    expect(rendererMain).toContain('desktop-workspace-directory');
+    expect(rendererMain).not.toContain('desktop-brand');
+    expect(rendererMain).not.toContain(
+      '<span class="desktop-brand">TeXRA</span>',
+    );
+    expect(styles).toContain('.desktop-workspace-directory');
+    expect(styles).not.toContain('.desktop-brand');
   });
 
   it('renders the launcher back action as an icon-only chrome button', () => {

--- a/src/test-kernel/webview/FileSelectGroupSource.vitest.mts
+++ b/src/test-kernel/webview/FileSelectGroupSource.vitest.mts
@@ -1,0 +1,49 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test paths
+import { repoPath } from '../desktop/desktopTestPaths.mjs';
+
+function readFileSelectGroup(): string {
+  return readFileSync(
+    repoPath(
+      'packages/extension/src/webview/frontend/components/FileSelectGroup.ts',
+    ),
+    'utf8',
+  );
+}
+
+function readMainApp(): string {
+  return readFileSync(
+    repoPath('packages/extension/src/webview/frontend/MainApp.ts'),
+    'utf8',
+  );
+}
+
+function readFileSelectStyles(): string {
+  return readFileSync(
+    repoPath(
+      'packages/extension/src/webview/frontend/styles/fileSelectStyles.ts',
+    ),
+    'utf8',
+  );
+}
+
+describe('file select groups', () => {
+  it('always renders the file list instead of hiding it behind a toggle', () => {
+    const component = readFileSelectGroup();
+    const mainApp = readMainApp();
+    const styles = readFileSelectStyles();
+
+    expect(component).toContain('class="multiple-files-container"');
+    expect(component).not.toContain('handleToggleList');
+    expect(component).not.toContain('config.toggleTitle');
+    expect(component).not.toContain('waIcon(chevronName)');
+    expect(component).not.toContain('data-expanded=');
+    expect(mainApp).not.toContain('@toggle-list=');
+    expect(styles).not.toContain('.file-select[data-expanded');
+  });
+});

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -70,7 +70,7 @@ describe('AgentConfigSchema', () => {
     assert.deepStrictEqual(parsed.mediaFiles, ['figure.png']);
   });
 
-  it('shows legacy main-view file lists after migration', () => {
+  it('migrates legacy main-view file slots into canonical file lists', () => {
     const parsed = MainViewPersistedStateSchema.parse({
       inputFile: 'main.tex',
       referenceFile: 'refs.bib',
@@ -80,8 +80,5 @@ describe('AgentConfigSchema', () => {
     assert.deepStrictEqual(parsed.inputFiles, ['main.tex']);
     assert.deepStrictEqual(parsed.contextFiles, ['refs.bib']);
     assert.deepStrictEqual(parsed.mediaFiles, ['figure.png']);
-    assert.strictEqual(parsed.inputFilesVisible, true);
-    assert.strictEqual(parsed.contextFilesVisible, true);
-    assert.strictEqual(parsed.mediaFilesVisible, true);
   });
 });


### PR DESCRIPTION
## Summary
- Show the workspace directory in the desktop chrome instead of the static TeXRA label.
- Remove the extra desktop first-run suggestion panel below the launcher.
- Retire the file-list collapse toggle so input, context, and media file lists are always visible.
- Remove the now-dead file-list visibility state from live context and persisted main-view state.

## Validation
- ../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/desktop/ElectronRendererShell.vitest.mts src/test-kernel/webview/FileSelectGroupSource.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- ../../node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.renderer.json
- ../../node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node --max-old-space-size=4096 ../../node_modules/eslint/bin/eslint.js packages/desktop/src/renderer/main.ts packages/extension/src/webview/frontend/MainApp.ts packages/extension/src/webview/frontend/components/FileSelectGroup.ts packages/extension/src/webview/frontend/events.ts packages/extension/src/webview/frontend/store.ts packages/extension/src/webview/frontend/styles/fileSelectStyles.ts src/shared/schemas/mainView.ts src/controllers/mainView/MainViewStateRestoreController.ts src/test-kernel/desktop/ElectronRendererShell.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/webview/FileSelectGroupSource.vitest.mts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes file-list visibility toggling and related persisted fields, which changes how main-view state is stored/restored and could affect upgrades from existing user state. UI tweaks to the desktop chrome and launcher are otherwise straightforward.
> 
> **Overview**
> **Desktop launcher chrome now shows the current workspace directory** (derived from `window.texraDesktop?.workspacePath`) instead of a static product label, with updated styling and e2e/kernel assertions.
> 
> **Removes the secondary “first run suggestions” empty-streams panel** from the desktop launcher and deletes its supporting template/CSS and tests.
> 
> **File selection panels no longer collapse/expand:** `FileSelectGroup` always renders the multi-file list, the chevron toggle + `toggle-list` event are removed, and all `multiFilesVisible` state (live context, defaults, schema fields, migrations, restore/save wiring) is retired across the webview and state-restore controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbf6b9a8ada205111f9d3ac75b4ec624854a30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->