### PR TITLE
chore(cli): prepare @texra/cli for npm publish

### DIFF
--- a/packages/cli/LICENSE.txt
+++ b/packages/cli/LICENSE.txt
@@ -1,0 +1,6 @@
+TeXRA Proprietary License
+
+TeXRA CLI is proprietary software. All rights reserved.
+
+Use of the TeXRA CLI is governed by the TeXRA terms of service:
+https://texra.ai/terms

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,17 @@
-# TeXRA CLI package
+# TeXRA CLI
 
-This package contains the scaffold for the standalone `texra` command.
+This package provides the standalone `texra` command.
+
+## Install from npm
+
+```sh
+npm install -g @texra/cli
+texra --help
+```
+
+The published command is a self-contained esbuild bundle. Runtime libraries are
+inlined into `dist/bin/texra.js`, so npm only needs to install the generated
+binary and packaged resources.
 
 ## Package locally
 
@@ -16,13 +27,11 @@ The build writes the manifest-declared executable to:
 packages/cli/dist/bin/texra.js
 ```
 
-The `package.json` `bin` entry maps `texra` to that generated file. The package
-is still marked `private: true`, so publication is not ready yet.
+The `package.json` `bin` entry maps `texra` to that generated file. Packaging
+runs the build through `prepack`, so `npm pack` and `npm publish` rebuild the
+binary before producing a tarball.
 
-## Install locally
-
-The CLI is not published as an npm package yet. Install it from a repository
-checkout:
+## Install locally from a checkout
 
 ```sh
 corepack pnpm install
@@ -40,10 +49,10 @@ inlines everything except `fsevents`), so the symlink is all that is needed.
 Rebuild after changing CLI or shared runtime code — the symlink target stays
 valid.
 
-> `pnpm link --global` is not used here because the CLI's `package.json` lists
-> `@texra/core` as a `workspace:*` dependency. pnpm refuses to resolve that spec
-> when linking the package as a standalone target, so the link step fails even
-> though the runtime binary does not need the dep (it is already bundled).
+> `pnpm link --global` is not used here because package-manager link commands
+> can expose workspace dependencies differently from the published bundle. The
+> generated binary is the published artifact, so the symlink points directly at
+> that file.
 
 To remove the linked command:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,10 +5,6 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",
   "homepage": "https://texra.ai",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/texra-ai/texra-issues.git"
-  },
   "bugs": {
     "url": "https://github.com/texra-ai/texra-issues/issues"
   },
@@ -24,11 +20,12 @@
     "texra"
   ],
   "files": [
-    "dist"
+    "dist",
+    "LICENSE.txt"
   ],
   "type": "module",
   "bin": {
-    "texra": "./dist/bin/texra.js"
+    "texra": "dist/bin/texra.js"
   },
   "engines": {
     "node": ">=22"
@@ -42,32 +39,31 @@
     "bundle": "node scripts/build-bundle.mjs",
     "copy:resources": "node scripts/copy-resources.mjs",
     "smoke:react-compiler": "node scripts/smoke-react-compiler.mjs",
-    "build": "pnpm run typecheck && pnpm run check:architecture && pnpm run smoke:react-compiler && pnpm run bundle && pnpm run copy:resources",
+    "build": "npm run typecheck && npm run check:architecture && npm run smoke:react-compiler && npm run bundle && npm run copy:resources",
+    "prepack": "npm run build",
     "validate:run": "node scripts/validate-run.mjs"
   },
