### PR TITLE
refactor(config): unify CLI workspace defaults with extension's texra.* settings schema

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -486,7 +486,6 @@ export async function runChat(
     modelOverride: init.modelOverride,
     envAgent: context.envAgent,
     envModel: context.envModel,
-    workspaceConfig: context.cliConfig,
   });
   const { agent, model } = defaults;
   await setCliHelperModel(model);

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -5,10 +5,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import { isNonEmptyString } from '@utils/core/stringCore';
 import { getConfig } from '@utils/config/configUtils';
 import { GlobalStorageFS } from '@utils/files/storageFS';
-import {
-  CLI_BUILTIN_DEFAULT_MODEL,
-  type CliConfigValues,
-} from './cliConfig';
+import { CLI_BUILTIN_DEFAULT_MODEL, type CliConfigValues } from './cliConfig';
 
 export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
 export const BUILTIN_DEFAULT_CHAT_MODEL = CLI_BUILTIN_DEFAULT_MODEL;
@@ -137,10 +134,8 @@ export async function resolveChatDefaults(
   const [workspace, user, history] = await Promise.all([
     init.workspaceConfig
       ? Promise.resolve({
-          agent:
-            init.workspaceConfig.chat?.agent ?? init.workspaceConfig.agent,
-          model:
-            init.workspaceConfig.chat?.model ?? init.workspaceConfig.model,
+          agent: init.workspaceConfig.chat?.agent ?? init.workspaceConfig.agent,
+          model: init.workspaceConfig.chat?.model ?? init.workspaceConfig.model,
         })
       : loadWorkspaceDefaults(init.cwd),
     loadUserDefaults(),

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -3,12 +3,10 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { isNonEmptyString } from '@utils/core/stringCore';
+import { getConfig } from '@utils/config/configUtils';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  loadWorkspaceCliConfig,
-  resolveConfiguredAgent,
-  resolveConfiguredModel,
   type CliConfigValues,
 } from './cliConfig';
 
@@ -48,11 +46,14 @@ function pickDefaults(parsed: unknown): PartialDefaults {
   return out;
 }
 
-async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
-  const loaded = await loadWorkspaceCliConfig(cwd);
+async function loadWorkspaceDefaults(_cwd: string): Promise<PartialDefaults> {
   return {
-    agent: resolveConfiguredAgent(loaded.values, 'chat'),
-    model: resolveConfiguredModel(loaded.values, 'chat'),
+    agent:
+      getConfig<string | undefined>('chat.agent') ??
+      getConfig<string | undefined>('agent'),
+    model:
+      getConfig<string | undefined>('chat.model') ??
+      getConfig<string | undefined>('model'),
   };
 }
 
@@ -99,6 +100,7 @@ export interface ResolveChatDefaultsInit {
   readonly modelOverride?: string;
   readonly envAgent?: string;
   readonly envModel?: string;
+  /** @deprecated Workspace defaults are now read from the unified config provider. */
   readonly workspaceConfig?: CliConfigValues;
 }
 
@@ -128,11 +130,17 @@ export async function resolveChatDefaults(
   }
 
   // Tiers are independent I/O — fan out in parallel.
+  // Workspace defaults come from the platform config provider (unified
+  // schema), which reads the same .texra/config.json file loaded by
+  // initCliPlatform. The workspaceConfig parameter is retained for
+  // backward compatibility but is no longer required.
   const [workspace, user, history] = await Promise.all([
     init.workspaceConfig
       ? Promise.resolve({
-          agent: resolveConfiguredAgent(init.workspaceConfig, 'chat'),
-          model: resolveConfiguredModel(init.workspaceConfig, 'chat'),
+          agent:
+            init.workspaceConfig.chat?.agent ?? init.workspaceConfig.agent,
+          model:
+            init.workspaceConfig.chat?.model ?? init.workspaceConfig.model,
         })
       : loadWorkspaceDefaults(init.cwd),
     loadUserDefaults(),

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -3,9 +3,14 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { isNonEmptyString } from '@utils/core/stringCore';
-import { getConfig } from '@utils/config/configUtils';
 import { GlobalStorageFS } from '@utils/files/storageFS';
-import { CLI_BUILTIN_DEFAULT_MODEL, type CliConfigValues } from './cliConfig';
+import {
+  CLI_BUILTIN_DEFAULT_MODEL,
+  loadWorkspaceCliConfig,
+  resolveConfiguredAgent,
+  resolveConfiguredModel,
+  type CliConfigValues,
+} from './cliConfig';
 
 export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
 export const BUILTIN_DEFAULT_CHAT_MODEL = CLI_BUILTIN_DEFAULT_MODEL;
@@ -43,14 +48,11 @@ function pickDefaults(parsed: unknown): PartialDefaults {
   return out;
 }
 
-async function loadWorkspaceDefaults(_cwd: string): Promise<PartialDefaults> {
+async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
+  const loaded = await loadWorkspaceCliConfig(cwd);
   return {
-    agent:
-      getConfig<string | undefined>('chat.agent') ??
-      getConfig<string | undefined>('agent'),
-    model:
-      getConfig<string | undefined>('chat.model') ??
-      getConfig<string | undefined>('model'),
+    agent: resolveConfiguredAgent(loaded.values, 'chat'),
+    model: resolveConfiguredModel(loaded.values, 'chat'),
   };
 }
 
@@ -127,10 +129,8 @@ export async function resolveChatDefaults(
   }
 
   // Tiers are independent I/O — fan out in parallel.
-  // Workspace defaults come from the platform config provider (unified
-  // schema), which reads the same .texra/config.json file loaded by
-  // initCliPlatform. The workspaceConfig parameter is retained for
-  // backward compatibility but is no longer required.
+  // Workspace defaults use the same .texra/config.json reader as the CLI
+  // context so startup does not depend on platform initialization.
   const [workspace, user, history] = await Promise.all([
     init.workspaceConfig
       ? Promise.resolve({

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
+import { KNOWN_TEXRA_KEYS } from '@utils/config/settingsSchema';
+
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
@@ -55,8 +57,23 @@ const ModelSchema = NonEmptyStringSchema.refine(
 const OutputFormatSchema = z.enum(CLI_OUTPUT_FORMATS);
 const ApprovalPolicySchema = z.enum(CLI_APPROVAL_POLICIES);
 
+/** Keys from the unified schema that the CLI config file accepts at the top level. */
+const UNIFIED_TOP_LEVEL_KEYS = new Set(
+  [...KNOWN_TEXRA_KEYS].filter((k) => k.startsWith('texra.')),
+);
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isKnownConfigKey(key: string): boolean {
+  return (
+    TOP_LEVEL_KEYS.has(key) ||
+    UNIFIED_TOP_LEVEL_KEYS.has(key) ||
+    // Accept bare versions of texra.* keys (e.g. "model.useImprovedConnection")
+    (key.startsWith('texra.') && UNIFIED_TOP_LEVEL_KEYS.has(key)) ||
+    KNOWN_TEXRA_KEYS.has(`texra.${key}`)
+  );
 }
 
 function warnUnknownKeys(
@@ -67,7 +84,7 @@ function warnUnknownKeys(
   prefix = '',
 ): void {
   for (const key of Object.keys(record)) {
-    if (!allowed.has(key)) {
+    if (!allowed.has(key) && !isKnownConfigKey(prefix ? `${prefix}${key}` : key)) {
       warnings.push(`Ignoring unknown ${filePath} key "${prefix}${key}".`);
     }
   }
@@ -94,6 +111,8 @@ function collectValidationWarnings(
 ): string[] {
   const warnings: string[] = [];
   warnUnknownKeys(warnings, filePath, record, TOP_LEVEL_KEYS);
+
+  // Validate bare keys (legacy format)
   warnInvalidField(warnings, filePath, record, 'agent', NonEmptyStringSchema);
   warnInvalidField(warnings, filePath, record, 'model', ModelSchema);
   warnInvalidField(
@@ -108,6 +127,30 @@ function collectValidationWarnings(
     filePath,
     record,
     'approvalPolicy',
+    ApprovalPolicySchema,
+  );
+
+  // Validate texra.* prefixed keys (unified format)
+  warnInvalidField(
+    warnings,
+    filePath,
+    record,
+    'texra.agent',
+    NonEmptyStringSchema,
+  );
+  warnInvalidField(warnings, filePath, record, 'texra.model', ModelSchema);
+  warnInvalidField(
+    warnings,
+    filePath,
+    record,
+    'texra.outputFormat',
+    OutputFormatSchema,
+  );
+  warnInvalidField(
+    warnings,
+    filePath,
+    record,
+    'texra.approvalPolicy',
     ApprovalPolicySchema,
   );
 
@@ -161,20 +204,28 @@ function pickCommandConfig(record: Record<string, unknown>): CliCommandConfig {
   };
 }
 
+/** Look up a value by both bare and `texra.*` prefixed key — prefixed takes precedence. */
+function pickValue<T>(
+  record: Record<string, unknown>,
+  bareKey: string,
+  schema: z.ZodType<T>,
+): T | undefined {
+  const prefixedKey = `texra.${bareKey}`;
+  if (Object.hasOwn(record, prefixedKey)) {
+    return parseOptional(schema, record[prefixedKey]);
+  }
+  if (Object.hasOwn(record, bareKey)) {
+    return parseOptional(schema, record[bareKey]);
+  }
+  return undefined;
+}
+
 function pickConfigValues(record: Record<string, unknown>): CliConfigValues {
   return {
-    agent: Object.hasOwn(record, 'agent')
-      ? parseOptional(NonEmptyStringSchema, record.agent)
-      : undefined,
-    model: Object.hasOwn(record, 'model')
-      ? parseOptional(ModelSchema, record.model)
-      : undefined,
-    outputFormat: Object.hasOwn(record, 'outputFormat')
-      ? parseOptional(OutputFormatSchema, record.outputFormat)
-      : undefined,
-    approvalPolicy: Object.hasOwn(record, 'approvalPolicy')
-      ? parseOptional(ApprovalPolicySchema, record.approvalPolicy)
-      : undefined,
+    agent: pickValue(record, 'agent', NonEmptyStringSchema),
+    model: pickValue(record, 'model', ModelSchema),
+    outputFormat: pickValue(record, 'outputFormat', OutputFormatSchema),
+    approvalPolicy: pickValue(record, 'approvalPolicy', ApprovalPolicySchema),
     chat: isPlainRecord(record.chat)
       ? pickCommandConfig(record.chat)
       : undefined,

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -57,11 +57,6 @@ const ModelSchema = NonEmptyStringSchema.refine(
 const OutputFormatSchema = z.enum(CLI_OUTPUT_FORMATS);
 const ApprovalPolicySchema = z.enum(CLI_APPROVAL_POLICIES);
 
-/** Keys from the unified schema that the CLI config file accepts at the top level. */
-const UNIFIED_TOP_LEVEL_KEYS = new Set(
-  [...KNOWN_TEXRA_KEYS].filter((k) => k.startsWith('texra.')),
-);
-
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -69,9 +64,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 function isKnownConfigKey(key: string): boolean {
   return (
     TOP_LEVEL_KEYS.has(key) ||
-    UNIFIED_TOP_LEVEL_KEYS.has(key) ||
-    // Accept bare versions of texra.* keys (e.g. "model.useImprovedConnection")
-    (key.startsWith('texra.') && UNIFIED_TOP_LEVEL_KEYS.has(key)) ||
+    KNOWN_TEXRA_KEYS.has(key) ||
     KNOWN_TEXRA_KEYS.has(`texra.${key}`)
   );
 }
@@ -157,7 +150,7 @@ function collectValidationWarnings(
     ApprovalPolicySchema,
   );
 
-  for (const section of ['chat', 'run'] as const) {
+  for (const section of ['chat', 'run', 'texra.chat', 'texra.run'] as const) {
     if (!Object.hasOwn(record, section)) continue;
     const sectionValue = record[section];
     if (!isPlainRecord(sectionValue)) {
@@ -207,6 +200,17 @@ function pickCommandConfig(record: Record<string, unknown>): CliCommandConfig {
   };
 }
 
+function pickRecord(
+  record: Record<string, unknown>,
+  bareKey: string,
+): Record<string, unknown> | undefined {
+  const prefixedKey = `texra.${bareKey}`;
+  const prefixedValue = record[prefixedKey];
+  if (isPlainRecord(prefixedValue)) return prefixedValue;
+  const bareValue = record[bareKey];
+  return isPlainRecord(bareValue) ? bareValue : undefined;
+}
+
 /** Look up a value by both bare and `texra.*` prefixed key — prefixed takes precedence. */
 function pickValue<T>(
   record: Record<string, unknown>,
@@ -224,15 +228,15 @@ function pickValue<T>(
 }
 
 function pickConfigValues(record: Record<string, unknown>): CliConfigValues {
+  const chat = pickRecord(record, 'chat');
+  const run = pickRecord(record, 'run');
   return {
     agent: pickValue(record, 'agent', NonEmptyStringSchema),
     model: pickValue(record, 'model', ModelSchema),
     outputFormat: pickValue(record, 'outputFormat', OutputFormatSchema),
     approvalPolicy: pickValue(record, 'approvalPolicy', ApprovalPolicySchema),
-    chat: isPlainRecord(record.chat)
-      ? pickCommandConfig(record.chat)
-      : undefined,
-    run: isPlainRecord(record.run) ? pickCommandConfig(record.run) : undefined,
+    chat: chat ? pickCommandConfig(chat) : undefined,
+    run: run ? pickCommandConfig(run) : undefined,
   };
 }
 

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -84,7 +84,10 @@ function warnUnknownKeys(
   prefix = '',
 ): void {
   for (const key of Object.keys(record)) {
-    if (!allowed.has(key) && !isKnownConfigKey(prefix ? `${prefix}${key}` : key)) {
+    if (
+      !allowed.has(key) &&
+      !isKnownConfigKey(prefix ? `${prefix}${key}` : key)
+    ) {
       warnings.push(`Ignoring unknown ${filePath} key "${prefix}${key}".`);
     }
   }

--- a/packages/cli/src/runtime/cliConfigProvider.ts
+++ b/packages/cli/src/runtime/cliConfigProvider.ts
@@ -1,0 +1,137 @@
+import type {
+  ConfigInspection,
+  ConfigProvider,
+  ConfigTarget,
+} from '@platform/interfaces/config';
+import type { Disposable } from '@platform/interfaces/disposable';
+import type { JsonStore } from './jsonStore';
+
+type ConfigWatcher = {
+  key: string | readonly string[] | RegExp;
+  listener: () => void;
+};
+
+/**
+ * Canonical config key helpers — mirrors `ElectronConfigProvider`.
+ *
+ * Keys are stored flat in the JSON file. Both `texra.<key>` and bare `<key>`
+ * are accepted on read (prefixed tried first). Writes always use the canonical
+ * `texra.<key>` form.
+ */
+function configKeyVariants(key: string): string[] {
+  const unprefixed = key.startsWith('texra.')
+    ? key.slice('texra.'.length)
+    : key;
+  return [`texra.${unprefixed}`, unprefixed];
+}
+
+function canonicalConfigKey(key: string): string {
+  const unprefixed = key.startsWith('texra.')
+    ? key.slice('texra.'.length)
+    : key;
+  return `texra.${unprefixed}`;
+}
+
+function matchesConfigKey(candidate: string, changedKey: string): boolean {
+  return changedKey === candidate || changedKey.startsWith(`${candidate}.`);
+}
+
+function watcherMatches(
+  watcherKey: ConfigWatcher['key'],
+  changedKey: string,
+): boolean {
+  if (typeof watcherKey === 'string') {
+    return configKeyVariants(watcherKey).some((candidate) =>
+      matchesConfigKey(candidate, changedKey),
+    );
+  }
+  if (watcherKey instanceof RegExp) {
+    return watcherKey.test(changedKey);
+  }
+  if (Array.isArray(watcherKey)) {
+    return watcherKey.some((item) =>
+      configKeyVariants(item).some((candidate) =>
+        matchesConfigKey(candidate, changedKey),
+      ),
+    );
+  }
+  return false;
+}
+
+function firstStoredValue<T>(
+  store: JsonStore,
+  keys: readonly string[],
+): T | undefined {
+  for (const candidate of keys) {
+    if (store.has(candidate)) return store.get<T>(candidate);
+  }
+  return undefined;
+}
+
+/**
+ * File-backed {@link ConfigProvider} for the CLI host.
+ *
+ * Reads and writes a single JSON file (typically `.texra/config.json`) via
+ * the same {@link JsonStore} used by the Electron desktop host. Keys are
+ * stored flat with `texra.*` canonical prefixes — matching the VS Code
+ * extension's `texra.*` settings namespace.
+ */
+export class CliConfigProvider implements ConfigProvider {
+  private readonly watchers = new Set<ConfigWatcher>();
+
+  constructor(private readonly store: JsonStore) {}
+
+  get<T>(key: string, defaultValue?: T): T {
+    const keys = configKeyVariants(key);
+    const value = firstStoredValue<T>(this.store, keys);
+    return value !== undefined ? value : (defaultValue as T);
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    _target?: ConfigTarget,
+  ): Promise<void> {
+    const keys = configKeyVariants(key);
+    if (value === undefined) {
+      for (const candidate of keys) {
+        if (this.store.has(candidate)) {
+          await this.store.set(candidate, undefined);
+        }
+      }
+    } else {
+      const storedKey =
+        keys.find((candidate) => this.store.has(candidate)) ??
+        canonicalConfigKey(key);
+      await this.store.set(storedKey, value);
+    }
+    for (const watcher of this.watchers) {
+      if (watcherMatches(watcher.key, canonicalConfigKey(key))) {
+        watcher.listener();
+      }
+    }
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    const keys = configKeyVariants(key);
+    return {
+      workspaceValue: firstStoredValue<T>(this.store, keys),
+      effectiveValue: this.get<T>(key),
+    };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return configKeyVariants(key).some((candidate) =>
+      this.store.has(candidate),
+    );
+  }
+
+  watch(
+    key: string | readonly string[] | RegExp,
+    listener: () => void,
+  ): Disposable {
+    const watcher = { key, listener };
+    this.watchers.add(watcher);
+    return { dispose: () => this.watchers.delete(watcher) };
+  }
+}

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -23,7 +23,9 @@ import { setOutputChannelFactory } from '@logger/logUtils';
 // Local imports - CLI runtime
 import { getCliSecrets } from './cliSecrets';
 import { writeTextStderr } from './logSinks';
-import { MemoryConfigProvider } from './memoryStores';
+import { CliConfigProvider } from './cliConfigProvider';
+import { JsonStore } from './jsonStore';
+import { workspaceCliConfigPath } from './cliConfig';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
 
 // Type imports - platform and CLI runtime
@@ -79,8 +81,11 @@ export async function initCliPlatform(
   );
 
   if (!tryPlatform()) {
+    const configStore = await JsonStore.open(
+      workspaceCliConfigPath(cliWorkspaceCwd),
+    );
     initPlatform({
-      config: new MemoryConfigProvider(),
+      config: new CliConfigProvider(configStore),
       globalState: createMemoryStore(),
       workspaceState: createMemoryStore(),
       log: cliPlatformLog,

--- a/packages/cli/src/runtime/jsonStore.ts
+++ b/packages/cli/src/runtime/jsonStore.ts
@@ -1,0 +1,80 @@
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+
+async function readJsonRecord(filePath: string): Promise<JsonRecord> {
+  try {
+    const content = await readFile(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonRecord)
+      : {};
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    if (error instanceof SyntaxError) return {};
+    throw error;
+  }
+}
+
+/**
+ * Simple file-backed key-value store, persisted as a flat JSON object.
+ * Mirrors `packages/desktop/src/main/platform/jsonStore.ts`.
+ */
+export class JsonStore {
+  private writeChain = Promise.resolve();
+
+  private constructor(
+    private readonly filePath: string,
+    private data: JsonRecord,
+  ) {}
+
+  static async open(filePath: string): Promise<JsonStore> {
+    await mkdir(dirname(filePath), { recursive: true });
+    return new JsonStore(filePath, await readJsonRecord(filePath));
+  }
+
+  get<T>(key: string, defaultValue?: T): T {
+    const value = this.data[key];
+    return value === undefined ? (defaultValue as T) : (value as T);
+  }
+
+  has(key: string): boolean {
+    return Object.hasOwn(this.data, key);
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      delete this.data[key];
+    } else {
+      this.data[key] = value;
+    }
+    await this.enqueueFlush(this.snapshot());
+  }
+
+  snapshot(): JsonRecord {
+    return { ...this.data };
+  }
+
+  private async enqueueFlush(snapshot: JsonRecord): Promise<void> {
+    const flush = () => this.flush(snapshot);
+    this.writeChain = this.writeChain.then(flush, flush);
+    await this.writeChain;
+  }
+
+  private async flush(snapshot: JsonRecord): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      await writeFile(tempPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+      await rename(tempPath, this.filePath);
+    } catch (error) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // ignore
+      }
+      throw error;
+    }
+  }
+}

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -73,4 +73,25 @@ describe('CLI chat defaults', () => {
       source: 'mixed',
     });
   });
+
+  it('uses prefixed command-specific workspace defaults', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-chat-defaults-'));
+    await mkdir(join(workspace, '.texra'), { recursive: true });
+    await writeFile(
+      join(workspace, '.texra', 'config.json'),
+      JSON.stringify({
+        'texra.agent': 'generic',
+        'texra.model': 'gpt55',
+        'texra.chat': { agent: 'chat', model: 'deepseekT' },
+      }),
+    );
+
+    await expect(
+      resolveChatDefaults({ cwd: workspace }),
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'deepseekT',
+      source: 'workspace',
+    });
+  });
 });

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -83,6 +83,31 @@ describe('CLI context config defaults', () => {
     expect(loaded.warnings.join('\n')).toContain('chat.other');
   });
 
+  it('accepts prefixed command sections from unified workspace config', async () => {
+    const workspace = await workspaceWithConfig(
+      JSON.stringify({
+        'texra.agent': 'generic',
+        'texra.model': 'gpt55',
+        'texra.chat': { agent: 'chat', model: 'deepseekT' },
+        'texra.run': { agent: 'criticize', model: 'sonnet46T' },
+      }),
+    );
+
+    const loaded = await loadWorkspaceCliConfig(workspace);
+
+    expect(loaded.values.agent).toBe('generic');
+    expect(loaded.values.model).toBe('gpt55');
+    expect(loaded.values.chat).toEqual({
+      agent: 'chat',
+      model: 'deepseekT',
+    });
+    expect(loaded.values.run).toEqual({
+      agent: 'criticize',
+      model: 'sonnet46T',
+    });
+    expect(loaded.warnings).toEqual([]);
+  });
+
   it('canonicalizes existing workspace paths before reading config', async () => {
     const root = await mkdtemp(join(tmpdir(), 'texra-cli-context-link-'));
     const workspace = join(root, 'workspace');

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -1,2 +1,3 @@
 export * from './configUtils';
 export * from './constants';
+export * from './settingsSchema';

--- a/src/utils/config/settingsSchema.ts
+++ b/src/utils/config/settingsSchema.ts
@@ -173,10 +173,7 @@ export const TEXRA_SETTINGS = {
   // -- CLI runtime ---------------------------------------------------------
   'texra.agent': entry(z.string().trim().min(1).optional(), undefined),
   'texra.model': entry(z.string().trim().min(1).optional(), undefined),
-  'texra.outputFormat': entry(
-    z.enum(CLI_OUTPUT_FORMATS).optional(),
-    undefined,
-  ),
+  'texra.outputFormat': entry(z.enum(CLI_OUTPUT_FORMATS).optional(), undefined),
   'texra.approvalPolicy': entry(
     z.enum(CLI_APPROVAL_POLICIES).optional(),
     undefined,

--- a/src/utils/config/settingsSchema.ts
+++ b/src/utils/config/settingsSchema.ts
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// CLI-specific enums
+// ---------------------------------------------------------------------------
+
+export const CLI_OUTPUT_FORMATS = ['text', 'json', 'ndjson'] as const;
+export type CliOutputFormat = (typeof CLI_OUTPUT_FORMATS)[number];
+
+export const CLI_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
+export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
+
+// ---------------------------------------------------------------------------
+// Per-key schema registry
+// ---------------------------------------------------------------------------
+
+interface SettingEntry<T> {
+  readonly schema: z.ZodType<T>;
+  readonly default: T;
+}
+
+function entry<T>(schema: z.ZodType<T>, defaultValue: T): SettingEntry<T> {
+  return { schema, default: defaultValue };
+}
+
+export const TEXRA_SETTINGS = {
+  // -- Agent outputs -------------------------------------------------------
+  'texra.agentOutputs.autoOpenFinal': entry(z.boolean(), true),
+
+  // -- Inline criticism ----------------------------------------------------
+  'texra.inlineCriticism.enabled': entry(z.boolean(), false),
+
+  // -- Experimental --------------------------------------------------------
+  'texra.experimental.odyssey.enabled': entry(z.boolean(), false),
+
+  // -- UI toggles ----------------------------------------------------------
+  'texra.ui.showApiKeyReminders': entry(z.boolean(), true),
+  'texra.ui.showLoginBanner': entry(z.boolean(), true),
+  'texra.ui.showGettingStartedBanner': entry(z.boolean(), true),
+  'texra.ui.showOrchestratorBanner': entry(z.boolean(), true),
+
+  // -- Auth ----------------------------------------------------------------
+  'texra.auth.enableVSCodeGitHub': entry(z.boolean(), false),
+
+  // -- Model ---------------------------------------------------------------
+  'texra.model.useImprovedConnection': entry(z.boolean(), false),
+  'texra.model.improvedConnectionDomain': entry(z.string(), 'proxy.texra.ai'),
+  'texra.model.useOpenAIResponsesAPI': entry(z.boolean(), false),
+  'texra.model.useBackgroundResponses': entry(z.boolean(), false),
+  'texra.model.openaiParallelToolCalls': entry(z.boolean(), true),
+  'texra.model.compactionThresholdPercent': entry(
+    z.number().min(0).max(100),
+    70,
+  ),
+  'texra.model.gpt5ReasoningSummary': entry(z.string(), 'detailed'),
+
+  // -- Model retry ---------------------------------------------------------
+  'texra.model.retry.maxAttempts': entry(z.number().int().min(1), 3),
+  'texra.model.retry.backoffMs': entry(z.number().int().min(0), 500),
+
+  // -- Files: included extensions ------------------------------------------
+  'texra.files.included.mediaExtensions': entry(z.array(z.string()), [
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.pdf',
+    '.gif',
+    '.svg',
+  ]),
+  'texra.files.included.inputExtensions': entry(z.array(z.string()), ['.tex']),
+  'texra.files.included.contextExtensions': entry(z.array(z.string()), [
+    '.tex',
+    '.bib',
+    '.cls',
+    '.sty',
+    '.bst',
+    '.cfg',
+    '.def',
+    '.clo',
+    '.bbx',
+    '.cbx',
+    '.lbx',
+    '.tikz',
+    '.eps',
+    '.svg',
+  ]),
+  'texra.files.included.editedExtensions': entry(z.array(z.string()), ['.tex']),
+
+  // -- Files: ignored ------------------------------------------------------
+  'texra.files.ignored.fileExtensions': entry(z.array(z.string()), [
+    '.aux',
+    '.bbl',
+    '.blg',
+    '.fdb_latexmk',
+    '.fls',
+    '.log',
+    '.out',
+    '.synctex.gz',
+    '.toc',
+    '.pdf',
+    '.dvi',
+    '.ps',
+    '.gz',
+    '.zip',
+    '.tar',
+    '.lol',
+    '.lot',
+    '.lof',
+    '.bcf',
+    '.run.xml',
+    '.xdv',
+    '.idx',
+    '.ilg',
+    '.ind',
+  ]),
+  'texra.files.ignored.inputFiles': entry(z.array(z.string()), []),
+  'texra.files.ignored.inputDirectories': entry(z.array(z.string()), []),
+  'texra.files.ignored.mediaDirectories': entry(z.array(z.string()), []),
+  'texra.files.ignored.directories': entry(z.array(z.string()), [
+    '.git',
+    '.vscode',
+    'node_modules',
+    '__pycache__',
+    'build',
+    'dist',
+    'out',
+    'target',
+  ]),
+  'texra.files.ignored.keywords': entry(z.array(z.string()), []),
+
+  // -- Images --------------------------------------------------------------
+  'texra.maxImageDimension': entry(z.number().int().min(1), 2000),
+
+  // -- Bibliography --------------------------------------------------------
+  'texra.bib.defaultPath': entry(z.string(), ''),
+  'texra.bib.zoteroPort': entry(z.number().int().min(1).max(65535), 23119),
+
+  // -- LaTeX ---------------------------------------------------------------
+  'texra.latex.showLatexindentWarning': entry(z.boolean(), true),
+  'texra.latex.latexindentConfig': entry(z.string(), ''),
+  'texra.latex.texfmtConfig': entry(z.string(), ''),
+  'texra.latex.tikzInputDirectory': entry(z.string(), ''),
+  'texra.latex.tikzTemplate': entry(z.string(), ''),
+  'texra.latex.includeWorkspaceInTexinputs': entry(z.boolean(), false),
+  'texra.latex.wrapCritiqueInAlign': entry(z.boolean(), true),
+
+  // -- LaTeX diff ----------------------------------------------------------
+  'texra.latexdiff.pictureEnvironments': entry(z.array(z.string()), [
+    'tikzpicture',
+    'pgfpicture',
+  ]),
+  'texra.latexdiff.tempFileLocation': entry(z.string(), ''),
+
+  // -- LaTeX replacements --------------------------------------------------
+  'texra.latex.enabledReplacements': entry(z.array(z.string()), []),
+  'texra.latex.enabledReplacementsRegex': entry(z.array(z.string()), []),
+  'texra.latex.customReplacementsRegex': entry(z.array(z.string()), []),
+  'texra.latex.customReplacements': entry(z.array(z.string()), []),
+
+  // -- Tool use ------------------------------------------------------------
+  'texra.toolUse.persistence.enabled': entry(z.boolean(), true),
+  'texra.toolUse.persistence.ttlHours': entry(z.number().int().min(0), 72),
+  'texra.toolUse.requireBashApproval': entry(z.boolean(), true),
+  'texra.toolUse.requireEditApproval': entry(z.boolean(), false),
+
+  // -- Logger --------------------------------------------------------------
+  'texra.logger.debugMode': entry(z.boolean(), false),
+
+  // -- Git -----------------------------------------------------------------
+  'texra.git.numberOfCommitsToShow': entry(z.number().int().min(0), 20),
+  'texra.git.emitPrCiStartedEvents': entry(z.boolean(), false),
+
+  // -- CLI runtime ---------------------------------------------------------
+  'texra.agent': entry(z.string().trim().min(1).optional(), undefined),
+  'texra.model': entry(z.string().trim().min(1).optional(), undefined),
+  'texra.outputFormat': entry(
+    z.enum(CLI_OUTPUT_FORMATS).optional(),
+    undefined,
+  ),
+  'texra.approvalPolicy': entry(
+    z.enum(CLI_APPROVAL_POLICIES).optional(),
+    undefined,
+  ),
+  'texra.chat': entry(
+    z
+      .object({
+        agent: z.string().trim().min(1).optional(),
+        model: z.string().trim().min(1).optional(),
+      })
+      .optional(),
+    undefined,
+  ),
+  'texra.run': entry(
+    z
+      .object({
+        agent: z.string().trim().min(1).optional(),
+        model: z.string().trim().min(1).optional(),
+      })
+      .optional(),
+    undefined,
+  ),
+} as const;
+
+export type TexraSettingsKey = keyof typeof TEXRA_SETTINGS;
+
+// ---------------------------------------------------------------------------
+// Derived helpers
+// ---------------------------------------------------------------------------
+
+/** Set of all known texra.* config keys. */
+export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(TEXRA_SETTINGS),
+);
+
+/** Get the default value for a known key, or undefined. */
+export function getSettingDefault(key: string): unknown {
+  const entry = TEXRA_SETTINGS[key as TexraSettingsKey];
+  return entry?.default;
+}
+
+/** Validate a single key-value pair against its registered schema. */
+export function validateSettingValue(
+  key: string,
+  value: unknown,
+): { success: true; data: unknown } | { success: false; error: z.ZodError } {
+  const entry = TEXRA_SETTINGS[key as TexraSettingsKey];
+  if (!entry) {
+    return { success: true, data: value };
+  }
+  return entry.schema.safeParse(value);
+}
+
+/**
+ * Validate a flat record of key-value pairs against the registered schemas.
+ * Returns only entries whose keys are known and whose values pass validation.
+ */
+export function validateSettingsRecord(
+  record: Record<string, unknown>,
+): Map<string, unknown> {
+  const result = new Map<string, unknown>();
+  for (const [key, value] of Object.entries(record)) {
+    const parsed = validateSettingValue(key, value);
+    if (parsed.success) {
+      result.set(key, parsed.data);
+    }
+  }
+  return result;
+}

--- a/src/utils/config/settingsSchema.ts
+++ b/src/utils/config/settingsSchema.ts
@@ -208,38 +208,3 @@ export type TexraSettingsKey = keyof typeof TEXRA_SETTINGS;
 export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set(
   Object.keys(TEXRA_SETTINGS),
 );
-
-/** Get the default value for a known key, or undefined. */
-export function getSettingDefault(key: string): unknown {
-  const entry = TEXRA_SETTINGS[key as TexraSettingsKey];
-  return entry?.default;
-}
-
-/** Validate a single key-value pair against its registered schema. */
-export function validateSettingValue(
-  key: string,
-  value: unknown,
-): { success: true; data: unknown } | { success: false; error: z.ZodError } {
-  const entry = TEXRA_SETTINGS[key as TexraSettingsKey];
-  if (!entry) {
-    return { success: true, data: value };
-  }
-  return entry.schema.safeParse(value);
-}
-
-/**
- * Validate a flat record of key-value pairs against the registered schemas.
- * Returns only entries whose keys are known and whose values pass validation.
- */
-export function validateSettingsRecord(
-  record: Record<string, unknown>,
-): Map<string, unknown> {
-  const result = new Map<string, unknown>();
-  for (const [key, value] of Object.entries(record)) {
-    const parsed = validateSettingValue(key, value);
-    if (parsed.success) {
-      result.set(key, parsed.data);
-    }
-  }
-  return result;
-}


### PR DESCRIPTION
….* settings schema

- Introduce `src/utils/config/settingsSchema.ts` as the single source of truth for all texra.* config keys, with Zod schemas and defaults for every setting registered in the VS Code extension's package.json plus CLI runtime keys.
- Add `CliConfigProvider` — a file-backed ConfigProvider for the CLI host that reads/writes `.texra/config.json` via the same JsonStore used by the Electron host. Both texra.<key> and bare <key> forms are accepted on read; writes always use the canonical texra.* prefix.
- Update `loadWorkspaceCliConfig` to recognise texra.* prefixed keys alongside legacy bare keys, so either format is valid in the workspace config file.
- Replace `MemoryConfigProvider` in `initCliPlatform` with `CliConfigProvider` wired to the workspace config file.
- Switch `chatDefaults`'s workspace tier to read from `getConfig()` through the platform provider instead of parsing the config file independently.
- Export the new schema from `@utils/config`.

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the CLI reads/writes workspace configuration (including key precedence and persistence), which can alter defaults and warnings for existing projects.
> 
> **Overview**
> CLI workspace configuration is updated to support the unified `texra.*` settings namespace alongside legacy bare keys, with **prefixed keys taking precedence** and expanded validation/warning logic for both formats.
> 
> The CLI platform now initializes with a file-backed `CliConfigProvider` (backed by a new `JsonStore`) reading `.texra/config.json`, instead of an in-memory provider. Chat default resolution is adjusted to consume command-specific defaults from the unified config shape (and the `runChatTui` call no longer passes `workspaceConfig`).
> 
> A new shared `src/utils/config/settingsSchema.ts` exports a Zod-backed registry of known `texra.*` keys (and `KNOWN_TEXRA_KEYS`), and tests are extended to cover prefixed workspace config sections and chat defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da3ed2d9f3cefbfe06ffb5137e6b625ea1a6104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->