### PR TITLE
docs(ui): rename external chat handoff to external inquiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **Odyssey mode** — let an agent run a long task to completion on its own. A budget auto-pauses the run for your approval before going further, and a dedicated panel shows progress so you can step in any time.
-- **Integrations settings tab** — a new **Settings → Integrations** tab groups external agent integrations (Codex CLI, Claude Code CLI, external chat handoff) in one place, with reasoning-effort and adaptive-thinking controls for Claude Code CLI.
+- **Integrations settings tab** — a new **Settings → Integrations** tab groups external agent integrations (Codex CLI, Claude Code CLI, External Inquiry) in one place, with reasoning-effort and adaptive-thinking controls for Claude Code CLI.
 - **Ask-user-question tool** — agents can now ask you a multiple-choice question mid-run instead of guessing.
 - **Ink-based CLI TUI is the default** — `texra chat` now uses the Ink TUI for interactive sessions, with a
   multi-pane layout, structured slash forms, persistent input history, and shared key hints. Deprecated renderer flags

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -75,9 +75,9 @@ Set `texra.bib.defaultPath` in your VS Code settings (<wa-icon library="texra" n
 
 The `research` agent can call `wolfram` to run Wolfram Language code and check symbolic algebra, integrals, or limits before you commit them to the manuscript. Requires a local [Wolfram Engine](https://www.wolfram.com/engine/); status shows on **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>) → **Computation** (<wa-icon library="texra" name="symbol-operator"></wa-icon>).
 
-### <wa-icon library="texra" name="comment-discussion"></wa-icon> Ask Another Model for a Second Opinion
+### <wa-icon library="texra" name="comment-discussion"></wa-icon> External Inquiry
 
-The `inquiry` tool lets a TeXRA agent dispatch a question to an external chat (ChatGPT, Claude, Gemini) via a copy/paste hand-off so you can bring a second opinion into the loop without switching windows. Dispatch is non-blocking — the agent's cycle continues while you fetch the answer, and resumes automatically once you paste it back (even after a reload). No API key required — uses your existing subscription.
+The `inquiry` tool lets a TeXRA agent ask one question in an external chat (ChatGPT, Claude, Gemini) through a copy/paste flow, then resume with the answer. Dispatch is non-blocking: the agent's cycle continues while you fetch the answer, and resumes automatically once you paste it back (even after a reload). No API key required — it uses your existing subscription. In the CLI, the same flow appears as a terminal modal: paste the prepared question into your chat subscription, then paste the answer back into TeXRA.
 
 ## Which Agent to Use
 

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -1,6 +1,6 @@
 /**
  * AI Agents tab — shows third-party agent integrations (Codex, Claude Code,
- * external chat handoffs) grouped on their own panel. Reuses the same
+ * external inquiries) grouped on their own panel. Reuses the same
  * `tool-card` component as the Tools tab, plus the Codex-specific inline
  * settings that used to live inside ToolsTab.
  */

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -338,12 +338,12 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   {
     id: 'external-inquiry',
     tools: ['inquiry'],
-    name: 'External Chat Handoff',
+    name: 'External Inquiry',
     category: 'ai-agents',
     description:
       'Tap your premium chat subscriptions — ChatGPT Pro, Claude Opus, Gemini Deep Think, Grok, and similar — without an API key. The agent drafts a question, you paste the answer back, and the run continues. Useful for the deep-reasoning tiers that aren’t available through the API.',
     configNotes:
-      'No local install required. Uses your own external chat subscription and a human-in-the-loop copy/paste flow.',
+      'No local install required. Uses your own external chat subscription through a human-in-the-loop copy/paste flow.',
     authNote: 'Uses your premium chat subscription',
     toggleable: true,
     check: async () => true,


### PR DESCRIPTION
## Summary

Closes #4294.

This adopts **External Inquiry** as the user-facing name for the `inquiry` tool surface. The name matches the existing modal/tool terminology and avoids implying that the user leaves TeXRA permanently; the agent asks one external question, then resumes with the pasted answer.

## Changes

- Rename the Settings/Integrations tool card from “External Chat Handoff” to “External Inquiry”.
- Update Settings tab source copy and changelog wording that used the old handoff language.
- Update the research-tools guide heading and description.
- Document the CLI decision: keep the CLI flow enabled as the existing terminal copy/paste modal, with explicit guidance that the user pastes the prepared question into their chat subscription and then pastes the answer back into TeXRA.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors, 18 existing warnings)

Note: the older `src/test/tools/externalToolDefs.test.ts` path is outside the current Vitest include pattern (`src/test-kernel/**/*.vitest.{ts,mts}`), so there was no runnable focused test for this string-only tool definition change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a terminology/copy update only, renaming the `inquiry` integration in UI/docs without changing tool behavior or data flow.
> 
> **Overview**
> Renames the user-facing `inquiry` integration from **External Chat Handoff** to **External Inquiry** across the changelog, documentation, and Settings → Integrations UI copy.
> 
> Updates the tool dashboard metadata (`external-inquiry` in `externalToolDefs.ts`) and guide wording to better describe the copy/paste external-chat flow (including explicitly documenting the CLI modal workflow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fe4d4fc10c654293f5485cf1e7724f50a6a50e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->