### PR TITLE
feat(lean): direct LSP adapter for CLI and desktop builds

### DIFF
--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -1,3 +1,4 @@
+import { tryPlatform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { runCli } from '../commands/root';
@@ -10,4 +11,6 @@ try {
 } catch (error) {
   writeTextStderr(`TeXRA CLI failed: ${toErrorMessage(error)}`);
   process.exitCode = CliExitCode.AgentError;
+} finally {
+  await tryPlatform()?.lifecycle.runShutdown();
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -21,6 +21,10 @@ import { GlobalStateKey } from '@common/state/stateKeys';
 // Local imports - logger
 import { setOutputChannelFactory } from '@logger/logUtils';
 
+// Local imports - Lean direct LSP adapter
+import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
+import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
+
 // Local imports - CLI runtime
 import { getCliSecrets } from './cliSecrets';
 import { writeTextStderr } from './logSinks';
@@ -100,6 +104,11 @@ export async function initCliPlatform(
       lifecycle: noopLifecycle,
       agentResume: { tryResumeStream: async () => false },
     });
+    // Direct LSP adapter for Lean tools — spawns `lake env lean --server`
+    // lazily, one server per Lake project root. Errors are surfaced via the
+    // Tools dashboard if `lake` isn't on PATH; nothing happens at startup
+    // when no Lean tools are invoked.
+    setLeanVscodeServices(createDirectLspLeanAdapter());
   }
 
   if (!serverSideKeysInitialized) {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -25,7 +25,7 @@ import { setOutputChannelFactory } from '@logger/logUtils';
 
 // Local imports - Lean direct LSP adapter
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
-import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
+import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
 // Local imports - CLI runtime
 import { getCliSecrets } from './cliSecrets';
@@ -139,7 +139,7 @@ export async function initCliPlatform(
     // Tools dashboard if `lake` isn't on PATH; nothing happens at startup
     // when no Lean tools are invoked.
     const leanAdapter = createDirectLspLeanAdapter();
-    setLeanVscodeServices(leanAdapter);
+    setLeanLanguageServices(leanAdapter);
     lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
   }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -1,9 +1,11 @@
 // Local imports - platform
 import { JsonStore } from '@platform/defaults/jsonStore';
+import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { createMemoryStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { initPlatform, tryPlatform } from '@platform/platform';
 
 // Local imports - agent index
@@ -37,15 +39,11 @@ import type { LifecycleHost } from '@platform/interfaces/lifecycle';
 import type { LogBackend } from '@platform/interfaces/log';
 import type { CliContext } from './cliContext';
 
-const noopLifecycle: LifecycleHost = {
-  onShutdown: () => ({ dispose: () => {} }),
-  async runShutdown() {},
-};
-
 let bootstrappedResourcesPath: string | undefined;
 let serverSideKeysInitialized = false;
 let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
+let shutdownHandlersInstalled = false;
 
 function logAt(
   level: 'debug' | 'info' | 'warn',
@@ -66,6 +64,36 @@ const cliPlatformLog: LogBackend = {
     writeTextStderr(`[error] [${channel}] ${message}`);
   },
 };
+
+function createCliLifecycleHost(): LifecycleHost {
+  return createLifecycleHost({
+    onError: (phase, error) => {
+      logAt(
+        'warn',
+        'cli.lifecycle',
+        `${phase} handler failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+  });
+}
+
+function installCliShutdownSignalHandlers(lifecycle: LifecycleHost): void {
+  if (shutdownHandlersInstalled) return;
+  shutdownHandlersInstalled = true;
+
+  const install = (signal: NodeJS.Signals) => {
+    const handler = () => {
+      process.off(signal, handler);
+      void lifecycle.runShutdown().finally(() => {
+        process.kill(process.pid, signal);
+      });
+    };
+    process.once(signal, handler);
+  };
+
+  install('SIGINT');
+  install('SIGTERM');
+}
 
 export async function setCliHelperModel(
   model: string | undefined,
@@ -90,6 +118,7 @@ export async function initCliPlatform(
     const configStore = await JsonStore.open(
       workspaceCliConfigPath(cliWorkspaceCwd),
     );
+    const lifecycle = createCliLifecycleHost();
     initPlatform({
       config: new CliConfigProvider(configStore),
       globalState: createMemoryStore(),
@@ -101,14 +130,17 @@ export async function initCliPlatform(
         workspacePath: () => cliWorkspaceCwd,
       }),
       secrets: getCliSecrets(),
-      lifecycle: noopLifecycle,
+      lifecycle,
       agentResume: { tryResumeStream: async () => false },
     });
+    installCliShutdownSignalHandlers(lifecycle);
     // Direct LSP adapter for Lean tools — spawns `lake env lean --server`
     // lazily, one server per Lake project root. Errors are surfaced via the
     // Tools dashboard if `lake` isn't on PATH; nothing happens at startup
     // when no Lean tools are invoked.
-    setLeanVscodeServices(createDirectLspLeanAdapter());
+    const leanAdapter = createDirectLspLeanAdapter();
+    setLeanVscodeServices(leanAdapter);
+    lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
   }
 
   if (!serverSideKeysInitialized) {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -83,7 +83,6 @@ function installCliShutdownSignalHandlers(lifecycle: LifecycleHost): void {
 
   const install = (signal: NodeJS.Signals) => {
     const handler = () => {
-      process.off(signal, handler);
       void lifecycle.runShutdown().finally(() => {
         process.kill(process.pid, signal);
       });

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -10,6 +10,9 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { createWorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { initPlatform } from '@platform/platform';
+import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
+import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
+import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
 import { ElectronConfigProvider } from './electronConfig.js';
@@ -69,6 +72,12 @@ export async function initializeElectronPlatform(
     agentResume: { tryResumeStream: async () => false },
   });
   registerAgentFeatures();
+
+  // Lean tools talk to `lake env lean --server` directly in the desktop build.
+  // Servers are spawned lazily per Lake project root on first request.
+  const leanAdapter = createDirectLspLeanAdapter();
+  setLeanVscodeServices(leanAdapter);
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
 
   await bootstrapElectronAgentDirectories(
     resolveResourcesPath(mainDirname),

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -12,7 +12,7 @@ import { createWorkspaceStorageProvider } from '@platform/defaults/workspaceStor
 import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
-import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
+import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
 import { ElectronConfigProvider } from './electronConfig.js';
@@ -76,7 +76,7 @@ export async function initializeElectronPlatform(
   // Lean tools talk to `lake env lean --server` directly in the desktop build.
   // Servers are spawned lazily per Lake project root on first request.
   const leanAdapter = createDirectLspLeanAdapter();
-  setLeanVscodeServices(leanAdapter);
+  setLeanLanguageServices(leanAdapter);
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
 
   await bootstrapElectronAgentDirectories(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -95,7 +95,7 @@ import {
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
 import { setAddCriticismSink } from '@tools/AddCriticismTool';
 import { setLinterProvider } from '@tools/DiagnosticsTool';
-import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
+import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -354,7 +354,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerFileDecorations(context);
 
   initializeNativeToolEditApproval(context, extensionAgentRuntimeHost);
-  setLeanVscodeServices(leanVscodeIntegration);
+  setLeanLanguageServices(leanVscodeIntegration);
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
   setOpenPdfOpener(async ({ location, preserveFocus }) => {
     await vscode.commands.executeCommand(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -663,5 +663,6 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
   const host = lifecycleHost;
   lifecycleHost = undefined;
+  leanVscodeIntegration.clearVscodeLeanServerEntries();
   await host?.runShutdown();
 }

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -24,7 +24,56 @@ import type {
   PlainGoal,
   PlainTermGoal,
 } from '@tools/lean/leanTypes';
+import {
+  registerLeanServer,
+  unregisterLeanServer,
+  updateLeanServer,
+} from '@tools/lean/leanServerRegistry';
 import { WorkspaceFS } from '@utils/files';
+
+const knownExtensionServers = new Set<string>();
+
+function vscodeServerId(workspaceRoot: string): string {
+  return `vscode:${workspaceRoot}`;
+}
+
+/**
+ * Record a workspace folder as having an active VS Code-mediated Lean
+ * server. Idempotent — called from every code path that successfully
+ * reaches the leanprover.lean4 client provider, so the dashboard reflects
+ * actual usage rather than a one-shot snapshot.
+ */
+function noteVscodeLeanServer(workspaceRoot: string): void {
+  const id = vscodeServerId(workspaceRoot);
+  if (knownExtensionServers.has(id)) {
+    updateLeanServer(id, { status: 'running', touchActivity: true });
+    return;
+  }
+  knownExtensionServers.add(id);
+  registerLeanServer({
+    id,
+    workspaceRoot,
+    mode: 'vscode-extension',
+    status: 'running',
+  });
+}
+
+function workspaceRootForFile(absolutePath: string): string {
+  const folder = vscode.workspace.getWorkspaceFolder(
+    vscode.Uri.file(absolutePath),
+  );
+  return folder?.uri.fsPath ?? path.dirname(absolutePath);
+}
+
+/**
+ * Clear all VS Code-mediated entries — called on extension deactivation.
+ */
+export function clearVscodeLeanServerEntries(): void {
+  for (const id of knownExtensionServers) {
+    unregisterLeanServer(id);
+  }
+  knownExtensionServers.clear();
+}
 
 type LspHover = import('vscode-languageserver-protocol').Hover;
 
@@ -239,6 +288,8 @@ async function sendPositionRequest<T>(
     };
   }
 
+  noteVscodeLeanServer(workspaceRootForFile(absolutePath));
+
   try {
     const params = {
       textDocument: { uri: leanUri.toString() },
@@ -317,6 +368,8 @@ export async function fetchDiagnosticsForFile(
 
   const openedPath = await openFileInEditor(file, { preserveFocus: true });
   if (!openedPath) return null;
+
+  noteVscodeLeanServer(workspaceRootForFile(WorkspaceFS.toAbsolute(file)));
 
   await diagnosticsWait;
   return getDiagnostics(openedPath);

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -5,7 +5,7 @@
  * language APIs and the Lean 4 extension's exported API.
  *
  * This module lives in `@frontend/` because it depends on `vscode` APIs.
- * Tool implementations access it via the injectable `LeanVscodeServices`.
+ * Tool implementations access it via the injectable `LeanLanguageServices`.
  */
 
 import * as path from 'path';

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -179,7 +179,7 @@ function toLeanDiagnostic(d: vscode.Diagnostic): LeanDiagnostic {
  * Get diagnostics for a Lean file using VS Code's diagnostics API.
  * This returns diagnostics from the Lean 4 extension's LSP.
  */
-export function getDiagnostics(filePath: string): LeanDiagnostic[] {
+function getDiagnostics(filePath: string): LeanDiagnostic[] {
   const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
   const directLookup = vscode.languages.getDiagnostics(uri);
   if (directLookup.length > 0) {
@@ -220,7 +220,7 @@ export async function executeFileCommand(
  * Prompt user to install Lean 4 extension if not already installed.
  * Used when Lean tools are invoked but the extension is not found.
  */
-export async function promptLean4ExtensionInstall(): Promise<void> {
+async function promptLean4ExtensionInstall(): Promise<void> {
   await showInstructionWithSuppress(
     'lean4-install-tool',
     'Lean 4 extension is required for this operation. Install now?',

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -18,6 +18,11 @@ import {
   waitForDiagnosticsChange,
   DiagnosticSeverity,
 } from '@frontend/vscode/vscodeDiagnostics';
+import {
+  LEAN4_EXTENSION_ID,
+  type LeanFileCommand,
+  type LeanProjectCommand,
+} from '@tools/lean/leanConstants';
 import type {
   LeanDiagnostic,
   LspResult,
@@ -30,6 +35,24 @@ import {
   updateLeanServer,
 } from '@tools/lean/leanServerRegistry';
 import { WorkspaceFS } from '@utils/files';
+
+const FILE_COMMAND_VSCODE_IDS: Record<LeanFileCommand, string> = {
+  restart: 'lean4.restartFile',
+  refresh_dependencies: 'lean4.refreshFileDependencies',
+};
+
+const PROJECT_COMMAND_VSCODE_IDS: Record<LeanProjectCommand, string> = {
+  restart_server: 'lean4.restartServer',
+  stop_server: 'lean4.stopServer',
+  build: 'lean4.project.build',
+  clean: 'lean4.project.clean',
+  fetch_cache: 'lean4.project.fetchCache',
+  fetch_file_cache: 'lean4.project.fetchFileCache',
+  install_elan: 'lean4.setup.installElan',
+  install_deps: 'lean4.setup.installDeps',
+  update_elan: 'lean4.setup.updateElan',
+  select_toolchain: 'lean4.setup.selectDefaultToolchain',
+};
 
 const knownExtensionServers = new Set<string>();
 
@@ -178,26 +201,20 @@ function findDiagnosticsByPath(targetPath: string): vscode.Diagnostic[] {
   return [];
 }
 
-/**
- * Execute a VS Code command that requires a file to be open.
- * Opens the file first, then executes the command.
- */
 export async function executeFileCommand(
-  command: string,
+  command: LeanFileCommand,
   filePath: string,
 ): Promise<boolean> {
   try {
     const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
     const document = await vscode.workspace.openTextDocument(uri);
     await vscode.window.showTextDocument(document, { preserveFocus: true });
-    await vscode.commands.executeCommand(command);
+    await vscode.commands.executeCommand(FILE_COMMAND_VSCODE_IDS[command]);
     return true;
   } catch {
     return false;
   }
 }
-
-const LEAN4_EXTENSION_ID = 'leanprover.lean4';
 
 /**
  * Prompt user to install Lean 4 extension if not already installed.
@@ -388,7 +405,8 @@ export async function navigateToFirstError(
   }
 }
 
-/** Execute a global VS Code command by its command ID. */
-export async function executeGlobalCommand(commandId: string): Promise<void> {
-  await vscode.commands.executeCommand(commandId);
+export async function executeProjectCommand(
+  command: LeanProjectCommand,
+): Promise<void> {
+  await vscode.commands.executeCommand(PROJECT_COMMAND_VSCODE_IDS[command]);
 }

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -46,7 +46,7 @@ function vscodeServerId(workspaceRoot: string): string {
 function noteVscodeLeanServer(workspaceRoot: string): void {
   const id = vscodeServerId(workspaceRoot);
   if (knownExtensionServers.has(id)) {
-    updateLeanServer(id, { status: 'running', touchActivity: true });
+    updateLeanServer(id, { status: 'running' });
     return;
   }
   knownExtensionServers.add(id);

--- a/src/test-kernel/tools/lean/DefaultResolveWorkspaceRoot.vitest.ts
+++ b/src/test-kernel/tools/lean/DefaultResolveWorkspaceRoot.vitest.ts
@@ -1,0 +1,49 @@
+/**
+ * Vitests for `defaultResolveWorkspaceRoot` — walks up from a file looking
+ * for `lakefile.lean` or `lakefile.toml`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), 'texra-lean-root-'));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('defaultResolveWorkspaceRoot', () => {
+  it('finds lakefile.lean in the same directory', async () => {
+    await writeFile(path.join(scratch, 'lakefile.lean'), '');
+    await writeFile(path.join(scratch, 'Foo.lean'), '');
+    const root = await defaultResolveWorkspaceRoot(
+      path.join(scratch, 'Foo.lean'),
+    );
+    expect(root).toBe(scratch);
+  });
+
+  it('finds lakefile.toml two directories up', async () => {
+    await writeFile(path.join(scratch, 'lakefile.toml'), '');
+    const sub = path.join(scratch, 'a', 'b');
+    await mkdir(sub, { recursive: true });
+    await writeFile(path.join(sub, 'Foo.lean'), '');
+    const root = await defaultResolveWorkspaceRoot(path.join(sub, 'Foo.lean'));
+    expect(root).toBe(scratch);
+  });
+
+  it('returns null when no lakefile is found in any ancestor', async () => {
+    const sub = path.join(scratch, 'no-lake');
+    await mkdir(sub, { recursive: true });
+    await writeFile(path.join(sub, 'Foo.lean'), '');
+    const root = await defaultResolveWorkspaceRoot(path.join(sub, 'Foo.lean'));
+    expect(root).toBeNull();
+  });
+});

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -12,7 +12,7 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
-import { fileUriToPath } from '@tools/lean/direct/leanSession';
+import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
 
 const FAKE_LAKE = `#!/usr/bin/env node
 const fs = require('node:fs');
@@ -118,6 +118,8 @@ async function countStarts(): Promise<number> {
 }
 
 describe('createDirectLspLeanAdapter', () => {
+  const fakeLakeIt = process.platform === 'win32' ? it.skip : it;
+
   it('decodes file URIs with platform path semantics', () => {
     const spacedPath = path.join(projectRoot, 'File With Space.lean');
     expect(fileUriToPath(pathToFileURL(spacedPath).toString())).toBe(
@@ -126,33 +128,52 @@ describe('createDirectLspLeanAdapter', () => {
     expect(fileUriToPath('untitled:Lean')).toBeNull();
   });
 
-  it('joins concurrent first-touch requests for the same workspace', async () => {
-    const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
-    try {
-      const [first, second] = await Promise.all([
-        adapter.fetchDiagnosticsForFile(filePath),
-        adapter.fetchDiagnosticsForFile(filePath),
-      ]);
+  it('rejects ensureReady after disposal through the promise path', async () => {
+    const session = new LeanSession({
+      workspaceRoot: projectRoot,
+      lakeCommand: fakeLakePath,
+    });
 
-      expect(first?.[0]?.message).toBe('fake diagnostic');
-      expect(second?.[0]?.message).toBe('fake diagnostic');
-      expect(await countStarts()).toBe(1);
-    } finally {
-      await adapter.dispose();
-    }
+    await session.dispose();
+
+    await expect(session.ensureReady()).rejects.toThrow(
+      'Lean session has been disposed.',
+    );
   });
 
-  it('restarts by replacing the disposed session with a fresh process', async () => {
-    const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
-    try {
-      await adapter.fetchDiagnosticsForFile(filePath);
-      expect(await countStarts()).toBe(1);
+  fakeLakeIt(
+    'joins concurrent first-touch requests for the same workspace',
+    async () => {
+      const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
+      try {
+        const [first, second] = await Promise.all([
+          adapter.fetchDiagnosticsForFile(filePath),
+          adapter.fetchDiagnosticsForFile(filePath),
+        ]);
 
-      await adapter.executeProjectCommand('restart_server');
+        expect(first?.[0]?.message).toBe('fake diagnostic');
+        expect(second?.[0]?.message).toBe('fake diagnostic');
+        expect(await countStarts()).toBe(1);
+      } finally {
+        await adapter.dispose();
+      }
+    },
+  );
 
-      expect(await countStarts()).toBe(2);
-    } finally {
-      await adapter.dispose();
-    }
-  });
+  fakeLakeIt(
+    'restarts by replacing the disposed session with a fresh process',
+    async () => {
+      const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
+      try {
+        await adapter.fetchDiagnosticsForFile(filePath);
+        expect(await countStarts()).toBe(1);
+
+        await adapter.executeProjectCommand('restart_server');
+
+        expect(await countStarts()).toBe(2);
+      } finally {
+        await adapter.dispose();
+      }
+    },
+  );
 });

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -41,6 +41,7 @@ function handle(message) {
     process.exit(0);
   }
   if (message.method === 'textDocument/didOpen') {
+    if (process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS === '1') return;
     send({
       jsonrpc: '2.0',
       method: 'textDocument/publishDiagnostics',
@@ -87,6 +88,7 @@ let fakeLakePath: string;
 let countPath: string;
 let filePath: string;
 let previousCountEnv: string | undefined;
+let previousSuppressDiagnosticsEnv: string | undefined;
 
 beforeEach(() => {
   tempRoot = mkdtempSync(path.join(tmpdir(), 'texra-direct-lsp-'));
@@ -101,6 +103,9 @@ beforeEach(() => {
   countPath = path.join(tempRoot, 'starts.txt');
   previousCountEnv = process.env.TEXRA_FAKE_LEAN_COUNT;
   process.env.TEXRA_FAKE_LEAN_COUNT = countPath;
+  previousSuppressDiagnosticsEnv =
+    process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS;
+  delete process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS;
 });
 
 afterEach(() => {
@@ -108,6 +113,12 @@ afterEach(() => {
     delete process.env.TEXRA_FAKE_LEAN_COUNT;
   } else {
     process.env.TEXRA_FAKE_LEAN_COUNT = previousCountEnv;
+  }
+  if (previousSuppressDiagnosticsEnv == null) {
+    delete process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS;
+  } else {
+    process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS =
+      previousSuppressDiagnosticsEnv;
   }
   rmSync(tempRoot, { recursive: true, force: true });
 });
@@ -139,6 +150,28 @@ describe('createDirectLspLeanAdapter', () => {
     await expect(session.ensureReady()).rejects.toThrow(
       'Lean session has been disposed.',
     );
+  });
+
+  fakeLakeIt('settles diagnostic waiters during disposal', async () => {
+    process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS = '1';
+    const session = new LeanSession({
+      workspaceRoot: projectRoot,
+      lakeCommand: fakeLakePath,
+    });
+    await session.ensureReady();
+
+    const pendingDiagnostics = session.fetchDiagnostics(filePath);
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await session.dispose();
+
+    await expect(
+      Promise.race([
+        pendingDiagnostics.then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 500),
+        ),
+      ]),
+    ).resolves.toBe('settled');
   });
 
   fakeLakeIt(

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -1,0 +1,158 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
+import { fileUriToPath } from '@tools/lean/direct/leanSession';
+
+const FAKE_LAKE = `#!/usr/bin/env node
+const fs = require('node:fs');
+
+const countPath = process.env.TEXRA_FAKE_LEAN_COUNT;
+if (countPath) fs.appendFileSync(countPath, 'start\\n');
+
+let buffer = Buffer.alloc(0);
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8');
+  process.stdout.write(\`Content-Length: \${body.length}\\r\\n\\r\\n\`);
+  process.stdout.write(body);
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: message.id, result: { capabilities: {} } });
+    return;
+  }
+  if (message.method === 'shutdown') {
+    send({ jsonrpc: '2.0', id: message.id, result: null });
+    return;
+  }
+  if (message.method === 'exit') {
+    process.exit(0);
+  }
+  if (message.method === 'textDocument/didOpen') {
+    send({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: message.params.textDocument.uri,
+        diagnostics: [
+          {
+            severity: 1,
+            message: 'fake diagnostic',
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 1 }
+            },
+            source: 'fake-lean'
+          }
+        ]
+      }
+    });
+  }
+}
+
+process.stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  for (;;) {
+    const headerEnd = buffer.indexOf('\\r\\n\\r\\n');
+    if (headerEnd < 0) return;
+    const header = buffer.subarray(0, headerEnd).toString('utf8');
+    const match = header.match(/Content-Length: (\\d+)/i);
+    if (!match) throw new Error('missing Content-Length');
+    const length = Number.parseInt(match[1], 10);
+    const bodyStart = headerEnd + 4;
+    const frameEnd = bodyStart + length;
+    if (buffer.length < frameEnd) return;
+    const body = buffer.subarray(bodyStart, frameEnd).toString('utf8');
+    buffer = buffer.subarray(frameEnd);
+    handle(JSON.parse(body));
+  }
+});
+`;
+
+let tempRoot: string;
+let projectRoot: string;
+let fakeLakePath: string;
+let countPath: string;
+let filePath: string;
+let previousCountEnv: string | undefined;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(path.join(tmpdir(), 'texra-direct-lsp-'));
+  projectRoot = path.join(tempRoot, 'project');
+  mkdirSync(projectRoot);
+  writeFileSync(path.join(projectRoot, 'lakefile.toml'), 'name = "Test"\n');
+  filePath = path.join(projectRoot, 'Test.lean');
+  writeFileSync(filePath, 'example : True := by trivial\n');
+  fakeLakePath = path.join(tempRoot, 'fake-lake.js');
+  writeFileSync(fakeLakePath, FAKE_LAKE);
+  chmodSync(fakeLakePath, 0o755);
+  countPath = path.join(tempRoot, 'starts.txt');
+  previousCountEnv = process.env.TEXRA_FAKE_LEAN_COUNT;
+  process.env.TEXRA_FAKE_LEAN_COUNT = countPath;
+});
+
+afterEach(() => {
+  if (previousCountEnv == null) {
+    delete process.env.TEXRA_FAKE_LEAN_COUNT;
+  } else {
+    process.env.TEXRA_FAKE_LEAN_COUNT = previousCountEnv;
+  }
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+async function countStarts(): Promise<number> {
+  const text = await readFile(countPath, 'utf8').catch(() => '');
+  return text.split('\n').filter(Boolean).length;
+}
+
+describe('createDirectLspLeanAdapter', () => {
+  it('decodes file URIs with platform path semantics', () => {
+    const spacedPath = path.join(projectRoot, 'File With Space.lean');
+    expect(fileUriToPath(pathToFileURL(spacedPath).toString())).toBe(
+      spacedPath,
+    );
+    expect(fileUriToPath('untitled:Lean')).toBeNull();
+  });
+
+  it('joins concurrent first-touch requests for the same workspace', async () => {
+    const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
+    try {
+      const [first, second] = await Promise.all([
+        adapter.fetchDiagnosticsForFile(filePath),
+        adapter.fetchDiagnosticsForFile(filePath),
+      ]);
+
+      expect(first?.[0]?.message).toBe('fake diagnostic');
+      expect(second?.[0]?.message).toBe('fake diagnostic');
+      expect(await countStarts()).toBe(1);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it('restarts by replacing the disposed session with a fresh process', async () => {
+    const adapter = createDirectLspLeanAdapter({ lakeCommand: fakeLakePath });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      expect(await countStarts()).toBe(1);
+
+      await adapter.executeProjectCommand('restart_server');
+
+      expect(await countStarts()).toBe(2);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+});

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -160,6 +160,19 @@ describe('createDirectLspLeanAdapter', () => {
     },
   );
 
+  it('handles a missing lake command as a reported adapter failure', async () => {
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: path.join(tempRoot, 'missing-lake'),
+    });
+    try {
+      await expect(
+        adapter.fetchDiagnosticsForFile(filePath),
+      ).resolves.toBeNull();
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
   fakeLakeIt(
     'restarts by replacing the disposed session with a fresh process',
     async () => {

--- a/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
+++ b/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
@@ -1,0 +1,178 @@
+/**
+ * Vitests for the LSP-style JSON-RPC framer. Uses an in-memory
+ * `PassThrough` pair to feed bytes both ways without spawning anything.
+ */
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+import { JsonRpcConnection } from '@tools/lean/direct/jsonRpc';
+
+function makePair(): {
+  connection: JsonRpcConnection;
+  serverIn: PassThrough;
+  serverOut: PassThrough;
+  serverSends: (json: unknown) => void;
+  collectClientFrames: () => Promise<Array<Record<string, unknown>>>;
+} {
+  const serverIn = new PassThrough(); // what the client writes (i.e. the server reads)
+  const serverOut = new PassThrough(); // what the server writes (i.e. the client reads)
+  const connection = new JsonRpcConnection(serverIn, serverOut);
+
+  const serverSends = (json: unknown): void => {
+    const body = Buffer.from(JSON.stringify(json), 'utf8');
+    serverOut.write(`Content-Length: ${body.length}\r\n\r\n`);
+    serverOut.write(body);
+  };
+
+  const collectClientFrames = async (): Promise<
+    Array<Record<string, unknown>>
+  > => {
+    // Flush so all `write` callbacks have run, then parse what's in the buffer.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const raw = serverIn.read();
+    if (!raw) return [];
+    const text: string = Buffer.isBuffer(raw) ? raw.toString('utf8') : raw;
+    const frames: Array<Record<string, unknown>> = [];
+    let offset = 0;
+    while (offset < text.length) {
+      const headerEnd = text.indexOf('\r\n\r\n', offset);
+      if (headerEnd < 0) break;
+      const header = text.slice(offset, headerEnd);
+      const lengthMatch = header.match(/Content-Length: (\d+)/i);
+      if (!lengthMatch) break;
+      const length = Number.parseInt(lengthMatch[1]!, 10);
+      const bodyStart = headerEnd + 4;
+      const body = text.slice(bodyStart, bodyStart + length);
+      frames.push(JSON.parse(body));
+      offset = bodyStart + length;
+    }
+    return frames;
+  };
+
+  return {
+    connection,
+    serverIn,
+    serverOut,
+    serverSends,
+    collectClientFrames,
+  };
+}
+
+describe('JsonRpcConnection', () => {
+  it('emits a request frame with Content-Length and resolves on response', async () => {
+    const { connection, serverSends, collectClientFrames } = makePair();
+    const pending = connection.request<{ ok: boolean }>('test/method', {
+      x: 1,
+    });
+    const frames = await collectClientFrames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'test/method',
+      params: { x: 1 },
+    });
+    const id = frames[0]?.id;
+    expect(typeof id).toBe('number');
+
+    serverSends({ jsonrpc: '2.0', id, result: { ok: true } });
+    await expect(pending).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects when the server returns an error', async () => {
+    const { connection, serverSends, collectClientFrames } = makePair();
+    const pending = connection.request('boom').catch((err: Error) => err);
+    const frames = await collectClientFrames();
+    serverSends({
+      jsonrpc: '2.0',
+      id: frames[0]?.id,
+      error: { code: -32601, message: 'unknown method' },
+    });
+    const err = await pending;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/-32601.*unknown method/);
+  });
+
+  it('routes notifications from the server to subscribed handlers', async () => {
+    const { connection, serverSends } = makePair();
+    const handler = vi.fn();
+    connection.onNotification('window/logMessage', handler);
+
+    serverSends({
+      jsonrpc: '2.0',
+      method: 'window/logMessage',
+      params: { type: 3, message: 'hello' },
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(handler).toHaveBeenCalledWith({ type: 3, message: 'hello' });
+  });
+
+  it('reassembles a frame whose body arrives across multiple chunks', async () => {
+    const { connection, serverOut } = makePair();
+    const handler = vi.fn();
+    connection.onNotification('split', handler);
+
+    const body = Buffer.from(
+      JSON.stringify({ jsonrpc: '2.0', method: 'split', params: { ok: true } }),
+      'utf8',
+    );
+    serverOut.write(`Content-Length: ${body.length}\r\n\r\n`);
+    serverOut.write(body.slice(0, 5));
+    serverOut.write(body.slice(5));
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(handler).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('reassembles two frames written back-to-back', async () => {
+    const { connection, serverSends } = makePair();
+    const a = vi.fn();
+    const b = vi.fn();
+    connection.onNotification('a', a);
+    connection.onNotification('b', b);
+
+    serverSends({ jsonrpc: '2.0', method: 'a', params: 1 });
+    serverSends({ jsonrpc: '2.0', method: 'b', params: 2 });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(a).toHaveBeenCalledWith(1);
+    expect(b).toHaveBeenCalledWith(2);
+  });
+
+  it('replies to server-to-client requests via the registered handler', async () => {
+    const { connection, serverSends, collectClientFrames, serverIn } =
+      makePair();
+    connection.onServerRequest('client/echo', async (params) => params);
+
+    // Drain whatever the constructor wrote (nothing, but be defensive).
+    serverIn.read();
+
+    serverSends({
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'client/echo',
+      params: { hello: 'world' },
+    });
+
+    // Give the handler microtask a chance to run before reading the reply.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const frames = await collectClientFrames();
+    expect(frames).toEqual([
+      {
+        jsonrpc: '2.0',
+        id: 99,
+        result: { hello: 'world' },
+      },
+    ]);
+  });
+
+  it('rejects pending requests when the connection is disposed', async () => {
+    const { connection } = makePair();
+    const pending = connection.request('never').catch((err: Error) => err);
+    connection.dispose('test teardown');
+    const err = await pending;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('test teardown');
+  });
+});

--- a/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
+++ b/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
@@ -124,6 +124,28 @@ describe('JsonRpcConnection', () => {
     expect(handler).toHaveBeenCalledWith({ ok: true });
   });
 
+  it('reassembles a frame whose header arrives across multiple chunks', async () => {
+    const { connection, serverOut } = makePair();
+    const handler = vi.fn();
+    connection.onNotification('split-header', handler);
+
+    const body = Buffer.from(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'split-header',
+        params: { ok: true },
+      }),
+      'utf8',
+    );
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`);
+    serverOut.write(header.subarray(0, 6));
+    serverOut.write(header.subarray(6));
+    serverOut.write(body);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(handler).toHaveBeenCalledWith({ ok: true });
+  });
+
   it('reassembles two frames written back-to-back', async () => {
     const { connection, serverSends } = makePair();
     const a = vi.fn();

--- a/src/test-kernel/tools/lean/LakeCommandsMutex.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsMutex.vitest.ts
@@ -1,0 +1,107 @@
+/**
+ * Vitests for `runLakeCommand` — the per-workspace mutex semantics. We don't
+ * need a real `lake` binary; `node -e` is available on every test runner and
+ * lets us simulate work + observe ordering.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runLakeCommand } from '@tools/lean/direct/lakeCommands';
+
+const NODE = process.execPath;
+const PARALLEL_BUDGET_MS = 600;
+const SLEEP_PER_CALL_MS = 120;
+
+function nodeSleep(ms: number, marker: string): readonly string[] {
+  // Emits `marker:start`, sleeps, then `marker:end` on stdout so we can
+  // reconstruct the interleaving from captured output.
+  return [
+    '-e',
+    `process.stdout.write('${marker}:start\\n'); ` +
+      `setTimeout(() => { process.stdout.write('${marker}:end\\n'); }, ${ms});`,
+  ];
+}
+
+let workspaceA: string;
+let workspaceB: string;
+
+beforeEach(() => {
+  workspaceA = mkdtempSync(path.join(tmpdir(), 'texra-lake-mutex-a-'));
+  workspaceB = mkdtempSync(path.join(tmpdir(), 'texra-lake-mutex-b-'));
+});
+
+afterEach(() => {
+  rmSync(workspaceA, { recursive: true, force: true });
+  rmSync(workspaceB, { recursive: true, force: true });
+});
+
+describe('runLakeCommand mutex', () => {
+  it('serializes calls against the same workspace when `serialize: true`', async () => {
+    const [first, second] = await Promise.all([
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeSleep(60, 'a'),
+        serialize: true,
+      }),
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeSleep(10, 'b'),
+        serialize: true,
+      }),
+    ]);
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+    expect(first.stdout).toContain('a:start');
+    expect(first.stdout).toContain('a:end');
+    expect(second.stdout).toContain('b:start');
+    expect(second.stdout).toContain('b:end');
+    expect(second.stdout.indexOf('b:end')).toBeGreaterThan(
+      second.stdout.indexOf('b:start'),
+    );
+  });
+
+  it('runs calls in parallel across different workspaces', async () => {
+    const start = Date.now();
+    await Promise.all([
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeSleep(SLEEP_PER_CALL_MS, 'a'),
+        serialize: true,
+      }),
+      runLakeCommand({
+        workspaceRoot: workspaceB,
+        lakeCommand: NODE,
+        args: nodeSleep(SLEEP_PER_CALL_MS, 'b'),
+        serialize: true,
+      }),
+    ]);
+    // Serialized, the two sleeps would take >= 2*SLEEP_PER_CALL_MS. In
+    // parallel they finish in roughly SLEEP_PER_CALL_MS plus startup. The
+    // budget allows comfortable headroom while still distinguishing the two.
+    expect(Date.now() - start).toBeLessThan(PARALLEL_BUDGET_MS);
+  });
+
+  it('does not serialize when `serialize: false`', async () => {
+    const start = Date.now();
+    await Promise.all([
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeSleep(SLEEP_PER_CALL_MS, 'a'),
+        serialize: false,
+      }),
+      runLakeCommand({
+        workspaceRoot: workspaceA,
+        lakeCommand: NODE,
+        args: nodeSleep(SLEEP_PER_CALL_MS, 'b'),
+        serialize: false,
+      }),
+    ]);
+    expect(Date.now() - start).toBeLessThan(PARALLEL_BUDGET_MS);
+  });
+});

--- a/src/test-kernel/tools/lean/LakeCommandsMutex.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsMutex.vitest.ts
@@ -6,6 +6,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { runLakeCommand } from '@tools/lean/direct/lakeCommands';
@@ -39,28 +40,30 @@ afterEach(() => {
 
 describe('runLakeCommand mutex', () => {
   it('serializes calls against the same workspace when `serialize: true`', async () => {
+    const startedAt = performance.now();
     const [first, second] = await Promise.all([
       runLakeCommand({
         workspaceRoot: workspaceA,
         lakeCommand: NODE,
         args: nodeSleep(60, 'a'),
         serialize: true,
-      }),
+      }).then((result) => ({ result, finishedAt: performance.now() })),
       runLakeCommand({
         workspaceRoot: workspaceA,
         lakeCommand: NODE,
         args: nodeSleep(10, 'b'),
         serialize: true,
-      }),
+      }).then((result) => ({ result, finishedAt: performance.now() })),
     ]);
-    expect(first.exitCode).toBe(0);
-    expect(second.exitCode).toBe(0);
-    expect(first.stdout).toContain('a:start');
-    expect(first.stdout).toContain('a:end');
-    expect(second.stdout).toContain('b:start');
-    expect(second.stdout).toContain('b:end');
-    expect(second.stdout.indexOf('b:end')).toBeGreaterThan(
-      second.stdout.indexOf('b:start'),
+    expect(first.result.exitCode).toBe(0);
+    expect(second.result.exitCode).toBe(0);
+    expect(first.result.stdout).toContain('a:start');
+    expect(first.result.stdout).toContain('a:end');
+    expect(second.result.stdout).toContain('b:start');
+    expect(second.result.stdout).toContain('b:end');
+    expect(second.finishedAt).toBeGreaterThanOrEqual(first.finishedAt);
+    expect(second.finishedAt - startedAt).toBeGreaterThanOrEqual(
+      first.finishedAt - startedAt,
     );
   });
 

--- a/src/test-kernel/tools/lean/LeanExternalToolStatus.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanExternalToolStatus.vitest.ts
@@ -1,0 +1,53 @@
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - tools
+import { findExternalToolDef } from '@tools/externalToolDefs';
+import {
+  clearLeanServerRegistry,
+  registerLeanServer,
+  updateLeanServer,
+} from '@tools/lean/leanServerRegistry';
+
+afterEach(() => {
+  clearLeanServerRegistry();
+});
+
+describe('Lean external tool status', () => {
+  it('counts only starting and running Lean servers as active', async () => {
+    const lean = findExternalToolDef('lean4');
+    expect(lean?.statusLabel).toBeDefined();
+
+    registerLeanServer({
+      id: 'direct:/failed',
+      workspaceRoot: '/failed',
+      mode: 'direct-lsp',
+      status: 'error',
+    });
+    registerLeanServer({
+      id: 'direct:/stopped',
+      workspaceRoot: '/stopped',
+      mode: 'direct-lsp',
+      status: 'stopped',
+    });
+
+    await expect(
+      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+    ).resolves.toBeUndefined();
+
+    registerLeanServer({
+      id: 'direct:/running',
+      workspaceRoot: '/running',
+      mode: 'direct-lsp',
+      status: 'starting',
+    });
+    await expect(
+      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+    ).resolves.toBe('1 server active');
+
+    updateLeanServer('direct:/running', { status: 'running' });
+    await expect(
+      lean!.statusLabel!({ extensionAvailable: false, lakeAvailable: true }),
+    ).resolves.toBe('1 server active');
+  });
+});

--- a/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
@@ -1,0 +1,164 @@
+/**
+ * Vitests for the Lean server registry — covers register/update/list/
+ * unregister plus the dashboard-facing `summarizeLeanServers` formatter.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearLeanServerRegistry,
+  formatUptime,
+  listLeanServers,
+  registerLeanServer,
+  subscribeLeanServers,
+  summarizeLeanServers,
+  unregisterLeanServer,
+  updateLeanServer,
+  type LeanServerInfo,
+} from '@tools/lean/leanServerRegistry';
+
+afterEach(() => {
+  clearLeanServerRegistry();
+});
+
+describe('leanServerRegistry', () => {
+  it('registers, updates, and unregisters servers', () => {
+    registerLeanServer({
+      id: 'direct:/work/proj',
+      workspaceRoot: '/work/proj',
+      mode: 'direct-lsp',
+    });
+    expect(listLeanServers().map((s) => s.id)).toEqual(['direct:/work/proj']);
+    expect(listLeanServers()[0]?.status).toBe('starting');
+
+    updateLeanServer('direct:/work/proj', { status: 'running', pid: 4242 });
+    const after = listLeanServers()[0]!;
+    expect(after.status).toBe('running');
+    expect(after.pid).toBe(4242);
+
+    unregisterLeanServer('direct:/work/proj');
+    expect(listLeanServers()).toEqual([]);
+  });
+
+  it('clears errorMessage when transitioning out of error', () => {
+    registerLeanServer({
+      id: 'direct:/a',
+      workspaceRoot: '/a',
+      mode: 'direct-lsp',
+      status: 'error',
+    });
+    updateLeanServer('direct:/a', {
+      status: 'error',
+      errorMessage: 'spawn failed',
+    });
+    expect(listLeanServers()[0]?.errorMessage).toBe('spawn failed');
+
+    updateLeanServer('direct:/a', { status: 'running' });
+    expect(listLeanServers()[0]?.errorMessage).toBeUndefined();
+  });
+
+  it('sorts the snapshot by workspace root', () => {
+    registerLeanServer({ id: 'a', workspaceRoot: '/zeta', mode: 'direct-lsp' });
+    registerLeanServer({
+      id: 'b',
+      workspaceRoot: '/alpha',
+      mode: 'vscode-extension',
+    });
+    expect(listLeanServers().map((s) => s.workspaceRoot)).toEqual([
+      '/alpha',
+      '/zeta',
+    ]);
+  });
+
+  it('notifies subscribers and stops once unsubscribed', () => {
+    const seen: number[] = [];
+    const unsubscribe = subscribeLeanServers((view) => seen.push(view.length));
+
+    registerLeanServer({ id: 'a', workspaceRoot: '/a', mode: 'direct-lsp' });
+    registerLeanServer({ id: 'b', workspaceRoot: '/b', mode: 'direct-lsp' });
+    unsubscribe();
+    registerLeanServer({ id: 'c', workspaceRoot: '/c', mode: 'direct-lsp' });
+
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it('does not call listeners when nothing matches an update id', () => {
+    let calls = 0;
+    subscribeLeanServers(() => {
+      calls += 1;
+    });
+    updateLeanServer('does-not-exist', { status: 'running' });
+    expect(calls).toBe(0);
+  });
+});
+
+describe('formatUptime', () => {
+  it.each([
+    [0, '0s'],
+    [1500, '1s'],
+    [59_000, '59s'],
+    [60_000, '1m 0s'],
+    [185_000, '3m 5s'],
+    [3_600_000, '1h 0m'],
+    [3_660_000, '1h 1m'],
+  ])('renders %i ms as %s', (ms, label) => {
+    expect(formatUptime(ms)).toBe(label);
+  });
+});
+
+describe('summarizeLeanServers', () => {
+  const NOW = Date.UTC(2026, 0, 1, 12, 0, 0);
+
+  function makeServer(partial: Partial<LeanServerInfo>): LeanServerInfo {
+    return {
+      id: 'direct:/work/proj',
+      workspaceRoot: '/work/proj',
+      mode: 'direct-lsp',
+      status: 'running',
+      startedAt: NOW - 65_000,
+      ...partial,
+    };
+  }
+
+  it('handles the empty case', () => {
+    expect(summarizeLeanServers([], NOW)).toBe('No Lean servers active.');
+  });
+
+  it('renders a running server with uptime and toolchain', () => {
+    const summary = summarizeLeanServers(
+      [makeServer({ toolchain: 'leanprover/lean4:v4.12.0' })],
+      NOW,
+    );
+    expect(summary).toBe(
+      '1 Lean server active:\n' +
+        '• /work/proj (direct LSP, leanprover/lean4:v4.12.0) — uptime 1m 5s',
+    );
+  });
+
+  it('labels the VS Code mode as leanprover.lean4', () => {
+    const summary = summarizeLeanServers(
+      [makeServer({ mode: 'vscode-extension' })],
+      NOW,
+    );
+    expect(summary).toContain('(leanprover.lean4)');
+  });
+
+  it('reports starting, error, and stopped states', () => {
+    const summary = summarizeLeanServers(
+      [
+        makeServer({ id: 'a', workspaceRoot: '/a', status: 'starting' }),
+        makeServer({
+          id: 'b',
+          workspaceRoot: '/b',
+          status: 'error',
+          errorMessage: 'spawn ENOENT',
+        }),
+        makeServer({ id: 'c', workspaceRoot: '/c', status: 'stopped' }),
+      ],
+      NOW,
+    );
+    expect(summary).toContain('/a (direct LSP) — starting…');
+    expect(summary).toContain('/b (direct LSP) — error: spawn ENOENT');
+    expect(summary).toContain('/c (direct LSP) — stopped');
+    expect(summary.startsWith('3 Lean servers active:')).toBe(true);
+  });
+});

--- a/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   clearLeanServerRegistry,
   formatUptime,
+  isLeanServerActive,
   listLeanServers,
   registerLeanServer,
   subscribeLeanServers,
@@ -81,6 +82,25 @@ describe('leanServerRegistry', () => {
     expect(seen).toEqual([1, 2]);
   });
 
+  it('counts only starting and running servers as active', () => {
+    expect(
+      [
+        { status: 'starting' },
+        { status: 'running' },
+        { status: 'error' },
+        { status: 'stopped' },
+      ].filter((partial) =>
+        isLeanServerActive({
+          id: `direct:${partial.status}`,
+          workspaceRoot: '/work/proj',
+          mode: 'direct-lsp',
+          startedAt: Date.now(),
+          ...partial,
+        } as LeanServerInfo),
+      ),
+    ).toHaveLength(2);
+  });
+
   it('does not call listeners when nothing matches an update id', () => {
     let calls = 0;
     subscribeLeanServers(() => {
@@ -120,7 +140,7 @@ describe('summarizeLeanServers', () => {
   }
 
   it('handles the empty case', () => {
-    expect(summarizeLeanServers([], NOW)).toBe('No Lean servers active.');
+    expect(summarizeLeanServers([], NOW)).toBe('No Lean servers registered.');
   });
 
   it('renders a running server with uptime and toolchain', () => {
@@ -129,7 +149,7 @@ describe('summarizeLeanServers', () => {
       NOW,
     );
     expect(summary).toBe(
-      '1 Lean server active:\n' +
+      '1 Lean server registered:\n' +
         '• /work/proj (direct LSP, leanprover/lean4:v4.12.0) — uptime 1m 5s',
     );
   });
@@ -159,6 +179,6 @@ describe('summarizeLeanServers', () => {
     expect(summary).toContain('/a (direct LSP) — starting…');
     expect(summary).toContain('/b (direct LSP) — error: spawn ENOENT');
     expect(summary).toContain('/c (direct LSP) — stopped');
-    expect(summary.startsWith('3 Lean servers active:')).toBe(true);
+    expect(summary.startsWith('3 Lean servers registered:')).toBe(true);
   });
 });

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -332,7 +332,9 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         resolveLean4Prerequisites(probeResult);
       if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
       const activeCount = listLeanServers().length;
-      return activeCount > 0 ? `${activeCount} server${activeCount > 1 ? 's' : ''} active` : undefined;
+      return activeCount > 0
+        ? `${activeCount} server${activeCount > 1 ? 's' : ''} active`
+        : undefined;
     },
     detailCheck: async (probeResult) => {
       const { extensionAvailable, lakeAvailable } =

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -26,6 +26,7 @@ import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
   PR_POLL_INTERVAL_MS,
 } from '@tools/github/prSubscriptionConstants';
+import { LEAN4_EXTENSION_ID } from '@tools/lean/leanConstants';
 import {
   listLeanServers,
   summarizeLeanServers,
@@ -35,7 +36,6 @@ import { isGitRepository } from '@utils/system/isGitRepository';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { isWSL } from '@utils/system/wslDetect';
 
-const LEAN4_EXT_ID = 'leanprover.lean4';
 const ZOTERO_PROBE_TIMEOUT_MS = 2000;
 const TEXRA_CLI_CHECK = {
   command: 'texra --version',
@@ -310,12 +310,12 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  3. Open a folder containing a lakefile.lean / lakefile.toml',
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
-    installExtensionId: LEAN4_EXT_ID,
+    installExtensionId: LEAN4_EXTENSION_ID,
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
       'CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
     probe: async () => {
-      const extensionAvailable = extensionChecker(LEAN4_EXT_ID);
+      const extensionAvailable = extensionChecker(LEAN4_EXTENSION_ID);
       const lakeAvailable = await checkToolInstalled(
         { command: 'lake --version', errorMessage: 'lake not on PATH' },
         false,

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -26,6 +26,10 @@ import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
   PR_POLL_INTERVAL_MS,
 } from '@tools/github/prSubscriptionConstants';
+import {
+  listLeanServers,
+  summarizeLeanServers,
+} from '@tools/lean/leanServerRegistry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { isGitRepository } from '@utils/system/isGitRepository';
 import { checkToolInstalled } from '@utils/system/toolUtils';
@@ -167,6 +171,27 @@ async function probeTexraCli(): Promise<boolean> {
   return checkToolInstalled(TEXRA_CLI_CHECK, false);
 }
 
+interface Lean4Prerequisites {
+  extensionAvailable: boolean;
+  lakeAvailable: boolean;
+}
+
+function resolveLean4Prerequisites(probeResult: unknown): Lean4Prerequisites {
+  if (
+    probeResult &&
+    typeof probeResult === 'object' &&
+    'extensionAvailable' in probeResult &&
+    'lakeAvailable' in probeResult
+  ) {
+    const r = probeResult as Lean4Prerequisites;
+    return {
+      extensionAvailable: Boolean(r.extensionAvailable),
+      lakeAvailable: Boolean(r.lakeAvailable),
+    };
+  }
+  return { extensionAvailable: false, lakeAvailable: false };
+}
+
 function resolveBooleanProbe(probeResult: unknown): boolean | undefined {
   return typeof probeResult === 'boolean' ? probeResult : undefined;
 }
@@ -266,20 +291,68 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     name: 'Lean 4 Proof Assistant',
     category: 'lean',
     description:
-      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files. Active language servers (one per project root) are listed below.',
     installGuide:
-      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
-      'Setup:\n' +
+      'TeXRA can drive Lean 4 in two ways:\n\n' +
+      '  • VS Code build — uses the "lean4" extension\n' +
+      '    (leanprover.lean4) and its running language server.\n' +
+      '  • CLI / desktop build — spawns `lake env lean --server`\n' +
+      '    directly, one process per Lake project root. Requires\n' +
+      '    `lake` (from elan/Lean) on PATH; install via\n' +
+      '    https://leanprover-community.github.io/install/.\n\n' +
+      'Setup (VS Code):\n' +
       '  1. Install the "lean4" extension from VS Code Marketplace\n' +
-      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
+      '  2. Open a Lean 4 project (with lakefile.lean or lakefile.toml)\n' +
       '  3. The extension will auto-install elan and Lean toolchain\n\n' +
-      'The Lean tools communicate via the Lean Language Server\n' +
-      'provided by the VS Code extension.',
+      'Setup (CLI / desktop):\n' +
+      '  1. Install elan: `curl https://elan.lean-lang.org/elan-init.sh -sSf | sh`\n' +
+      '  2. Make sure `lake --version` works in a fresh shell\n' +
+      '  3. Open a folder containing a lakefile.lean / lakefile.toml',
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
     installExtensionId: LEAN4_EXT_ID,
-    configNotes: 'Lean 4 VS Code extension must be installed and active.',
-    check: async () => extensionChecker(LEAN4_EXT_ID),
+    configNotes:
+      'VS Code build: requires the leanprover.lean4 extension. ' +
+      'CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
+    probe: async () => {
+      const extensionAvailable = extensionChecker(LEAN4_EXT_ID);
+      const lakeAvailable = await checkToolInstalled(
+        { command: 'lake --version', errorMessage: 'lake not on PATH' },
+        false,
+      );
+      return { extensionAvailable, lakeAvailable };
+    },
+    check: async (probeResult) => {
+      const { extensionAvailable, lakeAvailable } =
+        resolveLean4Prerequisites(probeResult);
+      return extensionAvailable || lakeAvailable;
+    },
+    statusLabel: async (probeResult) => {
+      const { extensionAvailable, lakeAvailable } =
+        resolveLean4Prerequisites(probeResult);
+      if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
+      const activeCount = listLeanServers().length;
+      return activeCount > 0 ? `${activeCount} server${activeCount > 1 ? 's' : ''} active` : undefined;
+    },
+    detailCheck: async (probeResult) => {
+      const { extensionAvailable, lakeAvailable } =
+        resolveLean4Prerequisites(probeResult);
+      const lines: string[] = [];
+      if (extensionAvailable) {
+        lines.push('VS Code Lean 4 extension installed.');
+      }
+      if (lakeAvailable) {
+        lines.push('Direct LSP mode available (`lake` on PATH).');
+      }
+      if (!extensionAvailable && !lakeAvailable) {
+        lines.push(
+          'Neither the leanprover.lean4 extension nor a `lake` binary was detected. Install one of them to enable Lean tools.',
+        );
+      }
+      lines.push('');
+      lines.push(summarizeLeanServers());
+      return lines.join('\n');
+    },
   },
   {
     // ID kept as `github-pr-subscription` for back-compat with persisted

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -28,6 +28,7 @@ import {
 } from '@tools/github/prSubscriptionConstants';
 import { LEAN4_EXTENSION_ID } from '@tools/lean/leanConstants';
 import {
+  isLeanServerActive,
   listLeanServers,
   summarizeLeanServers,
 } from '@tools/lean/leanServerRegistry';
@@ -331,7 +332,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       const { extensionAvailable, lakeAvailable } =
         resolveLean4Prerequisites(probeResult);
       if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
-      const activeCount = listLeanServers().length;
+      const activeCount = listLeanServers().filter(isLeanServerActive).length;
       return activeCount > 0
         ? `${activeCount} server${activeCount > 1 ? 's' : ''} active`
         : undefined;

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -8,6 +8,12 @@ import {
   formatCounts,
   formatGroupedSections,
 } from '@utils/diagnostics/diagnosticFormatting';
+import {
+  LEAN_FILE_COMMANDS,
+  LEAN_PROJECT_COMMANDS,
+  type LeanFileCommand,
+  type LeanProjectCommand,
+} from './leanConstants';
 import { getLeanVscodeServices } from './leanVscodeServices';
 import { extractHoverText } from './leanTypes';
 
@@ -23,27 +29,15 @@ const LeanDiagnosticsInputSchema = z.strictObject({
 
 export type LeanDiagnosticsInput = z.infer<typeof LeanDiagnosticsInputSchema>;
 
-const FILE_COMMANDS = ['restart', 'refresh_dependencies'] as const;
-type FileCommand = (typeof FILE_COMMANDS)[number];
-
-const FILE_COMMAND_CONFIG: Record<
-  FileCommand,
-  { vscode: string; description: string }
-> = {
-  restart: {
-    vscode: 'lean4.restartFile',
-    description: 'Restart Lean server for this file',
-  },
-  refresh_dependencies: {
-    vscode: 'lean4.refreshFileDependencies',
-    description: 'Refresh file dependencies without full restart',
-  },
+const FILE_COMMAND_DESCRIPTIONS: Record<LeanFileCommand, string> = {
+  restart: 'Restart Lean server for this file',
+  refresh_dependencies: 'Refresh file dependencies without full restart',
 };
 
 const LeanFileInputSchema = z.strictObject({
   /** Command to execute on the file */
   command: z
-    .enum(FILE_COMMANDS)
+    .enum(LEAN_FILE_COMMANDS)
     .describe('Command: "restart" or "refresh_dependencies"'),
   /** Path to the Lean file */
   file: z.string().describe('Path to the .lean file'),
@@ -51,72 +45,22 @@ const LeanFileInputSchema = z.strictObject({
 
 export type LeanFileInput = z.infer<typeof LeanFileInputSchema>;
 
-const PROJECT_COMMANDS = [
-  // Server commands
-  'restart_server',
-  'stop_server',
-  // Project commands
-  'build',
-  'clean',
-  'fetch_cache',
-  'fetch_file_cache',
-  // Setup commands
-  'install_elan',
-  'install_deps',
-  'update_elan',
-  'select_toolchain',
-] as const;
-type ProjectCommand = (typeof PROJECT_COMMANDS)[number];
-
-const PROJECT_COMMAND_CONFIG: Record<
-  ProjectCommand,
-  { vscode: string; description: string }
-> = {
-  restart_server: {
-    vscode: 'lean4.restartServer',
-    description: 'Restart the entire Lean language server',
-  },
-  stop_server: {
-    vscode: 'lean4.stopServer',
-    description: 'Stop the Lean language server',
-  },
-  build: {
-    vscode: 'lean4.project.build',
-    description: 'Build the project (runs lake build)',
-  },
-  clean: {
-    vscode: 'lean4.project.clean',
-    description: 'Clean project build artifacts',
-  },
-  fetch_cache: {
-    vscode: 'lean4.project.fetchCache',
-    description: 'Download Mathlib build cache for the project',
-  },
-  fetch_file_cache: {
-    vscode: 'lean4.project.fetchFileCache',
-    description: "Download Mathlib cache for current file's imports only",
-  },
-  install_elan: {
-    vscode: 'lean4.setup.installElan',
-    description: 'Install Elan (Lean version manager)',
-  },
-  install_deps: {
-    vscode: 'lean4.setup.installDeps',
-    description: 'Install Lean dependencies',
-  },
-  update_elan: {
-    vscode: 'lean4.setup.updateElan',
-    description: 'Update Elan to latest version',
-  },
-  select_toolchain: {
-    vscode: 'lean4.setup.selectDefaultToolchain',
-    description: 'Select default Lean toolchain version',
-  },
+const PROJECT_COMMAND_DESCRIPTIONS: Record<LeanProjectCommand, string> = {
+  restart_server: 'Restart the entire Lean language server',
+  stop_server: 'Stop the Lean language server',
+  build: 'Build the project (runs lake build)',
+  clean: 'Clean project build artifacts',
+  fetch_cache: 'Download Mathlib build cache for the project',
+  fetch_file_cache: "Download Mathlib cache for current file's imports only",
+  install_elan: 'Install Elan (Lean version manager)',
+  install_deps: 'Install Lean dependencies',
+  update_elan: 'Update Elan to latest version',
+  select_toolchain: 'Select default Lean toolchain version',
 };
 
 const LeanProjectInputSchema = z.strictObject({
   /** Command to execute */
-  command: z.enum(PROJECT_COMMANDS).describe(
+  command: z.enum(LEAN_PROJECT_COMMANDS).describe(
     `Global command to execute:
 Server: restart_server, stop_server
 Project: build, clean, fetch_cache, fetch_file_cache
@@ -236,11 +180,11 @@ Requires: Lean 4 VS Code extension installed and active.`,
 }) {
   protected async execute(input: LeanFileInput): Promise<ToolResult> {
     const { command, file } = input;
-    const config = FILE_COMMAND_CONFIG[command];
+    const description = FILE_COMMAND_DESCRIPTIONS[command];
 
     try {
       const success = await getLeanVscodeServices().executeFileCommand(
-        config.vscode,
+        command,
         file,
       );
       if (!success) {
@@ -251,7 +195,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
         };
       }
       return {
-        summary: config.description,
+        summary: description,
         output: `Executed "${command}" on ${file}`,
       };
     } catch (error) {
@@ -291,20 +235,20 @@ Requires: Lean 4 VS Code extension installed.`,
 }) {
   protected async execute(input: LeanProjectInput): Promise<ToolResult> {
     const { command } = input;
-    const config = PROJECT_COMMAND_CONFIG[command];
+    const description = PROJECT_COMMAND_DESCRIPTIONS[command];
 
     try {
-      await getLeanVscodeServices().executeGlobalCommand(config.vscode);
+      await getLeanVscodeServices().executeProjectCommand(command);
 
       if (command === 'build') {
         return {
-          summary: config.description,
+          summary: description,
           output: `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
         };
       }
 
       return {
-        summary: config.description,
+        summary: description,
         output: `Executed "${command}" successfully`,
       };
     } catch (error) {

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -216,7 +216,7 @@ Tips:
     } catch (error) {
       return {
         summary: 'Failed to get diagnostics',
-        output: `Error: ${toErrorMessage(error)}\n\nMake sure the Lean 4 VS Code extension is installed and active.`,
+        output: `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
         isError: true,
       };
     }

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -14,7 +14,7 @@ import {
   type LeanFileCommand,
   type LeanProjectCommand,
 } from './leanConstants';
-import { getLeanVscodeServices } from './leanVscodeServices';
+import { getLeanLanguageServices } from './leanLanguageServices';
 import { extractHoverText } from './leanTypes';
 
 const LeanDiagnosticsInputSchema = z.strictObject({
@@ -124,7 +124,7 @@ Tips:
 
     try {
       const diagnostics =
-        await getLeanVscodeServices().fetchDiagnosticsForFile(file);
+        await getLeanLanguageServices().fetchDiagnosticsForFile(file);
       if (!diagnostics) {
         return {
           summary: 'Failed to open file',
@@ -133,7 +133,7 @@ Tips:
         };
       }
 
-      await getLeanVscodeServices().navigateToFirstError(file, diagnostics);
+      await getLeanLanguageServices().navigateToFirstError(file, diagnostics);
 
       const counts = countBySeverity(diagnostics);
       const countsStr = formatCounts(counts);
@@ -183,7 +183,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     const description = FILE_COMMAND_DESCRIPTIONS[command];
 
     try {
-      const success = await getLeanVscodeServices().executeFileCommand(
+      const success = await getLeanLanguageServices().executeFileCommand(
         command,
         file,
       );
@@ -238,7 +238,7 @@ Requires: Lean 4 VS Code extension installed.`,
     const description = PROJECT_COMMAND_DESCRIPTIONS[command];
 
     try {
-      await getLeanVscodeServices().executeProjectCommand(command);
+      await getLeanLanguageServices().executeProjectCommand(command);
 
       if (command === 'build') {
         return {
@@ -311,7 +311,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     column: number,
     location: string,
   ): Promise<ToolResult> {
-    const { data, error } = await getLeanVscodeServices().getGoalState(
+    const { data, error } = await getLeanLanguageServices().getGoalState(
       file,
       line,
       column,
@@ -351,7 +351,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     column: number,
     location: string,
   ): Promise<ToolResult> {
-    const { data, error } = await getLeanVscodeServices().getTermGoal(
+    const { data, error } = await getLeanLanguageServices().getTermGoal(
       file,
       line,
       column,
@@ -374,7 +374,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     column: number,
     location: string,
   ): Promise<ToolResult> {
-    const { data, error } = await getLeanVscodeServices().getHoverInfo(
+    const { data, error } = await getLeanLanguageServices().getHoverInfo(
       file,
       line,
       column,

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -1,0 +1,333 @@
+/**
+ * Direct LSP adapter for Lean tools — used by the CLI and desktop builds.
+ *
+ * Implements the same {@link LeanVscodeServices} interface as the VS Code
+ * integration. Per-workspace sessions are cached: the first request that
+ * targets a file in a given Lake project spawns `lake env lean --server` from
+ * that project root; subsequent requests from any agent reuse the same
+ * session. Sessions are torn down on platform shutdown.
+ *
+ * VS Code command IDs (e.g. `lean4.project.build`) are translated to either
+ * direct `lake` subprocess calls or session-level operations.
+ */
+
+import { access } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { warn } from '@logger/logUtils';
+
+import { runLakeCommand } from './lakeCommands';
+import { LeanSession } from './leanSession';
+import type { LeanVscodeServices } from '../leanVscodeServices';
+import type {
+  LeanDiagnostic,
+  LspResult,
+  PlainGoal,
+  PlainTermGoal,
+} from '../leanTypes';
+import type { Hover } from 'vscode-languageserver-protocol';
+
+const LOG_CHANNEL = 'lean.direct';
+
+export interface DirectLspLeanAdapterOptions {
+  /** Path or name of the `lake` binary (defaults to `lake` on PATH). */
+  lakeCommand?: string;
+  /** Override the project-root locator (mostly for tests). */
+  resolveWorkspaceRoot?: (filePath: string) => Promise<string | null>;
+}
+
+/**
+ * Build a {@link LeanVscodeServices} implementation that talks directly to
+ * `lake env lean --server`. Register the returned object with
+ * `setLeanVscodeServices(...)` during platform startup.
+ */
+export function createDirectLspLeanAdapter(
+  options: DirectLspLeanAdapterOptions = {},
+): LeanVscodeServices & { dispose(): Promise<void> } {
+  const lakeCommand = options.lakeCommand ?? 'lake';
+  const resolveRoot =
+    options.resolveWorkspaceRoot ?? defaultResolveWorkspaceRoot;
+  const sessions = new Map<string, LeanSession>();
+
+  async function getSession(filePath: string): Promise<LeanSession> {
+    const absolute = path.resolve(filePath);
+    const root = await resolveRoot(absolute);
+    if (!root) {
+      throw new Error(
+        `No Lean project found for ${absolute}. Lake projects need a lakefile.lean or lakefile.toml in an ancestor directory.`,
+      );
+    }
+    const existing = sessions.get(root);
+    if (existing) {
+      await existing.ensureReady();
+      return existing;
+    }
+    const session = new LeanSession({
+      workspaceRoot: root,
+      lakeCommand,
+      onExit: () => {
+        if (sessions.get(root) === session) {
+          sessions.delete(root);
+        }
+      },
+    });
+    sessions.set(root, session);
+    try {
+      await session.ensureReady();
+    } catch (error) {
+      sessions.delete(root);
+      throw error;
+    }
+    return session;
+  }
+
+  return {
+    getDiagnostics(filePath) {
+      // Synchronous mirror of `vscode.languages.getDiagnostics` — returns
+      // whatever we've buffered for an already-open file. Use
+      // `fetchDiagnosticsForFile` to force an open+wait.
+      const session = sessionForFile(sessions, filePath);
+      return session?.getDiagnosticsCache(filePath) ?? [];
+    },
+
+    async fetchDiagnosticsForFile(file: string): Promise<LeanDiagnostic[] | null> {
+      try {
+        const session = await getSession(file);
+        return await session.fetchDiagnostics(file);
+      } catch (error) {
+        warn(
+          LOG_CHANNEL,
+          `fetchDiagnosticsForFile failed for ${file}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return null;
+      }
+    },
+
+    async navigateToFirstError(): Promise<void> {
+      // No editor to navigate in CLI/desktop. The tool result still carries
+      // the diagnostic list so the agent can act on it.
+    },
+
+    async executeFileCommand(command: string, filePath: string): Promise<boolean> {
+      try {
+        switch (command) {
+          case 'lean4.restartFile':
+          case 'lean4.refreshFileDependencies': {
+            const session = await getSession(filePath);
+            await session.restartFile(filePath);
+            return true;
+          }
+          default:
+            warn(LOG_CHANNEL, `Unsupported file command: ${command}`);
+            return false;
+        }
+      } catch (error) {
+        warn(
+          LOG_CHANNEL,
+          `executeFileCommand(${command}) failed for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return false;
+      }
+    },
+
+    async executeGlobalCommand(commandId: string): Promise<void> {
+      // Global commands aren't tied to a file. We pick whichever workspace
+      // has an active session; if there are several we apply to all.
+      switch (commandId) {
+        case 'lean4.restartServer': {
+          const targets = [...sessions.values()];
+          if (targets.length === 0) {
+            throw new Error('No Lean server running to restart.');
+          }
+          await Promise.all(
+            targets.map(async (session) => {
+              await session.dispose();
+              await session.ensureReady().catch(() => undefined);
+            }),
+          );
+          return;
+        }
+        case 'lean4.stopServer': {
+          await Promise.all(
+            [...sessions.values()].map((session) => session.dispose()),
+          );
+          sessions.clear();
+          return;
+        }
+        case 'lean4.project.build': {
+          await runForAllSessions(sessions, lakeCommand, ['build'], true);
+          return;
+        }
+        case 'lean4.project.clean': {
+          await runForAllSessions(sessions, lakeCommand, ['clean'], true);
+          return;
+        }
+        case 'lean4.project.fetchCache': {
+          await runForAllSessions(
+            sessions,
+            lakeCommand,
+            ['exe', 'cache', 'get'],
+            true,
+          );
+          return;
+        }
+        case 'lean4.project.fetchFileCache': {
+          // VS Code's "fetch file cache" needs the active editor's file; we
+          // don't have one in CLI/desktop, so fall back to the project-wide
+          // cache fetch.
+          await runForAllSessions(
+            sessions,
+            lakeCommand,
+            ['exe', 'cache', 'get'],
+            true,
+          );
+          return;
+        }
+        case 'lean4.setup.installElan':
+        case 'lean4.setup.installDeps':
+        case 'lean4.setup.updateElan':
+        case 'lean4.setup.selectDefaultToolchain':
+          throw new Error(
+            `Command "${commandId}" is only available inside VS Code with the leanprover.lean4 extension. ` +
+              'In CLI/desktop builds, run the matching shell command directly (see https://leanprover-community.github.io/install/linux.html).',
+          );
+        default:
+          throw new Error(`Unsupported Lean global command: ${commandId}`);
+      }
+    },
+
+    async getGoalState(
+      filePath: string,
+      line: number,
+      column: number,
+    ): Promise<LspResult<PlainGoal>> {
+      return positionRequest<PlainGoal>(filePath, async (session) => {
+        const data = await session.getPlainGoal(filePath, line, column);
+        return data;
+      });
+    },
+
+    async getTermGoal(
+      filePath: string,
+      line: number,
+      column: number,
+    ): Promise<LspResult<PlainTermGoal>> {
+      return positionRequest<PlainTermGoal>(filePath, async (session) => {
+        return session.getPlainTermGoal(filePath, line, column);
+      });
+    },
+
+    async getHoverInfo(
+      filePath: string,
+      line: number,
+      column: number,
+    ): Promise<LspResult<Hover>> {
+      return positionRequest<Hover>(filePath, async (session) => {
+        return session.getHover(filePath, line, column);
+      });
+    },
+
+    async promptLean4ExtensionInstall(): Promise<void> {
+      // No-op outside VS Code. The Tools dashboard already surfaces a
+      // "needs setup" hint when `lake` isn't on PATH.
+    },
+
+    async dispose(): Promise<void> {
+      const all = [...sessions.values()];
+      sessions.clear();
+      await Promise.all(all.map((session) => session.dispose()));
+    },
+  };
+
+  async function positionRequest<T>(
+    filePath: string,
+    invoke: (session: LeanSession) => Promise<T | null>,
+  ): Promise<LspResult<T>> {
+    try {
+      const session = await getSession(filePath);
+      // Open the file before the request so the LSP server has parsed it.
+      await session.fetchDiagnostics(filePath).catch(() => undefined);
+      const data = await invoke(session);
+      if (!data) return { data: null, error: 'Lean returned no data for this position.' };
+      return { data };
+    } catch (error) {
+      return {
+        data: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+function sessionForFile(
+  sessions: Map<string, LeanSession>,
+  filePath: string,
+): LeanSession | null {
+  const absolute = path.resolve(filePath);
+  for (const [root, session] of sessions) {
+    if (absolute === root || absolute.startsWith(`${root}${path.sep}`)) {
+      return session;
+    }
+  }
+  return null;
+}
+
+async function runForAllSessions(
+  sessions: Map<string, LeanSession>,
+  lakeCommand: string,
+  args: readonly string[],
+  serialize: boolean,
+): Promise<void> {
+  if (sessions.size === 0) {
+    throw new Error(
+      `No Lean project session active. Run a Lean tool against a file in your project first, then retry "${args.join(' ')}".`,
+    );
+  }
+  const results = await Promise.all(
+    [...sessions.values()].map((session) =>
+      runLakeCommand({
+        workspaceRoot: session.workspaceRoot,
+        lakeCommand,
+        args,
+        serialize,
+      }),
+    ),
+  );
+  const failed = results.filter((r) => r.exitCode !== 0);
+  if (failed.length > 0) {
+    throw new Error(
+      `lake ${args.join(' ')} failed in ${failed.length} workspace(s):\n${failed
+        .map((r) => r.stderr.trim() || r.stdout.trim())
+        .join('\n---\n')}`,
+    );
+  }
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Walk up from `filePath` looking for a Lake project root. */
+export async function defaultResolveWorkspaceRoot(
+  filePath: string,
+): Promise<string | null> {
+  let dir = path.dirname(path.resolve(filePath));
+  const root = path.parse(dir).root;
+  for (;;) {
+    if (
+      (await pathExists(path.join(dir, 'lakefile.lean'))) ||
+      (await pathExists(path.join(dir, 'lakefile.toml')))
+    ) {
+      return dir;
+    }
+    if (dir === root) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -18,6 +18,10 @@ import { warn } from '@logger/logUtils';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
+import type {
+  LeanFileCommand,
+  LeanProjectCommand,
+} from '../leanConstants';
 import type { LeanVscodeServices } from '../leanVscodeServices';
 import type {
   LeanDiagnostic,
@@ -108,19 +112,16 @@ export function createDirectLspLeanAdapter(
       // the diagnostic list so the agent can act on it.
     },
 
-    async executeFileCommand(command: string, filePath: string): Promise<boolean> {
+    async executeFileCommand(
+      command: LeanFileCommand,
+      filePath: string,
+    ): Promise<boolean> {
       try {
-        switch (command) {
-          case 'lean4.restartFile':
-          case 'lean4.refreshFileDependencies': {
-            const session = await getSession(filePath);
-            await session.restartFile(filePath);
-            return true;
-          }
-          default:
-            warn(LOG_CHANNEL, `Unsupported file command: ${command}`);
-            return false;
-        }
+        // Both file commands have the same effect from our point of view: drop
+        // the cached open state and re-open with fresh contents.
+        const session = await getSession(filePath);
+        await session.restartFile(filePath);
+        return true;
       } catch (error) {
         warn(
           LOG_CHANNEL,
@@ -130,11 +131,11 @@ export function createDirectLspLeanAdapter(
       }
     },
 
-    async executeGlobalCommand(commandId: string): Promise<void> {
-      // Global commands aren't tied to a file. We pick whichever workspace
-      // has an active session; if there are several we apply to all.
-      switch (commandId) {
-        case 'lean4.restartServer': {
+    async executeProjectCommand(command: LeanProjectCommand): Promise<void> {
+      // Project commands aren't tied to a file. We apply to every active
+      // session; lake commands serialize per workspace via the mutex.
+      switch (command) {
+        case 'restart_server': {
           const targets = [...sessions.values()];
           if (targets.length === 0) {
             throw new Error('No Lean server running to restart.');
@@ -147,26 +148,24 @@ export function createDirectLspLeanAdapter(
           );
           return;
         }
-        case 'lean4.stopServer': {
+        case 'stop_server': {
           await Promise.all(
             [...sessions.values()].map((session) => session.dispose()),
           );
           sessions.clear();
           return;
         }
-        case 'lean4.project.build': {
+        case 'build':
           await runForAllSessions(sessions, lakeCommand, ['build'], true);
           return;
-        }
-        case 'lean4.project.clean': {
+        case 'clean':
           await runForAllSessions(sessions, lakeCommand, ['clean'], true);
           return;
-        }
-        // `fetchFileCache` normally needs the active editor's file; we don't
-        // have one in CLI/desktop, so it falls back to the project-wide
-        // cache fetch (same as `fetchCache`).
-        case 'lean4.project.fetchCache':
-        case 'lean4.project.fetchFileCache': {
+        // `fetch_file_cache` normally needs the active editor's file; we don't
+        // have one in CLI/desktop, so it falls back to the project-wide cache
+        // fetch (same as `fetch_cache`).
+        case 'fetch_cache':
+        case 'fetch_file_cache':
           await runForAllSessions(
             sessions,
             lakeCommand,
@@ -174,17 +173,14 @@ export function createDirectLspLeanAdapter(
             true,
           );
           return;
-        }
-        case 'lean4.setup.installElan':
-        case 'lean4.setup.installDeps':
-        case 'lean4.setup.updateElan':
-        case 'lean4.setup.selectDefaultToolchain':
+        case 'install_elan':
+        case 'install_deps':
+        case 'update_elan':
+        case 'select_toolchain':
           throw new Error(
-            `Command "${commandId}" is only available inside VS Code with the leanprover.lean4 extension. ` +
+            `Command "${command}" is only available inside VS Code with the leanprover.lean4 extension. ` +
               'In CLI/desktop builds, run the matching shell command directly (see https://leanprover-community.github.io/install/linux.html).',
           );
-        default:
-          throw new Error(`Unsupported Lean global command: ${commandId}`);
       }
     },
 

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -198,22 +198,21 @@ export function createDirectLspLeanAdapter(
           return;
         }
         case 'build':
-          await runForAllSessions(sessions, lakeCommand, ['build'], true);
+          await runForAllSessions(sessions, lakeCommand, ['build']);
           return;
         case 'clean':
-          await runForAllSessions(sessions, lakeCommand, ['clean'], true);
+          await runForAllSessions(sessions, lakeCommand, ['clean']);
           return;
         // `fetch_file_cache` normally needs the active editor's file; we don't
         // have one in CLI/desktop, so it falls back to the project-wide cache
         // fetch (same as `fetch_cache`).
         case 'fetch_cache':
         case 'fetch_file_cache':
-          await runForAllSessions(
-            sessions,
-            lakeCommand,
-            ['exe', 'cache', 'get'],
-            true,
-          );
+          await runForAllSessions(sessions, lakeCommand, [
+            'exe',
+            'cache',
+            'get',
+          ]);
           return;
         case 'install_elan':
         case 'install_deps':
@@ -290,7 +289,6 @@ async function runForAllSessions(
   sessions: Map<string, LeanSession>,
   lakeCommand: string,
   args: readonly string[],
-  serialize: boolean,
 ): Promise<void> {
   if (sessions.size === 0) {
     throw new Error(
@@ -303,7 +301,7 @@ async function runForAllSessions(
         workspaceRoot: session.workspaceRoot,
         lakeCommand,
         args,
-        serialize,
+        serialize: true,
       }),
     ),
   );

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -18,10 +18,7 @@ import { warn } from '@logger/logUtils';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
-import type {
-  LeanFileCommand,
-  LeanProjectCommand,
-} from '../leanConstants';
+import type { LeanFileCommand, LeanProjectCommand } from '../leanConstants';
 import type { LeanVscodeServices } from '../leanVscodeServices';
 import type {
   LeanDiagnostic,
@@ -94,7 +91,9 @@ export function createDirectLspLeanAdapter(
       return session?.getDiagnosticsCache(filePath) ?? [];
     },
 
-    async fetchDiagnosticsForFile(file: string): Promise<LeanDiagnostic[] | null> {
+    async fetchDiagnosticsForFile(
+      file: string,
+    ): Promise<LeanDiagnostic[] | null> {
       try {
         const session = await getSession(file);
         return await session.fetchDiagnostics(file);
@@ -235,7 +234,11 @@ export function createDirectLspLeanAdapter(
       // Open the file before the request so the LSP server has parsed it.
       await session.fetchDiagnostics(filePath).catch(() => undefined);
       const data = await invoke(session);
-      if (!data) return { data: null, error: 'Lean returned no data for this position.' };
+      if (!data)
+        return {
+          data: null,
+          error: 'Lean returned no data for this position.',
+        };
       return { data };
     } catch (error) {
       return {

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -1,7 +1,7 @@
 /**
  * Direct LSP adapter for Lean tools — used by the CLI and desktop builds.
  *
- * Implements the same {@link LeanVscodeServices} interface as the VS Code
+ * Implements the same {@link LeanLanguageServices} interface as the VS Code
  * integration. Per-workspace sessions are cached: the first request that
  * targets a file in a given Lake project spawns `lake env lean --server`
  * from that project root; subsequent requests from any agent reuse the
@@ -16,7 +16,7 @@ import { warn } from '@logger/logUtils';
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
 import type { LeanFileCommand, LeanProjectCommand } from '../leanConstants';
-import type { LeanVscodeServices } from '../leanVscodeServices';
+import type { LeanLanguageServices } from '../leanLanguageServices';
 import type {
   LeanDiagnostic,
   LspResult,
@@ -35,13 +35,13 @@ export interface DirectLspLeanAdapterOptions {
 }
 
 /**
- * Build a {@link LeanVscodeServices} implementation that talks directly to
+ * Build a {@link LeanLanguageServices} implementation that talks directly to
  * `lake env lean --server`. Register the returned object with
- * `setLeanVscodeServices(...)` during platform startup.
+ * `setLeanLanguageServices(...)` during platform startup.
  */
 export function createDirectLspLeanAdapter(
   options: DirectLspLeanAdapterOptions = {},
-): LeanVscodeServices & { dispose(): Promise<void> } {
+): LeanLanguageServices & { dispose(): Promise<void> } {
   const lakeCommand = options.lakeCommand ?? 'lake';
   const resolveRoot =
     options.resolveWorkspaceRoot ?? defaultResolveWorkspaceRoot;

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -162,19 +162,11 @@ export function createDirectLspLeanAdapter(
           await runForAllSessions(sessions, lakeCommand, ['clean'], true);
           return;
         }
-        case 'lean4.project.fetchCache': {
-          await runForAllSessions(
-            sessions,
-            lakeCommand,
-            ['exe', 'cache', 'get'],
-            true,
-          );
-          return;
-        }
+        // `fetchFileCache` normally needs the active editor's file; we don't
+        // have one in CLI/desktop, so it falls back to the project-wide
+        // cache fetch (same as `fetchCache`).
+        case 'lean4.project.fetchCache':
         case 'lean4.project.fetchFileCache': {
-          // VS Code's "fetch file cache" needs the active editor's file; we
-          // don't have one in CLI/desktop, so fall back to the project-wide
-          // cache fetch.
           await runForAllSessions(
             sessions,
             lakeCommand,
@@ -201,10 +193,9 @@ export function createDirectLspLeanAdapter(
       line: number,
       column: number,
     ): Promise<LspResult<PlainGoal>> {
-      return positionRequest<PlainGoal>(filePath, async (session) => {
-        const data = await session.getPlainGoal(filePath, line, column);
-        return data;
-      });
+      return positionRequest<PlainGoal>(filePath, (session) =>
+        session.getPlainGoal(filePath, line, column),
+      );
     },
 
     async getTermGoal(
@@ -212,9 +203,9 @@ export function createDirectLspLeanAdapter(
       line: number,
       column: number,
     ): Promise<LspResult<PlainTermGoal>> {
-      return positionRequest<PlainTermGoal>(filePath, async (session) => {
-        return session.getPlainTermGoal(filePath, line, column);
-      });
+      return positionRequest<PlainTermGoal>(filePath, (session) =>
+        session.getPlainTermGoal(filePath, line, column),
+      );
     },
 
     async getHoverInfo(
@@ -222,9 +213,9 @@ export function createDirectLspLeanAdapter(
       line: number,
       column: number,
     ): Promise<LspResult<Hover>> {
-      return positionRequest<Hover>(filePath, async (session) => {
-        return session.getHover(filePath, line, column);
-      });
+      return positionRequest<Hover>(filePath, (session) =>
+        session.getHover(filePath, line, column),
+      );
     },
 
     async promptLean4ExtensionInstall(): Promise<void> {

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -46,6 +46,7 @@ export function createDirectLspLeanAdapter(
   const resolveRoot =
     options.resolveWorkspaceRoot ?? defaultResolveWorkspaceRoot;
   const sessions = new Map<string, LeanSession>();
+  const sessionStarts = new Map<string, Promise<LeanSession>>();
 
   async function getSession(filePath: string): Promise<LeanSession> {
     const absolute = path.resolve(filePath);
@@ -55,11 +56,39 @@ export function createDirectLspLeanAdapter(
         `No Lean project found for ${absolute}. Lake projects need a lakefile.lean or lakefile.toml in an ancestor directory.`,
       );
     }
+    return getOrStartSession(root);
+  }
+
+  function getOrStartSession(root: string): Promise<LeanSession> {
+    const inFlight = sessionStarts.get(root);
+    if (inFlight) return inFlight;
+
     const existing = sessions.get(root);
     if (existing) {
-      await existing.ensureReady();
-      return existing;
+      const ready = existing
+        .ensureReady()
+        .then(() => existing)
+        .catch((error) => {
+          if (sessions.get(root) === existing) {
+            sessions.delete(root);
+          }
+          throw error;
+        });
+      sessionStarts.set(root, ready);
+      void ready
+        .catch(() => undefined)
+        .finally(() => {
+          if (sessionStarts.get(root) === ready) {
+            sessionStarts.delete(root);
+          }
+        });
+      return ready;
     }
+
+    return startFreshSession(root);
+  }
+
+  function startFreshSession(root: string): Promise<LeanSession> {
     const session = new LeanSession({
       workspaceRoot: root,
       lakeCommand,
@@ -70,13 +99,43 @@ export function createDirectLspLeanAdapter(
       },
     });
     sessions.set(root, session);
-    try {
+    const start = (async () => {
       await session.ensureReady();
-    } catch (error) {
-      sessions.delete(root);
-      throw error;
-    }
-    return session;
+      return session;
+    })();
+    sessionStarts.set(root, start);
+    void start
+      .catch(() => {
+        if (sessions.get(root) === session) {
+          sessions.delete(root);
+        }
+      })
+      .finally(() => {
+        if (sessionStarts.get(root) === start) {
+          sessionStarts.delete(root);
+        }
+      });
+    return start;
+  }
+
+  function restartSession(root: string): Promise<LeanSession> {
+    const restart = (async () => {
+      const existing = sessions.get(root);
+      if (existing) {
+        sessions.delete(root);
+        await existing.dispose();
+      }
+      return startFreshSession(root);
+    })();
+    sessionStarts.set(root, restart);
+    void restart
+      .catch(() => undefined)
+      .finally(() => {
+        if (sessionStarts.get(root) === restart) {
+          sessionStarts.delete(root);
+        }
+      });
+    return restart;
   }
 
   return {
@@ -124,16 +183,11 @@ export function createDirectLspLeanAdapter(
       // session; lake commands serialize per workspace via the mutex.
       switch (command) {
         case 'restart_server': {
-          const targets = [...sessions.values()];
-          if (targets.length === 0) {
+          const roots = [...sessions.keys()];
+          if (roots.length === 0) {
             throw new Error('No Lean server running to restart.');
           }
-          await Promise.all(
-            targets.map(async (session) => {
-              await session.dispose();
-              await session.ensureReady().catch(() => undefined);
-            }),
-          );
+          await Promise.all(roots.map((root) => restartSession(root)));
           return;
         }
         case 'stop_server': {

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -191,10 +191,10 @@ export function createDirectLspLeanAdapter(
           return;
         }
         case 'stop_server': {
-          await Promise.all(
-            [...sessions.values()].map((session) => session.dispose()),
-          );
+          const all = [...sessions.values()];
           sessions.clear();
+          sessionStarts.clear();
+          await Promise.all(all.map((session) => session.dispose()));
           return;
         }
         case 'build':
@@ -259,6 +259,7 @@ export function createDirectLspLeanAdapter(
     async dispose(): Promise<void> {
       const all = [...sessions.values()];
       sessions.clear();
+      sessionStarts.clear();
       await Promise.all(all.map((session) => session.dispose()));
     },
   };

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -3,12 +3,9 @@
  *
  * Implements the same {@link LeanVscodeServices} interface as the VS Code
  * integration. Per-workspace sessions are cached: the first request that
- * targets a file in a given Lake project spawns `lake env lean --server` from
- * that project root; subsequent requests from any agent reuse the same
- * session. Sessions are torn down on platform shutdown.
- *
- * VS Code command IDs (e.g. `lean4.project.build`) are translated to either
- * direct `lake` subprocess calls or session-level operations.
+ * targets a file in a given Lake project spawns `lake env lean --server`
+ * from that project root; subsequent requests from any agent reuse the
+ * same session. Sessions are torn down on platform shutdown.
  */
 
 import { access } from 'node:fs/promises';
@@ -83,14 +80,6 @@ export function createDirectLspLeanAdapter(
   }
 
   return {
-    getDiagnostics(filePath) {
-      // Synchronous mirror of `vscode.languages.getDiagnostics` — returns
-      // whatever we've buffered for an already-open file. Use
-      // `fetchDiagnosticsForFile` to force an open+wait.
-      const session = sessionForFile(sessions, filePath);
-      return session?.getDiagnosticsCache(filePath) ?? [];
-    },
-
     async fetchDiagnosticsForFile(
       file: string,
     ): Promise<LeanDiagnostic[] | null> {
@@ -213,11 +202,6 @@ export function createDirectLspLeanAdapter(
       );
     },
 
-    async promptLean4ExtensionInstall(): Promise<void> {
-      // No-op outside VS Code. The Tools dashboard already surfaces a
-      // "needs setup" hint when `lake` isn't on PATH.
-    },
-
     async dispose(): Promise<void> {
       const all = [...sessions.values()];
       sessions.clear();
@@ -231,8 +215,6 @@ export function createDirectLspLeanAdapter(
   ): Promise<LspResult<T>> {
     try {
       const session = await getSession(filePath);
-      // Open the file before the request so the LSP server has parsed it.
-      await session.fetchDiagnostics(filePath).catch(() => undefined);
       const data = await invoke(session);
       if (!data)
         return {
@@ -247,19 +229,6 @@ export function createDirectLspLeanAdapter(
       };
     }
   }
-}
-
-function sessionForFile(
-  sessions: Map<string, LeanSession>,
-  filePath: string,
-): LeanSession | null {
-  const absolute = path.resolve(filePath);
-  for (const [root, session] of sessions) {
-    if (absolute === root || absolute.startsWith(`${root}${path.sep}`)) {
-      return session;
-    }
-  }
-  return null;
 }
 
 async function runForAllSessions(

--- a/src/tools/lean/direct/jsonRpc.ts
+++ b/src/tools/lean/direct/jsonRpc.ts
@@ -1,0 +1,190 @@
+/**
+ * Minimal LSP-style JSON-RPC framing over a Node duplex stream.
+ *
+ * The Lean language server speaks the standard LSP wire format:
+ * `Content-Length: <n>\r\n\r\n<json>`. This module owns the framing and
+ * routing layer so callers only deal with typed JSON-RPC payloads.
+ *
+ * Kept dependency-free (no `vscode-jsonrpc`) so it can ship in the CLI and
+ * Electron desktop builds without dragging in VS Code's language client.
+ */
+
+import type { Readable, Writable } from 'node:stream';
+
+export type RpcId = number | string;
+
+export interface RpcRequest {
+  jsonrpc: '2.0';
+  id: RpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface RpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+export interface RpcResponse {
+  jsonrpc: '2.0';
+  id: RpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+type RpcMessage = RpcRequest | RpcNotification | RpcResponse;
+
+export type NotificationHandler = (params: unknown) => void;
+export type ServerRequestHandler = (params: unknown) => Promise<unknown>;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+export class JsonRpcConnection {
+  private nextId = 1;
+  private buffer = Buffer.alloc(0);
+  private readonly pending = new Map<RpcId, PendingRequest>();
+  private readonly notificationHandlers = new Map<string, NotificationHandler>();
+  private readonly serverRequestHandlers = new Map<string, ServerRequestHandler>();
+  private closed = false;
+  private closeError?: Error;
+
+  constructor(
+    private readonly stdin: Writable,
+    stdout: Readable,
+  ) {
+    stdout.on('data', (chunk: Buffer) => this.onData(chunk));
+    stdout.on('close', () => this.onClose(new Error('LSP stdout closed')));
+    stdout.on('error', (err) => this.onClose(err));
+    stdin.on('error', (err) => this.onClose(err));
+  }
+
+  onNotification(method: string, handler: NotificationHandler): void {
+    this.notificationHandlers.set(method, handler);
+  }
+
+  onServerRequest(method: string, handler: ServerRequestHandler): void {
+    this.serverRequestHandlers.set(method, handler);
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.write({ jsonrpc: '2.0', method, params });
+  }
+
+  async request<T>(method: string, params?: unknown): Promise<T> {
+    if (this.closed) {
+      throw this.closeError ?? new Error('LSP connection is closed');
+    }
+    const id = this.nextId++;
+    const promise = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.write({ jsonrpc: '2.0', id, method, params });
+    return promise as Promise<T>;
+  }
+
+  dispose(reason: string = 'JsonRpcConnection.dispose'): void {
+    this.onClose(new Error(reason));
+  }
+
+  private write(message: RpcMessage): void {
+    if (this.closed) return;
+    const json = JSON.stringify(message);
+    const body = Buffer.from(json, 'utf8');
+    const header = Buffer.from(
+      `Content-Length: ${body.length}\r\n\r\n`,
+      'ascii',
+    );
+    this.stdin.write(header);
+    this.stdin.write(body);
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    // Drain as many complete messages as we have in the buffer.
+    for (;;) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd < 0) return;
+      const headerText = this.buffer.slice(0, headerEnd).toString('ascii');
+      const match = headerText.match(/Content-Length: (\d+)/i);
+      if (!match) {
+        // Malformed header — drop and resync at the next blank line.
+        this.buffer = this.buffer.slice(headerEnd + 4);
+        continue;
+      }
+      const length = Number.parseInt(match[1]!, 10);
+      const bodyStart = headerEnd + 4;
+      if (this.buffer.length < bodyStart + length) return;
+      const body = this.buffer.slice(bodyStart, bodyStart + length);
+      this.buffer = this.buffer.slice(bodyStart + length);
+      let parsed: RpcMessage | undefined;
+      try {
+        parsed = JSON.parse(body.toString('utf8')) as RpcMessage;
+      } catch {
+        // Drop malformed payload and keep going.
+      }
+      if (parsed) this.dispatch(parsed);
+    }
+  }
+
+  private dispatch(message: RpcMessage): void {
+    if ('id' in message && 'method' in message) {
+      // Server-to-client request.
+      const handler = this.serverRequestHandlers.get(message.method);
+      if (!handler) {
+        this.write({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32601, message: `Unhandled method: ${message.method}` },
+        });
+        return;
+      }
+      handler(message.params).then(
+        (result) =>
+          this.write({ jsonrpc: '2.0', id: message.id, result }),
+        (error: unknown) =>
+          this.write({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: { code: -32603, message: errorMessage(error) },
+          }),
+      );
+      return;
+    }
+    if ('id' in message) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(
+          new Error(`LSP error ${message.error.code}: ${message.error.message}`),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+    if ('method' in message) {
+      const handler = this.notificationHandlers.get(message.method);
+      if (handler) handler(message.params);
+    }
+  }
+
+  private onClose(error: Error): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeError = error;
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/tools/lean/direct/jsonRpc.ts
+++ b/src/tools/lean/direct/jsonRpc.ts
@@ -45,7 +45,9 @@ interface PendingRequest {
 
 export class JsonRpcConnection {
   private nextId = 1;
-  private buffer = Buffer.alloc(0);
+  private readonly chunks: Buffer[] = [];
+  private bufferedLength = 0;
+  private pendingBodyLength: number | undefined;
   private readonly pending = new Map<RpcId, PendingRequest>();
   private readonly notificationHandlers = new Map<
     string,
@@ -109,30 +111,105 @@ export class JsonRpcConnection {
   }
 
   private onData(chunk: Buffer): void {
-    this.buffer = Buffer.concat([this.buffer, chunk]);
+    this.chunks.push(chunk);
+    this.bufferedLength += chunk.length;
     // Drain as many complete messages as we have in the buffer.
     for (;;) {
-      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (this.pendingBodyLength !== undefined) {
+        if (this.bufferedLength < this.pendingBodyLength) return;
+        this.dispatchBody(this.consumeBytes(this.pendingBodyLength));
+        this.pendingBodyLength = undefined;
+        continue;
+      }
+
+      const headerEnd = this.findHeaderEnd();
       if (headerEnd < 0) return;
-      const headerText = this.buffer.slice(0, headerEnd).toString('ascii');
+      const headerText = this.consumeBytes(headerEnd).toString('ascii');
+      this.discardBytes(4);
       const match = headerText.match(/Content-Length: (\d+)/i);
       if (!match) {
         // Malformed header — drop and resync at the next blank line.
-        this.buffer = this.buffer.slice(headerEnd + 4);
         continue;
       }
       const length = Number.parseInt(match[1]!, 10);
-      const bodyStart = headerEnd + 4;
-      if (this.buffer.length < bodyStart + length) return;
-      const body = this.buffer.slice(bodyStart, bodyStart + length);
-      this.buffer = this.buffer.slice(bodyStart + length);
-      let parsed: RpcMessage | undefined;
-      try {
-        parsed = JSON.parse(body.toString('utf8')) as RpcMessage;
-      } catch {
-        // Drop malformed payload and keep going.
+      if (this.bufferedLength < length) {
+        this.pendingBodyLength = length;
+        return;
       }
-      if (parsed) this.dispatch(parsed);
+      this.dispatchBody(this.consumeBytes(length));
+    }
+  }
+
+  private dispatchBody(body: Buffer): void {
+    let parsed: RpcMessage | undefined;
+    try {
+      parsed = JSON.parse(body.toString('utf8')) as RpcMessage;
+    } catch {
+      // Drop malformed payload and keep going.
+    }
+    if (parsed) this.dispatch(parsed);
+  }
+
+  private findHeaderEnd(): number {
+    const delimiter = [13, 10, 13, 10];
+    let matched = 0;
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      for (const byte of chunk) {
+        if (byte === delimiter[matched]) {
+          matched += 1;
+          if (matched === delimiter.length) {
+            return offset - delimiter.length + 1;
+          }
+        } else {
+          matched = byte === delimiter[0] ? 1 : 0;
+        }
+        offset += 1;
+      }
+    }
+    return -1;
+  }
+
+  private consumeBytes(length: number): Buffer {
+    if (length === 0) return Buffer.alloc(0);
+    const parts: Buffer[] = [];
+    let remaining = length;
+    while (remaining > 0) {
+      const head = this.chunks[0];
+      if (!head) {
+        throw new Error('JSON-RPC buffer underflow');
+      }
+      if (head.length <= remaining) {
+        parts.push(head);
+        this.chunks.shift();
+        this.bufferedLength -= head.length;
+        remaining -= head.length;
+      } else {
+        parts.push(head.subarray(0, remaining));
+        this.chunks[0] = head.subarray(remaining);
+        this.bufferedLength -= remaining;
+        remaining = 0;
+      }
+    }
+    return parts.length === 1 ? parts[0]! : Buffer.concat(parts, length);
+  }
+
+  private discardBytes(length: number): void {
+    let remaining = length;
+    while (remaining > 0) {
+      const head = this.chunks[0];
+      if (!head) {
+        throw new Error('JSON-RPC buffer underflow');
+      }
+      if (head.length <= remaining) {
+        this.chunks.shift();
+        this.bufferedLength -= head.length;
+        remaining -= head.length;
+      } else {
+        this.chunks[0] = head.subarray(remaining);
+        this.bufferedLength -= remaining;
+        remaining = 0;
+      }
     }
   }
 
@@ -187,6 +264,9 @@ export class JsonRpcConnection {
     if (this.closed) return;
     this.closed = true;
     this.closeError = error;
+    this.chunks.length = 0;
+    this.bufferedLength = 0;
+    this.pendingBodyLength = undefined;
     for (const pending of this.pending.values()) {
       pending.reject(error);
     }

--- a/src/tools/lean/direct/jsonRpc.ts
+++ b/src/tools/lean/direct/jsonRpc.ts
@@ -47,8 +47,14 @@ export class JsonRpcConnection {
   private nextId = 1;
   private buffer = Buffer.alloc(0);
   private readonly pending = new Map<RpcId, PendingRequest>();
-  private readonly notificationHandlers = new Map<string, NotificationHandler>();
-  private readonly serverRequestHandlers = new Map<string, ServerRequestHandler>();
+  private readonly notificationHandlers = new Map<
+    string,
+    NotificationHandler
+  >();
+  private readonly serverRequestHandlers = new Map<
+    string,
+    ServerRequestHandler
+  >();
   private closed = false;
   private closeError?: Error;
 
@@ -138,13 +144,15 @@ export class JsonRpcConnection {
         this.write({
           jsonrpc: '2.0',
           id: message.id,
-          error: { code: -32601, message: `Unhandled method: ${message.method}` },
+          error: {
+            code: -32601,
+            message: `Unhandled method: ${message.method}`,
+          },
         });
         return;
       }
       handler(message.params).then(
-        (result) =>
-          this.write({ jsonrpc: '2.0', id: message.id, result }),
+        (result) => this.write({ jsonrpc: '2.0', id: message.id, result }),
         (error: unknown) =>
           this.write({
             jsonrpc: '2.0',
@@ -160,7 +168,9 @@ export class JsonRpcConnection {
       this.pending.delete(message.id);
       if (message.error) {
         pending.reject(
-          new Error(`LSP error ${message.error.code}: ${message.error.message}`),
+          new Error(
+            `LSP error ${message.error.code}: ${message.error.message}`,
+          ),
         );
       } else {
         pending.resolve(message.result);

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -11,16 +11,16 @@ import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 
 const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
-const LAKE_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+const LAKE_MAX_OUTPUT_CHARS = 4 * 1024 * 1024;
 
 const workspaceMutexes = new Map<string, Promise<unknown>>();
 
 function appendCapped(existing: string, chunk: string): string {
   const combined = existing + chunk;
-  if (combined.length <= LAKE_MAX_OUTPUT_BYTES) return combined;
+  if (combined.length <= LAKE_MAX_OUTPUT_CHARS) return combined;
   return (
     '…[output truncated]…\n' +
-    combined.slice(combined.length - LAKE_MAX_OUTPUT_BYTES)
+    combined.slice(combined.length - LAKE_MAX_OUTPUT_CHARS)
   );
 }
 

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -84,13 +84,18 @@ function executeLake(options: LakeCommandOptions): Promise<LakeCommandResult> {
     const timer = setTimeout(() => {
       child.kill();
     }, options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS);
+    let settled = false;
+    function finish(action: () => void): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      action();
+    }
     child.on('error', (error) => {
-      clearTimeout(timer);
-      reject(error);
+      finish(() => reject(error));
     });
-    child.on('exit', (code) => {
-      clearTimeout(timer);
-      resolve({ exitCode: code ?? -1, stdout, stderr });
+    child.on('close', (code) => {
+      finish(() => resolve({ exitCode: code ?? -1, stdout, stderr }));
     });
   });
 }

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -11,8 +11,18 @@ import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 
 const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
+const LAKE_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 
 const workspaceMutexes = new Map<string, Promise<unknown>>();
+
+function appendCapped(existing: string, chunk: string): string {
+  const combined = existing + chunk;
+  if (combined.length <= LAKE_MAX_OUTPUT_BYTES) return combined;
+  return (
+    '…[output truncated]…\n' +
+    combined.slice(combined.length - LAKE_MAX_OUTPUT_BYTES)
+  );
+}
 
 export interface LakeCommandResult {
   exitCode: number;
@@ -66,10 +76,10 @@ function executeLake(options: LakeCommandOptions): Promise<LakeCommandResult> {
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
+      stdout = appendCapped(stdout, chunk);
     });
     child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
+      stderr = appendCapped(stderr, chunk);
     });
     const timer = setTimeout(() => {
       child.kill();

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -1,0 +1,86 @@
+/**
+ * Subprocess wrappers for the `lake` commands invoked by `lean_project`.
+ *
+ * The VS Code Lean extension exposes these as command IDs; the direct adapter
+ * has to run the real `lake` binary itself. We serialize per-workspace via an
+ * in-process mutex so two agents in the same TeXRA instance can't fire two
+ * concurrent `lake build` invocations against the same `.lake/build`.
+ */
+
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+
+const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
+
+const workspaceMutexes = new Map<string, Promise<unknown>>();
+
+export interface LakeCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface LakeCommandOptions {
+  workspaceRoot: string;
+  lakeCommand: string;
+  args: readonly string[];
+  /** When true, serialize this invocation against other commands on the same workspace. */
+  serialize?: boolean;
+  /** Override the default 10-minute timeout. */
+  timeoutMs?: number;
+}
+
+/**
+ * Run a `lake` subcommand against a workspace root. Returns a result instead of
+ * throwing on non-zero exit so callers can decide how to format failures.
+ */
+export async function runLakeCommand(
+  options: LakeCommandOptions,
+): Promise<LakeCommandResult> {
+  const workspaceKey = path.resolve(options.workspaceRoot);
+  if (!options.serialize) {
+    return executeLake(options);
+  }
+  const prior = workspaceMutexes.get(workspaceKey) ?? Promise.resolve();
+  const next = prior.catch(() => undefined).then(() => executeLake(options));
+  // Use a finally hook so we always clear ourselves out, even on rejection.
+  workspaceMutexes.set(workspaceKey, next);
+  try {
+    return await next;
+  } finally {
+    if (workspaceMutexes.get(workspaceKey) === next) {
+      workspaceMutexes.delete(workspaceKey);
+    }
+  }
+}
+
+function executeLake(options: LakeCommandOptions): Promise<LakeCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.lakeCommand, [...options.args], {
+      cwd: options.workspaceRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    const timer = setTimeout(() => {
+      child.kill();
+    }, options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS);
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve({ exitCode: code ?? -1, stdout, stderr });
+    });
+  });
+}

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -51,7 +51,6 @@ interface OpenedFile {
 export interface LeanSessionOptions {
   workspaceRoot: string;
   lakeCommand: string;
-  toolchainResolver?: () => Promise<string | undefined>;
   onExit?: () => void;
 }
 
@@ -138,7 +137,6 @@ export class LeanSession {
       textDocument: { uri: pathToUri(absolute) },
       position: { line, character: column },
     };
-    updateLeanServer(this.id, { touchActivity: true });
     return (await this.rpc!.request(method, params)) as T;
   }
 
@@ -200,16 +198,15 @@ export class LeanSession {
       throw new Error(`Failed to spawn 'lake env lean --server': ${message}`);
     }
     this.child = child;
-    const stderrChunks: string[] = [];
+    let stderrTail = '';
+    const STDERR_TAIL_LIMIT = 4096;
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk: string) => {
-      stderrChunks.push(chunk);
-      // Avoid unbounded retention.
-      if (stderrChunks.length > 200) stderrChunks.splice(0, stderrChunks.length - 200);
+      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
       warn(LOG_CHANNEL, `[${root}] ${chunk.trimEnd()}`);
     });
     child.on('exit', (code, signal) => {
-      const tail = stderrChunks.join('').slice(-1000);
+      const tail = stderrTail.slice(-1000);
       info(
         LOG_CHANNEL,
         `lake env lean --server exited (code=${code}, signal=${signal}) at ${root}${tail ? `\n${tail}` : ''}`,
@@ -260,12 +257,7 @@ export class LeanSession {
         'Lean LSP initialize timeout',
       );
       rpc.notify('initialized', {});
-      const toolchain = await this.options.toolchainResolver?.().catch(() => undefined);
-      updateLeanServer(this.id, {
-        status: 'running',
-        toolchain,
-        touchActivity: true,
-      });
+      updateLeanServer(this.id, { status: 'running' });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       updateLeanServer(this.id, { status: 'error', errorMessage: message });
@@ -348,7 +340,6 @@ export class LeanSession {
     if (!state) return;
     state.diagnostics = params.diagnostics.map(toLeanDiagnostic);
     state.lastDiagnosticsAt = Date.now();
-    updateLeanServer(this.id, { touchActivity: true });
     // Release any waiters — the quiet-window check above re-arms if needed.
     for (const waiter of state.diagnosticsWaiters.splice(0)) {
       clearTimeout(waiter.timeout);

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -99,15 +99,7 @@ export class LeanSession {
   }
 
   async fetchDiagnostics(filePath: string): Promise<LeanDiagnostic[]> {
-    const absolute = path.resolve(filePath);
-    await this.ensureReady();
-    await this.ensureFileOpen(absolute, { forceReload: false });
-    await this.waitForDiagnosticsQuiet(absolute);
-    return this.openFiles.get(absolute)?.diagnostics ?? [];
-  }
-
-  getDiagnosticsCache(filePath: string): LeanDiagnostic[] {
-    const absolute = path.resolve(filePath);
+    const absolute = await this.openAndSettle(filePath);
     return this.openFiles.get(absolute)?.diagnostics ?? [];
   }
 
@@ -123,15 +115,19 @@ export class LeanSession {
     await this.ensureFileOpen(absolute, { forceReload: true });
   }
 
-  async sendPositionRequest<T>(
+  /**
+   * Open the file (if needed), wait for Lean's diagnostics to settle, and
+   * send a position-scoped LSP request. Position requests like
+   * `$/lean/plainGoal` return stale data if the elaborator hasn't finished —
+   * the quiet-window wait is the only way to get correct goal state.
+   */
+  async requestSettled<T>(
     filePath: string,
     line: number,
     column: number,
     method: string,
   ): Promise<T> {
-    const absolute = path.resolve(filePath);
-    await this.ensureReady();
-    await this.ensureFileOpen(absolute, { forceReload: false });
+    const absolute = await this.openAndSettle(filePath);
     const params = {
       textDocument: { uri: pathToUri(absolute) },
       position: { line, character: column },
@@ -139,12 +135,20 @@ export class LeanSession {
     return (await this.rpc!.request(method, params)) as T;
   }
 
+  private async openAndSettle(filePath: string): Promise<string> {
+    const absolute = path.resolve(filePath);
+    await this.ensureReady();
+    await this.ensureFileOpen(absolute, { forceReload: false });
+    await this.waitForDiagnosticsQuiet(absolute);
+    return absolute;
+  }
+
   getPlainGoal(
     filePath: string,
     line: number,
     column: number,
   ): Promise<PlainGoal | null> {
-    return this.sendPositionRequest<PlainGoal | null>(
+    return this.requestSettled<PlainGoal | null>(
       filePath,
       line,
       column,
@@ -157,7 +161,7 @@ export class LeanSession {
     line: number,
     column: number,
   ): Promise<PlainTermGoal | null> {
-    return this.sendPositionRequest<PlainTermGoal | null>(
+    return this.requestSettled<PlainTermGoal | null>(
       filePath,
       line,
       column,
@@ -170,7 +174,7 @@ export class LeanSession {
     line: number,
     column: number,
   ): Promise<Hover | null> {
-    return this.sendPositionRequest<Hover | null>(
+    return this.requestSettled<Hover | null>(
       filePath,
       line,
       column,

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -29,7 +29,6 @@ import type {
   PublishDiagnosticsParams,
 } from 'vscode-languageserver-protocol';
 
-
 const LOG_CHANNEL = 'lean.direct';
 
 const LEAN_LANGUAGE_ID = 'lean4';
@@ -140,7 +139,11 @@ export class LeanSession {
     return (await this.rpc!.request(method, params)) as T;
   }
 
-  getPlainGoal(filePath: string, line: number, column: number): Promise<PlainGoal | null> {
+  getPlainGoal(
+    filePath: string,
+    line: number,
+    column: number,
+  ): Promise<PlainGoal | null> {
     return this.sendPositionRequest<PlainGoal | null>(
       filePath,
       line,
@@ -214,7 +217,8 @@ export class LeanSession {
       this.options.onExit?.();
       updateLeanServer(this.id, {
         status: code === 0 ? 'stopped' : 'error',
-        errorMessage: code === 0 ? undefined : `Server exited with code ${code}`,
+        errorMessage:
+          code === 0 ? undefined : `Server exited with code ${code}`,
       });
       this.child = undefined;
       this.rpc?.dispose('Lean server exited');
@@ -243,7 +247,9 @@ export class LeanSession {
           processId: process.pid,
           clientInfo: { name: 'texra-direct-lsp' },
           rootUri: pathToUri(root),
-          workspaceFolders: [{ uri: pathToUri(root), name: path.basename(root) }],
+          workspaceFolders: [
+            { uri: pathToUri(root), name: path.basename(root) },
+          ],
           capabilities: {
             textDocument: {
               synchronization: { didSave: false, willSave: false },
@@ -382,7 +388,11 @@ function uriToPath(uri: string): string | null {
   }
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(() => reject(new Error(message)), ms);

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -149,7 +149,11 @@ export class LeanSession {
       textDocument: { uri: pathToUri(absolute) },
       position: { line, character: column },
     };
-    return (await this.rpc!.request(method, params)) as T;
+    const rpc = this.rpc;
+    if (this.disposed || !rpc) {
+      throw new Error('Lean session is not running');
+    }
+    return (await rpc.request(method, params)) as T;
   }
 
   private async openAndSettle(filePath: string): Promise<string> {

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -13,7 +13,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { debug, info, warn } from '@logger/logUtils';
 import {
@@ -71,6 +71,9 @@ export class LeanSession {
 
   /** Start (or reuse) the server and complete `initialize`. Idempotent. */
   ensureReady(): Promise<void> {
+    if (this.disposed) {
+      throw new Error('Lean session has been disposed.');
+    }
     if (this.readyPromise) return this.readyPromise;
     this.readyPromise = this.spawnAndInitialize();
     return this.readyPromise;
@@ -84,6 +87,7 @@ export class LeanSession {
     const rpc = this.rpc;
     this.child = undefined;
     this.rpc = undefined;
+    this.readyPromise = undefined;
     this.openFiles.clear();
     unregisterLeanServer(this.id);
     if (!rpc || !child) return;
@@ -283,13 +287,15 @@ export class LeanSession {
     if (!this.rpc) {
       throw new Error('Lean session is not running');
     }
-    const existing = this.openFiles.get(absolute);
+    let existing = this.openFiles.get(absolute);
     if (existing && !options.forceReload) return;
     const text = await readFile(absolute, 'utf8').catch((error) => {
       throw new Error(
         `Failed to read ${absolute}: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
+    existing = this.openFiles.get(absolute);
+    if (existing && !options.forceReload) return;
     const version = (existing?.version ?? 0) + 1;
     if (existing) {
       this.rpc.notify('textDocument/didChange', {
@@ -300,6 +306,12 @@ export class LeanSession {
       existing.diagnostics = [];
       existing.lastDiagnosticsAt = 0;
     } else {
+      this.openFiles.set(absolute, {
+        version,
+        diagnostics: [],
+        lastDiagnosticsAt: 0,
+        diagnosticsWaiters: [],
+      });
       this.rpc.notify('textDocument/didOpen', {
         textDocument: {
           uri: pathToUri(absolute),
@@ -307,12 +319,6 @@ export class LeanSession {
           version,
           text,
         },
-      });
-      this.openFiles.set(absolute, {
-        version,
-        diagnostics: [],
-        lastDiagnosticsAt: 0,
-        diagnosticsWaiters: [],
       });
     }
   }
@@ -344,7 +350,7 @@ export class LeanSession {
 
   private handlePublishDiagnostics(params: PublishDiagnosticsParams): void {
     const uri = params.uri;
-    const absolute = uriToPath(uri);
+    const absolute = fileUriToPath(uri);
     if (!absolute) return;
     const state = this.openFiles.get(absolute);
     if (!state) return;
@@ -383,10 +389,10 @@ function pathToUri(absolute: string): string {
   return pathToFileURL(absolute).toString();
 }
 
-function uriToPath(uri: string): string | null {
+export function fileUriToPath(uri: string): string | null {
   if (!uri.startsWith('file://')) return null;
   try {
-    return new URL(uri).pathname.replace(/^\/([A-Za-z]:)/, '$1');
+    return fileURLToPath(uri);
   } catch {
     return null;
   }

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -70,13 +70,16 @@ export class LeanSession {
   }
 
   /** Start (or reuse) the server and complete `initialize`. Idempotent. */
-  ensureReady(): Promise<void> {
+  async ensureReady(): Promise<void> {
     if (this.disposed) {
       throw new Error('Lean session has been disposed.');
     }
-    if (this.readyPromise) return this.readyPromise;
+    if (this.readyPromise) {
+      await this.readyPromise;
+      return;
+    }
     this.readyPromise = this.spawnAndInitialize();
-    return this.readyPromise;
+    await this.readyPromise;
   }
 
   /** Tear down the server and clear cached file state. */

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -92,6 +92,7 @@ export class LeanSession {
     this.child = undefined;
     this.rpc = undefined;
     this.readyPromise = undefined;
+    this.releaseAllDiagnosticsWaiters();
     this.openFiles.clear();
     unregisterLeanServer(this.id);
     if (!rpc || !child) return;
@@ -122,7 +123,11 @@ export class LeanSession {
       this.rpc.notify('textDocument/didClose', {
         textDocument: { uri: pathToUri(absolute) },
       });
-      this.openFiles.delete(absolute);
+      const state = this.openFiles.get(absolute);
+      if (state) {
+        this.releaseDiagnosticsWaiters(state);
+        this.openFiles.delete(absolute);
+      }
     }
     await this.ensureFileOpen(absolute, { forceReload: true });
   }
@@ -229,6 +234,7 @@ export class LeanSession {
       this.rpc?.dispose(message ?? 'Lean server stopped');
       this.rpc = undefined;
       this.readyPromise = undefined;
+      this.releaseAllDiagnosticsWaiters();
       this.openFiles.clear();
     };
     const childError = new Promise<never>((_resolve, reject) => {
@@ -357,6 +363,7 @@ export class LeanSession {
     if (!state) return;
     const start = Date.now();
     while (Date.now() - start < DIAGNOSTICS_WAIT_MS) {
+      if (this.disposed || this.openFiles.get(absolute) !== state) return;
       const sinceLast = state.lastDiagnosticsAt
         ? Date.now() - state.lastDiagnosticsAt
         : 0;
@@ -387,9 +394,27 @@ export class LeanSession {
     state.lastDiagnosticsAt = Date.now();
     // Release any waiters — the quiet-window check above re-arms if needed.
     for (const waiter of state.diagnosticsWaiters.splice(0)) {
-      clearTimeout(waiter.timeout);
-      waiter.resolve();
+      this.resolveDiagnosticsWaiter(waiter);
     }
+  }
+
+  private releaseAllDiagnosticsWaiters(): void {
+    for (const state of this.openFiles.values()) {
+      this.releaseDiagnosticsWaiters(state);
+    }
+  }
+
+  private releaseDiagnosticsWaiters(state: OpenedFile): void {
+    for (const waiter of state.diagnosticsWaiters.splice(0)) {
+      this.resolveDiagnosticsWaiter(waiter);
+    }
+  }
+
+  private resolveDiagnosticsWaiter(
+    waiter: OpenedFile['diagnosticsWaiters'][number],
+  ): void {
+    clearTimeout(waiter.timeout);
+    waiter.resolve();
   }
 }
 

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -33,6 +33,7 @@ const LOG_CHANNEL = 'lean.direct';
 
 const LEAN_LANGUAGE_ID = 'lean4';
 const HANDSHAKE_TIMEOUT_MS = 15_000;
+const SHUTDOWN_TIMEOUT_MS = 2_000;
 const DIAGNOSTICS_WAIT_MS = 10_000;
 const DIAGNOSTICS_QUIET_WINDOW_MS = 400;
 
@@ -95,7 +96,11 @@ export class LeanSession {
     unregisterLeanServer(this.id);
     if (!rpc || !child) return;
     try {
-      await rpc.request('shutdown').catch(() => undefined);
+      await withTimeout(
+        rpc.request('shutdown'),
+        SHUTDOWN_TIMEOUT_MS,
+        'Lean LSP shutdown timeout',
+      ).catch(() => undefined);
       rpc.notify('exit');
     } finally {
       rpc.dispose('LeanSession.dispose');
@@ -214,6 +219,27 @@ export class LeanSession {
     this.child = child;
     let stderrTail = '';
     const STDERR_TAIL_LIMIT = 4096;
+    let finalized = false;
+    const finalizeServer = (status: 'stopped' | 'error', message?: string) => {
+      if (finalized) return;
+      finalized = true;
+      this.options.onExit?.();
+      updateLeanServer(this.id, { status, errorMessage: message });
+      this.child = undefined;
+      this.rpc?.dispose(message ?? 'Lean server stopped');
+      this.rpc = undefined;
+      this.readyPromise = undefined;
+      this.openFiles.clear();
+    };
+    const childError = new Promise<never>((_resolve, reject) => {
+      child.once('error', (error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        finalizeServer('error', message);
+        reject(
+          new Error(`Failed to spawn 'lake env lean --server': ${message}`),
+        );
+      });
+    });
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk: string) => {
       stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
@@ -225,17 +251,10 @@ export class LeanSession {
         LOG_CHANNEL,
         `lake env lean --server exited (code=${code}, signal=${signal}) at ${root}${tail ? `\n${tail}` : ''}`,
       );
-      this.options.onExit?.();
-      updateLeanServer(this.id, {
-        status: code === 0 ? 'stopped' : 'error',
-        errorMessage:
-          code === 0 ? undefined : `Server exited with code ${code}`,
-      });
-      this.child = undefined;
-      this.rpc?.dispose('Lean server exited');
-      this.rpc = undefined;
-      this.readyPromise = undefined;
-      this.openFiles.clear();
+      finalizeServer(
+        code === 0 ? 'stopped' : 'error',
+        code === 0 ? undefined : `Server exited with code ${code}`,
+      );
     });
 
     const rpc = new JsonRpcConnection(child.stdin, child.stdout);
@@ -254,22 +273,25 @@ export class LeanSession {
 
     try {
       await withTimeout(
-        rpc.request('initialize', {
-          processId: process.pid,
-          clientInfo: { name: 'texra-direct-lsp' },
-          rootUri: pathToUri(root),
-          workspaceFolders: [
-            { uri: pathToUri(root), name: path.basename(root) },
-          ],
-          capabilities: {
-            textDocument: {
-              synchronization: { didSave: false, willSave: false },
-              hover: { contentFormat: ['plaintext', 'markdown'] },
-              publishDiagnostics: {},
+        Promise.race([
+          rpc.request('initialize', {
+            processId: process.pid,
+            clientInfo: { name: 'texra-direct-lsp' },
+            rootUri: pathToUri(root),
+            workspaceFolders: [
+              { uri: pathToUri(root), name: path.basename(root) },
+            ],
+            capabilities: {
+              textDocument: {
+                synchronization: { didSave: false, willSave: false },
+                hover: { contentFormat: ['plaintext', 'markdown'] },
+                publishDiagnostics: {},
+              },
+              workspace: {},
             },
-            workspace: {},
-          },
-        }),
+          }),
+          childError,
+        ]),
         HANDSHAKE_TIMEOUT_MS,
         'Lean LSP initialize timeout',
       );

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -287,7 +287,7 @@ export class LeanSession {
     absolute: string,
     options: { forceReload: boolean },
   ): Promise<void> {
-    if (!this.rpc) {
+    if (this.disposed || !this.rpc) {
       throw new Error('Lean session is not running');
     }
     let existing = this.openFiles.get(absolute);
@@ -299,9 +299,13 @@ export class LeanSession {
     });
     existing = this.openFiles.get(absolute);
     if (existing && !options.forceReload) return;
+    const rpc = this.rpc;
+    if (this.disposed || !rpc) {
+      throw new Error('Lean session is not running');
+    }
     const version = (existing?.version ?? 0) + 1;
     if (existing) {
-      this.rpc.notify('textDocument/didChange', {
+      rpc.notify('textDocument/didChange', {
         textDocument: { uri: pathToUri(absolute), version },
         contentChanges: [{ text }],
       });
@@ -315,7 +319,7 @@ export class LeanSession {
         lastDiagnosticsAt: 0,
         diagnosticsWaiters: [],
       });
-      this.rpc.notify('textDocument/didOpen', {
+      rpc.notify('textDocument/didOpen', {
         textDocument: {
           uri: pathToUri(absolute),
           languageId: LEAN_LANGUAGE_ID,

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -1,0 +1,405 @@
+/**
+ * One Lean LSP session per workspace root.
+ *
+ * Spawns `lake env lean --server` from the project root, completes the
+ * `initialize` handshake, and handles `textDocument/didOpen` lazily on the
+ * first request that touches a file. Diagnostics arrive asynchronously via
+ * `textDocument/publishDiagnostics` and are buffered per file.
+ *
+ * Lives under `src/tools/lean/direct/` (host-neutral): Node-only, no `vscode`
+ * imports, suitable for both the CLI and the desktop main process.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { debug, info, warn } from '@logger/logUtils';
+import {
+  registerLeanServer,
+  unregisterLeanServer,
+  updateLeanServer,
+} from '../leanServerRegistry';
+import { JsonRpcConnection } from './jsonRpc';
+import type { LeanDiagnostic, PlainGoal, PlainTermGoal } from '../leanTypes';
+import type {
+  Diagnostic,
+  Hover,
+  PublishDiagnosticsParams,
+} from 'vscode-languageserver-protocol';
+
+
+const LOG_CHANNEL = 'lean.direct';
+
+const LEAN_LANGUAGE_ID = 'lean4';
+const HANDSHAKE_TIMEOUT_MS = 15_000;
+const DIAGNOSTICS_WAIT_MS = 10_000;
+const DIAGNOSTICS_QUIET_WINDOW_MS = 400;
+
+interface OpenedFile {
+  version: number;
+  diagnostics: LeanDiagnostic[];
+  lastDiagnosticsAt: number;
+  // Resolved when diagnostics arrive after the next `didOpen`/`didChange`.
+  diagnosticsWaiters: Array<{
+    resolve: () => void;
+    timeout: NodeJS.Timeout;
+  }>;
+}
+
+export interface LeanSessionOptions {
+  workspaceRoot: string;
+  lakeCommand: string;
+  toolchainResolver?: () => Promise<string | undefined>;
+  onExit?: () => void;
+}
+
+export class LeanSession {
+  private child?: ChildProcessWithoutNullStreams;
+  private rpc?: JsonRpcConnection;
+  private readonly id: string;
+  private readyPromise?: Promise<void>;
+  private disposed = false;
+  private readonly openFiles = new Map<string, OpenedFile>();
+
+  constructor(private readonly options: LeanSessionOptions) {
+    this.id = `direct:${options.workspaceRoot}`;
+  }
+
+  get workspaceRoot(): string {
+    return this.options.workspaceRoot;
+  }
+
+  /** Start (or reuse) the server and complete `initialize`. Idempotent. */
+  ensureReady(): Promise<void> {
+    if (this.readyPromise) return this.readyPromise;
+    this.readyPromise = this.spawnAndInitialize();
+    return this.readyPromise;
+  }
+
+  /** Tear down the server and clear cached file state. */
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    const child = this.child;
+    const rpc = this.rpc;
+    this.child = undefined;
+    this.rpc = undefined;
+    this.openFiles.clear();
+    unregisterLeanServer(this.id);
+    if (!rpc || !child) return;
+    try {
+      await rpc.request('shutdown').catch(() => undefined);
+      rpc.notify('exit');
+    } finally {
+      rpc.dispose('LeanSession.dispose');
+      if (!child.killed) {
+        child.kill();
+      }
+    }
+  }
+
+  async fetchDiagnostics(filePath: string): Promise<LeanDiagnostic[]> {
+    const absolute = path.resolve(filePath);
+    await this.ensureReady();
+    await this.ensureFileOpen(absolute, { forceReload: false });
+    await this.waitForDiagnosticsQuiet(absolute);
+    return this.openFiles.get(absolute)?.diagnostics ?? [];
+  }
+
+  getDiagnosticsCache(filePath: string): LeanDiagnostic[] {
+    const absolute = path.resolve(filePath);
+    return this.openFiles.get(absolute)?.diagnostics ?? [];
+  }
+
+  async restartFile(filePath: string): Promise<void> {
+    const absolute = path.resolve(filePath);
+    if (!this.rpc) return;
+    if (this.openFiles.has(absolute)) {
+      this.rpc.notify('textDocument/didClose', {
+        textDocument: { uri: pathToUri(absolute) },
+      });
+      this.openFiles.delete(absolute);
+    }
+    await this.ensureFileOpen(absolute, { forceReload: true });
+  }
+
+  async sendPositionRequest<T>(
+    filePath: string,
+    line: number,
+    column: number,
+    method: string,
+  ): Promise<T> {
+    const absolute = path.resolve(filePath);
+    await this.ensureReady();
+    await this.ensureFileOpen(absolute, { forceReload: false });
+    const params = {
+      textDocument: { uri: pathToUri(absolute) },
+      position: { line, character: column },
+    };
+    updateLeanServer(this.id, { touchActivity: true });
+    return (await this.rpc!.request(method, params)) as T;
+  }
+
+  getPlainGoal(filePath: string, line: number, column: number): Promise<PlainGoal | null> {
+    return this.sendPositionRequest<PlainGoal | null>(
+      filePath,
+      line,
+      column,
+      '$/lean/plainGoal',
+    );
+  }
+
+  getPlainTermGoal(
+    filePath: string,
+    line: number,
+    column: number,
+  ): Promise<PlainTermGoal | null> {
+    return this.sendPositionRequest<PlainTermGoal | null>(
+      filePath,
+      line,
+      column,
+      '$/lean/plainTermGoal',
+    );
+  }
+
+  getHover(
+    filePath: string,
+    line: number,
+    column: number,
+  ): Promise<Hover | null> {
+    return this.sendPositionRequest<Hover | null>(
+      filePath,
+      line,
+      column,
+      'textDocument/hover',
+    );
+  }
+
+  private async spawnAndInitialize(): Promise<void> {
+    const root = this.options.workspaceRoot;
+    const lake = this.options.lakeCommand;
+    registerLeanServer({
+      id: this.id,
+      workspaceRoot: root,
+      mode: 'direct-lsp',
+      status: 'starting',
+    });
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(lake, ['env', 'lean', '--server'], {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // Force POSIX behavior on Windows-Node by relying on lake's resolver.
+        windowsHide: true,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      updateLeanServer(this.id, { status: 'error', errorMessage: message });
+      throw new Error(`Failed to spawn 'lake env lean --server': ${message}`);
+    }
+    this.child = child;
+    const stderrChunks: string[] = [];
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      stderrChunks.push(chunk);
+      // Avoid unbounded retention.
+      if (stderrChunks.length > 200) stderrChunks.splice(0, stderrChunks.length - 200);
+      warn(LOG_CHANNEL, `[${root}] ${chunk.trimEnd()}`);
+    });
+    child.on('exit', (code, signal) => {
+      const tail = stderrChunks.join('').slice(-1000);
+      info(
+        LOG_CHANNEL,
+        `lake env lean --server exited (code=${code}, signal=${signal}) at ${root}${tail ? `\n${tail}` : ''}`,
+      );
+      this.options.onExit?.();
+      updateLeanServer(this.id, {
+        status: code === 0 ? 'stopped' : 'error',
+        errorMessage: code === 0 ? undefined : `Server exited with code ${code}`,
+      });
+      this.child = undefined;
+      this.rpc?.dispose('Lean server exited');
+      this.rpc = undefined;
+      this.readyPromise = undefined;
+      this.openFiles.clear();
+    });
+
+    const rpc = new JsonRpcConnection(child.stdin, child.stdout);
+    this.rpc = rpc;
+    rpc.onNotification('textDocument/publishDiagnostics', (params) =>
+      this.handlePublishDiagnostics(params as PublishDiagnosticsParams),
+    );
+    rpc.onNotification('window/logMessage', (params) => {
+      debug(LOG_CHANNEL, `[${root}] ${JSON.stringify(params)}`);
+    });
+    rpc.onNotification('window/showMessage', (params) => {
+      info(LOG_CHANNEL, `[${root}] ${JSON.stringify(params)}`);
+    });
+
+    updateLeanServer(this.id, { pid: child.pid });
+
+    try {
+      await withTimeout(
+        rpc.request('initialize', {
+          processId: process.pid,
+          clientInfo: { name: 'texra-direct-lsp' },
+          rootUri: pathToUri(root),
+          workspaceFolders: [{ uri: pathToUri(root), name: path.basename(root) }],
+          capabilities: {
+            textDocument: {
+              synchronization: { didSave: false, willSave: false },
+              hover: { contentFormat: ['plaintext', 'markdown'] },
+              publishDiagnostics: {},
+            },
+            workspace: {},
+          },
+        }),
+        HANDSHAKE_TIMEOUT_MS,
+        'Lean LSP initialize timeout',
+      );
+      rpc.notify('initialized', {});
+      const toolchain = await this.options.toolchainResolver?.().catch(() => undefined);
+      updateLeanServer(this.id, {
+        status: 'running',
+        toolchain,
+        touchActivity: true,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      updateLeanServer(this.id, { status: 'error', errorMessage: message });
+      await this.dispose();
+      throw error;
+    }
+  }
+
+  private async ensureFileOpen(
+    absolute: string,
+    options: { forceReload: boolean },
+  ): Promise<void> {
+    if (!this.rpc) {
+      throw new Error('Lean session is not running');
+    }
+    const existing = this.openFiles.get(absolute);
+    if (existing && !options.forceReload) return;
+    const text = await readFile(absolute, 'utf8').catch((error) => {
+      throw new Error(
+        `Failed to read ${absolute}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    const version = (existing?.version ?? 0) + 1;
+    if (existing) {
+      this.rpc.notify('textDocument/didChange', {
+        textDocument: { uri: pathToUri(absolute), version },
+        contentChanges: [{ text }],
+      });
+      existing.version = version;
+      existing.diagnostics = [];
+      existing.lastDiagnosticsAt = 0;
+    } else {
+      this.rpc.notify('textDocument/didOpen', {
+        textDocument: {
+          uri: pathToUri(absolute),
+          languageId: LEAN_LANGUAGE_ID,
+          version,
+          text,
+        },
+      });
+      this.openFiles.set(absolute, {
+        version,
+        diagnostics: [],
+        lastDiagnosticsAt: 0,
+        diagnosticsWaiters: [],
+      });
+    }
+  }
+
+  private async waitForDiagnosticsQuiet(absolute: string): Promise<void> {
+    const state = this.openFiles.get(absolute);
+    if (!state) return;
+    const start = Date.now();
+    while (Date.now() - start < DIAGNOSTICS_WAIT_MS) {
+      const sinceLast = state.lastDiagnosticsAt
+        ? Date.now() - state.lastDiagnosticsAt
+        : 0;
+      if (state.lastDiagnosticsAt && sinceLast >= DIAGNOSTICS_QUIET_WINDOW_MS) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          // Clean up the waiter entry on timeout.
+          const idx = state.diagnosticsWaiters.findIndex(
+            (w) => w.timeout === timeout,
+          );
+          if (idx >= 0) state.diagnosticsWaiters.splice(idx, 1);
+          resolve();
+        }, DIAGNOSTICS_QUIET_WINDOW_MS);
+        state.diagnosticsWaiters.push({ resolve, timeout });
+      });
+    }
+  }
+
+  private handlePublishDiagnostics(params: PublishDiagnosticsParams): void {
+    const uri = params.uri;
+    const absolute = uriToPath(uri);
+    if (!absolute) return;
+    const state = this.openFiles.get(absolute);
+    if (!state) return;
+    state.diagnostics = params.diagnostics.map(toLeanDiagnostic);
+    state.lastDiagnosticsAt = Date.now();
+    updateLeanServer(this.id, { touchActivity: true });
+    // Release any waiters — the quiet-window check above re-arms if needed.
+    for (const waiter of state.diagnosticsWaiters.splice(0)) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+  }
+}
+
+function toLeanDiagnostic(d: Diagnostic): LeanDiagnostic {
+  return {
+    // LSP `DiagnosticSeverity` (Error=1) matches the VS Code numeric severity
+    // (Error=0) shifted by one — translate to keep formatting consistent with
+    // the extension-mediated path. Default to Error if absent.
+    severity: lspSeverityToVsCode(d.severity ?? 1),
+    message: d.message,
+    range: {
+      start: { line: d.range.start.line, character: d.range.start.character },
+      end: { line: d.range.end.line, character: d.range.end.character },
+    },
+    source: d.source,
+  };
+}
+
+function lspSeverityToVsCode(severity: number): number {
+  // VS Code: Error=0, Warning=1, Information=2, Hint=3
+  // LSP:     Error=1, Warning=2, Information=3, Hint=4
+  return Math.max(0, severity - 1);
+}
+
+function pathToUri(absolute: string): string {
+  return pathToFileURL(absolute).toString();
+}
+
+function uriToPath(uri: string): string | null {
+  if (!uri.startsWith('file://')) return null;
+  try {
+    return new URL(uri).pathname.replace(/^\/([A-Za-z]:)/, '$1');
+  } catch {
+    return null;
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) clearTimeout(timer);
+    }),
+    timeout,
+  ]);
+}

--- a/src/tools/lean/leanConstants.ts
+++ b/src/tools/lean/leanConstants.ts
@@ -1,7 +1,7 @@
 /**
  * Shared constants and abstract command types for the Lean integration.
  *
- * Two adapters implement {@link LeanVscodeServices}: the VS Code path that
+ * Two adapters implement {@link LeanLanguageServices}: the VS Code path that
  * talks to the leanprover.lean4 extension, and the direct LSP path used by
  * the CLI and desktop builds. Both speak in terms of the abstract command
  * names declared here, so the underlying VS Code command IDs only live in

--- a/src/tools/lean/leanConstants.ts
+++ b/src/tools/lean/leanConstants.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared constants and abstract command types for the Lean integration.
+ *
+ * Two adapters implement {@link LeanVscodeServices}: the VS Code path that
+ * talks to the leanprover.lean4 extension, and the direct LSP path used by
+ * the CLI and desktop builds. Both speak in terms of the abstract command
+ * names declared here, so the underlying VS Code command IDs only live in
+ * the VS Code adapter.
+ */
+
+/** Marketplace ID of the Lean 4 VS Code extension. */
+export const LEAN4_EXTENSION_ID = 'leanprover.lean4';
+
+/** Per-file commands surfaced by `lean_file`. */
+export const LEAN_FILE_COMMANDS = ['restart', 'refresh_dependencies'] as const;
+export type LeanFileCommand = (typeof LEAN_FILE_COMMANDS)[number];
+
+/** Project-scope commands surfaced by `lean_project`. */
+export const LEAN_PROJECT_COMMANDS = [
+  // Server commands
+  'restart_server',
+  'stop_server',
+  // Project commands
+  'build',
+  'clean',
+  'fetch_cache',
+  'fetch_file_cache',
+  // Setup commands
+  'install_elan',
+  'install_deps',
+  'update_elan',
+  'select_toolchain',
+] as const;
+export type LeanProjectCommand = (typeof LEAN_PROJECT_COMMANDS)[number];
+
+/** Human-readable label for each server mode (used in the dashboard surface). */
+export const LEAN_SERVER_MODE_LABELS = {
+  'vscode-extension': LEAN4_EXTENSION_ID,
+  'direct-lsp': 'direct LSP',
+} as const;

--- a/src/tools/lean/leanLanguageServices.ts
+++ b/src/tools/lean/leanLanguageServices.ts
@@ -1,5 +1,5 @@
 /**
- * Injectable VS Code services for Lean tools.
+ * Injectable language services for Lean tools.
  *
  * Provides a seam between the platform-agnostic tool implementations
  * in `src/tools/lean/` and the host-specific integrations (VS Code
@@ -21,7 +21,7 @@ import type {
   PlainTermGoal,
 } from './leanTypes';
 
-export interface LeanVscodeServices {
+export interface LeanLanguageServices {
   executeFileCommand(
     command: LeanFileCommand,
     filePath: string,
@@ -49,15 +49,15 @@ export interface LeanVscodeServices {
   executeProjectCommand(command: LeanProjectCommand): Promise<void>;
 }
 
-let services: LeanVscodeServices | undefined;
+let services: LeanLanguageServices | undefined;
 
-export function setLeanVscodeServices(s: LeanVscodeServices): void {
+export function setLeanLanguageServices(s: LeanLanguageServices): void {
   services = s;
 }
 
-export function getLeanVscodeServices(): LeanVscodeServices {
+export function getLeanLanguageServices(): LeanLanguageServices {
   if (!services) {
-    throw new Error('Lean VS Code services not initialized');
+    throw new Error('Lean language services not initialized');
   }
   return services;
 }

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -54,6 +54,10 @@ export function listLeanServers(): readonly LeanServerInfo[] {
   return snapshot();
 }
 
+export function isLeanServerActive(info: LeanServerInfo): boolean {
+  return info.status === 'starting' || info.status === 'running';
+}
+
 export function subscribeLeanServers(listener: Listener): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
@@ -147,7 +151,7 @@ export function summarizeLeanServers(
   list: readonly LeanServerInfo[] = snapshot(),
   now: number = Date.now(),
 ): string {
-  if (list.length === 0) return 'No Lean servers active.';
+  if (list.length === 0) return 'No Lean servers registered.';
   const lines = list.map((info) => {
     const modeLabel = LEAN_SERVER_MODE_LABELS[info.mode];
     const toolchain = info.toolchain ? `, ${info.toolchain}` : '';
@@ -155,7 +159,7 @@ export function summarizeLeanServers(
   });
   const header =
     list.length === 1
-      ? '1 Lean server active:'
-      : `${list.length} Lean servers active:`;
+      ? '1 Lean server registered:'
+      : `${list.length} Lean servers registered:`;
   return [header, ...lines].join('\n');
 }

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -11,7 +11,9 @@
  * surface across all three builds.
  */
 
-export type LeanServerMode = 'vscode-extension' | 'direct-lsp';
+import { LEAN_SERVER_MODE_LABELS } from './leanConstants';
+
+export type LeanServerMode = keyof typeof LEAN_SERVER_MODE_LABELS;
 
 export type LeanServerStatus =
   | 'starting'
@@ -148,8 +150,7 @@ export function summarizeLeanServers(
 ): string {
   if (list.length === 0) return 'No Lean servers active.';
   const lines = list.map((info) => {
-    const modeLabel =
-      info.mode === 'vscode-extension' ? 'leanprover.lean4' : 'direct LSP';
+    const modeLabel = LEAN_SERVER_MODE_LABELS[info.mode];
     const toolchain = info.toolchain ? `, ${info.toolchain}` : '';
     return `• ${info.workspaceRoot} (${modeLabel}${toolchain})${statusTail(info, now)}`;
   });

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -15,11 +15,7 @@ import { LEAN_SERVER_MODE_LABELS } from './leanConstants';
 
 export type LeanServerMode = keyof typeof LEAN_SERVER_MODE_LABELS;
 
-export type LeanServerStatus =
-  | 'starting'
-  | 'running'
-  | 'error'
-  | 'stopped';
+export type LeanServerStatus = 'starting' | 'running' | 'error' | 'stopped';
 
 export interface LeanServerInfo {
   readonly id: string;
@@ -92,7 +88,10 @@ export interface UpdateLeanServerPatch {
   readonly errorMessage?: string;
 }
 
-export function updateLeanServer(id: string, patch: UpdateLeanServerPatch): void {
+export function updateLeanServer(
+  id: string,
+  patch: UpdateLeanServerPatch,
+): void {
   const existing = servers.get(id);
   if (!existing) return;
   servers.set(id, {

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -1,0 +1,162 @@
+/**
+ * Per-process registry of active Lean language servers.
+ *
+ * Two adapters write to this registry:
+ *   1. The VS Code integration (one virtual entry per Lean client provided by
+ *      the leanprover.lean4 extension).
+ *   2. The direct LSP adapter used by CLI/desktop builds (one entry per
+ *      `lake env lean --server` subprocess we spawn).
+ *
+ * The Tools dashboard reads from here so users see the same "running servers"
+ * surface across all three builds.
+ */
+
+export type LeanServerMode = 'vscode-extension' | 'direct-lsp';
+
+export type LeanServerStatus =
+  | 'starting'
+  | 'running'
+  | 'error'
+  | 'stopped';
+
+export interface LeanServerInfo {
+  readonly id: string;
+  readonly workspaceRoot: string;
+  readonly mode: LeanServerMode;
+  readonly status: LeanServerStatus;
+  readonly startedAt: number;
+  readonly lastActivityAt: number;
+  readonly toolchain?: string;
+  readonly pid?: number;
+  readonly errorMessage?: string;
+}
+
+type Listener = (snapshot: readonly LeanServerInfo[]) => void;
+
+const servers = new Map<string, LeanServerInfo>();
+const listeners = new Set<Listener>();
+
+function snapshot(): readonly LeanServerInfo[] {
+  return [...servers.values()].sort((a, b) =>
+    a.workspaceRoot.localeCompare(b.workspaceRoot),
+  );
+}
+
+function notify(): void {
+  const view = snapshot();
+  for (const listener of listeners) {
+    try {
+      listener(view);
+    } catch {
+      // Ignore listener failures so one bad observer can't break the others.
+    }
+  }
+}
+
+export function listLeanServers(): readonly LeanServerInfo[] {
+  return snapshot();
+}
+
+export function subscribeLeanServers(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export interface RegisterLeanServerInit {
+  id: string;
+  workspaceRoot: string;
+  mode: LeanServerMode;
+  status?: LeanServerStatus;
+  toolchain?: string;
+  pid?: number;
+}
+
+export function registerLeanServer(init: RegisterLeanServerInit): void {
+  const now = Date.now();
+  servers.set(init.id, {
+    id: init.id,
+    workspaceRoot: init.workspaceRoot,
+    mode: init.mode,
+    status: init.status ?? 'starting',
+    startedAt: now,
+    lastActivityAt: now,
+    toolchain: init.toolchain,
+    pid: init.pid,
+  });
+  notify();
+}
+
+export interface UpdateLeanServerPatch {
+  status?: LeanServerStatus;
+  toolchain?: string;
+  pid?: number;
+  errorMessage?: string;
+  touchActivity?: boolean;
+}
+
+export function updateLeanServer(id: string, patch: UpdateLeanServerPatch): void {
+  const existing = servers.get(id);
+  if (!existing) return;
+  servers.set(id, {
+    ...existing,
+    status: patch.status ?? existing.status,
+    toolchain: patch.toolchain ?? existing.toolchain,
+    pid: patch.pid ?? existing.pid,
+    errorMessage:
+      patch.status && patch.status !== 'error'
+        ? undefined
+        : (patch.errorMessage ?? existing.errorMessage),
+    lastActivityAt: patch.touchActivity ? Date.now() : existing.lastActivityAt,
+  });
+  notify();
+}
+
+export function unregisterLeanServer(id: string): void {
+  if (!servers.delete(id)) return;
+  notify();
+}
+
+/** Clear all entries — only used by tests and shutdown handlers. */
+export function clearLeanServerRegistry(): void {
+  if (servers.size === 0) return;
+  servers.clear();
+  notify();
+}
+
+export function formatUptime(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return `${hours}h ${remMinutes}m`;
+}
+
+export function summarizeLeanServers(
+  list: readonly LeanServerInfo[] = snapshot(),
+  now: number = Date.now(),
+): string {
+  if (list.length === 0) return 'No Lean servers active.';
+  const lines = list.map((info) => {
+    const uptime = formatUptime(now - info.startedAt);
+    const modeLabel =
+      info.mode === 'vscode-extension' ? 'leanprover.lean4' : 'direct LSP';
+    const toolchain = info.toolchain ? `, ${info.toolchain}` : '';
+    const tail =
+      info.status === 'error'
+        ? ` — error: ${info.errorMessage ?? 'unknown'}`
+        : info.status === 'running'
+          ? ` — uptime ${uptime}`
+          : info.status === 'starting'
+            ? ' — starting…'
+            : ' — stopped';
+    return `• ${info.workspaceRoot} (${modeLabel}${toolchain})${tail}`;
+  });
+  const header =
+    list.length === 1
+      ? '1 Lean server active:'
+      : `${list.length} Lean servers active:`;
+  return [header, ...lines].join('\n');
+}

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -25,7 +25,6 @@ export interface LeanServerInfo {
   readonly mode: LeanServerMode;
   readonly status: LeanServerStatus;
   readonly startedAt: number;
-  readonly lastActivityAt: number;
   readonly toolchain?: string;
   readonly pid?: number;
   readonly errorMessage?: string;
@@ -63,23 +62,21 @@ export function subscribeLeanServers(listener: Listener): () => void {
 }
 
 export interface RegisterLeanServerInit {
-  id: string;
-  workspaceRoot: string;
-  mode: LeanServerMode;
-  status?: LeanServerStatus;
-  toolchain?: string;
-  pid?: number;
+  readonly id: string;
+  readonly workspaceRoot: string;
+  readonly mode: LeanServerMode;
+  readonly status?: LeanServerStatus;
+  readonly toolchain?: string;
+  readonly pid?: number;
 }
 
 export function registerLeanServer(init: RegisterLeanServerInit): void {
-  const now = Date.now();
   servers.set(init.id, {
     id: init.id,
     workspaceRoot: init.workspaceRoot,
     mode: init.mode,
     status: init.status ?? 'starting',
-    startedAt: now,
-    lastActivityAt: now,
+    startedAt: Date.now(),
     toolchain: init.toolchain,
     pid: init.pid,
   });
@@ -87,11 +84,10 @@ export function registerLeanServer(init: RegisterLeanServerInit): void {
 }
 
 export interface UpdateLeanServerPatch {
-  status?: LeanServerStatus;
-  toolchain?: string;
-  pid?: number;
-  errorMessage?: string;
-  touchActivity?: boolean;
+  readonly status?: LeanServerStatus;
+  readonly toolchain?: string;
+  readonly pid?: number;
+  readonly errorMessage?: string;
 }
 
 export function updateLeanServer(id: string, patch: UpdateLeanServerPatch): void {
@@ -106,7 +102,6 @@ export function updateLeanServer(id: string, patch: UpdateLeanServerPatch): void
       patch.status && patch.status !== 'error'
         ? undefined
         : (patch.errorMessage ?? existing.errorMessage),
-    lastActivityAt: patch.touchActivity ? Date.now() : existing.lastActivityAt,
   });
   notify();
 }
@@ -134,25 +129,29 @@ export function formatUptime(ms: number): string {
   return `${hours}h ${remMinutes}m`;
 }
 
+function statusTail(info: LeanServerInfo, now: number): string {
+  switch (info.status) {
+    case 'error':
+      return ` — error: ${info.errorMessage ?? 'unknown'}`;
+    case 'running':
+      return ` — uptime ${formatUptime(now - info.startedAt)}`;
+    case 'starting':
+      return ' — starting…';
+    case 'stopped':
+      return ' — stopped';
+  }
+}
+
 export function summarizeLeanServers(
   list: readonly LeanServerInfo[] = snapshot(),
   now: number = Date.now(),
 ): string {
   if (list.length === 0) return 'No Lean servers active.';
   const lines = list.map((info) => {
-    const uptime = formatUptime(now - info.startedAt);
     const modeLabel =
       info.mode === 'vscode-extension' ? 'leanprover.lean4' : 'direct LSP';
     const toolchain = info.toolchain ? `, ${info.toolchain}` : '';
-    const tail =
-      info.status === 'error'
-        ? ` — error: ${info.errorMessage ?? 'unknown'}`
-        : info.status === 'running'
-          ? ` — uptime ${uptime}`
-          : info.status === 'starting'
-            ? ' — starting…'
-            : ' — stopped';
-    return `• ${info.workspaceRoot} (${modeLabel}${toolchain})${tail}`;
+    return `• ${info.workspaceRoot} (${modeLabel}${toolchain})${statusTail(info, now)}`;
   });
   const header =
     list.length === 1

--- a/src/tools/lean/leanVscodeServices.ts
+++ b/src/tools/lean/leanVscodeServices.ts
@@ -2,12 +2,18 @@
  * Injectable VS Code services for Lean tools.
  *
  * Provides a seam between the platform-agnostic tool implementations
- * in `src/tools/lean/` and the VS Code integration layer in `src/frontend/lean/`.
- * The services are registered during extension activation.
+ * in `src/tools/lean/` and the host-specific integrations (VS Code
+ * extension in `packages/extension/src/frontend/lean/`, direct LSP for
+ * CLI / desktop in `src/tools/lean/direct/`).
+ *
+ * The interface speaks in abstract command names; each adapter owns the
+ * mapping to its native primitives (VS Code command IDs vs `lake` /
+ * LSP requests).
  */
 
 import type { Hover } from 'vscode-languageserver-protocol';
 
+import type { LeanFileCommand, LeanProjectCommand } from './leanConstants';
 import type {
   LeanDiagnostic,
   LspResult,
@@ -17,7 +23,10 @@ import type {
 
 export interface LeanVscodeServices {
   getDiagnostics(filePath: string): LeanDiagnostic[];
-  executeFileCommand(command: string, filePath: string): Promise<boolean>;
+  executeFileCommand(
+    command: LeanFileCommand,
+    filePath: string,
+  ): Promise<boolean>;
   getGoalState(
     filePath: string,
     line: number,
@@ -38,7 +47,7 @@ export interface LeanVscodeServices {
     filePath: string,
     diagnostics: LeanDiagnostic[],
   ): Promise<void>;
-  executeGlobalCommand(commandId: string): Promise<void>;
+  executeProjectCommand(command: LeanProjectCommand): Promise<void>;
   promptLean4ExtensionInstall(): Promise<void>;
 }
 

--- a/src/tools/lean/leanVscodeServices.ts
+++ b/src/tools/lean/leanVscodeServices.ts
@@ -22,7 +22,6 @@ import type {
 } from './leanTypes';
 
 export interface LeanVscodeServices {
-  getDiagnostics(filePath: string): LeanDiagnostic[];
   executeFileCommand(
     command: LeanFileCommand,
     filePath: string,
@@ -48,7 +47,6 @@ export interface LeanVscodeServices {
     diagnostics: LeanDiagnostic[],
   ): Promise<void>;
   executeProjectCommand(command: LeanProjectCommand): Promise<void>;
-  promptLean4ExtensionInstall(): Promise<void>;
 }
 
 let services: LeanVscodeServices | undefined;

--- a/src/tools/setup/InstallVscodeExtensionTool.ts
+++ b/src/tools/setup/InstallVscodeExtensionTool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 // Local imports
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { ToolError, type ToolResult } from '@tools/result';
+import { LEAN4_EXTENSION_ID } from '@tools/lean/leanConstants';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -15,7 +16,7 @@ import { getSetupPlatform } from './platform';
  */
 const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
   LATEX_WORKSHOP_EXT_ID,
-  'leanprover.lean4',
+  LEAN4_EXTENSION_ID,
 ]);
 
 const InstallVscodeExtensionInputSchema = z.strictObject({


### PR DESCRIPTION
Closes #4197.

## Summary

- Adds a host-neutral direct-LSP adapter that spawns `lake env lean --server` lazily per Lake project root, so the five Lean tools (`lean_diagnostics`, `lean_file`, `lean_project`, `lean_inspect`, `lean_loogle`) work in the CLI and desktop builds with no `leanprover.lean4` extension required.
- VS Code path unchanged: the extension still registers its `LeanVscodeServices` implementation at activation and pipes through the same tools.
- A per-process Lean server registry surfaces the running servers (workspace path, mode, status, uptime) in the Tools dashboard's `lean4` card across all three builds.

## What's in this branch

- **`feat(lean): direct LSP adapter for CLI and desktop builds`** — core implementation.
  - `src/tools/lean/direct/jsonRpc.ts` — `Content-Length`-framed JSON-RPC over Node stdio. No `vscode-jsonrpc` dependency.
  - `src/tools/lean/direct/leanSession.ts` — one Lean LSP session per workspace root: handshake, lazy `textDocument/didOpen`, buffered `publishDiagnostics` with quiet-window detection.
  - `src/tools/lean/direct/lakeCommands.ts` — `lake build/clean/exe cache get` via subprocess with a per-workspace `Promise`-chain mutex.
  - `src/tools/lean/direct/directLspAdapter.ts` — implements `LeanVscodeServices`. Cached sessions, walk-up project-root detection (`lakefile.lean` / `lakefile.toml`).
  - `src/tools/lean/leanServerRegistry.ts` — both adapters report into this registry; the dashboard reads from it.
  - Wiring: `packages/cli/src/runtime/initPlatform.ts` registers the direct adapter; `packages/desktop/src/main/platform/index.ts` registers it and hooks `lifecycle.onShutdown(SHUTDOWN_PHASE.ON, ...)` for cleanup; VS Code path in `packages/extension/src/frontend/lean/VscodeIntegration.ts` reports observed clients into the registry too.
  - `externalToolDefs.ts` `lean4` entry: probe now accepts either the extension OR `lake` on PATH; `statusLabel` shows "N servers active"; `detailCheck` lists each active server.

- **`refactor(lean): drop dead fields, cap subprocess output`** — review cleanup. Removes unused `lastActivityAt`/`touchActivity`/`toolchainResolver`, merges duplicate `fetchCache`/`fetchFileCache` cases, flattens a 3-level ternary, caps `lake` stdout/stderr capture at 4 MiB, replaces the quadratic stderr splice with a 4 KiB tail.

- **`refactor(lean): SSOT command names + test-kernel suite`** — consolidation and tests.
  - New `src/tools/lean/leanConstants.ts` exports `LEAN4_EXTENSION_ID`, `LeanFileCommand` / `LeanProjectCommand` unions, and the `LEAN_SERVER_MODE_LABELS` lookup. Five prior duplicates resolve to this one constant.
  - `LeanVscodeServices` now takes abstract command names. `executeFileCommand` takes `LeanFileCommand`; `executeGlobalCommand` renamed to `executeProjectCommand` taking `LeanProjectCommand`. The VS Code command IDs (`lean4.project.build`, ...) live only inside the VS Code adapter; the direct adapter switches on the abstract command. Adding a sixth project command now only requires updating the constants file and each adapter's local mapping — no more parallel string contracts.

## Concurrency model

- **Different worktrees / different projects:** independent `lake env lean --server` processes per workspace root; nothing to coordinate.
- **Same workspace, multiple agents in one TeXRA process:** sessions are cached per workspace root, so all agents share one server. LSP queries are stateless and safe to interleave. `lake build` invocations serialize through the per-workspace mutex.
- **Same workspace, multiple TeXRA processes:** queries are read-only and safe; concurrent `lake build` invocations from different processes rely on Lake's own file locks (same posture as a user running `lake build` in a terminal while VS Code is open). A per-workspace daemon would generalize this further and is the natural Option-1 (MCP) migration path once MCP support lands.

## Test plan

### Tier 1 — automated, host-neutral (included in this PR)

29 vitest cases under `src/test-kernel/tools/lean/`. No real Lean toolchain required; run as part of the existing `npm run typecheck` / vitest pipeline.

- **`JsonRpcConnection.vitest.ts`** — Content-Length framing via in-memory `PassThrough` pairs:
  - request → response round-trip
  - server error → rejected promise
  - notification routing to subscribed handlers
  - frame reassembly across split chunks
  - two frames written back-to-back
  - server-to-client request handler reply
  - pending requests reject on `dispose`
- **`LeanServerRegistry.vitest.ts`** — registry mechanics + UI text:
  - register / update / unregister
  - `errorMessage` clears on transition out of `error`
  - snapshot sorted by workspace root
  - subscriber notifications + unsubscribe
  - no-op update on missing id doesn't fire listeners
  - `formatUptime` table-driven across the second/minute/hour boundaries
  - `summarizeLeanServers` empty case, running with uptime + toolchain, `leanprover.lean4` label in VS Code mode, and a mix of `starting`/`error`/`stopped` states
- **`DefaultResolveWorkspaceRoot.vitest.ts`** — walk-up detection over real temp directories:
  - finds `lakefile.lean` in the same directory
  - finds `lakefile.toml` two directories up
  - returns `null` when no lakefile in any ancestor
- **`LakeCommandsMutex.vitest.ts`** — per-workspace mutex semantics, using `node -e` as a stand-in for `lake`:
  - serializes two `serialize: true` calls against the same workspace
  - runs `serialize: true` calls across different workspaces in parallel (timing budget)
  - `serialize: false` calls against the same workspace also run in parallel

### Tier 2 — gated integration test (follow-up, requires `elan`/`lake`)

Single vitest gated on `lake --version` in `beforeAll`; skipped when absent. Fixture at `src/test-kernel/fixtures/lean-project/`:

- `lakefile.toml`
- `lean-toolchain` pinned to a known release
- `Test.lean` with `example : 1 + 1 = 2 := rfl` plus a deliberately broken second example

Cases:
- `fetchDiagnosticsForFile` returns the expected error on the broken example.
- `getGoalState` on a `sorry` returns a non-empty goal list.
- Dispose: child process exits and the registry entry clears.

Not included here because the main CI runner doesn't have `elan`; should land alongside a Lean-specific CI lane.

### Tier 3 — manual CLI / desktop smoke (run before tagging)

Recipe:

1. Launch `texra` (CLI) inside a real Lean project (a small lean4 example or mathlib4 checkout).
2. In the chat, ask the agent to run `lean_diagnostics` on a specific file.
3. Open the Tools dashboard (or `/tools`) and verify the **Lean 4 Proof Assistant** card shows `1 server active` with the project's absolute path under it.
4. Open a second TeXRA instance against a *different* Lean project, re-run a tool; verify two distinct entries appear in the registry.
5. `Ctrl-C` the CLI (or quit the desktop app); confirm `pgrep -af 'lake env lean --server'` shows no leftover processes.

For the VS Code build: same recipe inside VS Code with the leanprover.lean4 extension installed, verifying the dashboard surfaces the extension-mediated server (mode label `leanprover.lean4`) rather than the direct-LSP mode.

## Verified locally

- `npm run typecheck` — root, test-kernel, `texra`, `@texra/cli`, and `@texra/desktop` all green.
- `npm run lint` — no new warnings on touched files.
- `corepack pnpm vitest run` — 923/923 pass (894 prior + 29 new).
- `node packages/cli/scripts/check-host-imports.mjs` — confirms no `vscode` / `electron` leaks into the CLI build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCoELSA7jGzzx3TfpQ5RCt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Lean execution path that spawns and manages `lake env lean --server` subprocesses and hooks shutdown/signal handling, which could affect process lifecycle and resource cleanup across CLI/desktop builds.
> 
> **Overview**
> Enables Lean tools to run outside VS Code by introducing a **direct LSP adapter** that lazily spawns `lake env lean --server` per Lake project root, caches sessions, and supports diagnostics/hover/goal requests plus basic project commands via real `lake` subprocesses (with per-workspace serialization).
> 
> Unifies the Lean tool layer behind a new injectable `LeanLanguageServices` interface (replacing `LeanVscodeServices`) with shared command constants, updates the VS Code integration to map abstract commands to VS Code command IDs, and registers/cleans up Lean server entries in a new `leanServerRegistry` that also drives updated Lean tool availability/status messaging in `externalToolDefs`.
> 
> Wires the direct adapter into **CLI and desktop** platform initialization with lifecycle shutdown cleanup (and CLI signal handlers), ensures CLI always runs shutdown in `texra.ts`, and adds a focused Vitest suite covering JSON-RPC framing, session behavior, lake mutexing, workspace root resolution, registry behavior, and dashboard status labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c223120455528cf578ab60accdd53ef7a95f9a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->