### PR TITLE
fix(cli): allow model switching between chat turns

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,37 +1,39 @@
 // Registers the slash commands the input palette surfaces.
-//
-// Idempotent at the call-site granularity: the module-scope `installed`
-// flag short-circuits repeat invocations, so registrations that were
-// individually unregistered won't reappear without a process restart.
 
 import { ModelForm } from '../forms/ModelForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 
-/** Adapter: wires the `/model` form's `(value)=>void` API into the generic
- *  `SlashFormProps<unknown>` shape the registry expects. */
-function ModelFormAdapter(props: SlashFormProps): React.JSX.Element {
-  const current = cliState.sessionMeta.get().model;
-  return (
-    <ModelForm
-      currentModel={current}
-      onSelect={(value) => {
-        cliState.sessionMeta.set({
-          ...cliState.sessionMeta.get(),
-          model: value,
-        });
-        props.onDone(value);
-      }}
-      onCancel={() => props.onDone(undefined)}
-    />
-  );
-}
+type ModelSelectHandler = (value: string) => void | Promise<void>;
 
-let installed = false;
+const defaultModelSelect: ModelSelectHandler = (value) => {
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    model: value,
+  });
+};
 
-export function registerBuiltinSlashCommands(): void {
-  if (installed) return;
-  installed = true;
+export function registerBuiltinSlashCommands(options?: {
+  onModelSelect?: ModelSelectHandler;
+}): void {
+  const onModelSelect = options?.onModelSelect ?? defaultModelSelect;
+
+  /** Adapter: wires the `/model` form's `(value)=>void` API into the generic
+   *  `SlashFormProps<unknown>` shape the registry expects. */
+  function ModelFormAdapter(props: SlashFormProps): React.JSX.Element {
+    const current = cliState.sessionMeta.get().model;
+    return (
+      <ModelForm
+        currentModel={current}
+        onSelect={(value) => {
+          void Promise.resolve(onModelSelect(value)).finally(() =>
+            props.onDone(value),
+          );
+        }}
+        onCancel={() => props.onDone(undefined)}
+      />
+    );
+  }
 
   registerSlashCommand({
     name: 'help',

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -15,7 +15,10 @@ import { interruptActiveChildren } from '@agent/runtime/executionRegistry';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
-import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  getInterruptible,
+  switchToolUseModel,
+} from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
@@ -73,6 +76,62 @@ interface SlashCommandContext {
   readonly initialModel: string;
   readonly interruptActive: () => void;
   readonly requestInputExit: () => void;
+  readonly runSessionMutation?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
+async function applyCliModelSelection(
+  model: string,
+  context: SlashCommandContext,
+): Promise<void> {
+  const nextModel = model.trim();
+  if (!nextModel) {
+    appendLocalAssistantTranscript('Usage: /model <name>');
+    return;
+  }
+
+  try {
+    if (!context.session.runPromise) {
+      await setCliHelperModel(nextModel);
+      cliState.sessionMeta.set({
+        ...cliState.sessionMeta.get(),
+        model: nextModel,
+      });
+      appendLocalAssistantTranscript(`Model set to ${nextModel}.`);
+      return;
+    }
+
+    const switchActiveModel = async (): Promise<void> => {
+      const streamId = context.session.streamId;
+      const status = streamId ? StreamStatusService.get(streamId) : undefined;
+      if (!streamId || status !== STREAM_STATUS.WAITING) {
+        appendLocalAssistantTranscript(
+          'The model can be changed while the chat is waiting for your next message.',
+        );
+        return;
+      }
+      const result = await switchToolUseModel(streamId, nextModel);
+      if (result.status === 'no_session') {
+        appendLocalAssistantTranscript(
+          'The active chat is no longer available. Start a new chat to use that model.',
+        );
+        return;
+      }
+      await setCliHelperModel(nextModel);
+      cliState.sessionMeta.set({
+        ...cliState.sessionMeta.get(),
+        model: nextModel,
+      });
+      appendLocalAssistantTranscript(`Model set to ${nextModel}.`);
+    };
+
+    if (context.runSessionMutation) {
+      await context.runSessionMutation(switchActiveModel);
+    } else {
+      await switchActiveModel();
+    }
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+  }
 }
 
 async function handleTuiSlashCommand(
@@ -117,24 +176,7 @@ async function handleTuiSlashCommand(
       }
       return true;
     case 'model':
-      if (context.session.runPromise) {
-        appendLocalAssistantTranscript(
-          'The model is fixed for this chat session. Start a new chat to use a different model.',
-        );
-      } else if (rest) {
-        try {
-          await setCliHelperModel(rest);
-          cliState.sessionMeta.set({
-            ...cliState.sessionMeta.get(),
-            model: rest,
-          });
-          appendLocalAssistantTranscript(`Model set to ${rest}.`);
-        } catch (error: unknown) {
-          appendLocalAssistantTranscript(toErrorMessage(error));
-        }
-      } else {
-        appendLocalAssistantTranscript('Usage: /model <name>');
-      }
+      await applyCliModelSelection(rest, context);
       return true;
     case 'status': {
       const meta = cliState.sessionMeta.get();
@@ -211,8 +253,6 @@ export async function runChat(
   await loadAgents();
 
   const inputHistory = await loadInputHistory();
-  // Pre-register the slash commands the input palette uses.
-  registerBuiltinSlashCommands();
 
   // DA1 sentinel discovery runs *before* Ink mounts so it owns the raw-mode
   // toggle exclusively — interleaving with Ink's own raw-mode lifecycle (set
@@ -237,6 +277,8 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
+  const runSessionMutation = async <T,>(task: () => Promise<T>): Promise<T> =>
+    followUpQueue.add(task);
   let requestInputExit: (() => void) | undefined;
 
   const interruptActive = (): void => {
@@ -245,6 +287,19 @@ export async function runChat(
     interruptActiveChildren(session.streamId);
     getInterruptible(session.streamId)?.interrupt();
   };
+
+  // Pre-register the slash commands the input palette uses.
+  registerBuiltinSlashCommands({
+    onModelSelect: (nextModel) =>
+      applyCliModelSelection(nextModel, {
+        session,
+        initialAgent: agent,
+        initialModel: model,
+        interruptActive,
+        requestInputExit: () => requestInputExit?.(),
+        runSessionMutation,
+      }),
+  });
 
   const startSession = (instruction: string): void => {
     const meta = cliState.sessionMeta.get();
@@ -327,6 +382,7 @@ export async function runChat(
         initialModel: model,
         interruptActive,
         requestInputExit: () => requestInputExit?.(),
+        runSessionMutation,
       })
     ) {
       return;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,4 +1,7 @@
+import { MODEL_CONFIGS } from 'llm-zoo';
+
 import { getExecutionStore } from '@agent/storage';
+import { createModelHandler } from '@agent/runtime/ModelFactory';
 import {
   registerInterruptible,
   unregisterInterruptible,
@@ -63,6 +66,11 @@ export interface RunToolUseFlowInput<
   ) => void | Promise<void>;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
+  /** Fires after a running tool-use chat changes its model. */
+  onModelChanged?: (
+    modelHandler: ToolUseServices['modelHandler'],
+    model: string,
+  ) => void;
 }
 
 export interface RunToolUseFlowResult {
@@ -76,8 +84,10 @@ export interface ToolUseFlowContext {
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: ToolUseServices['modelHandler'];
   readonly runtimeHost: ToolUseServices['runtimeHost'];
+  readonly model: string;
   interrupt(): void;
   requestImmediateCompaction(): void;
+  switchModel(model: string): Promise<void>;
 }
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
@@ -175,11 +185,53 @@ export async function runToolUseFlow<C = unknown>(
     delegationConfig,
     delegationTrimmed,
   };
+  const mutableServices = services as ToolUseServices<C> & {
+    modelHandler: ToolUseServices<C>['modelHandler'];
+    config: ToolUseServices<C>['config'];
+  };
+  const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();
+
+  const switchModel = async (model: string): Promise<void> => {
+    const nextConfig = MODEL_CONFIGS[model];
+    if (!nextConfig) {
+      throw new Error(`Model ${model} not found in MODEL_CONFIGS`);
+    }
+    if (mutableServices.config.model === model) return;
+
+    const previousHandler = mutableServices.modelHandler;
+    const nextHandler = (await createModelHandler(
+      nextConfig,
+    )) as ToolUseServices<C>['modelHandler'];
+    if (nextHandler.constructor !== previousHandler.constructor) {
+      nextHandler.dispose();
+      throw new Error(
+        'Cannot switch this conversation to a model with a different conversation format. Start a new chat to use that model.',
+      );
+    }
+    nextHandler.setAgentCategory(setting.agentCategory);
+    nextHandler.setLogger(logger);
+
+    mutableServices.modelHandler = nextHandler;
+    mutableServices.config = { ...mutableServices.config, model };
+    mutableServices.userVarChannels.transient.MODEL = model;
+
+    switchedHandlers.add(nextHandler);
+    if (previousHandler !== input.modelHandler) {
+      previousHandler.dispose();
+      switchedHandlers.delete(previousHandler);
+    }
+    input.onModelChanged?.(nextHandler, model);
+  };
 
   const flowContext: ToolUseFlowContext = {
     session: sessionLifecycle,
-    modelHandler: input.modelHandler,
+    get modelHandler() {
+      return mutableServices.modelHandler;
+    },
     runtimeHost,
+    get model() {
+      return mutableServices.config.model;
+    },
     interrupt(): void {
       onInterrupt?.();
       clearRetryRequest(streamId);
@@ -187,16 +239,19 @@ export async function runToolUseFlow<C = unknown>(
       sessionLifecycle.interrupt();
     },
     requestImmediateCompaction(): void {
-      input.modelHandler.requestCompaction();
+      mutableServices.modelHandler.requestCompaction();
       if (!sessionLifecycle.hasQueuedFollowUp()) {
         sessionLifecycle.appendSyntheticFollowUp(
           IMMEDIATE_COMPACTION_FOLLOW_UP,
         );
       }
     },
+    switchModel,
   };
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
+  let lastResponse: string | undefined;
+  let touchedFiles: string[] | undefined;
 
   let shared: ToolUseRunShared = {
     messages: [],
@@ -261,6 +316,13 @@ export async function runToolUseFlow<C = unknown>(
         ? EXECUTION_STATUS.INTERRUPTED
         : EXECUTION_STATUS.COMPLETED;
       status = executionToEndStatus(execStatus) as EndGroupStatus;
+      lastResponse = findLastAssistantText(shared.messages, (m) =>
+        mutableServices.modelHandler.extractAssistantText(m),
+      );
+      const extractedTouchedFiles = extractTouchedFiles(shared.stateSlices);
+      touchedFiles = extractedTouchedFiles.length
+        ? extractedTouchedFiles
+        : undefined;
     }
   } catch (error) {
     status = END_GROUP_STATUS.ERROR;
@@ -279,16 +341,14 @@ export async function runToolUseFlow<C = unknown>(
     sessionLifecycle.dispose();
     clearPlanApprovalForStream(streamId);
     unregisterInterruptible(streamId);
+    for (const handler of switchedHandlers) {
+      handler.dispose();
+    }
   }
-
-  const lastResponse = findLastAssistantText(shared.messages, (m) =>
-    input.modelHandler.extractAssistantText(m),
-  );
-  const touchedFiles = extractTouchedFiles(shared.stateSlices);
 
   return {
     status,
     lastResponse,
-    touchedFiles: touchedFiles.length ? touchedFiles : undefined,
+    touchedFiles,
   };
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -413,6 +413,13 @@ export async function executeAgent(
                 });
                 options.onFollowUpConsumed?.();
               },
+              onModelChanged: (modelHandler, model) => {
+                ctx.config.model = model;
+                ctx.usageMonitor.setModelInfo({
+                  capabilities: modelHandler.capabilities,
+                  config: modelHandler.config,
+                });
+              },
             });
             return {
               category: 'toolUse' as const,

--- a/src/agent/toolUse/ToolUseAgentRegistry.ts
+++ b/src/agent/toolUse/ToolUseAgentRegistry.ts
@@ -57,6 +57,22 @@ export function getToolUseFlowContext(
   return isToolUseFlowContext(entry) ? entry : undefined;
 }
 
+export type SwitchToolUseModelResult =
+  | { status: 'switched' }
+  | { status: 'no_session' }
+  | { status: 'unchanged' };
+
+export async function switchToolUseModel(
+  streamTabId: StreamTabId,
+  model: string,
+): Promise<SwitchToolUseModelResult> {
+  const context = getToolUseFlowContext(streamTabId);
+  if (!context) return { status: 'no_session' };
+  if (context.model === model) return { status: 'unchanged' };
+  await context.switchModel(model);
+  return { status: 'switched' };
+}
+
 export function cleanupInactiveAgents(activeStreams: Set<StreamTabId>): void {
   for (const streamId of registry.keys()) {
     if (!activeStreams.has(streamId)) {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -89,10 +89,14 @@ export class UsageMonitor {
   private activeGroupId: string | undefined;
 
   constructor(
-    private readonly modelInfo: UsageMonitorModelInfo,
+    private modelInfo: UsageMonitorModelInfo,
     private readonly context: UsageMonitorContext,
     private readonly metadata: UsageMonitorMetadata,
   ) {}
+
+  setModelInfo(modelInfo: UsageMonitorModelInfo): void {
+    this.modelInfo = modelInfo;
+  }
 
   /**
    * Set the active group ID for statistics logging.

--- a/src/test-kernel/agent/toolUse/ToolUseModelSwitch.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseModelSwitch.vitest.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
+import {
+  registerInterruptible,
+  switchToolUseModel,
+  unregisterInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import type { StreamTabId } from '@shared/schemas';
+
+const streamId = 'stream-model-switch' as StreamTabId;
+
+afterEach(() => {
+  unregisterInterruptible(streamId);
+});
+
+describe('switchToolUseModel', () => {
+  it('delegates model changes to the active tool-use flow', async () => {
+    let model = 'deepseekT';
+    const switchModel = vi.fn(async (nextModel: string) => {
+      model = nextModel;
+    });
+
+    registerInterruptible(streamId, {
+      session: { appendFollowUp: vi.fn() },
+      get model() {
+        return model;
+      },
+      modelHandler: {},
+      runtimeHost: {},
+      interrupt: vi.fn(),
+      requestImmediateCompaction: vi.fn(),
+      switchModel,
+    } as unknown as ToolUseFlowContext);
+
+    await expect(switchToolUseModel(streamId, 'deepseek')).resolves.toEqual({
+      status: 'switched',
+    });
+    expect(switchModel).toHaveBeenCalledWith('deepseek');
+  });
+
+  it('does not call the flow when the requested model is already active', async () => {
+    const switchModel = vi.fn();
+
+    registerInterruptible(streamId, {
+      session: { appendFollowUp: vi.fn() },
+      model: 'deepseekT',
+      modelHandler: {},
+      runtimeHost: {},
+      interrupt: vi.fn(),
+      requestImmediateCompaction: vi.fn(),
+      switchModel,
+    } as unknown as ToolUseFlowContext);
+
+    await expect(switchToolUseModel(streamId, 'deepseekT')).resolves.toEqual({
+      status: 'unchanged',
+    });
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- allow CLI `/model` and the model picker to update an active tool-use chat while it is waiting for the next user message
- switch the runtime model handler and usage metadata together so the next turn uses the selected model consistently
- reject switches to models with incompatible conversation formats; those still require a new chat

Closes #4164.

## Validation

- `npx vitest run src/test-kernel/agent/toolUse/ToolUseModelSwitch.vitest.ts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `git diff --check`

Full `npm run typecheck` was attempted, but this worktree lacks several package dependencies and the restricted network prevented pnpm from fetching them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds mid-session model switching for active tool-use chats, updating runtime handlers and usage tracking; mistakes could lead to inconsistent state or handler lifecycle issues during live sessions.
> 
> **Overview**
> Allows the CLI `/model` command (and the model picker) to update the model of an *active* tool-use chat **between turns**, guarded so switches only occur when the stream is `WAITING`.
> 
> Implements runtime model switching in tool-use flows via `ToolUseFlowContext.switchModel()`, including validation against `MODEL_CONFIGS`, rejecting incompatible conversation formats, updating transient `MODEL` vars, and disposing switched handlers.
> 
> Plumbs model changes through `ToolUseAgentRegistry.switchToolUseModel()` and updates `executeAgent` to refresh `ctx.config.model` and `UsageMonitor` model metadata on switches; adds a focused vitest covering `switchToolUseModel` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86c148a093ee8609b201afcc5cb63096a070bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->