### PR TITLE
refactor(schemas): derive DEFAULT_TOTALS from schema prefaults

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -5,7 +5,7 @@ import {
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
 import {
-  DEFAULT_TOTALS,
+  createDefaultTotals,
   RunUsageAccumulatorJSONSchema,
   recordNormalizedUsage,
 } from './RunUsageAccumulator';
@@ -35,10 +35,10 @@ export function createRoundState(
 export const AgentRunStateSnapshotSchema = z.object({
   totalRounds: z.int().nonnegative().prefault(0),
   totalResponseTimeMs: z.number().nonnegative().prefault(0),
-  usageAccumulator: RunUsageAccumulatorJSONSchema.prefault({
-    totals: DEFAULT_TOTALS,
+  usageAccumulator: RunUsageAccumulatorJSONSchema.prefault(() => ({
+    totals: createDefaultTotals(),
     normalizedSnapshots: [],
-  }),
+  })),
 });
 
 export type AgentRunStateSnapshot = z.output<
@@ -51,7 +51,7 @@ export function createRunState(): AgentRunStateSnapshot {
     totalRounds: 0,
     totalResponseTimeMs: 0,
     usageAccumulator: {
-      totals: { ...DEFAULT_TOTALS },
+      totals: createDefaultTotals(),
       normalizedSnapshots: [],
     },
   };

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -7,29 +7,15 @@ import {
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
 
+const TokenCountSchema = z.int().nonnegative();
+
 /**
- * Default values for run usage totals - exported for use in schema defaults.
+ * Schema for run usage totals. Internal only.
  *
  * `totalCost` is the running sum of `NormalizedUsage.cost`, which is already
  * calculated per provider (including prompt-cache discounts or creation
  * premiums). No extra adjustments are applied here.
  */
-export const DEFAULT_TOTALS = {
-  firstInputTokens: 0,
-  totalInputTokens: 0,
-  totalOutputTokens: 0,
-  totalCost: 0,
-  totalCacheReadInputTokens: 0,
-  totalCacheMissInputTokens: 0,
-  totalCacheCreationInputTokens: 0,
-  totalReasoningTokens: 0,
-  totalToolUsePromptTokens: 0,
-  totalServerToolRequests: 0,
-} as const;
-
-const TokenCountSchema = z.int().nonnegative();
-
-/** Schema for run usage totals. Internal only. */
 const RunUsageTotalsSchema = z.object({
   firstInputTokens: TokenCountSchema.prefault(0),
   totalInputTokens: TokenCountSchema.prefault(0),
@@ -44,6 +30,17 @@ const RunUsageTotalsSchema = z.object({
 });
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
+/**
+ * Build a fresh default totals object from the schema.
+ *
+ * Single source of truth: the per-field `.prefault(0)` declarations on
+ * `RunUsageTotalsSchema` drive the result, so adding a new field there
+ * automatically extends this default without manual sync.
+ */
+export function createDefaultTotals(): RunUsageTotals {
+  return RunUsageTotalsSchema.parse({});
+}
+
 /** Schema for normalized usage snapshot. Internal only. */
 const NormalizedUsageSnapshotSchema = z.object({
   round: z.int().nonnegative(),
@@ -55,7 +52,7 @@ const NormalizedUsageSnapshotSchema = z.object({
  * Uses .prefault() for input normalization before validation.
  */
 export const RunUsageAccumulatorJSONSchema = z.object({
-  totals: RunUsageTotalsSchema.prefault(DEFAULT_TOTALS),
+  totals: RunUsageTotalsSchema.prefault(() => createDefaultTotals()),
   normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).prefault([]),
 });
 


### PR DESCRIPTION
## Summary
Audited Zod schema SSOT across the entire repo (35+ schema files in `src/shared/schemas/`, plus `src/tools/`, `src/agent/`, `src/utils/config/`, `packages/cli/src/runtime/`, `src/replacement/`, `src/eventBus/`). Found **one** genuine drift to fix; the rest of the repo's Zod hygiene is strong.

### Fix: `DEFAULT_TOTALS` duplicated schema defaults

`src/agent/core/RunUsageAccumulator.ts` declared `RunUsageTotalsSchema` with `.prefault(0)` on every one of ten fields, yet a parallel `DEFAULT_TOTALS` const re-enumerated all ten. Adding a field would mean touching both with no compile-time link.

Replaced `DEFAULT_TOTALS` with `createDefaultTotals() = RunUsageTotalsSchema.parse({})`. The schema's `.prefault(0)` declarations are now the single source of truth; `createRunState` and both prefault call sites all derive from it. (As a bonus this fixes a latent TS error in `AgentState.ts` that referenced the duplicated const.)

## Investigated and confirmed clean
- `src/shared/schemas/**` (35+ files) — every shape uses `z.infer<typeof Schema>`.
- `src/tools/**` — `defineTool` factory drives runtime validation + JSON Schema export from one Zod source.
- `src/agent/modelHandlers/**`, `src/agent/output/**`, `src/agent/storage/**`, `src/agent/runtime/**` — sibling interfaces present are justified (SDK union types, runtime classes holding `Map`/`Set`/`Promise`/class instances, type-only event payloads).
- `rg "z\.custom<"` — all four hits (`ToolDefinition`, `AgentWorkspaceState`, `ProviderMessage`, `ResponseCycle`) are justified escape hatches for external Zod/SDK types.
- Settings layer — addressed in companion PR (#4254 if open).

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: any agent run — verify usage totals (`input_tokens`, `output_tokens`, etc.) start at 0 and accumulate correctly across rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to schema defaulting/initialization for usage totals; behavior should remain identical aside from avoiding shared mutable default objects.
> 
> **Overview**
> Removes the duplicated `DEFAULT_TOTALS` constant and instead derives fresh run-usage totals defaults via `createDefaultTotals()` (`RunUsageTotalsSchema.parse({})`), making the Zod schema `.prefault(0)` fields the single source of truth.
> 
> Updates both `RunUsageAccumulatorJSONSchema` and `AgentRunStateSnapshotSchema`/`createRunState` to use function-based defaults (`prefault(() => ...)`) so each parse/initialization gets a new totals object rather than reusing a shared literal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b983cb06511fc8cc61e84eb623bfd5eef07299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->