### PR TITLE
fix: prefer native SDK abort error checks

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -944,7 +944,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // classification; AnthropicUserAbortError is a sibling of
         // AnthropicAPIError, so wrapping it would break downstream
         // `instanceof AnthropicUserAbortError` checks.
-        const isAbort = isUserAbort(streamError);
+        const isAbort =
+          streamError instanceof AnthropicUserAbortError ||
+          isUserAbort(streamError);
         let enrichedError: unknown = streamError;
         if (
           !stream.currentMessage &&

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import OpenAI from 'openai';
+import OpenAI, { APIUserAbortError as OpenAIUserAbortError } from 'openai';
 
 // Local imports - core utilities
 import {
@@ -531,7 +531,9 @@ export class ModelHandlerOpenAI<
       if (partialText) {
         attachPartialText(streamError, partialText);
       }
-      if (!isUserAbort(streamError)) {
+      const isAbort =
+        streamError instanceof OpenAIUserAbortError || isUserAbort(streamError);
+      if (!isAbort) {
         this.logger.warn(
           `Stream failed: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
           {


### PR DESCRIPTION
## Summary
- prefer native SDK abort classes in stream failure paths before fallback heuristic checks
- keep existing fallback behavior via `isUserAbort(...)`

## Changes
- `src/agent/modelHandlers/modelHandlerOpenAI.ts`
  - import `APIUserAbortError` from OpenAI SDK
  - use `instanceof OpenAIUserAbortError` in stream error handling before fallback
- `src/agent/modelHandlers/modelHandlerAnthropic.ts`
  - use `instanceof AnthropicUserAbortError` in stream error handling before fallback

## Why
This reduces reliance on generic/class-name heuristic abort detection in hot streaming paths and uses SDK-native types where available.

## Validation
- `npm run compile:safe` could not run in this environment: `tsc: command not found`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to stream error handling, improving abort classification without altering request/response logic.
> 
> **Overview**
> Improves streaming failure handling by **preferring SDK-native abort error classes** over heuristic `isUserAbort(...)` checks.
> 
> OpenAI handler now imports and checks `APIUserAbortError` (and Anthropic checks `AnthropicUserAbortError`) so aborts are treated as control-flow earlier, avoiding unnecessary wrapping/logging and preserving correct downstream `instanceof` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430826d421829a5d255407b3a3c02e70c61e688e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->