### PR TITLE
fix: add CLI api mode startup override

### DIFF
--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -139,8 +139,16 @@ Supported top-level keys are `agent`, `model`, `outputFormat`, and
 defaults. The built-in CLI model default is `deepseekT`.
 
 The corresponding environment variables are `TEXRA_AGENT`, `TEXRA_MODEL`,
-`TEXRA_OUTPUT_FORMAT`, and `TEXRA_APPROVAL_POLICY`. Run `texra doctor` to see
-which workspace config file was loaded and whether any keys were ignored.
+`TEXRA_OUTPUT_FORMAT`, `TEXRA_APPROVAL_POLICY`, and `TEXRA_API_MODE`. Run
+`texra doctor` to see which workspace config file was loaded and whether any
+keys were ignored.
+
+Use `--api-mode personal` or `TEXRA_API_MODE=personal` to force a `run` or
+`chat` invocation to use provider API keys even when the CLI is signed in for
+included relay access. `--api-mode included` keeps the default relay behavior
+when the account is signed in. The accepted aliases match the TUI `/api`
+command: for example, `direct`, `api`, and `byok` select personal API keys,
+while `relay` selects included access.
 
 ## Remove the Linked Command
 

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -111,6 +111,7 @@ const GLOBAL_ARGS: {
   print: { type: 'boolean'; alias: 'p' };
   quiet: { type: 'boolean'; alias: 'q' };
   cwd: { type: 'string' };
+  'api-mode': { type: 'string' };
   'output-format': {
     type: 'enum';
     options: CliOutputFormat[];
@@ -123,6 +124,7 @@ const GLOBAL_ARGS: {
   print: { type: 'boolean', alias: 'p' },
   quiet: { type: 'boolean', alias: 'q' },
   cwd: { type: 'string' },
+  'api-mode': { type: 'string' },
   'output-format': {
     type: 'enum',
     options: [...CLI_OUTPUT_FORMATS],

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -20,7 +20,9 @@ export function shortCliApiMode(mode: CliApiMode): string {
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {
   const normalized = input.trim().toLowerCase();
-  if (['personal', 'api', 'byok', 'key', 'keys'].includes(normalized)) {
+  if (
+    ['personal', 'direct', 'api', 'byok', 'key', 'keys'].includes(normalized)
+  ) {
     return 'personal';
   }
   if (['included', 'relay', 'texra'].includes(normalized)) {

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -9,6 +9,7 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from './approvalPolicy';
+import { parseCliApiMode, type CliApiMode } from './apiAccessMode';
 import {
   CLI_OUTPUT_FORMATS,
   isKnownCliModel,
@@ -31,6 +32,7 @@ export interface CliContext {
   readonly outputFormat: CliOutputFormat;
   readonly approvalPolicy: CliApprovalPolicy;
   readonly helperModel?: string;
+  readonly apiMode?: CliApiMode;
   readonly quietLogs?: boolean;
   readonly renderRunProgress?: boolean;
   readonly stderrIsTty?: boolean;
@@ -130,6 +132,7 @@ export interface CliGlobalArgs {
   readonly cwd?: string;
   readonly outputFormat?: CliOutputFormat;
   readonly approvalPolicy?: CliApprovalPolicy;
+  readonly apiMode?: string;
 }
 
 function cliMode(globalArgs: CliGlobalArgs, ambient: CliAmbientState): CliMode {
@@ -183,6 +186,19 @@ function pickEnvModel(
   return undefined;
 }
 
+function pickCliApiMode(
+  candidates: readonly { readonly label: string; readonly value?: string }[],
+  warnings: string[],
+): CliApiMode | undefined {
+  for (const candidate of candidates) {
+    if (!candidate.value) continue;
+    const apiMode = parseCliApiMode(candidate.value);
+    if (apiMode) return apiMode;
+    warnings.push(`Ignoring invalid ${candidate.label} "${candidate.value}".`);
+  }
+  return undefined;
+}
+
 export async function buildCliContext(
   init: BuildCliContextInit,
 ): Promise<CliContext> {
@@ -195,6 +211,13 @@ export async function buildCliContext(
   const loadedConfig = await loadWorkspaceCliConfig(cwd);
   const configWarnings = [...loadedConfig.warnings];
   const envModel = pickEnvModel(env, configWarnings);
+  const apiMode = pickCliApiMode(
+    [
+      { label: '--api-mode', value: init.globalArgs.apiMode },
+      { label: 'TEXRA_API_MODE', value: envValue(env, 'TEXRA_API_MODE') },
+    ],
+    configWarnings,
+  );
   return {
     cwd,
     mode: cliMode(init.globalArgs, ambient),
@@ -220,6 +243,7 @@ export async function buildCliContext(
       configWarnings,
       'TEXRA_APPROVAL_POLICY',
     ),
+    apiMode,
     quietLogs: init.globalArgs.quiet === true,
     stderrIsTty: ambient.stderrIsTty,
     colorEnabled: ambient.colorEnabled,

--- a/packages/cli/src/runtime/completion.ts
+++ b/packages/cli/src/runtime/completion.ts
@@ -184,7 +184,7 @@ _texra_completion_path() {
   while (( i < COMP_CWORD )); do
     token="\${COMP_WORDS[i]}"
     case "$token" in
-      --output-format|--approval-policy|--cwd|--agent|--model|-m|--input|-i|--output|--instruction|--provider|--month|--login-hint)
+      --output-format|--approval-policy|--api-mode|--cwd|--agent|--model|-m|--input|-i|--output|--instruction|--provider|--month|--login-hint)
         ((i+=2)); continue ;;
       --*=*|-*) ((i++)); continue ;;
     esac

--- a/packages/cli/src/runtime/globalArgs.ts
+++ b/packages/cli/src/runtime/globalArgs.ts
@@ -1,6 +1,7 @@
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 import type { CliApprovalPolicy } from './approvalPolicy';
+import type { CliApiMode } from './apiAccessMode';
 import type { CliOutputFormat } from './cliConfig';
 import type { CliGlobalArgs } from './cliContext';
 
@@ -17,6 +18,7 @@ export interface ParsedGlobalArgs {
   readonly cwd?: string;
   readonly 'output-format'?: CliOutputFormat;
   readonly 'approval-policy'?: CliApprovalPolicy;
+  readonly 'api-mode'?: CliApiMode | string;
 }
 
 export function pickGlobalArgs(args: ParsedGlobalArgs): CliGlobalArgs {
@@ -26,5 +28,8 @@ export function pickGlobalArgs(args: ParsedGlobalArgs): CliGlobalArgs {
     cwd: isNonEmptyString(args.cwd) ? args.cwd.trim() : undefined,
     outputFormat: args['output-format'],
     approvalPolicy: args['approval-policy'],
+    apiMode: isNonEmptyString(args['api-mode'])
+      ? args['api-mode'].trim()
+      : undefined,
   };
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -69,7 +69,7 @@ export async function setCliHelperModel(
 export async function initCliPlatform(
   context: Pick<
     CliContext,
-    'cwd' | 'resourcesPath' | 'helperModel' | 'quietLogs'
+    'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel' | 'quietLogs'
   > & { skipIncludedModelAccess?: boolean },
 ): Promise<void> {
   cliWorkspaceCwd = context.cwd;
@@ -104,7 +104,9 @@ export async function initCliPlatform(
     serverSideKeysInitialized = true;
   }
 
-  const authed = context.skipIncludedModelAccess
+  const forcePersonalApiKeys =
+    context.skipIncludedModelAccess === true || context.apiMode === 'personal';
+  const authed = forcePersonalApiKeys
     ? false
     : await getCliAuthProvider().isAuthenticated();
   await getServerSideKeyService().setUseIncludedModelAccess(authed);

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -103,4 +103,38 @@ describe('CLI context config defaults', () => {
     expect(context.envModel).toBeUndefined();
     expect(context.configWarnings?.join('\n')).toContain('TEXRA_MODEL');
   });
+
+  it('parses TEXRA_API_MODE aliases before runtime initialization', async () => {
+    const context = await buildCliContext({
+      ambient,
+      env: { TEXRA_API_MODE: 'direct' },
+      globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+    });
+
+    expect(context.apiMode).toBe('personal');
+  });
+
+  it('lets --api-mode override TEXRA_API_MODE', async () => {
+    const context = await buildCliContext({
+      ambient,
+      env: { TEXRA_API_MODE: 'personal' },
+      globalArgs: {
+        apiMode: 'included',
+        cwd: '/tmp/no-such-texra-workspace',
+      },
+    });
+
+    expect(context.apiMode).toBe('included');
+  });
+
+  it('reports invalid TEXRA_API_MODE values without failing', async () => {
+    const context = await buildCliContext({
+      ambient,
+      env: { TEXRA_API_MODE: 'unknown-mode' },
+      globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+    });
+
+    expect(context.apiMode).toBeUndefined();
+    expect(context.configWarnings?.join('\n')).toContain('TEXRA_API_MODE');
+  });
 });

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -39,6 +39,12 @@ describe('CLI root argument routing', () => {
     ]);
   });
 
+  it('keeps leading api-mode flags attached to explicit subcommands', () => {
+    expect(
+      reorderGlobalFlags(['--api-mode', 'personal', 'run', 'polish']),
+    ).toEqual(['run', 'polish', '--api-mode', 'personal']);
+  });
+
   it('keeps unknown leading flags in place for citty to report', () => {
     expect(reorderGlobalFlags(['--unknown', 'auth'])).toEqual([
       '--unknown',

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -21,7 +21,7 @@ _texra_completion_path() {
   while (( i < COMP_CWORD )); do
     token="\${COMP_WORDS[i]}"
     case "$token" in
-      --output-format|--approval-policy|--cwd|--agent|--model|-m|--input|-i|--output|--instruction|--provider|--month|--login-hint)
+      --output-format|--approval-policy|--api-mode|--cwd|--agent|--model|-m|--input|-i|--output|--instruction|--provider|--month|--login-hint)
         ((i+=2)); continue ;;
       --*=*|-*) ((i++)); continue ;;
     esac
@@ -50,26 +50,26 @@ _texra() {
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'chat') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --agent --model -m' ;;
-    'run') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --input -i --output --model -m --instruction' ;;
-    'resume') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
+    '') subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
+    'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --output --model -m --instruction' ;;
+    'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history') subcommands='list show delete'; flags='' ;;
-    'history list') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'history show') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --all' ;;
+    'history list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'history show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --all' ;;
     'agents') subcommands='list'; flags='' ;;
-    'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
+    'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'models') subcommands='list'; flags='' ;;
-    'models list') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'login') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --provider --no-browser --select-account --login-hint' ;;
-    'logout') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'usage') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --month' ;;
+    'models list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'login') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --provider --no-browser --select-account --login-hint' ;;
+    'logout') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'usage') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --month' ;;
     'auth') subcommands='status usage'; flags='' ;;
