### PR TITLE
[codex] Make exact CLI slash commands submit on Enter

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -3,7 +3,12 @@
 import { Box, Text, useInput } from 'ink';
 import { useState, useEffect } from 'react';
 
-import { matchSlashCommands, type SlashCommand } from './slashRegistry';
+import {
+  matchSlashCommands,
+  slashPickIntent,
+  type SlashCommand,
+  type SlashPickIntent,
+} from './slashRegistry';
 import { isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 
@@ -11,7 +16,7 @@ export interface SlashPaletteProps {
   /** The current input value (excluding the leading `/`, after the slash). */
   readonly query: string;
   /** Accepted: caller should replace the input with the chosen command name. */
-  readonly onPick: (command: SlashCommand) => void;
+  readonly onPick: (command: SlashCommand, intent: SlashPickIntent) => void;
   readonly onCancel: () => void;
 }
 
@@ -54,7 +59,16 @@ export function SlashPalette(
       }
       if (isPlainReturnInput(input, key) || key.tab || input === '\t') {
         const chosen = visible[highlight];
-        if (chosen) props.onPick(chosen);
+        if (chosen) {
+          props.onPick(
+            chosen,
+            slashPickIntent(
+              props.query,
+              chosen,
+              isPlainReturnInput(input, key) ? 'enter' : 'tab',
+            ),
+          );
+        }
       }
     },
     { isActive: visibleCount > 0 },

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -27,6 +27,8 @@ export interface SlashCommand {
   readonly formComponent?: React.ComponentType<SlashFormProps>;
 }
 
+export type SlashPickIntent = 'complete' | 'submit';
+
 const COMMANDS = new Map<string, SlashCommand>();
 
 export function registerSlashCommand(command: SlashCommand): void {
@@ -51,6 +53,21 @@ export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
     if (cmd.name.toLowerCase().startsWith(lower)) return true;
     return cmd.aliases?.some((a) => a.toLowerCase().startsWith(lower)) ?? false;
   });
+}
+
+export function slashPickIntent(
+  query: string,
+  command: SlashCommand,
+  acceptKey: 'enter' | 'tab',
+): SlashPickIntent {
+  if (acceptKey !== 'enter') return 'complete';
+  if (command.formComponent) return 'complete';
+
+  const normalized = query.trim().toLowerCase();
+  if (normalized === command.name.toLowerCase()) return 'submit';
+  return command.aliases?.some((alias) => alias.toLowerCase() === normalized)
+    ? 'submit'
+    : 'complete';
 }
 
 /**

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -93,7 +93,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       {showPalette ? (
         <SlashPalette
           query={parsed.name}
-          onPick={(cmd) => {
+          onPick={(cmd, intent) => {
             if (cmd.formComponent) {
               // Structured forms own the screen — clear the input and let
               // the active-form signal mount the component (see App.tsx).
@@ -109,6 +109,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
                   />
                 ),
               });
+              return;
+            }
+            if (intent === 'submit') {
+              handleSubmit(
+                `/${cmd.name}${
+                  parsed.remainder ? ` ${parsed.remainder.trimStart()}` : ''
+                }`,
+              );
               return;
             }
             setValue(

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -7,6 +7,7 @@ import {
   matchSlashCommands,
   parseSlashInput,
   registerSlashCommand,
+  slashPickIntent,
   unregisterSlashCommand,
 } from '../../../packages/cli/src/chat/tui/commands/slashRegistry';
 import { registerBuiltinSlashCommands } from '../../../packages/cli/src/chat/tui/commands/registerBuiltins';
@@ -72,6 +73,27 @@ describe('slashRegistry', () => {
     });
     expect(matchSlashCommands('h').map((c) => c.name)).toEqual(['help']);
     expect(matchSlashCommands('us').map((c) => c.name)).toEqual(['help']);
+  });
+
+  it('submits exact no-form commands on Enter and completes partial commands', () => {
+    const help = { name: 'help', description: 'show help', aliases: ['h'] };
+    registerSlashCommand(help);
+
+    expect(slashPickIntent('help', help, 'enter')).toBe('submit');
+    expect(slashPickIntent('h', help, 'enter')).toBe('submit');
+    expect(slashPickIntent('he', help, 'enter')).toBe('complete');
+    expect(slashPickIntent('help', help, 'tab')).toBe('complete');
+  });
+
+  it('does not directly submit structured-form commands from the palette', () => {
+    const agent = {
+      name: 'agent',
+      description: 'pick an agent',
+      formComponent: () => null,
+    };
+    registerSlashCommand(agent);
+
+    expect(slashPickIntent('agent', agent, 'enter')).toBe('complete');
   });
 });
 


### PR DESCRIPTION
## Summary

- Make Enter execute exact, no-form slash commands such as `/help` and `/exit` instead of merely completing them with a trailing space.
- Preserve Tab completion and keep structured-form commands such as `/agent`, `/model`, `/api`, and `/approval` opening their forms.
- Add focused coverage for slash-palette pick intent.

Closes #4278.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- Built CLI PTY probe: typed `/help` then Enter and saw the slash-command list immediately; typed `/exit` then Enter and the TUI exited.
- `corepack pnpm --filter @texra/cli build`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TUI input/selection behavior so Enter can immediately execute certain slash commands; regressions could cause unintended command submission or missed completions in the CLI.
> 
> **Overview**
> Updates the slash-command palette so accepting a selection carries an explicit intent (`complete` vs `submit`) based on whether the user pressed Enter vs Tab and whether the typed query exactly matches a no-form command/alias.
> 
> `InputBar` now uses this intent to immediately submit exact, non-form slash commands on Enter (e.g. `/help`, including aliases), while preserving Tab completion and ensuring structured-form commands still open their forms. Adds targeted tests for `slashPickIntent` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe70d1906040c5fdbfcb9629909927bf737904a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->