-  "dependencies": {
+  "devDependencies": {
     "@inkjs/ui": "^2.0.0",
+    "@babel/core": "^7.29.0",
+    "@babel/preset-react": "^7.28.5",
+    "@babel/preset-typescript": "^7.28.5",
     "@lit-labs/signals": "^0.3.0",
+    "@texra/core": "workspace:*",
+    "@types/markdown-it": "^14.1.2",
+    "@types/react": "^19.2.0",
+    "babel-plugin-react-compiler": "^1.0.0",
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
     "diff": "^9.0.0",
+    "esbuild": "^0.28.0",
     "ink": "^7.0.3",
     "markdown-it": "^14.1.1",
     "p-queue": "^9.2.0",
     "picocolors": "^1.1.1",
     "react": "^19.2.0",
     "string-width": "^8.0.0",
-    "wrap-ansi": "^10.0.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.29.0",
-    "@babel/preset-react": "^7.28.5",
-    "@babel/preset-typescript": "^7.28.5",
-    "@texra/core": "workspace:*",
-    "@types/markdown-it": "^14.1.2",
-    "@types/react": "^19.2.0",
-    "babel-plugin-react-compiler": "^1.0.0",
-    "esbuild": "^0.28.0",
+    "wrap-ansi": "^10.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,28 @@
 {
   "name": "@texra/cli",
   "version": "0.37.8",
-  "private": true,
+  "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
+  "license": "SEE LICENSE IN LICENSE.txt",
+  "author": "TeXRA.ai",
+  "homepage": "https://texra.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/texra-ai/texra-issues.git"
+  },
+  "bugs": {
+    "url": "https://github.com/texra-ai/texra-issues/issues"
+  },
+  "keywords": [
+    "latex",
+    "tex",
+    "ai",
+    "cli",
+    "llm",
+    "research",
+    "academic",
+    "writing",
+    "texra"
+  ],
   "files": [
     "dist"
   ],
@@ -11,6 +32,9 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
@@ -24,7 +48,6 @@
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
     "@lit-labs/signals": "^0.3.0",
-    "@texra/core": "workspace:*",
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
     "diff": "^9.0.0",
@@ -40,6 +63,7 @@
     "@babel/core": "^7.29.0",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
+    "@texra/core": "workspace:*",
     "@types/markdown-it": "^14.1.2",
     "@types/react": "^19.2.0",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,9 +330,6 @@ importers:
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
-      '@texra/core':
-        specifier: workspace:*
-        version: link:../core
       citty:
         specifier: ^0.2.2
         version: 0.2.2
@@ -373,6 +370,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.29.0)
+      '@texra/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,13 +323,34 @@ importers:
         version: 1.21.1
 
   packages/cli:
-    dependencies:
+    devDependencies:
       '@inkjs/ui':
         specifier: ^2.0.0
         version: 2.0.0(ink@7.0.3(@types/react@19.2.14)(react@19.2.6))
+      '@babel/core':
+        specifier: ^7.29.0
+        version: 7.29.0
+      '@babel/preset-react':
+        specifier: ^7.28.5
+        version: 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript':
+        specifier: ^7.28.5
+        version: 7.28.5(@babel/core@7.29.0)
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
+      '@texra/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.14
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       citty:
         specifier: ^0.2.2
         version: 0.2.2
@@ -339,6 +360,9 @@ importers:
       diff:
         specifier: ^9.0.0
         version: 9.0.0
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       ink:
         specifier: ^7.0.3
         version: 7.0.3(@types/react@19.2.14)(react@19.2.6)
@@ -360,31 +384,6 @@ importers:
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0
-    devDependencies:
-      '@babel/core':
-        specifier: ^7.29.0
-        version: 7.29.0
-      '@babel/preset-react':
-        specifier: ^7.28.5
-        version: 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript':
-        specifier: ^7.28.5
-        version: 7.28.5(@babel/core@7.29.0)
-      '@texra/core':
-        specifier: workspace:*
-        version: link:../core
-      '@types/markdown-it':
-        specifier: ^14.1.2
-        version: 14.1.2
-      '@types/react':
-        specifier: ^19.2.0
-        version: 19.2.14
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
Prepare the `@texra/cli` package for public npm publication.

This PR removes the private-package marker, adds npm-facing metadata, sets `publishConfig.access` to `public`, and keeps the issues repository as the package support URL. The CLI bundle remains self-contained: esbuild inlines the runtime libraries into `dist/bin/texra.js`, so package dependencies are classified as build-time inputs.

The package now builds itself during npm packing through `prepack`. A clean `npm pack` or `npm publish` run therefore regenerates `dist/bin/texra.js`, copies packaged resources, and includes the CLI license file before producing the tarball.

Validation performed:
- `tsc --noEmit -p packages/cli/tsconfig.json`
- `node packages/cli/scripts/check-host-imports.mjs`
- `npm_config_cache=/private/tmp/texra-npm-cache npm pack --dry-run --json`
- `npm_config_cache=/private/tmp/texra-npm-cache npm publish --dry-run --json`

The dry-run tarball includes `dist/bin/texra.js`, packaged resources, `README.md`, `package.json`, and `LICENSE.txt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CLI package’s publish configuration and dependency classification, which could affect the resulting npm tarball contents and install/build behavior.
> 
> **Overview**
> Prepares `@texra/cli` to be published on npm by removing the `private` flag, adding required package metadata (description/license/author/homepage/bugs/keywords), and setting `publishConfig.access=public`.
> 
> Adds a proprietary `LICENSE.txt` to the published files, introduces a `prepack` build step, and tweaks the `bin` path/build script wiring so `npm pack`/`npm publish` ship a rebuilt, self-contained bundle.
> 
> Moves runtime libraries (including `@texra/core`) under `devDependencies` to reflect that the distributed CLI is an esbuild bundle, and updates `pnpm-lock.yaml` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3b51088cdbe8f91ce80e2ba54e3d0aff344d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->