### PR TITLE
[codex] Bound CLI TUI side pane height

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -95,6 +95,39 @@ export function allocateMiddleRows({
   };
 }
 
+export function allocateSidePanelRows({
+  hasSubagentPanel,
+  hasTodosPlanPanel,
+  rows,
+}: {
+  readonly hasSubagentPanel: boolean;
+  readonly hasTodosPlanPanel: boolean;
+  readonly rows: number;
+}): {
+  readonly subagentRows: number;
+  readonly todosPlanRows: number;
+} {
+  const availableRows = Math.max(0, rows);
+  if (!hasSubagentPanel && !hasTodosPlanPanel) {
+    return { subagentRows: 0, todosPlanRows: 0 };
+  }
+  if (!hasTodosPlanPanel) {
+    return { subagentRows: availableRows, todosPlanRows: 0 };
+  }
+  if (!hasSubagentPanel) {
+    return { subagentRows: 0, todosPlanRows: availableRows };
+  }
+  if (availableRows === 0) {
+    return { subagentRows: 0, todosPlanRows: 0 };
+  }
+
+  const subagentRows = Math.max(1, Math.floor(availableRows / 2));
+  return {
+    subagentRows,
+    todosPlanRows: availableRows - subagentRows,
+  };
+}
+
 export function appFocusShortcutsActive({
   inputDisabled,
   reverseSearchOpen,
@@ -141,13 +174,16 @@ export function App(props: AppProps): React.JSX.Element {
     sessionMeta,
     activeSlice,
   );
-  const showSideColumn =
+  const hasSubagentPanel =
     !foregroundOpen &&
     activeSlice !== undefined &&
     (activeSlice.activeSubagents.length > 0 ||
-      activeSlice.activeProcesses.length > 0 ||
-      activeSlice.todos.length > 0 ||
-      activeSlice.plan !== null);
+      activeSlice.activeProcesses.length > 0);
+  const hasTodosPlanPanel =
+    !foregroundOpen &&
+    activeSlice !== undefined &&
+    (activeSlice.todos.length > 0 || activeSlice.plan !== null);
+  const showSideColumn = hasSubagentPanel || hasTodosPlanPanel;
   const transcriptWidth = Math.max(
     MIN_TRANSCRIPT_WIDTH,
     columns - (showSideColumn ? SIDE_COLUMN_WIDTH : 0),
@@ -157,6 +193,11 @@ export function App(props: AppProps): React.JSX.Element {
     reverseSearchOpen,
     rows,
     slashPaletteOpen,
+  });
+  const { subagentRows, todosPlanRows } = allocateSidePanelRows({
+    hasSubagentPanel,
+    hasTodosPlanPanel,
+    rows: transcriptRows,
   });
   const foregroundSurface = pending ? (
     <ApprovalModal pending={pending} availableRows={foregroundRows} />
@@ -236,9 +277,14 @@ export function App(props: AppProps): React.JSX.Element {
           ) : null}
         </Box>
         {showSideColumn ? (
-          <Box flexDirection="column" minWidth={SIDE_COLUMN_WIDTH}>
-            <SubagentList />
-            <TodosPlanPanel />
+          <Box
+            flexDirection="column"
+            minWidth={SIDE_COLUMN_WIDTH}
+            height={transcriptRows}
+            overflowY="hidden"
+          >
+            <SubagentList maxRows={subagentRows} />
+            <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}
       </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -62,16 +62,29 @@ function Row({ child, index, tail }: RowProps): React.JSX.Element {
   );
 }
 
-export function SubagentList(): React.JSX.Element | null {
+export interface SubagentListProps {
+  readonly maxRows?: number;
+}
+
+export function SubagentList(
+  props: SubagentListProps = {},
+): React.JSX.Element | null {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (!slice) return null;
   const { activeSubagents, activeProcesses, processOutput } = slice;
   if (activeSubagents.length === 0 && activeProcesses.length === 0) return null;
+  if (props.maxRows !== undefined && props.maxRows <= 0) return null;
 
   return (
-    <Box flexDirection="column" paddingX={1} marginBottom={1}>
+    <Box
+      flexDirection="column"
+      height={props.maxRows}
+      overflowY={props.maxRows === undefined ? undefined : 'hidden'}
+      paddingX={1}
+      marginBottom={props.maxRows === undefined ? 1 : 0}
+    >
       {activeSubagents.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -41,16 +41,29 @@ function TodoRow({ todo }: { todo: TodoItem }): React.JSX.Element {
   );
 }
 
-export function TodosPlanPanel(): React.JSX.Element | null {
+export interface TodosPlanPanelProps {
+  readonly maxRows?: number;
+}
+
+export function TodosPlanPanel(
+  props: TodosPlanPanelProps = {},
+): React.JSX.Element | null {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (!slice) return null;
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;
+  if (props.maxRows !== undefined && props.maxRows <= 0) return null;
 
   return (
-    <Box flexDirection="column" paddingX={1} marginBottom={1}>
+    <Box
+      flexDirection="column"
+      height={props.maxRows}
+      overflowY={props.maxRows === undefined ? undefined : 'hidden'}
+      paddingX={1}
+      marginBottom={props.maxRows === undefined ? 1 : 0}
+    >
       {todos.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -19,6 +19,7 @@ import {
 } from '../../../packages/cli/src/chat/tui/state/cliState';
 import {
   allocateMiddleRows,
+  allocateSidePanelRows,
   appFocusShortcutsActive,
 } from '../../../packages/cli/src/chat/tui/App';
 import {
@@ -140,6 +141,32 @@ describe('CLI TUI row allocation', () => {
 
     expect(layout.transcriptRows).toBe(0);
     expect(layout.foregroundRows).toBe(0);
+  });
+
+  it('bounds side panels to the available middle row budget', () => {
+    expect(
+      allocateSidePanelRows({
+        hasSubagentPanel: true,
+        hasTodosPlanPanel: true,
+        rows: 13,
+      }),
+    ).toEqual({ subagentRows: 6, todosPlanRows: 7 });
+
+    expect(
+      allocateSidePanelRows({
+        hasSubagentPanel: false,
+        hasTodosPlanPanel: true,
+        rows: 13,
+      }),
+    ).toEqual({ subagentRows: 0, todosPlanRows: 13 });
+
+    expect(
+      allocateSidePanelRows({
+        hasSubagentPanel: true,
+        hasTodosPlanPanel: true,
+        rows: 1,
+      }),
+    ).toEqual({ subagentRows: 1, todosPlanRows: 0 });
   });
 
   it('lets input overlays own focus shortcuts', () => {


### PR DESCRIPTION
## Summary

- Bound the CLI TUI side column to the same middle-row budget as the transcript.
- Split the side-column budget between active subagent/process state and todo/plan state.
- Added a focused row-allocation regression test for the side panels.

## Root Cause

The transcript pane already had explicit row budgeting, but the adjacent side panes could still render as unbounded children. A long todo list, plan, or collection of active subagents could therefore make the live Ink surface taller than the terminal viewport, which reintroduced the scrollback corruption described in #4163.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run typecheck`
- `npm run lint` (18 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run format`

Closes #4163.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI layout change that constrains Ink side panes to the existing transcript row budget; main risk is minor rendering/regression in edge-case terminal sizes.
> 
> **Overview**
> Prevents the CLI TUI side column (subagents/processes and todos/plan) from growing beyond the terminal viewport by **explicitly budgeting its height** to match the transcript’s `transcriptRows`.
> 
> Adds `allocateSidePanelRows` to split the available rows between the two side panels (or allocate all rows to the single visible panel), updates `SubagentList`/`TodosPlanPanel` to accept `maxRows` and hide/clip overflow, and includes a focused regression test covering the row-allocation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9bd34d82006a268eaadcc41a77f6810e8a1c7d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->