### PR TITLE
[codex] Route GPT reasoning tool-use through Responses

### DIFF
--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -87,8 +87,22 @@ function withReasoningOverride<T extends ModelHandler>(handler: T): T {
   return handler;
 }
 
+function requiresOpenAIResponsesAPI(config: ModelConfig): boolean {
+  if (config.provider !== ModelProvider.OPENAI || config.openRouterOnly) {
+    return false;
+  }
+  if (config.requiresResponsesAPI) return true;
+
+  const { capabilities } = config;
+  return (
+    config.fullName.startsWith('gpt-5') &&
+    capabilities.supportsReasoningEffort === true &&
+    capabilities.supportsFunctionCalling === true
+  );
+}
+
 /** Check if OpenAI Responses API should be used for this config. */
-function shouldUseResponsesAPI(
+export function shouldUseResponsesAPI(
   config: ModelConfig,
   useOpenRouter: boolean,
 ): boolean {
@@ -96,7 +110,7 @@ function shouldUseResponsesAPI(
     return false;
   }
   return (
-    config.requiresResponsesAPI ||
+    requiresOpenAIResponsesAPI(config) ||
     (!useOpenRouter &&
       (getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
         config.fullName.startsWith('gpt-oss')))

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { shouldUseResponsesAPI } from '@agent/runtime/ModelFactory';
+
+describe('OpenAI model handler routing', () => {
+  it('routes current GPT reasoning tool-use models to Responses by default', () => {
+    expect(shouldUseResponsesAPI(MODEL_CONFIGS.gpt54, false)).toBe(true);
+    expect(shouldUseResponsesAPI(MODEL_CONFIGS.gpt55, false)).toBe(true);
+    expect(shouldUseResponsesAPI(MODEL_CONFIGS.gpt54, true)).toBe(true);
+  });
+
+  it('keeps OpenRouter-only models outside the Responses handler', () => {
+    expect(
+      shouldUseResponsesAPI(
+        {
+          ...MODEL_CONFIGS.gpt54,
+          openRouterOnly: true,
+        },
+        false,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `gpt54` CLI tool-use sessions failing on the first provider call with:

```text
Function tools with reasoning_effort are not supported for gpt-5.4-2026-03-05 in /v1/chat/completions. Please use /v1/responses instead.
```

Current OpenAI GPT reasoning models that support function calling (`gpt54`, `gpt55`) now route to the OpenAI Responses handler by default. This keeps the existing OpenRouter-only escape hatch intact and preserves the existing user setting for other OpenAI models.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts src/test/modelHandlers/ResponseToolConversion.test.ts`
- `npm run typecheck`
- `corepack pnpm --filter @texra/cli build`
- Built CLI PTY probe: `node packages/cli/dist/bin/texra.js --cwd "$tmpdir" chat --model gpt54 --approval-policy ask`; submitted a tool-use chat prompt and confirmed the request completed with `OK` instead of the previous HTTP 400.
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (passes with the existing 18 warnings)
- `git diff --check`

Closes #4282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model routing so certain OpenAI GPT-5 reasoning/function-calling configs use the Responses handler by default, which can affect request shape and provider behavior. Risk is moderated by provider/openRouter gating and added unit coverage for the new routing rules.
> 
> **Overview**
> Routes OpenAI GPT-5 *reasoning + function-calling* models (e.g. `gpt54`, `gpt55`) through the OpenAI **Responses** handler by default to avoid `/chat/completions` incompatibilities with `reasoning_effort`.
> 
> This factors the decision into a new `requiresOpenAIResponsesAPI` helper and exports `shouldUseResponsesAPI` for reuse/testing, while keeping the existing OpenRouter-only escape hatch and the user config flag behavior for other models. Adds a focused Vitest suite validating the new routing defaults and the `openRouterOnly` exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb98b3adcc26ef00973b087ac711ad1ceac3d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->