### PR TITLE
chore(cli): lift collapseWhitespace + TOOL_USE_STATUS constants

### DIFF
--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -11,9 +11,12 @@ import { useMemo } from 'react';
 
 import { Box, Text } from 'ink';
 
-import type { NormalizedToolUse } from '@shared/schemas';
+import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
 import { isPlainObject } from '@shared/utils/string';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
@@ -56,13 +59,9 @@ function previewInput(input: unknown): string {
   }
 }
 
-function collapseWhitespace(text: string): string {
-  return text.replaceAll(/\s+/g, ' ').trim();
-}
-
 function statusColor(toolUse: NormalizedToolUse): 'green' | 'red' | undefined {
   if (toolUse.isError) return 'red';
-  if (toolUse.status === 'completed') return 'green';
+  if (toolUse.status === TOOL_USE_STATUS.COMPLETED) return 'green';
   return undefined;
 }
 
@@ -100,7 +99,9 @@ export function ToolUseRow({
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   const showError = toolUse.isError;
   const showNoOutput =
-    toolUse.status === 'completed' && visibleOutput.length === 0 && !showError;
+    toolUse.status === TOOL_USE_STATUS.COMPLETED &&
+    visibleOutput.length === 0 &&
+    !showError;
 
   return (
     <Box flexDirection="column" marginBottom={1}>

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -31,7 +31,10 @@ import {
   type CodexMcpToolOutput,
 } from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 // Local imports - Lit template utilities
 import {
@@ -128,13 +131,12 @@ function getToolTimeoutMs(
 
 /** Truncate a prompt string for display in collapsed headers. */
 function truncatePrompt(text: string, maxLength: number): string {
-  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  return truncateWithEllipsis(oneLine, maxLength);
+  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
 }
 
 /** Truncate tool header text without pulling streamed stdout/stderr into it. */
 function truncateHeaderSummary(text: string, maxLength: number): string {
-  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
+  const oneLine = collapseWhitespace(text);
   const outputMarker = oneLine.search(/\s+<(?:stdout|stderr)>/i);
   const summary =
     outputMarker >= 0 ? oneLine.slice(0, outputMarker).trim() : oneLine;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -71,7 +71,15 @@ export const MissingOutputsPayloadSchema = z.object({
   documentTag: z.string().nullable().prefault(null),
 });
 
-const ToolUseStatusSchema = z.enum(['in_progress', 'completed']);
+export const TOOL_USE_STATUS = {
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+} as const;
+
+const ToolUseStatusSchema = z.enum([
+  TOOL_USE_STATUS.IN_PROGRESS,
+  TOOL_USE_STATUS.COMPLETED,
+]);
 
 export const ToolUseLogSchema = z.object({
   toolName: z.string().optional(),

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,7 +1,10 @@
 // Shared constants and helpers for the Claude Agent tool.
 
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 export const CLAUDE_AGENT_NAME = 'claude_agent';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
@@ -90,8 +93,7 @@ export function buildClaudeUsageStats(usage: {
 }
 
 function truncateSummary(text: string, maxLength: number): string {
-  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  return truncateWithEllipsis(oneLine, maxLength);
+  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
 }
 
 /**

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 import type {
   CommandExecutionItem,
   FileChangeItem,
@@ -88,8 +91,7 @@ export const CodexTurnToolInputSchema = z.object({
 export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;
 
 function truncateSummary(text: string, maxLength: number): string {
-  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  return truncateWithEllipsis(oneLine, maxLength);
+  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
 }
 
 function getPathBasename(filePath: string): string {

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -66,3 +66,15 @@ export function truncateWithEllipsis(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return `${text.slice(0, maxLen - 1)}…`;
 }
+
+/**
+ * Collapse every whitespace run (including newlines) to a single space
+ * and trim. Used by header-preview renderers that need a one-line summary
+ * of multi-line content.
+ *
+ * @example
+ * collapseWhitespace('foo\n  bar\t baz ') // 'foo bar baz'
+ */
+export function collapseWhitespace(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## Summary

Post-merge cleanup on #4166 surfaced by a /simplify review:

- **`collapseWhitespace`** — the one-line idiom `text.replaceAll(/\s+/g, ' ').trim()` was duplicated across five sites (`ToolUseRow.tsx`, `claudeAgentShared.ts`, `codexShared.ts`, and two helpers in extension's `toolFormatters.ts`). Promoted to `@utils/text/stringUtils` and reused everywhere.
- **`TOOL_USE_STATUS` constants** — `ToolUseLog.status` is a Zod enum (`'in_progress' | 'completed'`) but `ToolUseRow` was comparing against string literals. Exported `TOOL_USE_STATUS` constants next to `ToolUseStatusSchema` so the renderer mirrors the `MESSAGE_TYPES` / `STREAM_STATUS` pattern already used elsewhere. Scoped narrowly to the new consumer this PR adds — producer sites elsewhere in the codebase still use literals and aren't touched here.

## Test plan

- [x] `npm run typecheck`
- [x] `vitest src/test-kernel/cli/ src/test-kernel/shared/ src/test-kernel/agent/toolUse/` (19 files, 88 tests)

## Findings reviewed but not addressed

- `stringifyWithLanguage` (extension `parseUtils.ts`) and `formatOutputText` (`@shared/toolUse`) overlap on `yaml.stringify` + try/catch, but they have different return shapes (`{text, language}` vs `string`), different empty-object handling, and different fallbacks. Sharing just the four-line core isn't worth the indirection.
- Two-branch copy of `prev && entriesEqual(prev, next) ? prev : next` in `renderLogEntry` — the cache-bookkeeping in the tool branch breaks symmetric unification.
- JSX wrapper-`<Box>` nesting in `ToolUseRow`'s output-lines loop and a long block comment in `subscribeStreamLog.ts` — flagged but judged worth keeping as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: centralizes duplicated string-normalization logic and replaces a few status string comparisons with shared constants, with no behavioral changes expected beyond more consistent rendering.
> 
> **Overview**
> Promotes the repeated “collapse all whitespace to one line” logic into `@utils/text/stringUtils` as `collapseWhitespace`, and updates the CLI, extension progress view formatter, and tool-log builders (`claudeAgentShared`, `codexShared`) to reuse it for header/summary truncation.
> 
> Exports `TOOL_USE_STATUS` alongside the `ToolUseStatusSchema` and updates the CLI `ToolUseRow` renderer to compare against these constants instead of string literals (including the completed/no-output and green-status cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b8505899b7c63853f382a8fec1b443d2a7dff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->