### PR TITLE
fix(cli): reject unknown subcommands

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -1518,6 +1518,26 @@ interface LeadingGlobalFlags {
   readonly stoppedOnUnknownFlag: boolean;
 }
 
+function knownGlobalFlagTokenCount(
+  rawArgs: readonly string[],
+  index: number,
+): number | undefined {
+  const arg = rawArgs[index];
+  if (arg === undefined || !arg.startsWith('-') || arg === '--') {
+    return undefined;
+  }
+
+  const inline = arg.includes('=');
+  const baseFlag = inline ? arg.slice(0, arg.indexOf('=')) : arg;
+  if (GLOBAL_BOOL_FLAGS.has(baseFlag)) {
+    return 1;
+  }
+  if (GLOBAL_VALUE_FLAGS.has(baseFlag)) {
+    return inline || rawArgs[index + 1] === undefined ? 1 : 2;
+  }
+  return undefined;
+}
+
 function collectLeadingGlobalFlags(
   rawArgs: readonly string[],
 ): LeadingGlobalFlags {
@@ -1528,25 +1548,14 @@ function collectLeadingGlobalFlags(
     if (arg === undefined) break;
     if (!arg.startsWith('-')) break;
     if (arg === '--') break;
-    const inline = arg.includes('=');
-    const baseFlag = inline ? arg.slice(0, arg.indexOf('=')) : arg;
-    if (GLOBAL_BOOL_FLAGS.has(baseFlag)) {
-      leadingGlobals.push(arg);
-      i += 1;
+
+    const tokenCount = knownGlobalFlagTokenCount(rawArgs, i);
+    if (tokenCount !== undefined) {
+      leadingGlobals.push(...rawArgs.slice(i, i + tokenCount));
+      i += tokenCount;
       continue;
     }
-    if (GLOBAL_VALUE_FLAGS.has(baseFlag)) {
-      leadingGlobals.push(arg);
-      i += 1;
-      if (!inline) {
-        const value = rawArgs[i];
-        if (value !== undefined) {
-          leadingGlobals.push(value);
-          i += 1;
-        }
-      }
-      continue;
-    }
+
     return { leadingGlobals, restIndex: i, stoppedOnUnknownFlag: true };
   }
   return { leadingGlobals, restIndex: i, stoppedOnUnknownFlag: false };
@@ -1621,16 +1630,22 @@ function isCliError(error: unknown): error is Error & { code?: string } {
 // `showUsage` accept either width via cast at the call site.
 type AnyCommand = CommandDef<any>;
 
+async function commandSubCommands(
+  cmd: AnyCommand,
+): Promise<Record<string, AnyCommand> | undefined> {
+  const rawSubs = cmd.subCommands;
+  if (!rawSubs) return undefined;
+  return typeof rawSubs === 'function'
+    ? await (rawSubs as () => Promise<Record<string, AnyCommand>>)()
+    : ((await rawSubs) as Record<string, AnyCommand>);
+}
+
 async function resolveDeepestSubCommand(
   cmd: AnyCommand,
   rawArgs: readonly string[],
   parent?: AnyCommand,
 ): Promise<[AnyCommand, AnyCommand | undefined]> {
-  const rawSubs = cmd.subCommands;
-  const subCommands =
-    typeof rawSubs === 'function'
-      ? await (rawSubs as () => Promise<Record<string, AnyCommand>>)()
-      : ((await rawSubs) as Record<string, AnyCommand> | undefined);
+  const subCommands = await commandSubCommands(cmd);
   if (!subCommands) return [cmd, parent];
   for (let i = 0; i < rawArgs.length; i++) {
     const token = rawArgs[i];
@@ -1641,6 +1656,66 @@ async function resolveDeepestSubCommand(
     break;
   }
   return [cmd, parent];
+}
+
+export interface UnknownCliCommand {
+  readonly typedCommand: string;
+  readonly helpCommand: string;
+}
+
+function isPureSubCommandContainer(
+  cmd: AnyCommand,
+  subCommands: Record<string, AnyCommand>,
+): boolean {
+  return (
+    Object.keys(subCommands).length > 0 &&
+    typeof (cmd as { run?: unknown }).run !== 'function'
+  );
+}
+
+export async function detectUnknownCliCommand(
+  rawArgs: readonly string[],
+): Promise<UnknownCliCommand | undefined> {
+  let cmd = rootCommand as AnyCommand;
+  const pathParts = ['texra'];
+
+  for (let i = 0; i < rawArgs.length; ) {
+    const token = rawArgs[i];
+    if (token === undefined || token === '--') break;
+
+    if (token.startsWith('-')) {
+      const tokenCount = knownGlobalFlagTokenCount(rawArgs, i);
+      if (tokenCount === undefined) return undefined;
+      i += tokenCount;
+      continue;
+    }
+
+    const subCommands = await commandSubCommands(cmd);
+    if (!subCommands) return undefined;
+
+    const next = subCommands[token];
+    if (next) {
+      cmd = next;
+      pathParts.push(token);
+      i += 1;
+      continue;
+    }
+
+    if (isPureSubCommandContainer(cmd, subCommands)) {
+      return {
+        typedCommand: [...pathParts, token].join(' '),
+        helpCommand: pathParts.join(' '),
+      };
+    }
+
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function formatUnknownCliCommand(command: UnknownCliCommand): string {
+  return `Unknown command: ${command.typedCommand}. Run \`${command.helpCommand} --help\` for usage.`;
 }
 
 /**
@@ -1674,6 +1749,12 @@ export async function runCli(
   ) {
     writeTextStdout(await readCliVersion());
     return { exitCode: CliExitCode.Success };
+  }
+
+  const unknownCommand = await detectUnknownCliCommand(rawArgs);
+  if (unknownCommand) {
+    writeTextStderr(formatUnknownCliCommand(unknownCommand));
+    return { exitCode: CliExitCode.Usage };
   }
 
   try {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -10,9 +10,11 @@ import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 import {
   cliTerminalStatus,
   collectStringFlagValues,
+  detectUnknownCliCommand,
   doctorPlatformInitContext,
   expandWorkflowInputSpecs,
   formatCliModelListError,
+  formatUnknownCliCommand,
   isCliFetchStackLog,
   normalizeRootShortcuts,
   reorderGlobalFlags,
@@ -119,6 +121,64 @@ describe('CLI root argument routing', () => {
       '--unknown',
       'auth',
     ]);
+  });
+
+  it('detects unknown top-level commands before citty falls back to help', async () => {
+    await expect(detectUnknownCliCommand(['bogus'])).resolves.toEqual({
+      typedCommand: 'texra bogus',
+      helpCommand: 'texra',
+    });
+  });
+
+  it('detects unknown command-group children', async () => {
+    await expect(detectUnknownCliCommand(['agents', 'bogus'])).resolves.toEqual(
+      {
+        typedCommand: 'texra agents bogus',
+        helpCommand: 'texra agents',
+      },
+    );
+    await expect(
+      detectUnknownCliCommand(['history', 'bogus']),
+    ).resolves.toEqual({
+      typedCommand: 'texra history bogus',
+      helpCommand: 'texra history',
+    });
+    await expect(detectUnknownCliCommand(['auth', 'bogus'])).resolves.toEqual({
+      typedCommand: 'texra auth bogus',
+      helpCommand: 'texra auth',
+    });
+    await expect(detectUnknownCliCommand(['models', 'bogus'])).resolves.toEqual(
+      {
+        typedCommand: 'texra models bogus',
+        helpCommand: 'texra models',
+      },
+    );
+  });
+
+  it('formats unknown command usage guidance', () => {
+    expect(
+      formatUnknownCliCommand({
+        typedCommand: 'texra agents bogus',
+        helpCommand: 'texra agents',
+      }),
+    ).toBe(
+      'Unknown command: texra agents bogus. Run `texra agents --help` for usage.',
+    );
+  });
+
+  it('does not classify known command arguments as unknown commands', async () => {
+    await expect(
+      detectUnknownCliCommand(['run', 'polish', '--input', 'paper.tex']),
+    ).resolves.toBeUndefined();
+    await expect(
+      detectUnknownCliCommand(['history', 'show', 'abc123']),
+    ).resolves.toBeUndefined();
+    await expect(
+      detectUnknownCliCommand(['completion', 'zsh']),
+    ).resolves.toBeUndefined();
+    await expect(
+      detectUnknownCliCommand(['--unknown', 'bogus']),
+    ).resolves.toBeUndefined();
   });
 
   it('collects repeated run context flags from raw args', () => {


### PR DESCRIPTION
## Summary

- detect unknown root commands and pure subcommand-group children before dispatching to citty
- return usage exit code 2 with scoped help guidance instead of silently printing help with success
- preserve ordinary positional arguments for runnable commands such as `run`, `history show`, and `completion`

Closes #4302.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js bogus` -> `Unknown command: texra bogus...`, exit 2
- `node packages/cli/dist/bin/texra.js agents bogus` -> `Unknown command: texra agents bogus...`, exit 2
- `node packages/cli/dist/bin/texra.js history show abc123` -> reaches history handler and exits 2 for missing execution
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with pre-existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI dispatch to pre-validate command paths and return `CliExitCode.Usage` for certain previously-successful invocations, which can affect scripts relying on prior exit codes/behavior. Logic is scoped to argument routing and should be low blast-radius, but touches the CLI entrypoint flow.
> 
> **Overview**
> **Rejects unknown CLI command paths early instead of letting `citty` fall back to help/success.** Adds `detectUnknownCliCommand` + `formatUnknownCliCommand` to identify unknown top-level commands and unknown children of *pure command-group containers* (commands with `subCommands` but no `run`).
> 
> **Improves global-flag parsing reuse.** Extracts `knownGlobalFlagTokenCount` and uses it both for `reorderGlobalFlags` and for unknown-command detection so leading global flags (including `--flag=value`) are skipped consistently.
> 
> Updates `runCli` to emit a targeted "Unknown command… Run `... --help`" message and exit with usage code `2`, and adds vitest coverage for detection/formatting and for not misclassifying normal positional args for runnable commands (e.g. `run`, `history show`, `completion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2c5b87465ffcdf1e36c4a8502a8d70173733de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->