### PR TITLE
[codex] Bound CLI agent picker rows

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -46,6 +46,7 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <AgentListForm
         currentAgent={current}
+        availableRows={props.availableRows}
         selectable={selectable}
         onSelect={(value) => {
           void Promise.resolve(onAgentSelect(value)).finally(() =>

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -13,6 +13,7 @@ import { Select } from '../ui/Select';
 
 export interface AgentListFormProps {
   readonly currentAgent: string;
+  readonly availableRows?: number;
   readonly selectable?: boolean;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
@@ -59,6 +60,78 @@ function agentDescription(agent: AgentOptionData): string {
       : 'built-in';
   const kind = agent.isOrchestrator ? 'orchestrator' : 'tool-use';
   return agent.description ? `${kind}; ${source}; ${agent.description}` : kind;
+}
+
+export function agentSelectWindow({
+  availableRows,
+  itemCount,
+  workflowCount,
+}: {
+  readonly availableRows: number | undefined;
+  readonly itemCount: number;
+  readonly workflowCount: number;
+}): {
+  readonly maxVisibleItems: number | undefined;
+  readonly showOverflow: boolean;
+  readonly maxVisibleWorkflows: number;
+  readonly showWorkflowOverflow: boolean;
+} {
+  if (availableRows == null) {
+    return {
+      maxVisibleItems: undefined,
+      showOverflow: false,
+      maxVisibleWorkflows: workflowCount,
+      showWorkflowOverflow: false,
+    };
+  }
+
+  // Border, title, description, tool-use heading, and key hints are the fixed
+  // chrome for the primary selectable list.
+  const selectRows = Math.max(1, availableRows - 8);
+  if (itemCount > selectRows) {
+    if (selectRows < 3) {
+      return {
+        maxVisibleItems: selectRows,
+        showOverflow: false,
+        maxVisibleWorkflows: 0,
+        showWorkflowOverflow: false,
+      };
+    }
+
+    return {
+      maxVisibleItems: Math.max(1, selectRows - 2),
+      showOverflow: true,
+      maxVisibleWorkflows: 0,
+      showWorkflowOverflow: false,
+    };
+  }
+
+  const remainingRows = availableRows - 8 - itemCount;
+  if (workflowCount === 0 || remainingRows < 4) {
+    return {
+      maxVisibleItems: itemCount,
+      showOverflow: false,
+      maxVisibleWorkflows: 0,
+      showWorkflowOverflow: false,
+    };
+  }
+
+  const workflowRows = remainingRows - 3;
+  if (workflowCount <= workflowRows) {
+    return {
+      maxVisibleItems: itemCount,
+      showOverflow: false,
+      maxVisibleWorkflows: workflowCount,
+      showWorkflowOverflow: false,
+    };
+  }
+
+  return {
+    maxVisibleItems: itemCount,
+    showOverflow: false,
+    maxVisibleWorkflows: Math.max(0, workflowRows - 1),
+    showWorkflowOverflow: true,
+  };
 }
 
 export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
@@ -122,6 +195,15 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     name: agent.label,
     description: agentDescription(agent),
   }));
+  const selectWindow = agentSelectWindow({
+    availableRows: props.availableRows,
+    itemCount: items.length,
+    workflowCount: workflowRows.length,
+  });
+  const visibleWorkflowRows = workflowRows.slice(
+    0,
+    selectWindow.maxVisibleWorkflows,
+  );
 
   return (
     <Box
@@ -143,6 +225,8 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         <Select
           items={items}
           activeValue={props.currentAgent}
+          maxVisibleItems={selectWindow.maxVisibleItems}
+          showOverflow={selectWindow.showOverflow}
           onSelect={(value) => {
             if (selectable) {
               props.onSelect?.(value);
@@ -153,17 +237,22 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           onCancel={props.onClose}
         />
       </Box>
-      {workflowRows.length > 0 ? (
+      {visibleWorkflowRows.length > 0 || selectWindow.showWorkflowOverflow ? (
         <Box marginTop={1} flexDirection="column">
           <Text bold>Workflows</Text>
-          {workflowRows.map((workflow) => (
-            <Text key={workflow.name}>
+          {visibleWorkflowRows.map((workflow) => (
+            <Text key={workflow.name} wrap="truncate-end">
               {'  '}
               {workflow.name}
               <Text dimColor>{` — ${workflow.description}`}</Text>
             </Text>
           ))}
-          <Text dimColor>
+          {selectWindow.showWorkflowOverflow ? (
+            <Text dimColor>{`... ${
+              workflowRows.length - visibleWorkflowRows.length
+            } more workflows`}</Text>
+          ) : null}
+          <Text dimColor wrap="truncate-end">
             {'Run a workflow with texra run <name> --input=<file>.'}
           </Text>
         </Box>

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -141,9 +141,10 @@ function openCliAgentListForm(context: SlashCommandContext): void {
   const selectable = !context.session.runPromise;
   cliState.activeForm.set({
     commandName: 'agent',
-    render: (close) => (
+    render: (close, availableRows) => (
       <AgentListForm
         currentAgent={cliState.sessionMeta.get().agent}
+        availableRows={availableRows}
         selectable={selectable}
         onSelect={(value) => {
           applyInitialCliAgentSelection(value, context);

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentSelectWindow } from '../../../packages/cli/src/chat/tui/forms/AgentListForm';
+
+describe('CLI AgentListForm row budget', () => {
+  it('windows long agent lists inside the available foreground rows', () => {
+    expect(
+      agentSelectWindow({
+        availableRows: 12,
+        itemCount: 12,
+        workflowCount: 10,
+      }),
+    ).toEqual({
+      maxVisibleItems: 2,
+      showOverflow: true,
+      maxVisibleWorkflows: 0,
+      showWorkflowOverflow: false,
+    });
+  });
+
+  it('shows workflows only when the row budget has room for them', () => {
+    expect(
+      agentSelectWindow({
+        availableRows: 24,
+        itemCount: 6,
+        workflowCount: 3,
+      }),
+    ).toEqual({
+      maxVisibleItems: 6,
+      showOverflow: false,
+      maxVisibleWorkflows: 3,
+      showWorkflowOverflow: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the CLI TUI `/agent` form so long agent registries and long custom/remote descriptions cannot overflow the foreground region at normal terminal sizes.

The form now receives the available row budget, windows the tool-use agent list with overflow markers, hides the workflow advisory section when there is no row budget for it, and truncates workflow rows to one line when they are shown.

Closes #4271.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- PTY probe: `TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --approval-policy never --model deepseekT --agent chat`, then `/agent` + Enter at 80 columns. The picker rendered bounded rows with `... 3 earlier` / `... 13 more` and a clean footer.
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with the existing 18 warnings, 0 errors)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Ink TUI rendering/layout for the `/agent` form plus a small pure-function test; no auth, networking, or data handling is affected.
> 
> **Overview**
> Prevents the CLI TUI `/agent` picker from overflowing the foreground region by passing a row budget (`availableRows`) into `AgentListForm` and computing a bounded display window.
> 
> Adds `agentSelectWindow` to cap visible tool-use agents (with `... earlier/more` overflow markers via `Select`), conditionally hide/limit the workflows section when there isn’t enough space, and truncate workflow rows to a single line. Includes new Vitest coverage for the row-budgeting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f8d54af47d1b94fe99a55423a915966f8da3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->