### PR TITLE
refactor(agent-core): derive AgentState defaults from schema

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -5,7 +5,6 @@ import {
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
 import {
-  createDefaultTotals,
   RunUsageAccumulatorJSONSchema,
   recordNormalizedUsage,
 } from './RunUsageAccumulator';
@@ -20,28 +19,15 @@ export type ConversationRoundStateSnapshot = z.output<
   typeof ConversationRoundStateSnapshotSchema
 >;
 
-export function createRoundState(
-  roundIndex: number,
-): ConversationRoundStateSnapshot {
-  return ConversationRoundStateSnapshotSchema.parse({ roundIndex });
-}
-
 export const AgentRunStateSnapshotSchema = z.object({
   totalRounds: z.int().nonnegative().prefault(0),
   totalResponseTimeMs: z.number().nonnegative().prefault(0),
-  usageAccumulator: RunUsageAccumulatorJSONSchema.prefault(() => ({
-    totals: createDefaultTotals(),
-    normalizedSnapshots: [],
-  })),
+  usageAccumulator: RunUsageAccumulatorJSONSchema.prefault({}),
 });
 
 export type AgentRunStateSnapshot = z.output<
   typeof AgentRunStateSnapshotSchema
 >;
-
-export function createRunState(): AgentRunStateSnapshot {
-  return AgentRunStateSnapshotSchema.parse({});
-}
 
 /**
  * Record cycle metrics into run state. Mutates run in place.

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -20,16 +20,10 @@ export type ConversationRoundStateSnapshot = z.output<
   typeof ConversationRoundStateSnapshotSchema
 >;
 
-/** Create a fresh round state for the given round index. */
 export function createRoundState(
   roundIndex: number,
 ): ConversationRoundStateSnapshot {
-  return {
-    roundIndex,
-    continuationCount: 0,
-    responseTimeMs: 0,
-    normalizedUsage: null,
-  };
+  return ConversationRoundStateSnapshotSchema.parse({ roundIndex });
 }
 
 export const AgentRunStateSnapshotSchema = z.object({
@@ -45,16 +39,8 @@ export type AgentRunStateSnapshot = z.output<
   typeof AgentRunStateSnapshotSchema
 >;
 
-/** Create a fresh run state (all zeros). */
 export function createRunState(): AgentRunStateSnapshot {
-  return {
-    totalRounds: 0,
-    totalResponseTimeMs: 0,
-    usageAccumulator: {
-      totals: createDefaultTotals(),
-      normalizedSnapshots: [],
-    },
-  };
+  return AgentRunStateSnapshotSchema.parse({});
 }
 
 /**

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -1,5 +1,5 @@
 import { Node } from '@agent/node';
-import { createRoundState } from '@agent/core/AgentState';
+import { ConversationRoundStateSnapshotSchema } from '@agent/core/AgentState';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
@@ -33,7 +33,9 @@ export class PrepareContextNode<C = unknown> extends Node<
     const { promptBuilder, modelHandler, logger } = this.services;
     const { currentRound, conversation } = prepRes;
 
-    const stateRound = createRoundState(currentRound);
+    const stateRound = ConversationRoundStateSnapshotSchema.parse({
+      roundIndex: currentRound,
+    });
     const isFirstRound = currentRound === 0;
 
     let messages: ProviderMessage[];

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -19,7 +19,7 @@ import {
   clearRetryRequest,
 } from '@agent/runtime/runCoordinators';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
-import { createRunState } from '@agent/core/AgentState';
+import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
@@ -223,7 +223,7 @@ export async function runReflectionFlow<C = unknown>(
         context: null,
         outputLocation: null,
         conversation: [],
-        runStateSnapshot: createRunState(),
+        runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
         roundStateSnapshots: [],
         roundOutputs: [],
         continueRounds: true,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -1,6 +1,6 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { createRunState } from '@agent/core/AgentState';
+import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
@@ -69,7 +69,7 @@ export class ToolUsePrepareNode<C> extends Node<
       };
     }
 
-    const runState = createRunState();
+    const runState = AgentRunStateSnapshotSchema.parse({});
     const workspaceState = AgentWorkspaceState.create();
 
     const { systemPrompt, userPrefix, userRequest, instructionSuffix } =

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -4,7 +4,7 @@ import { strict as assert } from 'assert';
 // Local imports - agent
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import { createRunState } from '@agent/core/AgentState';
+import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
@@ -35,7 +35,7 @@ describe('ToolUseFollowUp', () => {
     }),
     messages: [],
     // State slices stored directly (v2 schema)
-    run: createRunState(),
+    run: AgentRunStateSnapshotSchema.parse({}),
     workspace: workspaceState.toSnapshot(),
     user: {
       input: {},

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'llm-zoo';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
-import { createRunState } from '@agent/core/AgentState';
+import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
@@ -143,7 +143,7 @@ describe('BashTool', () => {
     };
     const handler = new BashMockHandler(config);
     const workspaceState = AgentWorkspaceState.create();
-    const run = createRunState();
+    const run = AgentRunStateSnapshotSchema.parse({});
     const options: ToolUseCycleServices<OpenAI> = {
       modelHandler: handler,
       config: config as any,


### PR DESCRIPTION
## Summary
Follow-up to the post-0.37.8 simplifier batch (specifically #4255). \`claude[bot]\` left a non-blocking nit: both \`createRoundState()\` and \`createRunState()\` rebuilt the default object shape that the schema's per-field \`.prefault()\` declarations already encode.

Switch each factory to a schema \`.parse(...)\` so the schema stays the single source of truth — adding a field now needs only a matching prefault declaration, not a parallel branch in the factory.

\`\`\`diff
-export function createRunState(): AgentRunStateSnapshot {
-  return {
-    totalRounds: 0,
-    totalResponseTimeMs: 0,
-    usageAccumulator: {
-      totals: createDefaultTotals(),
-      normalizedSnapshots: [],
-    },
-  };
-}
+export function createRunState(): AgentRunStateSnapshot {
+  return AgentRunStateSnapshotSchema.parse({});
+}
\`\`\`

## Skipped
- \`#4251\` cli-tui nits — both were non-blocking observations:
  - The \`'tool'\` fallback in the name chain is unreachable from \`BashToolRow\` but still needed for \`UniversalToolRow\` (no \`fallbackName\`), so the current chain is correct as-is.
  - Narrowing \`previewColor?: 'cyan'\` / \`color?: 'red'\` to wider types would be designing for hypothetical future requirements (CLAUDE.md flags this anti-pattern).

## Test plan
- [ ] CI typecheck + lint
- [ ] Smoke: any agent run — confirm usage totals still start at 0 and accumulate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk refactor that centralizes `AgentState` default initialization in zod `.prefault()`/`.parse()`; main risk is unintended default-shape changes affecting usage metrics initialization.
> 
> **Overview**
> Removes the manual `createRoundState()`/`createRunState()` factories and instead initializes round/run state via `ConversationRoundStateSnapshotSchema.parse(...)` and `AgentRunStateSnapshotSchema.parse({})`, making the zod schemas the single source of truth for defaults.
> 
> Updates reflection and tool-use flow initialization (and related tests) to use the schema-based constructors, and simplifies `usageAccumulator` defaulting to rely on `RunUsageAccumulatorJSONSchema` prefaults rather than rebuilding totals/snapshots inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f400e40abeecc375306e32ddde8aac2b35d669e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->