### PR TITLE
[codex] validate chat export tool calls in batches

### DIFF
--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -519,7 +519,9 @@ function getAssistantToolCalls(
 
   // Prefer SDK-native validation for the full tool-call array.
   try {
-    const candidate = [...message.tool_calls] as ChatCompletionMessageToolCall[];
+    const candidate = [
+      ...message.tool_calls,
+    ] as ChatCompletionMessageToolCall[];
     assertToolCallsAreChatCompletionFunctionToolCalls(candidate);
     return candidate;
   } catch {

--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -517,11 +517,13 @@ function getAssistantToolCalls(
     return [];
   }
 
+  // Prefer SDK-native validation for the full tool-call array.
   try {
-    const candidate = message.tool_calls as ChatCompletionMessageToolCall[];
+    const candidate = [...message.tool_calls] as ChatCompletionMessageToolCall[];
     assertToolCallsAreChatCompletionFunctionToolCalls(candidate);
     return candidate;
   } catch {
+    // Fallback to per-call validation so malformed entries do not drop valid calls.
     const functionToolCalls: ChatCompletionMessageFunctionToolCall[] = [];
     for (const toolCall of message.tool_calls) {
       const candidate: ChatCompletionMessageToolCall[] = [toolCall];


### PR DESCRIPTION
## Summary

Use SDK-native validation on the full assistant tool-call array in chat export formatting, then fall back to per-call validation only when the batch contains malformed or non-function entries.

## Why

The formatter already preserves valid function calls when individual entries are malformed. Trying the full-array SDK assertion first keeps the normal path closer to the OpenAI SDK's intended helper surface while preserving the existing tolerant fallback behavior.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; existing unrelated warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to chat export formatting that only adjusts tool-call validation flow and retains the prior per-entry tolerant behavior.
> 
> **Overview**
> **Chat export tool-call parsing now validates `tool_calls` in one SDK assertion first.** If the batch validation fails (due to malformed or non-function entries), it falls back to validating each tool call individually so valid function calls are still exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555187a0c8d2e0cff329b0a6edac66fa515214b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->