### PR TITLE
feat(cli): add latex command surface

### DIFF
--- a/packages/cli/src/commands/latex.ts
+++ b/packages/cli/src/commands/latex.ts
@@ -129,13 +129,14 @@ async function initLatexCliPlatform(context: CliContext): Promise<void> {
 }
 
 async function assertReadableFile(filePath: string): Promise<void> {
+  let stats: Awaited<ReturnType<typeof fs.stat>>;
   try {
-    const stats = await fs.stat(filePath);
-    if (!stats.isFile()) {
-      throw new Error(`${filePath} is not a file.`);
-    }
+    stats = await fs.stat(filePath);
   } catch (error) {
     throw new Error(`Cannot read ${filePath}: ${toErrorMessage(error)}`);
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Cannot read ${filePath}: not a regular file.`);
   }
 }
 

--- a/packages/cli/src/commands/latex.ts
+++ b/packages/cli/src/commands/latex.ts
@@ -367,10 +367,13 @@ async function runLatexFigures(
   const filePath = resolveCliPath(context.cwd, file);
   await assertReadableFile(filePath);
   const paths = await extractFigurePathsFromLatex(pathToLocation(filePath));
+  const latexDir = path.dirname(filePath);
   return {
     kind: 'latex-figs',
     file: displayCliPath(context.cwd, filePath),
-    paths,
+    paths: paths.map((figurePath) =>
+      displayCliPath(context.cwd, path.resolve(latexDir, figurePath)),
+    ),
   };
 }
 

--- a/packages/cli/src/commands/latex.ts
+++ b/packages/cli/src/commands/latex.ts
@@ -1,0 +1,594 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { defineCommand } from 'citty';
+import { z } from 'zod';
+
+import { toErrorMessage } from '@common/errors/errorMessage';
+import { arxivProcessor } from '@latex/arxivProcessor';
+import {
+  extractBibliographyContext,
+  loadBibliographyEntries,
+} from '@latex/extractBibliography';
+import { extractFigurePathsFromLatex } from '@latex/extractFigure';
+import { extractLatexFileDependencies } from '@latex/extractFileDependencies';
+import { LaTeXdiffService } from '@latex/latexdiff';
+import { runLatexFormatter } from '@latex/texFormatter';
+import { getTeXCount, TexcountModeSchema } from '@latex/texcount';
+import { tikzPictureManager } from '@latex/TikzPictureManager';
+import { pathToLocation } from '@utils/files';
+
+import { CliExitCode } from '../runtime/exitCodes';
+import { initCliPlatform } from '../runtime/initPlatform';
+import {
+  writeNdjsonStdout,
+  writeTextStderr,
+  writeTextStdout,
+} from '../runtime/logSinks';
+import type { CliContext } from '../runtime/cliContext';
+import type { ParsedGlobalArgs } from '../runtime/globalArgs';
+
+const LatexDiffResultSchema = z.object({
+  kind: z.literal('latex-diff'),
+  oldFile: z.string(),
+  newFile: z.string(),
+  outputFile: z.string(),
+});
+
+const LatexCountSummarySchema = z.object({
+  wordsInText: z.number().nullable(),
+  wordsInHeaders: z.number().nullable(),
+  wordsOutsideText: z.number().nullable(),
+  totalWords: z.number().nullable(),
+  sourceCharacters: z.number().nullable(),
+});
+
+const LatexCountResultSchema = z.object({
+  kind: z.literal('latex-count'),
+  files: z.array(z.string()),
+  mode: TexcountModeSchema,
+  summary: LatexCountSummarySchema,
+  output: z.string().nullable(),
+  errors: z.array(z.string()),
+});
+
+const LatexPathListResultSchema = z.object({
+  kind: z.enum(['latex-figs', 'latex-deps', 'latex-tikz']),
+  file: z.string(),
+  paths: z.array(z.string()),
+});
+
+const LatexBibliographyResultSchema = z.object({
+  kind: z.literal('latex-bib'),
+  file: z.string(),
+  bibliographyFiles: z.array(z.string()),
+  missingBibliographyFiles: z.array(z.string()),
+  citationKeys: z.array(z.string()),
+  missingKeys: z.array(z.string()),
+  entries: z.record(z.string(), z.string()),
+});
+
+const LatexFormatResultSchema = z.object({
+  kind: z.literal('latex-fmt'),
+  file: z.string(),
+  formatted: z.boolean(),
+});
+
+const LatexArxivResultSchema = z.object({
+  kind: z.literal('latex-arxiv'),
+  id: z.string(),
+  path: z.string(),
+  alreadyExisted: z.boolean(),
+});
+
+export const LatexCliResultSchema = z.discriminatedUnion('kind', [
+  LatexDiffResultSchema,
+  LatexCountResultSchema,
+  LatexPathListResultSchema,
+  LatexBibliographyResultSchema,
+  LatexFormatResultSchema,
+  LatexArxivResultSchema,
+]);
+
+export type LatexCliResult = z.infer<typeof LatexCliResultSchema>;
+
+type GlobalArgsDef = Record<string, unknown>;
+const cliLatexdiffService = new LaTeXdiffService();
+
+interface LatexCommandDependencies {
+  readonly globalArgs: GlobalArgsDef;
+  readonly contextFromArgs: (args: ParsedGlobalArgs) => Promise<CliContext>;
+  readonly setExitCode: (code: number) => void;
+}
+
+function resolveCliPath(cwd: string, candidate: string): string {
+  return path.isAbsolute(candidate)
+    ? path.resolve(candidate)
+    : path.resolve(cwd, candidate);
+}
+
+function displayCliPath(cwd: string, candidate: string): string {
+  const absolutePath = resolveCliPath(cwd, candidate);
+  const relativePath = path.relative(cwd, absolutePath);
+  if (
+    relativePath &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  ) {
+    return relativePath.replaceAll(path.sep, '/');
+  }
+  return absolutePath;
+}
+
+async function initLatexCliPlatform(context: CliContext): Promise<void> {
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+}
+
+async function assertReadableFile(filePath: string): Promise<void> {
+  try {
+    const stats = await fs.stat(filePath);
+    if (!stats.isFile()) {
+      throw new Error(`${filePath} is not a file.`);
+    }
+  } catch (error) {
+    throw new Error(`Cannot read ${filePath}: ${toErrorMessage(error)}`);
+  }
+}
+
+function parseTexcountNumber(output: string, label: string): number | null {
+  const escaped = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(
+    `${escaped}(?:\\s*\\([^)]*\\))?:\\s*(\\d+)`,
+    'i',
+  ).exec(output);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+export function summarizeTexcountOutput(
+  output: string | null,
+): z.infer<typeof LatexCountSummarySchema> {
+  if (!output) {
+    return {
+      wordsInText: null,
+      wordsInHeaders: null,
+      wordsOutsideText: null,
+      totalWords: null,
+      sourceCharacters: null,
+    };
+  }
+
+  const wordsInText = parseTexcountNumber(output, 'Words in text');
+  const wordsInHeaders = parseTexcountNumber(output, 'Words in headers');
+  const wordsOutsideText = parseTexcountNumber(output, 'Words outside text');
+  const parts = [wordsInText, wordsInHeaders, wordsOutsideText];
+  const totalWords = parts.every((part) => part !== null)
+    ? parts.reduce((sum, part) => sum + (part ?? 0), 0)
+    : null;
+
+  return {
+    wordsInText,
+    wordsInHeaders,
+    wordsOutsideText,
+    totalWords,
+    sourceCharacters: null,
+  };
+}
+
+function formatLatexCliResultText(result: LatexCliResult): string {
+  switch (result.kind) {
+    case 'latex-diff':
+      return result.outputFile;
+    case 'latex-count': {
+      const total =
+        result.summary.totalWords === null
+          ? 'unknown'
+          : String(result.summary.totalWords);
+      const body = result.output ?? 'No texcount output.';
+      const characters =
+        result.summary.sourceCharacters === null
+          ? 'unknown'
+          : String(result.summary.sourceCharacters);
+      const errors = result.errors.length
+        ? `\n\nWarnings:\n${result.errors.join('\n')}`
+        : '';
+      return `Total words: ${total}\nSource characters: ${characters}\n\n${body}${errors}`;
+    }
+    case 'latex-figs':
+    case 'latex-deps':
+    case 'latex-tikz':
+      return result.paths.length ? result.paths.join('\n') : 'No files found.';
+    case 'latex-bib': {
+      const entries = Object.values(result.entries);
+      const sections = [
+        result.bibliographyFiles.length
+          ? `Bibliography files:\n${result.bibliographyFiles.join('\n')}`
+          : 'Bibliography files: none',
+        result.citationKeys.length
+          ? `Citation keys:\n${result.citationKeys.join('\n')}`
+          : 'Citation keys: none',
+        entries.length ? `Entries:\n${entries.join('\n\n')}` : 'Entries: none',
+      ];
+      if (result.missingBibliographyFiles.length) {
+        sections.push(
+          `Missing bibliography files:\n${result.missingBibliographyFiles.join('\n')}`,
+        );
+      }
+      if (result.missingKeys.length) {
+        sections.push(
+          `Missing citation keys:\n${result.missingKeys.join('\n')}`,
+        );
+      }
+      return sections.join('\n\n');
+    }
+    case 'latex-fmt':
+      return result.formatted
+        ? `Formatted ${result.file}.`
+        : `Could not format ${result.file}.`;
+    case 'latex-arxiv':
+      return result.alreadyExisted
+        ? `Already downloaded: ${result.path}`
+        : result.path;
+  }
+}
+
+function writeLatexCliResult(
+  context: CliContext,
+  result: LatexCliResult,
+): void {
+  const parsed = LatexCliResultSchema.parse(result);
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(parsed, null, 2));
+  } else if (context.outputFormat === 'ndjson') {
+    writeNdjsonStdout({
+      kind: 'latex-result',
+      ts: new Date().toISOString(),
+      result: parsed,
+    });
+  } else {
+    writeTextStdout(formatLatexCliResultText(parsed));
+  }
+}
+
+async function runLatexAction(
+  deps: LatexCommandDependencies,
+  args: unknown,
+  action: (context: CliContext) => Promise<LatexCliResult>,
+): Promise<void> {
+  const context = await deps.contextFromArgs(args as ParsedGlobalArgs);
+  try {
+    await initLatexCliPlatform(context);
+    const result = await action(context);
+    writeLatexCliResult(context, result);
+    deps.setExitCode(CliExitCode.Success);
+  } catch (error) {
+    writeTextStderr(toErrorMessage(error));
+    deps.setExitCode(CliExitCode.AgentError);
+  }
+}
+
+async function runLatexDiff(
+  context: CliContext,
+  oldFile: string,
+  newFile: string,
+  outputFile?: string,
+): Promise<LatexCliResult> {
+  const oldPath = resolveCliPath(context.cwd, oldFile);
+  const newPath = resolveCliPath(context.cwd, newFile);
+  await Promise.all([assertReadableFile(oldPath), assertReadableFile(newPath)]);
+
+  const requestedOutputPath = outputFile
+    ? resolveCliPath(context.cwd, outputFile)
+    : undefined;
+  const outputDirectory = requestedOutputPath
+    ? path.dirname(requestedOutputPath)
+    : path.dirname(newPath);
+  const result = await cliLatexdiffService.runDiff(
+    pathToLocation(oldPath),
+    pathToLocation(newPath),
+    '_diff',
+    false,
+    undefined,
+    { cwd: context.cwd, outputDirectory },
+  );
+  if (!result.success || !result.diffFileName) {
+    throw new Error(result.message || 'latexdiff failed.');
+  }
+
+  const generatedPath = path.join(outputDirectory, result.diffFileName);
+  const finalPath = requestedOutputPath ?? generatedPath;
+  if (path.resolve(generatedPath) !== path.resolve(finalPath)) {
+    await fs.mkdir(path.dirname(finalPath), { recursive: true });
+    await fs.rename(generatedPath, finalPath);
+  }
+
+  return {
+    kind: 'latex-diff',
+    oldFile: displayCliPath(context.cwd, oldPath),
+    newFile: displayCliPath(context.cwd, newPath),
+    outputFile: displayCliPath(context.cwd, finalPath),
+  };
+}
+
+async function runLatexCount(
+  context: CliContext,
+  file: string,
+  mode: unknown,
+): Promise<LatexCliResult> {
+  const parsedMode = TexcountModeSchema.catch('separate').parse(mode);
+  const filePath = resolveCliPath(context.cwd, file);
+  const result = await getTeXCount(filePath, {
+    mode: parsedMode,
+    channel: 'LaTeXCommands',
+  });
+  if (!result.output) {
+    throw new Error(
+      result.errors.join('\n') ||
+        'texcount produced no output. Check that texcount is installed.',
+    );
+  }
+  return {
+    kind: 'latex-count',
+    files: [displayCliPath(context.cwd, filePath)],
+    mode: parsedMode,
+    summary: {
+      ...summarizeTexcountOutput(result.output),
+      sourceCharacters: (await fs.readFile(filePath, 'utf8')).length,
+    },
+    output: result.output,
+    errors: result.errors,
+  };
+}
+
+async function runLatexArxiv(
+  context: CliContext,
+  id: string,
+  into?: string,
+): Promise<LatexCliResult> {
+  const result = await arxivProcessor.downloadSource(id, {
+    autoIndent: false,
+    ...(into ? { into } : {}),
+  });
+  return {
+    kind: 'latex-arxiv',
+    id,
+    path: displayCliPath(context.cwd, result.path),
+    alreadyExisted: result.alreadyExisted,
+  };
+}
+
+async function runLatexFigures(
+  context: CliContext,
+  file: string,
+): Promise<LatexCliResult> {
+  const filePath = resolveCliPath(context.cwd, file);
+  await assertReadableFile(filePath);
+  const paths = await extractFigurePathsFromLatex(pathToLocation(filePath));
+  return {
+    kind: 'latex-figs',
+    file: displayCliPath(context.cwd, filePath),
+    paths,
+  };
+}
+
+async function runLatexDependencies(
+  context: CliContext,
+  file: string,
+): Promise<LatexCliResult> {
+  const filePath = resolveCliPath(context.cwd, file);
+  await assertReadableFile(filePath);
+  const paths = await extractLatexFileDependencies(pathToLocation(filePath));
+  return {
+    kind: 'latex-deps',
+    file: displayCliPath(context.cwd, filePath),
+    paths: paths.map((p) => displayCliPath(context.cwd, p)),
+  };
+}
+
+async function runLatexBibliography(
+  context: CliContext,
+  file: string,
+): Promise<LatexCliResult> {
+  const filePath = resolveCliPath(context.cwd, file);
+  await assertReadableFile(filePath);
+  const reference = await extractBibliographyContext(
+    displayCliPath(context.cwd, filePath),
+  );
+  const entries = await loadBibliographyEntries(
+    reference.bibliographyFiles,
+    reference.citationKeys,
+  );
+  return {
+    kind: 'latex-bib',
+    file: displayCliPath(context.cwd, filePath),
+    bibliographyFiles: reference.bibliographyFiles,
+    missingBibliographyFiles: reference.missingBibliographyFiles,
+    citationKeys: reference.citationKeys,
+    missingKeys: entries.missingKeys,
+    entries: Object.fromEntries(entries.entries),
+  };
+}
+
+async function runLatexFormat(
+  context: CliContext,
+  file: string,
+): Promise<LatexCliResult> {
+  const filePath = resolveCliPath(context.cwd, file);
+  await assertReadableFile(filePath);
+  const formatted = await runLatexFormatter(filePath);
+  if (!formatted) {
+    throw new Error(
+      'Formatter failed. Check that latexindent or tex-fmt is installed and configured.',
+    );
+  }
+  return {
+    kind: 'latex-fmt',
+    file: displayCliPath(context.cwd, filePath),
+    formatted,
+  };
+}
+
+async function runLatexTikz(
+  context: CliContext,
+  file: string,
+): Promise<LatexCliResult> {
+  const filePath = resolveCliPath(context.cwd, file);
+  await assertReadableFile(filePath);
+  const compiled = await tikzPictureManager.compile(pathToLocation(filePath));
+  return {
+    kind: 'latex-tikz',
+    file: displayCliPath(context.cwd, filePath),
+    paths: compiled.map((location) =>
+      displayCliPath(context.cwd, location.absolutePath),
+    ),
+  };
+}
+
+export function createLatexCommand(deps: LatexCommandDependencies) {
+  const globalArgs = deps.globalArgs;
+
+  const diff = defineCommand({
+    meta: { name: 'diff', description: 'Run latexdiff on two LaTeX files' },
+    args: {
+      ...globalArgs,
+      old: { type: 'positional', required: true, description: 'Old .tex file' },
+      new: { type: 'positional', required: true, description: 'New .tex file' },
+      out: { type: 'string', description: 'Output diff .tex file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexDiff(context, ctx.args.old, ctx.args.new, ctx.args.out),
+      );
+    },
+  });
+
+  const count = defineCommand({
+    meta: { name: 'count', description: 'Run texcount on a LaTeX file' },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+      mode: {
+        type: 'enum',
+        options: TexcountModeSchema.options,
+        description: 'texcount mode',
+      },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexCount(context, ctx.args.file, ctx.args.mode),
+      );
+    },
+  });
+
+  const arxiv = defineCommand({
+    meta: { name: 'arxiv', description: 'Download arXiv source files' },
+    args: {
+      ...globalArgs,
+      id: {
+        type: 'positional',
+        required: true,
+        description: 'arXiv id or URL',
+      },
+      into: {
+        type: 'string',
+        description: 'Workspace-relative destination directory',
+      },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexArxiv(context, ctx.args.id, ctx.args.into),
+      );
+    },
+  });
+
+  const figs = defineCommand({
+    meta: {
+      name: 'figs',
+      description: 'List figures referenced by a LaTeX file',
+    },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexFigures(context, ctx.args.file),
+      );
+    },
+  });
+
+  const depsCommand = defineCommand({
+    meta: {
+      name: 'deps',
+      description: 'List LaTeX input and bibliography dependencies',
+    },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexDependencies(context, ctx.args.file),
+      );
+    },
+  });
+
+  const bib = defineCommand({
+    meta: {
+      name: 'bib',
+      description: 'Extract bibliography context for a LaTeX file',
+    },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexBibliography(context, ctx.args.file),
+      );
+    },
+  });
+
+  const fmt = defineCommand({
+    meta: { name: 'fmt', description: 'Format a LaTeX file' },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexFormat(context, ctx.args.file),
+      );
+    },
+  });
+
+  const tikz = defineCommand({
+    meta: { name: 'tikz', description: 'Extract and compile TikZ pictures' },
+    args: {
+      ...globalArgs,
+      file: { type: 'positional', required: true, description: 'LaTeX file' },
+    },
+    async run(ctx) {
+      await runLatexAction(deps, ctx.args, (context) =>
+        runLatexTikz(context, ctx.args.file),
+      );
+    },
+  });
+
+  return defineCommand({
+    meta: { name: 'latex', description: 'LaTeX utilities' },
+    subCommands: {
+      diff,
+      count,
+      arxiv,
+      figs,
+      deps: depsCommand,
+      bib,
+      fmt,
+      tikz,
+    },
+  });
+}

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -88,6 +88,7 @@ import {
   readCliHistoryConfig,
   readCliHistoryDetails,
 } from '../runtime/history';
+import { createLatexCommand } from './latex';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after
@@ -1187,6 +1188,12 @@ const chatCommand = defineCommand({
   },
 });
 
+const latexCommand = createLatexCommand({
+  globalArgs: GLOBAL_ARGS,
+  contextFromArgs,
+  setExitCode,
+});
+
 const helpCommand = defineCommand({
   meta: { name: 'help', description: 'Show TeXRA CLI commands' },
   async run() {
@@ -1238,6 +1245,7 @@ export const rootCommand = defineCommand({
   subCommands: {
     chat: chatCommand,
     run: runWorkflowCommand,
+    latex: latexCommand,
     resume: resumeCommand,
     history: historyCommand,
     agents: agentsCommand,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -29,6 +29,8 @@ export interface DownloadSourceOptions {
   progressCallback?: (msg: string, increment?: number) => void;
   autoIndent?: boolean;
   destination?: ArxivDownloadDestination;
+  /** Workspace-relative destination directory. Defaults to References/<id>. */
+  into?: string;
 }
 
 const INVALID_ARXIV_INPUT_ERROR =
@@ -188,6 +190,7 @@ export class ArxivSourceProcessor {
       progressCallback,
       autoIndent = true,
       destination = 'references',
+      into,
     } = options;
 
     // Normalize input (URL or ID) to plain arXiv ID
@@ -203,11 +206,14 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    const isRoot = destination === 'root';
+    const isRoot = destination === 'root' && !into;
     // Use forward slashes to match WorkspaceFS.relativePath() convention (not path.join which uses backslashes on Windows)
     const paperDirRelative = isRoot
       ? '.'
-      : `References/${id.replaceAll('/', '_')}`;
+      : (into?.trim() || `References/${id.replaceAll('/', '_')}`).replaceAll(
+          path.sep,
+          '/',
+        );
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -36,6 +36,28 @@ export interface DownloadSourceOptions {
 const INVALID_ARXIV_INPUT_ERROR =
   'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
 
+function normalizeWorkspaceRelativeDirectory(candidate: string): string {
+  return candidate
+    .trim()
+    .replaceAll(path.sep, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+}
+
+export function resolveArxivPaperDirectoryRelative(
+  id: string,
+  options: Pick<DownloadSourceOptions, 'destination' | 'into'> = {},
+): string {
+  const paperDirName = id.replaceAll('/', '_');
+  const customRoot = options.into
+    ? normalizeWorkspaceRelativeDirectory(options.into)
+    : '';
+  if (customRoot) {
+    return customRoot === '.' ? paperDirName : `${customRoot}/${paperDirName}`;
+  }
+  return options.destination === 'root' ? '.' : `References/${paperDirName}`;
+}
+
 export class ArxivSourceProcessor {
   constructor(private readonly channel: string = 'arxivProcessor') {
     logger.initialize(this.channel);
@@ -206,14 +228,11 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    const isRoot = destination === 'root' && !into;
-    // Use forward slashes to match WorkspaceFS.relativePath() convention (not path.join which uses backslashes on Windows)
-    const paperDirRelative = isRoot
-      ? '.'
-      : (into?.trim() || `References/${id.replaceAll('/', '_')}`).replaceAll(
-          path.sep,
-          '/',
-        );
+    const paperDirRelative = resolveArxivPaperDirectoryRelative(id, {
+      destination,
+      into,
+    });
+    const isRoot = paperDirRelative === '.';
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -29,7 +29,10 @@ const ERROR_MESSAGES = {
     `${commandType} operation timed out after ${timeoutMs}ms (retry)`,
   FAILED_BOTH: (commandType: string) =>
     `Failed to run ${commandType} (both with and without --flatten)`,
-  FAILED_GENERAL: (commandType: string) => `Failed to run ${commandType}`,
+  FAILED_GENERAL: (commandType: string, detail?: string | null) =>
+    detail
+      ? `Failed to run ${commandType}: ${detail}`
+      : `Failed to run ${commandType}`,
 } as const;
 
 export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = [
@@ -145,6 +148,7 @@ export class DiffCommandExecutor {
       '--encoding=utf8',
       '-c',
       `PICTUREENV=${pictureEnvs}`,
+      '--graphics-markup=none',
       buildLatexdiffTextCommandExclusionFlag(),
       `--math-markup=${mathMarkup}`,
       ...(subtype ? [`--subtype=${subtype}`] : []),
@@ -169,6 +173,7 @@ export class DiffCommandExecutor {
       `PICTUREENV=${pictureEnvs}`,
       '--force',
       '--git',
+      '--graphics-markup=none',
       buildLatexdiffTextCommandExclusionFlag(),
       `--math-markup=${mathMarkup}`,
       ...(subtype ? [`--subtype=${subtype}`] : []),
@@ -206,7 +211,9 @@ export class DiffCommandExecutor {
     }
 
     if (!this.isBibliographyError(result.stderr ?? '')) {
-      throw new Error(ERROR_MESSAGES.FAILED_GENERAL(commandType));
+      throw new Error(
+        ERROR_MESSAGES.FAILED_GENERAL(commandType, result.stderr),
+      );
     }
 
     return this.retryWithoutFlatten(

--- a/src/test-kernel/cli/LatexCommands.vitest.mts
+++ b/src/test-kernel/cli/LatexCommands.vitest.mts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { rootCommand } from '../../../packages/cli/src/commands/root';
+import {
+  LatexCliResultSchema,
+  summarizeTexcountOutput,
+} from '../../../packages/cli/src/commands/latex';
+
+describe('CLI latex commands', () => {
+  it('registers the latex subcommand surface', () => {
+    const subCommands = rootCommand.subCommands as Record<
+      string,
+      { subCommands?: Record<string, unknown> }
+    >;
+    const latex = subCommands.latex;
+
+    expect(latex).toBeDefined();
+    expect(Object.keys(latex.subCommands ?? {}).sort()).toEqual([
+      'arxiv',
+      'bib',
+      'count',
+      'deps',
+      'diff',
+      'figs',
+      'fmt',
+      'tikz',
+    ]);
+  });
+
+  it('keeps result json schemas stable across latex subcommands', () => {
+    const samples = [
+      {
+        kind: 'latex-diff',
+        oldFile: 'old.tex',
+        newFile: 'new.tex',
+        outputFile: 'diff.tex',
+      },
+      {
+        kind: 'latex-count',
+        files: ['paper.tex'],
+        mode: 'separate',
+        summary: {
+          wordsInText: 10,
+          wordsInHeaders: 2,
+          wordsOutsideText: 1,
+          totalWords: 13,
+          sourceCharacters: 100,
+        },
+        output: 'Words in text: 10',
+        errors: [],
+      },
+      {
+        kind: 'latex-arxiv',
+        id: '2404.12175',
+        path: 'References/2404.12175',
+        alreadyExisted: false,
+      },
+      { kind: 'latex-figs', file: 'paper.tex', paths: ['figures/a.pdf'] },
+      { kind: 'latex-deps', file: 'paper.tex', paths: ['sections/intro.tex'] },
+      {
+        kind: 'latex-bib',
+        file: 'paper.tex',
+        bibliographyFiles: ['refs.bib'],
+        missingBibliographyFiles: [],
+        citationKeys: ['key'],
+        missingKeys: [],
+        entries: { key: '@article{key}' },
+      },
+      { kind: 'latex-fmt', file: 'paper.tex', formatted: true },
+      { kind: 'latex-tikz', file: 'paper.tex', paths: ['build/fig.pdf'] },
+    ];
+
+    for (const sample of samples) {
+      expect(() => LatexCliResultSchema.parse(sample)).not.toThrow();
+    }
+  });
+
+  it('summarizes canonical texcount word totals', () => {
+    expect(
+      summarizeTexcountOutput(`
+Words in text: 10
+Words in headers: 2
+Words outside text: 1
+      `),
+    ).toEqual({
+      wordsInText: 10,
+      wordsInHeaders: 2,
+      wordsOutsideText: 1,
+      totalWords: 13,
+      sourceCharacters: null,
+    });
+  });
+});

--- a/src/test-kernel/cli/LatexCommands.vitest.mts
+++ b/src/test-kernel/cli/LatexCommands.vitest.mts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { resolveArxivPaperDirectoryRelative } from '@latex/arxivProcessor';
+
 import { rootCommand } from '../../../packages/cli/src/commands/root';
 import {
   LatexCliResultSchema,
@@ -89,5 +91,21 @@ Words outside text: 1
       totalWords: 13,
       sourceCharacters: null,
     });
+  });
+
+  it('keeps custom arxiv destinations id-specific', () => {
+    expect(
+      resolveArxivPaperDirectoryRelative('2404.12175', {
+        into: 'papers',
+      }),
+    ).toBe('papers/2404.12175');
+    expect(
+      resolveArxivPaperDirectoryRelative('math/0501234', {
+        into: 'papers/',
+      }),
+    ).toBe('papers/math_0501234');
+    expect(resolveArxivPaperDirectoryRelative('2404.12175')).toBe(
+      'References/2404.12175',
+    );
   });
 });

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " chat run resume history history list history show history delete agents agents list models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " chat run latex latex diff latex count latex arxiv latex figs latex deps latex bib latex fmt latex tikz resume history history list history show history delete agents agents list models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -44,15 +44,25 @@ _texra() {
   case "$prev" in
     --output-format) COMPREPLY=( $(compgen -W 'text json ndjson' -- "$cur") ); return ;;
     --approval-policy) COMPREPLY=( $(compgen -W 'never ask yolo' -- "$cur") ); return ;;
+    --mode) COMPREPLY=( $(compgen -W 'separate include sum' -- "$cur") ); return ;;
     --model|-m) COMPREPLY=( $(compgen -W "$(_texra_models)" -- "$cur") ); return ;;
     --agent) COMPREPLY=( $(compgen -W "$(_texra_agents)" -- "$cur") ); return ;;
   esac
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='chat run latex resume history agents models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
+    'latex') subcommands='diff count arxiv figs deps bib fmt tikz'; flags='' ;;
+    'latex diff') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --out' ;;
+    'latex count') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --mode' ;;
+    'latex arxiv') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --into' ;;
+    'latex figs') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'latex deps') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'latex bib') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'latex fmt') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'latex tikz') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history') subcommands='list show delete'; flags='' ;;
     'history list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -72,7 +82,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='chat run latex resume history agents models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -100,6 +110,7 @@ exports[`CLI shell completion > generates fish completion 1`] = `
 "# fish completion for texra
 complete -c texra -n '__fish_use_subcommand' -a 'chat'
 complete -c texra -n '__fish_use_subcommand' -a 'run'
+complete -c texra -n '__fish_use_subcommand' -a 'latex'
 complete -c texra -n '__fish_use_subcommand' -a 'resume'
 complete -c texra -n '__fish_use_subcommand' -a 'history'
 complete -c texra -n '__fish_use_subcommand' -a 'agents'
@@ -138,6 +149,65 @@ complete -c texra -n '__fish_seen_subcommand_from run' -l 'output' -r
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'output-dir' -r
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'model' -s 'm' -r
 complete -c texra -n '__fish_seen_subcommand_from run' -l 'instruction' -r
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'diff'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'count'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'arxiv'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'figs'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'deps'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'bib'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'fmt'
+complete -c texra -n '__fish_seen_subcommand_from latex' -a 'tikz'
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from diff' -l 'out' -r
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from count' -l 'mode' -r -a 'separate include sum'
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from arxiv' -l 'into' -r
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from figs' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from deps' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from bib' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from fmt' -l 'approval-policy' -r -a 'never ask yolo'
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'print' -s 'p'
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'quiet' -s 'q'
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'cwd' -r
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'api-mode' -r
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'output-format' -r -a 'text json ndjson'
+complete -c texra -n '__fish_seen_subcommand_from tikz' -l 'approval-policy' -r -a 'never ask yolo'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'print' -s 'p'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'quiet' -s 'q'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'cwd' -r
@@ -258,6 +328,15 @@ _texra() {
   case "$path" in
     'chat') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
     'run') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--context[Read-only context file passed to the workflow agent]:value:' '-c[Read-only context file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--output-dir[Directory to copy multi-input workflow outputs into]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
+    'latex') _values 'subcommands' 'diff' 'count' 'arxiv' 'figs' 'deps' 'bib' 'fmt' 'tikz'; true ;;
+    'latex diff') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--out[Output diff .tex file]:value:' ;;
+    'latex count') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--mode[texcount mode]: :(separate include sum)' ;;
+    'latex arxiv') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '--into[Workspace-relative destination directory]:value:' ;;
+    'latex figs') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'latex deps') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'latex bib') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'latex fmt') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
+    'latex tikz') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
     'resume') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
     'history') _values 'subcommands' 'list' 'show' 'delete'; true ;;
     'history list') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' ;;
