### PR TITLE
feat(cli): list multi-agent presets

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -93,6 +93,13 @@ import {
   readCliHistoryConfig,
   readCliHistoryDetails,
 } from '../runtime/history';
+import {
+  cliMultiAgentPresetNdjsonRecords,
+  findCliMultiAgentPreset,
+  formatCliMultiAgentPresetDetails,
+  formatCliMultiAgentPresetList,
+  readCliMultiAgentPresets,
+} from '../runtime/multiAgentPresets';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after
@@ -252,6 +259,95 @@ async function listAgents(context: CliContext): Promise<number> {
 const agentsCommand = defineCommand({
   meta: { name: 'agents', description: 'Inspect TeXRA agents' },
   subCommands: { list: agentsListCommand },
+});
+
+const multiAgentListCommand = defineCommand({
+  meta: { name: 'list', description: 'List multi-agent team presets' },
+  args: {
+    ...GLOBAL_ARGS,
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await runMultiAgentList(context));
+  },
+});
+
+async function runMultiAgentList(context: CliContext): Promise<number> {
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+  const presets = readCliMultiAgentPresets();
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(presets, null, 2));
+    return CliExitCode.Success;
+  }
+
+  if (context.outputFormat === 'ndjson') {
+    for (const record of cliMultiAgentPresetNdjsonRecords(presets)) {
+      writeNdjsonStdout(record);
+    }
+    return CliExitCode.Success;
+  }
+
+  writeTextStdout(formatCliMultiAgentPresetList(presets));
+  return CliExitCode.Success;
+}
+
+const multiAgentShowCommand = defineCommand({
+  meta: { name: 'show', description: 'Show one multi-agent team preset' },
+  args: {
+    ...GLOBAL_ARGS,
+    preset: {
+      type: 'positional',
+      required: true,
+      description: 'Preset id or name from `texra multi-agent list`',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await runMultiAgentShow(context, ctx.args.preset));
+  },
+});
+
+async function runMultiAgentShow(
+  context: CliContext,
+  presetIdOrName: string,
+): Promise<number> {
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+  const presets = readCliMultiAgentPresets();
+  const preset = findCliMultiAgentPreset(presets, presetIdOrName);
+  if (!preset) {
+    writeTextStderr(`Multi-agent preset not found: ${presetIdOrName}`);
+    return CliExitCode.Usage;
+  }
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(preset, null, 2));
+  } else if (context.outputFormat === 'ndjson') {
+    writeNdjsonStdout({
+      kind: 'multi-agent-preset',
+      ts: new Date().toISOString(),
+      preset,
+    });
+  } else {
+    writeTextStdout(formatCliMultiAgentPresetDetails(preset));
+  }
+  return CliExitCode.Success;
+}
+
+const multiAgentCommand = defineCommand({
+  meta: { name: 'multi-agent', description: 'Inspect multi-agent teams' },
+  subCommands: {
+    list: multiAgentListCommand,
+    show: multiAgentShowCommand,
+  },
 });
 
 const modelsListCommand = defineCommand({
@@ -1496,6 +1592,7 @@ export const rootCommand = defineCommand({
     resume: resumeCommand,
     history: historyCommand,
     agents: agentsCommand,
+    'multi-agent': multiAgentCommand,
     models: modelsCommand,
     login: loginCommand,
     logout: logoutCommand,

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -1,0 +1,49 @@
+import * as path from 'node:path';
+
+import { JsonStore } from '@platform/defaults/jsonStore';
+import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
+
+import type { StateStore } from '@platform/interfaces/state';
+import type { StorageProvider } from '@platform/interfaces/storage';
+
+class CliJsonStateStore implements StateStore {
+  constructor(private readonly store: JsonStore) {}
+
+  get<T>(key: string, defaultValue?: T): T {
+    return this.store.get(key, defaultValue);
+  }
+
+  update(key: string, value: unknown): PromiseLike<void> {
+    return this.store.set(key, value);
+  }
+}
+
+export interface CliStateStores {
+  readonly storage: StorageProvider;
+  readonly globalState: StateStore;
+  readonly workspaceState: StateStore;
+}
+
+export interface CliStateStoresInit {
+  readonly storageRoot?: string;
+  readonly workspacePath: string | (() => string | undefined);
+}
+
+export async function createCliStateStores(
+  init: CliStateStoresInit,
+): Promise<CliStateStores> {
+  const storage = createNodeStorageProvider({
+    storageRoot: init.storageRoot,
+    workspacePath: init.workspacePath,
+  });
+  const [globalStore, workspaceStore] = await Promise.all([
+    JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json')),
+    JsonStore.open(path.join(storage.getStoragePath(), 'state.json')),
+  ]);
+
+  return {
+    storage,
+    globalState: new CliJsonStateStore(globalStore),
+    workspaceState: new CliJsonStateStore(workspaceStore),
+  };
+}

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -1,9 +1,7 @@
 // Local imports - platform
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
-import { createMemoryStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { initPlatform, tryPlatform } from '@platform/platform';
@@ -33,6 +31,7 @@ import { writeTextStderr } from './logSinks';
 import { CliConfigProvider } from './cliConfigProvider';
 import { workspaceCliConfigPath } from './cliConfig';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
+import { createCliStateStores } from './cliStateStores';
 
 // Type imports - platform and CLI runtime
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
@@ -117,17 +116,18 @@ export async function initCliPlatform(
     const configStore = await JsonStore.open(
       workspaceCliConfigPath(cliWorkspaceCwd),
     );
+    const stateStores = await createCliStateStores({
+      workspacePath: () => cliWorkspaceCwd,
+    });
     const lifecycle = createCliLifecycleHost();
     initPlatform({
       config: new CliConfigProvider(configStore),
-      globalState: createMemoryStore(),
-      workspaceState: createMemoryStore(),
+      globalState: stateStores.globalState,
+      workspaceState: stateStores.workspaceState,
       log: cliPlatformLog,
       fs: nodeFilesystem,
       workspace: createNodeWorkspace(() => cliWorkspaceCwd),
-      storage: createNodeStorageProvider({
-        workspacePath: () => cliWorkspaceCwd,
-      }),
+      storage: stateStores.storage,
       secrets: getCliSecrets(),
       lifecycle,
       agentResume: { tryResumeStream: async () => false },

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,0 +1,111 @@
+import { platform } from '@platform/platform';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import {
+  AGENT_MODE_PRESETS,
+  AgentModePresetSchema,
+  type AgentModePreset,
+} from '@shared/schemas/agentPresets';
+
+export type CliMultiAgentPresetSource = 'built-in' | 'custom';
+
+export interface CliMultiAgentPreset extends AgentModePreset {
+  readonly source: CliMultiAgentPresetSource;
+}
+
+export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
+  return AgentModePresetSchema.array().catch([]).parse(raw);
+}
+
+export function readCliMultiAgentPresets(): CliMultiAgentPreset[] {
+  const customRaw = platform().workspaceState.get<unknown>(
+    WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+  );
+  return cliMultiAgentPresets(customRaw);
+}
+
+export function cliMultiAgentPresets(
+  customRaw: unknown,
+): CliMultiAgentPreset[] {
+  return [
+    ...AGENT_MODE_PRESETS.map((preset) => withSource(preset, 'built-in')),
+    ...parseCliCustomAgentPresets(customRaw).map((preset) =>
+      withSource(preset, 'custom'),
+    ),
+  ];
+}
+
+export function findCliMultiAgentPreset(
+  presets: readonly CliMultiAgentPreset[],
+  query: string,
+): CliMultiAgentPreset | undefined {
+  const key = lookupKey(query);
+  return presets.find(
+    (preset) =>
+      lookupKey(preset.id) === key ||
+      lookupKey(preset.name) === key ||
+      slugKey(preset.name) === key,
+  );
+}
+
+export function formatCliMultiAgentPresetList(
+  presets: readonly CliMultiAgentPreset[],
+): string {
+  if (presets.length === 0) return 'No multi-agent presets found.';
+
+  return presets
+    .map((preset) =>
+      [
+        preset.source,
+        preset.id,
+        preset.name,
+        `workflow:${preset.workflowAgents.length}`,
+        `tool-use:${preset.toolUseAgents.length}`,
+      ].join('\t'),
+    )
+    .join('\n');
+}
+
+export function formatCliMultiAgentPresetDetails(
+  preset: CliMultiAgentPreset,
+): string {
+  return [
+    `${preset.name} (${preset.id})`,
+    `Source: ${preset.source}`,
+    `Description: ${preset.description}`,
+    'Workflow agents:',
+    formatAgentNames(preset.workflowAgents),
+    'Tool-use agents:',
+    formatAgentNames(preset.toolUseAgents),
+  ].join('\n');
+}
+
+export function cliMultiAgentPresetNdjsonRecords(
+  presets: readonly CliMultiAgentPreset[],
+): unknown[] {
+  const ts = new Date().toISOString();
+  return presets.map((preset) => ({
+    kind: 'multi-agent-preset',
+    ts,
+    preset,
+  }));
+}
+
+function withSource(
+  preset: AgentModePreset,
+  source: CliMultiAgentPresetSource,
+): CliMultiAgentPreset {
+  return { ...preset, source };
+}
+
+function formatAgentNames(names: readonly string[]): string {
+  if (names.length === 0) return '  (none)';
+  return names.map((name) => `  ${name}`).join('\n');
+}
+
+function lookupKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function slugKey(value: string): string {
+  return lookupKey(value).replaceAll(/\s+/g, '-');
+}

--- a/src/test-kernel/cli/CliStateStores.vitest.mts
+++ b/src/test-kernel/cli/CliStateStores.vitest.mts
@@ -1,0 +1,46 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+
+import { createCliStateStores } from '../../../packages/cli/src/runtime/cliStateStores';
+
+describe('CLI state stores', () => {
+  it('persists workspace state across store instances', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-state-'));
+    const workspacePath = path.join(root, 'project');
+    const preset = {
+      id: 'custom-paper',
+      name: 'Paper Team',
+      description: 'For this paper',
+      icon: 'codicon-bookmark',
+      workflowAgents: ['polish'],
+      toolUseAgents: ['review'],
+    };
+
+    try {
+      const first = await createCliStateStores({
+        storageRoot: path.join(root, 'storage'),
+        workspacePath,
+      });
+      await first.workspaceState.update(
+        WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+        [preset],
+      );
+
+      const second = await createCliStateStores({
+        storageRoot: path.join(root, 'storage'),
+        workspacePath,
+      });
+
+      expect(
+        second.workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+      ).toEqual([preset]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cliMultiAgentPresets,
+  findCliMultiAgentPreset,
+  formatCliMultiAgentPresetDetails,
+  formatCliMultiAgentPresetList,
+  parseCliCustomAgentPresets,
+} from '../../../packages/cli/src/runtime/multiAgentPresets';
+
+describe('CLI multi-agent presets', () => {
+  it('lists built-in team presets with stable counts', () => {
+    const presets = cliMultiAgentPresets(undefined);
+
+    expect(presets.map((preset) => preset.id)).toContain('physicist');
+    expect(formatCliMultiAgentPresetList(presets)).toContain(
+      'built-in\tphysicist\tPhysicist\tworkflow:4\ttool-use:9',
+    );
+  });
+
+  it('parses valid custom team presets and ignores invalid state', () => {
+    const valid = [
+      {
+        id: 'custom-paper',
+        name: 'Paper Team',
+        description: 'For this paper',
+        icon: 'codicon-bookmark',
+        workflowAgents: ['polish'],
+        toolUseAgents: ['review'],
+      },
+    ];
+
+    expect(parseCliCustomAgentPresets(valid)).toEqual(valid);
+    expect(parseCliCustomAgentPresets([{ id: 'broken' }])).toEqual([]);
+  });
+
+  it('finds presets by id, name, or slugified name', () => {
+    const presets = cliMultiAgentPresets(undefined);
+
+    expect(findCliMultiAgentPreset(presets, 'PHYSICIST')?.name).toBe(
+      'Physicist',
+    );
+    expect(findCliMultiAgentPreset(presets, 'physicist')?.name).toBe(
+      'Physicist',
+    );
+    expect(findCliMultiAgentPreset(presets, 'Lean Project')?.id).toBe(
+      'lean-project',
+    );
+    expect(
+      findCliMultiAgentPreset(presets, 'computer-scientist-(ml)')?.id,
+    ).toBe('cs-ml');
+  });
+
+  it('formats details without dropping empty agent categories', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    );
+
+    expect(formatCliMultiAgentPresetDetails(preset!)).toContain(
+      'Workflow agents:\n  (none)',
+    );
+    expect(formatCliMultiAgentPresetDetails(preset!)).toContain(
+      'Tool-use agents:\n  lean',
+    );
+  });
+});

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " chat run resume history history list history show history delete agents agents list models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -50,7 +50,7 @@ _texra() {
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -60,6 +60,9 @@ _texra() {
     'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --all' ;;
     'agents') subcommands='list'; flags='' ;;
     'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'multi-agent') subcommands='list show'; flags='' ;;
+    'multi-agent list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'multi-agent show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'models') subcommands='list'; flags='' ;;
     'models list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'login') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --provider --no-browser --select-account --login-hint' ;;
@@ -72,7 +75,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='chat run resume history agents models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -103,6 +106,7 @@ complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
 complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Re-run a stored execution config'
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'
 complete -c texra -n '__fish_use_subcommand' -a 'agents' -d 'Inspect TeXRA agents'
+complete -c texra -n '__fish_use_subcommand' -a 'multi-agent' -d 'Inspect multi-agent teams'
 complete -c texra -n '__fish_use_subcommand' -a 'models' -d 'Inspect TeXRA models'
 complete -c texra -n '__fish_use_subcommand' -a 'login' -d 'Sign in to TeXRA for included access'
 complete -c texra -n '__fish_use_subcommand' -a 'logout' -d 'Sign out of TeXRA'
@@ -173,6 +177,20 @@ complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working 
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'list' -d 'List multi-agent team presets'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'show' -d 'Show one multi-agent team preset'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from models' -a 'list' -d 'List available models'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
@@ -265,6 +283,9 @@ _texra() {
     'history delete') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
     'agents') _values 'subcommands' 'list'; true ;;
     'agents list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'multi-agent') _values 'subcommands' 'list' 'show'; true ;;
+    'multi-agent list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'multi-agent show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'models') _values 'subcommands' 'list'; true ;;
     'models list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'login') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--provider[OAuth provider: github or google (alternative to positional)]:value:' '--no-browser[Print the sign-in URL instead of opening a browser]' '--select-account[Ask the OAuth provider to show account selection when supported]' '--login-hint[Suggest a specific provider account, such as a GitHub username or Google email]:value:' ;;
@@ -277,7 +298,7 @@ _texra() {
     'completion') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(chat run resume history agents models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(chat run resume history agents multi-agent models login logout usage auth doctor completion version help)' ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

Adds a CLI surface for inspecting the multi-agent team presets that are already used by the settings view. This implements the list/show portion of #4291.

- add `texra multi-agent list` for built-in and stored custom team presets
- add `texra multi-agent show <id-or-name>` with text, JSON, and NDJSON output
- persist CLI workspace/global state through JSON stores so custom presets are visible across CLI processes
- include the new command group in generated shell completions

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliStateStores.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run compile:fast`
- `npm run lint`
- `node packages/cli/dist/bin/texra.js multi-agent list --output-format json`
- `node packages/cli/dist/bin/texra.js multi-agent show physicist`
- `node packages/cli/dist/bin/texra.js multi-agent show missing-preset`
- seeded a temporary JSON workspace state and verified `texra --cwd <tmp> multi-agent list` and `show custom-paper --output-format json` include the custom preset from a fresh CLI process

## Notes

This PR deliberately does not implement `texra multi-agent run`; that requires a separate execution contract for composing and launching a team from the CLI. The present change makes the team catalogue inspectable first, with the same preset schema as the extension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI commands and switches CLI state storage from in-memory to persisted JSON stores, which changes runtime initialization and could affect existing CLI state behavior across sessions/workspaces.
> 
> **Overview**
> Adds a new `texra multi-agent` command group with `list` and `show` subcommands to inspect built-in and workspace-stored multi-agent team presets, supporting text/JSON/NDJSON output and usage errors for missing presets.
> 
> Updates CLI platform initialization to use persisted JSON-backed `globalState`/`workspaceState` (via new `createCliStateStores`) instead of in-memory stores so custom presets (and other workspace state) survive across CLI processes, and refreshes generated shell completion snapshots accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7517e995c68106b4ae389e6e7182b84bb3ea4657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->