-    'auth status') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'auth usage') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --month' ;;
-    'doctor') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
-    'completion') subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy' ;;
+    'auth status') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'auth usage') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --month' ;;
+    'doctor') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
     *) subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='' ;;
@@ -115,11 +115,13 @@ complete -c texra -n '__fish_use_subcommand' -a 'help'
 complete -c texra -n '__fish_use_subcommand' -l 'print' -s 'p'
 complete -c texra -n '__fish_use_subcommand' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_use_subcommand' -l 'cwd' -r
+complete -c texra -n '__fish_use_subcommand' -l 'api-mode' -r
 complete -c texra -n '__fish_use_subcommand' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_use_subcommand' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from chat' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'agent' -r
@@ -127,6 +129,7 @@ complete -c texra -n '__fish_seen_subcommand_from chat' -l 'model' -s 'm' -r
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'input' -s 'i' -r
@@ -136,6 +139,7 @@ complete -c texra -n '__fish_seen_subcommand_from run' -l 'instruction' -r
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from resume' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'list'
@@ -144,16 +148,19 @@ complete -c texra -n '__fish_seen_subcommand_from history' -a 'delete'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from delete' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from delete' -l 'all'
@@ -161,17 +168,20 @@ complete -c texra -n '__fish_seen_subcommand_from agents' -a 'list'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from models' -a 'list'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from login' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'provider' -r
@@ -181,11 +191,13 @@ complete -c texra -n '__fish_seen_subcommand_from login' -l 'login-hint' -r
 complete -c texra -n '__fish_seen_subcommand_from logout' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from logout' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from logout' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from logout' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from logout' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from logout' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from usage' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'month' -r
