### PR TITLE
[codex] Harden CLI npm package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,8 @@
     "smoke:react-compiler": "node scripts/smoke-react-compiler.mjs",
     "build": "npm run typecheck && npm run check:architecture && npm run smoke:react-compiler && npm run bundle && npm run copy:resources",
     "prepack": "npm run build",
-    "validate:run": "node scripts/validate-run.mjs"
+    "validate:run": "node scripts/validate-run.mjs",
+    "validate:pack": "node scripts/validate-pack.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -9,8 +9,13 @@ import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
 const reactDevtoolsStub = fileURLToPath(
   new URL('./react-devtools-core-stub.mjs', import.meta.url),
 );
+const internalValidationModelStub = fileURLToPath(
+  new URL('./internal-validation-model-stub.mjs', import.meta.url),
+);
 
 const outfile = 'dist/bin/texra.js';
+const includeInternalValidationModel =
+  process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL === '1';
 
 await build({
   entryPoints: ['src/bin/texra.ts'],
@@ -19,6 +24,27 @@ await build({
   format: 'esm',
   target: 'node20',
   external: ['fsevents'],
+  define: {
+    'process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL': JSON.stringify(
+      includeInternalValidationModel ? '1' : '',
+    ),
+    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV':
+      JSON.stringify(
+        includeInternalValidationModel
+          ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER'
+          : '',
+      ),
+    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV':
+      JSON.stringify(
+        includeInternalValidationModel
+          ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG'
+          : '',
+      ),
+    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT':
+      JSON.stringify(
+        includeInternalValidationModel ? 'texra-cli-run-validation' : '',
+      ),
+  },
   alias: {
     // Ink statically imports `react-devtools-core` from its `devtools.js`,
     // which is only reached when `process.env.DEV === 'true'`. We never
@@ -26,8 +52,17 @@ await build({
     // to a no-op stub. Avoids pulling the (heavy) real package into the
     // bundle while keeping ink's dynamic-import path resolvable.
     'react-devtools-core': reactDevtoolsStub,
+    ...(!includeInternalValidationModel
+      ? {
+          '@agent/modelHandlers/modelHandlerValidation':
+            internalValidationModelStub,
+        }
+      : {}),
   },
   outfile,
+  minify: true,
+  sourcemap: false,
+  legalComments: 'none',
   // The React Compiler runs as a Babel pre-pass scoped to .tsx files under
   // packages/cli/src/chat/tui/. Confirmed addition is only
   // `react/compiler-runtime`; see docs/prd/cli-tui-ink/20-implementation.md

--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -6,6 +6,24 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, '..');
 const source = path.resolve(packageDir, '../extension/resources');
 const target = path.resolve(packageDir, 'dist/resources');
+const runtimeResourceEntries = [
+  'agents',
+  'docs/agent-creation',
+  'odyssey',
+  'shared',
+  'templates/agentCreatorToolUse.yaml',
+  'templates/agentCreatorWorkflow.yaml',
+  'templates/agentTemplate-toolUse.yaml',
+  'templates/agentTemplate-workflowSingle.yaml',
+  'templates/instructionPolish.yaml',
+  'tool_use_agents',
+];
 
 await rm(target, { recursive: true, force: true });
-await cp(source, target, { recursive: true });
+await Promise.all(
+  runtimeResourceEntries.map((entry) =>
+    cp(path.join(source, entry), path.join(target, entry), {
+      recursive: true,
+    }),
+  ),
+);

--- a/packages/cli/scripts/internal-validation-model-stub.mjs
+++ b/packages/cli/scripts/internal-validation-model-stub.mjs
@@ -1,0 +1,5 @@
+export class ModelHandlerValidation {
+  constructor() {
+    throw new Error('This model handler is not available in this build.');
+  }
+}

--- a/packages/cli/scripts/validate-pack.mjs
+++ b/packages/cli/scripts/validate-pack.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const cliRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const packageName = '@texra/cli';
+const packageDir = 'package/';
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? cliRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL: '',
+      ...options.env,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  return result.stdout;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertNoForbiddenTarballEntries(entries) {
+  const forbidden = entries.filter((entry) => {
+    const relative = entry.startsWith(packageDir)
+      ? entry.slice(packageDir.length)
+      : entry;
+    return (
+      relative.endsWith('.map') ||
+      relative.endsWith('.ts') ||
+      relative.startsWith('src/') ||
+      relative.startsWith('scripts/') ||
+      relative.startsWith('dist/resources/walkthroughs/') ||
+      relative.startsWith('dist/resources/examples/') ||
+      relative.startsWith('dist/resources/logo-') ||
+      relative === 'dist/resources/templates/chatExport.tex'
+    );
+  });
+
+  assert(
+    forbidden.length === 0,
+    `npm package contains entries excluded from the public CLI artifact:\n${forbidden.join(
+      '\n',
+    )}`,
+  );
+}
+
+function assertBundleHardened(bundlePath) {
+  const bundle = readFileSync(bundlePath, 'utf8');
+  const forbiddenFragments = [
+    'sourceMappingURL',
+    'sourcesContent',
+    'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER',
+    'Validated CLI Runtime',
+    'modelHandlerValidation',
+    '/Users/',
+  ];
+  const present = forbiddenFragments.filter((fragment) =>
+    bundle.includes(fragment),
+  );
+  assert(
+    present.length === 0,
+    `CLI bundle contains forbidden production fragments: ${present.join(', ')}`,
+  );
+  assert(
+    !/^\/\/ .*src\//m.test(bundle),
+    'CLI bundle exposes source-module boundary comments.',
+  );
+}
+
+function parsePackResult(stdout) {
+  const jsonStart = stdout.lastIndexOf('\n[');
+  const jsonText = (
+    jsonStart >= 0 ? stdout.slice(jsonStart + 1) : stdout
+  ).trim();
+  const result = JSON.parse(jsonText);
+  const first = Array.isArray(result) ? result[0] : result;
+  assert(first?.filename, 'npm pack did not report a tarball filename.');
+  return first.filename;
+}
+
+const tmp = mkdtempSync(path.join(tmpdir(), 'texra-cli-pack-'));
+try {
+  const packOutput = run('npm', ['pack', '--json', '--pack-destination', tmp]);
+  const tarballPath = path.join(tmp, parsePackResult(packOutput));
+  const entries = run('tar', ['-tf', tarballPath])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort();
+  assertNoForbiddenTarballEntries(entries);
+
+  const installRoot = path.join(tmp, 'install');
+  run('npm', ['install', '--prefix', installRoot, tarballPath]);
+  const installedBin = path.join(
+    installRoot,
+    'node_modules',
+    packageName,
+    'dist',
+    'bin',
+    'texra.js',
+  );
+  assertBundleHardened(installedBin);
+
+  const help = run(process.execPath, [installedBin, '--help']);
+  assert(help.includes('TeXRA CLI'), 'installed CLI help should name TeXRA.');
+
+  const version = run(process.execPath, [installedBin, 'version']).trim();
+  assert(version.length > 0, 'installed CLI version should be non-empty.');
+
+  console.log(`CLI npm package validation passed: ${tarballPath}`);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -207,6 +207,9 @@ try {
   validateRunCommand();
   console.log('CLI run validation passed');
 } finally {
-  const rebuildResult = run('pnpm', ['run', 'build'], { cwd: cliRoot });
+  const rebuildResult = run('pnpm', ['run', 'build'], {
+    cwd: cliRoot,
+    env: { TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL: '' },
+  });
   assertSuccess(rebuildResult, 'pnpm run build after validation');
 }

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -17,6 +23,7 @@ function run(command, args, options = {}) {
   const env = {
     ...process.env,
     CI: '1',
+    ...options.env,
   };
   if (options.validationModel) {
     if (!options.validationFlagPath) {
@@ -130,7 +137,7 @@ function validateRunCommand() {
       validationFlagPath,
     });
     assertSuccess(text, 'texra run text');
-    const copiedOutputPath = path.join(cwd, 'paper.polished.tex');
+    const copiedOutputPath = path.join(realpathSync(cwd), 'paper.polished.tex');
     const outputPathPattern = /^r\d+\/paper\.polished\.tex$/;
     assert(
       text.stdout.trim() === copiedOutputPath,
@@ -190,8 +197,16 @@ function validateRunCommand() {
   }
 }
 
-const buildResult = run('pnpm', ['run', 'build'], { cwd: cliRoot });
-assertSuccess(buildResult, 'pnpm run build');
-validateBinarySmoke();
-validateRunCommand();
-console.log('CLI run validation passed');
+try {
+  const buildResult = run('pnpm', ['run', 'build'], {
+    cwd: cliRoot,
+    env: { TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL: '1' },
+  });
+  assertSuccess(buildResult, 'pnpm run build');
+  validateBinarySmoke();
+  validateRunCommand();
+  console.log('CLI run validation passed');
+} finally {
+  const rebuildResult = run('pnpm', ['run', 'build'], { cwd: cliRoot });
+  assertSuccess(rebuildResult, 'pnpm run build after validation');
+}

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -18,12 +18,14 @@ type ModelHandlerConstructor = new (
 
 type ProviderHandlerLoader = () => Promise<ModelHandlerConstructor>;
 
+const INCLUDE_INTERNAL_VALIDATION_MODEL_HANDLER =
+  process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL === '1';
 const INTERNAL_VALIDATION_MODEL_HANDLER_ENV =
-  'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
+  process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV ?? '';
 const INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV =
-  'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';
+  process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV ?? '';
 const INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT =
-  'texra-cli-run-validation';
+  process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT ?? '';
 
 // Record (not Map) so TypeScript enforces exhaustiveness over ModelProvider.
 // A new enum value in llm-zoo without an entry here will fail typecheck.
@@ -170,7 +172,10 @@ export async function createModelHandler(
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
 
-  if (await shouldUseInternalValidationModelHandler()) {
+  if (
+    INCLUDE_INTERNAL_VALIDATION_MODEL_HANDLER &&
+    (await shouldUseInternalValidationModelHandler())
+  ) {
     // Package validation still enters the real CLI and executeAgent path.
     // Only the provider boundary is deterministic, so this must not become
     // a user-facing model selector or an injected command-layer substitute.


### PR DESCRIPTION
## Summary

This PR hardens the npm CLI package before publication. It makes the production CLI bundle minified and explicitly sourcemap-free, keeps the internal validation model handler out of normal publish builds, and narrows copied runtime resources to the files the CLI can load.

It also adds `npm run validate:pack`, which builds the exact npm tarball, rejects source maps, TypeScript sources, source directories, package scripts, walkthrough/example/logo assets, and validation-handler fragments, then installs the tarball into a temporary prefix and runs the installed CLI.

## Design Notes

The existing workflow validation still needs a deterministic model boundary. Instead of shipping that test handler in every CLI bundle, `validate:run` now opts into a validation-enabled build with `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1`, runs the workflow checks, and then rebuilds the normal production bundle.

The production build aliases the internal validation handler to a small stub and supplies empty build-time constants for the validation environment names. Thus the published bundle no longer carries the validation handler implementation or its activation strings.

## Validation

- `npm run validate:run` from `packages/cli`
- `npm run validate:pack` from `packages/cli`
- `npm run lint` from repo root: passed with existing warnings only
- Manual bundle check: no `sourceMappingURL`, `sourcesContent`, validation-handler strings, local absolute paths, or source-boundary comments in `packages/cli/dist/bin/texra.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CLI’s production bundling/packaging (minification, resource inclusion) and gates a runtime model-handler selection path behind new build-time env constants, which could impact published artifact behavior if misconfigured.
> 
> **Overview**
> **Hardens the published `@texra/cli` npm artifact.** The production bundle is now *minified*, explicitly *sourcemap-free*, and strips legal comments; internal validation model-handler activation strings are compiled away unless explicitly opted in.
> 
> **Separates internal validation-only behavior from normal builds.** The internal validation model handler is excluded from standard CLI bundles via an esbuild alias to a throwing stub, while `ModelFactory.createModelHandler` only enables the validation handler when `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1` and the validation gate passes.
> 
> **Tightens what runtime resources get shipped and adds tarball validation.** Resource copying now whitelists only runtime-needed entries, and a new `npm run validate:pack` script builds/inspects the `npm pack` tarball, rejects forbidden files/fragments, installs the tarball into a temp prefix, and smoke-tests the installed CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64d5a15615224a60d3087356f31053fc5118b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->