### PR TITLE
[codex] Compact CLI approval footer hints

### DIFF
--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -16,7 +16,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
       borderStyle="double"
       color="yellow"
       title="Run bash command?"
-      alwaysAllow={{ kind: 'toolEdit', label: 'approve tools this session' }}
+      alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
       onDecide={props.onDecide}
     >
       <Box marginY={1}>

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -54,7 +54,7 @@ export function confirmCardKeyHints({
       ? []
       : [{ key: 'a', action: alwaysAllowLabel }]),
     ...extraActions,
-    { key: 'e', action: 'reject with feedback' },
+    { key: 'e', action: 'feedback' },
     { key: 'Esc', action: 'cancel' },
   ];
 }

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -46,7 +46,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       borderStyle="double"
       color="cyan"
       title={`Apply edit to ${props.request.path}?`}
-      alwaysAllow={{ kind: 'toolEdit', label: 'approve edits this session' }}
+      alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
       onDecide={props.onDecide}
     >
       <Text dimColor>

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -22,17 +22,24 @@ describe('CLI confirm-card key handling', () => {
     expect(confirmCardKeyAction('a', {}, false)).toBe('ignore');
   });
 
-  it('keeps session-wide approval in the full key-hint list', () => {
+  it('keeps session-wide approval hints compact enough for approval modals', () => {
     expect(
       confirmCardKeyHints({
-        alwaysAllowLabel: 'approve edits this session',
+        alwaysAllowLabel: 'approve session',
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'approve edits this session' },
-      { key: 'e', action: 'reject with feedback' },
+      { key: 'a', action: 'approve session' },
+      { key: 'e', action: 'feedback' },
       { key: 'Esc', action: 'cancel' },
     ]);
+
+    const rendered = confirmCardKeyHints({
+      alwaysAllowLabel: 'approve session',
+    })
+      .map((hint) => `${hint.key} ${hint.action}`)
+      .join(' · ');
+    expect(rendered.length).toBeLessThanOrEqual(72);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the CLI TUI approval footer so the edit and bash approval cards remain legible at a standard 80-column terminal width.

The previous footer could render as:

```text
y approve · n reject · a approve edits this session · e reject with feedbac…
```

This PR keeps the same key bindings and approval semantics, but shortens the session-approval and feedback labels to:

```text
y approve · n reject · a approve session · e feedback · Esc cancel
```

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts`
- `corepack pnpm --filter @texra/cli build`
- Built CLI PTY probe: `node packages/cli/dist/bin/texra.js --cwd "$tmpdir" chat --approval-policy ask`, requested a file edit, verified the approval footer rendered fully at 80 columns, approved the edit, and verified the file contents.
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (passes with the existing 18 warnings)
- `git diff --check`

Closes #4280.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only shortens key-hint labels in CLI TUI approval modals and updates a unit test; no changes to approval decisions or input handling semantics.
> 
> **Overview**
> Makes the CLI TUI approval modals more readable in narrow terminals by **shortening footer hint labels**.
> 
> Updates `BashApproval` and `EditApproval` to use a compact session-approval label (`approve session`), and renames the `e` hint text from `reject with feedback` to `feedback` in `confirmCardKeyHints`. Tests are updated to match and add a length assertion to keep the rendered hint string within ~80-column constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7b30377233850ad6461301154c476331dae361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->