### PR TITLE
docs(extension): repoint parseUtils header to @shared/toolUse

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
@@ -3,7 +3,7 @@
  * Provides text formatting helpers for rendering.
  *
  * For data validation and normalization, see:
- * - logDataParsers.ts - Complex normalization (toolUse)
+ * - @shared/toolUse - normalizeToolUseData (shared with the CLI TUI)
  * - @shared/schemas - Zod schemas for simple validation
  */
 


### PR DESCRIPTION
## Summary

- claude[bot] flagged on merged PR #4166 that `packages/extension/src/progressView/frontend/formatters/parseUtils.ts:6` still listed `logDataParsers.ts` as the source for tool-use normalization, but that file moved to `@shared/toolUse` as part of that PR. One-line header fix to match the new location.

## Test plan

- [x] Header reads correctly; no runtime effect (doc comment only).
- [x] Grepped repo for stale `logDataParsers` references — none remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only comment change with no runtime behavior impact.
> 
> **Overview**
> Updates the header comment in `parseUtils.ts` to point tool-use normalization guidance to `@shared/toolUse` (`normalizeToolUseData`) instead of the previously referenced location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d941a3bcece7574e90b81b1a819792860d8a6c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->