### PR TITLE
refactor(config-utils): simplify post-0.37.8 surface

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -101,6 +101,19 @@ function warnInvalidField(
   }
 }
 
+// Top-level fields validated under both bare (legacy) and `texra.*` forms.
+const TOP_LEVEL_FIELD_SCHEMAS: ReadonlyArray<[string, z.ZodType]> = [
+  ['agent', NonEmptyStringSchema],
+  ['model', ModelSchema],
+  ['outputFormat', OutputFormatSchema],
+  ['approvalPolicy', ApprovalPolicySchema],
+];
+
+const COMMAND_FIELD_SCHEMAS: ReadonlyArray<[string, z.ZodType]> = [
+  ['agent', NonEmptyStringSchema],
+  ['model', ModelSchema],
+];
+
 function collectValidationWarnings(
   filePath: string,
   record: Record<string, unknown>,
@@ -108,47 +121,11 @@ function collectValidationWarnings(
   const warnings: string[] = [];
   warnUnknownKeys(warnings, filePath, record, TOP_LEVEL_KEYS);
 
-  // Validate bare keys (legacy format)
-  warnInvalidField(warnings, filePath, record, 'agent', NonEmptyStringSchema);
-  warnInvalidField(warnings, filePath, record, 'model', ModelSchema);
-  warnInvalidField(
-    warnings,
-    filePath,
-    record,
-    'outputFormat',
-    OutputFormatSchema,
-  );
-  warnInvalidField(
-    warnings,
-    filePath,
-    record,
-    'approvalPolicy',
-    ApprovalPolicySchema,
-  );
-
-  // Validate texra.* prefixed keys (unified format)
-  warnInvalidField(
-    warnings,
-    filePath,
-    record,
-    'texra.agent',
-    NonEmptyStringSchema,
-  );
-  warnInvalidField(warnings, filePath, record, 'texra.model', ModelSchema);
-  warnInvalidField(
-    warnings,
-    filePath,
-    record,
-    'texra.outputFormat',
-    OutputFormatSchema,
-  );
-  warnInvalidField(
-    warnings,
-    filePath,
-    record,
-    'texra.approvalPolicy',
-    ApprovalPolicySchema,
-  );
+  // Validate top-level fields in both bare (legacy) and `texra.*` forms.
+  for (const [key, schema] of TOP_LEVEL_FIELD_SCHEMAS) {
+    warnInvalidField(warnings, filePath, record, key, schema);
+    warnInvalidField(warnings, filePath, record, `texra.${key}`, schema);
+  }
 
   for (const section of ['chat', 'run', 'texra.chat', 'texra.run'] as const) {
     if (!Object.hasOwn(record, section)) continue;
@@ -157,29 +134,11 @@ function collectValidationWarnings(
       warnings.push(`Ignoring invalid ${filePath} key "${section}".`);
       continue;
     }
-    warnUnknownKeys(
-      warnings,
-      filePath,
-      sectionValue,
-      COMMAND_KEYS,
-      `${section}.`,
-    );
-    warnInvalidField(
-      warnings,
-      filePath,
-      sectionValue,
-      'agent',
-      NonEmptyStringSchema,
-      `${section}.`,
-    );
-    warnInvalidField(
-      warnings,
-      filePath,
-      sectionValue,
-      'model',
-      ModelSchema,
-      `${section}.`,
-    );
+    const prefix = `${section}.`;
+    warnUnknownKeys(warnings, filePath, sectionValue, COMMAND_KEYS, prefix);
+    for (const [key, schema] of COMMAND_FIELD_SCHEMAS) {
+      warnInvalidField(warnings, filePath, sectionValue, key, schema, prefix);
+    }
   }
   return warnings;
 }
@@ -191,24 +150,9 @@ function parseOptional<T>(schema: z.ZodType<T>, value: unknown): T | undefined {
 
 function pickCommandConfig(record: Record<string, unknown>): CliCommandConfig {
   return {
-    agent: Object.hasOwn(record, 'agent')
-      ? parseOptional(NonEmptyStringSchema, record.agent)
-      : undefined,
-    model: Object.hasOwn(record, 'model')
-      ? parseOptional(ModelSchema, record.model)
-      : undefined,
+    agent: parseOptional(NonEmptyStringSchema, record.agent),
+    model: parseOptional(ModelSchema, record.model),
   };
-}
-
-function pickRecord(
-  record: Record<string, unknown>,
-  bareKey: string,
-): Record<string, unknown> | undefined {
-  const prefixedKey = `texra.${bareKey}`;
-  const prefixedValue = record[prefixedKey];
-  if (isPlainRecord(prefixedValue)) return prefixedValue;
-  const bareValue = record[bareKey];
-  return isPlainRecord(bareValue) ? bareValue : undefined;
 }
 
 /** Look up a value by both bare and `texra.*` prefixed key — prefixed takes precedence. */
@@ -217,12 +161,19 @@ function pickValue<T>(
   bareKey: string,
   schema: z.ZodType<T>,
 ): T | undefined {
-  const prefixedKey = `texra.${bareKey}`;
-  if (Object.hasOwn(record, prefixedKey)) {
-    return parseOptional(schema, record[prefixedKey]);
+  for (const key of [`texra.${bareKey}`, bareKey]) {
+    if (Object.hasOwn(record, key)) return parseOptional(schema, record[key]);
   }
-  if (Object.hasOwn(record, bareKey)) {
-    return parseOptional(schema, record[bareKey]);
+  return undefined;
+}
+
+function pickRecord(
+  record: Record<string, unknown>,
+  bareKey: string,
+): Record<string, unknown> | undefined {
+  for (const key of [`texra.${bareKey}`, bareKey]) {
+    const value = record[key];
+    if (isPlainRecord(value)) return value;
   }
   return undefined;
 }

--- a/packages/cli/src/runtime/cliConfigProvider.ts
+++ b/packages/cli/src/runtime/cliConfigProvider.ts
@@ -18,18 +18,19 @@ type ConfigWatcher = {
  * are accepted on read (prefixed tried first). Writes always use the canonical
  * `texra.<key>` form.
  */
-function configKeyVariants(key: string): string[] {
-  const unprefixed = key.startsWith('texra.')
-    ? key.slice('texra.'.length)
-    : key;
-  return [`texra.${unprefixed}`, unprefixed];
+const TEXRA_PREFIX = 'texra.';
+
+function stripPrefix(key: string): string {
+  return key.startsWith(TEXRA_PREFIX) ? key.slice(TEXRA_PREFIX.length) : key;
 }
 
 function canonicalConfigKey(key: string): string {
-  const unprefixed = key.startsWith('texra.')
-    ? key.slice('texra.'.length)
-    : key;
-  return `texra.${unprefixed}`;
+  return `${TEXRA_PREFIX}${stripPrefix(key)}`;
+}
+
+function configKeyVariants(key: string): string[] {
+  const unprefixed = stripPrefix(key);
+  return [`${TEXRA_PREFIX}${unprefixed}`, unprefixed];
 }
 
 function matchesConfigKey(candidate: string, changedKey: string): boolean {

--- a/src/utils/config/settingsSchema.ts
+++ b/src/utils/config/settingsSchema.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-
 // ---------------------------------------------------------------------------
 // CLI-specific enums
 // ---------------------------------------------------------------------------
@@ -11,200 +9,90 @@ export const CLI_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
 
 // ---------------------------------------------------------------------------
-// Per-key schema registry
+// Known `texra.*` configuration keys
 // ---------------------------------------------------------------------------
+//
+// This is the authoritative list of canonical `texra.*` setting keys used by
+// the extension and the CLI for "unknown key" detection. Per-key schemas and
+// defaults live in `src/shared/schemas/settingsConfiguration.ts`; this file
+// intentionally tracks only the names.
 
-interface SettingEntry<T> {
-  readonly schema: z.ZodType<T>;
-  readonly default: T;
-}
+const KEYS = [
+  // Agent outputs
+  'texra.agentOutputs.autoOpenFinal',
+  // Inline criticism
+  'texra.inlineCriticism.enabled',
+  // Experimental
+  'texra.experimental.odyssey.enabled',
+  // UI toggles
+  'texra.ui.showApiKeyReminders',
+  'texra.ui.showLoginBanner',
+  'texra.ui.showGettingStartedBanner',
+  'texra.ui.showOrchestratorBanner',
+  // Auth
+  'texra.auth.enableVSCodeGitHub',
+  // Model
+  'texra.model.useImprovedConnection',
+  'texra.model.improvedConnectionDomain',
+  'texra.model.useOpenAIResponsesAPI',
+  'texra.model.useBackgroundResponses',
+  'texra.model.openaiParallelToolCalls',
+  'texra.model.compactionThresholdPercent',
+  'texra.model.gpt5ReasoningSummary',
+  // Model retry
+  'texra.model.retry.maxAttempts',
+  'texra.model.retry.backoffMs',
+  // Files: included
+  'texra.files.included.mediaExtensions',
+  'texra.files.included.inputExtensions',
+  'texra.files.included.contextExtensions',
+  'texra.files.included.editedExtensions',
+  // Files: ignored
+  'texra.files.ignored.fileExtensions',
+  'texra.files.ignored.inputFiles',
+  'texra.files.ignored.inputDirectories',
+  'texra.files.ignored.mediaDirectories',
+  'texra.files.ignored.directories',
+  'texra.files.ignored.keywords',
+  // Images
+  'texra.maxImageDimension',
+  // Bibliography
+  'texra.bib.defaultPath',
+  'texra.bib.zoteroPort',
+  // LaTeX
+  'texra.latex.showLatexindentWarning',
+  'texra.latex.latexindentConfig',
+  'texra.latex.texfmtConfig',
+  'texra.latex.tikzInputDirectory',
+  'texra.latex.tikzTemplate',
+  'texra.latex.includeWorkspaceInTexinputs',
+  'texra.latex.wrapCritiqueInAlign',
+  // LaTeX diff
+  'texra.latexdiff.pictureEnvironments',
+  'texra.latexdiff.tempFileLocation',
+  // LaTeX replacements
+  'texra.latex.enabledReplacements',
+  'texra.latex.enabledReplacementsRegex',
+  'texra.latex.customReplacementsRegex',
+  'texra.latex.customReplacements',
+  // Tool use
+  'texra.toolUse.persistence.enabled',
+  'texra.toolUse.persistence.ttlHours',
+  'texra.toolUse.requireBashApproval',
+  'texra.toolUse.requireEditApproval',
+  // Logger
+  'texra.logger.debugMode',
+  // Git
+  'texra.git.numberOfCommitsToShow',
+  'texra.git.emitPrCiStartedEvents',
+  // CLI runtime
+  'texra.agent',
+  'texra.model',
+  'texra.outputFormat',
+  'texra.approvalPolicy',
+  'texra.chat',
+  'texra.run',
+] as const;
 
-function entry<T>(schema: z.ZodType<T>, defaultValue: T): SettingEntry<T> {
-  return { schema, default: defaultValue };
-}
-
-export const TEXRA_SETTINGS = {
-  // -- Agent outputs -------------------------------------------------------
-  'texra.agentOutputs.autoOpenFinal': entry(z.boolean(), true),
-
-  // -- Inline criticism ----------------------------------------------------
-  'texra.inlineCriticism.enabled': entry(z.boolean(), false),
-
-  // -- Experimental --------------------------------------------------------
-  'texra.experimental.odyssey.enabled': entry(z.boolean(), false),
-
-  // -- UI toggles ----------------------------------------------------------
-  'texra.ui.showApiKeyReminders': entry(z.boolean(), true),
-  'texra.ui.showLoginBanner': entry(z.boolean(), true),
-  'texra.ui.showGettingStartedBanner': entry(z.boolean(), true),
-  'texra.ui.showOrchestratorBanner': entry(z.boolean(), true),
-
-  // -- Auth ----------------------------------------------------------------
-  'texra.auth.enableVSCodeGitHub': entry(z.boolean(), false),
-
-  // -- Model ---------------------------------------------------------------
-  'texra.model.useImprovedConnection': entry(z.boolean(), false),
-  'texra.model.improvedConnectionDomain': entry(z.string(), 'proxy.texra.ai'),
-  'texra.model.useOpenAIResponsesAPI': entry(z.boolean(), false),
-  'texra.model.useBackgroundResponses': entry(z.boolean(), false),
-  'texra.model.openaiParallelToolCalls': entry(z.boolean(), true),
-  'texra.model.compactionThresholdPercent': entry(
-    z.number().min(0).max(100),
-    70,
-  ),
-  'texra.model.gpt5ReasoningSummary': entry(z.string(), 'detailed'),
-
-  // -- Model retry ---------------------------------------------------------
-  'texra.model.retry.maxAttempts': entry(z.number().int().min(1), 3),
-  'texra.model.retry.backoffMs': entry(z.number().int().min(0), 500),
-
-  // -- Files: included extensions ------------------------------------------
-  'texra.files.included.mediaExtensions': entry(z.array(z.string()), [
-    '.png',
-    '.jpg',
-    '.jpeg',
-    '.pdf',
-    '.gif',
-    '.svg',
-  ]),
-  'texra.files.included.inputExtensions': entry(z.array(z.string()), ['.tex']),
-  'texra.files.included.contextExtensions': entry(z.array(z.string()), [
-    '.tex',
-    '.bib',
-    '.cls',
-    '.sty',
-    '.bst',
-    '.cfg',
-    '.def',
-    '.clo',
-    '.bbx',
-    '.cbx',
-    '.lbx',
-    '.tikz',
-    '.eps',
-    '.svg',
-  ]),
-  'texra.files.included.editedExtensions': entry(z.array(z.string()), ['.tex']),
-
-  // -- Files: ignored ------------------------------------------------------
-  'texra.files.ignored.fileExtensions': entry(z.array(z.string()), [
-    '.aux',
-    '.bbl',
-    '.blg',
-    '.fdb_latexmk',
-    '.fls',
-    '.log',
-    '.out',
-    '.synctex.gz',
-    '.toc',
-    '.pdf',
-    '.dvi',
-    '.ps',
-    '.gz',
-    '.zip',
-    '.tar',
-    '.lol',
-    '.lot',
-    '.lof',
-    '.bcf',
-    '.run.xml',
-    '.xdv',
-    '.idx',
-    '.ilg',
-    '.ind',
-  ]),
-  'texra.files.ignored.inputFiles': entry(z.array(z.string()), []),
-  'texra.files.ignored.inputDirectories': entry(z.array(z.string()), []),
-  'texra.files.ignored.mediaDirectories': entry(z.array(z.string()), []),
-  'texra.files.ignored.directories': entry(z.array(z.string()), [
-    '.git',
-    '.vscode',
-    'node_modules',
-    '__pycache__',
-    'build',
-    'dist',
-    'out',
-    'target',
-  ]),
-  'texra.files.ignored.keywords': entry(z.array(z.string()), []),
-
-  // -- Images --------------------------------------------------------------
-  'texra.maxImageDimension': entry(z.number().int().min(1), 2000),
-
-  // -- Bibliography --------------------------------------------------------
-  'texra.bib.defaultPath': entry(z.string(), ''),
-  'texra.bib.zoteroPort': entry(z.number().int().min(1).max(65535), 23119),
-
-  // -- LaTeX ---------------------------------------------------------------
-  'texra.latex.showLatexindentWarning': entry(z.boolean(), true),
-  'texra.latex.latexindentConfig': entry(z.string(), ''),
-  'texra.latex.texfmtConfig': entry(z.string(), ''),
-  'texra.latex.tikzInputDirectory': entry(z.string(), ''),
-  'texra.latex.tikzTemplate': entry(z.string(), ''),
-  'texra.latex.includeWorkspaceInTexinputs': entry(z.boolean(), false),
-  'texra.latex.wrapCritiqueInAlign': entry(z.boolean(), true),
-
-  // -- LaTeX diff ----------------------------------------------------------
-  'texra.latexdiff.pictureEnvironments': entry(z.array(z.string()), [
-    'tikzpicture',
-    'pgfpicture',
-  ]),
-  'texra.latexdiff.tempFileLocation': entry(z.string(), ''),
-
-  // -- LaTeX replacements --------------------------------------------------
-  'texra.latex.enabledReplacements': entry(z.array(z.string()), []),
-  'texra.latex.enabledReplacementsRegex': entry(z.array(z.string()), []),
-  'texra.latex.customReplacementsRegex': entry(z.array(z.string()), []),
-  'texra.latex.customReplacements': entry(z.array(z.string()), []),
-
-  // -- Tool use ------------------------------------------------------------
-  'texra.toolUse.persistence.enabled': entry(z.boolean(), true),
-  'texra.toolUse.persistence.ttlHours': entry(z.number().int().min(0), 72),
-  'texra.toolUse.requireBashApproval': entry(z.boolean(), true),
-  'texra.toolUse.requireEditApproval': entry(z.boolean(), false),
-
-  // -- Logger --------------------------------------------------------------
-  'texra.logger.debugMode': entry(z.boolean(), false),
-
-  // -- Git -----------------------------------------------------------------
-  'texra.git.numberOfCommitsToShow': entry(z.number().int().min(0), 20),
-  'texra.git.emitPrCiStartedEvents': entry(z.boolean(), false),
-
-  // -- CLI runtime ---------------------------------------------------------
-  'texra.agent': entry(z.string().trim().min(1).optional(), undefined),
-  'texra.model': entry(z.string().trim().min(1).optional(), undefined),
-  'texra.outputFormat': entry(z.enum(CLI_OUTPUT_FORMATS).optional(), undefined),
-  'texra.approvalPolicy': entry(
-    z.enum(CLI_APPROVAL_POLICIES).optional(),
-    undefined,
-  ),
-  'texra.chat': entry(
-    z
-      .object({
-        agent: z.string().trim().min(1).optional(),
-        model: z.string().trim().min(1).optional(),
-      })
-      .optional(),
-    undefined,
-  ),
-  'texra.run': entry(
-    z
-      .object({
-        agent: z.string().trim().min(1).optional(),
-        model: z.string().trim().min(1).optional(),
-      })
-      .optional(),
-    undefined,
-  ),
-} as const;
-
-export type TexraSettingsKey = keyof typeof TEXRA_SETTINGS;
-
-// ---------------------------------------------------------------------------
-// Derived helpers
-// ---------------------------------------------------------------------------
-
-/** Set of all known texra.* config keys. */
-export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set(
-  Object.keys(TEXRA_SETTINGS),
-);
+/** Set of all known canonical `texra.*` config keys. */
+export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set(KEYS);

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -62,12 +62,11 @@ export async function getXmlFormatFromFiles(
  * @returns Comma-separated string of file paths
  */
 export function getListOfFiles(files: string[] | null | undefined): string {
-  return (
-    files
-      ?.filter((f) => f.trim() !== '')
-      .map((file) => getPromptFileName(file))
-      .join(', ') ?? ''
-  );
+  if (!files) return '';
+  return files
+    .filter((f) => f.trim() !== '')
+    .map(getPromptFileName)
+    .join(', ');
 }
 
 async function resolveValue(value: unknown): Promise<unknown> {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -47,6 +47,12 @@ function normalizeOutput(text: string | null | undefined): string | null {
   return text?.trim() || null;
 }
 
+/** Normalize Node's 'utf-8' alias to execa's 'utf8' encoding option. */
+function normalizeEncoding(encoding?: BufferEncoding): ExecaEncodingOption {
+  const raw = encoding ?? 'utf8';
+  return raw.toLowerCase() === 'utf-8' ? 'utf8' : (raw as ExecaEncodingOption);
+}
+
 function commandEnv(
   workspacePath: string,
   envOverrides?: Record<string, string>,
@@ -185,17 +191,10 @@ export async function executeCommand(
 
     const env = commandEnv(workspacePath, options.env);
 
-    // Normalize 'utf-8' to 'utf8' for execa compatibility
-    const rawEncoding = options.encoding ?? 'utf8';
-    const encodingOption: ExecaEncodingOption =
-      rawEncoding.toLowerCase() === 'utf-8'
-        ? 'utf8'
-        : (rawEncoding as ExecaEncodingOption);
-
     const execaOptions: Options = {
       cwd: workspacePath,
       env,
-      encoding: encodingOption,
+      encoding: normalizeEncoding(options.encoding),
       timeout: options.timeout,
       reject: false,
       input: options.stdin,
@@ -321,15 +320,10 @@ export function executeCommandSync(
   try {
     const [cmd, ...args] = command;
     const workspacePath = options.cwd ?? workspacePathOrProcessCwd();
-    const rawEncoding = options.encoding ?? 'utf8';
-    const encodingOption: ExecaEncodingOption =
-      rawEncoding.toLowerCase() === 'utf-8'
-        ? 'utf8'
-        : (rawEncoding as ExecaEncodingOption);
     const execaOptions: SyncOptions = {
       cwd: workspacePath,
       env: commandEnv(workspacePath, options.env),
-      encoding: encodingOption,
+      encoding: normalizeEncoding(options.encoding),
       timeout: options.timeout,
       reject: false,
     };


### PR DESCRIPTION
## Summary
- `settingsSchema`: drop unused per-entry schema/default registry (`TEXRA_SETTINGS`, `SettingEntry`, `entry()`, `TexraSettingsKey`). Only `KNOWN_TEXRA_KEYS` was consumed externally, and authoritative defaults already live in `src/shared/schemas/settingsConfiguration.ts` — the two were starting to drift (e.g. `useOpenAIResponsesAPI`, `compactionThresholdPercent`). File becomes a flat `KEYS` array.
- `cliConfig`: collapse repeated `warnInvalidField` calls into table-driven loops over `TOP_LEVEL_FIELD_SCHEMAS` and `COMMAND_FIELD_SCHEMAS`; unify bare/`texra.*` lookup precedence in `pickValue`/`pickRecord`; drop redundant `Object.hasOwn` guards in `pickCommandConfig`.
- `cliConfigProvider`: extract shared `TEXRA_PREFIX`/`stripPrefix` helper.
- `execUtils`: extract `normalizeEncoding` helper to dedupe the `'utf-8'→'utf8'` shim between sync and async paths.
- `promptUtils`: simplify `getListOfFiles` with an early return.

No behavior changes; CLI settings keys, validation warnings, and exported surface are identical.

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: CLI run with `texra.*` config keys in `~/.texra/settings.json` — confirm validation warnings still fire on bad types
- [ ] Smoke: command-scoped config (`commands.<name>.<field>`) still resolves correctly
- [ ] Smoke: `executeCommand` / `executeCommandSync` with explicit `encoding: 'utf-8'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refactors and deduplication around config key validation/lookup and command execution encoding normalization, with low likelihood of behavioral change but some risk of subtle precedence/unknown-key warning differences.
> 
> **Overview**
> **Refactors config handling to reduce duplication while preserving legacy compatibility.** `cliConfig` now validates top-level and command-scoped fields via table-driven loops and centralizes bare vs `texra.*` precedence in `pickValue`/`pickRecord` (prefixed wins), simplifying `pickCommandConfig`.
> 
> **Simplifies settings key surface.** `settingsSchema` drops the per-setting zod/default registry and keeps only an authoritative list used for unknown-key detection via `KNOWN_TEXRA_KEYS`.
> 
> **Small utility cleanups.** `cliConfigProvider` factors out `TEXRA_PREFIX`/`stripPrefix` for canonical key generation; `execUtils` dedupes the `'utf-8'`→`'utf8'` execa shim via `normalizeEncoding` for both async/sync execution; `promptUtils.getListOfFiles` is simplified with an early return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c6d65a483ee6a216b659a4a8688a348dbd36b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->