### PR TITLE
fix(cli): show run progress in text mode

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -53,6 +53,7 @@ import {
   writeTextStderr,
   writeTextStdout,
 } from '../runtime/logSinks';
+import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after
@@ -72,7 +73,7 @@ function optString(value: unknown): string | undefined {
 }
 
 /**
- * Single source of truth for the four global flags accepted by every TeXRA
+ * Single source of truth for the global flags accepted by every TeXRA
  * subcommand. `as const` + spread would lose literal-type narrowing (citty's
  * `ArgsDef` rejects `readonly string[]`), so each enum's `options` is
  * explicitly typed as a mutable literal tuple — assignable to `string[]` and
@@ -81,6 +82,7 @@ function optString(value: unknown): string | undefined {
  */
 const GLOBAL_ARGS: {
   print: { type: 'boolean'; alias: 'p' };
+  quiet: { type: 'boolean'; alias: 'q' };
   cwd: { type: 'string' };
   'output-format': {
     type: 'enum';
@@ -94,6 +96,7 @@ const GLOBAL_ARGS: {
   };
 } = {
   print: { type: 'boolean', alias: 'p' },
+  quiet: { type: 'boolean', alias: 'q' },
   cwd: { type: 'string' },
   'output-format': {
     type: 'enum',
@@ -561,10 +564,12 @@ async function runWorkflowAgent(
   init: WorkflowRunInit,
 ): Promise<number> {
   const model = init.model?.trim() || DEFAULT_AGENT_MODEL;
+  const renderRunProgress = shouldRenderRunProgress(context);
   const runContext: CliContext = {
     ...context,
     helperModel: model,
     quietLogs: true,
+    renderRunProgress,
   };
   await initCliPlatform(runContext);
   installCliApprovalHandlers(runContext);

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -25,6 +25,8 @@ export interface CliContext {
   readonly approvalPolicy: CliApprovalPolicy;
   readonly helperModel?: string;
   readonly quietLogs?: boolean;
+  readonly renderRunProgress?: boolean;
+  readonly stderrIsTty?: boolean;
   readonly colorEnabled: boolean;
   readonly version: string;
   readonly resourcesPath: string;
@@ -112,6 +114,7 @@ function resolveResourcesPath(): string {
 
 export interface CliGlobalArgs {
   readonly print?: boolean;
+  readonly quiet?: boolean;
   readonly cwd?: string;
   readonly outputFormat: CliOutputFormat;
   readonly approvalPolicy: CliApprovalPolicy;
@@ -144,6 +147,8 @@ export async function buildCliContext(
     mode: cliMode(init.globalArgs, ambient),
     outputFormat: init.globalArgs.outputFormat,
     approvalPolicy: init.globalArgs.approvalPolicy,
+    quietLogs: init.globalArgs.quiet === true,
+    stderrIsTty: ambient.stderrIsTty,
     colorEnabled: ambient.colorEnabled,
     version: await readCliVersion(),
     resourcesPath: resolveResourcesPath(),

--- a/packages/cli/src/runtime/globalArgs.ts
+++ b/packages/cli/src/runtime/globalArgs.ts
@@ -12,6 +12,7 @@ import type { CliGlobalArgs, CliOutputFormat } from './cliContext';
  */
 export interface ParsedGlobalArgs {
   readonly print?: boolean;
+  readonly quiet?: boolean;
   readonly cwd?: string;
   readonly 'output-format': CliOutputFormat;
   readonly 'approval-policy': CliApprovalPolicy;
@@ -20,6 +21,7 @@ export interface ParsedGlobalArgs {
 export function pickGlobalArgs(args: ParsedGlobalArgs): CliGlobalArgs {
   return {
     print: args.print === true,
+    quiet: args.quiet === true,
     cwd: isNonEmptyString(args.cwd) ? args.cwd.trim() : undefined,
     outputFormat: args['output-format'],
     approvalPolicy: args['approval-policy'],

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -1,0 +1,208 @@
+import path from 'node:path';
+
+// Local imports - progress events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+// Local imports - CLI runtime
+import { writeRawStderr } from './logSinks';
+import type { CliContext } from './cliContext';
+
+type ProgressEvent = keyof ProgressEventPayloads;
+
+interface RenderState {
+  round?: number;
+  toolCallCount?: number;
+  agent?: string;
+  inputFile?: string;
+  phase?: string;
+  activeWork?: string;
+}
+
+export interface RunProgressRenderer {
+  handle(event: ProgressEvent, payload: unknown): boolean;
+  clear(): void;
+  preserve(): void;
+}
+
+export interface RunProgressRendererInit {
+  readonly colorEnabled: boolean;
+  readonly write?: (text: string) => void;
+  readonly nowMs?: () => number;
+  readonly minIntervalMs?: number;
+}
+
+export function shouldRenderRunProgress(
+  context: Pick<
+    CliContext,
+    'mode' | 'outputFormat' | 'quietLogs' | 'stderrIsTty'
+  >,
+): boolean {
+  return (
+    context.quietLogs !== true &&
+    context.mode !== 'headless' &&
+    context.outputFormat === 'text' &&
+    context.stderrIsTty === true
+  );
+}
+
+export function createRunProgressRenderer(
+  context: CliContext,
+  init: RunProgressRendererInit = { colorEnabled: context.colorEnabled },
+): RunProgressRenderer | undefined {
+  if (context.renderRunProgress !== true) return undefined;
+  return new DefaultRunProgressRenderer(init);
+}
+
+class DefaultRunProgressRenderer implements RunProgressRenderer {
+  private readonly state: RenderState = {};
+  private readonly startedAt: number;
+  private readonly write: (text: string) => void;
+  private readonly nowMs: () => number;
+  private readonly minIntervalMs: number;
+  private readonly ansi: boolean;
+  private lastRenderAt = 0;
+  private lastLine = '';
+  private liveLine = false;
+
+  constructor(init: RunProgressRendererInit) {
+    this.write = init.write ?? writeRawStderr;
+    this.nowMs = init.nowMs ?? Date.now;
+    this.minIntervalMs = init.minIntervalMs ?? 100;
+    this.ansi = init.colorEnabled;
+    this.startedAt = this.nowMs();
+  }
+
+  handle(event: ProgressEvent, payload: unknown): boolean {
+    switch (event) {
+      case 'setTaskState':
+        this.applyTaskState(payload as ProgressEventPayloads['setTaskState']);
+        this.render(true);
+        return true;
+      case 'updateConversationProgress':
+        this.applyConversationProgress(
+          payload as ProgressEventPayloads['updateConversationProgress'],
+        );
+        this.render();
+        return true;
+      case 'updateActiveProcesses':
+        this.applyActiveProcesses(
+          payload as ProgressEventPayloads['updateActiveProcesses'],
+        );
+        this.render(true);
+        return true;
+      case 'updateActiveSubagents':
+        this.applyActiveSubagents(
+          payload as ProgressEventPayloads['updateActiveSubagents'],
+        );
+        this.render(true);
+        return true;
+      case 'updateStreamStatus':
+        this.state.phase = String(
+          (payload as ProgressEventPayloads['updateStreamStatus']).status,
+        );
+        this.render(true);
+        return true;
+      case 'updateStreamDescription':
+        this.state.phase = (
+          payload as ProgressEventPayloads['updateStreamDescription']
+        ).description;
+        this.render(true);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  clear(): void {
+    if (this.ansi && this.liveLine) {
+      this.write('\r\x1b[2K');
+      this.liveLine = false;
+    }
+  }
+
+  preserve(): void {
+    if (this.ansi && this.liveLine) {
+      this.write('\n');
+      this.liveLine = false;
+    }
+  }
+
+  private applyTaskState(payload: ProgressEventPayloads['setTaskState']): void {
+    const config = payload.taskState.agentConfig;
+    this.state.agent = config.agent;
+    this.state.inputFile = safeBasename(config.inputFiles.at(0));
+    this.state.phase ??= 'running';
+  }
+
+  private applyConversationProgress(
+    payload: ProgressEventPayloads['updateConversationProgress'],
+  ): void {
+    this.state.round = payload.progress.conversationTurns || undefined;
+    this.state.toolCallCount = payload.progress.toolCallCount || undefined;
+    this.state.phase ??= 'running';
+  }
+
+  private applyActiveProcesses(
+    payload: ProgressEventPayloads['updateActiveProcesses'],
+  ): void {
+    const activeProcess = payload.processes[0];
+    this.state.activeWork = activeProcess
+      ? `tool: ${activeProcess.toolName ?? activeProcess.agentName}`
+      : undefined;
+  }
+
+  private applyActiveSubagents(
+    payload: ProgressEventPayloads['updateActiveSubagents'],
+  ): void {
+    const child = payload.children[0];
+    this.state.activeWork = child ? `subagent: ${child.agentName}` : undefined;
+  }
+
+  private render(force = false): void {
+    const now = this.nowMs();
+    if (!force && now - this.lastRenderAt < this.minIntervalMs) return;
+
+    const line = this.formatLine(now);
+    if (!line || line === this.lastLine) return;
+
+    if (this.ansi) {
+      this.write(`\r\x1b[2K${line}`);
+      this.liveLine = true;
+    } else {
+      this.write(`${line}\n`);
+    }
+    this.lastLine = line;
+    this.lastRenderAt = now;
+  }
+
+  private formatLine(now: number): string {
+    const parts: string[] = [];
+    if (this.state.round != null) parts.push(`[r${this.state.round}]`);
+
+    const subject = [this.state.agent, this.state.inputFile]
+      .filter(Boolean)
+      .join(' ');
+    const phase = this.state.phase;
+    parts.push(subject || phase || 'running');
+    if (subject && phase && phase !== 'running') parts.push(phase);
+
+    if (this.state.activeWork) parts.push(this.state.activeWork);
+    if (this.state.toolCallCount != null && !this.state.activeWork) {
+      parts.push(`tools: ${this.state.toolCallCount}`);
+    }
+    parts.push(formatElapsed(now - this.startedAt));
+    return parts.join(' · ');
+  }
+}
+
+function safeBasename(file: string | undefined): string | undefined {
+  return file ? path.basename(file) : undefined;
+}
+
+function formatElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) return `${remainingSeconds}s`;
+  return `${minutes}m ${remainingSeconds.toString().padStart(2, '0')}s`;
+}

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -14,6 +14,7 @@ import {
   StderrTextSink,
   writeNdjsonStdout,
 } from './logSinks';
+import { createRunProgressRenderer } from './runProgressRenderer';
 import type { CliContext } from './cliContext';
 
 export type CliRuntimeHost = AgentRuntimeHost & {
@@ -23,6 +24,7 @@ export type CliRuntimeHost = AgentRuntimeHost & {
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   let sink: LogSink | undefined;
   let logger: Logger | undefined;
+  const runProgress = createRunProgressRenderer(context);
   function ensureLogger(): Logger {
     if (logger) return logger;
     sink =
@@ -48,11 +50,14 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       }
 
       if (event === 'requestShowError') {
+        runProgress?.preserve();
         ensureLogger().error(
           (payload as ProgressEventPayloads['requestShowError']).message,
         );
         return;
       }
+
+      if (runProgress?.handle(event, payload)) return;
 
       if (context.quietLogs) return;
 
@@ -67,6 +72,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       ensureLogger().debug(`Progress event: ${String(event)}`);
     },
     async close() {
+      runProgress?.clear();
       await sink?.flush?.();
       await sink?.close?.();
     },

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+import { pickGlobalArgs } from '../../../packages/cli/src/runtime/globalArgs';
+import {
+  createRunProgressRenderer,
+  shouldRenderRunProgress,
+} from '../../../packages/cli/src/runtime/runProgressRenderer';
+import { createCliRuntimeHost } from '../../../packages/cli/src/runtime/runtimeHost';
+import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+
+function context(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/project',
+    mode: 'interactive',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    quietLogs: false,
+    renderRunProgress: true,
+    stderrIsTty: true,
+    colorEnabled: true,
+    version: '0.0.0',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+function workflowTaskState() {
+  return {
+    streamId: 'stream-1',
+    taskState: {
+      agentConfig: {
+        agent: 'polish',
+        agentCategory: AgentCategory.Workflow,
+        model: 'deepseekT',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        mediaFiles: [],
+        outputFiles: [],
+        editedFile: null,
+        editedFiles: [],
+        toolConfig: {
+          autoExtractFigure: false,
+          autoExtractTikzFigure: false,
+          attachTeXCount: false,
+          attachDiagnostics: false,
+          autoCompileInputPdf: false,
+        },
+        memories: [],
+        instruction: '',
+        workingDirectory: '/tmp/project',
+      },
+      activeFiles: {
+        input: true,
+        output: false,
+        media: false,
+        context: false,
+      },
+    },
+  };
+}
+
+describe('CLI run progress renderer', () => {
+  it('renders a single ANSI status line and clears it on close', () => {
+    let now = 0;
+    let output = '';
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => now,
+    });
+
+    expect(renderer).toBeDefined();
+    renderer?.handle('setTaskState', workflowTaskState());
+    expect(output).toBe('\r\x1b[2Kpolish paper.tex · 0s');
+
+    now = 1200;
+    renderer?.handle('updateConversationProgress', {
+      streamId: 'stream-1',
+      progress: { conversationTurns: 2, toolCallCount: 0 },
+    });
+    expect(output).toContain('\r\x1b[2K[r2] · polish paper.tex · 1s');
+
+    renderer?.clear();
+    expect(output.endsWith('\r\x1b[2K')).toBe(true);
+  });
+
+  it('prints phase changes on separate lines when ANSI is disabled', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle('setTaskState', workflowTaskState());
+    renderer?.handle('updateStreamDescription', {
+      streamId: 'stream-1',
+      description: 'drafting',
+    });
+    renderer?.handle('updateActiveProcesses', {
+      parentStreamId: 'stream-1',
+      processes: [
+        {
+          executionId: 'process-1',
+          agentName: 'bash',
+          toolName: 'Bash',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(output).toBe(
+      'polish paper.tex · 0s\n' +
+        'polish paper.tex · drafting · 0s\n' +
+        'polish paper.tex · drafting · tool: Bash · 0s\n',
+    );
+  });
+
+  it('uses a separate render flag from platform log suppression', () => {
+    expect(
+      createRunProgressRenderer(
+        context({ quietLogs: true, renderRunProgress: true }),
+      ),
+    ).toBeDefined();
+    expect(
+      createRunProgressRenderer(context({ renderRunProgress: false })),
+    ).toBe(undefined);
+  });
+
+  it('derives the run progress flag from quiet, headless, structured, and non-TTY contexts', () => {
+    expect(shouldRenderRunProgress(context())).toBe(true);
+    expect(shouldRenderRunProgress(context({ quietLogs: true }))).toBe(false);
+    expect(shouldRenderRunProgress(context({ mode: 'headless' }))).toBe(false);
+    expect(shouldRenderRunProgress(context({ outputFormat: 'json' }))).toBe(
+      false,
+    );
+    expect(shouldRenderRunProgress(context({ outputFormat: 'ndjson' }))).toBe(
+      false,
+    );
+    expect(shouldRenderRunProgress(context({ stderrIsTty: false }))).toBe(
+      false,
+    );
+  });
+
+  it('routes progress events even when ordinary CLI logs are quiet', async () => {
+    let output = '';
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((
+      chunk: string | Uint8Array,
+      ...args: unknown[]
+    ) => {
+      output += String(chunk);
+      const callback = args.find(
+        (arg): arg is (error?: Error | null) => void =>
+          typeof arg === 'function',
+      );
+      callback?.();
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const host = createCliRuntimeHost(
+        context({ quietLogs: true, renderRunProgress: true }),
+      );
+      host.emit('setTaskState', workflowTaskState());
+      await host.close();
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(output).toContain('polish paper.tex · 0s');
+  });
+
+  it('maps the global quiet flag into CLI context args', () => {
+    expect(
+      pickGlobalArgs({
+        quiet: true,
+        'output-format': 'text',
+        'approval-policy': 'never',
+      }).quiet,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #4187.

## Summary
- add a terminal progress renderer for `texra run` text output
- show round, subject, active tool/subagent work, and elapsed time on one live stderr line
- add `--quiet`/`-q` and suppress progress for headless, structured, and non-TTY output

## Validation
- `./node_modules/.bin/eslint packages/cli/src/runtime/runProgressRenderer.ts packages/cli/src/runtime/runtimeHost.ts packages/cli/src/commands/root.ts packages/cli/src/runtime/cliContext.ts packages/cli/src/runtime/globalArgs.ts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `./node_modules/.bin/vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- `CI=1 npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI runtime output behavior by adding a live progress renderer on stderr and a new global `--quiet/-q` flag; risk is mainly around unexpected output interactions in different terminal/format/CI contexts.
> 
> **Overview**
> Adds a terminal **run progress renderer** for `texra run` in `text` output, showing a single live status line on stderr (round/phase, active tool or subagent, elapsed time) and clearing/preserving it around errors and shutdown.
> 
> Introduces a new global `--quiet`/`-q` flag, threads `quiet`/`stderrIsTty`/`renderRunProgress` through `CliContext`, and gates progress rendering off in headless mode, non-TTY stderr, or structured (`json`/`ndjson`) output. Includes new Vitest coverage for rendering behavior and event routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf54633748098a456dc216dba55d55e1da6b7b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->