@@ -277,7 +356,7 @@ _texra() {
     'completion') true; _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:command:(chat run resume history agents models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[]' '-p[]' '--quiet[]' '-q[]' '--cwd[]:value:' '--api-mode[]:value:' '--output-format[]: :(text json ndjson)' '--approval-policy[]: :(never ask yolo)' '1:command:(chat run latex resume history agents models login logout usage auth doctor completion version help)' ;;
   esac
 }
 


### PR DESCRIPTION
Closes #4186.\n\n## Summary\n- Add `texra latex` subcommands for diff, count, arxiv, figs, deps, bib, fmt, and tikz.\n- Reuse the shared LaTeX helpers from core/extension code and expose stable JSON/NDJSON/text output.\n- Fix the shared latexdiff command for newer latexdiff by disabling graphics markup and include stderr details when latexdiff fails.\n- Add workspace-relative `--into` support for arXiv source downloads.\n\n## Verification\n- `npx tsc --noEmit --pretty false`\n- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`\n- `npx vitest run src/test-kernel/cli/LatexCommands.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/latex/LatexdiffBibQuality.vitest.ts`\n- `npm run lint` (passes with existing 17 warnings)\n- `CI=true npm run compile:fast`\n- `corepack pnpm --filter @texra/cli build`\n- Smoke-tested `texra latex --help`, `texra latex count ... --output-format json`, and `texra latex diff old.tex new.tex --out diff.tex --output-format json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new CLI command surface with file-system side effects (writing/renaming outputs, downloading/extracting sources) and tweaks shared `latexdiff` invocation/error reporting that could affect existing diff workflows.
> 
> **Overview**
> Adds a new **`texra latex`** command group with subcommands for `diff`, `count`, `arxiv`, `figs`, `deps`, `bib`, `fmt`, and `tikz`, including stable `json`/`ndjson`/`text` outputs validated by a shared `zod` result schema.
> 
> Extends arXiv source downloading to support a workspace-relative `--into` destination (via `resolveArxivPaperDirectoryRelative`) and updates `latexdiff` execution to pass `--graphics-markup=none` and surface stderr details on non-bibliography failures. Tests/snapshots are updated to assert the new command surface and shell completion output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224f1b6b1eda32f30f8cc09d33ed95a21b371715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->