### PR TITLE
feat(cli): render tool calls in chat TUI

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -14,6 +14,7 @@ import { Box, Static, Text } from 'ink';
 import { Markdown } from '../render/Markdown';
 import { cliState, type ConversationEntry } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import { ToolUseRow } from './ToolUseRow';
 import { splitTranscriptEntries } from './transcriptEntries';
 
 export { splitTranscriptEntries } from './transcriptEntries';
@@ -41,6 +42,10 @@ function TranscriptEntry({
         <Text color="red">{entry.text}</Text>
       </Box>
     );
+  }
+
+  if (entry.role === 'tool' && entry.toolUse) {
+    return <ToolUseRow toolUse={entry.toolUse} />;
   }
 
   return (
@@ -73,7 +78,10 @@ export function ConversationPane(
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
-  const { finalized, live } = splitTranscriptEntries(entries, slice?.status);
+  const { finalized, pendingTools, live } = splitTranscriptEntries(
+    entries,
+    slice?.status,
+  );
 
   return (
     <Box flexDirection="column">
@@ -82,6 +90,14 @@ export function ConversationPane(
           <TranscriptEntry key={entry.id} entry={entry} width={props.width} />
         )}
       </Static>
+      {/* Tool calls still in `in_progress` re-render in place so the
+       *  status dot can transition to green/red when the result arrives.
+       *  Putting them in <Static> would freeze them at the running state. */}
+      {pendingTools.map((entry) =>
+        entry.toolUse ? (
+          <ToolUseRow key={entry.id} toolUse={entry.toolUse} />
+        ) : null,
+      )}
       {/* Reserve a single line for the live region even when nothing is
        * streaming. Ink renders Static items into scrollback above the
        * live area, so toggling live presence between renders made the

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -78,10 +78,7 @@ export function ConversationPane(
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
-  const { finalized, pendingTools, live } = splitTranscriptEntries(
-    entries,
-    slice?.status,
-  );
+  const { finalized, pending } = splitTranscriptEntries(entries, slice?.status);
 
   return (
     <Box flexDirection="column">
@@ -90,21 +87,23 @@ export function ConversationPane(
           <TranscriptEntry key={entry.id} entry={entry} width={props.width} />
         )}
       </Static>
-      {/* Tool calls still in `in_progress` re-render in place so the
-       *  status dot can transition to green/red when the result arrives.
-       *  Putting them in <Static> would freeze them at the running state. */}
-      {pendingTools.map((entry) =>
-        entry.toolUse ? (
-          <ToolUseRow key={entry.id} toolUse={entry.toolUse} />
-        ) : null,
-      )}
-      {/* Reserve a single line for the live region even when nothing is
-       * streaming. Ink renders Static items into scrollback above the
-       * live area, so toggling live presence between renders made the
-       * input bar appear to "shift down" by a line. A stable footer
-       * keeps the layout pinned. */}
-      <Box minHeight={1}>
-        {live ? <LiveTranscriptEntry entry={live} /> : null}
+      {/* `pending` interleaves the in-flight assistant entry with tool
+       *  rows in stream order — rendering them as separate buckets would
+       *  flip the visible order when the model emits text before a tool
+       *  call. <Static> can't carry these because they still mutate
+       *  (assistant text streaming, tool dot transitioning). The
+       *  minHeight=1 keeps the input bar pinned when the bucket is
+       *  empty. */}
+      <Box flexDirection="column" minHeight={1}>
+        {pending.map((entry) => {
+          if (entry.role === 'tool' && entry.toolUse) {
+            return <ToolUseRow key={entry.id} toolUse={entry.toolUse} />;
+          }
+          if (entry.role === 'assistant') {
+            return <LiveTranscriptEntry key={entry.id} entry={entry} />;
+          }
+          return null;
+        })}
       </Box>
     </Box>
   );

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -7,15 +7,30 @@
 // progress view; the CLI sticks to a universal renderer that works for
 // every tool without dispatch tables.
 
+import { useMemo } from 'react';
+
 import { Box, Text } from 'ink';
 
 import type { NormalizedToolUse } from '@shared/schemas';
 import { isPlainObject } from '@shared/utils/string';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
 const MAX_OUTPUT_LINES = 3;
 const MAX_HEADER_PREVIEW = 80;
+const MAX_ERROR_PREVIEW = 240;
+
+// Tool inputs vary in shape; show whichever of these "primary" fields
+// exists first. Order matters — earlier keys win.
+const PRIMARY_INPUT_KEYS = [
+  'command',
+  'code',
+  'path',
+  'file_path',
+  'query',
+  'url',
+] as const;
 
 function displayToolName(toolName: string): string {
   // Drop provider/handler prefixes like `claude:Bash` or `mcp:slack:send`
@@ -29,21 +44,9 @@ function previewInput(input: unknown): string {
   if (typeof input === 'string') return input;
   if (input === undefined || input === null) return '';
   if (isPlainObject(input)) {
-    // Heuristic: most tools have a primary "what" field. Show that
-    // first; otherwise fall back to a compact JSON dump.
-    const primary =
-      (typeof input.command === 'string' && input.command) ||
-      (typeof input.code === 'string' && input.code) ||
-      (typeof input.path === 'string' && input.path) ||
-      (typeof input.file_path === 'string' && input.file_path) ||
-      (typeof input.query === 'string' && input.query) ||
-      (typeof input.url === 'string' && input.url) ||
-      '';
-    if (primary) return primary;
-    try {
-      return JSON.stringify(input);
-    } catch {
-      return '';
+    for (const key of PRIMARY_INPUT_KEYS) {
+      const value = input[key];
+      if (typeof value === 'string' && value) return value;
     }
   }
   try {
@@ -53,10 +56,8 @@ function previewInput(input: unknown): string {
   }
 }
 
-function truncateOneLine(text: string, max: number): string {
-  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  if (oneLine.length <= max) return oneLine;
-  return `${oneLine.slice(0, max - 1)}…`;
+function collapseWhitespace(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim();
 }
 
 function statusColor(toolUse: NormalizedToolUse): 'green' | 'red' | undefined {
@@ -73,21 +74,30 @@ export function ToolUseRow({
   const color = statusColor(toolUse);
   const name = displayToolName(toolUse.toolName) || 'tool';
 
-  const previewSource =
-    toolUse.headerSummary || previewInput(toolUse.input) || '';
-  const preview = previewSource
-    ? truncateOneLine(previewSource, MAX_HEADER_PREVIEW)
-    : '';
+  // Memoize by toolUse identity. subscribeStreamLog's data-ref cache
+  // keeps `toolUse` stable across re-renders when nothing changed, so
+  // the heavy work (split, slice, JSON.stringify in previewInput) only
+  // runs when there's a real update.
+  const { preview, visibleOutput, hiddenCount } = useMemo(() => {
+    const sourceText =
+      toolUse.headerSummary || previewInput(toolUse.input) || '';
+    const previewText = sourceText
+      ? truncateWithEllipsis(collapseWhitespace(sourceText), MAX_HEADER_PREVIEW)
+      : '';
+    const lines = toolUse.outputText ? toolUse.outputText.split('\n') : [];
+    const visible = lines.slice(0, MAX_OUTPUT_LINES);
+    return {
+      preview: previewText,
+      visibleOutput: visible,
+      hiddenCount: Math.max(0, lines.length - visible.length),
+    };
+  }, [toolUse]);
 
-  const outputLines = toolUse.outputText ? toolUse.outputText.split('\n') : [];
-  const visibleOutput = outputLines.slice(0, MAX_OUTPUT_LINES);
-  const hiddenCount = Math.max(0, outputLines.length - visibleOutput.length);
-
-  const completed = toolUse.status === 'completed';
   const hasError = toolUse.isError && toolUse.errorText;
   // When a tool completes with neither output nor error, show "(no output)"
   // so the row doesn't look stuck. While running, we leave the body blank.
-  const showNoOutput = completed && outputLines.length === 0 && !hasError;
+  const showNoOutput =
+    toolUse.status === 'completed' && visibleOutput.length === 0 && !hasError;
 
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -116,7 +126,12 @@ export function ToolUseRow({
       {hasError ? (
         <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
           <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
-          <Text color="red">{truncateOneLine(toolUse.errorText, 240)}</Text>
+          <Text color="red">
+            {truncateWithEllipsis(
+              collapseWhitespace(toolUse.errorText),
+              MAX_ERROR_PREVIEW,
+            )}
+          </Text>
         </Box>
       ) : null}
       {showNoOutput ? (

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -93,11 +93,14 @@ export function ToolUseRow({
     };
   }, [toolUse]);
 
-  const hasError = toolUse.isError && toolUse.errorText;
-  // When a tool completes with neither output nor error, show "(no output)"
-  // so the row doesn't look stuck. While running, we leave the body blank.
+  // `isError` is the authoritative signal — `errorText` can be empty even
+  // when the upstream payload sets `isError: true` (no `error` string).
+  // Tracking only the text would let the "(no output)" branch fire on a
+  // failed tool, hiding the failure behind a misleading label.
+  const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
+  const showError = toolUse.isError;
   const showNoOutput =
-    toolUse.status === 'completed' && visibleOutput.length === 0 && !hasError;
+    toolUse.status === 'completed' && visibleOutput.length === 0 && !showError;
 
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -123,12 +126,12 @@ export function ToolUseRow({
           ) : null}
         </Box>
       ) : null}
-      {hasError ? (
+      {showError ? (
         <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
           <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
           <Text color="red">
             {truncateWithEllipsis(
-              collapseWhitespace(toolUse.errorText),
+              collapseWhitespace(errorText),
               MAX_ERROR_PREVIEW,
             )}
           </Text>

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -1,0 +1,129 @@
+// CLI-native tool-call row.
+//
+// Renders a single TOOL_USE entry as one compact header line plus an
+// optional indented output block (max 3 lines), mirroring the visual
+// language Claude Code uses in its Ink TUI. Per-tool rich renderers
+// (edit diffs, file links, ANSI bash output) live in the VS Code
+// progress view; the CLI sticks to a universal renderer that works for
+// every tool without dispatch tables.
+
+import { Box, Text } from 'ink';
+
+import type { NormalizedToolUse } from '@shared/schemas';
+import { isPlainObject } from '@shared/utils/string';
+
+const STATUS_DOT = '●';
+const OUTPUT_CORNER = '⎿';
+const MAX_OUTPUT_LINES = 3;
+const MAX_HEADER_PREVIEW = 80;
+
+function displayToolName(toolName: string): string {
+  // Drop provider/handler prefixes like `claude:Bash` or `mcp:slack:send`
+  // so the row reads as just the tool — `Bash`, `send`. Tools without a
+  // colon are returned as-is.
+  const lastColon = toolName.lastIndexOf(':');
+  return lastColon >= 0 ? toolName.slice(lastColon + 1) : toolName;
+}
+
+function previewInput(input: unknown): string {
+  if (typeof input === 'string') return input;
+  if (input === undefined || input === null) return '';
+  if (isPlainObject(input)) {
+    // Heuristic: most tools have a primary "what" field. Show that
+    // first; otherwise fall back to a compact JSON dump.
+    const primary =
+      (typeof input.command === 'string' && input.command) ||
+      (typeof input.code === 'string' && input.code) ||
+      (typeof input.path === 'string' && input.path) ||
+      (typeof input.file_path === 'string' && input.file_path) ||
+      (typeof input.query === 'string' && input.query) ||
+      (typeof input.url === 'string' && input.url) ||
+      '';
+    if (primary) return primary;
+    try {
+      return JSON.stringify(input);
+    } catch {
+      return '';
+    }
+  }
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return '';
+  }
+}
+
+function truncateOneLine(text: string, max: number): string {
+  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, max - 1)}…`;
+}
+
+function statusColor(toolUse: NormalizedToolUse): 'green' | 'red' | undefined {
+  if (toolUse.isError) return 'red';
+  if (toolUse.status === 'completed') return 'green';
+  return undefined;
+}
+
+export function ToolUseRow({
+  toolUse,
+}: {
+  readonly toolUse: NormalizedToolUse;
+}): React.JSX.Element {
+  const color = statusColor(toolUse);
+  const name = displayToolName(toolUse.toolName) || 'tool';
+
+  const previewSource =
+    toolUse.headerSummary || previewInput(toolUse.input) || '';
+  const preview = previewSource
+    ? truncateOneLine(previewSource, MAX_HEADER_PREVIEW)
+    : '';
+
+  const outputLines = toolUse.outputText ? toolUse.outputText.split('\n') : [];
+  const visibleOutput = outputLines.slice(0, MAX_OUTPUT_LINES);
+  const hiddenCount = Math.max(0, outputLines.length - visibleOutput.length);
+
+  const completed = toolUse.status === 'completed';
+  const hasError = toolUse.isError && toolUse.errorText;
+  // When a tool completes with neither output nor error, show "(no output)"
+  // so the row doesn't look stuck. While running, we leave the body blank.
+  const showNoOutput = completed && outputLines.length === 0 && !hasError;
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box flexDirection="row" flexWrap="nowrap">
+        <Text color={color} dimColor={!color}>
+          {STATUS_DOT}{' '}
+        </Text>
+        <Text bold>{name}</Text>
+        {preview ? <Text dimColor>{` (${preview})`}</Text> : null}
+      </Box>
+      {visibleOutput.length > 0 ? (
+        <Box flexDirection="column" paddingLeft={2}>
+          {visibleOutput.map((line, index) => (
+            <Box key={index} flexDirection="row" flexWrap="nowrap">
+              <Text dimColor>{index === 0 ? `${OUTPUT_CORNER} ` : '  '}</Text>
+              <Text>{line}</Text>
+            </Box>
+          ))}
+          {hiddenCount > 0 ? (
+            <Text
+              dimColor
+            >{`  … +${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}</Text>
+          ) : null}
+        </Box>
+      ) : null}
+      {hasError ? (
+        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
+          <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
+          <Text color="red">{truncateOneLine(toolUse.errorText, 240)}</Text>
+        </Box>
+      ) : null}
+      {showNoOutput ? (
+        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
+          <Text dimColor>{`${OUTPUT_CORNER} (no output)`}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -26,12 +26,23 @@ export function splitTranscriptEntries(
   status: StreamStatus | undefined,
 ): {
   readonly finalized: ConversationEntry[];
+  /** Tool calls still running. Re-rendered on every store sync so the
+   *  status dot transitions in place; promoted to `finalized` once the
+   *  underlying entry flips `finalized: true`. */
+  readonly pendingTools: ConversationEntry[];
   readonly live: ConversationEntry | undefined;
 } {
   const live = isAppending(status)
     ? findLiveAssistantEntry(entries)
     : undefined;
-  const finalized = entries.filter((entry) => entry.finalized);
-
-  return { finalized, live };
+  const finalized: ConversationEntry[] = [];
+  const pendingTools: ConversationEntry[] = [];
+  for (const entry of entries) {
+    if (entry.finalized) {
+      finalized.push(entry);
+      continue;
+    }
+    if (entry.role === 'tool') pendingTools.push(entry);
+  }
+  return { finalized, pendingTools, live };
 }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -26,23 +26,35 @@ export function splitTranscriptEntries(
   status: StreamStatus | undefined,
 ): {
   readonly finalized: ConversationEntry[];
-  /** Tool calls still running. Re-rendered on every store sync so the
-   *  status dot transitions in place; promoted to `finalized` once the
-   *  underlying entry flips `finalized: true`. */
-  readonly pendingTools: ConversationEntry[];
+  /** Non-finalized entries in original stream order. The renderer must
+   *  walk this list (rather than rendering tool rows and the live
+   *  assistant as separate buckets) so that text emitted before a tool
+   *  call appears above the tool row instead of below it. Tool entries
+   *  defer finalization until the stream itself finalizes — promoting
+   *  them earlier would let a fast tool jump ahead of still-streaming
+   *  assistant text in `<Static>` scrollback, where insertion order is
+   *  fixed. */
+  readonly pending: ConversationEntry[];
+  /** Kept for callers (and tests) that only care about the streaming
+   *  assistant entry. Derived from `entries`. */
   readonly live: ConversationEntry | undefined;
 } {
-  const live = isAppending(status)
-    ? findLiveAssistantEntry(entries)
-    : undefined;
+  const showLiveAssistant = isAppending(status);
   const finalized: ConversationEntry[] = [];
-  const pendingTools: ConversationEntry[] = [];
+  const pending: ConversationEntry[] = [];
   for (const entry of entries) {
     if (entry.finalized) {
       finalized.push(entry);
       continue;
     }
-    if (entry.role === 'tool') pendingTools.push(entry);
+    if (entry.role === 'tool') {
+      pending.push(entry);
+      continue;
+    }
+    if (entry.role === 'assistant' && showLiveAssistant) {
+      pending.push(entry);
+    }
   }
-  return { finalized, pendingTools, live };
+  const live = showLiveAssistant ? findLiveAssistantEntry(entries) : undefined;
+  return { finalized, pending, live };
 }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -10,17 +10,6 @@ function isAppending(status: StreamStatus | undefined): boolean {
   );
 }
 
-function findLiveAssistantEntry(
-  entries: readonly ConversationEntry[],
-): ConversationEntry | undefined {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (entry.role !== 'assistant' || entry.finalized) continue;
-    return entry;
-  }
-  return undefined;
-}
-
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
   status: StreamStatus | undefined,
@@ -35,9 +24,6 @@ export function splitTranscriptEntries(
    *  assistant text in `<Static>` scrollback, where insertion order is
    *  fixed. */
   readonly pending: ConversationEntry[];
-  /** Kept for callers (and tests) that only care about the streaming
-   *  assistant entry. Derived from `entries`. */
-  readonly live: ConversationEntry | undefined;
 } {
   const showLiveAssistant = isAppending(status);
   const finalized: ConversationEntry[] = [];
@@ -55,6 +41,5 @@ export function splitTranscriptEntries(
       pending.push(entry);
     }
   }
-  const live = showLiveAssistant ? findLiveAssistantEntry(entries) : undefined;
-  return { finalized, pending, live };
+  return { finalized, pending };
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -7,7 +7,7 @@
 
 import { signal, type Signal } from '@lit-labs/signals';
 
-import type { StreamTabId } from '@shared/schemas';
+import type { NormalizedToolUse, StreamTabId } from '@shared/schemas';
 import type {
   ActiveChildInfo,
   ConversationProgress,
@@ -20,11 +20,13 @@ import type {
 export interface ConversationEntry {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */
   readonly id: string;
-  readonly role: 'assistant' | 'error' | 'user';
-  /** Concatenated text for `MODEL_RESPONSE` entries. */
+  readonly role: 'assistant' | 'error' | 'tool' | 'user';
+  /** Concatenated text for `MODEL_RESPONSE` entries. Empty for tool rows. */
   readonly text: string;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */
   readonly finalized: boolean;
+  /** Populated only when `role === 'tool'`. */
+  readonly toolUse?: NormalizedToolUse;
   /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
   readonly synthetic?: boolean;
   /** Why the CLI synthesized this entry. */

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -27,11 +27,6 @@ export interface ConversationEntry {
   readonly finalized: boolean;
   /** Populated only when `role === 'tool'`. */
   readonly toolUse?: NormalizedToolUse;
-  /** Identity of the `StreamLogEntry.data` `toolUse` was derived from.
-   *  Cache key for `renderLogEntry` — when the next sync sees the same
-   *  ref it skips re-normalizing (Zod parse + YAML stringify on the
-   *  streaming hot path). */
-  readonly toolUseSource?: unknown;
   /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
   readonly synthetic?: boolean;
   /** Why the CLI synthesized this entry. */

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -27,6 +27,11 @@ export interface ConversationEntry {
   readonly finalized: boolean;
   /** Populated only when `role === 'tool'`. */
   readonly toolUse?: NormalizedToolUse;
+  /** Identity of the `StreamLogEntry.data` `toolUse` was derived from.
+   *  Cache key for `renderLogEntry` — when the next sync sees the same
+   *  ref it skips re-normalizing (Zod parse + YAML stringify on the
+   *  streaming hot path). */
+  readonly toolUseSource?: unknown;
   /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
   readonly synthetic?: boolean;
   /** Why the CLI synthesized this entry. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -76,16 +76,25 @@ function renderLogEntry(
     // fast-completing tool would otherwise jump into `<Static>`
     // scrollback while preceding assistant text from the same turn is
     // still streaming, reversing the visible order (Static items are
-    // append-only).
+    // append-only). Inherit the prior flag so a sync tick that fires
+    // after the finalize step doesn't roll the entry back to false.
     const next: ConversationEntry = {
       id: entry.id,
       role: 'tool',
       text: '',
-      finalized: false,
+      finalized: prev?.finalized ?? false,
       toolUse,
       toolUseSource: entry.data,
     };
-    return prev && entriesEqual(prev, next) ? prev : next;
+    if (prev && entriesEqual(prev, next)) {
+      // Same content under a fresh `data` reference: refresh the cache
+      // key on `prev` instead of returning it as-is, otherwise the
+      // identity fast path above keeps missing on every subsequent tick.
+      return prev.toolUseSource === entry.data
+        ? prev
+        : { ...prev, toolUseSource: entry.data };
+    }
+    return next;
   }
 
   const text = entry.text ?? '';
@@ -95,11 +104,16 @@ function renderLogEntry(
       : entry.messageType === MESSAGE_TYPES.ERROR
         ? 'error'
         : 'assistant';
+  // Assistant entries defer finalization (see comment above); inherit
+  // from `prev` so re-syncs after finalize don't de-finalize and drop
+  // the entry from `splitTranscriptEntries` once status flips to
+  // WAITING.
+  const finalized = role === 'assistant' ? (prev?.finalized ?? false) : true;
   const next: ConversationEntry = {
     id: entry.id,
     role,
     text,
-    finalized: role !== 'assistant',
+    finalized,
   };
   return prev && entriesEqual(prev, next) ? prev : next;
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -72,11 +72,16 @@ function renderLogEntry(
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
     if (!toolUse) return null;
+    // Defer finalization to `finalizeAssistantTranscriptEntries`. A
+    // fast-completing tool would otherwise jump into `<Static>`
+    // scrollback while preceding assistant text from the same turn is
+    // still streaming, reversing the visible order (Static items are
+    // append-only).
     const next: ConversationEntry = {
       id: entry.id,
       role: 'tool',
       text: '',
-      finalized: toolUse.status === 'completed',
+      finalized: false,
       toolUse,
       toolUseSource: entry.data,
     };

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -23,6 +23,9 @@ const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
 
 // Field-by-field — a stringified signature would allocate the full
 // outputText (potentially 50 KB+ of bash output) on every comparison.
+// Cover every field that `ToolUseRow` reads (notably `input`, which
+// `previewInput` consumes for the header preview, and the feedback
+// fields) so a future input change can't be silently swallowed.
 function toolUseEqual(
   prev: NormalizedToolUse,
   next: NormalizedToolUse,
@@ -33,9 +36,24 @@ function toolUseEqual(
     prev.outputText === next.outputText &&
     prev.errorText === next.errorText &&
     prev.headerSummary === next.headerSummary &&
-    prev.isError === next.isError
+    prev.isError === next.isError &&
+    prev.isUserFeedback === next.isUserFeedback &&
+    prev.userInstructionText === next.userInstructionText &&
+    prev.input === next.input
   );
 }
+
+// `normalizeToolUseData` is dominated by a Zod parse + YAML stringify
+// of `entry.data`. `StreamLog.update` spreads its patch into a fresh
+// `data` object every tick, so reference equality is a reliable signal
+// that nothing has actually changed. Keep the last-seen `data` ref off
+// to the side in a WeakMap rather than on `ConversationEntry` itself —
+// stashing it on the entry would mean either (a) the slice-level
+// `entriesEqual` check ignores `toolUseSource` and the cache refresh
+// never persists, or (b) we trigger a slice update on every tick just
+// to write the new reference. The WeakMap dodges both: the entry stays
+// immutable, and the cache is GC'd when the entry is replaced.
+const toolUseSourceCache = new WeakMap<ConversationEntry, unknown>();
 
 function entriesEqual(
   prev: ConversationEntry,
@@ -60,13 +78,10 @@ function renderLogEntry(
   prev: ConversationEntry | undefined,
 ): ConversationEntry | null {
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
-    // StreamLog.update spreads into a fresh `data` object on every patch
-    // (StreamLog.ts:89-94), so identity equality is a reliable signal
-    // that the entry hasn't changed since the last sync. Skipping the
-    // Zod parse + YAML stringify here matters because syncStreamLog runs
-    // ~every animation frame during streaming and tool output can be
-    // 50 KB+ per completed entry.
-    if (prev?.toolUse && prev.toolUseSource === entry.data) return prev;
+    // Cache hit: same `data` reference as last sync, no re-normalize.
+    if (prev?.toolUse && toolUseSourceCache.get(prev) === entry.data) {
+      return prev;
+    }
 
     const toolUse = normalizeToolUseData(entry.data);
     // Drop malformed tool entries rather than crash. The progress view
@@ -84,16 +99,17 @@ function renderLogEntry(
       text: '',
       finalized: prev?.finalized ?? false,
       toolUse,
-      toolUseSource: entry.data,
     };
     if (prev && entriesEqual(prev, next)) {
       // Same content under a fresh `data` reference: refresh the cache
-      // key on `prev` instead of returning it as-is, otherwise the
-      // identity fast path above keeps missing on every subsequent tick.
-      return prev.toolUseSource === entry.data
-        ? prev
-        : { ...prev, toolUseSource: entry.data };
+      // key on `prev` so the identity fast path hits on the next tick.
+      // Returning `prev` keeps the slice unchanged (no re-render
+      // cascade) — the cache lives outside the entry contract so this
+      // refresh doesn't need a slice update to persist.
+      toolUseSourceCache.set(prev, entry.data);
+      return prev;
     }
+    toolUseSourceCache.set(next, entry.data);
     return next;
   }
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -1,12 +1,15 @@
-// Mirror StreamLogStore user/model entries into `cliState.streams[].entries`.
-// Tool/approval entries land in side panels and modals.
+// Mirror StreamLogStore user/model/tool entries into
+// `cliState.streams[].entries`. Approval/permission entries land in side
+// panels and modals; tool rows render inline alongside assistant prose.
 
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   MESSAGE_TYPES,
+  type NormalizedToolUse,
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
+import { normalizeToolUseData } from '@shared/toolUse';
 
 import { cliState, patchStream, type ConversationEntry } from './cliState';
 import { getTranscriptStartSeq } from './transcript';
@@ -14,8 +17,78 @@ import { getTranscriptStartSeq } from './transcript';
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.ERROR,
   MESSAGE_TYPES.MODEL_RESPONSE,
+  MESSAGE_TYPES.TOOL_USE,
   MESSAGE_TYPES.USER_MESSAGE,
 ]);
+
+/** Signature of a tool entry's renderable fields. The store updates the
+ *  TOOL_USE entry in place (`status: 'in_progress'` → `'completed'`,
+ *  `output`/`error` filled later), so a text-only equality check would
+ *  miss those transitions. */
+function toolUseSignature(toolUse: NormalizedToolUse): string {
+  return [
+    toolUse.status ?? '',
+    toolUse.toolName,
+    toolUse.outputText,
+    toolUse.errorText,
+    toolUse.headerSummary,
+    toolUse.isError ? '1' : '0',
+  ].join(' ');
+}
+
+function entriesEqual(
+  prev: ConversationEntry,
+  next: ConversationEntry,
+): boolean {
+  if (
+    prev.role !== next.role ||
+    prev.text !== next.text ||
+    prev.finalized !== next.finalized
+  ) {
+    return false;
+  }
+  if (prev.role === 'tool') {
+    if (!prev.toolUse || !next.toolUse) return prev.toolUse === next.toolUse;
+    return toolUseSignature(prev.toolUse) === toolUseSignature(next.toolUse);
+  }
+  return true;
+}
+
+function renderLogEntry(
+  entry: StreamLogEntry,
+  prev: ConversationEntry | undefined,
+): ConversationEntry | null {
+  if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
+    const toolUse = normalizeToolUseData(entry.data);
+    // Drop malformed tool entries rather than crash. The progress view
+    // does the same — a bad payload shouldn't take down the transcript.
+    if (!toolUse) return null;
+    const finalized = toolUse.status === 'completed';
+    const next: ConversationEntry = {
+      id: entry.id,
+      role: 'tool',
+      text: '',
+      finalized,
+      toolUse,
+    };
+    return prev && entriesEqual(prev, next) ? prev : next;
+  }
+
+  const text = entry.text ?? '';
+  const role: ConversationEntry['role'] =
+    entry.messageType === MESSAGE_TYPES.USER_MESSAGE
+      ? 'user'
+      : entry.messageType === MESSAGE_TYPES.ERROR
+        ? 'error'
+        : 'assistant';
+  const next: ConversationEntry = {
+    id: entry.id,
+    role,
+    text,
+    finalized: role !== 'assistant',
+  };
+  return prev && entriesEqual(prev, next) ? prev : next;
+}
 
 // Coalesce bursts into a single render without visibly delaying the
 // first paint. 200ms looks like a hang on short replies (an entire reply
@@ -69,21 +142,13 @@ export function syncStreamLog(streamId: StreamTabId): void {
   patchStream(streamId, (slice) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
     const syntheticEntries = slice.entries.filter((entry) => entry.synthetic);
-    const logEntries = responses.map((entry: StreamLogEntry) => {
-      const text = entry.text ?? '';
-      const role: ConversationEntry['role'] =
-        entry.messageType === MESSAGE_TYPES.USER_MESSAGE
-          ? 'user'
-          : entry.messageType === MESSAGE_TYPES.ERROR
-            ? 'error'
-            : 'assistant';
-      const prev = existing.get(entry.id);
-      const rendered =
-        prev && prev.text === text && prev.role === role
-          ? prev
-          : { id: entry.id, role, text, finalized: role !== 'assistant' };
-      return { entry, rendered };
-    });
+    const logEntries: { entry: StreamLogEntry; rendered: ConversationEntry }[] =
+      [];
+    for (const entry of responses) {
+      const rendered = renderLogEntry(entry, existing.get(entry.id));
+      if (!rendered) continue;
+      logEntries.push({ entry, rendered });
+    }
     const logCandidates: TranscriptCandidate[] = logEntries.map(
       ({ entry, rendered }) => ({
         rendered,
@@ -124,9 +189,7 @@ export function syncStreamLog(streamId: StreamTabId): void {
         return (
           !candidate ||
           entry.id !== candidate.id ||
-          entry.role !== candidate.role ||
-          entry.text !== candidate.text ||
-          entry.finalized !== candidate.finalized
+          !entriesEqual(entry, candidate)
         );
       });
     if (!changed) return slice;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -21,19 +21,20 @@ const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.USER_MESSAGE,
 ]);
 
-/** Signature of a tool entry's renderable fields. The store updates the
- *  TOOL_USE entry in place (`status: 'in_progress'` → `'completed'`,
- *  `output`/`error` filled later), so a text-only equality check would
- *  miss those transitions. */
-function toolUseSignature(toolUse: NormalizedToolUse): string {
-  return [
-    toolUse.status ?? '',
-    toolUse.toolName,
-    toolUse.outputText,
-    toolUse.errorText,
-    toolUse.headerSummary,
-    toolUse.isError ? '1' : '0',
-  ].join(' ');
+// Field-by-field — a stringified signature would allocate the full
+// outputText (potentially 50 KB+ of bash output) on every comparison.
+function toolUseEqual(
+  prev: NormalizedToolUse,
+  next: NormalizedToolUse,
+): boolean {
+  return (
+    prev.status === next.status &&
+    prev.toolName === next.toolName &&
+    prev.outputText === next.outputText &&
+    prev.errorText === next.errorText &&
+    prev.headerSummary === next.headerSummary &&
+    prev.isError === next.isError
+  );
 }
 
 function entriesEqual(
@@ -49,7 +50,7 @@ function entriesEqual(
   }
   if (prev.role === 'tool') {
     if (!prev.toolUse || !next.toolUse) return prev.toolUse === next.toolUse;
-    return toolUseSignature(prev.toolUse) === toolUseSignature(next.toolUse);
+    return toolUseEqual(prev.toolUse, next.toolUse);
   }
   return true;
 }
@@ -59,17 +60,25 @@ function renderLogEntry(
   prev: ConversationEntry | undefined,
 ): ConversationEntry | null {
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
+    // StreamLog.update spreads into a fresh `data` object on every patch
+    // (StreamLog.ts:89-94), so identity equality is a reliable signal
+    // that the entry hasn't changed since the last sync. Skipping the
+    // Zod parse + YAML stringify here matters because syncStreamLog runs
+    // ~every animation frame during streaming and tool output can be
+    // 50 KB+ per completed entry.
+    if (prev?.toolUse && prev.toolUseSource === entry.data) return prev;
+
     const toolUse = normalizeToolUseData(entry.data);
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
     if (!toolUse) return null;
-    const finalized = toolUse.status === 'completed';
     const next: ConversationEntry = {
       id: entry.id,
       role: 'tool',
       text: '',
-      finalized,
+      finalized: toolUse.status === 'completed',
       toolUse,
+      toolUseSource: entry.data,
     };
     return prev && entriesEqual(prev, next) ? prev : next;
   }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -21,11 +21,24 @@ const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.USER_MESSAGE,
 ]);
 
-// Field-by-field — a stringified signature would allocate the full
-// outputText (potentially 50 KB+ of bash output) on every comparison.
-// Cover every field that `ToolUseRow` reads (notably `input`, which
-// `previewInput` consumes for the header preview, and the feedback
-// fields) so a future input change can't be silently swallowed.
+/** Tool inputs are typed `unknown` (model-supplied JSON) and reach us
+ *  via Zod passthrough, so a `===` compare would defeat the cache the
+ *  moment any upstream code reconstructs `data` (deserialization,
+ *  structured clone, future log replay). Inputs are small — tool call
+ *  args, not output — so a JSON serialization is cheap. */
+function inputEqual(prev: unknown, next: unknown): boolean {
+  if (prev === next) return true;
+  try {
+    return JSON.stringify(prev) === JSON.stringify(next);
+  } catch {
+    return false;
+  }
+}
+
+// Field-by-field — a stringified signature over the whole NormalizedToolUse
+// would allocate the full outputText (potentially 50 KB+ of bash output) on
+// every comparison. Cover every field ToolUseRow reads so future changes
+// can't be silently swallowed.
 function toolUseEqual(
   prev: NormalizedToolUse,
   next: NormalizedToolUse,
@@ -39,7 +52,7 @@ function toolUseEqual(
     prev.isError === next.isError &&
     prev.isUserFeedback === next.isUserFeedback &&
     prev.userInstructionText === next.userInstructionText &&
-    prev.input === next.input
+    inputEqual(prev.input, next.input)
   );
 }
 

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -102,13 +102,19 @@ export function moveLocalTranscriptToStream(streamId: StreamTabId): void {
   removeStream(CLI_LOCAL_STREAM_ID);
 }
 
+/** Finalizes any entries that defer finalization to end-of-stream
+ *  (assistant text and tool rows). Tool rows are included so that a
+ *  fast-completing tool doesn't jump ahead of still-streaming assistant
+ *  text in `<Static>` scrollback — see the deferral comment in
+ *  `subscribeStreamLog.renderLogEntry`. */
 export function finalizeAssistantTranscriptEntries(
   streamId: StreamTabId,
 ): void {
   patchStream(streamId, (slice) => {
     let changed = false;
     const entries = slice.entries.map((entry) => {
-      if (entry.role !== 'assistant' || entry.finalized) return entry;
+      if (entry.finalized) return entry;
+      if (entry.role !== 'assistant' && entry.role !== 'tool') return entry;
       changed = true;
       return { ...entry, finalized: true };
     });

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -56,7 +56,7 @@ import {
   buildDetailsSummary,
   SPINNER_ICON_NAME,
 } from '../htmlBuilders';
-import { normalizeToolUseData } from '../logDataParsers';
+import { normalizeToolUseData } from '@shared/toolUse';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage, extractCodeOnlyInput } from '../parseUtils';
 import {

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -37,7 +37,10 @@ function extractOutputContent(candidate: unknown): unknown {
 
 function formatOutputText(content: unknown): string {
   if (typeof content === 'string') return content;
-  if (content === undefined) return '';
+  // `null` must short-circuit alongside `undefined`. yaml.stringify(null)
+  // renders the literal string "null", which would surface a spurious
+  // output section for tools that return `output: null`.
+  if (content === undefined || content === null) return '';
   if (isPlainObject(content) && Object.keys(content).length === 0) return '';
   try {
     const yamlString = yaml.stringify(content);

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -1,36 +1,28 @@
-/**
- * Data parsing utilities for progress view formatters.
- * Uses Zod schemas as the source of truth for data validation.
- *
- * Provides normalization logic for complex types that need transformation
- * beyond simple validation (toolUse). Simpler types use Schema.safeParse(data)
- * directly in formatters or compute display fields inline in renderers.
- */
+// Host-neutral normalization for tool-use log payloads.
+//
+// Both the VS Code progress view and the CLI TUI read the same
+// `ToolUseLog` payload off `StreamLogStore.data` and need a flat,
+// renderer-friendly view: tool name, derived output text, error/summary
+// strings, and the in-progress vs completed status. This module is the
+// single entry point for that derivation so hosts don't drift.
 
-// Local imports - shared schemas
+import yaml from 'yaml';
+
 import { ToolUseLogSchema, type NormalizedToolUse } from '@shared/schemas';
 import { isPlainObject } from '@shared/utils/string';
 
-// Local imports - formatter helpers
-import { stringifyWithLanguage } from './parseUtils';
-
-/** Return trimmed string if non-empty, null otherwise. */
 function trimmedOrNull(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed || null;
 }
 
-/** Get first non-empty trimmed string from primary or fallback. */
 function firstTrimmed(primary: unknown, fallback: unknown): string {
   return trimmedOrNull(primary) ?? trimmedOrNull(fallback) ?? '';
 }
 
-/** Extract output content from possibly nested structure, stripping metadata. */
 function extractOutputContent(candidate: unknown): unknown {
   if (!isPlainObject(candidate)) return candidate;
-
-  // Extract nested output, stripping metadata fields
   const {
     output,
     summary: _summary,
@@ -40,37 +32,26 @@ function extractOutputContent(candidate: unknown): unknown {
     userInstruction: _userInstruction,
     ...rest
   } = candidate;
-  // Use explicit undefined check since null is a valid output value
   return output !== undefined ? output : rest;
 }
 
-/** Format output content as display string. */
 function formatOutputText(content: unknown): string {
   if (typeof content === 'string') return content;
   if (content === undefined) return '';
   if (isPlainObject(content) && Object.keys(content).length === 0) return '';
-  return stringifyWithLanguage(content).text;
+  try {
+    const yamlString = yaml.stringify(content);
+    return typeof yamlString === 'string' ? yamlString.trimEnd() : '';
+  } catch {
+    return String(content);
+  }
 }
 
-/**
- * Normalize raw tool use log data into a structured format for rendering.
- * This is the only complex normalization function needed - it extracts nested
- * fields, computes derived values, and formats output text.
- *
- * @param data - Raw structured data from the log message
- * @returns Normalized tool use data, or null if parsing fails
- */
 export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
-  // Validate the basic structure with Zod
   const parseResult = ToolUseLogSchema.safeParse(data);
-  if (!parseResult.success) {
-    return null;
-  }
+  if (!parseResult.success) return null;
 
-  // Use validated data from schema
   const validated = parseResult.data;
-
-  // Extract nested fields from output (may contain summary, error, etc.)
   const nested = isPlainObject(validated.output) ? validated.output : {};
 
   const summaryText = firstTrimmed(validated.summary, nested.summary);
@@ -86,8 +67,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   const toolName = trimmedOrNull(validated.toolName ?? validated.tool) ?? '';
   const isUserFeedback = userInstructionText.length > 0;
 
-  // Build parsed record for fallback rendering
-  // Use original data (not validated) to preserve unknown fields that Zod strips
+  // Preserve unknown fields stripped by the schema for fallback rendering.
   const parsed: Record<string, unknown> = isPlainObject(data)
     ? { ...data }
     : { ...validated };

--- a/src/test-kernel/cli/ConversationPane.vitest.ts
+++ b/src/test-kernel/cli/ConversationPane.vitest.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type NormalizedToolUse,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import { splitTranscriptEntries } from '../../../packages/cli/src/chat/tui/panes/transcriptEntries';
 import {
@@ -20,6 +24,30 @@ function entry(
   finalized: boolean,
 ): ConversationEntry {
   return { id, role, text, finalized };
+}
+
+function toolEntry(
+  id: string,
+  status: NormalizedToolUse['status'],
+): ConversationEntry {
+  return {
+    id,
+    role: 'tool',
+    text: '',
+    finalized: false,
+    toolUse: {
+      parsed: {},
+      toolName: 'Bash',
+      errorText: '',
+      outputText: status === 'completed' ? 'ok' : '',
+      userInstructionText: '',
+      input: { command: 'ls' },
+      isError: false,
+      isUserFeedback: false,
+      headerSummary: '',
+      status,
+    },
+  };
 }
 
 describe('CLI conversation transcript splitting', () => {
@@ -62,5 +90,56 @@ describe('CLI conversation transcript splitting', () => {
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1', 'a1']);
     expect(split.live).toBeUndefined();
+  });
+
+  // Regression: pending tool rows must render after preceding live
+  // assistant text, not before. The previous renderer used a separate
+  // `pendingTools` bucket that always sat above the live region, so a
+  // model emitting prose before a tool call appeared as
+  // user → tool → assistant text on screen.
+  it('keeps pending entries in stream order so tool rows trail prior text', () => {
+    const user = entry('u1', 'user', 'do a thing', true);
+    const assistant = entry('a1', 'assistant', 'sure, running…', false);
+    const tool = toolEntry('t1', 'in_progress');
+
+    const split = splitTranscriptEntries(
+      [user, assistant, tool],
+      STREAM_STATUS.RUNNING,
+    );
+
+    expect(split.finalized.map((e) => e.id)).toEqual(['u1']);
+    expect(split.pending.map((e) => e.id)).toEqual(['a1', 't1']);
+    expect(split.live?.id).toBe('a1');
+  });
+
+  // Regression: tool rows must not finalize on their own — the stream-
+  // level finalizer is the single promotion edge. Otherwise a fast tool
+  // call jumps into <Static> ahead of still-streaming assistant text
+  // and the scrollback order ends up reversed.
+  it('defers tool finalization to the stream-level finalize step', () => {
+    resetCliState();
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      entries: [
+        entry('a1', 'assistant', 'about to run a tool', false),
+        toolEntry('t1', 'completed'),
+      ],
+    }));
+
+    let split = splitTranscriptEntries(
+      cliState.streams.get().get(STREAM_ID)?.entries ?? [],
+      STREAM_STATUS.RUNNING,
+    );
+    expect(split.finalized).toHaveLength(0);
+    expect(split.pending.map((e) => e.id)).toEqual(['a1', 't1']);
+
+    finalizeAssistantTranscriptEntries(STREAM_ID);
+
+    split = splitTranscriptEntries(
+      cliState.streams.get().get(STREAM_ID)?.entries ?? [],
+      STREAM_STATUS.WAITING,
+    );
+    expect(split.finalized.map((e) => e.id)).toEqual(['a1', 't1']);
+    expect(split.pending).toHaveLength(0);
   });
 });

--- a/src/test-kernel/cli/ConversationPane.vitest.ts
+++ b/src/test-kernel/cli/ConversationPane.vitest.ts
@@ -60,14 +60,14 @@ describe('CLI conversation transcript splitting', () => {
       STREAM_STATUS.RUNNING,
     );
     expect(running.finalized).toEqual([user]);
-    expect(running.live).toBe(assistant);
+    expect(running.pending).toEqual([assistant]);
 
     const waitingBeforeFinalize = splitTranscriptEntries(
       [user, assistant],
       STREAM_STATUS.WAITING,
     );
     expect(waitingBeforeFinalize.finalized).toEqual([user]);
-    expect(waitingBeforeFinalize.live).toBeUndefined();
+    expect(waitingBeforeFinalize.pending).toEqual([]);
   });
 
   it('freezes assistant entries before they enter static scrollback', () => {
@@ -89,7 +89,7 @@ describe('CLI conversation transcript splitting', () => {
       STREAM_STATUS.WAITING,
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1', 'a1']);
-    expect(split.live).toBeUndefined();
+    expect(split.pending).toEqual([]);
   });
 
   // Regression: pending tool rows must render after preceding live
@@ -109,7 +109,6 @@ describe('CLI conversation transcript splitting', () => {
 
     expect(split.finalized.map((e) => e.id)).toEqual(['u1']);
     expect(split.pending.map((e) => e.id)).toEqual(['a1', 't1']);
-    expect(split.live?.id).toBe('a1');
   });
 
   // Regression: tool rows must not finalize on their own — the stream-

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -288,7 +288,7 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps a model response live when local output follows it', () => {
-    const { finalized, live } = splitTranscriptEntries(
+    const { finalized, pending } = splitTranscriptEntries(
       [
         {
           id: 'model-response',
@@ -309,7 +309,7 @@ describe('CLI transcript state', () => {
       STREAM_STATUS.RUNNING,
     );
 
-    expect(live?.id).toBe('model-response');
+    expect(pending.map((entry) => entry.id)).toEqual(['model-response']);
     expect(finalized.map((entry) => entry.id)).toEqual(['local-help']);
   });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -101,6 +101,46 @@ describe('CLI transcript state', () => {
     }
   });
 
+  // Regression: a sync tick that fires after `finalizeAssistantTranscriptEntries`
+  // must not roll the entry back to `finalized: false`. Cursor Bugbot flagged
+  // this when `entriesEqual` started comparing `finalized` — without this
+  // guard, the de-finalized entry would land in neither bucket of
+  // `splitTranscriptEntries` once status flipped to WAITING and silently
+  // disappear from the transcript.
+  it('preserves the finalized flag through a post-finalize sync tick', () => {
+    const previousStore = AgentLogger.getStreamLogStore();
+    const store = new StreamLogStore();
+    AgentLogger.setStreamLogStore(store);
+
+    try {
+      const logger = new AgentLogger(root, true);
+      logger.info('streaming assistant chunk', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+      syncStreamLog(root);
+
+      // Stream-level finalize promotes the deferred-finalization entries.
+      patchStream(root, (slice) => ({
+        ...slice,
+        entries: slice.entries.map((entry) =>
+          entry.role === 'assistant' ? { ...entry, finalized: true } : entry,
+        ),
+      }));
+
+      // A second sync after finalize must not regress the flag.
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        role: 'assistant',
+        finalized: true,
+      });
+    } finally {
+      AgentLogger.setStreamLogStore(previousStore);
+    }
+  });
+
   it('adds a final assistant response only when the stream log did not render it', () => {
     appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
     appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');

--- a/src/test-kernel/shared/NormalizeToolUse.vitest.ts
+++ b/src/test-kernel/shared/NormalizeToolUse.vitest.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeToolUseData } from '@shared/toolUse';
+
+describe('normalizeToolUseData', () => {
+  it('returns null for non-object payloads', () => {
+    expect(normalizeToolUseData('not an object')).toBeNull();
+    expect(normalizeToolUseData(42)).toBeNull();
+    expect(normalizeToolUseData(null)).toBeNull();
+  });
+
+  it('extracts toolName, input, and output text from a flat payload', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      input: { command: 'ls' },
+      output: 'foo\nbar',
+      status: 'completed',
+    });
+
+    expect(normalized?.toolName).toBe('Bash');
+    expect(normalized?.input).toEqual({ command: 'ls' });
+    expect(normalized?.outputText).toBe('foo\nbar');
+    expect(normalized?.status).toBe('completed');
+    expect(normalized?.isError).toBe(false);
+  });
+
+  // Regression: a previous inline refactor of `formatOutputText` dropped
+  // the explicit `null` short-circuit that `stringifyWithLanguage` had,
+  // so `output: null` fell through to `yaml.stringify(null)` and surfaced
+  // the literal text "null" in the rendered output section. Verify both
+  // the top-level and nested cases stay empty.
+  it('renders null output as empty text, not the string "null"', () => {
+    const topLevel = normalizeToolUseData({
+      toolName: 'Bash',
+      input: { command: 'true' },
+      output: null,
+      status: 'completed',
+    });
+    expect(topLevel?.outputText).toBe('');
+
+    const nested = normalizeToolUseData({
+      toolName: 'Bash',
+      input: { command: 'true' },
+      output: { output: null, summary: 'ran ok' },
+      status: 'completed',
+    });
+    expect(nested?.outputText).toBe('');
+    expect(nested?.headerSummary).toBe('ran ok');
+  });
+
+  it('unwraps nested `output` and metadata fields', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      output: {
+        output: 'stdout content',
+        summary: 'ran 1 command',
+        isError: false,
+      },
+      status: 'completed',
+    });
+    expect(normalized?.outputText).toBe('stdout content');
+    expect(normalized?.headerSummary).toBe('ran 1 command');
+  });
+
+  it('reports errors via isError and errorText', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      output: { error: 'no such file', isError: true },
+      status: 'completed',
+    });
+    expect(normalized?.isError).toBe(true);
+    expect(normalized?.errorText).toBe('no such file');
+    // headerSummary falls back to errorText when there's no summary
+    expect(normalized?.headerSummary).toBe('no such file');
+  });
+
+  it('treats userInstruction as a feedback marker', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'AskUserQuestion',
+      output: { userInstruction: 'pick option A' },
+      status: 'completed',
+    });
+    expect(normalized?.isUserFeedback).toBe(true);
+    expect(normalized?.userInstructionText).toBe('pick option A');
+    // headerSummary skips errorText when this is feedback
+    expect(normalized?.headerSummary).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- The chat TUI previously dropped every `StreamLog` entry except `USER_MESSAGE` / `MODEL_RESPONSE` / `ERROR`, so the user saw the assistant talking but never saw any of the tool calls it was making.
- This pipes `TOOL_USE` entries through the same transcript path and renders them as compact rows in the visual style Claude Code's Ink TUI uses: `● ToolName (preview)` header, indented `⎿ output` body capped at three lines, status-colored dot.
- `normalizeToolUseData` moves out of `packages/extension/.../logDataParsers.ts` into `@shared/toolUse` so the VS Code progress view and the CLI share one normalizer; the extension import is updated and the empty parser file is deleted.

## Design notes

- `subscribeStreamLog` previously skipped `data` entirely and compared entries by `text` only. Tool entries carry no text and update in place (`status: 'in_progress'` → `'completed'`), so a `text === text` check would have masked completions. Replaced with a `toolUseSignature`-aware equality check.
- In-progress tool rows can't live in Ink's `<Static>` (Static items are immutable), so `splitTranscriptEntries` returns a third `pendingTools` bucket that re-renders in place. Completed rows migrate into the Static scrollback on the next sync tick.
- One universal renderer rather than per-tool dispatch tables. The webview's per-tool formatters (Bash terminal panel, edit diff, file link, …) all rely on DOM affordances that don't translate to a terminal; keeping the CLI's renderer flat avoids two dispatch trees diverging.
- Errors render in red below the row instead of blocking the header so the row stays one line.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run src/test-kernel/cli/ConversationPane.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (21/21)
- [ ] Run `texra chat` and confirm: tool rows appear with the dim/green/red dot transitions, output truncates to 3 lines with a `… +N lines` hint, and `(no output)` renders for completions with empty output.

## Deferred to follow-ups

- `ctrl+t` / `ctrl+o` style expand-to-full-output modal.
- Per-tool renderers (Bash ANSI passthrough, Edit diff, Read file link). The schema and dispatch tables already exist in `@progressView/.../toolFormatters.ts`; can be lifted once we know which tools are common in CLI sessions.
- Grouping consecutive same-tool calls.
- `THINKING` / `WEB_SEARCH` / `WEB_FETCH` rows — same plumbing, different renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the CLI transcript/state pipeline to include `TOOL_USE` entries and changes how non-finalized entries are bucketed/finalized, which could affect transcript ordering and re-render behavior during streaming.
> 
> **Overview**
> **CLI chat now shows tool calls inline.** `TOOL_USE` stream-log entries are piped into `cliState` as `ConversationEntry` records (`role: 'tool'`) and rendered in the conversation pane via a new `ToolUseRow` component with a compact header, status dot coloring, and truncated output/error blocks.
> 
> **Transcript rendering/ordering was reworked for streaming correctness.** `splitTranscriptEntries` now returns `finalized` + ordered `pending` entries (interleaving live assistant text and tool rows) and tool/assistant finalization is deferred to the stream-level finalize step to avoid `<Static>` scrollback order flips; `subscribeStreamLog` gained tool-aware equality/caching so tool status/output updates propagate without unnecessary re-renders.
> 
> **Tool-use normalization is centralized.** The VS Code progress view switches to `@shared/toolUse.normalizeToolUseData` (now YAML-based, with a `null`-output guard), and new tests cover tool normalization plus regressions around pending ordering and finalized-flag preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929981e8092a2d8c505e0b01d5cd50525426088a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->