### PR TITLE
[codex] Restore CLI resume output copies

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -985,6 +985,18 @@ function shouldUseOutputForCopy(
   return existing == null || candidate.round > existing.round;
 }
 
+function latestWorkflowOutput(
+  outputs: readonly OutputFileSummary[],
+): OutputFileSummary | undefined {
+  let latest: OutputFileSummary | undefined;
+  for (const output of outputs) {
+    if (latest == null || output.round >= latest.round) {
+      latest = output;
+    }
+  }
+  return latest;
+}
+
 export async function resolveWorkflowOutput(
   outputFile: string | undefined,
   outputDir: string | undefined,
@@ -1072,7 +1084,7 @@ export async function resolveWorkflowOutput(
     return { copiedOutput: undefined, displayResult: baseResult };
   }
 
-  const finalOutput = result.outputs.at(-1);
+  const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
     return { copiedOutput: undefined, displayResult: baseResult };
   }
@@ -1134,6 +1146,29 @@ function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
   return finalOutput?.absolutePath ?? result.runDirectory ?? result.status;
 }
 
+export function resumeWorkflowOutputFile(
+  config: AgentConfigPayload,
+): string | undefined {
+  if (config.agentCategory !== AgentCategory.Workflow) return undefined;
+
+  const resolveStoredOutputFile = (outputFile: string | undefined | null) => {
+    const trimmed = outputFile?.trim();
+    if (!trimmed) return undefined;
+    if (path.isAbsolute(trimmed)) return trimmed;
+
+    const workingDirectory = config.workingDirectory?.trim();
+    return workingDirectory ? path.join(workingDirectory, trimmed) : trimmed;
+  };
+
+  const cliOutputFile = resolveStoredOutputFile(config.cliOutputFile);
+  if (cliOutputFile) return cliOutputFile;
+
+  const outputFiles = config.outputFiles ?? [];
+  return outputFiles.length === 1
+    ? resolveStoredOutputFile(outputFiles[0])
+    : undefined;
+}
+
 async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
@@ -1182,6 +1217,7 @@ async function runWorkflowAgent(
     inputFiles,
     contextFiles: init.contextFiles,
     outputFiles: modelOutputFile ? [modelOutputFile] : [],
+    cliOutputFile: init.output,
     instruction: init.instruction,
     workingDirectory: runContext.cwd,
     agentCategory: AgentCategory.Workflow,
@@ -1317,22 +1353,49 @@ async function runResumeExecution(
     await runtimeHost.close();
   }
 
+  const terminalStatus = await readCliTerminalStatus(result);
+  let displayResult: CliRunResult;
+  try {
+    ({ displayResult } = await resolveWorkflowOutput(
+      resumeWorkflowOutputFile(config),
+      undefined,
+      result,
+      runContext,
+      { terminalStatus },
+    ));
+  } catch (error) {
+    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+      writeTextStderr(toErrorMessage(error));
+      return CliExitCode.Interrupted;
+    }
+    await writeTerminalStatus(id, EXECUTION_STATUS.ERROR);
+    writeTextStderr(toErrorMessage(error));
+    return CliExitCode.AgentError;
+  }
+
   if (runContext.outputFormat === 'json') {
-    writeTextStdout(JSON.stringify(result, null, 2));
+    writeTextStdout(JSON.stringify(displayResult, null, 2));
   } else if (runContext.outputFormat === 'ndjson') {
     writeNdjsonStdout({
       kind: 'result',
       ts: new Date().toISOString(),
-      result,
+      result: displayResult,
     });
+  } else if (displayResult.category === AgentCategory.Workflow) {
+    writeTextStdout(formatWorkflowTextResult(displayResult));
   } else {
-    writeTextStdout(result.status);
+    writeTextStdout(displayResult.status);
   }
 
