### PR TITLE
refactor(flows): share post-compaction, debug-meta, and usage helpers

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -97,18 +97,10 @@ export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
 
 // --- Shared Helpers for Cycle Flows ---
 
-/** Services subset required by `defaultPostCompactionContext`. */
-type PostCompactionServices = Pick<AgentCore, 'streamId'> & {
-  workspace: Pick<AgentWorkspaceState, 'workPlan'>;
-};
+type CycleServices = AgentCore & { workspace: AgentWorkspaceState };
 
-/**
- * Default post-compaction context for cycle flows: surfaces active subagents,
- * background processes, and the current work plan after a compaction event so
- * the next model call retains awareness of in-flight work.
- */
 export function defaultPostCompactionContext(
-  services: PostCompactionServices,
+  services: CycleServices,
 ): string | null {
   const { subagents, processes } = getActiveChildren(services.streamId);
   return formatPostCompactionContext(
@@ -118,44 +110,21 @@ export function defaultPostCompactionContext(
   );
 }
 
-/** Services subset required by `defaultDebugMeta`. */
-type DebugMetaServices = Pick<AgentCore, 'config'>;
-
-/** Build the `{ modelName, isRemote }` pair used by every cycle debug-save call. */
-export function defaultDebugMeta(services: DebugMetaServices): {
-  modelName?: string;
-  isRemote?: boolean;
-} {
+export function defaultDebugMeta(services: CycleServices) {
   return {
     modelName: services.config.model,
     isRemote: isRemoteAgent(services.config.agent),
   };
 }
 
-/** Services subset required by `logAndNormalizeUsage`. */
-type UsageLoggingServices = {
-  modelHandler: Pick<
-    AgentCore['modelHandler'],
-    'normalizeUsage' | 'getEffectiveContextWindow'
-  >;
-  logger: Pick<AgentLogger, 'logContextState'>;
-};
-
-/**
- * Normalize provider usage and emit the context-window state log when
- * sufficient data is available. Returns `undefined` for nullish usage so
- * callers can short-circuit downstream stats updates.
- */
+/** Returns `undefined` for nullish usage so callers can skip stats updates. */
 export function logAndNormalizeUsage(
   usage: ProviderUsage,
   responseTimeMs: number,
-  services: UsageLoggingServices,
+  services: CycleServices,
 ): NormalizedUsage | undefined {
   if (usage == null) return undefined;
-  const normalized = services.modelHandler.normalizeUsage(
-    usage,
-    responseTimeMs,
-  );
+  const normalized = services.modelHandler.normalizeUsage(usage, responseTimeMs);
   const { inputTokens } = normalized;
   const contextWindow = services.modelHandler.getEffectiveContextWindow();
   if (inputTokens > 0 && contextWindow > 0) {

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -36,7 +36,7 @@ export const BaseCycleFieldsSchema = z.object({
 export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;
 
 /** Derive debug context from services at call site. */
-export function getDebugContext(
+function getDebugContext(
   services: { logger: AgentLogger; executionId?: ExecutionId },
   params: { modelName?: string; isRemote?: boolean },
 ): DebugContext {
@@ -141,15 +141,25 @@ export interface ExtractedModelResponse {
   stopReason: ProviderStopReason;
   thinking: string | null;
   useStreaming: boolean;
-  /** `undefined` for nullish raw usage so callers can skip stats updates. */
+  /** `undefined` when the caller chooses to skip nullish raw usage. */
   normalizedUsage: NormalizedUsage | undefined;
 }
+
+export type ExtractModelResponseOptions = {
+  /**
+   * Response flows historically normalized null provider usage into a zero
+   * snapshot. Tool-use flows historically skipped missing usage. Keep that
+   * distinction explicit at the call site.
+   */
+  normalizeNullUsage?: boolean;
+};
 
 export function extractModelResponse(
   response: unknown,
   responseTimeMs: number | undefined,
   endTag: string,
   services: CycleServices,
+  options: ExtractModelResponseOptions = {},
 ): ExtractedModelResponse {
   const { modelHandler, workspace, logger } = services;
   const thinking = modelHandler.processThinkingBlock(response, workspace);
@@ -160,7 +170,7 @@ export function extractModelResponse(
   );
 
   let normalizedUsage: NormalizedUsage | undefined;
-  if (usage != null) {
+  if (usage != null || options.normalizeNullUsage === true) {
     normalizedUsage = modelHandler.normalizeUsage(usage, responseTimeMs ?? 0);
     const { inputTokens } = normalizedUsage;
     const contextWindow = modelHandler.getEffectiveContextWindow();

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -9,10 +9,14 @@ import {
   ProviderMessageSchema,
   type ProviderMessage,
 } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/ResponseUsage';
 import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import type { DebugContext } from '@agent/utils/debugMessageSaver';
+import {
+  maybeSaveDebugObject,
+  type DebugContext,
+} from '@agent/utils/debugMessageSaver';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { RetryErrorInfoSchema } from '@shared/schemas';
 import type { ExecutionId } from '@shared/schemas';
@@ -95,9 +99,30 @@ export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
   target.push(...newContents);
 }
 
-// --- Shared Helpers for Cycle Flows ---
-
 type CycleServices = AgentCore & { workspace: AgentWorkspaceState };
+
+export type CycleDebugFileOptions = {
+  continuationCount: number;
+  baseName: string;
+  outputFile?: string;
+};
+
+export async function saveCycleDebug(
+  object: unknown,
+  objectType: 'messages' | 'response',
+  services: AgentCore,
+  fileOptions: CycleDebugFileOptions,
+): Promise<void> {
+  await maybeSaveDebugObject({
+    object,
+    objectType,
+    context: getDebugContext(services, {
+      modelName: services.config.model,
+      isRemote: isRemoteAgent(services.config.agent),
+    }),
+    fileOptions,
+  });
+}
 
 export function defaultPostCompactionContext(
   services: CycleServices,
@@ -110,25 +135,39 @@ export function defaultPostCompactionContext(
   );
 }
 
-export function defaultDebugMeta(services: CycleServices) {
-  return {
-    modelName: services.config.model,
-    isRemote: isRemoteAgent(services.config.agent),
-  };
+export interface ExtractedModelResponse {
+  text: string;
+  usage: ProviderUsage;
+  stopReason: ProviderStopReason;
+  thinking: string | null;
+  useStreaming: boolean;
+  /** `undefined` for nullish raw usage so callers can skip stats updates. */
+  normalizedUsage: NormalizedUsage | undefined;
 }
 
-/** Returns `undefined` for nullish usage so callers can skip stats updates. */
-export function logAndNormalizeUsage(
-  usage: ProviderUsage,
-  responseTimeMs: number,
+export function extractModelResponse(
+  response: unknown,
+  responseTimeMs: number | undefined,
+  endTag: string,
   services: CycleServices,
-): NormalizedUsage | undefined {
-  if (usage == null) return undefined;
-  const normalized = services.modelHandler.normalizeUsage(usage, responseTimeMs);
-  const { inputTokens } = normalized;
-  const contextWindow = services.modelHandler.getEffectiveContextWindow();
-  if (inputTokens > 0 && contextWindow > 0) {
-    services.logger.logContextState(inputTokens, contextWindow);
+): ExtractedModelResponse {
+  const { modelHandler, workspace, logger } = services;
+  const thinking = modelHandler.processThinkingBlock(response, workspace);
+  const useStreaming = modelHandler.getStreamingConfig();
+  const { text, usage, stopReason } = modelHandler.extractResponse(
+    response,
+    endTag,
+  );
+
+  let normalizedUsage: NormalizedUsage | undefined;
+  if (usage != null) {
+    normalizedUsage = modelHandler.normalizeUsage(usage, responseTimeMs ?? 0);
+    const { inputTokens } = normalizedUsage;
+    const contextWindow = modelHandler.getEffectiveContextWindow();
+    if (inputTokens > 0 && contextWindow > 0) {
+      logger.logContextState(inputTokens, contextWindow);
+    }
   }
-  return normalized;
+
+  return { text, usage, stopReason, thinking, useStreaming, normalizedUsage };
 }

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -2,14 +2,21 @@
 
 import { z } from 'zod';
 
+import { isRemoteAgent } from '@agent/index/agentRegistry';
+import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import type { AgentCore } from '@agent/implementations/flows/common/BaseFlowServices';
 import {
   ProviderMessageSchema,
   type ProviderMessage,
 } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderUsage } from '@agent/core/ResponseUsage';
+import { getActiveChildren } from '@agent/runtime/executionRegistry';
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { DebugContext } from '@agent/utils/debugMessageSaver';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { RetryErrorInfoSchema } from '@shared/schemas';
 import type { ExecutionId } from '@shared/schemas';
+import { formatPostCompactionContext } from '@tools/subagentResults';
 
 /** Base schema for fields common to all cycle flows. */
 export const BaseCycleFieldsSchema = z.object({
@@ -86,4 +93,73 @@ export interface BaseInvocationSuccessData {
 export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
   target.length = 0;
   target.push(...newContents);
+}
+
+// --- Shared Helpers for Cycle Flows ---
+
+/** Services subset required by `defaultPostCompactionContext`. */
+type PostCompactionServices = Pick<AgentCore, 'streamId'> & {
+  workspace: Pick<AgentWorkspaceState, 'workPlan'>;
+};
+
+/**
+ * Default post-compaction context for cycle flows: surfaces active subagents,
+ * background processes, and the current work plan after a compaction event so
+ * the next model call retains awareness of in-flight work.
+ */
+export function defaultPostCompactionContext(
+  services: PostCompactionServices,
+): string | null {
+  const { subagents, processes } = getActiveChildren(services.streamId);
+  return formatPostCompactionContext(
+    subagents,
+    processes,
+    services.workspace.workPlan.toSnapshot(),
+  );
+}
+
+/** Services subset required by `defaultDebugMeta`. */
+type DebugMetaServices = Pick<AgentCore, 'config'>;
+
+/** Build the `{ modelName, isRemote }` pair used by every cycle debug-save call. */
+export function defaultDebugMeta(services: DebugMetaServices): {
+  modelName?: string;
+  isRemote?: boolean;
+} {
+  return {
+    modelName: services.config.model,
+    isRemote: isRemoteAgent(services.config.agent),
+  };
+}
+
+/** Services subset required by `logAndNormalizeUsage`. */
+type UsageLoggingServices = {
+  modelHandler: Pick<
+    AgentCore['modelHandler'],
+    'normalizeUsage' | 'getEffectiveContextWindow'
+  >;
+  logger: Pick<AgentLogger, 'logContextState'>;
+};
+
+/**
+ * Normalize provider usage and emit the context-window state log when
+ * sufficient data is available. Returns `undefined` for nullish usage so
+ * callers can short-circuit downstream stats updates.
+ */
+export function logAndNormalizeUsage(
+  usage: ProviderUsage,
+  responseTimeMs: number,
+  services: UsageLoggingServices,
+): NormalizedUsage | undefined {
+  if (usage == null) return undefined;
+  const normalized = services.modelHandler.normalizeUsage(
+    usage,
+    responseTimeMs,
+  );
+  const { inputTokens } = normalized;
+  const contextWindow = services.modelHandler.getEffectiveContextWindow();
+  if (inputTokens > 0 && contextWindow > 0) {
+    services.logger.logContextState(inputTokens, contextWindow);
+  }
+  return normalized;
 }

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -3,11 +3,11 @@ import {
   type BaseInvocationPrepResult,
   type BaseInvocationSuccessData,
   type BaseCycleFields,
-  getDebugContext,
+  type CycleDebugFileOptions,
   replaceMessagesInPlace,
+  saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import type { ToolDefinition } from '@model';
 
 import { FlowTransition } from './FlowTransitions';
@@ -31,17 +31,10 @@ export interface ModelInvocationConfig<TShared, TServices> {
    * as a user follow-up message, or null if no context is needed.
    */
   getPostCompactionContext?: (services: TServices) => string | null;
-  getDebugSaveOptions?: (
+  getDebugFileOptions?: (
     shared: TShared,
     services: TServices,
-  ) => {
-    context: { modelName?: string; isRemote?: boolean };
-    fileOptions: {
-      continuationCount: number;
-      baseName: string;
-      outputFile?: string;
-    };
-  };
+  ) => CycleDebugFileOptions;
 }
 
 type InvocationServices = BaseFlowContextInit<any> & {
@@ -154,17 +147,17 @@ export class ModelInvocationNode<
     shared.responseTimeMs = successRes.responseTimeMs;
     this._config.storeResponse(shared, successRes.response);
 
-    if (this._config.getDebugSaveOptions) {
-      const { context, fileOptions } = this._config.getDebugSaveOptions(
+    if (this._config.getDebugFileOptions) {
+      const fileOptions = this._config.getDebugFileOptions(
         shared,
         this.services,
       );
-      await maybeSaveDebugObject({
-        object: successRes.response,
-        objectType: 'response',
-        context: getDebugContext(this.services, context),
+      await saveCycleDebug(
+        successRes.response,
+        'response',
+        this.services,
         fileOptions,
-      });
+      );
     }
 
     return FlowTransition.DEFAULT;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -7,18 +7,16 @@ import { recordRound } from '@agent/core/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   BaseCycleFieldsSchema,
-  defaultDebugMeta,
   defaultPostCompactionContext,
-  getDebugContext,
-  logAndNormalizeUsage,
+  extractModelResponse,
   resetCycleState,
+  saveCycleDebug,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/ResponseUsage';
 
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 
@@ -140,15 +138,10 @@ class ResponsePrepNode<C> extends BaseNode<
     shared.systemPrompt = prepRes.systemPrompt;
     resetCycleState(shared, ['responseObject', 'processedResponse']);
 
-    await maybeSaveDebugObject({
-      object: shared.messages,
-      objectType: 'messages',
-      context: getDebugContext(this.services, defaultDebugMeta(this.services)),
-      fileOptions: {
-        continuationCount: round.continuationCount,
-        baseName: 'response',
-        outputFile: shared.outputLocation!.relativePath,
-      },
+    await saveCycleDebug(shared.messages, 'messages', this.services, {
+      continuationCount: round.continuationCount,
+      baseName: 'response',
+      outputFile: shared.outputLocation!.relativePath,
     });
 
     return FlowTransition.DEFAULT;
@@ -229,7 +222,7 @@ class ResponseProcessNode<C> extends BaseNode<
   }
 
   async exec(prepRes: ProcessPrepResult): Promise<ProcessNodeResult> {
-    const { workspace, logger, modelHandler, setting } = this.services;
+    const { logger } = this.services;
 
     if (prepRes.shouldStop || !prepRes.responseObject) {
       return { kind: 'skipped' };
@@ -244,26 +237,26 @@ class ResponseProcessNode<C> extends BaseNode<
         text: newResponse,
         usage: responseUsage,
         stopReason,
-      } = modelHandler.extractResponse(prepRes.responseObject, setting.endTag);
+        thinking: thinkingContent,
+        useStreaming,
+        normalizedUsage,
+      } = extractModelResponse(
+        prepRes.responseObject,
+        prepRes.responseTimeMs,
+        this.services.setting.endTag,
+        this.services,
+      );
 
       if (newResponse) {
         logger.debug(`Model response: ${newResponse.slice(0, 100)}`);
       }
-
       if (prepRes.responseTimeMs != null) {
         logger.debug(
           `Response time: ${(prepRes.responseTimeMs / 1000).toFixed(2)}s`,
         );
       }
-
       logger.debug(`Stop reason: ${stopReason}`);
       logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`);
-
-      const thinkingContent = modelHandler.processThinkingBlock(
-        prepRes.responseObject,
-        workspace,
-      );
-      const useStreaming = modelHandler.getStreamingConfig();
 
       if (thinkingContent && !useStreaming) {
         logger.info(thinkingContent, {
@@ -277,12 +270,6 @@ class ResponseProcessNode<C> extends BaseNode<
           messageType: MESSAGE_TYPES.SCRATCHPAD,
         });
       }
-
-      const normalizedUsage = logAndNormalizeUsage(
-        responseUsage,
-        prepRes.responseTimeMs ?? 0,
-        this.services,
-      );
 
       const repetitionResult = checkForMassiveRepetition(
         prepRes.lastResponse,
@@ -631,13 +618,10 @@ export function createResponseCycleFlow<C>(): Flow<
       shared.responseObject = response;
     },
     getPostCompactionContext: defaultPostCompactionContext,
-    getDebugSaveOptions: (shared, services) => ({
-      context: defaultDebugMeta(services),
-      fileOptions: {
-        continuationCount: services.round.continuationCount,
-        baseName: 'response',
-        outputFile: shared.outputLocation!.relativePath,
-      },
+    getDebugFileOptions: (shared, services) => ({
+      continuationCount: services.round.continuationCount,
+      baseName: 'response',
+      outputFile: shared.outputLocation!.relativePath,
     }),
   });
   const processNode = new ResponseProcessNode<C>();

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -245,6 +245,7 @@ class ResponseProcessNode<C> extends BaseNode<
         prepRes.responseTimeMs,
         this.services.setting.endTag,
         this.services,
+        { normalizeNullUsage: true },
       );
 
       if (newResponse) {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -2,13 +2,15 @@ import { dirname } from 'path';
 
 import { z } from 'zod';
 
-import { isRemoteAgent } from '@agent/index';
 import { BaseNode, Flow } from '@agent/node';
 import { recordRound } from '@agent/core/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   BaseCycleFieldsSchema,
+  defaultDebugMeta,
+  defaultPostCompactionContext,
   getDebugContext,
+  logAndNormalizeUsage,
   resetCycleState,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
@@ -21,12 +23,10 @@ import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';
-import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@agent/core/constants';
 import { bestConnectionMethod } from '@latex';
 import replacementEngine from '@replacement/engine';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
-import { formatPostCompactionContext } from '@tools/subagentResults';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getSystemPromptWithRules } from '@utils/prompt';
 import { extractScratchpad } from '@utils/text/xmlUtils';
@@ -135,7 +135,7 @@ class ResponsePrepNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
-    const { config, round } = this.services;
+    const { round } = this.services;
     shared.outputExists = prepRes.exists;
     shared.systemPrompt = prepRes.systemPrompt;
     resetCycleState(shared, ['responseObject', 'processedResponse']);
@@ -143,10 +143,7 @@ class ResponsePrepNode<C> extends BaseNode<
     await maybeSaveDebugObject({
       object: shared.messages,
       objectType: 'messages',
-      context: getDebugContext(this.services, {
-        modelName: config.model,
-        isRemote: isRemoteAgent(config.agent),
-      }),
+      context: getDebugContext(this.services, defaultDebugMeta(this.services)),
       fileOptions: {
         continuationCount: round.continuationCount,
         baseName: 'response',
@@ -180,7 +177,7 @@ interface ProcessResult {
   thinkingContent?: string | null;
   useStreaming: boolean;
   responseUsage: ProviderUsage;
-  normalizedUsage: NormalizedUsage;
+  normalizedUsage?: NormalizedUsage;
   repetitionDetected: boolean;
   updatedLastResponse?: string;
   updatedAccumulatedOutput?: string;
@@ -281,16 +278,11 @@ class ResponseProcessNode<C> extends BaseNode<
         });
       }
 
-      const normalizedUsage = modelHandler.normalizeUsage(
+      const normalizedUsage = logAndNormalizeUsage(
         responseUsage,
         prepRes.responseTimeMs ?? 0,
+        { modelHandler, logger },
       );
-
-      const { inputTokens } = normalizedUsage;
-      const contextWindow = modelHandler.getEffectiveContextWindow();
-      if (inputTokens > 0 && contextWindow > 0) {
-        logger.logContextState(inputTokens, contextWindow);
-      }
 
       const repetitionResult = checkForMassiveRepetition(
         prepRes.lastResponse,
@@ -638,19 +630,9 @@ export function createResponseCycleFlow<C>(): Flow<
     storeResponse: (shared, response) => {
       shared.responseObject = response;
     },
-    getPostCompactionContext: (services) => {
-      const { subagents, processes } = getActiveChildren(services.streamId);
-      return formatPostCompactionContext(
-        subagents,
-        processes,
-        services.workspace.workPlan.toSnapshot(),
-      );
-    },
+    getPostCompactionContext: defaultPostCompactionContext,
     getDebugSaveOptions: (shared, services) => ({
-      context: {
-        modelName: services.config.model,
-        isRemote: isRemoteAgent(services.config.agent),
-      },
+      context: defaultDebugMeta(services),
       fileOptions: {
         continuationCount: services.round.continuationCount,
         baseName: 'response',

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -281,7 +281,7 @@ class ResponseProcessNode<C> extends BaseNode<
       const normalizedUsage = logAndNormalizeUsage(
         responseUsage,
         prepRes.responseTimeMs ?? 0,
-        { modelHandler, logger },
+        this.services,
       );
 
       const repetitionResult = checkForMassiveRepetition(

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -3,13 +3,15 @@ import stableStringify from 'fast-json-stable-stringify';
 import { z } from 'zod';
 
 // Local imports - core flow primitives
-import { isRemoteAgent } from '@agent/index';
 import { BaseNode, BatchNode, Flow, Node } from '@agent/node';
 import { recordCycleMetrics } from '@agent/core/AgentState';
 import {
   BaseCycleFieldsSchema,
-  resetCycleState,
+  defaultDebugMeta,
+  defaultPostCompactionContext,
   getDebugContext,
+  logAndNormalizeUsage,
+  resetCycleState,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
@@ -33,7 +35,6 @@ import type {
   WorkPlanState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ToolResult } from '@agent/core/ToolTypes';
-import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
@@ -44,7 +45,6 @@ import {
   formatZodIssuesForDiagnostics,
   type ValidationErrorDiagnostics,
 } from '@tools/result';
-import { formatPostCompactionContext } from '@tools/subagentResults';
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
@@ -270,14 +270,10 @@ class ToolUsePrepNode<C> extends BaseNode<
     ]);
     shared.cycleResponseTimeMs = 0;
 
-    const { config } = this.services;
     await maybeSaveDebugObject({
       object: shared.messages,
       objectType: 'messages',
-      context: getDebugContext(this.services, {
-        modelName: config.model,
-        isRemote: isRemoteAgent(config.agent),
-      }),
+      context: getDebugContext(this.services, defaultDebugMeta(this.services)),
       fileOptions: {
         continuationCount: shared.cycleIndex,
         baseName: 'tooluse',
@@ -380,18 +376,11 @@ class ToolUseProcessNode<C> extends BaseNode<
       }
     }
 
-    let normalizedUsage: NormalizedUsage | undefined;
-    if (usage) {
-      normalizedUsage = services.modelHandler.normalizeUsage(
-        usage,
-        prepRes.responseTimeMs ?? 0,
-      );
-      const { inputTokens } = normalizedUsage;
-      const contextWindow = services.modelHandler.getEffectiveContextWindow();
-      if (inputTokens > 0 && contextWindow > 0) {
-        services.logger.logContextState(inputTokens, contextWindow);
-      }
-    }
+    const normalizedUsage = logAndNormalizeUsage(
+      usage,
+      prepRes.responseTimeMs ?? 0,
+      services,
+    );
 
     const endTurn =
       services.modelHandler.isEndTurnStop(stopReason) || !toolCalls?.length;
@@ -891,19 +880,9 @@ export function createToolUseCycleFlow<C>(): Flow<
     storeResponse: (shared, response) => {
       shared.response = response;
     },
-    getPostCompactionContext: (services) => {
-      const { subagents, processes } = getActiveChildren(services.streamId);
-      return formatPostCompactionContext(
-        subagents,
-        processes,
-        services.workspace.workPlan.toSnapshot(),
-      );
-    },
+    getPostCompactionContext: defaultPostCompactionContext,
     getDebugSaveOptions: (shared, services) => ({
-      context: {
-        modelName: services.config.model,
-        isRemote: isRemoteAgent(services.config.agent),
-      },
+      context: defaultDebugMeta(services),
       fileOptions: {
         continuationCount: shared.cycleIndex,
         baseName: 'tooluse_response',

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -7,11 +7,10 @@ import { BaseNode, BatchNode, Flow, Node } from '@agent/node';
 import { recordCycleMetrics } from '@agent/core/AgentState';
 import {
   BaseCycleFieldsSchema,
-  defaultDebugMeta,
   defaultPostCompactionContext,
-  getDebugContext,
-  logAndNormalizeUsage,
+  extractModelResponse,
   resetCycleState,
+  saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
@@ -20,9 +19,6 @@ import {
   NormalizedUsageSchema,
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
-
-// Local imports - utilities
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 
 // Internal imports - use core ToolTypes as single source of truth
 import {
@@ -270,14 +266,9 @@ class ToolUsePrepNode<C> extends BaseNode<
     ]);
     shared.cycleResponseTimeMs = 0;
 
-    await maybeSaveDebugObject({
-      object: shared.messages,
-      objectType: 'messages',
-      context: getDebugContext(this.services, defaultDebugMeta(this.services)),
-      fileOptions: {
-        continuationCount: shared.cycleIndex,
-        baseName: 'tooluse',
-      },
+    await saveCycleDebug(shared.messages, 'messages', this.services, {
+      continuationCount: shared.cycleIndex,
+      baseName: 'tooluse',
     });
 
     return FlowTransition.DEFAULT;
@@ -327,13 +318,15 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     const services = this.services;
-    const { workspace } = services;
 
-    const thinking = services.modelHandler.processThinkingBlock(
-      prepRes.response,
-      workspace,
-    );
-    const useStreaming = services.modelHandler.getStreamingConfig();
+    const { text, stopReason, thinking, useStreaming, normalizedUsage } =
+      extractModelResponse(
+        prepRes.response,
+        prepRes.responseTimeMs,
+        '',
+        services,
+      );
+
     if (thinking && !useStreaming) {
       const formatted = await formatContent(thinking);
       if (isNonEmptyString(formatted)) {
@@ -344,11 +337,6 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     const toolCalls = services.modelHandler.extractToolUse(prepRes.response);
-    const { text, usage, stopReason } = services.modelHandler.extractResponse(
-      prepRes.response,
-      '',
-    );
-
     const serverToolData = services.modelHandler.extractServerToolData(
       prepRes.response,
     );
@@ -375,12 +363,6 @@ class ToolUseProcessNode<C> extends BaseNode<
         });
       }
     }
-
-    const normalizedUsage = logAndNormalizeUsage(
-      usage,
-      prepRes.responseTimeMs ?? 0,
-      services,
-    );
 
     const endTurn =
       services.modelHandler.isEndTurnStop(stopReason) || !toolCalls?.length;
@@ -881,12 +863,9 @@ export function createToolUseCycleFlow<C>(): Flow<
       shared.response = response;
     },
     getPostCompactionContext: defaultPostCompactionContext,
-    getDebugSaveOptions: (shared, services) => ({
-      context: defaultDebugMeta(services),
-      fileOptions: {
-        continuationCount: shared.cycleIndex,
-        baseName: 'tooluse_response',
-      },
+    getDebugFileOptions: (shared) => ({
+      continuationCount: shared.cycleIndex,
+      baseName: 'tooluse_response',
     }),
   });
   const processNode = new ToolUseProcessNode<C>();


### PR DESCRIPTION
Refactor cycle-flow plumbing so response and tool-use flows share the same helpers for post-compaction context, debug object saving, and model-response extraction.

The shared response extractor preserves the old behavior of both callers: response cycles still normalize null provider usage into a zero usage snapshot, while tool-use cycles still skip missing usage. Debug context construction is now private to the shared debug-save helper.

Validation performed after rebasing onto current `main`:
- `tsc --noEmit`
- `tsc --noEmit -p tsconfig.test-kernel.json`
- `tsc --noEmit` in `packages/extension`
- `tsc --noEmit -p tsconfig.json` in `packages/cli`

`npm run typecheck` was also attempted, but pnpm stopped at its non-TTY module-purge guard in the symlinked worktree before running the package-filter scripts. The equivalent typecheck commands above completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk refactor in core cycle-flow plumbing that changes how response/tool-use flows extract usage and save debug artifacts; regressions could affect metrics, logging, or continuation behavior if helper semantics diverge.
> 
> **Overview**
> **Cycle flows now share common helpers** for post-compaction context, debug object saving, and model response extraction.
> 
> `CommonCycleTypes` adds `saveCycleDebug`, `defaultPostCompactionContext`, and `extractModelResponse` (with an option to normalize null usage) and makes debug-context construction internal. `ModelInvocationNode`, `ResponseCycleFlow`, and `ToolUseCycleFlow` are updated to use these helpers, including renaming `getDebugSaveOptions` → `getDebugFileOptions` and shifting response-cycle `normalizedUsage` to be optional to match the extracted helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f60ed8fc23f46ded214463d14c9510f3e4d383e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->