### PR TITLE
chore: bump version to 0.37.9

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '22'
-          cache: 'npm'
 
       - name: Configure Git
         run: |
@@ -31,26 +30,10 @@ jobs:
 
       - name: Bump to next version
         id: bump_version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          # Get current version
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-
-          # Split version into parts
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-
-          # Increment patch, but if it reaches 11, increment minor and reset patch to 0
-          PATCH=$((PATCH + 1))
-          if [ $PATCH -gt 10 ]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
-          fi
-
-          # Construct new version
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-
-          # Update package.json
-          npm version $NEW_VERSION --no-git-tag-version --allow-same-version
-
+          NEW_VERSION=$(node scripts/bump-workspace-version.mjs --from "$RELEASE_TAG")
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
@@ -60,7 +43,7 @@ jobs:
           commit-message: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'
           title: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'
           body: |
-            This PR automatically bumps the version in package.json to the next patch version after release.
+            This PR automatically bumps the workspace package manifests to the next patch version after release.
 
             Release: ${{ github.event.release.name }}
             Tag: ${{ github.event.release.tag_name }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-workspace",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "private": true,
   "packageManager": "pnpm@11.1.1",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/cli",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/core",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/desktop",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "description": "TeXRA standalone desktop application",
   "author": "TeXRA.ai <contact@texra.ai>",
   "homepage": "https://texra.ai",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+// Node.js imports
+import fs from 'node:fs';
+import process from 'node:process';
+
+const MANIFEST_PATHS = [
+  'package.json',
+  'packages/core/package.json',
+  'packages/cli/package.json',
+  'packages/desktop/package.json',
+  'packages/extension/package.json',
+];
+
+const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
+function printUsage() {
+  console.error(
+    [
+      'Usage:',
+      '  node scripts/bump-workspace-version.mjs --from <release-tag> [--check]',
+      '  node scripts/bump-workspace-version.mjs --version <version> [--check]',
+      '',
+      'Examples:',
+      '  node scripts/bump-workspace-version.mjs --from v0.37.8',
+      '  node scripts/bump-workspace-version.mjs --version 0.37.9 --check',
+    ].join('\n'),
+  );
+}
+
+function fail(message) {
+  console.error(message);
+  printUsage();
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {
+    check: false,
+    from: undefined,
+    version: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--check') {
+      args.check = true;
+      continue;
+    }
+
+    if (arg === '--from' || arg === '--version') {
+      const value = argv[index + 1];
+      if (value == null || value.startsWith('--')) {
+        fail(`${arg} requires a value.`);
+      }
+      args[arg.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if ((args.from == null) === (args.version == null)) {
+    fail('Pass exactly one of --from or --version.');
+  }
+
+  return args;
+}
+
+function parseVersion(rawVersion, label) {
+  const match = VERSION_PATTERN.exec(rawVersion);
+  if (match == null) {
+    fail(`${label} must be MAJOR.MINOR.PATCH, with an optional leading v.`);
+  }
+
+  const [, major, minor, patch] = match;
+  return {
+    major,
+    minor,
+    patch: Number(patch),
+  };
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function nextPatchVersion(rawVersion) {
+  const version = parseVersion(rawVersion, 'Release tag');
+  return formatVersion({
+    ...version,
+    patch: version.patch + 1,
+  });
+}
+
+function normalizeVersion(rawVersion) {
+  return formatVersion(parseVersion(rawVersion, 'Version'));
+}
+
+function readManifest(manifestPath) {
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+}
+
+function writeManifest(manifestPath, manifest) {
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const newVersion =
+    args.version == null
+      ? nextPatchVersion(args.from)
+      : normalizeVersion(args.version);
+
+  const mismatches = [];
+
+  for (const manifestPath of MANIFEST_PATHS) {
+    const manifest = readManifest(manifestPath);
+
+    if (args.check) {
+      if (manifest.version !== newVersion) {
+        mismatches.push(
+          `${manifestPath}: expected ${newVersion}, found ${manifest.version}`,
+        );
+      }
+      continue;
+    }
+
+    manifest.version = newVersion;
+    writeManifest(manifestPath, manifest);
+  }
+
+  if (mismatches.length > 0) {
+    console.error(mismatches.join('\n'));
+    process.exit(1);
+  }
+
+  process.stdout.write(`${newVersion}\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- bump all workspace package manifests from 0.37.8 to 0.37.9 after the v0.37.8 release
- add a shared workspace version bump script so the root, extension, CLI, core, and desktop manifests stay synchronized
- update the release version-bump workflow to derive the next patch version from the published release tag

## Verification
- node scripts/bump-workspace-version.mjs --from v0.37.8 --check
- node scripts/bump-workspace-version.mjs --version 0.37.9 --check
- corepack pnpm prettier --check .github/workflows/version-bump.yml scripts/bump-workspace-version.mjs package.json packages/core/package.json packages/cli/package.json packages/desktop/package.json packages/extension/package.json
- git diff --check
- npm run typecheck
- npm run lint (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to version metadata and CI automation for computing/updating workspace package versions, with no runtime application logic impact.
> 
> **Overview**
> **Automates workspace-wide version bumps on release.** The `version-bump` GitHub Action now derives the next patch version from the published release tag and runs a new `scripts/bump-workspace-version.mjs` helper instead of inline shell logic.
> 
> **Keeps package manifests in sync.** The new script updates (or `--check`s) the `version` field across the root and key workspace packages, and this PR bumps those manifests from `0.37.8` to `0.37.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693eed507900df27385736cc05e442593ad1b039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->