### PR TITLE
fix(welcome): use vscode css variables so dark-mode text is readable

### DIFF
--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -42,7 +42,7 @@ function renderWelcomeHtml(): string {
       line-height: 1.5;
     }
     p { margin: 0 0 12px; }
-    .muted { color: var(--vscode-descriptionForeground, var(--vscode-foreground)); }
+    .muted { color: color-mix(in srgb, var(--vscode-foreground) 70%, transparent); }
     ol { margin: 0 0 12px; padding-left: 22px; }
     li { margin-bottom: 6px; }
     .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -34,23 +34,26 @@ function renderWelcomeHtml(): string {
   />
   <style>
     body {
-      font-family: var(--wa-font-family-body);
-      font-size: var(--wa-font-size-m);
-      color: var(--wa-color-text-normal);
+      font-family: var(--vscode-font-family, ui-sans-serif, system-ui, sans-serif);
+      font-size: var(--vscode-font-size, 13px);
+      color: var(--vscode-foreground);
       background: transparent;
       padding: 16px;
       line-height: 1.5;
     }
     p { margin: 0 0 12px; }
-    .muted { color: var(--wa-color-text-quiet); }
+    .muted { color: var(--vscode-descriptionForeground, var(--vscode-foreground)); }
     ol { margin: 0 0 12px; padding-left: 22px; }
     li { margin-bottom: 6px; }
     .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }
     a {
-      color: var(--wa-color-text-link);
+      color: var(--vscode-textLink-foreground);
       text-decoration: none;
     }
-    a:hover { text-decoration: underline; }
+    a:hover {
+      color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
@@ -59,7 +62,7 @@ function renderWelcomeHtml(): string {
     coordinates specialized agents to edit manuscripts, derive results, draw
     figures, and verify proofs.
   </p>
-  <p class="muted"><strong>To get started:</strong></p>
+  <p><strong>To get started:</strong></p>
   <ol>
     <li>Open a folder containing your LaTeX project (or create a sample).</li>
     <li>TeXRA will reload and walk you through sign-in or API key setup.</li>


### PR DESCRIPTION
The no-workspace welcome webview referenced --wa-* tokens, but those are
defined in common.css which the welcome view never loads — so the text
fell back to browser defaults and rendered illegibly in dark mode.
Switch to the --vscode-* variables VS Code injects into every webview,
and stop muting the "To get started:" heading so the primary steps read
at full contrast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts inline CSS and link hover styling in the welcome webview to use VS Code-provided theme variables, improving readability in dark mode.
> 
> **Overview**
> Updates the no-workspace welcome webview styling in `welcomeView.ts` to use VS Code-injected `--vscode-*` theme variables (font, foreground, and link colors) instead of undefined `--wa-*` tokens, fixing illegible text in dark mode.
> 
> Also tweaks emphasis by no longer muting the **“To get started:”** heading and refines link hover colors using `--vscode-textLink-activeForeground` with a fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce5e8261be19ff8f143242cd15375bc50651229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->