### PR TITLE
refactor(settings): unify schema/CLI/extension SSOT

### DIFF
--- a/packages/cli/src/runtime/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approvalPolicy.ts
@@ -1,2 +1,4 @@
-export const CLI_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
-export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
+export {
+  CLI_APPROVAL_POLICIES,
+  type CliApprovalPolicy,
+} from '@utils/config/settingsSchema';

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -4,19 +4,21 @@ import path from 'node:path';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
-import { KNOWN_TEXRA_KEYS } from '@utils/config/settingsSchema';
-
 import {
   CLI_APPROVAL_POLICIES,
+  CLI_OUTPUT_FORMATS,
+  KNOWN_TEXRA_KEYS,
   type CliApprovalPolicy,
-} from './approvalPolicy';
+  type CliOutputFormat,
+} from '@utils/config/settingsSchema';
+
+// Re-export so existing call sites (`from './cliConfig'`) keep working — the
+// canonical home is `@utils/config/settingsSchema`.
+export { CLI_OUTPUT_FORMATS, type CliOutputFormat };
 
 export const CLI_CONFIG_DIR = '.texra';
 export const CLI_CONFIG_FILE = 'config.json';
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekT';
-
-export const CLI_OUTPUT_FORMATS = ['text', 'json', 'ndjson'] as const;
-export type CliOutputFormat = (typeof CLI_OUTPUT_FORMATS)[number];
 
 export interface CliCommandConfig {
   readonly agent?: string;

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -46,6 +46,11 @@ export const DEFAULT_TEXRA_SETTINGS = {
   inlineCriticism: {
     enabled: false,
   },
+  experimental: {
+    odyssey: {
+      enabled: false,
+    },
+  },
   ui: {
     showApiKeyReminders: true,
     showLoginBanner: true,
@@ -256,6 +261,17 @@ export const TexraSettingsSchema = z
           .prefault(DEFAULT_TEXRA_SETTINGS.inlineCriticism.enabled),
       })
       .prefault(DEFAULT_TEXRA_SETTINGS.inlineCriticism),
+    experimental: z
+      .strictObject({
+        odyssey: z
+          .strictObject({
+            enabled: z
+              .boolean()
+              .prefault(DEFAULT_TEXRA_SETTINGS.experimental.odyssey.enabled),
+          })
+          .prefault(DEFAULT_TEXRA_SETTINGS.experimental.odyssey),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.experimental),
     ui: z
       .strictObject({
         showApiKeyReminders: z
@@ -493,6 +509,7 @@ export type TexraSettings = z.infer<typeof TexraSettingsSchema>;
 export const TEXRA_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',
   'inlineCriticism.enabled',
+  'experimental.odyssey.enabled',
   'ui.showApiKeyReminders',
   'ui.showLoginBanner',
   'ui.showGettingStartedBanner',

--- a/src/utils/config/settingsSchema.ts
+++ b/src/utils/config/settingsSchema.ts
@@ -12,80 +12,16 @@ export type CliApprovalPolicy = (typeof CLI_APPROVAL_POLICIES)[number];
 // Known `texra.*` configuration keys
 // ---------------------------------------------------------------------------
 //
-// This is the authoritative list of canonical `texra.*` setting keys used by
-// the extension and the CLI for "unknown key" detection. Per-key schemas and
-// defaults live in `src/shared/schemas/settingsConfiguration.ts`; this file
-// intentionally tracks only the names.
+// Authoritative list of canonical `texra.*` setting keys recognized by the
+// extension and the CLI for "unknown key" detection. The structured per-key
+// schemas and defaults are the canonical source (`TEXRA_SETTING_KEYS` from
+// `@shared/schemas/settingsConfiguration`); CLI-runtime-only keys are
+// appended here so they can also pass validation.
 
-const KEYS = [
-  // Agent outputs
-  'texra.agentOutputs.autoOpenFinal',
-  // Inline criticism
-  'texra.inlineCriticism.enabled',
-  // Experimental
-  'texra.experimental.odyssey.enabled',
-  // UI toggles
-  'texra.ui.showApiKeyReminders',
-  'texra.ui.showLoginBanner',
-  'texra.ui.showGettingStartedBanner',
-  'texra.ui.showOrchestratorBanner',
-  // Auth
-  'texra.auth.enableVSCodeGitHub',
-  // Model
-  'texra.model.useImprovedConnection',
-  'texra.model.improvedConnectionDomain',
-  'texra.model.useOpenAIResponsesAPI',
-  'texra.model.useBackgroundResponses',
-  'texra.model.openaiParallelToolCalls',
-  'texra.model.compactionThresholdPercent',
-  'texra.model.gpt5ReasoningSummary',
-  // Model retry
-  'texra.model.retry.maxAttempts',
-  'texra.model.retry.backoffMs',
-  // Files: included
-  'texra.files.included.mediaExtensions',
-  'texra.files.included.inputExtensions',
-  'texra.files.included.contextExtensions',
-  'texra.files.included.editedExtensions',
-  // Files: ignored
-  'texra.files.ignored.fileExtensions',
-  'texra.files.ignored.inputFiles',
-  'texra.files.ignored.inputDirectories',
-  'texra.files.ignored.mediaDirectories',
-  'texra.files.ignored.directories',
-  'texra.files.ignored.keywords',
-  // Images
-  'texra.maxImageDimension',
-  // Bibliography
-  'texra.bib.defaultPath',
-  'texra.bib.zoteroPort',
-  // LaTeX
-  'texra.latex.showLatexindentWarning',
-  'texra.latex.latexindentConfig',
-  'texra.latex.texfmtConfig',
-  'texra.latex.tikzInputDirectory',
-  'texra.latex.tikzTemplate',
-  'texra.latex.includeWorkspaceInTexinputs',
-  'texra.latex.wrapCritiqueInAlign',
-  // LaTeX diff
-  'texra.latexdiff.pictureEnvironments',
-  'texra.latexdiff.tempFileLocation',
-  // LaTeX replacements
-  'texra.latex.enabledReplacements',
-  'texra.latex.enabledReplacementsRegex',
-  'texra.latex.customReplacementsRegex',
-  'texra.latex.customReplacements',
-  // Tool use
-  'texra.toolUse.persistence.enabled',
-  'texra.toolUse.persistence.ttlHours',
-  'texra.toolUse.requireBashApproval',
-  'texra.toolUse.requireEditApproval',
-  // Logger
-  'texra.logger.debugMode',
-  // Git
-  'texra.git.numberOfCommitsToShow',
-  'texra.git.emitPrCiStartedEvents',
-  // CLI runtime
+import { TEXRA_SETTING_KEYS } from '@shared/schemas/settingsConfiguration';
+
+// CLI-only top-level keys (no structured schema; consumed by CLI runtime).
+const CLI_RUNTIME_KEYS = [
   'texra.agent',
   'texra.model',
   'texra.outputFormat',
@@ -95,4 +31,7 @@ const KEYS = [
 ] as const;
 
 /** Set of all known canonical `texra.*` config keys. */
-export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set(KEYS);
+export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
+  ...TEXRA_SETTING_KEYS,
+  ...CLI_RUNTIME_KEYS,
+]);


### PR DESCRIPTION
## Summary
SSOT audit across `src/shared/schemas/settingsConfiguration.ts`, `src/utils/config/settingsSchema.ts`, `packages/extension/package.json` `contributes.configuration`, and the CLI's settings layer. Found four real issues — one of them a latent bug.

### 1. Missing key in canonical schema (latent bug)
`texra.experimental.odyssey.enabled` existed in `packages/extension/package.json` and in the CLI's `KEYS` array, with a typed constant in `src/tools/odyssey/odysseyMeta.ts`, but was absent from `TEXRA_SETTING_PATHS` / `DEFAULT_TEXRA_SETTINGS`. Confirmed: \`node scripts/sync-settings-configuration.mjs --check\` threw `unknown setting key: texra.experimental.odyssey.enabled` before the fix. Added the schema entry, default, and path.

### 2. Duplicated `KEYS` list in `settingsSchema.ts`
The 50+ entry hand-maintained array duplicated `TEXRA_SETTING_KEYS` from the canonical schema. Replaced with `[...TEXRA_SETTING_KEYS, ...CLI_RUNTIME_KEYS]` where `CLI_RUNTIME_KEYS` holds only the 6 CLI-only top-level keys (`agent`, `model`, `outputFormat`, `approvalPolicy`, `chat`, `run`). Drift is now structurally impossible.

### 3. Duplicate `CLI_OUTPUT_FORMATS` / `CliOutputFormat`
Identical `['text', 'json', 'ndjson']` literal lived in both `settingsSchema.ts` and `packages/cli/src/runtime/cliConfig.ts`. Removed CLI-side definition; `cliConfig.ts` imports + re-exports.

### 4. Duplicate `CLI_APPROVAL_POLICIES` / `CliApprovalPolicy`
Identical `['never', 'ask', 'yolo']` literal in both `settingsSchema.ts` and `packages/cli/src/runtime/approvalPolicy.ts`. Converted `approvalPolicy.ts` to a thin re-export.

## Investigated and OK
- Three-way key set now matches exactly between canonical schema, `package.json`, and CLI.
- `package.json` defaults/types/descriptions are already auto-derived via `scripts/sync-settings-configuration.mjs` — no drift surface.
- `cliConfigProvider.ts` bare/`texra.*` dual-resolution is intentional backward compat.

## Verified (by simplifier)
- `node scripts/sync-settings-configuration.mjs --check` — in sync
- `node scripts/verify-extension-package-invariants.mjs` — passes
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: settings UI in extension still shows odyssey toggle
- [ ] Smoke: \`texra\` CLI with custom `~/.texra/settings.json` setting `outputFormat: "ndjson"` and `approvalPolicy: "yolo"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared settings defaults/schema and the CLI’s unknown-key validation list; mistakes could cause settings to be rejected or silently ignored across CLI/extension.
> 
> **Overview**
> Unifies the source-of-truth for recognized `texra.*` configuration keys by deriving `KNOWN_TEXRA_KEYS` from `TEXRA_SETTING_KEYS` and appending a small `CLI_RUNTIME_KEYS` list, removing the large hand-maintained key array.
> 
> Fixes a latent schema drift by adding the missing `experimental.odyssey.enabled` default + Zod schema entry and including it in `TEXRA_SETTING_PATHS`.
> 
> Deduplicates CLI enums by making `packages/cli` import (and in one case re-export) `CLI_OUTPUT_FORMATS`/`CliOutputFormat` and `CLI_APPROVAL_POLICIES`/`CliApprovalPolicy` from `@utils/config/settingsSchema` instead of defining them locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9d924c5722e17fed342750a569e827e48c5fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->