### PR TITLE
[codex] Fail incomplete CLI output-dir workflows

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -4,7 +4,12 @@ import * as path from 'node:path';
 import { defineCommand, runCommand, showUsage, type CommandDef } from 'citty';
 import { glob, hasMagic } from 'glob';
 
-import { getAgent, getVisibleAgents, loadAgents } from '@agent/index';
+import {
+  getAgent,
+  getVisibleAgents,
+  loadAgents,
+  type AgentEntry,
+} from '@agent/index';
 import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import {
@@ -859,6 +864,12 @@ type CliRunResult = ExecuteAgentResult & {
 };
 type CliWorkflowRunResult = Extract<CliRunResult, { category: 'workflow' }>;
 
+interface WorkflowOutputResolutionOptions {
+  readonly expectedOutputFiles?: readonly string[];
+  readonly runDirectory?: string;
+  readonly terminalStatus?: ExecutionStatus;
+}
+
 interface WorkflowRunInit {
   readonly agent: string;
   readonly inputFiles: string[];
@@ -955,16 +966,29 @@ function outputCopyRelativePath(output: OutputFileSummary) {
   return getSafeDocumentRelativePath(withoutRoundDir.join('/'));
 }
 
+function expectedOutputCopyRelativePath(outputFile: string): string {
+  return getSafeDocumentRelativePath(outputFile);
+}
+
+function expectedOutputFilesForOutputDir(
+  agent: AgentEntry | undefined,
+  inputFiles: readonly string[],
+): readonly string[] {
+  const defaultOutputFiles = (agent?.defaultOutputFiles ?? []).filter(Boolean);
+  return defaultOutputFiles.length > 0 ? defaultOutputFiles : inputFiles;
+}
+
 export async function resolveWorkflowOutput(
   outputFile: string | undefined,
   outputDir: string | undefined,
   result: ExecuteAgentResult,
   context: CliContext,
-  terminalStatus = cliTerminalStatus(result),
+  options: WorkflowOutputResolutionOptions = {},
 ): Promise<{
   copiedOutput: string | undefined;
   displayResult: CliRunResult;
 }> {
+  const terminalStatus = options.terminalStatus ?? cliTerminalStatus(result);
   if (
     result.category === AgentCategory.Workflow &&
     result.outputs.length === 0 &&
@@ -995,19 +1019,34 @@ export async function resolveWorkflowOutput(
     ...result,
     terminalStatus,
     ...(result.category === AgentCategory.Workflow
-      ? { runDirectory: getRunDir(result.executionId) }
+      ? { runDirectory: options.runDirectory ?? getRunDir(result.executionId) }
       : {}),
   };
   if (outputDir && result.category === AgentCategory.Workflow) {
     const targetRoot = path.isAbsolute(outputDir)
       ? outputDir
       : path.join(context.cwd, outputDir);
-    const copiedOutputs: string[] = [];
+    const outputsByRelativePath = new Map<string, OutputFileSummary>();
     for (const output of result.outputs) {
-      const targetPath = path.join(targetRoot, outputCopyRelativePath(output));
+      outputsByRelativePath.set(outputCopyRelativePath(output), output);
+    }
+
+    const copiedOutputs: string[] = [];
+    for (const [relativePath, output] of outputsByRelativePath) {
+      const targetPath = path.join(targetRoot, relativePath);
       await fs.mkdir(path.dirname(targetPath), { recursive: true });
       await fs.copyFile(output.absolutePath, targetPath);
       copiedOutputs.push(targetPath);
+    }
+
+    const expectedOutputFiles = options.expectedOutputFiles ?? [];
+    const missing = expectedOutputFiles
+      .map(expectedOutputCopyRelativePath)
+      .filter((expected) => !outputsByRelativePath.has(expected));
+    if (missing.length > 0) {
+      throw new Error(
+        `Workflow ${terminalStatus} without expected output${missing.length === 1 ? '' : 's'}: ${missing.join(', ')}; copied ${copiedOutputs.length} of ${expectedOutputFiles.length} expected output${expectedOutputFiles.length === 1 ? '' : 's'} to ${targetRoot}.`,
+      );
     }
 
     const displayResult: CliRunResult = {
@@ -1115,11 +1154,10 @@ async function runWorkflowAgent(
   await initCliPlatform(runContext);
   installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
-  if (
-    !getAgent(init.agent) ||
-    (await shouldHonorRemoteAgentPriority(init.agent))
-  ) {
+  let agent = getAgent(init.agent);
+  if (!agent || (await shouldHonorRemoteAgentPriority(init.agent))) {
     await loadAgents();
+    agent = getAgent(init.agent);
   }
 
   const modelOutputFile =
@@ -1165,7 +1203,12 @@ async function runWorkflowAgent(
       init.outputDir,
       result,
       runContext,
-      terminalStatus,
+      {
+        expectedOutputFiles: init.outputDir
+          ? expectedOutputFilesForOutputDir(agent, inputFiles)
+          : undefined,
+        terminalStatus,
+      },
     ));
   } catch (error) {
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -978,6 +978,13 @@ function expectedOutputFilesForOutputDir(
   return defaultOutputFiles.length > 0 ? defaultOutputFiles : inputFiles;
 }
 
+function shouldUseOutputForCopy(
+  existing: OutputFileSummary | undefined,
+  candidate: OutputFileSummary,
+): boolean {
+  return existing == null || candidate.round > existing.round;
+}
+
 export async function resolveWorkflowOutput(
   outputFile: string | undefined,
   outputDir: string | undefined,
@@ -1028,7 +1035,12 @@ export async function resolveWorkflowOutput(
       : path.join(context.cwd, outputDir);
     const outputsByRelativePath = new Map<string, OutputFileSummary>();
     for (const output of result.outputs) {
-      outputsByRelativePath.set(outputCopyRelativePath(output), output);
+      const relativePath = outputCopyRelativePath(output);
+      if (
+        shouldUseOutputForCopy(outputsByRelativePath.get(relativePath), output)
+      ) {
+        outputsByRelativePath.set(relativePath, output);
+      }
     }
 
     const copiedOutputs: string[] = [];
@@ -1211,6 +1223,10 @@ async function runWorkflowAgent(
       },
     ));
   } catch (error) {
+    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+      writeTextStderr(toErrorMessage(error));
+      return CliExitCode.Interrupted;
+    }
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
     writeTextStderr(toErrorMessage(error));
     return CliExitCode.AgentError;

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -192,7 +192,7 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         cliContext(),
-        EXECUTION_STATUS.COMPLETED,
+        { terminalStatus: EXECUTION_STATUS.COMPLETED },
       ),
     ).rejects.toThrow(
       'Workflow completed without a generated output; corrected.tex was not written.',
@@ -213,7 +213,7 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         cliContext(),
-        EXECUTION_STATUS.INTERRUPTED,
+        { terminalStatus: EXECUTION_STATUS.INTERRUPTED },
       ),
     ).resolves.toMatchObject({
       copiedOutput: undefined,

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -39,7 +39,11 @@ function testContext(cwd: string): CliContext {
 }
 
 function workflowResult(
-  outputs: Array<{ absolutePath: string; relativePath: string }>,
+  outputs: Array<{
+    absolutePath: string;
+    relativePath: string;
+    round?: number;
+  }>,
 ): WorkflowResult {
   return {
     category: AgentCategory.Workflow,
@@ -48,7 +52,7 @@ function workflowResult(
     streamId: 'workflow-output-test',
     compileFailures: [],
     outputs: outputs.map((output) => ({
-      round: 1,
+      round: output.round ?? 1,
       relativePath: output.relativePath,
       absolutePath: output.absolutePath,
       location: 'runStorage',
@@ -96,9 +100,9 @@ describe('CLI workflow output resolution', () => {
       undefined,
       'out',
       workflowResult([
-        { absolutePath: runA1, relativePath: 'r1/a.tex' },
+        { absolutePath: runA1, relativePath: 'r1/a.tex', round: 1 },
         { absolutePath: runB, relativePath: 'r1/b.tex' },
-        { absolutePath: runA2, relativePath: 'r2/a.tex' },
+        { absolutePath: runA2, relativePath: 'r2/a.tex', round: 2 },
       ]),
       testContext(cwd),
       {
@@ -116,6 +120,35 @@ describe('CLI workflow output resolution', () => {
     );
     await expect(readFile(join(cwd, 'out', 'b.tex'), 'utf8')).resolves.toBe(
       'B',
+    );
+  });
+
+  it('uses the latest round when --output-dir workflow outputs arrive out of order', async () => {
+    const cwd = await makeTempDir();
+    const runA1 = join(cwd, 'run', 'r1', 'a.tex');
+    const runA2 = join(cwd, 'run', 'r2', 'a.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await mkdir(join(cwd, 'run', 'r2'), { recursive: true });
+    await writeFile(runA1, 'A1');
+    await writeFile(runA2, 'A2');
+
+    await resolveWorkflowOutput(
+      undefined,
+      'out',
+      workflowResult([
+        { absolutePath: runA2, relativePath: 'r2/a.tex', round: 2 },
+        { absolutePath: runA1, relativePath: 'r1/a.tex', round: 1 },
+      ]),
+      testContext(cwd),
+      {
+        expectedOutputFiles: ['a.tex'],
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(
+      'A2',
     );
   });
 });

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -1,0 +1,121 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
+
+import { resolveWorkflowOutput } from '../../../packages/cli/src/commands/root';
+import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+
+type WorkflowResult = Parameters<typeof resolveWorkflowOutput>[2];
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'texra-workflow-output-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function testContext(cwd: string): CliContext {
+  return {
+    cwd,
+    mode: 'headless',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    colorEnabled: false,
+    version: 'test',
+    resourcesPath: cwd,
+  };
+}
+
+function workflowResult(
+  outputs: Array<{ absolutePath: string; relativePath: string }>,
+): WorkflowResult {
+  return {
+    category: AgentCategory.Workflow,
+    status: END_GROUP_STATUS.STOPPED,
+    executionId: 'workflow-output-test',
+    streamId: 'workflow-output-test',
+    compileFailures: [],
+    outputs: outputs.map((output) => ({
+      round: 1,
+      relativePath: output.relativePath,
+      absolutePath: output.absolutePath,
+      location: 'runStorage',
+      originalPath: null,
+      added: null,
+      removed: null,
+    })),
+  } as WorkflowResult;
+}
+
+describe('CLI workflow output resolution', () => {
+  it('fails --output-dir resolution when an expected multi-input output is missing', async () => {
+    const cwd = await makeTempDir();
+    const runOutput = join(cwd, 'run', 'r1', 'a.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await writeFile(runOutput, 'A');
+
+    await expect(
+      resolveWorkflowOutput(
+        undefined,
+        'out',
+        workflowResult([{ absolutePath: runOutput, relativePath: 'r1/a.tex' }]),
+        testContext(cwd),
+        {
+          expectedOutputFiles: ['a.tex', 'b.tex'],
+          runDirectory: join(cwd, 'run'),
+          terminalStatus: EXECUTION_STATUS.COMPLETED,
+        },
+      ),
+    ).rejects.toThrow(/b\.tex/);
+  });
+
+  it('copies every expected --output-dir workflow output', async () => {
+    const cwd = await makeTempDir();
+    const runA1 = join(cwd, 'run', 'r1', 'a.tex');
+    const runA2 = join(cwd, 'run', 'r2', 'a.tex');
+    const runB = join(cwd, 'run', 'r1', 'b.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await mkdir(join(cwd, 'run', 'r2'), { recursive: true });
+    await writeFile(runA1, 'A1');
+    await writeFile(runA2, 'A2');
+    await writeFile(runB, 'B');
+
+    const { displayResult } = await resolveWorkflowOutput(
+      undefined,
+      'out',
+      workflowResult([
+        { absolutePath: runA1, relativePath: 'r1/a.tex' },
+        { absolutePath: runB, relativePath: 'r1/b.tex' },
+        { absolutePath: runA2, relativePath: 'r2/a.tex' },
+      ]),
+      testContext(cwd),
+      {
+        expectedOutputFiles: ['a.tex', 'b.tex'],
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      copiedOutputs: [join(cwd, 'out', 'a.tex'), join(cwd, 'out', 'b.tex')],
+    });
+    await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(
+      'A2',
+    );
+    await expect(readFile(join(cwd, 'out', 'b.tex'), 'utf8')).resolves.toBe(
+      'B',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Make `texra run --output-dir` validate that the expected workflow outputs were actually copied.
- Derive expected output names from the agent's default outputs, or from the input filenames for rewrite-style workflow agents such as `correct` and `polish`.
- Deduplicate repeated round outputs by copied relative path and keep the latest round's file.
- Add focused tests for missing expected outputs, duplicate round outputs, and the existing interrupted-output path.

## Root Cause

The CLI copied whatever workflow outputs the runtime returned, then exited successfully as long as at least one output existed. For multi-input rewrite workflows this allowed a partial result, for example only `a.tex` for inputs `a.tex` and `b.tex`, to be treated as a successful `--output-dir` run.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run typecheck`
- `npm run lint` (18 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run format`
- Built CLI probe with the internal validation model: two input files, one produced document, `--output-dir`; command exited `1` and reported `Workflow completed without expected outputs: a.tex, b.tex; copied 1 of 2 expected outputs ...`

Closes #4269.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI workflow output copy/validation behavior and exit codes for `--output-dir`, which can cause previously successful runs to fail when outputs are incomplete. Logic is contained to CLI output resolution and covered by new focused tests, keeping overall risk moderate.
> 
> **Overview**
> **`texra run --output-dir` now validates completeness of copied workflow outputs.** The CLI derives an expected output set (from an agent’s `defaultOutputFiles` or falling back to input filenames) and throws an error if any expected outputs are missing, instead of succeeding after copying a partial set.
> 
> When copying to `--output-dir`, outputs are **deduplicated by normalized relative path** and the **latest `round` wins** to avoid stale overwrites. Error handling was tweaked so interrupted runs preserve `Interrupted` exit behavior, and new vitest coverage was added for missing outputs and multi-round dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965712db9dc23bc9c11aeb290cacd1c367bb57fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->