### PR TITLE
refactor(cli-tui): simplify post-0.37.8 surface

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -16,26 +16,12 @@ type ApprovalPolicySelectHandler = (
 type ModelSelectHandler = (value: string) => void | Promise<void>;
 type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
 
-const defaultAgentSelect: AgentSelectHandler = (value) => {
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    agent: value,
-  });
-};
-
-const defaultModelSelect: ModelSelectHandler = (value) => {
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    model: value,
-  });
-};
-
-const defaultApiModeSelect: ApiModeSelectHandler = (value) => {
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    apiMode: value,
-  });
-};
+function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
+  key: K,
+  value: K extends 'apiMode' ? CliApiMode : string,
+): void {
+  cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), [key]: value });
+}
 
 export function registerBuiltinSlashCommands(options?: {
   onAgentSelect?: AgentSelectHandler;
@@ -46,10 +32,13 @@ export function registerBuiltinSlashCommands(options?: {
   canSelectModel?: () => boolean;
   onApiModeSelect?: ApiModeSelectHandler;
 }): void {
-  const onAgentSelect = options?.onAgentSelect ?? defaultAgentSelect;
+  const onAgentSelect: AgentSelectHandler =
+    options?.onAgentSelect ?? ((value) => patchSessionMeta('agent', value));
   const onApprovalPolicySelect = options?.onApprovalPolicySelect;
-  const onModelSelect = options?.onModelSelect ?? defaultModelSelect;
-  const onApiModeSelect = options?.onApiModeSelect ?? defaultApiModeSelect;
+  const onModelSelect: ModelSelectHandler =
+    options?.onModelSelect ?? ((value) => patchSessionMeta('model', value));
+  const onApiModeSelect: ApiModeSelectHandler =
+    options?.onApiModeSelect ?? ((value) => patchSessionMeta('apiMode', value));
 
   function AgentListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = cliState.sessionMeta.get().agent;

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -183,29 +183,22 @@ function TaskDetailView({
   readonly onKill: () => void;
 }): React.JSX.Element {
   const [scrollOffset, setScrollOffset] = useState(0);
-  const metaRows = [
+  const metaParts = [
     item.kind === 'process' ? 'shell' : 'stream',
     item.label,
     item.status,
     item.elapsed,
-  ].filter(Boolean).length;
+  ].filter((part): part is string => Boolean(part));
   const layout = computeTaskDetailLayout({
     availableRows,
     hasTailLines: item.tailLines.length > 0,
-    metaRows,
+    metaRows: metaParts.length,
   });
   const visibleLineCount = layout.visibleLineCount;
   const maxOffset = Math.max(0, item.tailLines.length - visibleLineCount);
   const offset = Math.min(scrollOffset, maxOffset);
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
-  const compactMeta = [
-    item.kind === 'process' ? 'shell' : 'stream',
-    item.label,
-    item.status,
-    item.elapsed,
-  ]
-    .filter(Boolean)
-    .join(' · ');
+  const compactMeta = metaParts.join(' · ');
 
   useEffect(() => {
     setScrollOffset((current) => Math.min(current, maxOffset));

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -27,6 +27,41 @@ import { splitTranscriptEntries } from './transcriptEntries';
 
 export { splitTranscriptEntries } from './transcriptEntries';
 
+function ProcessEntryRow({
+  process,
+}: {
+  readonly process: NonNullable<ConversationEntry['process']>;
+}): React.JSX.Element {
+  const color = process.isError ? 'red' : 'green';
+  const [, ...tailLines] = completedProcessDisplayLines(process);
+  return (
+    <Box marginBottom={1} paddingX={1} flexDirection="column">
+      <Box>
+        <Text color={color}>● </Text>
+        <Text>{process.title}</Text>
+        {process.status ? <Text dimColor>{` · ${process.status}`}</Text> : null}
+        {process.elapsed ? (
+          <Text dimColor>{` · ${process.elapsed}`}</Text>
+        ) : null}
+        {process.isError ? <Text color="red"> · error</Text> : null}
+      </Box>
+      {process.tailLines.length > 0 ? (
+        <Box marginLeft={2} flexDirection="column">
+          {tailLines.map((line, index) => (
+            <Text
+              key={index}
+              color={process.isError ? 'red' : undefined}
+              dimColor={!process.isError}
+            >
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
 function TranscriptEntry({
   entry,
   width,
@@ -34,62 +69,28 @@ function TranscriptEntry({
   readonly entry: ConversationEntry;
   readonly width?: number;
 }): React.JSX.Element {
-  if (entry.role === 'user') {
-    return (
-      <Box marginBottom={1} paddingX={1}>
-        <Text dimColor>› </Text>
-        <Text>{entry.text}</Text>
-      </Box>
-    );
-  }
-
-  if (entry.role === 'error') {
-    return (
-      <Box marginBottom={1} paddingX={1}>
-        <Text color="red">! </Text>
-        <Text color="red">{entry.text}</Text>
-      </Box>
-    );
-  }
-
-  if (entry.role === 'tool' && entry.toolUse) {
-    return <ToolUseRow toolUse={entry.toolUse} />;
-  }
-
-  if (entry.role === 'process' && entry.process) {
-    const process = entry.process;
-    const color = process.isError ? 'red' : 'green';
-    const [, ...tailLines] = completedProcessDisplayLines(process);
-    return (
-      <Box marginBottom={1} paddingX={1} flexDirection="column">
-        <Box>
-          <Text color={color}>● </Text>
-          <Text>{process.title}</Text>
-          {process.status ? (
-            <Text dimColor>{` · ${process.status}`}</Text>
-          ) : null}
-          {process.elapsed ? (
-            <Text dimColor>{` · ${process.elapsed}`}</Text>
-          ) : null}
-          {process.isError ? <Text color="red"> · error</Text> : null}
+  switch (entry.role) {
+    case 'user':
+      return (
+        <Box marginBottom={1} paddingX={1}>
+          <Text dimColor>› </Text>
+          <Text>{entry.text}</Text>
         </Box>
-        {process.tailLines.length > 0 ? (
-          <Box marginLeft={2} flexDirection="column">
-            {tailLines.map((line, index) => (
-              <Text
-                key={index}
-                color={process.isError ? 'red' : undefined}
-                dimColor={!process.isError}
-              >
-                {line}
-              </Text>
-            ))}
-          </Box>
-        ) : null}
-      </Box>
-    );
+      );
+    case 'error':
+      return (
+        <Box marginBottom={1} paddingX={1}>
+          <Text color="red">! </Text>
+          <Text color="red">{entry.text}</Text>
+        </Box>
+      );
+    case 'tool':
+      if (entry.toolUse) return <ToolUseRow toolUse={entry.toolUse} />;
+      break;
+    case 'process':
+      if (entry.process) return <ProcessEntryRow process={entry.process} />;
+      break;
   }
-
   return (
     <Box marginBottom={1}>
       <Markdown content={entry.text} width={width} />

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -59,20 +59,17 @@ export function statusLabel(status: string | undefined): string {
   }
 }
 
+function compactScale(scaled: number, suffix: string): string {
+  const rounded = Number.isInteger(scaled)
+    ? `${scaled}`
+    : scaled.toFixed(1).replace(/\.0$/, '');
+  return `${rounded}${suffix}`;
+}
+
 function formatCompactNumber(value: number): string {
   if (value < 1000) return `${value}`;
-  if (value < 1_000_000) {
-    const thousands = value / 1000;
-    const rounded = Number.isInteger(thousands)
-      ? `${thousands}`
-      : thousands.toFixed(1).replace(/\.0$/, '');
-    return `${rounded}k`;
-  }
-  const millions = value / 1_000_000;
-  const rounded = Number.isInteger(millions)
-    ? `${millions}`
-    : millions.toFixed(1).replace(/\.0$/, '');
-  return `${rounded}M`;
+  if (value < 1_000_000) return compactScale(value / 1000, 'k');
+  return compactScale(value / 1_000_000, 'M');
 }
 
 function formatUsage(
@@ -90,8 +87,10 @@ function formatUsage(
 
   const ratio = total / contextWindow;
   const percent = Math.max(1, Math.round(ratio * 100));
-  const color =
-    ratio >= 0.9 ? 'red' : ratio >= 0.6 ? 'yellow' : ('dim' as const);
+  let color: StatusBarColor;
+  if (ratio >= 0.9) color = 'red';
+  else if (ratio >= 0.6) color = 'yellow';
+  else color = 'dim';
   return {
     text: `${formatCompactNumber(total)}/${formatCompactNumber(
       contextWindow,

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -51,16 +51,16 @@ function lastSegmentToolName(toolName: string): string {
   return lastColon >= 0 ? toolName.slice(lastColon + 1) : toolName;
 }
 
-function displayToolName(toolName: string): string {
-  return displayMcpToolName(toolName) ?? lastSegmentToolName(toolName);
-}
-
 function displayMcpToolName(toolName: string): string | undefined {
   const parts = toolName.split(':').filter(Boolean);
   if (parts.length < 3 || parts[0].toLowerCase() !== 'mcp') {
     return undefined;
   }
   return `${parts[1]}/${parts.slice(2).join(':')}`;
+}
+
+function displayToolName(toolName: string): string {
+  return displayMcpToolName(toolName) ?? lastSegmentToolName(toolName);
 }
 
 function previewInput(input: unknown): string {
@@ -245,15 +245,69 @@ function PatchPreview({
   );
 }
 
-export function UniversalToolRow({
-  toolUse,
-  displayName,
+function OutputBlock({
+  lines,
+  hiddenCount,
 }: {
+  readonly lines: readonly string[];
+  readonly hiddenCount: number;
+}): React.JSX.Element | null {
+  if (lines.length === 0) return null;
+  return (
+    <Box flexDirection="column" paddingLeft={2}>
+      {lines.map((line, index) => (
+        <Box key={index} flexDirection="row" flexWrap="nowrap">
+          <Text dimColor>{index === 0 ? `${OUTPUT_CORNER} ` : '  '}</Text>
+          <Text>{line}</Text>
+        </Box>
+      ))}
+      {hiddenCount > 0 ? (
+        <Text
+          dimColor
+        >{`  … +${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}</Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function CornerLine({
+  color,
+  children,
+}: {
+  readonly color?: 'red';
+  readonly children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
+      <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
+      <Text color={color} dimColor={!color}>
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+interface ToolRowProps {
   readonly toolUse: NormalizedToolUse;
   readonly displayName?: string;
-}): React.JSX.Element {
+  readonly fallbackName?: string;
+  readonly previewColor?: 'cyan';
+  readonly showPatch?: boolean;
+  readonly showExitCode?: boolean;
+}
+
+function ToolRow(props: ToolRowProps): React.JSX.Element {
+  const {
+    toolUse,
+    previewColor,
+    showPatch = false,
+    showExitCode = false,
+  } = props;
   const color = statusColor(toolUse);
-  const name = (displayName ?? displayToolName(toolUse.toolName)) || 'tool';
+  const name =
+    (props.displayName ?? displayToolName(toolUse.toolName)) ||
+    props.fallbackName ||
+    'tool';
 
   const { patchGroups, preview, visibleOutput, hiddenCount } = useMemo(() => {
     const sourceText =
@@ -263,82 +317,19 @@ export function UniversalToolRow({
       : '';
     const { lines, hiddenCount: hidden } = visibleOutputLines(toolUse);
     return {
-      patchGroups: toolUsePatchGroups(toolUse),
+      patchGroups: showPatch ? toolUsePatchGroups(toolUse) : undefined,
       preview: previewText,
       visibleOutput: lines,
       hiddenCount: hidden,
     };
-  }, [toolUse]);
+  }, [toolUse, showPatch]);
 
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
-  const showError = toolUse.isError;
+  const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
   const showNoOutput =
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
     visibleOutput.length === 0 &&
     !patchGroups &&
-    !showError;
-
-  return (
-    <Box flexDirection="column" marginBottom={1}>
-      <Box flexDirection="row" flexWrap="nowrap">
-        <Text color={color} dimColor={!color}>
-          {STATUS_DOT}{' '}
-        </Text>
-        <Text bold>{name}</Text>
-        {preview ? <Text dimColor>{` (${preview})`}</Text> : null}
-      </Box>
-      {visibleOutput.length > 0 ? (
-        <Box flexDirection="column" paddingLeft={2}>
-          {visibleOutput.map((line, index) => (
-            <Box key={index} flexDirection="row" flexWrap="nowrap">
-              <Text dimColor>{index === 0 ? `${OUTPUT_CORNER} ` : '  '}</Text>
-              <Text>{line}</Text>
-            </Box>
-          ))}
-          {hiddenCount > 0 ? (
-            <Text
-              dimColor
-            >{`  … +${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}</Text>
-          ) : null}
-        </Box>
-      ) : null}
-      {patchGroups ? <PatchPreview groups={patchGroups} /> : null}
-      {showError ? (
-        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-          <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
-          <Text color="red">
-            {truncateWithEllipsis(
-              collapseWhitespace(errorText),
-              MAX_ERROR_PREVIEW,
-            )}
-          </Text>
-        </Box>
-      ) : null}
-      {showNoOutput ? (
-        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-          <Text dimColor>{`${OUTPUT_CORNER} (no output)`}</Text>
-        </Box>
-      ) : null}
-    </Box>
-  );
-}
-
-function BashToolRow({
-  toolUse,
-}: {
-  readonly toolUse: NormalizedToolUse;
-}): React.JSX.Element {
-  const color = statusColor(toolUse);
-  const exitCode = extractExitCode(toolUse);
-  const { lines: visibleOutput, hiddenCount } = visibleOutputLines(toolUse);
-  const preview = previewInput(toolUse.input) || toolUse.headerSummary;
-  const previewText = preview
-    ? truncateWithEllipsis(collapseWhitespace(preview), MAX_HEADER_PREVIEW)
-    : '';
-  const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
-  const showNoOutput =
-    toolUse.status === TOOL_USE_STATUS.COMPLETED &&
-    visibleOutput.length === 0 &&
     !toolUse.isError;
 
   return (
@@ -347,47 +338,55 @@ function BashToolRow({
         <Text color={color} dimColor={!color}>
           {STATUS_DOT}{' '}
         </Text>
-        <Text bold>{displayToolName(toolUse.toolName) || 'bash'}</Text>
-        {previewText ? <Text color="cyan">{` (${previewText})`}</Text> : null}
+        <Text bold>{name}</Text>
+        {preview ? (
+          <Text color={previewColor} dimColor={!previewColor}>
+            {` (${preview})`}
+          </Text>
+        ) : null}
       </Box>
-      {visibleOutput.length > 0 ? (
-        <Box flexDirection="column" paddingLeft={2}>
-          {visibleOutput.map((line, index) => (
-            <Box key={index} flexDirection="row" flexWrap="nowrap">
-              <Text dimColor>{index === 0 ? `${OUTPUT_CORNER} ` : '  '}</Text>
-              <Text>{line}</Text>
-            </Box>
-          ))}
-          {hiddenCount > 0 ? (
-            <Text
-              dimColor
-            >{`  … +${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}</Text>
-          ) : null}
-        </Box>
-      ) : null}
+      <OutputBlock lines={visibleOutput} hiddenCount={hiddenCount} />
+      {patchGroups ? <PatchPreview groups={patchGroups} /> : null}
       {toolUse.isError && exitCode !== undefined ? (
-        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-          <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
-          <Text color="red">{`exit ${exitCode}`}</Text>
-        </Box>
+        <CornerLine color="red">{`exit ${exitCode}`}</CornerLine>
       ) : null}
       {toolUse.isError ? (
-        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-          <Text dimColor>{`${OUTPUT_CORNER} `}</Text>
-          <Text color="red">
-            {truncateWithEllipsis(
-              collapseWhitespace(errorText),
-              MAX_ERROR_PREVIEW,
-            )}
-          </Text>
-        </Box>
+        <CornerLine color="red">
+          {truncateWithEllipsis(
+            collapseWhitespace(errorText),
+            MAX_ERROR_PREVIEW,
+          )}
+        </CornerLine>
       ) : null}
-      {showNoOutput ? (
-        <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-          <Text dimColor>{`${OUTPUT_CORNER} (no output)`}</Text>
-        </Box>
-      ) : null}
+      {showNoOutput ? <CornerLine>(no output)</CornerLine> : null}
     </Box>
+  );
+}
+
+export function UniversalToolRow({
+  toolUse,
+  displayName,
+}: {
+  readonly toolUse: NormalizedToolUse;
+  readonly displayName?: string;
+}): React.JSX.Element {
+  return (
+    <ToolRow toolUse={toolUse} displayName={displayName} showPatch={true} />
+  );
+}
+
+function BashToolRow({
+  toolUse,
+}: {
+  readonly toolUse: NormalizedToolUse;
+}): React.JSX.Element {
+  return (
+    <ToolRow
+      toolUse={toolUse}
+      fallbackName="bash"
+      previewColor="cyan"
+      showExitCode={true}
+    />
   );
 }
 

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -294,6 +294,7 @@ interface ToolRowProps {
   readonly previewColor?: 'cyan';
   readonly showPatch?: boolean;
   readonly showExitCode?: boolean;
+  readonly preferInputPreview?: boolean;
 }
 
 function ToolRow(props: ToolRowProps): React.JSX.Element {
@@ -302,6 +303,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     previewColor,
     showPatch = false,
     showExitCode = false,
+    preferInputPreview = false,
   } = props;
   const color = statusColor(toolUse);
   const name =
@@ -310,8 +312,11 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     'tool';
 
   const { patchGroups, preview, visibleOutput, hiddenCount } = useMemo(() => {
-    const sourceText =
-      toolUse.headerSummary || previewInput(toolUse.input) || '';
+    // Bash rows prefer the command text (input) over the generic header summary;
+    // all other tools prefer the summary (which is curated per-tool) first.
+    const sourceText = preferInputPreview
+      ? previewInput(toolUse.input) || toolUse.headerSummary || ''
+      : toolUse.headerSummary || previewInput(toolUse.input) || '';
     const previewText = sourceText
       ? truncateWithEllipsis(collapseWhitespace(sourceText), MAX_HEADER_PREVIEW)
       : '';
@@ -322,7 +327,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
       visibleOutput: lines,
       hiddenCount: hidden,
     };
-  }, [toolUse, showPatch]);
+  }, [toolUse, showPatch, preferInputPreview]);
 
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
@@ -386,6 +391,7 @@ function BashToolRow({
       fallbackName="bash"
       previewColor="cyan"
       showExitCode={true}
+      preferInputPreview={true}
     />
   );
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -52,7 +52,7 @@ import { AgentListForm } from './forms/AgentListForm';
 import { ApiModeForm } from './forms/ApiModeForm';
 import {
   ApprovalPolicyForm,
-  formatApprovalPolicyForCli,
+  formatApprovalPolicyForCli as formatApprovalPolicy,
 } from './forms/ApprovalPolicyForm';
 import { ModelListForm } from './forms/ModelListForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
@@ -245,10 +245,6 @@ function openCliApiModeForm(
 
 async function showCliAuthStatus(): Promise<void> {
   appendLocalAssistantTranscript((await loadCliApiStatusLines()).join('\n'));
-}
-
-function formatApprovalPolicy(policy: CliApprovalPolicy): string {
-  return formatApprovalPolicyForCli(policy);
 }
 
 function parseApprovalPolicy(input: string): CliApprovalPolicy | undefined {
@@ -657,7 +653,7 @@ export async function runChat(
         getApprovalPolicy,
         setApprovalPolicy,
         resetSession: resetSessionForClear,
-        startStoredExecution: (config) => startAgentRun(config),
+        startStoredExecution: startAgentRun,
       }),
     getApprovalPolicy,
     onApprovalPolicySelect: (policy) => {
@@ -677,9 +673,9 @@ export async function runChat(
         getApprovalPolicy,
         setApprovalPolicy,
         resetSession: resetSessionForClear,
-        startStoredExecution: (config) => startAgentRun(config),
+        startStoredExecution: startAgentRun,
       }),
-    onApiModeSelect: (nextMode) => applyCliApiModeSelection(nextMode),
+    onApiModeSelect: applyCliApiModeSelection,
   });
 
   const startSession = (instruction: string): void => {
@@ -710,7 +706,7 @@ export async function runChat(
         getApprovalPolicy,
         setApprovalPolicy,
         resetSession: resetSessionForClear,
-        startStoredExecution: (config) => startAgentRun(config),
+        startStoredExecution: startAgentRun,
       })
     ) {
       return;

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -14,33 +14,24 @@ function processTitle(info: ActiveChildInfo): string {
   return info.agentName || info.toolName || info.executionId;
 }
 
+const ERROR_STATUSES = new Set(['error', 'failed', 'stopped']);
+const IN_FLIGHT_STATUSES = new Set([
+  'initializing',
+  'resuming',
+  'running',
+  'waiting',
+]);
+
 export function isCompletedProcessError(status: string | undefined): boolean {
   const normalized = status?.trim().toLowerCase();
   if (!normalized) return false;
-  if (
-    normalized === 'error' ||
-    normalized === 'failed' ||
-    normalized === 'stopped'
-  ) {
-    return true;
-  }
-  if (/exit(?:ed)?(?:\s+with)?(?:\s+code)?\s+[1-9]\d*/.test(normalized)) {
-    return true;
-  }
-  return false;
+  if (ERROR_STATUSES.has(normalized)) return true;
+  return /exit(?:ed)?(?:\s+with)?(?:\s+code)?\s+[1-9]\d*/.test(normalized);
 }
 
 function completedProcessStatus(status: string | undefined): string {
   const normalized = status?.trim().toLowerCase();
-  if (
-    !normalized ||
-    normalized === 'initializing' ||
-    normalized === 'resuming' ||
-    normalized === 'running' ||
-    normalized === 'waiting'
-  ) {
-    return 'completed';
-  }
+  if (!normalized || IN_FLIGHT_STATUSES.has(normalized)) return 'completed';
   return status ?? 'completed';
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -100,6 +100,14 @@ function entriesEqual(
   return true;
 }
 
+function logEntryRole(
+  messageType: string | undefined,
+): ConversationEntry['role'] {
+  if (messageType === MESSAGE_TYPES.USER_MESSAGE) return 'user';
+  if (messageType === MESSAGE_TYPES.ERROR) return 'error';
+  return 'assistant';
+}
+
 function renderLogEntry(
   entry: StreamLogEntry,
   prev: ConversationEntry | undefined,
@@ -141,12 +149,7 @@ function renderLogEntry(
   }
 
   const text = entry.text ?? '';
-  const role: ConversationEntry['role'] =
-    entry.messageType === MESSAGE_TYPES.USER_MESSAGE
-      ? 'user'
-      : entry.messageType === MESSAGE_TYPES.ERROR
-        ? 'error'
-        : 'assistant';
+  const role = logEntryRole(entry.messageType);
   const renderedText = role === 'error' ? appendCliApiSwitchHint(text) : text;
   // Assistant entries defer finalization (see comment above); inherit
   // from `prev` so re-syncs after finalize don't de-finalize and drop


### PR DESCRIPTION
## Summary
Trim duplication and ternary nests across the CLI TUI surface added since v0.37.8. Net −29 LOC across 8 files.

- `commands/registerBuiltins.tsx`: collapse three default `cliState.sessionMeta` mutators into one generic `patchSessionMeta` helper.
- `state/subscribeStreamLog.ts`: extract `logEntryRole`; replace nested message-type ternary with an if/else chain.
- `panes/StatusBar.tsx`: factor `compactScale` rounding helper for `k`/`M`; switch usage-ratio color picking from nested ternary to if/else.
- `state/completedProcessTranscript.ts`: extract `ERROR_STATUSES` / `IN_FLIGHT_STATUSES` sets, remove manual `||` chains.
- `modals/ChildControlPicker.tsx`: compute `metaParts` once for both row-count and compact-meta string.
- `panes/ConversationPane.tsx`: convert role dispatch in `TranscriptEntry` to a `switch`; factor process render into `ProcessEntryRow`.
- `panes/toolRenderers.tsx`: consolidate `UniversalToolRow` and `BashToolRow` onto a shared `ToolRow` + `OutputBlock` / `CornerLine` helpers.
- `runChatTui.tsx`: drop trivial `formatApprovalPolicy` wrapper (import rename); drop two `(arg) => f(arg)` arrows.

## Verified
- `npx tsc -p packages/cli/tsconfig.json --noEmit` → exit 0
- `npx vitest run src/test-kernel/cli/` → 27 files, 159 tests passing
- No `vscode` imports introduced.

## Out of scope (intentional)
- `runChatTui.tsx` (~830 LOC) — large but cohesive entry point; splitting would scatter slash-command surface for marginal gain.
- `ChildControlPicker.tsx` / `toolRenderers.tsx` trimmed in place rather than split — display-lines + React row share enough constants that splitting would add boilerplate.

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: \`texra chat\` — sidebar status bar, conversation pane, tool-output rendering, child-control picker (Ctrl+C twice)
- [ ] Smoke: trigger a subagent and observe its stream tab + completion transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI TUI rendering/formatting and small helper extraction; main risk is minor regressions in how tool/process rows or status numbers are displayed.
> 
> **Overview**
> Simplifies several CLI TUI surfaces by extracting small helpers and removing duplicated rendering/formatting logic.
> 
> This consolidates tool row rendering (`UniversalToolRow`/bash) onto a shared `ToolRow` with reusable output/error line components, factors process-entry rendering into `ProcessEntryRow`, and replaces a few nested ternaries/`||` chains with clearer helpers/sets (`logEntryRole`, `compactScale`, status sets).
> 
> Also cleans up slash-command defaults by patching `cliState.sessionMeta` via a generic helper and removes a couple of trivial wrapper/forwarding functions in `runChatTui.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e31e293cfc70fc7784ffb7ad74e29c4a300c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->