### PR TITLE
refactor(auth): simplify tier & server-key services

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -172,9 +172,7 @@ export class ServerSideKeyService {
     this.onCacheCleared = this._onCacheCleared.event;
     this._tierServiceClearSubscription = this._onCacheCleared.event(
       (options) => {
-        if (options.preserveTierCache === true) {
-          return;
-        }
+        if (options.preserveTierCache) return;
         this.tierService.clearCache();
       },
     );
@@ -223,11 +221,8 @@ export class ServerSideKeyService {
   ): Promise<void> {
     const changed = this.useIncludedModelAccess !== value;
     this.useIncludedModelAccess = value;
-    if (value) {
-      this.quotaAutoSwitchActive = false;
-    } else {
-      this.quotaAutoSwitchActive = cacheOptions.quotaAutoSwitch === true;
-    }
+    this.quotaAutoSwitchActive =
+      !value && cacheOptions.quotaAutoSwitch === true;
 
     if (this.globalState) {
       await this.globalState.update(USE_INCLUDED_ACCESS_KEY, value);
@@ -253,7 +248,7 @@ export class ServerSideKeyService {
     this.accessTimestamp = 0;
     this.accessFetchPromise = null;
     this.userTier = null;
-    if (options.resetQuotaFlip === true) {
+    if (options.resetQuotaFlip) {
       this.quotaFlipApplied = false;
       this.quotaAutoSwitchActive = false;
     }
@@ -383,7 +378,7 @@ export class ServerSideKeyService {
   shouldUseServerSideKeysSync(provider: string, modelName?: string): boolean {
     if (
       !this.getUseIncludedModelAccess() ||
-      !this.isProviderOnServer(provider.toLowerCase()) ||
+      !this.isProviderOnServer(provider) ||
       !this.accessResult
     ) {
       return false;

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -13,6 +13,7 @@
  * - Ultra: All models including premium ($3+/M input)
  */
 
+import type { z } from 'zod';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   SpendingStatusSchema,
@@ -91,6 +92,26 @@ export class TierService {
   }
 
   /**
+   * Parse an optional user-specific block returned by the relay. Returns
+   * null when the block is absent or fails validation; parse failures are
+   * logged so relay-side schema drift is visible.
+   */
+  private parseOptionalBlock<T>(
+    raw: unknown,
+    schema: z.ZodType<T>,
+    label: string,
+  ): T | null {
+    if (raw === undefined || raw === null) return null;
+    const parsed = schema.safeParse(raw);
+    if (parsed.success) return parsed.data;
+    this.logger.error(
+      CHANNEL,
+      `Invalid ${label} payload: ${parsed.error.message}`,
+    );
+    return null;
+  }
+
+  /**
    * Fetch tier configuration from the relay server.
    * @param authToken - Optional JWT token to include user access status in response
    */
@@ -127,40 +148,24 @@ export class TierService {
       }
 
       const data = await response.json();
-      const isCurrentFetch = (): boolean => generation === this.fetchGeneration;
 
       // Parse user-specific blocks. Both are only present when the
       // request carries auth, so clear them on absence (anonymous fetch)
       // and on parse failure — a relay-side schema drift should not
       // silently serve stale values to the quota meter / BYOK switch.
-      if (data.userStatus) {
-        const statusParsed = UserAccessStatusSchema.safeParse(data.userStatus);
-        if (statusParsed.success) {
-          if (isCurrentFetch()) this.userStatus = statusParsed.data;
-        } else {
-          this.logger.error(
-            CHANNEL,
-            `Invalid userStatus payload: ${statusParsed.error.message}`,
-          );
-          if (isCurrentFetch()) this.userStatus = null;
-        }
-      } else {
-        if (isCurrentFetch()) this.userStatus = null;
-      }
-
-      if (data.spendingStatus) {
-        const spendParsed = SpendingStatusSchema.safeParse(data.spendingStatus);
-        if (spendParsed.success) {
-          if (isCurrentFetch()) this.spendingStatus = spendParsed.data;
-        } else {
-          this.logger.error(
-            CHANNEL,
-            `Invalid spendingStatus payload: ${spendParsed.error.message}`,
-          );
-          if (isCurrentFetch()) this.spendingStatus = null;
-        }
-      } else {
-        if (isCurrentFetch()) this.spendingStatus = null;
+      const userStatus = this.parseOptionalBlock(
+        data.userStatus,
+        UserAccessStatusSchema,
+        'userStatus',
+      );
+      const spendingStatus = this.parseOptionalBlock(
+        data.spendingStatus,
+        SpendingStatusSchema,
+        'spendingStatus',
+      );
+      if (generation === this.fetchGeneration) {
+        this.userStatus = userStatus;
+        this.spendingStatus = spendingStatus;
       }
 
       const parsed = TierModelConfigSchema.safeParse(data);
@@ -202,8 +207,7 @@ export class TierService {
     // where concurrent calls see fetchPromise !== null but timestamp is stale
     this.cacheTimestamp = Date.now();
     this.cachedWithAuth = tokenPresent;
-    const generation = this.fetchGeneration + 1;
-    this.fetchGeneration = generation;
+    const generation = ++this.fetchGeneration;
     this.fetchPromise = this.fetchFromServer(authToken, generation).then(
       (result) => {
         if (generation !== this.fetchGeneration) {


### PR DESCRIPTION
## Summary
- `TierService`: extract `parseOptionalBlock` helper to dedupe the `userStatus`/`spendingStatus` parsing branches; collapse the per-field generation guards into a single check at apply time; prefix-increment `fetchGeneration`.
- `ServerSideKeyService`: collapse if/else assignment of `quotaAutoSwitchActive` to a single boolean expression; drop redundant `=== true` comparisons on optional boolean flags; remove double-lowercase of provider when calling `isProviderOnServer`.

No public API changes. Vitest auth suite passes locally.

## Test plan
- [ ] CI typecheck + lint
- [ ] Vitest `src/test-kernel/auth/` (3 tests)
- [ ] Smoke: sign in / fetch tier in extension; observe quota-switch indicator still toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactoring, but it touches tier-config fetching/caching and provider checks used to gate server-side key usage, so subtle regressions could impact access decisions or quota auto-switch behavior.
> 
> **Overview**
> Simplifies `TierService` tier-config fetching by extracting a `parseOptionalBlock` helper for `userStatus`/`spendingStatus`, applying the generation guard once when committing parsed user-specific state, and switching to prefix-increment for `fetchGeneration`.
> 
> Cleans up `ServerSideKeyService` cache/toggle logic by collapsing boolean flag checks/assignments (e.g., `quotaAutoSwitchActive`, `resetQuotaFlip`, `preserveTierCache`) and removing redundant provider lowercasing in `shouldUseServerSideKeysSync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632b66ab5d1e8d7f0576cd63e7e072537222f827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->