### PR TITLE
[codex] guard desktop release publishing token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
 
   publish-desktop-release-artifacts:
     name: publish desktop release artifacts
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.DESKTOP_RELEASES_TOKEN != ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:


### PR DESCRIPTION
## Summary

Require `DESKTOP_RELEASES_TOKEN` to be present before running the `publish-desktop-release-artifacts` job on pushes to `main`.

## Why

The desktop release publishing job is only useful when the publishing token is configured. Guarding on the secret avoids running that publishing path in environments where the token is absent.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small GitHub Actions condition change that only affects whether the release-publishing job runs, not build/test behavior.
> 
> **Overview**
> **CI now skips desktop release publishing when the token is missing.** The `publish-desktop-release-artifacts` job is additionally gated on `secrets.DESKTOP_RELEASES_TOKEN != ''`, so pushes to `main` won’t attempt to publish desktop release artifacts unless the publishing token is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2310602fc49350b08b6de1cfbf0dcad9ab8fe412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->