### PR TITLE
fix(cli): clarify approval card title hints

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Box, Text, type BoxProps } from 'ink';
 import { useInput } from 'ink';
 
-import { confirmCardKeyAction } from './ConfirmCardState';
+import { confirmCardKeyAction, confirmCardKeyHints } from './ConfirmCardState';
 import type {
   ApprovalBypassKind,
   ApprovalDecision,
@@ -83,17 +83,15 @@ export function ConfirmCard({
     { isActive: true },
   );
 
-  const hints = [
-    { key: 'y', action: approveLabel },
-    { key: 'n', action: rejectLabel },
-    ...(alwaysAllow ? [{ key: 'a', action: alwaysAllow.label }] : []),
-    ...extraActions.map((action) => ({
+  const hints = confirmCardKeyHints({
+    approveLabel,
+    rejectLabel,
+    alwaysAllowLabel: alwaysAllow?.label,
+    extraActions: extraActions.map((action) => ({
       key: action.key,
       action: action.label,
     })),
-    { key: 'e', action: 'reject with feedback' },
-    { key: 'Esc', action: 'cancel' },
-  ];
+  });
 
   return (
     <Box
@@ -104,7 +102,6 @@ export function ConfirmCard({
     >
       <Text bold color={color}>
         {title}
-        {alwaysAllow ? <Text dimColor> · a = {alwaysAllow.label}</Text> : null}
       </Text>
       {children}
       {feedbackMode ? (

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -9,6 +9,18 @@ export interface ConfirmCardKey {
   readonly escape?: boolean;
 }
 
+export interface ConfirmCardHintAction {
+  readonly key: string;
+  readonly action: string;
+}
+
+export interface ConfirmCardHintOptions {
+  readonly approveLabel?: string;
+  readonly rejectLabel?: string;
+  readonly alwaysAllowLabel?: string;
+  readonly extraActions?: readonly ConfirmCardHintAction[];
+}
+
 export function confirmCardKeyAction(
   input: string,
   key: ConfirmCardKey,
@@ -27,4 +39,22 @@ export function confirmCardKeyAction(
     default:
       return 'ignore';
   }
+}
+
+export function confirmCardKeyHints({
+  approveLabel = 'approve',
+  rejectLabel = 'reject',
+  alwaysAllowLabel,
+  extraActions = [],
+}: ConfirmCardHintOptions): ConfirmCardHintAction[] {
+  return [
+    { key: 'y', action: approveLabel },
+    { key: 'n', action: rejectLabel },
+    ...(alwaysAllowLabel == null
+      ? []
+      : [{ key: 'a', action: alwaysAllowLabel }]),
+    ...extraActions,
+    { key: 'e', action: 'reject with feedback' },
+    { key: 'Esc', action: 'cancel' },
+  ];
 }

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { confirmCardKeyAction } from '../../../packages/cli/src/chat/tui/modals/ConfirmCardState';
+import {
+  confirmCardKeyAction,
+  confirmCardKeyHints,
+} from '../../../packages/cli/src/chat/tui/modals/ConfirmCardState';
 
 describe('CLI confirm-card key handling', () => {
   it('keeps y/n and escape approval behavior', () => {
@@ -17,5 +20,19 @@ describe('CLI confirm-card key handling', () => {
   it('only enables approve-always where the modal allows it', () => {
     expect(confirmCardKeyAction('a', {}, true)).toBe('approveAlways');
     expect(confirmCardKeyAction('a', {}, false)).toBe('ignore');
+  });
+
+  it('keeps session-wide approval in the full key-hint list', () => {
+    expect(
+      confirmCardKeyHints({
+        alwaysAllowLabel: 'approve edits this session',
+      }),
+    ).toEqual([
+      { key: 'y', action: 'approve' },
+      { key: 'n', action: 'reject' },
+      { key: 'a', action: 'approve edits this session' },
+      { key: 'e', action: 'reject with feedback' },
+      { key: 'Esc', action: 'cancel' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #4263.

The shared CLI confirmation card no longer appends the session-wide `a` approval action to the title line. The title now remains the question being approved, while the footer remains the single source for key bindings, including `a approve edits this session`.

This avoids presenting `a` as an ordinary one-shot approve action in edit approval modals at normal terminal widths.

## Verification

- Real TUI probe before the fix: in an 80-column PTY, `texra chat --agent chat --model deepseekT --approval-policy ask` showed `Apply edit to ...? · a = approve` for an edit approval, while the footer said `a approve edits this session`.
- Real TUI probe after the fix: rebuilt CLI, repeated the same edit approval path, and verified the title line is only `Apply edit to .../note.txt?`; the footer still shows `a approve edits this session`.
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run typecheck`
- `npm run lint` (passes with existing 18 warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/TUI change that only affects how approval key hints are generated and displayed; no changes to approval decisions or data handling.
> 
> **Overview**
> Keeps the confirmation card title line as just the prompt by removing the session-wide `a` hint from the header, relying on the footer as the single source of key bindings.
> 
> Refactors key-hint construction into a shared `confirmCardKeyHints()` helper in `ConfirmCardState`, and adds a unit test to lock in the expected hint list (including session-wide `a` when provided).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03bfbc206ee530dab5760ade4d642907ffd8127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->