### PR TITLE
chore(supabase): pin search_path + revoke RPC EXECUTE on pre-existing SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260517110000_harden_pre_existing_functions.sql
+++ b/supabase/migrations/20260517110000_harden_pre_existing_functions.sql
@@ -1,0 +1,67 @@
+-- Address Supabase advisor warnings on pre-existing functions:
+--   0011 function_search_path_mutable
+--   0028 anon_security_definer_function_executable
+--   0029 authenticated_security_definer_function_executable
+--
+-- Pin search_path on all four flagged functions so a malicious schema
+-- on the calling role's search_path cannot shadow `public`/`auth`
+-- references. For the three SECURITY DEFINER functions, revoke EXECUTE
+-- from anon/authenticated so they can't be invoked over /rest/v1/rpc.
+-- Service role keeps EXECUTE (used by edge functions and the
+-- handle_new_user trigger, which fires regardless of role grants).
+
+-- 1) get_user_by_email — exposes auth.users rows. SECURITY DEFINER.
+DO $$
+BEGIN
+  IF to_regprocedure('public.get_user_by_email(text)') IS NOT NULL THEN
+    ALTER FUNCTION public.get_user_by_email(text)
+      SET search_path = public, auth, pg_temp;
+    REVOKE EXECUTE ON FUNCTION public.get_user_by_email(text)
+      FROM PUBLIC, anon, authenticated;
+    GRANT EXECUTE ON FUNCTION public.get_user_by_email(text) TO service_role;
+  END IF;
+END $$;
+
+-- 2) get_user_monthly_relay_spend — STABLE, not SECURITY DEFINER, so
+-- it inherits the caller's privileges. Only search_path needs pinning;
+-- existing grants stay (relay edge fn uses service_role).
+DO $$
+BEGIN
+  IF to_regprocedure(
+    'public.get_user_monthly_relay_spend(uuid,timestamp with time zone)'
+  ) IS NOT NULL THEN
+    ALTER FUNCTION public.get_user_monthly_relay_spend(uuid, timestamptz)
+      SET search_path = public, pg_temp;
+  END IF;
+END $$;
+
+-- 3) handle_new_user — auth.users INSERT trigger. SECURITY DEFINER so
+-- it can write into public.profiles. The trigger runs without going
+-- through RPC permission checks, so REVOKE here just closes off
+-- privilege escalation via /rest/v1/rpc/handle_new_user.
+DO $$
+BEGIN
+  IF to_regprocedure('public.handle_new_user()') IS NOT NULL THEN
+    ALTER FUNCTION public.handle_new_user()
+      SET search_path = public, pg_temp;
+    REVOKE EXECUTE ON FUNCTION public.handle_new_user()
+      FROM PUBLIC, anon, authenticated;
+  END IF;
+END $$;
+
+-- 4) user_has_visibility_access — reads profiles bypassing RLS via
+-- SECURITY DEFINER. Currently unreferenced by any RLS policy (the
+-- remote_agents policy was inlined in
+-- 20260517100300_rls_initplan_wrap_auth_uid.sql) but keep it for any
+-- edge-function caller. Service role only.
+DO $$
+BEGIN
+  IF to_regprocedure('public.user_has_visibility_access(text[])') IS NOT NULL THEN
+    ALTER FUNCTION public.user_has_visibility_access(text[])
+      SET search_path = public, pg_temp;
+    REVOKE EXECUTE ON FUNCTION public.user_has_visibility_access(text[])
+      FROM PUBLIC, anon, authenticated;
+    GRANT EXECUTE ON FUNCTION public.user_has_visibility_access(text[])
+      TO service_role;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Pre-existing functions in \`public\` were flagged by the Supabase advisor after #4159 surfaced the linter output. Locking them down so the advisor is clean:

| Function | search_path | EXECUTE access |
|---|---|---|
| \`get_user_by_email(text)\` | \`public, auth, pg_temp\` | only \`service_role\` |
| \`get_user_monthly_relay_spend(uuid, timestamptz)\` | \`public, pg_temp\` | unchanged (not SECURITY DEFINER) |
| \`handle_new_user()\` | \`public, pg_temp\` | revoked from anon/authenticated; trigger keeps working |
| \`user_has_visibility_access(text[])\` | \`public, pg_temp\` | only \`service_role\` |

Bodies are untouched. Already applied to production via MCP \`apply_migration\` (\`harden_pre_existing_functions\`); this commit just makes it reproducible.

## What this fixes (advisor)

- 0011 function_search_path_mutable × 4
- 0028 anon_security_definer_function_executable × 3
- 0029 authenticated_security_definer_function_executable × 3

Verified post-apply: those 10 warnings are gone. Remaining advisor signals are:
- \`rls_enabled_no_policy\` INFO on \`usage_logs_backup_20260517\` — intentional (service role only, see #4159)
- \`auth_leaked_password_protection\` WARN — dashboard toggle, not a SQL change

## Test plan

- [x] Advisor security run confirms 0/4 search_path warnings and 0/6 RPC-executable warnings remain
- [x] \`handle_new_user\` trigger fires on auth.users INSERT (REVOKE doesn't affect triggers)
- [ ] Relay edge function still reports correct monthly spend via \`get_user_monthly_relay_spend\` (called from service-role client; not affected by anon/authenticated revoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database security posture by revoking RPC-executable access to several `SECURITY DEFINER` functions and pinning `search_path`, which could break any callers relying on anon/authenticated execution or implicit schema resolution.
> 
> **Overview**
> Adds a new Supabase migration that conditionally hardens four pre-existing `public` functions flagged by the advisor.
> 
> It **pins `search_path`** on `get_user_by_email`, `get_user_monthly_relay_spend`, `handle_new_user`, and `user_has_visibility_access` to prevent schema-shadowing, and **revokes `EXECUTE` from `PUBLIC`/`anon`/`authenticated`** for the `SECURITY DEFINER` functions (granting back to `service_role` where needed) to stop invocation via `/rest/v1/rpc` while leaving function bodies unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b760503a9514f0e2cf1eefd0f378e8a66ce3a858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->