### PR TITLE
fix(cli): show resume command in exit hint

### DIFF
--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -131,6 +131,7 @@ Resume a stored execution configuration headlessly:
 
 ```bash
 texra resume <id>
+texra --resume <id>
 ```
 
 The interactive chat also accepts `/resume`. With no id it prints recent

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -30,6 +30,7 @@ export interface StatusBarSegment {
 export interface StatusBarDisplayInput {
   readonly status: string | undefined;
   readonly pendingExitHint: boolean;
+  readonly pendingExitResumeId: string | undefined;
   readonly bypass: BypassState;
   readonly queuedFollowUps: number;
   readonly usage: TokenUsageStats | undefined;
@@ -186,7 +187,10 @@ export function buildStatusBarDisplay(
       input.queuedFollowUps > 0
         ? `queued: ${input.queuedFollowUps}`
         : undefined,
-    bindings: statusBarBindingsText(input.subagentControlsAvailable),
+    bindings:
+      input.pendingExitHint && input.pendingExitResumeId
+        ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
+        : statusBarBindingsText(input.subagentControlsAvailable),
   };
 }
 
@@ -199,11 +203,13 @@ export function StatusBar(): React.JSX.Element {
   const streams = useSignal(cliState.streams);
   const sessionMeta = useSignal(cliState.sessionMeta);
   const pendingExitHint = useSignal(cliState.pendingExitHint);
+  const pendingExitResumeId = useSignal(cliState.pendingExitResumeId);
   const approvals = useSignal(approvalQueueDepth);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const display = buildStatusBarDisplay({
     status: slice?.status,
     pendingExitHint,
+    pendingExitResumeId,
     bypass: slice?.bypass ?? NO_BYPASS,
     queuedFollowUps: slice?.queuedFollowUps ?? 0,
     usage: slice?.usage,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -22,6 +22,7 @@ import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { generateExecutionId } from '@utils/core/executionId';
 
 import { type CliContext, readCliVersion } from '../../runtime/cliContext';
 import { hasCliApprovalDenied } from '../../runtime/approvalAdapter';
@@ -89,12 +90,26 @@ export interface RunChatInit {
   readonly modelOverride?: string;
 }
 
-interface TuiSession {
+export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
+  executionId: string | undefined;
   runPromise: Promise<void> | undefined;
   runExitCode: CliExitCode;
   runCompleted: boolean;
   stopRequested: boolean;
+}
+
+interface TuiSession extends ClearableTuiSessionState {}
+
+export function clearTuiSessionRunState(
+  session: ClearableTuiSessionState,
+): void {
+  session.streamId = undefined;
+  session.executionId = undefined;
+  session.runPromise = undefined;
+  session.runExitCode = CliExitCode.Success;
+  session.runCompleted = false;
+  session.stopRequested = false;
 }
 
 export function chatTuiCanInterruptActiveRun(session: {
@@ -549,6 +564,7 @@ export async function runChat(
 
   const session: TuiSession = {
     streamId: undefined,
+    executionId: undefined,
     runPromise: undefined,
     runExitCode: CliExitCode.Success,
     runCompleted: false,
@@ -589,11 +605,7 @@ export async function runChat(
     if (isRunPending) interruptActive();
     clearApprovals();
     followUpQueue.clear();
-    session.streamId = undefined;
-    session.runPromise = undefined;
-    session.runExitCode = CliExitCode.Success;
-    session.runCompleted = false;
-    session.stopRequested = false;
+    clearTuiSessionRunState(session);
     resetCliState(meta);
   };
 
@@ -610,10 +622,12 @@ export async function runChat(
     const wrapped = wrapRuntimeHost(runtimeHost);
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
     disposers.push(unbindApprovals);
+    const executionId = generateExecutionId();
+    session.executionId = executionId;
 
     session.runPromise = setCliHelperModel(currentModel)
       .then(() =>
-        executeAgent(config, undefined, {
+        executeAgent(config, executionId, {
           runtimeHost: wrapped,
           enforceCategory: true,
           onStreamResolved: (resolvedStreamId) => {
@@ -784,6 +798,7 @@ export async function runChat(
     pendingExitTimer = undefined;
     exitArmed = false;
     cliState.pendingExitHint.set(false);
+    cliState.pendingExitResumeId.set(undefined);
   };
   const removeProcessHandlers = (): void => {
     process.off('SIGINT', handleSigint);
@@ -800,6 +815,7 @@ export async function runChat(
   const armExit = (): void => {
     exitArmed = true;
     cliState.pendingExitHint.set(true);
+    cliState.pendingExitResumeId.set(session.executionId);
     if (pendingExitTimer) clearTimeout(pendingExitTimer);
     pendingExitTimer = setTimeout(clearPendingExit, 800);
   };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -129,6 +129,7 @@ const SLASH_PALETTE_OPEN = signal<boolean>(false);
 const REVERSE_SEARCH_OPEN = signal<boolean>(false);
 
 const PENDING_EXIT_HINT = signal<boolean>(false);
+const PENDING_EXIT_RESUME_ID = signal<string | undefined>(undefined);
 
 const RESET_HOOKS = new Set<() => void>();
 
@@ -143,6 +144,9 @@ export const cliState = {
   slashPaletteOpen: SLASH_PALETTE_OPEN as Signal.State<boolean>,
   reverseSearchOpen: REVERSE_SEARCH_OPEN as Signal.State<boolean>,
   pendingExitHint: PENDING_EXIT_HINT as Signal.State<boolean>,
+  pendingExitResumeId: PENDING_EXIT_RESUME_ID as Signal.State<
+    string | undefined
+  >,
 };
 
 export const NO_BYPASS: BypassState = { toolEdit: false, superYolo: false };
@@ -231,6 +235,7 @@ export function resetCliState(sessionMeta = defaultSessionMeta()): void {
   cliState.slashPaletteOpen.set(false);
   cliState.reverseSearchOpen.set(false);
   cliState.pendingExitHint.set(false);
+  cliState.pendingExitResumeId.set(undefined);
   for (const resetHook of RESET_HOOKS) resetHook();
 }
 

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -1576,8 +1576,25 @@ export function reorderGlobalFlags(rawArgs: readonly string[]): string[] {
 
 export function normalizeRootShortcuts(rawArgs: readonly string[]): string[] {
   const { leadingGlobals, restIndex } = collectLeadingGlobalFlags(rawArgs);
-  if (rawArgs[restIndex] !== '--logout') return [...rawArgs];
-  return ['logout', ...leadingGlobals, ...rawArgs.slice(restIndex + 1)];
+  const shortcut = rawArgs[restIndex];
+  if (shortcut === '--logout') {
+    return ['logout', ...leadingGlobals, ...rawArgs.slice(restIndex + 1)];
+  }
+  if (shortcut === '--resume') {
+    const id = rawArgs[restIndex + 1];
+    if (!id || id.startsWith('-')) {
+      return ['resume', ...leadingGlobals, ...rawArgs.slice(restIndex + 1)];
+    }
+    return ['resume', id, ...leadingGlobals, ...rawArgs.slice(restIndex + 2)];
+  }
+  if (shortcut?.startsWith('--resume=')) {
+    const id = shortcut.slice('--resume='.length);
+    if (!id) {
+      return ['resume', ...leadingGlobals, ...rawArgs.slice(restIndex + 1)];
+    }
+    return ['resume', id, ...leadingGlobals, ...rawArgs.slice(restIndex + 1)];
+  }
+  return [...rawArgs];
 }
 
 function isCliError(error: unknown): error is Error & { code?: string } {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -73,6 +73,26 @@ describe('CLI root argument routing', () => {
     ]);
   });
 
+  it('routes top-level --resume to the resume subcommand', () => {
+    expect(normalizeRootShortcuts(['--resume', 'abc123'])).toEqual([
+      'resume',
+      'abc123',
+    ]);
+  });
+
+  it('routes inline top-level --resume values to the resume subcommand', () => {
+    expect(normalizeRootShortcuts(['--resume=abc123'])).toEqual([
+      'resume',
+      'abc123',
+    ]);
+  });
+
+  it('preserves global flags when routing top-level --resume', () => {
+    expect(
+      normalizeRootShortcuts(['--output-format', 'json', '--resume', 'abc123']),
+    ).toEqual(['resume', 'abc123', '--output-format', 'json']);
+  });
+
   it('does not rewrite unknown leading flags before --logout', () => {
     expect(normalizeRootShortcuts(['--unknown', '--logout'])).toEqual([
       '--unknown',

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -13,6 +13,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,
       pendingExitHint: false,
+      pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
       queuedFollowUps: 0,
       usage: undefined,
@@ -41,6 +42,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,
       pendingExitHint: false,
+      pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
       queuedFollowUps: 2,
       usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
@@ -71,6 +73,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,
       pendingExitHint: false,
+      pendingExitResumeId: undefined,
       bypass: { superYolo: true, toolEdit: true },
       queuedFollowUps: 0,
       usage: undefined,
@@ -98,5 +101,32 @@ describe('CLI StatusBar display model', () => {
       badge: true,
       badgeColor: 'yellow',
     });
+  });
+
+  it('shows the resume command while exit confirmation is armed', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: true,
+      pendingExitResumeId: 'abc123',
+      bypass: NO_BYPASS,
+      queuedFollowUps: 0,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'Press Ctrl-C again to exit',
+      'api',
+    ]);
+    expect(display.bindings).toBe(
+      'Resume this session with: texra --resume abc123',
+    );
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -46,7 +46,11 @@ import {
   splitTranscriptEntries,
 } from '../../../packages/cli/src/chat/tui/panes/ConversationPane';
 import { renderAnsiMarkdown } from '../../../packages/cli/src/chat/tui/render/ansiMarkdown';
-import { chatTuiCanInterruptActiveRun } from '../../../packages/cli/src/chat/tui/runChatTui';
+import {
+  chatTuiCanInterruptActiveRun,
+  clearTuiSessionRunState,
+} from '../../../packages/cli/src/chat/tui/runChatTui';
+import { CliExitCode } from '../../../packages/cli/src/runtime/exitCodes';
 import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
@@ -269,6 +273,28 @@ describe('CLI TUI row allocation', () => {
         streamId: root,
       }),
     ).toBe(true);
+  });
+
+  it('clears stale resume ids when clearing chat session run state', () => {
+    const session = {
+      streamId: root,
+      executionId: 'old-execution',
+      runPromise: Promise.resolve(),
+      runExitCode: CliExitCode.Interrupted,
+      runCompleted: true,
+      stopRequested: true,
+    };
+
+    clearTuiSessionRunState(session);
+
+    expect(session).toMatchObject({
+      streamId: undefined,
+      executionId: undefined,
+      runPromise: undefined,
+      runExitCode: 0,
+      runCompleted: false,
+      stopRequested: false,
+    });
   });
 });
 


### PR DESCRIPTION
Closes #4300.

## Summary
- Preallocate the chat TUI execution id when a run starts so the exit path can show the resumable session id before final output arrives.
- Replace the normal keybinding footer during the Ctrl-C confirmation window with `Resume this session with: texra --resume <id>`.
- Add a top-level `texra --resume <id>` alias that routes to the existing `texra resume <id>` implementation, including support for `--resume=<id>`.
- Clear the resume hint whenever the pending exit confirmation is cleared, and document the alias in the CLI guide.

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 18 existing warnings)
- `corepack pnpm --filter @texra/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes touch interactive TUI lifecycle and CLI argument routing, which can affect session interruption/cleanup and command parsing, but scope is contained and covered by new tests.
> 
> **Overview**
> **Improves Ctrl-C exit UX in `texra chat`** by preallocating an `executionId` at run start and surfacing it during the exit-confirmation window so users can immediately resume the session.
> 
> The StatusBar now swaps its normal keybinding footer for a *resume hint* (`texra --resume <id>`) while exit is armed, and TUI state/handlers clear this resume id when the pending-exit hint is cleared or the session is reset.
> 
> Adds a top-level `--resume` shortcut (including `--resume=<id>`) that routes to the existing `resume` subcommand while preserving leading global flags, updates docs, and extends vitest coverage for the new routing and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d001b590f7656a0eaf4aa798451749df4c13971c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->