### PR TITLE
chore(relay): roll back monthly tier limits to $10/$50

### DIFF
--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -120,12 +120,11 @@ export const TIER_CONFIG: TierModelConfig = {
  * Monthly spending limits by tier (in USD).
  *
  * These limits apply to relay usage only. Users can always use their own
- * API keys without any limits. Current values reflect the sponsor-credit
- * promotion: free and Max tiers are bumped while the donated credits last.
+ * API keys without any limits.
  */
 export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
-  free: 20, // $20/month - promo (bumped from $10)
-  Max: 100, // $100/month - promo (bumped from $50)
+  free: 10, // $10/month
+  Max: 50, // $50/month
   Ultra: 300, // $300/month - sponsor access
 };
 


### PR DESCRIPTION
## Summary

Roll back the relay monthly spending limits to the base values:
- free: \$20 → **\$10**
- Max: \$100 → **\$50**
- Ultra: \$300 (unchanged, sponsor access)

The previous values were a temporary bump while sponsor credits were available; comment updated accordingly.

The relay edge function (v61) has already been redeployed against prod with these values via \`supabase functions deploy relay --no-verify-jwt\`.

## Test plan

- [x] Edge function v61 deployed with verify_jwt=false (matches previous behavior)
- [x] GET /relay/tier-config returns the new \`spendingLimits\` payload
- [ ] Watch \`get_user_monthly_relay_spend\` quota-check responses over the next day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relay quota configuration, which can immediately affect user request throttling/denials if they now exceed the lower monthly caps. Scope is small and limited to constants/comments in the relay edge function.
> 
> **Overview**
> Reverts relay monthly tier spending caps to their baseline values by lowering `TIER_SPENDING_LIMITS` for `free` ($20→$10) and `Max` ($100→$50), leaving `Ultra` unchanged.
> 
> Updates the accompanying comment to remove the prior sponsor-credit promotion rationale so the limits are documented as standard, non-promotional values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c70ff546f5d07531a552b2169788f3803f9a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->