### PR TITLE
Bundle README in VSIX and polish settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ a web-based launch page.
   be resumed via **Resume Tool-Use Agent**, and **Pack Output into History
   Folder** archives a finished run's outputs into the workspace's `History/`
   directory.
+- **Odyssey mode (experimental)** – let a tool-use agent run a long task to
+  completion on its own. A configurable budget auto-pauses the run for your
+  approval before going further, and a dedicated panel shows progress so
+  you can step in at any time. Off by default; enable it under
+  Settings → Experimental.
 - **Model flexibility with guardrails** – mix and match per agent: OpenAI
   (incl. GPT-5.5 and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google
   Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen (DashScope),

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -1,5 +1,5 @@
-// `/agent` form. It lists the visible tool-use agents and, before the first
-// message, can choose the root agent for the chat.
+// `/agent` form. It lists visible tool-use agents and workflows. Before the
+// first message, tool-use agents can be chosen as the root chat agent.
 
 import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
@@ -16,6 +16,11 @@ export interface AgentListFormProps {
   readonly selectable?: boolean;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
+}
+
+interface AgentGroups {
+  readonly toolUse: readonly AgentOptionData[];
+  readonly workflow: readonly AgentOptionData[];
 }
 
 interface AgentFrameProps {
@@ -57,7 +62,10 @@ function agentDescription(agent: AgentOptionData): string {
 }
 
 export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
-  const [agents, setAgents] = useState<readonly AgentOptionData[]>([]);
+  const [agents, setAgents] = useState<AgentGroups>({
+    toolUse: [],
+    workflow: [],
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>(undefined);
 
@@ -72,7 +80,10 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     void computeAgentOptionsData()
       .then((options) => {
         if (cancelled) return;
-        setAgents(options.toolUse);
+        setAgents({
+          toolUse: options.toolUse,
+          workflow: options.workflow,
+        });
         setLoading(false);
       })
       .catch((err: unknown) => {
@@ -102,9 +113,13 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   }
 
   const selectable = props.selectable === true;
-  const items = agents.map((agent) => ({
+  const items = agents.toolUse.map((agent) => ({
     value: agent.label,
     label: agent.label,
+    description: agentDescription(agent),
+  }));
+  const workflowRows = agents.workflow.map((agent) => ({
+    name: agent.label,
     description: agentDescription(agent),
   }));
 
@@ -120,10 +135,11 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       </Text>
       <Text dimColor>
         {selectable
-          ? 'Choose the root agent for the first message.'
-          : 'Available agents. Start a new chat with texra --agent=<name> to choose the root agent.'}
+          ? 'Choose the root tool-use agent for the first message.'
+          : 'Available agents. Start a new chat with texra --agent=<name> to choose the root tool-use agent.'}
       </Text>
       <Box marginTop={1} flexDirection="column">
+        <Text bold>Tool-use agents</Text>
         <Select
           items={items}
           activeValue={props.currentAgent}
@@ -137,6 +153,21 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           onCancel={props.onClose}
         />
       </Box>
+      {workflowRows.length > 0 ? (
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Workflows</Text>
+          {workflowRows.map((workflow) => (
+            <Text key={workflow.name}>
+              {'  '}
+              {workflow.name}
+              <Text dimColor>{` — ${workflow.description}`}</Text>
+            </Text>
+          ))}
+          <Text dimColor>
+            {'Run a workflow with texra run <name> --input=<file>.'}
+          </Text>
+        </Box>
+      ) : null}
       <Box marginTop={1}>
         {selectable ? (
           <KeyHints

--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -1,6 +1,8 @@
 import { Box, Text } from 'ink';
+import { useEffect, useState } from 'react';
 
 import { type CliApiMode } from '../../../runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '../../../runtime/apiStatus';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 
@@ -11,6 +13,24 @@ export interface ApiModeFormProps {
 }
 
 export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
+  const [statusLines, setStatusLines] = useState<readonly string[]>([
+    'loading API status...',
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadCliApiStatusLines()
+      .then((lines) => {
+        if (!cancelled) setStatusLines(lines);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) setStatusLines([String(error)]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <Box
       borderStyle="round"
@@ -24,6 +44,13 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
       <Text dimColor>
         Choose which credentials model calls should use. Press 1 for API keys.
       </Text>
+      <Box marginTop={1} flexDirection="column">
+        {statusLines.map((line) => (
+          <Text key={line} dimColor>
+            {line}
+          </Text>
+        ))}
+      </Box>
       <Box marginTop={1} flexDirection="column">
         <Select
           items={[

--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -45,8 +45,8 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
         Choose which credentials model calls should use. Press 1 for API keys.
       </Text>
       <Box marginTop={1} flexDirection="column">
-        {statusLines.map((line) => (
-          <Text key={line} dimColor>
+        {statusLines.map((line, index) => (
+          <Text key={`${index}:${line}`} dimColor>
             {line}
           </Text>
         ))}

--- a/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
+++ b/packages/cli/src/chat/tui/panes/HeaderBanner.tsx
@@ -36,7 +36,7 @@ export interface HeaderBannerInfo {
 export function renderHeaderBanner(info: HeaderBannerInfo): string {
   const lines = [
     `${pc.bold(pc.cyan('TeXRA'))} ${pc.dim(`v${info.version}`)}`,
-    `${pc.cyan(info.agent || 'chat')} ${pc.dim('·')} ${info.model || '—'}`,
+    `agent: ${pc.cyan(info.agent || 'chat')} ${pc.dim('·')} model: ${info.model || '—'}`,
     pc.dim(shortenCwd(info.cwd)),
   ];
   return `\n${lines.join('\n')}\n\n`;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -31,12 +31,12 @@ import {
   setCliApiMode,
   type CliApiMode,
 } from '../../runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '../../runtime/apiStatus';
 import { resolveChatDefaults } from '../../runtime/chatDefaults';
 import { CliExitCode } from '../../runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '../../runtime/initPlatform';
 import { createCliRuntimeHost } from '../../runtime/runtimeHost';
 import { writeTextStderr } from '../../runtime/logSinks';
-import { getCliAuthProfile } from '../../runtime/supabaseAuth';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
@@ -193,11 +193,9 @@ async function applyCliApiModeSelection(
   const normalized = mode.trim().toLowerCase();
 
   if (!normalized || normalized === 'status') {
+    const lines = await loadCliApiStatusLines();
     appendLocalAssistantTranscript(
-      [
-        `api: ${formatCliApiMode(getCliApiMode())}`,
-        'Usage: /api personal | /api included',
-      ].join('\n'),
+      [...lines, 'Usage: /api personal | /api included'].join('\n'),
     );
     return;
   }
@@ -247,15 +245,7 @@ function openCliApiModeForm(
 }
 
 async function showCliAuthStatus(): Promise<void> {
-  const profile = await getCliAuthProfile();
-  const lines = [
-    `api: ${formatCliApiMode(getCliApiMode())}`,
-    profile.authenticated
-      ? `auth: signed in${profile.accountLabel ? ` as ${profile.accountLabel}` : ''}`
-      : 'auth: signed out',
-  ];
-  if (profile.tier) lines.push(`tier: ${profile.tier}`);
-  appendLocalAssistantTranscript(lines.join('\n'));
+  appendLocalAssistantTranscript((await loadCliApiStatusLines()).join('\n'));
 }
 
 function formatApprovalPolicy(policy: CliApprovalPolicy): string {

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,0 +1,38 @@
+import { toErrorMessage } from '@common/errors/errorMessage';
+
+import { formatCliApiMode, getCliApiMode } from './apiAccessMode';
+import { fetchRelayUsageSummary, type RelayUsageSummary } from './relayUsage';
+import { getCliAuthProfile } from './supabaseAuth';
+
+function formatUsd(value: number): string {
+  return value.toFixed(2);
+}
+
+export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
+  return `relay usage: $${formatUsd(summary.costUsd)} / $${formatUsd(summary.limitUsd)} (${summary.usagePercent.toFixed(1)}%), $${formatUsd(summary.remainingUsd)} remaining`;
+}
+
+export async function loadCliApiStatusLines(): Promise<string[]> {
+  const [mode, profile] = [getCliApiMode(), await getCliAuthProfile()];
+  const lines = [
+    `api: ${formatCliApiMode(mode)}`,
+    profile.authenticated
+      ? `auth: signed in${profile.accountLabel ? ` as ${profile.accountLabel}` : ''}`
+      : 'auth: signed out',
+  ];
+
+  if (profile.tier) lines.push(`tier: ${profile.tier}`);
+  if (!profile.authenticated || !profile.tier) return lines;
+
+  try {
+    lines.push(
+      formatRelayUsageStatus(
+        await fetchRelayUsageSummary({ tier: profile.tier }),
+      ),
+    );
+  } catch (error: unknown) {
+    lines.push(`relay usage: unavailable (${toErrorMessage(error)})`);
+  }
+
+  return lines;
+}

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -13,7 +13,8 @@ export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
 }
 
 export async function loadCliApiStatusLines(): Promise<string[]> {
-  const [mode, profile] = [getCliApiMode(), await getCliAuthProfile()];
+  const mode = getCliApiMode();
+  const profile = await getCliAuthProfile();
   const lines = [
     `api: ${formatCliApiMode(mode)}`,
     profile.authenticated

--- a/packages/extension/.gitignore
+++ b/packages/extension/.gitignore
@@ -1,0 +1,5 @@
+# Copied from the repo root by scripts/copy-extension-docs.mjs during
+# `pnpm run build:fast` so vsce includes them in the VSIX. The source of
+# truth lives at the repo root.
+README.md
+CHANGELOG.md

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1622,6 +1622,7 @@
     "vscode:prepublish": "[ \"$SKIP_VSCE_PREPUBLISH\" = \"1\" ] || corepack pnpm run package",
     "clean:dist": "node ../../scripts/clean-extension-dist.mjs",
     "clean:webview-dist": "node ../../scripts/clean-extension-dist.mjs --webviews-only",
+    "prepare:docs": "node ../../scripts/copy-extension-docs.mjs",
     "compile": "corepack pnpm run clean:dist && webpack",
     "watch": "webpack --watch",
     "package": "corepack pnpm run clean:dist && webpack --mode production --devtool hidden-source-map",
@@ -1641,7 +1642,7 @@
     "watch:fast": "concurrently \"corepack pnpm run esbuild:ext:watch\" \"corepack pnpm run vite:webviews:watch\"",
     "package:fast": "corepack pnpm run clean:dist && corepack pnpm run esbuild:ext:prod && corepack pnpm run vite:webviews",
     "package:safe": "corepack pnpm run typecheck && corepack pnpm run package:fast",
-    "build:fast": "corepack pnpm run package:fast && mkdir -p ../../releases && SKIP_VSCE_PREPUBLISH=1 vsce package --no-dependencies --out ../../releases/texra-$npm_package_version.vsix",
+    "build:fast": "corepack pnpm run package:fast && corepack pnpm run prepare:docs && mkdir -p ../../releases && SKIP_VSCE_PREPUBLISH=1 vsce package --no-dependencies --out ../../releases/texra-$npm_package_version.vsix",
     "build:safe": "corepack pnpm run typecheck && corepack pnpm run build:fast"
   }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1625,7 +1625,7 @@
     "prepare:docs": "node ../../scripts/copy-extension-docs.mjs",
     "compile": "corepack pnpm run clean:dist && webpack",
     "watch": "webpack --watch",
-    "package": "corepack pnpm run clean:dist && webpack --mode production --devtool hidden-source-map",
+    "package": "corepack pnpm run prepare:docs && corepack pnpm run clean:dist && webpack --mode production --devtool hidden-source-map",
     "compile-tests": "tsc -p tsconfig.json --outDir out",
     "watch-tests": "tsc -p tsconfig.json -w --outDir out",
     "lint": "eslint src",

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -252,10 +252,46 @@ export class HistoryItemElement extends LitElement {
       }
     }
 
+    // Title for the row — instruction text when present, otherwise the
+    // human description. Falls back to "(no instruction)" so we always have
+    // something prominent at the top, mirroring the memory row's storagePath.
+    const titleText = instructionText ?? descriptionText ?? '(no instruction)';
+
+    // Compact metadata strip — same · separated style the Memory row uses.
+    const metaParts: Array<string | TemplateResult> = [
+      timestamp,
+      html`<wa-tag
+        class="agent-category-badge"
+        variant=${categoryVariant}
+        size="small"
+      >
+        ${decorator.icon
+          ? html`<wa-icon library="texra" name=${decorator.icon}></wa-icon>`
+          : nothing}
+        ${decorator.label}
+      </wa-tag>`,
+      `Agent: ${config.agent ?? 'Unknown'}`,
+      `Model: ${config.model ?? 'Unknown'}`,
+    ];
+    if (config.agentCategory === AGENT_CATEGORY.WORKFLOW) {
+      if (config.inputFiles?.length) {
+        metaParts.push(`Inputs: ${config.inputFiles.join(', ')}`);
+      }
+      if (config.mediaFiles?.length) {
+        metaParts.push(`Media: ${config.mediaFiles.join(', ')}`);
+      }
+    }
+
     return html`
       <div class="list-item history-item">
         <div class="list-item-header">
-          <div class="text-secondary history-timestamp">${timestamp}</div>
+          <div class="history-title">
+            ${instructionText
+              ? html`<div class="markdown-content">
+                  ${unsafeHTML(this.renderMarkdown(titleText))}
+                </div>`
+              : html`<span>${titleText}</span>`}
+          </div>
           <div
             class="history-actions action-button-group"
             @click=${this.handleActionClick}
@@ -293,58 +329,10 @@ export class HistoryItemElement extends LitElement {
               : nothing}
           </div>
         </div>
-        ${descriptionText
-          ? html`<div class="history-description">${descriptionText}</div>`
-          : nothing}
-        <div class="history-details basic-details">
-          <span class="history-label">Category:</span>
-          <span class="history-value">
-            <wa-tag
-              class="agent-category-badge"
-              variant=${categoryVariant}
-              size="small"
-            >
-              ${decorator.icon
-                ? html`<wa-icon
-                    library="texra"
-                    name=${decorator.icon}
-                  ></wa-icon>`
-                : nothing}
-              ${decorator.label}
-            </wa-tag>
-          </span>
-          <span class="history-label">Agent:</span>
-          <span class="history-value">${config.agent ?? 'Unknown'}</span>
-          <span class="history-label">Model:</span>
-          <span class="history-value">${config.model ?? 'Unknown'}</span>
-          <span class="history-label">Instruction:</span>
-          <div class="history-value">
-            ${instructionText
-              ? html`<div class="markdown-content">
-                  ${unsafeHTML(this.renderMarkdown(instructionText))}
-                </div>`
-              : html`<em class="history-none">Not set</em>`}
-          </div>
-          ${config.agentCategory === AGENT_CATEGORY.WORKFLOW
-            ? html`
-                ${config.inputFiles?.length
-                  ? html`
-                      <span class="history-label">InputFiles:</span>
-                      <span class="history-value"
-                        >${config.inputFiles.join(', ')}</span
-                      >
-                    `
-                  : nothing}
-                ${config.mediaFiles?.length
-                  ? html`
-                      <span class="history-label">MediaFiles:</span>
-                      <span class="history-value"
-                        >${config.mediaFiles.join(', ')}</span
-                      >
-                    `
-                  : nothing}
-              `
-            : nothing}
+        <div class="text-secondary history-meta">
+          ${metaParts.map(
+            (part, i) => html`${i > 0 ? html` · ` : nothing}${part}`,
+          )}
         </div>
         ${extraDetails.length
           ? html`

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -255,6 +255,10 @@ export class HistoryItemElement extends LitElement {
     }
 
     const titleText = instructionText ?? descriptionText ?? '(no instruction)';
+    const summaryText =
+      instructionText && descriptionText && descriptionText !== instructionText
+        ? descriptionText
+        : null;
 
     const metaParts: Array<string | TemplateResult> = [
       timestamp,
@@ -327,6 +331,9 @@ export class HistoryItemElement extends LitElement {
               : nothing}
           </div>
         </div>
+        ${summaryText
+          ? html`<div class="history-description">${summaryText}</div>`
+          : nothing}
         <div class="text-secondary meta-strip">${renderDotMeta(metaParts)}</div>
         ${extraDetails.length
           ? html`

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -14,6 +14,7 @@ import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -34,6 +35,7 @@ export class HistoryItemElement extends LitElement {
     commonViewStyles,
     ...badgeStyles,
     historyStyles,
+    metaStripStyles,
     markdownStyles,
   ];
 
@@ -252,12 +254,8 @@ export class HistoryItemElement extends LitElement {
       }
     }
 
-    // Title for the row — instruction text when present, otherwise the
-    // human description. Falls back to "(no instruction)" so we always have
-    // something prominent at the top, mirroring the memory row's storagePath.
     const titleText = instructionText ?? descriptionText ?? '(no instruction)';
 
-    // Compact metadata strip — same · separated style the Memory row uses.
     const metaParts: Array<string | TemplateResult> = [
       timestamp,
       html`<wa-tag
@@ -329,11 +327,7 @@ export class HistoryItemElement extends LitElement {
               : nothing}
           </div>
         </div>
-        <div class="text-secondary history-meta">
-          ${metaParts.map(
-            (part, i) => html`${i > 0 ? html` · ` : nothing}${part}`,
-          )}
-        </div>
+        <div class="text-secondary meta-strip">${renderDotMeta(metaParts)}</div>
         ${extraDetails.length
           ? html`
               <wa-details

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -142,6 +142,11 @@ export class MemoryItem extends LitElement {
     this.requestPreviewIfNeeded();
   }
 
+  private handleContentsHide(event: Event): void {
+    if (event.target !== event.currentTarget) return;
+    this.contentsOpened = false;
+  }
+
   private requestPreviewIfNeeded(): void {
     if (!this.item || this.item.preview !== undefined) return;
     if (this.item.previewError) return;
@@ -233,8 +238,9 @@ export class MemoryItem extends LitElement {
         <wa-details
           class="collapsible memory-contents"
           summary="Contents"
-          ?open=${this.item.pinned}
+          ?open=${this.contentsOpened}
           @wa-show=${this.handleContentsShow}
+          @wa-hide=${this.handleContentsHide}
         >
           ${this.contentsOpened
             ? html`<div class="memory-preview">

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -23,6 +23,7 @@ import {
 } from '@shared/utils/string';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
@@ -33,6 +34,7 @@ export class MemoryItem extends LitElement {
     designTokens,
     commonViewStyles,
     markdownStyles,
+    metaStripStyles,
     css`
       :host {
         display: block;
@@ -44,10 +46,6 @@ export class MemoryItem extends LitElement {
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-link);
         word-break: break-all;
-      }
-
-      .memory-meta {
-        margin-top: var(--wa-space-2xs);
       }
 
       .memory-contents {
@@ -154,7 +152,7 @@ export class MemoryItem extends LitElement {
     );
   }
 
-  private renderMeta(item: MemoryViewItem): string {
+  private renderMeta(item: MemoryViewItem): TemplateResult {
     const parts: string[] = [];
     if (item.pinned) {
       parts.push('Pinned');
@@ -167,7 +165,7 @@ export class MemoryItem extends LitElement {
     if (item.modifiedBy) {
       parts.push(`by ${item.modifiedBy}`);
     }
-    return parts.join(' · ');
+    return renderDotMeta(parts);
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
@@ -181,8 +179,6 @@ export class MemoryItem extends LitElement {
       }
       return;
     }
-    // Pinned items render contents expanded by default; only unpinned items
-    // start collapsed and defer the markdown render until first open.
     this.contentsOpened = this.item?.pinned ?? false;
     this.requestedPreviewFor = null;
     this.cachedPreviewSource = null;
@@ -231,7 +227,7 @@ export class MemoryItem extends LitElement {
             })}
           </div>
         </div>
-        <div class="text-secondary memory-meta">
+        <div class="text-secondary meta-strip">
           ${this.renderMeta(this.item)}
         </div>
         <wa-details

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -181,7 +181,9 @@ export class MemoryItem extends LitElement {
       }
       return;
     }
-    this.contentsOpened = false;
+    // Pinned items render contents expanded by default; only unpinned items
+    // start collapsed and defer the markdown render until first open.
+    this.contentsOpened = this.item?.pinned ?? false;
     this.requestedPreviewFor = null;
     this.cachedPreviewSource = null;
     this.cachedPreviewHtml = '';
@@ -235,6 +237,7 @@ export class MemoryItem extends LitElement {
         <wa-details
           class="collapsible memory-contents"
           summary="Contents"
+          ?open=${this.item.pinned}
           @wa-show=${this.handleContentsShow}
         >
           ${this.contentsOpened

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
@@ -1,15 +1,15 @@
-/** Checkbox to enable/disable memory for chat agents. */
+/** Switch to enable/disable memory for chat agents. */
 
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 @customElement('memory-toggle')
 export class MemoryToggle extends LitElement {
@@ -33,7 +33,7 @@ export class MemoryToggle extends LitElement {
   @property({ attribute: false }) disabled = false;
 
   private handleChange(event: Event): void {
-    const target = event.currentTarget as WaCheckbox | null;
+    const target = event.currentTarget as WaSwitch | null;
     this.dispatchEvent(
       MemoryViewEvents.toggleEnabled({ enabled: Boolean(target?.checked) }),
     );
@@ -42,13 +42,13 @@ export class MemoryToggle extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="memory-settings">
-        <wa-checkbox
+        <wa-switch
           ?checked=${this.enabled}
           ?disabled=${this.disabled}
           @change=${this.handleChange}
         >
           Enable memory for chat agents
-        </wa-checkbox>
+        </wa-switch>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -13,6 +13,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 // Local imports - shared constants
 import {
@@ -36,6 +37,7 @@ import { ModelSelectionEvents, ProviderKeyEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 /** Display labels for reasoning level options. */
 const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
@@ -394,17 +396,17 @@ export class ModelSelectionList extends LitElement {
         <h2>Model Selection</h2>
         ${this.renderHelperModelDropdown()}
         <div class="short-names-toggle">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.preferShortModelNames}
             @change=${(e: Event) => {
-              const enabled = (e.target as WaCheckbox).checked;
+              const enabled = (e.target as WaSwitch).checked;
               this.dispatchEvent(
                 ModelSelectionEvents.setPreferShortModelNames({ enabled }),
               );
             }}
           >
             Use short model names
-          </wa-checkbox>
+          </wa-switch>
           <span class="short-names-description">
             Send unpinned names (e.g. gpt-5.5 instead of gpt-5.5-2026-04-15)
           </span>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -7,6 +7,10 @@ import { customElement, property, state } from 'lit/decorators.js';
 // Local imports - shared styles
 import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import {
+  renderSetStatusIcon,
+  statusCheckIconStyles,
+} from '@shared/wa/statusIcons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -24,17 +28,14 @@ import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
-const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
-  set: 'Set',
+type FallbackStatus = Exclude<ProviderKeyStatus['status'], 'set'>;
+
+const STATUS_LABELS: Record<FallbackStatus, string> = {
   env: 'Env',
   'not-set': 'Not Set',
 };
 
-const STATUS_VARIANTS: Record<
-  ProviderKeyStatus['status'],
-  'brand' | 'neutral' | 'success' | 'warning' | 'danger'
-> = {
-  set: 'success',
+const STATUS_VARIANTS: Record<FallbackStatus, 'neutral'> = {
   env: 'neutral',
   'not-set': 'neutral',
 };
@@ -45,6 +46,7 @@ export class ProviderKeyList extends LitElement {
     designTokens,
     commonViewStyles,
     ...badgeStyles,
+    statusCheckIconStyles,
     profileViewStyles,
   ];
 
@@ -62,19 +64,17 @@ export class ProviderKeyList extends LitElement {
 
   private renderKeyStatus(status: ProviderKeyStatus['status']): TemplateResult {
     if (status === 'set') {
-      return html`<wa-icon
-        library="texra"
-        name="check"
-        class="key-status-check"
-        title="Key set"
-      ></wa-icon>`;
+      return renderSetStatusIcon({
+        isSet: true,
+        fallbackLabel: '',
+        title: 'Key set',
+      });
     }
-    return html`<wa-tag
-      class="key-status-badge"
-      variant=${STATUS_VARIANTS[status]}
-      size="small"
-      >${STATUS_LABELS[status]}</wa-tag
-    >`;
+    return renderSetStatusIcon({
+      isSet: false,
+      fallbackLabel: STATUS_LABELS[status],
+      fallbackVariant: STATUS_VARIANTS[status],
+    });
   }
 
   private renderActions(entry: ProviderKeyStatus): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -28,16 +28,12 @@ import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 
-type FallbackStatus = Exclude<ProviderKeyStatus['status'], 'set'>;
-
-const STATUS_LABELS: Record<FallbackStatus, string> = {
+const STATUS_LABELS: Record<
+  Exclude<ProviderKeyStatus['status'], 'set'>,
+  string
+> = {
   env: 'Env',
-  'not-set': 'Not Set',
-};
-
-const STATUS_VARIANTS: Record<FallbackStatus, 'neutral'> = {
-  env: 'neutral',
-  'not-set': 'neutral',
+  'not-set': 'Not set',
 };
 
 @customElement('provider-key-list')
@@ -63,17 +59,13 @@ export class ProviderKeyList extends LitElement {
   }
 
   private renderKeyStatus(status: ProviderKeyStatus['status']): TemplateResult {
-    if (status === 'set') {
-      return renderSetStatusIcon({
-        isSet: true,
-        fallbackLabel: '',
-        title: 'Key set',
-      });
-    }
     return renderSetStatusIcon({
-      isSet: false,
-      fallbackLabel: STATUS_LABELS[status],
-      fallbackVariant: STATUS_VARIANTS[status],
+      status,
+      title: 'Key set',
+      fallbacks: {
+        env: { label: STATUS_LABELS.env },
+        'not-set': { label: STATUS_LABELS['not-set'] },
+      },
     });
   }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -60,6 +60,23 @@ export class ProviderKeyList extends LitElement {
       this.expandedProvider === provider ? null : provider;
   }
 
+  private renderKeyStatus(status: ProviderKeyStatus['status']): TemplateResult {
+    if (status === 'set') {
+      return html`<wa-icon
+        library="texra"
+        name="check"
+        class="key-status-check"
+        title="Key set"
+      ></wa-icon>`;
+    }
+    return html`<wa-tag
+      class="key-status-badge"
+      variant=${STATUS_VARIANTS[status]}
+      size="small"
+      >${STATUS_LABELS[status]}</wa-tag
+    >`;
+  }
+
   private renderActions(entry: ProviderKeyStatus): TemplateResult {
     const { provider } = entry;
     const removeButton =
@@ -213,14 +230,7 @@ export class ProviderKeyList extends LitElement {
             <span class="provider-name">${entry.displayName}</span>
           </div>
         </td>
-        <td>
-          <wa-tag
-            class="key-status-badge"
-            variant=${STATUS_VARIANTS[entry.status]}
-            size="small"
-            >${STATUS_LABELS[entry.status]}</wa-tag
-          >
-        </td>
+        <td>${this.renderKeyStatus(entry.status)}</td>
         <td>${this.renderActions(entry)}</td>
       </tr>
     `;

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -14,8 +14,8 @@ import {
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 // Local imports - profile view styles and events
 import type {
@@ -26,7 +26,7 @@ import { profileViewStyles } from './styles';
 import { ProviderKeyEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 const STATUS_LABELS: Record<
   Exclude<ProviderKeyStatus['status'], 'set'>,
@@ -106,10 +106,10 @@ export class ProviderKeyList extends LitElement {
   private renderDetailRow(entry: ProviderKeyStatus): TemplateResult {
     const streamingToggle = html`
       <div class="provider-setting">
-        <wa-checkbox
+        <wa-switch
           ?checked=${entry.streaming}
           @change=${(e: Event) => {
-            const checked = (e.target as WaCheckbox).checked;
+            const checked = (e.target as WaSwitch).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setStreaming({
                 provider: entry.provider,
@@ -119,7 +119,7 @@ export class ProviderKeyList extends LitElement {
           }}
         >
           Streaming
-        </wa-checkbox>
+        </wa-switch>
       </div>
     `;
 
@@ -181,10 +181,10 @@ export class ProviderKeyList extends LitElement {
 
     return html`
       <div class="provider-setting provider-setting--block">
-        <wa-checkbox
+        <wa-switch
           ?checked=${setting.value}
           @change=${(e: Event) => {
-            const checked = (e.target as WaCheckbox).checked;
+            const checked = (e.target as WaSwitch).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setVscodeSetting({
                 key: setting.key,
@@ -194,7 +194,7 @@ export class ProviderKeyList extends LitElement {
           }}
         >
           ${setting.label}
-        </wa-checkbox>
+        </wa-switch>
         <span class="provider-setting-description">${setting.description}</span>
         ${warning}
       </div>
@@ -236,17 +236,17 @@ export class ProviderKeyList extends LitElement {
   private renderGlobalStreamingToggle(): TemplateResult {
     return html`
       <div class="global-streaming-toggle">
-        <wa-checkbox
+        <wa-switch
           ?checked=${this.globalStreamingDefault}
           @change=${(e: Event) => {
-            const checked = (e.target as WaCheckbox).checked;
+            const checked = (e.target as WaSwitch).checked;
             this.dispatchEvent(
               ProviderKeyEvents.setGlobalStreaming({ enabled: checked }),
             );
           }}
         >
           Enable streaming
-        </wa-checkbox>
+        </wa-switch>
         <span class="global-streaming-description"
           >Global default for all providers</span
         >

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -202,7 +202,7 @@ export const profileViewStyles: CSSResult = css`
     border-radius: var(--border-radius);
   }
 
-  .global-streaming-toggle wa-checkbox {
+  .global-streaming-toggle wa-switch {
     font-weight: var(--font-weight-medium);
   }
 
@@ -254,7 +254,7 @@ export const profileViewStyles: CSSResult = css`
     min-width: 120px;
   }
 
-  .provider-setting wa-checkbox {
+  .provider-setting wa-switch {
     font-size: var(--font-size-sm);
     min-width: 120px;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -431,6 +431,11 @@ export const profileViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
+  .key-status-check {
+    color: var(--wa-color-success-fill-loud);
+    font-size: 1em;
+  }
+
   .provider-group-key-button {
     flex-shrink: 0;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -431,11 +431,6 @@ export const profileViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
-  .key-status-check {
-    color: var(--wa-color-success-fill-loud);
-    font-size: 1em;
-  }
-
   .provider-group-key-button {
     flex-shrink: 0;
   }

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -285,10 +285,6 @@ export class ToolCard extends LitElement {
       ToolCard.STATUS_CONFIG[status] ?? ToolCard.STATUS_CONFIG.unknown;
     const label = this.item.statusLabel ?? config.label;
 
-    if (status === 'available') {
-      return this.renderAvailableStatusIcon();
-    }
-
     return html`
       <wa-tag
         class="tool-badge"

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -263,23 +263,30 @@ export class ToolCard extends LitElement {
     },
   };
 
-  private renderBadge(): TemplateResult {
+  private renderAvailableStatusIcon(): TemplateResult {
+    const config = ToolCard.STATUS_CONFIG.available;
+    const label = this.item.statusLabel ?? config.label;
+
+    return html`
+      <span
+        class="tool-status-icon"
+        role="img"
+        aria-label=${label}
+        title=${label}
+      >
+        <wa-icon library="texra" name=${config.icon}></wa-icon>
+      </span>
+    `;
+  }
+
+  private renderStatusBadge(): TemplateResult {
     const { status } = this.item;
     const config =
       ToolCard.STATUS_CONFIG[status] ?? ToolCard.STATUS_CONFIG.unknown;
     const label = this.item.statusLabel ?? config.label;
 
     if (status === 'available') {
-      return html`
-        <span
-          class="tool-status-icon"
-          role="img"
-          aria-label=${label}
-          title=${label}
-        >
-          <wa-icon library="texra" name=${config.icon}></wa-icon>
-        </span>
-      `;
+      return this.renderAvailableStatusIcon();
     }
 
     return html`
@@ -452,9 +459,13 @@ export class ToolCard extends LitElement {
       <div class="tool-card">
         <div class="tool-header">
           <div class="tool-title-group">
-            ${this.item.status === 'available' ? this.renderBadge() : nothing}
+            ${this.item.status === 'available'
+              ? this.renderAvailableStatusIcon()
+              : nothing}
             <span class="tool-name">${this.item.name}</span>
-            ${this.item.status !== 'available' ? this.renderBadge() : nothing}
+            ${this.item.status === 'available'
+              ? this.renderAvailableStatusIcon()
+              : this.renderStatusBadge()}
             ${this.renderAuthNote()}
           </div>
           ${this.renderToggle()}

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -454,7 +454,8 @@ export class ToolCard extends LitElement {
           <div class="tool-title-group">
             ${this.item.status === 'available' ? this.renderBadge() : nothing}
             <span class="tool-name">${this.item.name}</span>
-            ${this.renderBadge()} ${this.renderAuthNote()}
+            ${this.item.status !== 'available' ? this.renderBadge() : nothing}
+            ${this.renderAuthNote()}
           </div>
           ${this.renderToggle()}
         </div>

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -3,6 +3,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -17,7 +18,7 @@ import type {
   ToolCommandKind,
   ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 @customElement('tool-card')
 export class ToolCard extends LitElement {
@@ -233,7 +234,7 @@ export class ToolCard extends LitElement {
   }
 
   private handleToggle(e: Event): void {
-    const target = e.currentTarget as WaCheckbox | null;
+    const target = e.currentTarget as WaSwitch | null;
     this.dispatchEvent(
       createEvent('tool-toggle', {
         toolId: this.item.id,
@@ -423,7 +424,7 @@ export class ToolCard extends LitElement {
   private renderToggle(): TemplateResult | typeof nothing {
     if (!this.item.toggleable) return nothing;
     return html`
-      <wa-checkbox
+      <wa-switch
         class="tool-toggle"
         title="${this.item.enabled !== false ? 'Disable' : 'Enable'} ${this.item
           .name} for agent runs"
@@ -433,7 +434,7 @@ export class ToolCard extends LitElement {
         @change=${this.handleToggle}
       >
         Use in runs
-      </wa-checkbox>
+      </wa-switch>
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -452,6 +452,7 @@ export class ToolCard extends LitElement {
       <div class="tool-card">
         <div class="tool-header">
           <div class="tool-title-group">
+            ${this.item.status === 'available' ? this.renderBadge() : nothing}
             <span class="tool-name">${this.item.name}</span>
             ${this.renderBadge()} ${this.renderAuthNote()}
           </div>

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -1,7 +1,6 @@
 /** Single tool group with status, description, and optional installation guide. */
 
 import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -13,7 +13,7 @@ import {
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared schemas
@@ -28,7 +28,7 @@ import {
   DEFAULT_GIT_AUTHOR_EMAIL,
 } from '@shared/constants/git';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 @customElement('git-tab')
 export class GitTab extends LitElement {
@@ -183,7 +183,7 @@ export class GitTab extends LitElement {
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
   private handleMarkCommitsToggle(event: Event): void {
-    const target = event.target as WaCheckbox | null;
+    const target = event.target as WaSwitch | null;
     this.dispatchEvent(
       createEvent('git-mark-commits-toggle', {
         enabled: Boolean(target?.checked),
@@ -388,13 +388,13 @@ export class GitTab extends LitElement {
           : nothing}
 
         <div class="setting-block">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.markCommits}
             ?disabled=${this.toggleDisabled}
             @change=${this.handleMarkCommitsToggle}
           >
             Mark commits with TeXRA author info
-          </wa-checkbox>
+          </wa-switch>
           <p class="setting-description">
             When enabled, commits made by TeXRA agents are attributed to a
             custom author identity instead of your personal git config.

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -99,6 +99,11 @@ export class GitTab extends LitElement {
         color: var(--wa-color-danger-on-quiet);
       }
 
+      .token-status-check {
+        color: var(--wa-color-success-fill-loud);
+        font-size: 1em;
+      }
+
       .instructions {
         margin: var(--wa-space-2xs) 0 0 0;
         font-size: var(--font-size-sm);
@@ -227,7 +232,12 @@ export class GitTab extends LitElement {
   private renderTokenStatusBadge(): TemplateResult {
     switch (this.githubTokenStatus) {
       case 'secret':
-        return html`<wa-tag variant="success" size="small">Set</wa-tag>`;
+        return html`<wa-icon
+          library="texra"
+          name="check"
+          class="token-status-check"
+          title="Token set"
+        ></wa-icon>`;
       case 'env':
         return html`<wa-tag variant="neutral" size="small">Env</wa-tag>`;
       default:

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -6,6 +6,10 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
+import {
+  renderSetStatusIcon,
+  statusCheckIconStyles,
+} from '@shared/wa/statusIcons';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -31,6 +35,7 @@ export class GitTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    statusCheckIconStyles,
     css`
       :host {
         display: block;
@@ -97,11 +102,6 @@ export class GitTab extends LitElement {
 
       .token-remove-btn:hover {
         color: var(--wa-color-danger-on-quiet);
-      }
-
-      .token-status-check {
-        color: var(--wa-color-success-fill-loud);
-        font-size: 1em;
       }
 
       .instructions {
@@ -232,16 +232,23 @@ export class GitTab extends LitElement {
   private renderTokenStatusBadge(): TemplateResult {
     switch (this.githubTokenStatus) {
       case 'secret':
-        return html`<wa-icon
-          library="texra"
-          name="check"
-          class="token-status-check"
-          title="Token set"
-        ></wa-icon>`;
+        return renderSetStatusIcon({
+          isSet: true,
+          fallbackLabel: '',
+          title: 'Token set',
+        });
       case 'env':
-        return html`<wa-tag variant="neutral" size="small">Env</wa-tag>`;
+        return renderSetStatusIcon({
+          isSet: false,
+          fallbackLabel: 'Env',
+          fallbackVariant: 'neutral',
+        });
       default:
-        return html`<wa-tag variant="warning" size="small">Not set</wa-tag>`;
+        return renderSetStatusIcon({
+          isSet: false,
+          fallbackLabel: 'Not set',
+          fallbackVariant: 'warning',
+        });
     }
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -230,26 +230,14 @@ export class GitTab extends LitElement {
   }
 
   private renderTokenStatusBadge(): TemplateResult {
-    switch (this.githubTokenStatus) {
-      case 'secret':
-        return renderSetStatusIcon({
-          isSet: true,
-          fallbackLabel: '',
-          title: 'Token set',
-        });
-      case 'env':
-        return renderSetStatusIcon({
-          isSet: false,
-          fallbackLabel: 'Env',
-          fallbackVariant: 'neutral',
-        });
-      default:
-        return renderSetStatusIcon({
-          isSet: false,
-          fallbackLabel: 'Not set',
-          fallbackVariant: 'warning',
-        });
-    }
+    return renderSetStatusIcon({
+      status: this.githubTokenStatus,
+      title: 'Token set',
+      fallbacks: {
+        env: { label: 'Env', variant: 'neutral' },
+        none: { label: 'Not set', variant: 'warning' },
+      },
+    });
   }
 
   override render(): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -240,6 +240,12 @@ export class LaTeXTab extends LitElement {
         color: var(--wa-color-testing-failed, #f48771);
       }
 
+      /* Using-default state for non-boolean settings (number/enum). Not a
+         problem — just hasn't been overridden. Render neutral, not red. */
+      .setting-status-icon.is-default {
+        color: var(--color-text-secondary);
+      }
+
       .dependency-info {
         flex: 1;
         min-width: 0;
@@ -498,9 +504,7 @@ export class LaTeXTab extends LitElement {
             )}
           </div>
           ${installed
-            ? html`<wa-tag class="setting-badge" variant="success" size="small"
-                >Installed</wa-tag
-              >`
+            ? nothing
             : dep.actionEvent
               ? html`
                   <button
@@ -950,8 +954,9 @@ export class LaTeXTab extends LitElement {
       <div class="setting-card">
         <wa-icon
           library="texra"
-          name=${isCustom ? 'edit' : 'circle-outline'}
-          class="setting-status-icon ${isCustom ? 'is-set' : 'not-set'}"
+          name=${isCustom ? 'edit' : 'gear'}
+          class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
+          title=${isCustom ? 'Customized' : 'Using default'}
         ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
@@ -1009,8 +1014,9 @@ export class LaTeXTab extends LitElement {
       <div class="setting-card">
         <wa-icon
           library="texra"
-          name=${isCustom ? 'edit' : 'circle-outline'}
-          class="setting-status-icon ${isCustom ? 'is-set' : 'not-set'}"
+          name=${isCustom ? 'edit' : 'gear'}
+          class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
+          title=${isCustom ? 'Customized' : 'Using default'}
         ></wa-icon>
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -919,13 +919,14 @@ export class LaTeXTab extends LitElement {
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
         </div>
-        <button
-          class="tab-action-btn"
-          @click=${() => this.dispatchSetConfigValue(opts.field, !effective)}
+        <wa-switch
+          ?checked=${effective}
+          @change=${(e: Event) => {
+            const checked = (e.target as WaSwitch).checked;
+            this.dispatchSetConfigValue(opts.field, checked);
+          }}
           title="Toggle"
-        >
-          ${effective ? 'On' : 'Off'}
-        </button>
+        ></wa-switch>
         ${isCustom
           ? html`<button
               class="tab-action-btn"

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -940,6 +940,20 @@ export class LaTeXTab extends LitElement {
     `;
   }
 
+  /**
+   * Icon for non-boolean settings (number/enum): an "edit" pencil when the
+   * value has been customized, a neutral gear when it's still the default.
+   * Red is reserved for booleans that are Off, where it carries meaning.
+   */
+  private renderSettingStatusIcon(isCustom: boolean): TemplateResult {
+    return html`<wa-icon
+      library="texra"
+      name=${isCustom ? 'edit' : 'gear'}
+      class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
+      title=${isCustom ? 'Customized' : 'Using default'}
+    ></wa-icon>`;
+  }
+
   private renderNumberSetting(opts: {
     field: 'workflowAutoCompileTimeoutMs' | 'latexdiffTimeoutMs';
     label: string;
@@ -953,12 +967,7 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <wa-icon
-          library="texra"
-          name=${isCustom ? 'edit' : 'gear'}
-          class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
-          title=${isCustom ? 'Customized' : 'Using default'}
-        ></wa-icon>
+        ${this.renderSettingStatusIcon(isCustom)}
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
@@ -1013,12 +1022,7 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <wa-icon
-          library="texra"
-          name=${isCustom ? 'edit' : 'gear'}
-          class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
-          title=${isCustom ? 'Customized' : 'Using default'}
-        ></wa-icon>
+        ${this.renderSettingStatusIcon(isCustom)}
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -9,7 +9,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared utils
@@ -25,7 +25,7 @@ import {
   clampNestedDelegationDepth,
 } from '@shared/constants/delegationPolicy';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
@@ -232,7 +232,7 @@ export class MultiAgentTab extends LitElement {
   @state() private activePresetId: string | null = null;
 
   private emitToggle(eventName: string, event: Event): void {
-    const target = event.target as WaCheckbox | null;
+    const target = event.target as WaSwitch | null;
     this.dispatchEvent(
       createEvent(eventName, { enabled: Boolean(target?.checked) }),
     );
@@ -417,13 +417,13 @@ export class MultiAgentTab extends LitElement {
         </p>
 
         <div class="setting-block">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.allowOrchestratorKill}
             @change=${(e: Event) =>
               this.emitToggle('allow-orchestrator-kill-toggle', e)}
           >
             Let orchestrator stop agents early
-          </wa-checkbox>
+          </wa-switch>
           <p class="text-secondary setting-description">
             The orchestrator can cancel agents that are stuck or no longer
             needed. Turn this off if you want every agent to finish no matter
@@ -432,13 +432,13 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.detachSubagentsOnStop}
             @change=${(e: Event) =>
               this.emitToggle('detach-subagents-on-stop-toggle', e)}
           >
             Keep agents running if I stop the orchestrator
-          </wa-checkbox>
+          </wa-switch>
           <p class="text-secondary setting-description">
             Normally everything stops when you stop the orchestrator. Turn this
             on to let agents that are mid-task finish on their own.
@@ -446,13 +446,13 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.worktreeSupport}
             @change=${(e: Event) =>
               this.emitToggle('worktree-support-toggle', e)}
           >
             Allow agents to work in git worktrees
-          </wa-checkbox>
+          </wa-switch>
           <p class="text-secondary setting-description">
             When enabled, delegated agents can operate in git worktrees outside
             the main workspace. All tool calls within the subagent automatically

--- a/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
@@ -181,7 +181,9 @@ export class OdysseyTab extends LitElement {
         >
         <div>
           <div class="objective" title=${item.objective}>${item.objective}</div>
-          <div class="meta-strip">${renderDotMeta(metaParts)}</div>
+          <div class="text-secondary meta-strip">
+            ${renderDotMeta(metaParts)}
+          </div>
         </div>
         ${inFlight
           ? html`<wa-icon library="texra" name="arrow-right"></wa-icon>`

--- a/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
@@ -178,7 +178,10 @@ export class OdysseyTab extends LitElement {
           <div class="objective" title=${item.objective}>${item.objective}</div>
           <div class="meta">
             <span class="stream-id">${item.streamId}</span>
-            <span>· ${formatOdysseyTime(odysseyElapsedMs(item))} elapsed</span>
+            <span
+              title="Wall-clock time since the odyssey was started (includes idle time between agent turns)"
+              >· started ${formatOdysseyTime(odysseyElapsedMs(item))} ago</span
+            >
             ${item.continuationCount > 0
               ? html`<span>· ${item.continuationCount} continuations</span>`
               : nothing}

--- a/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
@@ -11,6 +11,8 @@ import {
   odysseyElapsedMs,
 } from '@shared/schemas';
 import type { Odyssey, OdysseyStatus } from '@shared/schemas';
+import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
+import type { MetaPart } from '@shared/wa/metaStrip';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
@@ -23,6 +25,7 @@ export class OdysseyTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    metaStripStyles,
     css`
       :host {
         display: block;
@@ -92,14 +95,6 @@ export class OdysseyTab extends LitElement {
         -webkit-box-orient: vertical;
       }
 
-      .meta {
-        display: flex;
-        gap: var(--wa-space-s);
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-quiet);
-        margin-top: 2px;
-      }
-
       .stream-id {
         font-family: var(--wa-font-family-mono);
         font-size: var(--wa-font-size-xs);
@@ -161,6 +156,16 @@ export class OdysseyTab extends LitElement {
 
   private renderRow(item: Odyssey): TemplateResult {
     const inFlight = isOdysseyInFlight(item);
+    const metaParts: MetaPart[] = [
+      html`<span class="stream-id">${item.streamId}</span>`,
+      html`<span
+        title="Wall-clock time since the odyssey was started (includes idle time between agent turns)"
+        >started ${formatOdysseyTime(odysseyElapsedMs(item))} ago</span
+      >`,
+    ];
+    if (item.continuationCount > 0) {
+      metaParts.push(`${item.continuationCount} continuations`);
+    }
     return html`
       <div
         class=${'odyssey-row' + (inFlight ? ' is-clickable' : '')}
@@ -176,16 +181,7 @@ export class OdysseyTab extends LitElement {
         >
         <div>
           <div class="objective" title=${item.objective}>${item.objective}</div>
-          <div class="meta">
-            <span class="stream-id">${item.streamId}</span>
-            <span
-              title="Wall-clock time since the odyssey was started (includes idle time between agent turns)"
-              >· started ${formatOdysseyTime(odysseyElapsedMs(item))} ago</span
-            >
-            ${item.continuationCount > 0
-              ? html`<span>· ${item.continuationCount} continuations</span>`
-              : nothing}
-          </div>
+          <div class="meta-strip">${renderDotMeta(metaParts)}</div>
         </div>
         ${inFlight
           ? html`<wa-icon library="texra" name="arrow-right"></wa-icon>`

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -18,8 +18,8 @@ import type {
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 // Side-effect: register tool card component
 import '../components/tools/ToolCard';
@@ -229,7 +229,7 @@ export class ToolsTab extends LitElement {
   }
 
   private emitToggle(eventName: string, e: Event): void {
-    const target = e.target as WaCheckbox | null;
+    const target = e.target as WaSwitch | null;
     this.dispatchEvent(
       createEvent(eventName, { enabled: Boolean(target?.checked) }),
     );
@@ -256,12 +256,12 @@ export class ToolsTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <wa-checkbox
+          <wa-switch
             ?checked=${this.bashApprovalEnabled}
             @change=${this.handleBashApprovalToggle}
           >
             Require approval for shell commands &amp; agent sessions
-          </wa-checkbox>
+          </wa-switch>
         </div>
       </div>
     `;
@@ -282,12 +282,12 @@ export class ToolsTab extends LitElement {
             are scrubbed before upload and performance tracing stays disabled.
           </p>
           <div class="desktop-settings-row">
-            <wa-checkbox
+            <wa-switch
               ?checked=${this.desktopCrashReportingEnabled}
               @change=${this.handleDesktopCrashReportingToggle}
             >
               Enable native crash reporting
-            </wa-checkbox>
+            </wa-switch>
             <wa-tag
               variant=${this.desktopCrashReportingConfigured
                 ? 'success'

--- a/scripts/copy-extension-docs.mjs
+++ b/scripts/copy-extension-docs.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { copyFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const extensionDir = path.join(repoRoot, 'packages', 'extension');
+
+const docs = ['README.md', 'CHANGELOG.md'];
+
+await Promise.all(
+  docs.map((name) =>
+    copyFile(path.join(repoRoot, name), path.join(extensionDir, name)),
+  ),
+);

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1470,6 +1470,8 @@
   ],
   "requiredPackagedPaths": [
     "LICENSE.txt",
+    "changelog.md",
+    "readme.md",
     "resources/agents",
     "resources/docs/agent-creation",
     "resources/examples",

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -37,6 +37,8 @@ const MANIFEST_KEYS = [
 
 const REQUIRED_PACKAGED_PATHS = [
   'LICENSE.txt',
+  'changelog.md',
+  'readme.md',
   'resources/agents',
   'resources/docs/agent-creation',
   'resources/examples',
@@ -51,6 +53,12 @@ const REQUIRED_PACKAGED_PATHS = [
   'src/settingsView/index.html',
   'src/webview/index.html',
 ];
+
+// Paths in REQUIRED_PACKAGED_PATHS produced by the build (copied from the
+// repo root by scripts/copy-extension-docs.mjs). They do not need to exist
+// in the source tree, but verify-vsix-contents.mjs still checks the built
+// VSIX includes them.
+const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
@@ -166,6 +174,7 @@ function verifyAssets(snapshot, failures) {
   }
 
   for (const packagedPath of snapshot.requiredPackagedPaths) {
+    if (BUILD_TIME_PACKAGED_PATHS.has(packagedPath)) continue;
     const absolutePath = path.join(packageDir, packagedPath);
     const exists = fs.existsSync(absolutePath);
     assert(

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -44,7 +44,7 @@ export enum WorkspaceStateKey {
   CODEX_REASONING_EFFORT = 'texra.codexReasoningEffort',
   CODEX_APPROVAL_POLICY = 'texra.codexApprovalPolicy',
 
-  // Claude Agent settings
+  // Claude Code CLI settings
   CLAUDE_AGENT_MODEL = 'texra.claudeAgentModel',
   CLAUDE_AGENT_PERMISSION_MODE = 'texra.claudeAgentPermissionMode',
   CLAUDE_AGENT_EFFORT = 'texra.claudeAgentEffort',

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -362,7 +362,7 @@ export const CodexApprovalPolicySchema = z.enum([
 ]);
 export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
 
-/** Claude Agent model options surfaced in the picker. The SDK accepts any
+/** Claude Code CLI model options surfaced in the picker. The SDK accepts any
  * string, but the dropdown is fixed to the canonical Anthropic families. */
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-4-6',
@@ -371,7 +371,7 @@ export const ClaudeAgentModelSchema = z.enum([
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
 
-/** Claude Agent permission modes (mirrors CLAUDE_AGENT_PERMISSION_MODES). */
+/** Claude Code CLI permission modes (mirrors CLAUDE_AGENT_PERMISSION_MODES). */
 export const ClaudeAgentPermissionModeSchema = z.enum([
   'default',
   'acceptEdits',
@@ -382,7 +382,7 @@ export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
 
-/** Claude Agent effort levels (mirrors CLAUDE_AGENT_EFFORT_LEVELS). */
+/** Claude Code CLI effort levels (mirrors CLAUDE_AGENT_EFFORT_LEVELS). */
 export const ClaudeAgentEffortSchema = z.enum([
   'low',
   'medium',

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -100,6 +100,30 @@ export const historyListStyles: CSSResult = css`
     line-height: var(--line-height-normal);
   }
 
+  /* Compact one-line metadata strip — matches the · separator style used by
+     the Memory list, so both tabs feel like the same product. */
+  .history-meta {
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+    margin-top: var(--wa-space-3xs);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--wa-space-3xs) 0;
+    align-items: center;
+  }
+
+  .history-title {
+    flex: 1;
+    min-width: 0;
+    font-weight: var(--font-weight-medium);
+    color: var(--wa-color-text-normal);
+    word-break: break-word;
+  }
+
+  .history-title .markdown-content {
+    font-weight: var(--font-weight-medium);
+  }
+
   .config-section {
     display: flex;
     flex-direction: column;

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -100,18 +100,6 @@ export const historyListStyles: CSSResult = css`
     line-height: var(--line-height-normal);
   }
 
-  /* Compact one-line metadata strip — matches the · separator style used by
-     the Memory list, so both tabs feel like the same product. */
-  .history-meta {
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    margin-top: var(--wa-space-3xs);
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--wa-space-3xs) 0;
-    align-items: center;
-  }
-
   .history-title {
     flex: 1;
     min-width: 0;

--- a/src/shared/wa/metaStrip.ts
+++ b/src/shared/wa/metaStrip.ts
@@ -3,20 +3,13 @@ import { css, html, nothing, type CSSResult, type TemplateResult } from 'lit';
 
 export type MetaPart = string | TemplateResult;
 
-/**
- * Render a compact one-line metadata strip with parts joined by " · ".
- * Used by Memory and History rows so both tabs feel like the same product.
- */
+/** Render a compact one-line metadata strip with parts joined by " · ". */
 export function renderDotMeta(parts: readonly MetaPart[]): TemplateResult {
   return html`${parts.map(
     (part, i) => html`${i > 0 ? html` · ` : nothing}${part}`,
   )}`;
 }
 
-/**
- * Single source of truth for the dot-joined meta strip styling. Apply the
- * `meta-strip` class to the container that renders `renderDotMeta` output.
- */
 export const metaStripStyles: CSSResult = css`
   .meta-strip {
     font-size: var(--font-size-sm);

--- a/src/shared/wa/metaStrip.ts
+++ b/src/shared/wa/metaStrip.ts
@@ -1,0 +1,30 @@
+// Third-party imports
+import { css, html, nothing, type CSSResult, type TemplateResult } from 'lit';
+
+export type MetaPart = string | TemplateResult;
+
+/**
+ * Render a compact one-line metadata strip with parts joined by " · ".
+ * Used by Memory and History rows so both tabs feel like the same product.
+ */
+export function renderDotMeta(parts: readonly MetaPart[]): TemplateResult {
+  return html`${parts.map(
+    (part, i) => html`${i > 0 ? html` · ` : nothing}${part}`,
+  )}`;
+}
+
+/**
+ * Single source of truth for the dot-joined meta strip styling. Apply the
+ * `meta-strip` class to the container that renders `renderDotMeta` output.
+ */
+export const metaStripStyles: CSSResult = css`
+  .meta-strip {
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+    margin-top: var(--wa-space-3xs);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--wa-space-3xs) 0;
+    align-items: center;
+  }
+`;

--- a/src/shared/wa/statusIcons.ts
+++ b/src/shared/wa/statusIcons.ts
@@ -1,0 +1,53 @@
+// Third-party imports
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import { css, html, type CSSResult, type TemplateResult } from 'lit';
+
+type TagVariant = 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
+
+export interface SetStatusIconOptions {
+  /** Whether the underlying value is "set" (renders as a green check). */
+  readonly isSet: boolean;
+  /** Label shown in the fallback wa-tag when `isSet` is false. */
+  readonly fallbackLabel: string;
+  /** Variant applied to the fallback wa-tag. */
+  readonly fallbackVariant?: TagVariant;
+  /** Tooltip text for the green check when `isSet` is true. */
+  readonly title?: string;
+}
+
+/**
+ * Render a green-check wa-icon when the underlying value is set, or a labeled
+ * wa-tag otherwise. Used by provider API keys, GitHub tokens, and similar
+ * "is configured" indicators across the settings UI.
+ */
+export function renderSetStatusIcon({
+  isSet,
+  fallbackLabel,
+  fallbackVariant = 'neutral',
+  title,
+}: SetStatusIconOptions): TemplateResult {
+  if (isSet) {
+    return html`<wa-icon
+      library="texra"
+      name="check"
+      class="status-check-icon"
+      title=${title ?? 'Set'}
+    ></wa-icon>`;
+  }
+  return html`<wa-tag variant=${fallbackVariant} size="small"
+    >${fallbackLabel}</wa-tag
+  >`;
+}
+
+/**
+ * Single source of truth for the green-check status icon styling. Consumed by
+ * any view that renders `renderSetStatusIcon` or the `status-check-icon`
+ * class directly.
+ */
+export const statusCheckIconStyles: CSSResult = css`
+  .status-check-icon {
+    color: var(--wa-color-success-fill-loud);
+    font-size: 1em;
+  }
+`;

--- a/src/shared/wa/statusIcons.ts
+++ b/src/shared/wa/statusIcons.ts
@@ -3,31 +3,36 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { css, html, type CSSResult, type TemplateResult } from 'lit';
 
-type TagVariant = 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
+export type WaTagVariant =
+  | 'brand'
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'danger';
 
-export interface SetStatusIconOptions {
-  /** Whether the underlying value is "set" (renders as a green check). */
-  readonly isSet: boolean;
-  /** Label shown in the fallback wa-tag when `isSet` is false. */
-  readonly fallbackLabel: string;
-  /** Variant applied to the fallback wa-tag. */
-  readonly fallbackVariant?: TagVariant;
-  /** Tooltip text for the green check when `isSet` is true. */
+export interface SetStatusFallback {
+  readonly label: string;
+  readonly variant?: WaTagVariant;
+}
+
+export interface SetStatusIconOptions<Status extends string> {
+  readonly status: Status;
+  readonly fallbacks: Partial<Record<Status, SetStatusFallback>>;
+  /** Tooltip text for the green check rendered when `status` is not in `fallbacks`. */
   readonly title?: string;
 }
 
 /**
- * Render a green-check wa-icon when the underlying value is set, or a labeled
- * wa-tag otherwise. Used by provider API keys, GitHub tokens, and similar
- * "is configured" indicators across the settings UI.
+ * Render a green-check wa-icon when `status` has no entry in `fallbacks`, or a
+ * labeled wa-tag using the matching fallback otherwise.
  */
-export function renderSetStatusIcon({
-  isSet,
-  fallbackLabel,
-  fallbackVariant = 'neutral',
+export function renderSetStatusIcon<Status extends string>({
+  status,
+  fallbacks,
   title,
-}: SetStatusIconOptions): TemplateResult {
-  if (isSet) {
+}: SetStatusIconOptions<Status>): TemplateResult {
+  const fallback = fallbacks[status];
+  if (!fallback) {
     return html`<wa-icon
       library="texra"
       name="check"
@@ -35,16 +40,11 @@ export function renderSetStatusIcon({
       title=${title ?? 'Set'}
     ></wa-icon>`;
   }
-  return html`<wa-tag variant=${fallbackVariant} size="small"
-    >${fallbackLabel}</wa-tag
+  return html`<wa-tag variant=${fallback.variant ?? 'neutral'} size="small"
+    >${fallback.label}</wa-tag
   >`;
 }
 
-/**
- * Single source of truth for the green-check status icon styling. Consumed by
- * any view that renders `renderSetStatusIcon` or the `status-check-icon`
- * class directly.
- */
 export const statusCheckIconStyles: CSSResult = css`
   .status-check-icon {
     color: var(--wa-color-success-fill-loud);

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRelayUsageStatus } from '../../../packages/cli/src/runtime/apiStatus';
+import type { RelayUsageSummary } from '../../../packages/cli/src/runtime/relayUsage';
+
+describe('CLI API status text', () => {
+  it('shows relay quota usage as a percentage', () => {
+    const summary: RelayUsageSummary = {
+      periodStart: '2026-05-01T00:00:00.000Z',
+      periodEnd: '2026-06-01T00:00:00.000Z',
+      tier: 'Ultra',
+      limitUsd: 300,
+      costUsd: 42,
+      remainingUsd: 258,
+      usagePercent: 14,
+      streamCount: 3,
+      inputTokens: 1,
+      netInputTokens: 1,
+      outputTokens: 1,
+      cachedTokens: 0,
+      reasoningTokens: 0,
+      modelsUsed: 2,
+      providersUsed: 1,
+    };
+
+    expect(formatRelayUsageStatus(summary)).toBe(
+      'relay usage: $42.00 / $300.00 (14.0%), $258.00 remaining',
+    );
+  });
+});

--- a/src/test-kernel/cli/HeaderBanner.vitest.mts
+++ b/src/test-kernel/cli/HeaderBanner.vitest.mts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import stripAnsi from 'strip-ansi';
+
+import { renderHeaderBanner } from '../../../packages/cli/src/chat/tui/panes/HeaderBanner';
+
+describe('CLI header banner', () => {
+  it('labels the agent and model fields explicitly', () => {
+    const text = stripAnsi(
+      renderHeaderBanner({
+        version: '0.37.8',
+        agent: 'bash',
+        model: 'gemini31p',
+        cwd: '/tmp/project',
+      }),
+    );
+
+    expect(text).toContain('agent: bash · model: gemini31p');
+  });
+});

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -26,7 +26,7 @@ async function loadBuildClaudeAgentEnv(): Promise<
   return (await import('@tools/claudeAgentConfig')).buildClaudeAgentEnv;
 }
 
-describe('Claude Agent configuration', () => {
+describe('Claude Code CLI configuration', () => {
   beforeEach(() => {
     secretStore = new Map();
     vi.resetModules();

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -77,6 +77,7 @@ import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
   CLAUDE_AGENT_EFFORT_LEVELS,
+  CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_PERMISSION_MODES,
   modelSupportsAdaptiveThinking,
   type ClaudeAgentEffort,
@@ -658,7 +659,7 @@ function startClaudeAgentLoop(params: {
 // ============================================================================
 
 export class ClaudeAgentTool extends defineTool({
-  name: 'claude_code',
+  name: CLAUDE_AGENT_NAME,
   description:
     'Spin off a Claude Code agent (via @anthropic-ai/claude-agent-sdk) to perform code analysis, generation, or research. ' +
     'The agent runs the native `claude` binary locally and can read files, run commands, and make edits within its permission mode. ' +
@@ -675,7 +676,7 @@ export class ClaudeAgentTool extends defineTool({
     const model = input.model ?? config.getClaudeAgentModel();
     const effort = input.effort ?? config.getClaudeAgentEffort();
 
-    const approvalLabel = `[claude_code ${permissionMode}] ${input.prompt}`;
+    const approvalLabel = `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });
     if (!approval.accepted) {
       return buildBashApprovalRejectedResult(
@@ -739,7 +740,7 @@ async function launchClaudeAgentSession(
     await registerExecution(
       executionId,
       agentConfig,
-      'claude_code',
+      CLAUDE_AGENT_NAME,
       parentExecutionId,
     );
   } catch {
@@ -752,10 +753,10 @@ async function launchClaudeAgentSession(
     {
       streamPrefix: 'claude@agent-sdk',
       streamCategory: AgentCategory.ToolUse,
-      agentName: 'claude_code',
+      agentName: CLAUDE_AGENT_NAME,
       description: input.prompt,
       config: agentConfig,
-      toolName: 'claude_code',
+      toolName: CLAUDE_AGENT_NAME,
       runtimeHost,
     },
   );

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Agent tool — spin off a Claude Code agent via @anthropic-ai/claude-agent-sdk.
+ * Claude Code CLI tool — spin off a Claude Code agent via @anthropic-ai/claude-agent-sdk.
  *
  * Mirrors the codex / delegate_agent model: every call is async. Without a
  * session_id, a new Claude Code session is started and the result is delivered
@@ -149,7 +149,7 @@ const sessionRegistry = new Map<string, ActiveSession>();
 function storeSession(sessionId: string, entry: ActiveSession): void {
   sessionRegistry.set(sessionId, entry);
   void getExecutionStore(entry.executionId)
-    .write('claude_agent_session_id', sessionId)
+    .write('claude_code_session_id', sessionId)
     .catch(() => {});
 }
 
@@ -658,7 +658,7 @@ function startClaudeAgentLoop(params: {
 // ============================================================================
 
 export class ClaudeAgentTool extends defineTool({
-  name: 'claude_agent',
+  name: 'claude_code',
   description:
     'Spin off a Claude Code agent (via @anthropic-ai/claude-agent-sdk) to perform code analysis, generation, or research. ' +
     'The agent runs the native `claude` binary locally and can read files, run commands, and make edits within its permission mode. ' +
@@ -675,7 +675,7 @@ export class ClaudeAgentTool extends defineTool({
     const model = input.model ?? config.getClaudeAgentModel();
     const effort = input.effort ?? config.getClaudeAgentEffort();
 
-    const approvalLabel = `[claude_agent ${permissionMode}] ${input.prompt}`;
+    const approvalLabel = `[claude_code ${permissionMode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });
     if (!approval.accepted) {
       return buildBashApprovalRejectedResult(
@@ -721,7 +721,7 @@ async function launchClaudeAgentSession(
 ): Promise<ToolResult> {
   if (!parentStreamId || !runtimeHost) {
     throw new ToolError(
-      'Claude Agent requires a parent stream runtime context — it must be called from an active tool-use agent.',
+      'Claude Code CLI requires a parent stream runtime context — it must be called from an active tool-use agent.',
     );
   }
 
@@ -739,11 +739,11 @@ async function launchClaudeAgentSession(
     await registerExecution(
       executionId,
       agentConfig,
-      'claude_agent',
+      'claude_code',
       parentExecutionId,
     );
   } catch {
-    throw new ToolError('Failed to register Claude Agent execution.');
+    throw new ToolError('Failed to register Claude Code CLI execution.');
   }
 
   const { childStreamId, logger } = createChildStream(
@@ -752,10 +752,10 @@ async function launchClaudeAgentSession(
     {
       streamPrefix: 'claude@agent-sdk',
       streamCategory: AgentCategory.ToolUse,
-      agentName: 'claude_agent',
+      agentName: 'claude_code',
       description: input.prompt,
       config: agentConfig,
-      toolName: 'claude_agent',
+      toolName: 'claude_code',
       runtimeHost,
     },
   );
@@ -778,7 +778,7 @@ async function launchClaudeAgentSession(
 
   const preview = truncateWithEllipsis(input.prompt, 60);
   return {
-    summary: `Launched Claude Agent: ${preview}`,
+    summary: `Launched Claude Code CLI: ${preview}`,
     output: [
       `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,
       `Execution ID: ${executionId}`,
@@ -796,13 +796,13 @@ function resumeClaudeAgentSession(
   const stored = sessionRegistry.get(sessionId);
   if (!stored) {
     throw new ToolError(
-      `Claude Agent session '${sessionId}' is not active. It may have completed or been stopped; start a new session without session_id.`,
+      `Claude Code CLI session '${sessionId}' is not active. It may have completed or been stopped; start a new session without session_id.`,
     );
   }
 
   if (callerStreamId && stored.parentStreamId !== callerStreamId) {
     throw new ToolError(
-      `Claude Agent session '${sessionId}' is owned by a different session; start a new session without session_id to run in this context.`,
+      `Claude Code CLI session '${sessionId}' is owned by a different session; start a new session without session_id to run in this context.`,
     );
   }
 
@@ -811,7 +811,7 @@ function resumeClaudeAgentSession(
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {
-    summary: `Follow-up queued for Claude Agent: ${preview}`,
+    summary: `Follow-up queued for Claude Code CLI: ${preview}`,
     output: [
       `Follow-up instruction queued for Claude Code session '${sessionId}'. The agent will process it and deliver a new result automatically.`,
       `Execution ID: ${stored.executionId}`,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -150,7 +150,7 @@ const sessionRegistry = new Map<string, ActiveSession>();
 function storeSession(sessionId: string, entry: ActiveSession): void {
   sessionRegistry.set(sessionId, entry);
   void getExecutionStore(entry.executionId)
-    .write('claude_code_session_id', sessionId)
+    .write('claude_agent_session_id', sessionId)
     .catch(() => {});
 }
 

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -1,5 +1,5 @@
 /**
- * Helpers for the Claude Agent tool.
+ * Helpers for the Claude Code CLI tool.
  *
  * 1. `importClaudeAgentSdk()` — import `query` from `@anthropic-ai/claude-agent-sdk`.
  *    The SDK is ESM-only; esbuild converts it to CJS at bundle time (so it must

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,4 +1,4 @@
-// Shared constants and helpers for the Claude Agent tool.
+// Shared constants and helpers for the Claude Code CLI tool.
 
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import {
@@ -6,7 +6,7 @@ import {
   truncateWithEllipsis,
 } from '@utils/text/stringUtils';
 
-export const CLAUDE_AGENT_NAME = 'claude_agent';
+export const CLAUDE_AGENT_NAME = 'claude_code';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
 export const CLAUDE_AGENT_PERMISSION_MODES = [
   'default',

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -402,12 +402,16 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   },
 
   {
+    // ID kept as `claude-agent` for back-compat with persisted disabled-tool
+    // preferences. The user-facing name has been rebranded to "Claude Code CLI"
+    // and the tool name string is `claude_code`, but the persistence key is
+    // stable.
     id: 'claude-agent',
-    tools: ['claude_agent'],
-    name: 'Claude Agent',
+    tools: ['claude_code'],
+    name: 'Claude Code CLI',
     category: 'ai-agents',
     description:
-      'Spin off a Claude agent that works in your workspace. It can read files, run commands, edit code, and search the web on your behalf — great for delegating focused exploration or implementation while another agent stays in charge.',
+      'Spin off a Claude Code CLI agent that works in your workspace. It can read files, run commands, edit code, and search the web on your behalf — great for delegating focused exploration or implementation while another agent stays in charge.',
     installGuide:
       'Install the Claude Code CLI (choose one):\n\n' +
       '  npm install -g @anthropic-ai/claude-code\n' +
@@ -447,13 +451,13 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         ) {
           return '@anthropic-ai/claude-agent-sdk not found. Reinstall TeXRA or run: npm install @anthropic-ai/claude-agent-sdk';
         }
-        return `Claude Agent SDK import failed: ${msg}`;
+        return `Claude Code SDK import failed: ${msg}`;
       }
 
       const claudePath = findClaudeBinaryPath();
       if (!claudePath) {
         return (
-          'Claude Agent SDK loaded but native `claude` binary not found. ' +
+          'Claude Code SDK loaded but native `claude` binary not found. ' +
           'Install via: npm install -g @anthropic-ai/claude-code' +
           (isWSL() ? ' (run this inside WSL, not on the Windows side)' : '')
         );

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -209,7 +209,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'zotero_export',
     ],
     name: 'Zotero Integration',
-    category: 'academic',
+    category: 'ai-agents',
     description:
       'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
     installGuide:
@@ -274,7 +274,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     id: 'github-pr-subscription',
     tools: ['github_subscription'],
     name: 'GitHub Activity Subscription',
-    category: 'workflow',
+    category: 'ai-agents',
     description:
       'Poll GitHub for pull request, issue, and repository activity. Path mirrors GitHub URL shape: "owner/repo" for coarse repo-wide events, "owner/repo/pulls/N" for per-PR comments/reviews/CI, "owner/repo/issues/N" for issue comments and lifecycle.',
     installGuide:

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -122,7 +122,7 @@ function createDefaultTools() {
     lean_inspect: new LeanInspectTool(),
     lean_loogle: new LeanLoogleTool(),
     codex: new CodexTool(),
-    claude_agent: new ClaudeAgentTool(),
+    claude_code: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,7 @@ import {
 } from './zotero';
 import { CodexTool } from './codex';
 import { ClaudeAgentTool } from './claudeAgent';
+import { CLAUDE_AGENT_NAME } from './claudeAgentShared';
 import {
   LeanDiagnosticsTool,
   LeanFileTool,
@@ -122,7 +123,7 @@ function createDefaultTools() {
     lean_inspect: new LeanInspectTool(),
     lean_loogle: new LeanLoogleTool(),
     codex: new CodexTool(),
-    claude_code: new ClaudeAgentTool(),
+    [CLAUDE_AGENT_NAME]: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),


### PR DESCRIPTION
## Summary

Three commits, all driven by user feedback during this session:

### 1. Bundle README in the VSIX (`5488a2484`)
The Marketplace tab no longer reads "No README available." A new `prepare:docs` step copies `README.md` and `CHANGELOG.md` from the repo root into `packages/extension/` at build time; the source of truth stays at the root, and the copies are gitignored. The VSIX invariants check now requires both files in the built artifact.

### 2. Rename "Claude Agent" → "Claude Code CLI" (`90983fe48`)
The tool's registered name on the agent surface changes from `claude_agent` to `claude_code`, and every user-visible "Claude Agent" string becomes "Claude Code CLI" (Tools dashboard card, install-error messages, log summaries, doc comments). Internal identifiers were preserved on purpose:
- File names, class names, type names — internal only.
- State keys (`texra.claudeAgentModel`, …) — renaming would silently drop persisted user settings.
- IPC command keys — internal protocol.
- The external `id: 'claude-agent'` group key — back-compat with persisted disabled-tool prefs.
- The npm package `@anthropic-ai/claude-agent-sdk` — external.

### 3. Settings UI polish (`5488a2484`, `46f321267`)
Visible cleanups the user called out in screenshots:
- Tools dashboard cards for available tools now flank the title with the green ✓ on both sides.
- "Set" status pills replaced with a plain green ✓ (provider API keys, GitHub personal access token).
- LaTeX dependencies tab: dropped the redundant green "Installed" pill — the ✓ on the left already conveys it.
- LaTeX settings: non-boolean rows using their default value now show a neutral gear with a "Using default" tooltip instead of an alarming red dot. Red is reserved for booleans that are Off, where it carries meaning.
- Odyssey list: "X elapsed" → "started X ago" with a tooltip clarifying the value is wall-clock since the odyssey began (idle time included), not accumulated agent runtime.
- GitHub Activity Subscription and Zotero Integration moved into the **Integrations** (ai-agents) category alongside Claude Code CLI, Codex CLI, and External Chat Handoff.
- Three competing boolean UIs (`wa-switch`, `wa-checkbox` "Use in runs", text-button "On/Off") collapsed onto `wa-switch` as the single canonical control.
- Memory rows: pinned entries render their contents expanded by default; unpinned entries stay collapsed (click to open).
- History rows: replaced the multi-row label/value grid with a compact one-line "·" metadata strip matching the Memory tab — timestamp, category badge, agent, model, and (for workflow runs) inputs/media. The instruction is promoted to the row title.
- README: added an Odyssey-mode bullet under "Why TeXRA" to surface the 0.37.8 headline feature.

### Companion issue

Filed https://github.com/LionSR/TeXRA/issues/4197 — Lean 4 tools depend on the leanprover.lean4 VS Code language server, so they don't work natively in the CLI / desktop builds. Proposes an MCP-server bridge as the cleanest fix.

## Test plan

- [ ] Run `npm run build:fast` and confirm the produced VSIX contains `extension/readme.md` and `extension/changelog.md` (or run `node scripts/verify-vsix-contents.mjs`).
- [ ] Install the VSIX locally — Marketplace/Extensions tab shows the README content.
- [ ] Settings → Tools: the green ✓ flanks the title for available tools; `claude_code` is the tool tag (not `claude_agent`); name reads "Claude Code CLI".
- [ ] Settings → Git: GitHub token status renders as a green ✓ icon (not a "Set" pill).
- [ ] Profile → API keys: provider rows render the same green ✓.
- [ ] Settings → LaTeX: "Installed" pill is gone; number/enum rows using defaults show a neutral gear with "Using default" tooltip; boolean settings use a wa-switch (not an On/Off text button).
- [ ] Settings → Odyssey: timing label reads "started X ago" with the explanatory tooltip.
- [ ] Settings → AI Agents (Integrations): GitHub Activity Subscription + Zotero Integration appear there alongside Claude Code CLI / Codex CLI.
- [ ] Settings → Memory: pinned entries are expanded by default; unpinned entries are collapsed.
- [ ] Settings → History: rows show the one-line `·` metadata strip and the instruction as the title.
- [ ] Tools dashboard tool toggle is a wa-switch (not a wa-checkbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI/UX and packaging changes, but it also renames the registered Claude tool from `claude_agent` to `claude_code` and changes tool grouping/categories, which could affect persisted configs, automation, or tool invocation paths if anything relies on the old name.
> 
> **Overview**
> **Bundles root docs into the VSIX** by adding a build-time `prepare:docs` step that copies `README.md`/`CHANGELOG.md` into `packages/extension/` (gitignored) and updating extension packaging invariants to require the generated `readme.md`/`changelog.md`.
> 
> **Polishes CLI + settings UX**: `/agent` now lists *tool-use agents* separately from *workflows*; `/api` and `/auth` show richer status (including relay quota usage) via new `apiStatus` helpers; the CLI header banner labels `agent` and `model` explicitly.
> 
> **Standardizes settings UI components and status visuals**: swaps many checkboxes/buttons to `wa-switch`, introduces reusable `metaStrip` and green-check `statusIcons`, simplifies History/Memory/Odyssey metadata layouts, improves LaTeX settings/dependency indicators, and updates tool cards and key/token status displays.
> 
> **Rebrands and rekeys the Claude tool** to “Claude Code CLI” with tool name `claude_code` (while keeping some internal IDs for back-compat), and moves some integrations (e.g., Zotero, GitHub subscription) into the `ai-agents` category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63aada6cf81919dfb85ed92426e000c821b315c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->