### PR TITLE
fix: reset CLI session on clear

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -122,7 +122,7 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'clear',
-    description: 'Clear the current transcript view',
+    description: 'Start a fresh chat session',
   });
   registerSlashCommand({
     name: 'agent',

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -54,7 +54,8 @@ export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
 
 /**
  * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
- * Returns `undefined` if `text` does not begin with `/`.
+ * Also accepts `\clear` as a compatibility alias.
+ * Returns `undefined` if `text` is not a slash command.
  */
 export function parseSlashInput(
   text: string,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -71,7 +71,6 @@ import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
-  clearActiveTranscript,
   moveLocalTranscriptToStream,
 } from './state/transcript';
 import {
@@ -106,6 +105,7 @@ interface SlashCommandContext {
   readonly requestInputExit: () => void;
   readonly getApprovalPolicy: () => CliApprovalPolicy;
   readonly setApprovalPolicy: (policy: CliApprovalPolicy) => void;
+  readonly resetSession: () => void;
   readonly startStoredExecution: (config: AgentConfigPayload) => void;
 }
 
@@ -336,7 +336,7 @@ async function handleTuiSlashCommand(
       return true;
     }
     case 'clear':
-      clearActiveTranscript();
+      context.resetSession();
       return true;
     case 'exit':
     case 'quit':
@@ -547,6 +547,37 @@ export async function runChat(
     getInterruptible(session.streamId)?.interrupt();
   };
 
+  const resetSessionForClear = (): void => {
+    const activeStreamId = session.streamId ?? cliState.activeStreamId.get();
+    const activeStatus = activeStreamId
+      ? (cliState.streams.get().get(activeStreamId)?.status ??
+        StreamStatusService.get(activeStreamId))
+      : undefined;
+
+    if (
+      (session.runPromise && !session.runCompleted) ||
+      activeStatus === STREAM_STATUS.INITIALIZING ||
+      activeStatus === STREAM_STATUS.RUNNING ||
+      activeStatus === STREAM_STATUS.RESUMING
+    ) {
+      appendLocalAssistantTranscript(
+        'Wait for the active response to finish, or press Ctrl-C before /clear.',
+      );
+      return;
+    }
+
+    const meta = cliState.sessionMeta.get();
+    clearApprovals();
+    followUpQueue.clear();
+    session.streamId = undefined;
+    session.runPromise = undefined;
+    session.runExitCode = CliExitCode.Success;
+    session.runCompleted = false;
+    session.stopRequested = false;
+    resetCliState();
+    cliState.sessionMeta.set(meta);
+  };
+
   const startAgentRun = (config: AgentConfigPayload): void => {
     const currentModel = config.model;
     const sessionContext = currentSessionContext(currentModel);
@@ -624,6 +655,7 @@ export async function runChat(
         requestInputExit: () => requestInputExit?.(),
         getApprovalPolicy,
         setApprovalPolicy,
+        resetSession: resetSessionForClear,
         startStoredExecution: (config) => startAgentRun(config),
       }),
     getApprovalPolicy,
@@ -643,6 +675,7 @@ export async function runChat(
         requestInputExit: () => requestInputExit?.(),
         getApprovalPolicy,
         setApprovalPolicy,
+        resetSession: resetSessionForClear,
         startStoredExecution: (config) => startAgentRun(config),
       }),
     onApiModeSelect: (nextMode) => applyCliApiModeSelection(nextMode),
@@ -675,6 +708,7 @@ export async function runChat(
         requestInputExit: () => requestInputExit?.(),
         getApprovalPolicy,
         setApprovalPolicy,
+        resetSession: resetSessionForClear,
         startStoredExecution: (config) => startAgentRun(config),
       })
     ) {


### PR DESCRIPTION
## Summary
- make /clear and the existing \clear alias reset the CLI chat session instead of only hiding the active transcript
- preserve the selected agent, model, cwd, API mode, and approval mode for the next first message
- keep /clear from detaching an actively running response; it asks the user to wait or interrupt first

## Verification
- corepack pnpm prettier --check packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/commands/registerBuiltins.tsx packages/cli/src/chat/tui/commands/slashRegistry.ts
- npm run typecheck
- npm run lint (passes with existing warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core TUI session lifecycle by resetting `cliState` and in-memory session fields, and adds guards based on stream status to avoid clearing mid-run; could affect follow-up handling or state persistence if edge cases were missed.
> 
> **Overview**
> `/clear` now **resets the Ink chat session** (clearing approvals, follow-up queue, stream/run state, and `cliState`) rather than just hiding the transcript, effectively starting a fresh chat while preserving `sessionMeta` for the next first message.
> 
> The clear flow is guarded to avoid detaching an active execution: if the current stream is *initializing/running/resuming* (or the run promise hasn’t completed), the user is prompted to wait or interrupt first. `parseSlashInput` also documents and continues to accept the legacy `\clear` alias, and the `/clear` help text is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f376a3eb3d58992d96356a9edd96de0924936e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->