### PR TITLE
fix(cli): add resume picker to chat TUI

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -1,0 +1,173 @@
+// `/resume` form. It lists recent execution configurations that can be
+// restarted in the current chat TUI.
+
+import { Box, Text, useInput } from 'ink';
+import { Spinner } from '@inkjs/ui';
+import { useEffect, useState } from 'react';
+
+import type { ExecutionId } from '@shared/schemas';
+
+import {
+  listCliHistoryEntries,
+  type CliHistoryEntry,
+} from '../../../runtime/history';
+import { KeyHints } from '../ui/KeyHints';
+import { Select } from '../ui/Select';
+
+export interface ResumeListFormProps {
+  readonly availableRows?: number;
+  readonly onSelect: (value: ExecutionId) => void;
+  readonly onClose: () => void;
+}
+
+export function resumeSelectWindow({
+  availableRows,
+  itemCount,
+}: {
+  readonly availableRows: number | undefined;
+  readonly itemCount: number;
+}): {
+  readonly maxVisibleItems: number | undefined;
+  readonly showOverflow: boolean;
+} {
+  if (availableRows == null) {
+    return { maxVisibleItems: undefined, showOverflow: false };
+  }
+
+  const selectRows = Math.max(1, availableRows - 7);
+  if (itemCount <= selectRows) {
+    return { maxVisibleItems: itemCount, showOverflow: false };
+  }
+  if (selectRows < 3) {
+    return { maxVisibleItems: selectRows, showOverflow: false };
+  }
+  return { maxVisibleItems: Math.max(1, selectRows - 2), showOverflow: true };
+}
+
+export function resumeEntryDescription(entry: CliHistoryEntry): string {
+  const input = entry.inputBasename === '-' ? 'no input' : entry.inputBasename;
+  return `${entry.timestamp}; ${entry.agent}; ${entry.status}; ${input}`;
+}
+
+function ResumeFrame(props: {
+  readonly color: string;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={props.color}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={props.color}>
+        {props.title}
+      </Text>
+      {props.children}
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[{ key: 'Esc', action: 'close' }]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
+  const [entries, setEntries] = useState<readonly CliHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useInput((_input, key) => {
+    if ((loading || error || entries.length === 0) && key.escape) {
+      props.onClose();
+    }
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void listCliHistoryEntries()
+      .then((nextEntries) => {
+        if (cancelled) return;
+        setEntries(nextEntries.slice(0, 50));
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <ResumeFrame color="cyan" title="/resume">
+        <Spinner label="Loading execution history..." />
+      </ResumeFrame>
+    );
+  }
+
+  if (error) {
+    return (
+      <ResumeFrame color="red" title="/resume - error">
+        <Text>{error}</Text>
+      </ResumeFrame>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <ResumeFrame color="yellow" title="/resume">
+        <Text>No execution history found.</Text>
+      </ResumeFrame>
+    );
+  }
+
+  const selectWindow = resumeSelectWindow({
+    availableRows: props.availableRows,
+    itemCount: entries.length,
+  });
+  const items = entries.map((entry) => ({
+    value: entry.id,
+    label: entry.id,
+    description: resumeEntryDescription(entry),
+  }));
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        /resume
+      </Text>
+      <Text dimColor>Choose a stored execution configuration.</Text>
+      <Box marginTop={1}>
+        <Select
+          items={items}
+          maxVisibleItems={selectWindow.maxVisibleItems}
+          showOverflow={selectWindow.showOverflow}
+          onSelect={props.onSelect}
+          onCancel={props.onClose}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: '1-9/Enter', action: 'resume' },
+            { key: 'Esc', action: 'close' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -21,7 +21,11 @@ import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { type CliContext, readCliVersion } from '../../runtime/cliContext';
@@ -43,12 +47,7 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../../runtime/approvalPolicy';
-import {
-  formatCliHistoryText,
-  listCliHistoryEntries,
-  parseCliHistoryId,
-  readCliHistoryConfig,
-} from '../../runtime/history';
+import { parseCliHistoryId, readCliHistoryConfig } from '../../runtime/history';
 import { App } from './App';
 import { AgentListForm } from './forms/AgentListForm';
 import { ApiModeForm } from './forms/ApiModeForm';
@@ -57,6 +56,7 @@ import {
   formatApprovalPolicyForCli as formatApprovalPolicy,
 } from './forms/ApprovalPolicyForm';
 import { ModelListForm } from './forms/ModelListForm';
+import { ResumeListForm } from './forms/ResumeListForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { listSlashCommands, parseSlashInput } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
@@ -350,6 +350,43 @@ function applyCliApprovalPolicySelection(
   );
 }
 
+async function resumeStoredExecution(
+  id: ExecutionId,
+  context: SlashCommandContext,
+): Promise<void> {
+  if (context.session.runPromise) {
+    appendLocalAssistantTranscript(
+      'Finish the active chat before resuming a stored execution.',
+    );
+    return;
+  }
+  const config = await readCliHistoryConfig(id);
+  if (!config) {
+    appendLocalAssistantTranscript(`Execution not found: ${id}`);
+    return;
+  }
+  context.startStoredExecution(config);
+  appendLocalAssistantTranscript(`Resuming execution ${id}.`);
+}
+
+function openCliResumeListForm(context: SlashCommandContext): void {
+  cliState.activeForm.set({
+    commandName: 'resume',
+    render: (close, availableRows) => (
+      <ResumeListForm
+        availableRows={availableRows}
+        onSelect={(id) => {
+          close();
+          void resumeStoredExecution(id, context).catch((error: unknown) => {
+            appendLocalAssistantTranscript(toErrorMessage(error));
+          });
+        }}
+        onClose={close}
+      />
+    ),
+  });
+}
+
 async function handleTuiSlashCommand(
   line: string,
   context: SlashCommandContext,
@@ -437,17 +474,7 @@ async function handleTuiSlashCommand(
     }
     case 'resume': {
       if (!rest) {
-        const entries = (await listCliHistoryEntries()).slice(0, 20);
-        appendLocalAssistantTranscript(
-          entries.length
-            ? [
-                'Recent executions:',
-                formatCliHistoryText(entries),
-                '',
-                'Usage: /resume <id>',
-              ].join('\n')
-            : 'No execution history found.',
-        );
+        openCliResumeListForm(context);
         return true;
       }
       const id = parseCliHistoryId(rest);
@@ -455,19 +482,7 @@ async function handleTuiSlashCommand(
         appendLocalAssistantTranscript(`Invalid execution id: ${rest}`);
         return true;
       }
-      if (context.session.runPromise) {
-        appendLocalAssistantTranscript(
-          'Finish the active chat before resuming a stored execution.',
-        );
-        return true;
-      }
-      const config = await readCliHistoryConfig(id);
-      if (!config) {
-        appendLocalAssistantTranscript(`Execution not found: ${id}`);
-        return true;
-      }
-      context.startStoredExecution(config);
-      appendLocalAssistantTranscript(`Resuming execution ${id}.`);
+      await resumeStoredExecution(id, context);
       return true;
     }
     default: {

--- a/src/test-kernel/cli/ResumeListForm.vitest.mts
+++ b/src/test-kernel/cli/ResumeListForm.vitest.mts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resumeEntryDescription,
+  resumeSelectWindow,
+} from '../../../packages/cli/src/chat/tui/forms/ResumeListForm';
+
+describe('CLI ResumeListForm row budget', () => {
+  it('windows long execution lists inside the available foreground rows', () => {
+    expect(resumeSelectWindow({ availableRows: 10, itemCount: 12 })).toEqual({
+      maxVisibleItems: 1,
+      showOverflow: true,
+    });
+  });
+
+  it('uses the full list when it fits', () => {
+    expect(resumeSelectWindow({ availableRows: 12, itemCount: 4 })).toEqual({
+      maxVisibleItems: 4,
+      showOverflow: false,
+    });
+  });
+});
+
+describe('CLI ResumeListForm labels', () => {
+  it('summarizes the execution facts needed to choose a run', () => {
+    expect(
+      resumeEntryDescription({
+        id: 'abc',
+        timestamp: '2026-05-20T21:00:00.000Z',
+        agent: 'polish',
+        model: 'deepseekT',
+        status: 'completed',
+        inputBasename: 'paper.tex',
+      }),
+    ).toBe('2026-05-20T21:00:00.000Z; polish; completed; paper.tex');
+  });
+});


### PR DESCRIPTION
Part of #4277.

## Summary
- Replace the no-argument `/resume` transcript dump with an Ink picker over recent stored executions.
- Reuse the existing `/resume <id>` stored-execution path when a picker row is selected, including active-run and missing-config checks.
- Add a focused row-budget and row-description test for the new picker.

This intentionally handles only the `/resume` picker slice of #4277; `/memory`, multi-agent parity, and `/compact` remain separate work.

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/ResumeListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 18 existing warnings)
- `corepack pnpm --filter @texra/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Ink form and refactors `/resume` handling without changing storage formats or execution semantics; main risk is minor UI/interaction regressions in the chat TUI.
> 
> **Overview**
> Replaces the no-argument `/resume` transcript dump in the chat TUI with an Ink-based picker (`ResumeListForm`) that loads recent executions, shows a concise per-run description, and supports windowing/overflow based on available terminal rows.
> 
> Refactors the resume flow in `runChatTui.tsx` to reuse a shared `resumeStoredExecution` helper for both picker selections and `/resume <id>`, preserving existing guards (active run, missing config) and adding a small Vitest suite covering row budgeting and description formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6900dbe363fb12f9c2416258e75294b4661b9910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->