### PR TITLE
[codex] restore generated-file latexdiff action

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -546,16 +546,25 @@ export class FileList extends LitElement {
       ${renderFileActionButton({
         icon: 'diff',
         label: 'Compare with base',
-        title: 'Compare with base',
+        title: 'Compare with base in a side-by-side diff',
         className: 'compare-btn',
         command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
         file: filePath,
         base: basePath,
       })}
       ${renderFileActionButton({
+        icon: 'diff-multiple',
+        label: 'Run latexdiff',
+        title: 'Run latexdiff against the base file',
+        className: 'latexdiff-btn',
+        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+        file: filePath,
+        base: basePath,
+      })}
+      ${renderFileActionButton({
         icon: 'check',
         label: 'Accept edits',
-        title: 'Accept edits',
+        title: 'Accept edits into the workspace file',
         className: 'accept-btn',
         command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
         file: filePath,
@@ -564,7 +573,7 @@ export class FileList extends LitElement {
       ${renderFileActionButton({
         icon: 'git-merge',
         label: 'Merge edits',
-        title: 'Merge edits',
+        title: 'Merge edits into the workspace file',
         className: 'merge-btn',
         command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
         file: filePath,
@@ -583,7 +592,7 @@ export class FileList extends LitElement {
     return renderFileActionButton({
       icon: 'diff-added',
       label: 'Compare with previous round',
-      title: 'Compare with previous round',
+      title: 'Compare with previous round in a side-by-side diff',
       className: 'prev-btn',
       command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
       file: filePath,

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -19,15 +19,17 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   transition: 'opacity var(--transition-fast, 0.15s ease)',
 };
 
+const TOOLTIP_TARGET_TAGS = new Set(['VSCODE-TOOLBAR-BUTTON', 'WA-BUTTON']);
+
 /**
- * Find the nearest `vscode-toolbar-button[title]` in a composed event path.
+ * Find the nearest icon-only button with a title in a composed event path.
  * Works across shadow DOM boundaries.
  */
-function findToolbarButton(e: Event): Element | null {
+function findTooltipTarget(e: Event): Element | null {
   for (const el of e.composedPath()) {
     if (
       el instanceof Element &&
-      el.tagName === 'VSCODE-TOOLBAR-BUTTON' &&
+      TOOLTIP_TARGET_TAGS.has(el.tagName) &&
       el.hasAttribute('title')
     ) {
       return el;
@@ -84,11 +86,11 @@ function hide(): void {
     window.clearTimeout(showTimeoutId);
     showTimeoutId = null;
   }
-  // Restore native title
-  if (currentTarget && savedTitle) {
+  // Restore the title only if no code changed it while the tooltip was shown.
+  if (currentTarget && savedTitle && !currentTarget.hasAttribute('title')) {
     currentTarget.setAttribute('title', savedTitle);
-    savedTitle = '';
   }
+  savedTitle = '';
   currentTarget = null;
   if (tooltipEl) {
     tooltipEl.style.opacity = '0';
@@ -97,7 +99,7 @@ function hide(): void {
 }
 
 function handleOver(e: Event): void {
-  const target = findToolbarButton(e);
+  const target = findTooltipTarget(e);
   if (!target || target === currentTarget) return;
 
   // Skip buttons with text content (they're self-explanatory)

--- a/src/test-kernel/shared/TooltipController.vitest.mts
+++ b/src/test-kernel/shared/TooltipController.vitest.mts
@@ -1,0 +1,81 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  Element: globalThis.Element,
+  HTMLElement: globalThis.HTMLElement,
+  MouseEvent: globalThis.MouseEvent,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+};
+
+function installDom(): void {
+  const dom = new JSDOM('<!doctype html><body></body>', {
+    url: 'http://localhost',
+  });
+
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.Element = dom.window.Element;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  }) as typeof requestAnimationFrame;
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+  globalThis.Element = originalGlobals.Element;
+  globalThis.HTMLElement = originalGlobals.HTMLElement;
+  globalThis.MouseEvent = originalGlobals.MouseEvent;
+  if (originalGlobals.requestAnimationFrame === undefined) {
+    delete (globalThis as { requestAnimationFrame?: unknown })
+      .requestAnimationFrame;
+  } else {
+    globalThis.requestAnimationFrame = originalGlobals.requestAnimationFrame;
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetModules();
+  restoreDom();
+});
+
+describe('toolbar tooltip controller', () => {
+  it('does not clobber a wa-button title that changes while hovered', async () => {
+    vi.useFakeTimers();
+    installDom();
+
+    const { installToolbarTooltips } =
+      await import('@shared/controllers/TooltipController');
+    installToolbarTooltips();
+
+    const button = document.createElement('wa-button');
+    button.setAttribute('title', 'Copy text');
+    document.body.append(button);
+
+    button.dispatchEvent(
+      new MouseEvent('mouseover', { bubbles: true, composed: true }),
+    );
+    vi.advanceTimersByTime(501);
+
+    expect(button.hasAttribute('title')).toBe(false);
+
+    button.setAttribute('title', 'Copied!');
+    button.dispatchEvent(
+      new MouseEvent('mouseout', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: document.body,
+      }),
+    );
+
+    expect(button.getAttribute('title')).toBe('Copied!');
+  });
+});


### PR DESCRIPTION
## Summary

Restores the generated-file row action for running `latexdiff` against the base file. The backend command path was still present, but commit `5c646e154` removed the per-file button from the progress-view file list, making the action inaccessible from that row.

This also broadens the shared tooltip controller so icon-only Web Awesome buttons receive the same delayed tip text as the older toolbar buttons, and makes the row action titles more explicit.

## Validation

- `npm run compile:fast`
- `npm run lint` (warnings only, no errors)
- `corepack pnpm --filter texra typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a missing UI action and refines tooltip handling; changes are localized to the progress view UI and shared tooltip controller.
> 
> **Overview**
> Restores a per-generated-file **Run `latexdiff`** row action in the progress view, wiring it to `PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE` alongside the existing base/accept/merge actions.
> 
> Improves tooltip UX by broadening the shared tooltip controller to also target `wa-button` icon buttons (not just `vscode-toolbar-button`), and avoids clobbering titles that are updated while hovered; adds a Vitest regression test for this behavior. Also makes several action `title` strings more explicit (e.g., side-by-side diff, accept/merge into workspace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5288c120524a2cbfcb1b565a137b2b3181a97510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->