### PR TITLE
fix(cli): accept raw enter in TUI controls

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useInput } from 'ink';
 import { useState, useEffect } from 'react';
 
 import { matchSlashCommands, type SlashCommand } from './slashRegistry';
+import { isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 
 export interface SlashPaletteProps {
@@ -51,7 +52,7 @@ export function SlashPalette(
         setHighlight((h) => (h + 1) % visibleCount);
         return;
       }
-      if (key.return || key.tab || input === '\t') {
+      if (isPlainReturnInput(input, key) || key.tab || input === '\t') {
         const chosen = visible[highlight];
         if (chosen) props.onPick(chosen);
       }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -17,6 +17,7 @@ import {
   insertText,
   type TextEdit,
 } from './textInputEditing';
+import { isPlainReturnInput } from './inputKeys';
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -87,13 +88,13 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   useInput(
     (input, key) => {
-      if (key.return) {
-        onSubmit(value);
-        return;
-      }
       if (key.ctrl && input === 'j') {
         // Ctrl-J → literal newline (kills the legacy `/multi` ceremony).
         applyEdit(insertText(value, cursor, '\n'));
+        return;
+      }
+      if (isPlainReturnInput(input, key)) {
+        onSubmit(value);
         return;
       }
       if (key.backspace) {

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -1,0 +1,13 @@
+export interface ReturnKeyInput {
+  readonly return?: boolean;
+  readonly ctrl?: boolean;
+  readonly meta?: boolean;
+}
+
+export function isPlainReturnInput(
+  input: string,
+  key: ReturnKeyInput,
+): boolean {
+  if (key.ctrl || key.meta) return false;
+  return key.return === true || input === '\r' || input === '\n';
+}

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -215,7 +215,9 @@ function TaskDetailView({
   useInput((input, key) => {
     const action = childPickerKeyAction({
       input,
+      ctrl: key.ctrl,
       escape: key.escape,
+      meta: key.meta,
       upArrow: key.upArrow,
       downArrow: key.downArrow,
       return: key.return,
@@ -338,7 +340,9 @@ export function ChildControlPicker({
     (input, key) => {
       const action = childPickerKeyAction({
         input,
+        ctrl: key.ctrl,
         escape: key.escape,
+        meta: key.meta,
         upArrow: key.upArrow,
         downArrow: key.downArrow,
         return: key.return,

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -15,6 +15,7 @@ import {
 } from './UserQuestionState';
 import type { ApprovalDecision } from '../state/approvalQueue';
 import { BaseTextInput } from '../input/BaseTextInput';
+import { isPlainReturnInput } from '../input/inputKeys';
 import { Select } from '../ui/Select';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { parseUserQuestionAnswer } from '../../../runtime/userQuestionAnswer';
@@ -108,7 +109,7 @@ function MultiSelectQuestion(
       }
       return;
     }
-    if (key.return) {
+    if (isPlainReturnInput(input, key)) {
       props.onSubmit([...selected]);
       return;
     }

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -4,6 +4,7 @@
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
+import { isPlainReturnInput } from '../input/inputKeys';
 import { orderedDescendantsFromSlice } from './focusCycle';
 import type { ProcessOutputTail, StreamSlice } from './cliState';
 
@@ -27,6 +28,8 @@ export interface PickerKeyInput {
   readonly downArrow?: boolean;
   readonly return?: boolean;
   readonly escape?: boolean;
+  readonly ctrl?: boolean;
+  readonly meta?: boolean;
 }
 
 export type PickerKeyAction =
@@ -188,7 +191,7 @@ export function childPickerKeyAction(key: PickerKeyInput): PickerKeyAction {
   if (key.escape) return { kind: 'close' };
   if (key.upArrow) return { kind: 'up' };
   if (key.downArrow) return { kind: 'down' };
-  if (key.return) return { kind: 'select' };
+  if (isPlainReturnInput(key.input, key)) return { kind: 'select' };
   if (key.input.toLowerCase() === 'k') return { kind: 'kill' };
 
   const digit = Number(key.input);

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -10,6 +10,8 @@
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
+import { isPlainReturnInput } from '../input/inputKeys';
+
 export const SELECT_LABEL_MAX_COLS = 24;
 
 export interface SelectItem<T> {
@@ -65,7 +67,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       );
       return;
     }
-    if (key.return) {
+    if (isPlainReturnInput(input, key)) {
       const choice = props.items[highlight];
       if (choice && !choice.disabled) props.onSelect(choice.value);
       return;

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -8,8 +8,17 @@ import {
   deleteToStart,
   insertText,
 } from '../../../packages/cli/src/chat/tui/input/textInputEditing';
+import { isPlainReturnInput } from '../../../packages/cli/src/chat/tui/input/inputKeys';
 
 describe('CLI TUI text input editing', () => {
+  it('recognizes normalized and raw Enter without stealing Ctrl-J', () => {
+    expect(isPlainReturnInput('', { return: true })).toBe(true);
+    expect(isPlainReturnInput('\r', {})).toBe(true);
+    expect(isPlainReturnInput('\n', {})).toBe(true);
+    expect(isPlainReturnInput('j', { ctrl: true })).toBe(false);
+    expect(isPlainReturnInput('\n', { ctrl: true })).toBe(false);
+  });
+
   it('inserts pasted multi-line text without submitting embedded newlines', () => {
     expect(insertText('ab', 1, 'x\ny')).toEqual({
       value: 'ax\nyb',


### PR DESCRIPTION
## Summary

This patch makes the CLI TUI accept both Ink-normalized Enter events and raw CR/LF input in the interactive controls that submit or select a choice. In PTY-driven probes, Enter can arrive as `\r` instead of `key.return`; before this change, `/model` followed by Enter inserted a carriage return into the input buffer instead of opening the form.

The change introduces a small `isPlainReturnInput` helper and applies it to:

- the main chat text input
- the slash command palette
- shared select forms
- user-question multi-select submission
- child-control pickers

Ctrl-J remains a literal newline in the text input.

## Evidence

Observed before the patch:

1. Build the CLI.
2. Run `TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --approval-policy ask`.
3. Type `/model` and send Enter through the PTY.
4. The input line displayed `/model^M` instead of opening the model form.

Verified after the patch:

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` — 0 errors, existing 18 warnings
- `npm run validate:run` from `packages/cli`
- Built CLI PTY probe: `TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --approval-policy ask`, type `/model`, send Enter as a separate keystroke; the model picker opens.

## Follow-up

While probing the fixed path, I found a separate model-picker layout defect and filed #4257.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI input handling across multiple interactive components; while scoped and covered by a small unit test, it could subtly change keybinding behavior in terminals/PTYs (especially around Enter vs modified keys).
> 
> **Overview**
> Fixes TUI controls to treat raw `\r`/`\n` input as Enter (in addition to Ink’s `key.return`) so PTY-driven environments correctly submit/select instead of inserting a carriage return.
> 
> Introduces a shared `isPlainReturnInput` helper and applies it to chat text submission, slash palette selection, generic `Select`, user-question multi-select submit, and child-control pickers (including passing `ctrl`/`meta` through the picker key-action path). Adds a targeted unit test to ensure Ctrl-J still inserts a literal newline rather than triggering submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ebb6a1149ecce6c2365242624a5e2b0abf4e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->