### PR TITLE
fix(cli): bound model picker rows

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -172,7 +172,7 @@ export function App(props: AppProps): React.JSX.Element {
       streams={streams}
     />
   ) : activeForm ? (
-    activeForm.render(() => cliState.activeForm.set(undefined))
+    activeForm.render(() => cliState.activeForm.set(undefined), foregroundRows)
   ) : null;
 
   const focusShortcutsActive = appFocusShortcutsActive({

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -94,6 +94,7 @@ export function registerBuiltinSlashCommands(options?: {
       <ModelListForm
         currentModel={current}
         apiMode={cliState.sessionMeta.get().apiMode}
+        availableRows={props.availableRows}
         selectable={selectable}
         onSelect={(value) => {
           void Promise.resolve(onModelSelect(value)).finally(() =>

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -6,6 +6,7 @@
 export interface SlashFormProps<T = unknown> {
   readonly onDone: (result: T | undefined) => void;
   readonly remainder: string;
+  readonly availableRows?: number;
 }
 
 export interface SlashCommand {

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -20,6 +20,7 @@ import {
 export interface ModelListFormProps {
   readonly currentModel: string;
   readonly apiMode: CliApiMode;
+  readonly availableRows?: number;
   readonly selectable?: boolean;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
@@ -75,6 +76,38 @@ export function formatModelStatusForCliMode(
   }
 }
 
+export function modelSelectWindow({
+  availableRows,
+  itemCount,
+}: {
+  readonly availableRows: number | undefined;
+  readonly itemCount: number;
+}): {
+  readonly maxVisibleItems: number | undefined;
+  readonly showOverflow: boolean;
+} {
+  if (availableRows == null) {
+    return { maxVisibleItems: undefined, showOverflow: false };
+  }
+
+  // Border, title, description, and key hints are the irreducible chrome.
+  const selectRows = Math.max(1, availableRows - 5);
+  if (itemCount <= selectRows) {
+    return { maxVisibleItems: itemCount, showOverflow: false };
+  }
+
+  // Overflow markers cost rows too. On very short terminals, keep the active
+  // choice visible instead of spending the whole budget on markers.
+  if (selectRows < 3) {
+    return { maxVisibleItems: selectRows, showOverflow: false };
+  }
+
+  return {
+    maxVisibleItems: Math.max(1, selectRows - 2),
+    showOverflow: true,
+  };
+}
+
 export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   const [models, setModels] = useState<readonly CliModelAccess[]>([]);
   const [loading, setLoading] = useState(true);
@@ -126,6 +159,10 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     disabled: props.selectable ? !m.available : false,
   }));
   const selectable = props.selectable === true;
+  const selectWindow = modelSelectWindow({
+    availableRows: props.availableRows,
+    itemCount: items.length,
+  });
 
   return (
     <Box
@@ -142,10 +179,12 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           ? 'Choose the root model for the first message.'
           : 'Available models. Start a new chat with texra --model=<name> to choose the root model.'}
       </Text>
-      <Box marginTop={1} flexDirection="column">
+      <Box flexDirection="column">
         <Select
           items={items}
           activeValue={props.currentModel}
+          maxVisibleItems={selectWindow.maxVisibleItems}
+          showOverflow={selectWindow.showOverflow}
           onSelect={(value) => {
             if (selectable) {
               props.onSelect?.(value);
@@ -156,7 +195,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           onCancel={props.onClose}
         />
       </Box>
-      <Box marginTop={1}>
+      <Box>
         {selectable ? (
           <KeyHints
             hints={[

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -101,9 +101,10 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
               setValue('');
               cliState.activeForm.set({
                 commandName: cmd.name,
-                render: (close) => (
+                render: (close, availableRows) => (
                   <Form
                     remainder={parsed.remainder.trimStart()}
+                    availableRows={availableRows}
                     onDone={() => close()}
                   />
                 ),

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -182,10 +182,11 @@ function openCliModelListForm(context: SlashCommandContext): void {
   const selectable = !context.session.runPromise;
   cliState.activeForm.set({
     commandName: 'model',
-    render: (close) => (
+    render: (close, availableRows) => (
       <ModelListForm
         currentModel={cliState.sessionMeta.get().model}
         apiMode={cliState.sessionMeta.get().apiMode}
+        availableRows={availableRows}
         selectable={selectable}
         onSelect={(value) => {
           void applyInitialCliModelSelection(value, context).finally(close);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -115,7 +115,10 @@ export interface ActiveSlashForm {
   /** The slash command that mounted the form (for the header strip). */
   readonly commandName: string;
   /** Render the form body. Receives the close callback. */
-  readonly render: (onDone: () => void) => React.ReactNode;
+  readonly render: (
+    onDone: () => void,
+    availableRows: number,
+  ) => React.ReactNode;
 }
 const ACTIVE_FORM = signal<ActiveSlashForm | undefined>(undefined);
 

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -29,11 +29,36 @@ export interface SelectProps<T> {
   readonly onCancel: () => void;
   /** Focus the Nth item on mount (defaults to the active value's index, or 0). */
   readonly initialIndex?: number;
+  readonly maxVisibleItems?: number;
+  readonly showOverflow?: boolean;
 }
 
 function clampIndex(index: number, length: number): number {
   if (length <= 0) return 0;
   return Math.min(Math.max(index, 0), length - 1);
+}
+
+export function visibleSelectRange({
+  itemCount,
+  highlight,
+  maxVisibleItems,
+}: {
+  readonly itemCount: number;
+  readonly highlight: number;
+  readonly maxVisibleItems: number | undefined;
+}): { readonly start: number; readonly end: number } {
+  if (itemCount <= 0) return { start: 0, end: 0 };
+  const visibleCount =
+    maxVisibleItems == null
+      ? itemCount
+      : Math.min(Math.max(1, maxVisibleItems), itemCount);
+  const clampedHighlight = clampIndex(highlight, itemCount);
+  const centerOffset = Math.floor(visibleCount / 2);
+  const start = Math.min(
+    Math.max(0, clampedHighlight - centerOffset),
+    itemCount - visibleCount,
+  );
+  return { start, end: start + visibleCount };
 }
 
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
@@ -49,6 +74,15 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   useEffect(() => {
     setHighlight((h) => clampIndex(h, props.items.length));
   }, [props.items.length]);
+
+  const visibleRange = visibleSelectRange({
+    itemCount: props.items.length,
+    highlight,
+    maxVisibleItems: props.maxVisibleItems,
+  });
+  const hiddenBefore = visibleRange.start;
+  const hiddenAfter = props.items.length - visibleRange.end;
+  const visibleItems = props.items.slice(visibleRange.start, visibleRange.end);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -88,7 +122,11 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
 
   return (
     <Box flexDirection="column">
-      {props.items.map((item, i) => {
+      {props.showOverflow && hiddenBefore > 0 ? (
+        <Text dimColor>{`... ${hiddenBefore} earlier`}</Text>
+      ) : null}
+      {visibleItems.map((item, offset) => {
+        const i = visibleRange.start + offset;
         const focused = i === highlight;
         const active = item.value === props.activeValue;
         const pointer = focused ? '›' : ' ';
@@ -119,6 +157,9 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
           </Box>
         );
       })}
+      {props.showOverflow && hiddenAfter > 0 ? (
+        <Text dimColor>{`... ${hiddenAfter} more`}</Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import type { ModelOptionData } from '@shared/schemas';
 
-import { formatModelStatusForCliMode } from '../../../packages/cli/src/chat/tui/forms/ModelListForm';
+import {
+  formatModelStatusForCliMode,
+  modelSelectWindow,
+} from '../../../packages/cli/src/chat/tui/forms/ModelListForm';
+import { visibleSelectRange } from '../../../packages/cli/src/chat/tui/ui/Select';
 import type { CliModelAccess } from '../../../packages/cli/src/runtime/modelAccess';
 
 function access(
@@ -46,5 +50,54 @@ describe('CLI ModelListForm status text', () => {
         'included',
       ),
     ).toBe('relay: unavailable; api key set');
+  });
+});
+
+describe('CLI Select visible range', () => {
+  it('keeps a contiguous window around the highlighted row', () => {
+    expect(
+      visibleSelectRange({
+        itemCount: 8,
+        highlight: 5,
+        maxVisibleItems: 5,
+      }),
+    ).toEqual({ start: 3, end: 8 });
+  });
+
+  it('clamps the visible window at list edges', () => {
+    expect(
+      visibleSelectRange({
+        itemCount: 8,
+        highlight: 0,
+        maxVisibleItems: 5,
+      }),
+    ).toEqual({ start: 0, end: 5 });
+    expect(
+      visibleSelectRange({
+        itemCount: 8,
+        highlight: 7,
+        maxVisibleItems: 5,
+      }),
+    ).toEqual({ start: 3, end: 8 });
+  });
+});
+
+describe('CLI ModelListForm row budget', () => {
+  it('removes the row floor on short terminals', () => {
+    expect(modelSelectWindow({ availableRows: 6, itemCount: 8 })).toEqual({
+      maxVisibleItems: 1,
+      showOverflow: false,
+    });
+    expect(modelSelectWindow({ availableRows: 7, itemCount: 8 })).toEqual({
+      maxVisibleItems: 2,
+      showOverflow: false,
+    });
+  });
+
+  it('spends overflow rows only when the budget can fit them', () => {
+    expect(modelSelectWindow({ availableRows: 12, itemCount: 8 })).toEqual({
+      maxVisibleItems: 5,
+      showOverflow: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4257.

The chat TUI now passes the foreground row budget to slash forms, and the shared `Select` primitive can render a bounded contiguous window around the highlighted row. The `/model` form uses this budget instead of relying on parent clipping, so a normal-height terminal shows an intelligible window such as `... 3 earlier`, then rows `4, 5, 6, 7, 8`, with the highlighted active model visible.

This keeps the selection geometry coherent: visible numeric shortcuts are contiguous, clipped choices are explicitly indicated, and the form remains within its allocated region.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run build` from `packages/cli`
- `npm run format`
- `npm run lint` — 0 errors, existing 18 warnings
- `npm run compile:fast`
- Built CLI PTY probe: `TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --approval-policy ask`, type `/model`, press Enter. The model picker renders a bounded contiguous window rather than gapped rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the `ActiveSlashForm` render contract and list-rendering behavior in the TUI, which can affect all slash forms/palettes and keyboard selection if edge cases are missed.
> 
> **Overview**
> **Slash forms now receive a foreground row budget**: `App` passes `foregroundRows` into `ActiveSlashForm.render`, `SlashFormProps` gains optional `availableRows`, and callers (`InputBar`, `/model` in `runChatTui`, and builtin `/model` adapter) thread this through.
> 
> **Model picker rendering is bounded and explicit**: `/model` computes a row budget via `modelSelectWindow` and configures `Select` to show a contiguous window around the highlighted item, optionally adding `... N earlier/more` overflow markers.
> 
> **`Select` gains windowing support**: adds `maxVisibleItems`/`showOverflow` and `visibleSelectRange` to slice items around the highlight while keeping numeric shortcuts consistent; covered by new Vitest cases for range/windowing and model row budgeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14753ead29bac3298ded052facbaa61c7cb7ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->