@@ -194,22 +206,26 @@ complete -c texra -n '__fish_seen_subcommand_from auth' -a 'usage'
 complete -c texra -n '__fish_seen_subcommand_from status' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from status' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from status' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from status' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from status' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from status' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from usage' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'month' -r
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from completion' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from completion' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from completion' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from completion' -l 'api-mode' -r
 complete -c texra -n '__fish_seen_subcommand_from completion' -l 'output-format' -r -a 'text json ndjson'
 complete -c texra -n '__fish_seen_subcommand_from completion' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
@@ -238,28 +254,28 @@ _texra() {
   [[ -n "\${words[3]}" && "\${words[3]}" != -* ]] && path="$path \${words[3]}"
 
   case "$path" in
-    'chat') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
-    'run') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
-    'resume') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'chat') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
+    'run') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
+    'resume') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
     'history') _values 'subcommands' 'list' 'show' 'delete'; true ;;
-    'history list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'history show') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'history delete') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
+    'history list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'history show') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'history delete') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
     'agents') _values 'subcommands' 'list'; true ;;
-    'agents list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'agents list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
     'models') _values 'subcommands' 'list'; true ;;
-    'models list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'login') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--provider[OAuth provider: github or google (alternative to positional)]:value:' '--no-browser[Print the sign-in URL instead of opening a browser]' '--select-account[Ask the OAuth provider to show account selection when supported]' '--login-hint[Suggest a specific provider account, such as a GitHub username or Google email]:value:' ;;
-    'logout') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'usage') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--month[UTC month to show, formatted as YYYY-MM]:value:' ;;
+    'models list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'login') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--provider[OAuth provider: github or google (alternative to positional)]:value:' '--no-browser[Print the sign-in URL instead of opening a browser]' '--select-account[Ask the OAuth provider to show account selection when supported]' '--login-hint[Suggest a specific provider account, such as a GitHub username or Google email]:value:' ;;
+    'logout') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'usage') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--month[UTC month to show, formatted as YYYY-MM]:value:' ;;
     'auth') _values 'subcommands' 'status' 'usage'; true ;;
