### PR TITLE
fix(cli): align doctor model access mode

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -597,29 +597,33 @@ const doctorCommand = defineCommand({
   },
 });
 
+export function doctorPlatformInitContext(context: CliContext) {
+  return { ...context, quietLogs: true };
+}
+
 async function runDoctor(context: CliContext): Promise<number> {
   let initError: unknown;
   try {
-    await initCliPlatform({
-      ...context,
-      quietLogs: true,
-      skipIncludedModelAccess: true,
+    await suppressCliFetchStackLogs(async () => {
+      await initCliPlatform(doctorPlatformInitContext(context));
     });
   } catch (error) {
     initError = error;
   }
-  const report = await buildDoctorReport(
-    context,
-    initError == null
-      ? undefined
-      : {
-          authProfile: async () => {
-            throw initError;
+  const report = await suppressCliFetchStackLogs(() =>
+    buildDoctorReport(
+      context,
+      initError == null
+        ? undefined
+        : {
+            authProfile: async () => {
+              throw initError;
+            },
+            modelAccessList: async () => {
+              throw initError;
+            },
           },
-          modelAccessList: async () => {
-            throw initError;
-          },
-        },
+    ),
   );
   writeDoctorReport(context, report);
   return doctorExitCode(report);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -10,6 +10,7 @@ import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 import {
   cliTerminalStatus,
   collectStringFlagValues,
+  doctorPlatformInitContext,
   expandWorkflowInputSpecs,
   formatCliModelListError,
   isCliFetchStackLog,
@@ -239,6 +240,15 @@ describe('CLI root argument routing', () => {
 
     expect(isCliFetchStackLog([error])).toBe(true);
     expect(isCliFetchStackLog([new Error('unrelated')])).toBe(false);
+  });
+
+  it('does not force doctor into personal-key model availability', () => {
+    const init = doctorPlatformInitContext(
+      cliContext({ apiMode: 'included' }),
+    ) as { skipIncludedModelAccess?: boolean; quietLogs?: boolean };
+
+    expect(init.quietLogs).toBe(true);
+    expect(init.skipIncludedModelAccess).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #4261.

This makes `texra doctor` compute model availability under the same API access mode as normal CLI model commands. In the default signed-in state, the Models check now reflects included relay access rather than forcing the unrelated personal-key count.

The doctor path still suppresses raw relay fetch stack logs while it initializes and builds the report, so offline/network failures remain readable.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Doctor.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run lint` (passes with the existing 18 warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli validate:run`
- `npm run typecheck`
- Built binary probe: `node packages/cli/dist/bin/texra.js doctor --output-format json` now reports `6 models available` in this signed-in included-access environment.
- PTY probe: started `node packages/cli/dist/bin/texra.js chat --approval-policy ask`, opened `/model`, pressed `5`, and verified the header changed to `model: gpt54`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI behavior change limited to `texra doctor` initialization and log suppression, plus a targeted unit test; main risk is slightly different model-availability reporting for users relying on the previous forced mode.
> 
> **Overview**
> `texra doctor` now initializes the CLI platform using a shared `doctorPlatformInitContext` that only enables `quietLogs`, **no longer forcing** `skipIncludedModelAccess` (aligning doctor’s model availability checks with normal CLI model commands).
> 
> Doctor’s init and report generation are wrapped in `suppressCliFetchStackLogs` to keep network/offline failures readable, and a unit test asserts the doctor init context does not set `skipIncludedModelAccess`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e542111dbfab910b45271c656af49fe0b6b0494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->