-  if (result.status !== 'error') return CliExitCode.Success;
-  return hasCliApprovalDenied(runContext)
-    ? CliExitCode.ApprovalDenied
-    : CliExitCode.AgentError;
+  if (terminalStatus === EXECUTION_STATUS.ERROR) {
+    return hasCliApprovalDenied(runContext)
+      ? CliExitCode.ApprovalDenied
+      : CliExitCode.AgentError;
+  }
+  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+    return CliExitCode.Interrupted;
+  }
+  return CliExitCode.Success;
 }
 
 async function shouldHonorRemoteAgentPriority(

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -23,6 +23,8 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   memories: z.array(z.string()).prefault([]),
   /** Working directory override for subagent tool calls (e.g. a git worktree). */
   workingDirectory: z.string().nullish(),
+  /** CLI-only workspace copy target for `texra run --output`, preserved for resume. */
+  cliOutputFile: z.string().nullish(),
 });
 
 /**

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -17,6 +17,7 @@ import {
   normalizeRootShortcuts,
   reorderGlobalFlags,
   resolveLoginProvider,
+  resumeWorkflowOutputFile,
   resolveWorkflowOutput,
 } from '../../../packages/cli/src/commands/root';
 import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
@@ -33,6 +34,23 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
     colorEnabled: false,
     version: '0.0.0',
     resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+function storedConfig(
+  overrides: Partial<Parameters<typeof resumeWorkflowOutputFile>[0]> = {},
+): Parameters<typeof resumeWorkflowOutputFile>[0] {
+  return {
+    agent: 'polish',
+    model: 'deepseekT',
+    inputFiles: ['paper.tex'],
+    contextFiles: [],
+    outputFiles: [],
+    cliOutputFile: undefined,
+    instruction: undefined,
+    workingDirectory: '/tmp/project',
+    agentCategory: AgentCategory.Workflow,
     ...overrides,
   };
 }
@@ -176,6 +194,66 @@ describe('CLI root argument routing', () => {
         EXECUTION_STATUS.INTERRUPTED,
       ),
     ).toBe(EXECUTION_STATUS.INTERRUPTED);
+  });
+
+  it('restores one requested workflow output path for resume', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({ outputFiles: ['paper.polished.tex'] }),
+      ),
+    ).toBe(path.join('/tmp/project', 'paper.polished.tex'));
+  });
+
+  it('restores the exact absolute CLI output target for resume', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({
+          cliOutputFile: '/tmp/elsewhere/paper.polished.tex',
+          outputFiles: ['paper.polished.tex'],
+        }),
+      ),
+    ).toBe('/tmp/elsewhere/paper.polished.tex');
+  });
+
+  it('resolves relative CLI output targets against the stored working directory', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({
+          cliOutputFile: 'out/paper.polished.tex',
+          outputFiles: ['paper.polished.tex'],
+        }),
+      ),
+    ).toBe(path.join('/tmp/project', 'out/paper.polished.tex'));
+  });
+
+  it('keeps legacy resume output paths relative when no stored working directory exists', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({
+          workingDirectory: undefined,
+          outputFiles: ['paper.polished.tex'],
+        }),
+      ),
+    ).toBe('paper.polished.tex');
+  });
+
+  it('does not infer resume output targets for multi-output workflows', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({ outputFiles: ['paper.tex', 'appendix.tex'] }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('does not infer resume output targets for tool-use configs', () => {
+    expect(
+      resumeWorkflowOutputFile(
+        storedConfig({
+          agentCategory: AgentCategory.ToolUse,
+          outputFiles: ['paper.polished.tex'],
+        }),
+      ),
+    ).toBeUndefined();
   });
 
   it('reports successful stopped workflows with missing requested outputs as failed copies', async () => {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -151,4 +151,35 @@ describe('CLI workflow output resolution', () => {
       'A2',
     );
   });
+
+  it('uses the latest round when a single requested output arrives out of order', async () => {
+    const cwd = await makeTempDir();
+    const runA1 = join(cwd, 'run', 'r1', 'a.tex');
+    const runA2 = join(cwd, 'run', 'r2', 'a.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await mkdir(join(cwd, 'run', 'r2'), { recursive: true });
+    await writeFile(runA1, 'A1');
+    await writeFile(runA2, 'A2');
+
+    const { displayResult } = await resolveWorkflowOutput(
+      'out/a.tex',
+      undefined,
+      workflowResult([
+        { absolutePath: runA2, relativePath: 'r2/a.tex', round: 2 },
+        { absolutePath: runA1, relativePath: 'r1/a.tex', round: 1 },
+      ]),
+      testContext(cwd),
+      {
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      copiedOutput: join(cwd, 'out', 'a.tex'),
+    });
+    await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(
+      'A2',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Reuse the workflow output resolver when `texra resume <id>` re-runs a stored workflow config.
- Preserve the original CLI `--output` copy target in stored configs so resumed runs restore relative and absolute destinations correctly.
- Keep a conservative fallback for existing histories that only contain one workflow output file, resolving that legacy target against the stored working directory when available.
- Select the newest workflow round for single-file copies, matching the existing multi-output behavior when outputs arrive out of order.

Closes #4273.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1 corepack pnpm --filter @texra/cli build`
- Built-CLI isolated resume probe: after deleting `paper.polished.tex`, `texra resume <id> --output-format json` reported `copiedOutput=/private/tmp/texra-resume-probe-JxMisR/work/paper.polished.tex` and `COPIED_AFTER_RESUME=yes`.
- Built-CLI absolute-output resume probe: after deleting the absolute target, resume reported `copiedOutput=/tmp/texra-resume-absolute-probe-QcRPKO/absolute/paper.polished.tex`, `COPIED_ABSOLUTE_AFTER_RESUME=yes`, and `COPIED_TO_WORKSPACE_BASENAME=no`.
- `corepack pnpm --filter @texra/cli build`
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `git diff --check`