### PR TITLE
refactor(tools): simplify post-0.37.8 surface

### DIFF
--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -66,19 +66,14 @@ function toPdfRelativePath(options: PublishCompiledPdfOptions): string {
   return normalizePdfRelativePath(path.join(directory, `${pdfStem}.pdf`));
 }
 
-async function ensureParentDir(filePath: string): Promise<void> {
-  await platform().fs.createDirectory(path.dirname(filePath));
-}
-
 async function copyArtifactFile(
   source: string,
   destination: string,
 ): Promise<void> {
-  await ensureParentDir(destination);
-  await platform()
-    .fs.delete(destination, { recursive: true })
-    .catch(() => {});
-  await platform().fs.copy(source, destination, { overwrite: true });
+  const fs = platform().fs;
+  await fs.createDirectory(path.dirname(destination));
+  await fs.delete(destination, { recursive: true }).catch(() => {});
+  await fs.copy(source, destination, { overwrite: true });
 }
 
 export async function publishCompiledPdfArtifact(

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -205,7 +205,7 @@ async function findClaudeBinaryPathUncached(): Promise<string | undefined> {
  * Locate the Claude binary inside an Electron packaged app's unpacked
  * resources directory.
  */
-export async function findClaudeBinaryInElectronResources(
+async function findClaudeBinaryInElectronResources(
   resourcesPath: string,
 ): Promise<string | undefined> {
   const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -92,9 +92,10 @@ function formatWorkflowOutputs(
   return lines;
 }
 
-/** Map internal end-group statuses to agent-friendly labels. */
-function agentFriendlyStatus(status: string): string {
-  return status === 'stopped' ? 'completed' : status;
+function workingDirectoryElement(value: string | undefined): string | null {
+  return value
+    ? `<working-directory>${escapeText(value)}</working-directory>`
+    : null;
 }
 
 /**
@@ -106,12 +107,6 @@ function agentFriendlyStatus(status: string): string {
  * /executions/{id}/files/{diffRelPath} — the delivery only includes
  * the path reference, not the diff content itself.
  */
-function workingDirectoryElement(value: string | undefined): string | null {
-  return value
-    ? `<working-directory>${escapeText(value)}</working-directory>`
-    : null;
-}
-
 export function formatSubagentDelivery(
   agentName: string,
   result: AgentFlowResult,
@@ -121,7 +116,9 @@ export function formatSubagentDelivery(
     workingDirectory?: string;
   },
 ): string {
-  const displayStatus = agentFriendlyStatus(result.status);
+  // Internal status "stopped" is shown to agents as "completed".
+  const displayStatus =
+    result.status === 'stopped' ? 'completed' : result.status;
   const lines = [
     `<subagent-result id="${escapeAttr(result.executionId)}" agent="${escapeAttr(agentName)}" category="${escapeAttr(result.category)}" status="${escapeAttr(displayStatus)}">`,
   ];

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -44,22 +44,15 @@ let cached: ReadonlySet<string> | null = null;
 /** Last check results — kept for rebuilding the cache without re-probing. */
 let lastResults: ExternalToolCheckResult[] | null = null;
 
-/** Current disabled tool names derived from persisted Settings state. */
-function buildDisabledToolNameSet(): ReadonlySet<string> {
+/** Read the current set of disabled tool names from persisted Settings state. */
+export function getDisabledToolNames(): ReadonlySet<string> {
   const disabledIds = getDisabledToolIds();
   const disabled = new Set<string>();
-
   for (const def of EXTERNAL_TOOL_DEFS) {
     if (!disabledIds.has(def.id)) continue;
     for (const toolName of def.tools) disabled.add(toolName);
   }
-
   return disabled;
-}
-
-/** Read the current set of disabled tool names from persisted Settings state. */
-export function getDisabledToolNames(): ReadonlySet<string> {
-  return buildDisabledToolNameSet();
 }
 
 /**
@@ -121,27 +114,12 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
         // (Codex, Zotero, GitHub PR) touch async local state, so running the
         // callbacks independently can duplicate the same probe work.
         let probeResult: unknown;
-        let available: boolean;
+        let probedStatus: 'available' | 'not-found' | 'unknown';
         try {
           probeResult = await probe?.();
-          available = await check(probeResult);
+          probedStatus = (await check(probeResult)) ? 'available' : 'not-found';
         } catch {
-          const statusDetail = await resolveOptionalStatus(
-            detailCheck,
-            probeResult,
-          );
-          const statusLabel = await resolveOptionalStatus(
-            getStatusLabel,
-            probeResult,
-          );
-          return {
-            id,
-            tools,
-            name,
-            status: comingSoon ? 'coming-soon' : 'unknown',
-            statusLabel,
-            statusDetail,
-          };
+          probedStatus = 'unknown';
         }
         const statusDetail = await resolveOptionalStatus(
           detailCheck,
@@ -155,11 +133,7 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
           id,
           tools,
           name,
-          status: comingSoon
-            ? 'coming-soon'
-            : available
-              ? 'available'
-              : 'not-found',
+          status: comingSoon ? 'coming-soon' : probedStatus,
           statusLabel,
           statusDetail,
         };


### PR DESCRIPTION
## Summary
- Inline single-use helpers and collapse redundant branches in the tools layer touched since v0.37.8.
- `toolAvailability`: inline trivial `getDisabledToolNames` wrapper; collapse duplicated `resolveOptionalStatus` calls and the nested status ternary in `runProbes`.
- `subagentResults`: inline single-use `agentFriendlyStatus` helper; fix misplaced JSDoc that was sitting above `workingDirectoryElement`.
- `claudeAgentImport`: stop exporting `findClaudeBinaryInElectronResources` (only used internally).
- `compiledPdfArtifacts`: inline single-use `ensureParentDir` and cache the `platform().fs` handle.

No public API changes; no `vscode` imports introduced.

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: agent run that exercises the subagent results path
- [ ] Smoke: PDF artifact copy path in a workflow agent run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mostly inlines single-use helpers and simplifies status computation; behavior should be unchanged aside from slightly different handling of probe exceptions when deriving tool availability status.
> 
> **Overview**
> Simplifies several post-`v0.37.8` tool-layer utilities by inlining single-use helpers and tightening control flow.
> 
> In `toolAvailability`, `getDisabledToolNames` is now the direct implementation (no wrapper), and probe result handling in `runProbes` is collapsed into a single `probedStatus` with shared `statusLabel`/`statusDetail` resolution.
> 
> In `subagentResults`, the internal `stopped`→`completed` status mapping is inlined into `formatSubagentDelivery` and the misplaced JSDoc is corrected. `claudeAgentImport` stops exporting `findClaudeBinaryInElectronResources` (now internal-only), and `compiledPdfArtifacts` inlines parent-dir creation while caching `platform().fs` during artifact copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28bfe0893a18456a80f8b33a245404238165444e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->