### PR TITLE
refactor: route agent runtime platform calls through adapters

### DIFF
--- a/src/agent/core/logger.ts
+++ b/src/agent/core/logger.ts
@@ -9,7 +9,7 @@
  */
 import { tryPlatform } from '@platform/platform';
 import { consoleLog } from '@platform/defaults/consoleLog';
-import type { LogBackend } from '@platform/interfaces/log';
+import type { LogBackend, LogBackendOptions } from '@platform/interfaces/log';
 
 function backend(): LogBackend {
   return tryPlatform()?.log ?? consoleLog;
@@ -19,18 +19,34 @@ export function initialize(channel: string, isAgent = false): void {
   backend().initialize(channel, isAgent);
 }
 
-export function debug(channel: string, message: string): void {
-  backend().debug(channel, message);
+export function debug(
+  channel: string,
+  message: string,
+  options?: LogBackendOptions,
+): void {
+  backend().debug(channel, message, options);
 }
 
-export function info(channel: string, message: string): void {
-  backend().info(channel, message);
+export function info(
+  channel: string,
+  message: string,
+  options?: LogBackendOptions,
+): void {
+  backend().info(channel, message, options);
 }
 
-export function warn(channel: string, message: string): void {
-  backend().warn(channel, message);
+export function warn(
+  channel: string,
+  message: string,
+  options?: LogBackendOptions,
+): void {
+  backend().warn(channel, message, options);
 }
 
-export function error(channel: string, message: string): void {
-  backend().error(channel, message);
+export function error(
+  channel: string,
+  message: string,
+  options?: LogBackendOptions,
+): void {
+  backend().error(channel, message, options);
 }

--- a/src/agent/index/worktreeInfo.ts
+++ b/src/agent/index/worktreeInfo.ts
@@ -1,8 +1,8 @@
 /**
  * Resolve git worktree context (branch, dirty status) for a working directory.
  *
- * Host-neutral: shells out via `execFile` so the same resolver is usable from
- * the VS Code extension host and the Electron desktop main process. PR
+ * Host-neutral: shells out via the shared command runner so the same resolver
+ * is usable from the VS Code extension host and the Electron desktop main process. PR
  * enrichment is intentionally out of scope for this module — that will layer
  * on top once the chip is in the UI.
  *
@@ -11,12 +11,9 @@
  * triggered separately by callers (e.g. on stream creation).
  */
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-
 import type { WorktreeInfo } from '@shared/schemas';
 
-const execFileAsync = promisify(execFile);
+import { executeCommand } from '@utils/system/execUtils';
 
 const GIT_TIMEOUT_MS = 5_000;
 const CACHE_TTL_MS = 10_000;
@@ -73,27 +70,20 @@ async function probeWorktree(workingDirectory: string): Promise<WorktreeInfo> {
 }
 
 async function readBranch(cwd: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync(
-      'git',
-      ['rev-parse', '--abbrev-ref', 'HEAD'],
-      { cwd, timeout: GIT_TIMEOUT_MS },
-    );
-    const name = stdout.trim();
-    return name && name !== 'HEAD' ? name : undefined;
-  } catch {
-    return undefined;
-  }
+  const result = await executeCommand(
+    ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+    { cwd, timeout: GIT_TIMEOUT_MS, channel: 'worktreeInfo' },
+  );
+  if (!result.success) return undefined;
+  const name = result.stdout?.trim();
+  return name && name !== 'HEAD' ? name : undefined;
 }
 
 async function readDirty(cwd: string): Promise<boolean | undefined> {
-  try {
-    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
-      cwd,
-      timeout: GIT_TIMEOUT_MS,
-    });
-    return stdout.trim().length > 0;
-  } catch {
-    return undefined;
-  }
+  const result = await executeCommand(['git', 'status', '--porcelain'], {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    channel: 'worktreeInfo',
+  });
+  return result.success ? (result.stdout ?? '').trim().length > 0 : undefined;
 }

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,3 +1,4 @@
+import * as logger from '@agent/core/logger';
 import { delay } from '@utils/core';
 
 export type NonIterableObject = Partial<Record<string, unknown>> & {
@@ -7,7 +8,9 @@ export type NonIterableObject = Partial<Record<string, unknown>> & {
 /** Flow transition action - typically 'default' or a custom action name */
 export type Action = string;
 
+const CHANNEL = 'PocketFlow';
 const TERMINAL_ACTIONS = new Set<Action>(['complete']);
+logger.initialize(CHANNEL);
 
 /**
  * Base node class for PocketFlow.
@@ -61,7 +64,7 @@ class BaseNode<
   }
   async run(shared: S): Promise<Action | undefined> {
     if (this._successors.size > 0)
-      console.warn("Node won't run successors. Use Flow.");
+      logger.warn(CHANNEL, "Node won't run successors. Use Flow.");
     return await this._run(shared);
   }
   setParams(params: P): this {
@@ -78,7 +81,7 @@ class BaseNode<
   }
   on(action: Action, node: BaseNode): this {
     if (this._successors.has(action))
-      console.warn(`Overwriting successor for action '${action}'`);
+      logger.warn(CHANNEL, `Overwriting successor for action '${action}'`);
     this._successors.set(action, node);
     return this;
   }
@@ -86,7 +89,8 @@ class BaseNode<
     const next = this._successors.get(action);
     if (!next && TERMINAL_ACTIONS.has(action)) return undefined;
     if (!next && this._successors.size > 0) {
-      console.warn(
+      logger.warn(
+        CHANNEL,
         `Flow ends: '${action}' not found in [${[...this._successors.keys()]}]`,
       );
     }
@@ -177,7 +181,8 @@ class Node<
   async _exec(prepRes: unknown): Promise<unknown> {
     // Guard against infinite loop: ensure at least 1 retry attempt
     if (this.maxRetries < 1) {
-      console.warn(
+      logger.warn(
+        CHANNEL,
         `Node maxRetries must be >= 1, got ${this.maxRetries}. Using 1.`,
       );
     }

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -3,12 +3,18 @@
 
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 
+import * as logger from '@agent/core/logger';
+import { toErrorMessage } from '@common/errors';
+
 import { BaseNode, Flow, type Action } from '.';
 
 /** KV key for a flow record. Single source of truth for the prefix. */
 export function flowKey(runId: string): string {
   return `flow_${runId}`;
 }
+
+const CHANNEL = 'PersistedFlow';
+logger.initialize(CHANNEL);
 
 interface NodeRecord {
   action?: string;
@@ -105,7 +111,9 @@ export class PersistedFlow<
     try {
       await this.projection(shared, this.kv);
     } catch (err) {
-      console.warn('[PersistedFlow] projection failed:', err);
+      logger.warn(CHANNEL, `Projection failed: ${toErrorMessage(err)}`, {
+        data: err,
+      });
     }
   }
 

--- a/src/platform/interfaces/log.ts
+++ b/src/platform/interfaces/log.ts
@@ -2,10 +2,14 @@
  * Platform logging backend interface — infrastructure diagnostics
  * (separate from the agent-transcript logger in `src/logger/`).
  */
+export interface LogBackendOptions {
+  data?: unknown;
+}
+
 export interface LogBackend {
   initialize(channel: string, isAgent?: boolean): void;
-  debug(channel: string, message: string): void;
-  info(channel: string, message: string): void;
-  warn(channel: string, message: string): void;
-  error(channel: string, message: string): void;
+  debug(channel: string, message: string, options?: LogBackendOptions): void;
+  info(channel: string, message: string, options?: LogBackendOptions): void;
+  warn(channel: string, message: string, options?: LogBackendOptions): void;
+  error(channel: string, message: string, options?: LogBackendOptions): void;
 }

--- a/src/test-kernel/utils/ExecUtils.vitest.ts
+++ b/src/test-kernel/utils/ExecUtils.vitest.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { executeCommandSync } from '@utils/system/execUtils';
+
+describe('executeCommandSync', () => {
+  it('returns normalized stdout for successful commands', () => {
+    const result = executeCommandSync([
+      process.execPath,
+      '-e',
+      'process.stdout.write("ok\\n")',
+    ]);
+
+    expect(result).toMatchObject({
+      success: true,
+      stdout: 'ok',
+      stderr: null,
+      timedOut: false,
+      exitCode: 0,
+    });
+  });
+
+  it('returns stderr and exit code for failing commands', () => {
+    const result = executeCommandSync([
+      process.execPath,
+      '-e',
+      'process.stderr.write("bad\\n"); process.exit(7)',
+    ]);
+
+    expect(result).toMatchObject({
+      success: false,
+      stdout: null,
+      stderr: 'bad',
+      timedOut: false,
+      exitCode: 7,
+    });
+  });
+});

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -15,10 +15,11 @@
  *    `query()`. Results are cached for the session.
  */
 
-import { execSync } from 'child_process';
 import { createRequire } from 'module';
 import * as path from 'path';
 import { existsSync } from 'fs';
+
+import { executeCommandSync } from '@utils/system/execUtils';
 
 type QueryFn = (params: {
   prompt: string | AsyncIterable<unknown>;
@@ -149,54 +150,52 @@ function findClaudeBinaryPathUncached(): string | undefined {
 
   // Strategy 3: resolve from global npm prefix
   // Preferred over PATH because the npm-installed binary matches the SDK.
-  try {
-    const prefix = execSync('npm prefix -g', {
-      encoding: 'utf8',
+  {
+    const prefixResult = executeCommandSync(['npm', 'prefix', '-g'], {
       timeout: 5000,
-    }).trim();
+    });
+    const prefix = prefixResult.success ? prefixResult.stdout : undefined;
 
-    const roots = [
-      path.join(
-        prefix,
-        'lib',
-        'node_modules',
-        '@anthropic-ai',
-        'claude-agent-sdk',
-      ),
-      path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
-    ];
+    if (prefix) {
+      const roots = [
+        path.join(
+          prefix,
+          'lib',
+          'node_modules',
+          '@anthropic-ai',
+          'claude-agent-sdk',
+        ),
+        path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+      ];
 
-    for (const sdkRoot of roots) {
-      const result = resolveClaudeBinary(sdkRoot, info);
-      if (result) return result;
+      for (const sdkRoot of roots) {
+        const result = resolveClaudeBinary(sdkRoot, info);
+        if (result) return result;
+      }
     }
-  } catch {
-    // npm prefix -g failed
   }
 
   // Strategy 4: PATH lookup (native installer, Homebrew, manual install)
   // The Claude Code CLI's recommended installer drops a `claude` binary into
   // ~/.local/bin (or similar) that the SDK is happy to invoke directly.
-  try {
-    const whichCmd =
-      process.platform === 'win32' ? 'where claude' : 'which claude';
-    const pathHits = execSync(whichCmd, {
-      encoding: 'utf8',
-      timeout: 5000,
-    })
-      .trim()
-      .split(/\r?\n/);
+  {
+    const lookupResult = executeCommandSync(
+      [process.platform === 'win32' ? 'where' : 'which', 'claude'],
+      {
+        timeout: 5000,
+      },
+    );
+    const pathHits = lookupResult.success
+      ? (lookupResult.stdout ?? '').split(/\r?\n/)
+      : [];
 
-    // On Windows, skip .cmd/.ps1 shims (npm wrappers) — the SDK spawns
-    // the binary directly without shell:true, so shims aren't executable.
     for (const hit of pathHits) {
       const p = hit.trim();
       if (!p) continue;
+      // The SDK spawns the binary directly, so skip shell-only npm shims.
       if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
       if (existsSync(p)) return p;
     }
-  } catch {
-    // claude not on PATH
   }
 
   return undefined;

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -14,10 +14,11 @@
  *    are cached for the session.
  */
 
-import { execSync } from 'child_process';
 import { createRequire } from 'module';
 import * as path from 'path';
 import { existsSync } from 'fs';
+
+import { executeCommandSync } from '@utils/system/execUtils';
 
 type CodexConstructor = new (options?: any) => any;
 type PlatformInfo = { pkg: string; triple: string };
@@ -150,47 +151,45 @@ function findCodexBinaryPathUncached(): string | undefined {
 
   // Strategy 3: resolve from global npm prefix
   // Preferred over PATH because the npm-installed binary matches the SDK.
-  try {
-    const prefix = execSync('npm prefix -g', {
-      encoding: 'utf8',
+  {
+    const prefixResult = executeCommandSync(['npm', 'prefix', '-g'], {
       timeout: 5000,
-    }).trim();
+    });
+    const prefix = prefixResult.success ? prefixResult.stdout : undefined;
 
-    const roots = [
-      path.join(prefix, 'lib', 'node_modules', '@openai', 'codex'),
-      path.join(prefix, 'node_modules', '@openai', 'codex'),
-    ];
+    if (prefix) {
+      const roots = [
+        path.join(prefix, 'lib', 'node_modules', '@openai', 'codex'),
+        path.join(prefix, 'node_modules', '@openai', 'codex'),
+      ];
 
-    for (const codexPkgDir of roots) {
-      const result = resolveCodexBinary(codexPkgDir, info, binaryName);
-      if (result) return result;
+      for (const codexPkgDir of roots) {
+        const result = resolveCodexBinary(codexPkgDir, info, binaryName);
+        if (result) return result;
+      }
     }
-  } catch {
-    // npm prefix -g failed
   }
 
   // Strategy 4: PATH lookup (Homebrew, manual install, etc.)
   // Fallback — may find an older version that doesn't match the SDK.
-  try {
-    const whichCmd =
-      process.platform === 'win32' ? 'where codex' : 'which codex';
-    const pathHits = execSync(whichCmd, {
-      encoding: 'utf8',
-      timeout: 5000,
-    })
-      .trim()
-      .split(/\r?\n/);
+  {
+    const lookupResult = executeCommandSync(
+      [process.platform === 'win32' ? 'where' : 'which', 'codex'],
+      {
+        timeout: 5000,
+      },
+    );
+    const pathHits = lookupResult.success
+      ? (lookupResult.stdout ?? '').split(/\r?\n/)
+      : [];
 
-    // On Windows, skip .cmd/.ps1 shims (npm wrappers) — the SDK spawns
-    // the binary directly without shell:true, so shims aren't executable.
     for (const hit of pathHits) {
       const p = hit.trim();
       if (!p) continue;
+      // The SDK spawns the binary directly, so skip shell-only npm shims.
       if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
       if (existsSync(p)) return p;
     }
-  } catch {
-    // codex not on PATH
   }
 
   return undefined;

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -17,9 +17,6 @@
  * - `owner/repo/pulls/N` and `owner/repo/issues/N` are nuanced (worker-friendly).
  */
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-
 import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -29,6 +26,7 @@ import type { StreamTabId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
+import { executeCommand } from '@utils/system/execUtils';
 
 import { defineTool } from '../core/define';
 import {
@@ -52,8 +50,6 @@ import { issuePollingSource } from './IssuePollingSource';
 import { prPollingSource } from './PRPollingSource';
 import { repoPollingSource } from './RepoPollingSource';
 import type { GhIssue, GhPullRequest } from './prTypes';
-
-const execFileAsync = promisify(execFile);
 
 const GitHubSubscriptionInputSchema = z.strictObject({
   command: z.enum(['subscribe', 'unsubscribe', 'list', 'find_current']),
@@ -365,12 +361,17 @@ function parseGitHubRemote(
 }
 
 async function gitInDir(args: string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, {
+  const result = await executeCommand(['git', ...args], {
     cwd,
     timeout: 10_000,
-    maxBuffer: 1024 * 1024,
+    channel: 'github_subscription',
   });
-  return stdout.trim();
+  if (!result.success) {
+    throw new ToolError(
+      result.stderr ?? `git ${args.join(' ')} failed with no stderr.`,
+    );
+  }
+  return (result.stdout ?? '').trim();
 }
 
 interface OpenPullSummary {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,13 +1,16 @@
 // Third-party imports
 import * as path from 'path';
 
-import { execa, type Options, type ResultPromise, ExecaError } from 'execa';
+import {
+  execa,
+  execaSync,
+  type Options,
+  type ResultPromise,
+  ExecaError,
+  type SyncOptions,
+} from 'execa';
 import { quote as shellQuote } from 'shell-quote';
 
-/**
- * Encoding options compatible with execa v9.
- * execa uses a stricter encoding type than Node's BufferEncoding.
- */
 // Local imports - log
 import type { ExecResult } from '@agent/types/ResultTypes';
 
@@ -23,6 +26,10 @@ import { IS_WINDOWS, extendEnvPath } from '@utils/system/platformPaths';
 const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);
 
+/**
+ * Encoding options compatible with execa v9.
+ * execa uses a stricter encoding type than Node's BufferEncoding.
+ */
 type ExecaEncodingOption =
   | 'utf8'
   | 'utf16le'
@@ -38,6 +45,77 @@ const FORCE_KILL_DELAY_MS = 5_000;
 
 function normalizeOutput(text: string | null | undefined): string | null {
   return text?.trim() || null;
+}
+
+function commandEnv(
+  workspacePath: string,
+  envOverrides?: Record<string, string>,
+): Record<string, string | undefined> {
+  const env = { ...process.env, ...getGitAuthorEnv(), ...envOverrides };
+  env.PATH = extendEnvPath(env.PATH);
+
+  // Export project context so AI agents can orient themselves immediately.
+  env.PROJECT_DIR = workspacePath;
+  env.PROJECT_NAME = path.basename(workspacePath);
+  return env;
+}
+
+function resultFromProcessOutput(
+  stdout: string | null | undefined,
+  stderr: string | null | undefined,
+  exitCode: number,
+  timedOut = false,
+): ExecResult {
+  return {
+    success: exitCode === 0 && !timedOut,
+    stdout: normalizeOutput(stdout),
+    stderr: normalizeOutput(stderr),
+    timedOut,
+    exitCode,
+  };
+}
+
+function resultFromExecutionError(err: unknown): ExecResult {
+  if (err instanceof ExecaError) {
+    return {
+      success: false,
+      stdout: normalizeOutput(`${err.stdout ?? ''}`),
+      stderr: normalizeOutput(`${err.stderr || toErrorMessage(err)}`),
+      timedOut: err.timedOut ?? false,
+      exitCode: err.exitCode ?? 127,
+    };
+  }
+
+  return {
+    success: false,
+    stdout: null,
+    stderr: normalizeOutput(toErrorMessage(err)),
+    timedOut: false,
+    exitCode: 127,
+  };
+}
+
+function logCommandStderr(
+  channel: string,
+  stderr: string | null | undefined,
+  truncate = false,
+): void {
+  const normalizedStderr = normalizeOutput(stderr);
+  if (!normalizedStderr) return;
+
+  const stderrForLog =
+    truncate && normalizedStderr.length > MAX_OUTPUT_LENGTH
+      ? `...${normalizedStderr.slice(-MAX_OUTPUT_LENGTH)}`
+      : normalizedStderr;
+  logger.debug(channel, `Command stderr: ${stderrForLog}`);
+}
+
+function workspacePathOrProcessCwd(): string {
+  try {
+    return WorkspaceFS.getPath() ?? process.cwd();
+  } catch {
+    return process.cwd();
+  }
 }
 
 /**
@@ -105,12 +183,7 @@ export async function executeCommand(
       throw new Error('No workspace path found');
     }
 
-    const env = { ...process.env, ...getGitAuthorEnv(), ...options.env };
-    env.PATH = extendEnvPath(env.PATH);
-
-    // Export project context so AI agents can orient themselves immediately.
-    env.PROJECT_DIR = workspacePath;
-    env.PROJECT_NAME = path.basename(workspacePath);
+    const env = commandEnv(workspacePath, options.env);
 
     // Normalize 'utf-8' to 'utf8' for execa compatibility
     const rawEncoding = options.encoding ?? 'utf8';
@@ -212,42 +285,71 @@ export async function executeCommand(
     const exitCode = result.exitCode ?? 1;
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
 
-    const normalizedStdout = normalizeOutput(stdout);
-    const normalizedStderr = normalizeOutput(stderr);
+    logCommandStderr(logChannel, stderr, options.truncate);
 
-    if (normalizedStderr) {
-      const stderrForLog =
-        options.truncate && normalizedStderr.length > MAX_OUTPUT_LENGTH
-          ? `...${normalizedStderr.slice(-MAX_OUTPUT_LENGTH)}`
-          : normalizedStderr;
-      logger.debug(logChannel, `Command stderr: ${stderrForLog}`);
-    }
-
-    return {
-      success: exitCode === 0 && !timedOut,
-      stdout: normalizedStdout,
-      stderr: normalizedStderr,
-      timedOut,
-      exitCode,
-    };
+    return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
   } catch (err) {
     logger.error(
       options.channel ?? CHANNEL,
       `Error executing command: ${toErrorMessage(err)}`,
     );
 
-    const stderr =
-      err instanceof ExecaError && err.stderr ? `${err.stderr}`.trim() : null;
-    const normalizedError = normalizeOutput(stderr || toErrorMessage(err));
-    return {
-      success: false,
-      stdout: null,
-      stderr: normalizedError,
-      timedOut: false, // Real timeouts are handled in the main flow via result.timedOut
-      exitCode: 127, // Convention for command not found / execution failure
-    };
+    return resultFromExecutionError(err);
   } finally {
     if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
     if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
+  }
+}
+
+/**
+ * Synchronous companion to executeCommand for APIs that must return a value
+ * synchronously, such as native binary resolvers passed to SDK constructors.
+ * If no cwd is passed and the platform is not initialized yet, this falls back
+ * to process.cwd(); prefer executeCommand for normal workspace command execution.
+ */
+export function executeCommandSync(
+  command: readonly [string, ...string[]],
+  options: {
+    encoding?: BufferEncoding;
+    channel?: string;
+    truncate?: boolean;
+    env?: Record<string, string>;
+    timeout?: number;
+    cwd?: string;
+  } = {},
+): ExecResult {
+  try {
+    const [cmd, ...args] = command;
+    const workspacePath = options.cwd ?? workspacePathOrProcessCwd();
+    const rawEncoding = options.encoding ?? 'utf8';
+    const encodingOption: ExecaEncodingOption =
+      rawEncoding.toLowerCase() === 'utf-8'
+        ? 'utf8'
+        : (rawEncoding as ExecaEncodingOption);
+    const execaOptions: SyncOptions = {
+      cwd: workspacePath,
+      env: commandEnv(workspacePath, options.env),
+      encoding: encodingOption,
+      timeout: options.timeout,
+      reject: false,
+    };
+    const logChannel = options.channel ?? CHANNEL;
+    logger.debug(logChannel, `Running command: ${shellQuote([cmd, ...args])}`);
+    const result = execaSync(cmd, args, execaOptions);
+    const stdout = (result.stdout as string) ?? '';
+    const stderr = (result.stderr as string) ?? '';
+    const exitCode = result.exitCode ?? 1;
+    const timedOut = result.timedOut ?? false;
+
+    logCommandStderr(logChannel, stderr, options.truncate);
+
+    return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
+  } catch (err) {
+    logger.error(
+      options.channel ?? CHANNEL,
+      `Error executing command: ${toErrorMessage(err)}`,
+    );
+
+    return resultFromExecutionError(err);
   }
 }


### PR DESCRIPTION
## Summary
- Replace PocketFlow console warnings with the shared logger.
- Add a synchronous companion to the shared command runner and reuse the same environment, output normalization, stderr logging, and error conversion policy.
- Route Claude/Codex binary resolution, GitHub subscription git probes, and worktree metadata git probes through shared command helpers.

Closes #4202.

## Verification
- /private/tmp/texra-open-issue-audit/node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/utils/ExecUtils.vitest.ts src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts src/test-kernel/agent/index/StreamTabInfo.vitest.ts
- /private/tmp/texra-open-issue-audit/node_modules/.bin/tsc --noEmit
- /private/tmp/texra-open-issue-audit/node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- node --max-old-space-size=4096 /private/tmp/texra-open-issue-audit/node_modules/eslint/bin/eslint.js src/agent/index/worktreeInfo.ts src/agent/node/index.ts src/agent/node/persistedFlow.ts src/tools/claudeAgentImport.ts src/tools/codexImport.ts src/tools/github/githubSubscriptionTool.ts src/utils/system/execUtils.ts src/test-kernel/utils/ExecUtils.vitest.ts
- git diff --check
- rg -n "console\.warn|child_process|execSync|execFile" src/agent src/tools

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shared command execution and logging interfaces used across multiple host environments (extension/Electron), which could alter error handling or output parsing in subtle ways.
> 
> **Overview**
> **Refactors command execution to a single policy.** Adds `executeCommandSync()` to `execUtils` and factors shared env setup, output normalization, stderr logging, and error-to-`ExecResult` conversion so both async and sync execution behave consistently.
> 
> **Migrates ad-hoc process spawning to shared helpers.** Worktree git probes, GitHub subscription git calls, and Claude/Codex binary resolution now route through `executeCommand`/`executeCommandSync` instead of `child_process`/`execSync`, with improved failure handling (explicit `ToolError` on git failures).
> 
> **Extends infrastructure logging.** `LogBackend` and the agent `logger` facade now accept optional `LogBackendOptions` (e.g. `data`) and PocketFlow/PersistedFlow console warnings are routed through the shared logger with channel initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb38ef922cab646ff131e6e96f3a2c91fddaa6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->