### PR TITLE
fix(cli): surface retry error cause and skip credential-exhausted retries

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -77,13 +77,19 @@ const newlineCountCache = new Map<
 >();
 registerCliStateResetHook(() => newlineCountCache.clear());
 
-function countNewlinesUpTo(entryId: string, text: string, upTo: number): number {
+function countNewlinesUpTo(
+  entryId: string,
+  text: string,
+  upTo: number,
+): number {
   const cached = newlineCountCache.get(entryId);
   // Append-only invariant: if `upTo` ≥ cached.length and the cached
   // prefix is still a prefix of `text`, we can extend. Otherwise (text
   // shrank or rewrote earlier chars) recount from scratch.
   const canExtend =
-    cached !== undefined && upTo >= cached.length && cached.length <= text.length;
+    cached !== undefined &&
+    upTo >= cached.length &&
+    cached.length <= text.length;
   let count = canExtend ? cached.newlines : 0;
   const start = canExtend ? cached.length : 0;
   for (let i = start; i < upTo; i += 1) {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -33,6 +33,7 @@ import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool'
 import {
   denyMessage,
   immediateDecision,
+  immediateDecisionForApproval,
   markApprovalDenied,
 } from '../../../runtime/approvalAdapter';
 import { assertNever } from '../assertNever';
@@ -170,7 +171,14 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   payload: P,
   dispatch: (payload: P, decision: ApprovalDecision) => void,
 ): void {
-  const policy = immediateDecision(context);
+  const policy =
+    kind === 'retry'
+      ? immediateDecisionForApproval(
+          'showRetryRequest',
+          payload as ProgressEventPayloads['showRetryRequest'],
+          context,
+        )
+      : immediateDecision(context);
   if (policy) {
     dispatch(payload, policy);
     return;

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -94,6 +94,38 @@ export function immediateDecision(
   return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
 }
 
+/** Retry requests caused by exhausted credentials or auth failures need user
+ *  action (key swap, top-up, re-login). Auto-accepting them under `yolo` just
+ *  burns the 100-retry budget and reports the meaningless "maximum manual
+ *  retry limit" error to the user. Force-deny these regardless of policy. */
+function isUnretryableRetryRequest(
+  event: ApprovalEvent,
+  payload: ProgressEventPayloads[ApprovalEvent],
+): boolean {
+  if (event !== 'showRetryRequest') return false;
+  const details = (payload as ProgressEventPayloads['showRetryRequest'])
+    .errorDetails;
+  if (!details) return false;
+  if (details.isCredentialExhausted) return true;
+  if (details.statusCode === 401 || details.statusCode === 403) return true;
+  return false;
+}
+
+function immediateDecisionForApproval(
+  event: ApprovalEvent,
+  payload: ProgressEventPayloads[ApprovalEvent],
+  context: CliContext,
+): ApprovalDecision | undefined {
+  if (isUnretryableRetryRequest(event, payload)) {
+    markApprovalDenied(context);
+    return {
+      accepted: false,
+      userMessage: 'Retry skipped: credential exhausted or unauthorized.',
+    };
+  }
+  return immediateDecision(context);
+}
+
 async function askApproval(
   context: CliContext,
   summary: string,
@@ -389,7 +421,23 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
   if (!isApprovalEvent(event)) return false;
 
   const approvalPayload = payload as ProgressEventPayloads[typeof event];
-  const immediate = immediateDecision(context);
+
+  // Surface the upstream cause of every retry request before any auto-decision.
+  // Without this, non-interactive runs (--print + never/yolo) lose the only
+  // place the relay/provider error appears, leaving users with an opaque
+  // "Node exceeded maximum manual retry limit" after the budget runs out.
+  if (event === 'showRetryRequest') {
+    const data = approvalPayload as ProgressEventPayloads['showRetryRequest'];
+    writeTextStderr(
+      `Retry requested (${data.operation}): ${data.errorMessage ?? 'unknown error'}`,
+    );
+  }
+
+  const immediate = immediateDecisionForApproval(
+    event,
+    approvalPayload,
+    context,
+  );
   if (immediate) {
     dispatchApprovalDecision(event, approvalPayload, immediate);
     return true;

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -111,7 +111,7 @@ function isUnretryableRetryRequest(
   return false;
 }
 
-function immediateDecisionForApproval(
+export function immediateDecisionForApproval(
   event: ApprovalEvent,
   payload: ProgressEventPayloads[ApprovalEvent],
   context: CliContext,


### PR DESCRIPTION
## Summary

- **Surface the upstream cause of every retry.** `handleCliApprovalEvent` was swallowing `showRetryRequest` events before they could reach stderr or ndjson. Non-interactive runs (`texra run --print`) only saw the final `Node exceeded maximum manual retry limit (100)` and had no way to learn that the real cause was, e.g., a relay 429 billing cap or an expired key. Now the retry operation + `errorMessage` are written to stderr before the auto-decision.
- **Stop auto-retrying permanent failures under `yolo`.** `--approval-policy yolo` was auto-accepting every retry request, including ones whose `errorDetails` already flag them as `isCredentialExhausted` or 401/403. The retry loop ran the full 100-attempt budget (~3 minutes) against an error the user had to fix manually anyway. Added `isUnretryableRetryRequest` to force-deny these regardless of policy.

## Before / after

`texra run correct --input test.tex --model sonnet46T --print --approval-policy yolo` on an account over its monthly cap:

| | Before | After |
|---|---|---|
| Time to failure | ~3 min (100 retries) | ~5.5 s (1 attempt) |
| User-visible error | `Node exceeded maximum manual retry limit (100)` | `Retry requested (Model invocation): HTTP 429 ... Monthly spending limit reached ($300) ... limitReached: true` |

Both `never` and `yolo` policies now surface the underlying cause and exit promptly.

## Test plan

- [x] `pnpm typecheck` in `packages/cli`
- [x] `pnpm bundle` in `packages/cli`
- [x] `texra run correct --print --approval-policy never` → upstream error visible on stderr, exits in one cycle
- [x] `texra run correct --print --approval-policy yolo` → upstream error visible on stderr, exits in one cycle (no 100x loop)
- [ ] Confirm interactive `--approval-policy ask` retry prompt still works (existing summary path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI approval/retry decision logic, which can alter non-interactive run behavior and error handling paths (especially for `showRetryRequest`). Low blast radius otherwise, but could affect automation that relied on prior retry/printing behavior.
> 
> **Overview**
> Ensures `showRetryRequest` events are **always** surfaced by writing the retry operation and upstream `errorMessage` to stderr before any auto-decision, improving observability in non-interactive/`--print` runs.
> 
> Adds `immediateDecisionForApproval` to force-deny retry requests flagged as credential-exhausted or unauthorized (401/403), and updates the TUI approval routing to apply this stricter policy specifically for retry approvals. Also includes a small formatting-only update in `ConversationPane.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e482c90578b4697b33313f72f7d968981f7d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->