### PR TITLE
refactor(tools): consolidate summary helpers

### DIFF
--- a/packages/extension/src/webview/frontend/constants.ts
+++ b/packages/extension/src/webview/frontend/constants.ts
@@ -1,7 +1,7 @@
 // Local imports - shared schemas
 import {
   DocumentFileTypeSchema,
-  MultipleDocumentFileTypeSchema,
+  MULTIPLE_DOCUMENT_FILE_TYPES,
   SessionTypeSchema,
   type DocumentFileType,
   type MultipleDocumentFileType,
@@ -19,8 +19,7 @@ export const SESSION_TYPES = {
 export type { SessionType, DocumentFileType, MultipleDocumentFileType };
 
 export const DOCUMENT_FILE_TYPES = DocumentFileTypeSchema.options;
-export const MULTIPLE_DOCUMENT_FILE_TYPES =
-  MultipleDocumentFileTypeSchema.options;
+export { MULTIPLE_DOCUMENT_FILE_TYPES };
 
 export const ELEMENT_IDS = {
   INSTRUCTION: 'instruction',

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,10 +1,7 @@
 // Shared constants and helpers for the Claude Code CLI tool.
 
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
-import {
-  collapseWhitespace,
-  truncateWithEllipsis,
-} from '@utils/text/stringUtils';
+import { truncateSummary } from '@utils/text/stringUtils';
 
 export const CLAUDE_AGENT_NAME = 'claude_code';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
@@ -90,10 +87,6 @@ export function buildClaudeUsageStats(usage: {
         cacheCreationInputTokens: usage.cache_creation_input_tokens,
       }),
   };
-}
-
-function truncateSummary(text: string, maxLength: number): string {
-  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
 }
 
 /**

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
-import {
-  collapseWhitespace,
-  truncateWithEllipsis,
-} from '@utils/text/stringUtils';
+import { truncateSummary } from '@utils/text/stringUtils';
 import type {
   CommandExecutionItem,
   FileChangeItem,
@@ -80,8 +77,8 @@ export const CodexTodoToolInputSchema = z.object({
 
 export type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
 
-export const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
-export type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
+const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
+type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
 
 export const CodexTurnToolInputSchema = z.object({
   state: CodexTurnStateSchema,
@@ -89,10 +86,6 @@ export const CodexTurnToolInputSchema = z.object({
 });
 
 export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;
-
-function truncateSummary(text: string, maxLength: number): string {
-  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
-}
 
 function getPathBasename(filePath: string): string {
   const normalized = filePath.replaceAll('\\', '/');

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -78,3 +78,10 @@ export function truncateWithEllipsis(text: string, maxLen: number): string {
 export function collapseWhitespace(text: string): string {
   return text.replaceAll(/\s+/g, ' ').trim();
 }
+
+/**
+ * Collapse whitespace first, then truncate to a fixed-width one-line summary.
+ */
+export function truncateSummary(text: string, maxLength: number): string {
+  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
+}


### PR DESCRIPTION
## Summary

- import the canonical `MULTIPLE_DOCUMENT_FILE_TYPES` constant in the main webview constants module
- move the shared whitespace-collapse/truncate helper into `@utils/text/stringUtils`
- make the Codex turn-state schema/type internal to `codexShared.ts`

Closes #4264.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/ToolStatusFormatting.vitest.ts`
- `corepack pnpm --filter @texra/cli typecheck`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with 18 existing warnings)
- `npm run compile:fast`

## Manual CLI probe

Before this cleanup, I also exercised the built CLI TUI with a real `creator` session, approved a `delegate_agent` launch to `chat`, observed the child stream read `task.txt`, sent a follow-up, and opened the subagent picker. The workflow completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: consolidates small helper logic and adjusts exports without changing tool-log formats or data flow. Main risk is minor TypeScript/export breakage where previously public schemas/constants were re-exported differently.
> 
> **Overview**
> Consolidates the one-line tool-summary truncation logic by introducing `truncateSummary` in `@utils/text/stringUtils` and switching both `claudeAgentShared` and `codexShared` to use it (removing their local implementations).
> 
> Updates the webview `constants.ts` to re-export the canonical `MULTIPLE_DOCUMENT_FILE_TYPES` from `@shared/schemas` instead of deriving it from a local schema, and makes `CodexTurnStateSchema`/`CodexTurnState` internal to `codexShared.ts` (no longer exported).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f7c558568130585599bcb0530583bd7c08ec1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->