### PR TITLE
fix(cli): describe paper2 workflow agents

### DIFF
--- a/packages/extension/resources/agents/write/paper2poster.yaml
+++ b/packages/extension/resources/agents/write/paper2poster.yaml
@@ -1,4 +1,6 @@
 name: paper2poster
+description: Converts a research paper into a LaTeX conference poster using a provided template.
+
 settings:
   agentCategory: workflow
   documentTag: documents

--- a/packages/extension/resources/agents/write/paper2slide.yaml
+++ b/packages/extension/resources/agents/write/paper2slide.yaml
@@ -1,4 +1,6 @@
 name: paper2slide
+description: Converts a research paper into a LaTeX Beamer slide deck using a provided template.
+
 settings:
   agentCategory: workflow
   documentTag: documents


### PR DESCRIPTION
## Summary

- add top-level descriptions to the bundled `paper2slide` and `paper2poster` workflow YAMLs
- make `texra agents list` show useful descriptions for those agents after bundled resources sync

Closes #4304.

## Verification

- `corepack pnpm --filter @texra/cli build`
- `HOME=$(mktemp -d) node packages/cli/dist/bin/texra.js agents list | grep -E "^workflow[[:space:]]+paper2"`
- `npm run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: adds top-level `description` fields to bundled agent YAMLs, affecting only how agents are displayed/listed.
> 
> **Overview**
> Adds human-readable `description` metadata to the bundled `paper2slide` and `paper2poster` workflow agent YAMLs so CLI/UI listings can show meaningful summaries for these agents after resource sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461bbaf8786e904c7dfc755f5b6497f4d39c8ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->