### PR TITLE
refactor(agent-runtime): simplify post-0.37.8 surface

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -55,14 +55,10 @@ export class LatexDiffManager {
     this.latexdiffService = new LaTeXdiffService(streamId);
   }
 
-  private resolveSymlinks(target: string): Promise<string> {
-    return platform()
-      .fs.realPath(target)
-      .catch(() => target);
-  }
-
   private async getWorkingDirectory(location: FileLocation): Promise<string> {
-    const resolved = await this.resolveSymlinks(location.absolutePath);
+    const resolved = await platform()
+      .fs.realPath(location.absolutePath)
+      .catch(() => location.absolutePath);
     return path.dirname(resolved);
   }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -25,6 +25,7 @@ import {
   STREAM_STATUS,
   END_GROUP_STATUS,
   EXECUTION_STATUS,
+  type EndGroupStatus,
   type StreamTabId,
   type ExecutionId,
   type OutputFileInfo,
@@ -230,11 +231,21 @@ async function runFlowWithLifecycle(
     }
 
     if (kind === 'abort') {
-      return buildStoppedFlowResult(category, ctx.executionId, streamId);
+      return buildTerminalFlowResult(
+        category,
+        END_GROUP_STATUS.STOPPED,
+        ctx.executionId,
+        streamId,
+      );
     }
 
     if (options?.isSubagent) {
-      const result = buildErrorFlowResult(category, ctx.executionId, streamId);
+      const result = buildTerminalFlowResult(
+        category,
+        END_GROUP_STATUS.ERROR,
+        ctx.executionId,
+        streamId,
+      );
       try {
         await options.onError?.(err, result);
       } catch (deliveryError) {
@@ -253,47 +264,18 @@ async function runFlowWithLifecycle(
   }
 }
 
-function buildErrorFlowResult(
+function buildTerminalFlowResult(
   category: 'workflow' | 'toolUse',
+  status: EndGroupStatus,
   executionId: ExecutionId,
   streamId: StreamTabId,
 ): AgentFlowResult {
   if (category === 'toolUse') {
-    return {
-      category,
-      status: END_GROUP_STATUS.ERROR,
-      executionId,
-      streamId,
-    };
+    return { category, status, executionId, streamId };
   }
-
   return {
     category,
-    status: END_GROUP_STATUS.ERROR,
-    executionId,
-    streamId,
-    outputs: [],
-    compileFailures: [],
-  };
-}
-
-function buildStoppedFlowResult(
-  category: 'workflow' | 'toolUse',
-  executionId: ExecutionId,
-  streamId: StreamTabId,
-): AgentFlowResult {
-  if (category === 'toolUse') {
-    return {
-      category,
-      status: END_GROUP_STATUS.STOPPED,
-      executionId,
-      streamId,
-    };
-  }
-
-  return {
-    category,
-    status: END_GROUP_STATUS.STOPPED,
+    status,
     executionId,
     streamId,
     outputs: [],


### PR DESCRIPTION
## Summary
Trim duplication in the agent runtime/output area changed since v0.37.8. Net +20/−42 across 2 files.

- `src/agent/runtime/executeAgent.ts` — collapse the near-identical `buildErrorFlowResult` and `buildStoppedFlowResult` into one `buildTerminalFlowResult(category, status, executionId, streamId)`. The two original builders only differed by hardcoded status; consolidating removes ~30 lines of duplicated `if (category === 'toolUse') ... else ...` scaffolding.
- `src/agent/output/LatexDiffManager.ts` — inline the one-line `resolveSymlinks` helper into its sole caller `getWorkingDirectory`. Verified no test or extension/desktop/cli call reaches into `(LatexDiffManager as any).resolveSymlinks`.

## Out of scope (intentional)
- `runExecutionRequest.ts`, `ProcessOutputPoller.ts`, `compileCheck.ts`, `ToolUseAgentRegistry.ts` — each has justified extractions or callers (CLI/desktop) that rely on the current shape.
- `LatexDiffManager` helpers other than `resolveSymlinks` carry meaningful logic.

## Verified
- `npx tsc --noEmit` — same 16 pre-existing baseline errors (cli/desktop/openrouter), no new errors from these edits.
- `npx vitest run src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/agent/toolUse/ToolUseModelSwitch.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts` → 21 tests pass.

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: agent run that errors or is stopped — confirm both terminal-result paths still surface correctly in history
- [ ] Smoke: \`latex diff\` workflow that resolves working dir via a symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes small helper/builder duplication without changing core runtime control flow. Main risk is minor regressions in terminal status shaping for `workflow` vs `toolUse` results or in how latexdiff working directories resolve symlinks.
> 
> **Overview**
> Refactors agent termination result creation by replacing the duplicated `buildErrorFlowResult`/`buildStoppedFlowResult` helpers with a single `buildTerminalFlowResult(category, status, executionId, streamId)` used for both abort and subagent error paths.
> 
> Simplifies `LatexDiffManager` by inlining the `realPath`/symlink resolution into `getWorkingDirectory`, removing the now-unused `resolveSymlinks` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebe6f71fe4cc82ce5ed0194005fbfd0831500b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->