### PR TITLE
fix(cli): cap live streaming region so scrollback isn't truncated

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -55,14 +55,34 @@ function TranscriptEntry({
   );
 }
 
+// Cap the streaming live region to a short tail. Ink redraws the live
+// region on every text delta by moving the cursor up and rewriting the
+// rows; if the live region grows taller than the terminal viewport the
+// cursor-up overshoots and clobbers Static items that have already been
+// pushed into scrollback (truncating earlier turns when the user scrolls
+// back). The full content is preserved — the assistant entry transitions
+// into Ink's <Static> the moment it finalizes, which writes it to
+// scrollback in one shot. Keep this number small; it bounds the
+// scrollback damage during long streaming responses.
+const LIVE_TAIL_LINES = 12;
+
 function LiveTranscriptEntry({
   entry,
 }: {
   readonly entry: ConversationEntry;
 }): React.JSX.Element {
+  const lines = entry.text.split('\n');
+  const hiddenLines = Math.max(0, lines.length - LIVE_TAIL_LINES);
+  const tail = hiddenLines > 0 ? lines.slice(-LIVE_TAIL_LINES) : lines;
   return (
-    <Box>
-      <Text>{entry.text}</Text>
+    <Box flexDirection="column">
+      {hiddenLines > 0 ? (
+        <Text dimColor>
+          ⋯ {hiddenLines} earlier line{hiddenLines === 1 ? '' : 's'} hidden
+          while streaming
+        </Text>
+      ) : null}
+      <Text>{tail.join('\n')}</Text>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -13,7 +13,11 @@ import { Box, Static, Text } from 'ink';
 
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
-import { cliState, type ConversationEntry } from '../state/cliState';
+import {
+  cliState,
+  registerCliStateResetHook,
+  type ConversationEntry,
+} from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import { ToolUseRow } from './ToolUseRow';
 import { splitTranscriptEntries } from './transcriptEntries';
@@ -60,6 +64,34 @@ function TranscriptEntry({
 // streaming delta; if it overflows the viewport the cursor-up rewrite
 // overshoots and clobbers Static rows already in scrollback.
 const LIVE_TAIL_ROWS = 12;
+const NEWLINE_CHAR_CODE = 10;
+
+// Incremental newline count keyed by entry id. The live text grows
+// monotonically per delta; without a cache we'd rescan the full prefix
+// every frame and reintroduce the O(text²) cumulative cost the wrap
+// budget is here to avoid. Cleared per session in `resetCliState` via
+// `registerCliStateResetHook` below.
+const newlineCountCache = new Map<
+  string,
+  { length: number; newlines: number }
+>();
+registerCliStateResetHook(() => newlineCountCache.clear());
+
+function countNewlinesUpTo(entryId: string, text: string, upTo: number): number {
+  const cached = newlineCountCache.get(entryId);
+  // Append-only invariant: if `upTo` ≥ cached.length and the cached
+  // prefix is still a prefix of `text`, we can extend. Otherwise (text
+  // shrank or rewrote earlier chars) recount from scratch.
+  const canExtend =
+    cached !== undefined && upTo >= cached.length && cached.length <= text.length;
+  let count = canExtend ? cached.newlines : 0;
+  const start = canExtend ? cached.length : 0;
+  for (let i = start; i < upTo; i += 1) {
+    if (text.charCodeAt(i) === NEWLINE_CHAR_CODE) count += 1;
+  }
+  newlineCountCache.set(entryId, { length: upTo, newlines: count });
+  return count;
+}
 
 function LiveTranscriptEntry({
   entry,
@@ -78,18 +110,13 @@ function LiveTranscriptEntry({
   const cols = width ?? 80;
   const wrapBudget = cols * LIVE_TAIL_ROWS * 2;
   const slicedChars = Math.max(0, entry.text.length - wrapBudget);
-  const slicedPrefix = slicedChars > 0 ? entry.text.slice(0, slicedChars) : '';
   const candidate =
     slicedChars > 0 ? entry.text.slice(slicedChars) : entry.text;
   const rows = wrapAnsiToWidth(candidate, cols).split('\n');
-  // Estimate rows lost to the raw-char slice: each hard newline in the
-  // sliced prefix adds a row regardless of width, plus a width-based
-  // estimate for the remaining non-newline characters. An exact count
-  // would require wrapping the full buffer — the work this avoids.
-  let slicedNewlines = 0;
-  for (let i = 0; i < slicedPrefix.length; i += 1) {
-    if (slicedPrefix.charCodeAt(i) === 10) slicedNewlines += 1;
-  }
+  // Estimate rows lost to the raw-char slice: each hard newline counts
+  // one row, remaining chars wrap by width. Approximate (exact would
+  // need wrapping the full buffer).
+  const slicedNewlines = countNewlinesUpTo(entry.id, entry.text, slicedChars);
   const slicedRows =
     slicedNewlines + Math.ceil((slicedChars - slicedNewlines) / cols);
   const needsHint = rows.length + slicedRows > LIVE_TAIL_ROWS;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -69,13 +69,23 @@ function LiveTranscriptEntry({
   readonly width?: number;
 }): React.JSX.Element {
   // Cap by *wrapped* rows, not by `\n` count — an LLM often streams one
-  // long paragraph with no hard newlines, which Ink still wraps to many
-  // terminal rows. wrapAnsiToWidth gives us the rendered row layout so
-  // the cap reflects what Ink actually paints.
-  const wrapped = wrapAnsiToWidth(entry.text, width);
-  const rows = wrapped.split('\n');
-  const hiddenRows = Math.max(0, rows.length - LIVE_TAIL_ROWS);
-  const tail = hiddenRows > 0 ? rows.slice(-LIVE_TAIL_ROWS) : rows;
+  // long paragraph with no hard newlines, which Ink would still wrap to
+  // many terminal rows. Slice the raw text down to a tail-sized window
+  // before wrapping so per-delta wrap work stays bounded; otherwise the
+  // whole growing buffer is re-wrapped on every keystroke (O(text²)
+  // over the response). Live text is plain (see file header), so
+  // slicing mid-string can't corrupt an ANSI escape.
+  const cols = width ?? 80;
+  const wrapBudget = cols * LIVE_TAIL_ROWS * 2;
+  const slicedChars = Math.max(0, entry.text.length - wrapBudget);
+  const candidate =
+    slicedChars > 0 ? entry.text.slice(slicedChars) : entry.text;
+  const rows = wrapAnsiToWidth(candidate, width).split('\n');
+  const tail = rows.slice(-LIVE_TAIL_ROWS);
+  // Approximate: rows above the tail in the wrapped window + a width-
+  // based estimate of rows lost to the raw-char slice. Exact count would
+  // require wrapping the full buffer — the work this avoids.
+  const hiddenRows = rows.length - tail.length + Math.ceil(slicedChars / cols);
   return (
     <Box flexDirection="column">
       {hiddenRows > 0 ? (

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -78,13 +78,20 @@ function LiveTranscriptEntry({
   const cols = width ?? 80;
   const wrapBudget = cols * LIVE_TAIL_ROWS * 2;
   const slicedChars = Math.max(0, entry.text.length - wrapBudget);
+  const slicedPrefix = slicedChars > 0 ? entry.text.slice(0, slicedChars) : '';
   const candidate =
     slicedChars > 0 ? entry.text.slice(slicedChars) : entry.text;
   const rows = wrapAnsiToWidth(candidate, cols).split('\n');
-  // Approximate: rows above the tail in the wrapped window + a width-
-  // based estimate of rows lost to the raw-char slice. Exact count would
-  // require wrapping the full buffer — the work this avoids.
-  const slicedRows = Math.ceil(slicedChars / cols);
+  // Estimate rows lost to the raw-char slice: each hard newline in the
+  // sliced prefix adds a row regardless of width, plus a width-based
+  // estimate for the remaining non-newline characters. An exact count
+  // would require wrapping the full buffer — the work this avoids.
+  let slicedNewlines = 0;
+  for (let i = 0; i < slicedPrefix.length; i += 1) {
+    if (slicedPrefix.charCodeAt(i) === 10) slicedNewlines += 1;
+  }
+  const slicedRows =
+    slicedNewlines + Math.ceil((slicedChars - slicedNewlines) / cols);
   const needsHint = rows.length + slicedRows > LIVE_TAIL_ROWS;
   const tailLimit = needsHint ? LIVE_TAIL_ROWS - 1 : LIVE_TAIL_ROWS;
   const tail = rows.slice(-tailLimit);

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -12,6 +12,7 @@
 import { Box, Static, Text } from 'ink';
 
 import { Markdown } from '../render/Markdown';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { cliState, type ConversationEntry } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import { ToolUseRow } from './ToolUseRow';
@@ -55,31 +56,32 @@ function TranscriptEntry({
   );
 }
 
-// Cap the streaming live region to a short tail. Ink redraws the live
-// region on every text delta by moving the cursor up and rewriting the
-// rows; if the live region grows taller than the terminal viewport the
-// cursor-up overshoots and clobbers Static items that have already been
-// pushed into scrollback (truncating earlier turns when the user scrolls
-// back). The full content is preserved — the assistant entry transitions
-// into Ink's <Static> the moment it finalizes, which writes it to
-// scrollback in one shot. Keep this number small; it bounds the
-// scrollback damage during long streaming responses.
-const LIVE_TAIL_LINES = 12;
+// Bounds the live-region row count. Ink redraws the live region on every
+// streaming delta; if it overflows the viewport the cursor-up rewrite
+// overshoots and clobbers Static rows already in scrollback.
+const LIVE_TAIL_ROWS = 12;
 
 function LiveTranscriptEntry({
   entry,
+  width,
 }: {
   readonly entry: ConversationEntry;
+  readonly width?: number;
 }): React.JSX.Element {
-  const lines = entry.text.split('\n');
-  const hiddenLines = Math.max(0, lines.length - LIVE_TAIL_LINES);
-  const tail = hiddenLines > 0 ? lines.slice(-LIVE_TAIL_LINES) : lines;
+  // Cap by *wrapped* rows, not by `\n` count — an LLM often streams one
+  // long paragraph with no hard newlines, which Ink still wraps to many
+  // terminal rows. wrapAnsiToWidth gives us the rendered row layout so
+  // the cap reflects what Ink actually paints.
+  const wrapped = wrapAnsiToWidth(entry.text, width);
+  const rows = wrapped.split('\n');
+  const hiddenRows = Math.max(0, rows.length - LIVE_TAIL_ROWS);
+  const tail = hiddenRows > 0 ? rows.slice(-LIVE_TAIL_ROWS) : rows;
   return (
     <Box flexDirection="column">
-      {hiddenLines > 0 ? (
+      {hiddenRows > 0 ? (
         <Text dimColor>
-          ⋯ {hiddenLines} earlier line{hiddenLines === 1 ? '' : 's'} hidden
-          while streaming
+          ⋯ {hiddenRows} earlier row{hiddenRows === 1 ? '' : 's'} hidden while
+          streaming
         </Text>
       ) : null}
       <Text>{tail.join('\n')}</Text>
@@ -120,7 +122,13 @@ export function ConversationPane(
             return <ToolUseRow key={entry.id} toolUse={entry.toolUse} />;
           }
           if (entry.role === 'assistant') {
-            return <LiveTranscriptEntry key={entry.id} entry={entry} />;
+            return (
+              <LiveTranscriptEntry
+                key={entry.id}
+                entry={entry}
+                width={props.width}
+              />
+            );
           }
           return null;
         })}

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -80,12 +80,15 @@ function LiveTranscriptEntry({
   const slicedChars = Math.max(0, entry.text.length - wrapBudget);
   const candidate =
     slicedChars > 0 ? entry.text.slice(slicedChars) : entry.text;
-  const rows = wrapAnsiToWidth(candidate, width).split('\n');
-  const tail = rows.slice(-LIVE_TAIL_ROWS);
+  const rows = wrapAnsiToWidth(candidate, cols).split('\n');
   // Approximate: rows above the tail in the wrapped window + a width-
   // based estimate of rows lost to the raw-char slice. Exact count would
   // require wrapping the full buffer — the work this avoids.
-  const hiddenRows = rows.length - tail.length + Math.ceil(slicedChars / cols);
+  const slicedRows = Math.ceil(slicedChars / cols);
+  const needsHint = rows.length + slicedRows > LIVE_TAIL_ROWS;
+  const tailLimit = needsHint ? LIVE_TAIL_ROWS - 1 : LIVE_TAIL_ROWS;
+  const tail = rows.slice(-tailLimit);
+  const hiddenRows = rows.length - tail.length + slicedRows;
   return (
     <Box flexDirection="column">
       {hiddenRows > 0 ? (


### PR DESCRIPTION
## Summary

Long assistant responses streaming into the chat TUI were truncating earlier turns from terminal scrollback. The culprit: Ink redraws the live region on every text delta by moving the cursor up and rewriting the rows. When the live region grew taller than the viewport (a multi-paragraph response easily does), the cursor-up overshoots and clobbers `<Static>` items that were already pushed into scrollback — so when the user scrolled back they saw missing/torn earlier history.

This PR caps `LiveTranscriptEntry` to the **last 12 lines** of the in-flight entry, with a dim hint showing how many earlier lines are hidden. The full content is never lost: the entry transitions into Ink's `<Static>` the moment it finalizes (which writes it to scrollback in one shot), so all the text reappears intact.

## Why not a deeper fix

Claude Code solves this with a custom Ink fork that diffs frames against terminal scrollback and emits full-reset sequences when the cursor would overshoot. We don't ship a fork. Bounding the live region is the smallest change that stops the regression without restructuring the renderer — a future PR can revisit (e.g. forklift the conversation onto a stdout-write path independent of Ink).

## Test plan

- [ ] `node packages/cli/dist/bin/texra.js --model=deepseekT` — ask something that returns a long response (e.g. "explain tensor networks in detail").
- [ ] During streaming: only the last ~12 lines of the response are visible above the input bar; a dim "⋯ N earlier lines hidden while streaming" line shows above them.
- [ ] After the response finalizes: the full body appears in scrollback (scroll up to see it).
- [ ] Submit several more long-response turns. Scroll back — all earlier turns are intact (no torn / clipped messages).
- [ ] Short responses (≤12 lines) render normally without the truncation hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to streaming rendering; main risk is minor regressions in live transcript wrapping/truncation behavior for edge-case terminal widths.
> 
> **Overview**
> Prevents long, streaming assistant responses from overwriting prior `<Static>` transcript rows by **capping the live (in-flight) render to the last 12 wrapped terminal rows** and showing a dim hint when earlier rows are hidden.
> 
> Adds width-aware wrapping via `wrapAnsiToWidth`, plus an incremental newline-count cache (cleared on `cliState` reset) to keep per-delta work bounded while estimating how many rows were truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d96aa67c2cd8e626c84a9a6be6e50ce1a453dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->