### PR TITLE
cli: add -V alias for version and drop deprecated chat flags

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -855,9 +855,7 @@ export async function runCli(
   }
   if (
     rawArgs.length === 1 &&
-    (rawArgs[0] === '--version' ||
-      rawArgs[0] === '-v' ||
-      rawArgs[0] === '-V')
+    (rawArgs[0] === '--version' || rawArgs[0] === '-v' || rawArgs[0] === '-V')
   ) {
     writeTextStdout(await readCliVersion());
     return { exitCode: CliExitCode.Success };

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -642,31 +642,9 @@ const chatCommand = defineCommand({
     ...GLOBAL_ARGS,
     agent: { type: 'string', description: 'Tool-use agent for the session' },
     model: { type: 'string', alias: 'm', description: 'Model for the session' },
-    'tool-display': {
-      type: 'enum',
-      options: ['grouped', 'minimal', 'hidden'],
-      description: 'Deprecated: accepted for compatibility and ignored',
-    },
-    tui: {
-      type: 'boolean',
-      description: 'Deprecated: chat always uses the Ink TUI',
-    },
-    'legacy-renderer': {
-      type: 'boolean',
-      description: 'Deprecated: the legacy renderer was retired',
-    },
   },
   async run(ctx) {
     const context = await contextFromArgs(ctx.args);
-    if (
-      ctx.args.tui !== undefined ||
-      ctx.args['legacy-renderer'] !== undefined ||
-      ctx.args['tool-display'] !== undefined
-    ) {
-      writeTextStderr(
-        'texra chat: --tui/--no-tui, --legacy-renderer, and --tool-display are deprecated and ignored; chat now always uses the Ink TUI.',
-      );
-    }
     const { runChat } = await import('../chat/tui/runChatTui');
     const result = await runChat(context, {
       agentOverride: optString(ctx.args.agent),
@@ -877,7 +855,9 @@ export async function runCli(
   }
   if (
     rawArgs.length === 1 &&
-    (rawArgs[0] === '--version' || rawArgs[0] === '-v')
+    (rawArgs[0] === '--version' ||
+      rawArgs[0] === '-v' ||
+      rawArgs[0] === '-V')
   ) {
     writeTextStdout(await readCliVersion());
     return { exitCode: CliExitCode.Success };


### PR DESCRIPTION
Tighten the CLI argument surface.

This PR adds `-V` as an alias for `texra --version` and `texra -v`, matching common command-line convention. It also removes the deprecated `texra chat` flags that were already ignored by the current Ink TUI path: `--tui`, `--no-tui`, `--legacy-renderer`, and `--tool-display`.

Validation performed after rebasing onto current `main`:
- `tsc --noEmit -p packages/cli/tsconfig.json`
- `node packages/cli/scripts/check-host-imports.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI argument parsing/usage by adding a `-V` alias for version output and deleting already-ignored `chat` flags, with no changes to core runtime/auth/data logic.
> 
> **Overview**
> **Tightens the CLI argument surface.** `texra -V` is now accepted as an alias for `--version`/`-v` when invoked as the sole argument.
> 
> The `texra chat` command no longer advertises or checks deprecated flags (`--tui/--no-tui`, `--legacy-renderer`, `--tool-display`), removing the compatibility warning path since chat always uses the Ink TUI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a84aaae6de37fdb5f66837bff4da29eb3108acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->