-    'auth status') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'auth usage') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--month[UTC month to show, formatted as YYYY-MM]:value:' ;;
-    'doctor') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
-    'completion') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
+    'auth status') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'auth usage') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--month[UTC month to show, formatted as YYYY-MM]:value:' ;;
+    'doctor') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'completion') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:command:(chat run resume history agents models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:command:(chat run resume history agents models login logout usage auth doctor completion version help)' ;;
   esac
 }
 


### PR DESCRIPTION
## Summary
- add a global `--api-mode` startup option and `TEXRA_API_MODE` env override
- parse the requested mode once into `CliContext`, then let CLI platform initialization choose relay vs personal keys from that field
- document personal/included mode aliases and update CLI completion snapshots

Closes #4198.

## Verification
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI decides between relay (included) access and personal API keys at startup, which can affect authentication-dependent behavior and model availability. Scope is contained to argument/env parsing, platform init toggling, and completion/docs updates.
> 
> **Overview**
> Adds a global `--api-mode` flag (and `TEXRA_API_MODE`) to force **personal API keys vs included relay** behavior for `texra run`/`chat`, with alias parsing aligned to the TUI (e.g. `direct` → personal).
> 
> Threads the parsed mode into `CliContext` and updates `initCliPlatform` to disable included access when `apiMode=personal` (or when `skipIncludedModelAccess` is set). Updates shell completions/snapshots, routing tests, and CLI docs to cover the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d10aed964d01fc1028a93ea319d27474ad81c1e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->