### PR TITLE
feat(cli): add compact slash command

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -178,6 +178,10 @@ export function registerBuiltinSlashCommands(options?: {
     formComponent: MemoryListFormAdapter,
   });
   registerSlashCommand({
+    name: 'compact',
+    description: 'Request context compaction',
+  });
+  registerSlashCommand({
     name: 'exit',
     description: 'Exit the CLI session',
     aliases: ['quit'],

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -17,8 +17,14 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
-import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  notifyFollowUpSent,
+  sendFollowUp,
+} from '@agent/toolUse/ToolUseFollowUp';
+import {
+  getInterruptible,
+  getToolUseFlowContext,
+} from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import {
@@ -419,6 +425,37 @@ function openCliMemoryListForm(): void {
   });
 }
 
+function requestCliCompaction(): void {
+  const streamId = cliState.activeStreamId.get();
+  if (!streamId) {
+    appendLocalAssistantTranscript(
+      'No active tool-use session found for context compaction.',
+    );
+    return;
+  }
+
+  const flowContext = getToolUseFlowContext(streamId);
+  if (!flowContext) {
+    appendLocalAssistantTranscript(
+      'No active tool-use session found for context compaction.',
+    );
+    return;
+  }
+
+  if (!flowContext.modelHandler.supportsManualCompaction) {
+    appendLocalAssistantTranscript(
+      'Manual context compaction is not available for the current model.',
+    );
+    return;
+  }
+
+  flowContext.requestImmediateCompaction();
+  notifyFollowUpSent(streamId, flowContext.runtimeHost);
+  appendLocalAssistantTranscript(
+    'Context compaction requested. The agent will process it on the next model call.',
+  );
+}
+
 async function handleTuiSlashCommand(
   line: string,
   context: SlashCommandContext,
@@ -531,6 +568,9 @@ async function handleTuiSlashCommand(
       }
       return true;
     }
+    case 'compact':
+      requestCliCompaction();
+      return true;
     default: {
       const registered = listSlashCommands().find(
         (cmd) =>

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -29,6 +29,7 @@ describe('slashRegistry', () => {
         'yolo',
         'status',
         'memory',
+        'compact',
       ]),
     );
     expect(
@@ -52,6 +53,11 @@ describe('slashRegistry', () => {
       expect.objectContaining({
         description: 'List stored memories',
         formComponent: expect.any(Function),
+      }),
+    );
+    expect(listSlashCommands().find((cmd) => cmd.name === 'compact')).toEqual(
+      expect.objectContaining({
+        description: 'Request context compaction',
       }),
     );
   });


### PR DESCRIPTION
## Summary

Adds `/compact` to the CLI chat TUI so an active tool-use session can request context compaction from the same model-handler path used by the extension.

The command reports clear inline messages when there is no active tool-use session or when the current model does not support manual compaction. For supported models, it queues immediate compaction on the next model call and emits the usual follow-up notification.

This addresses the manual `/compact` portion of #4277. The larger issue also tracks multi-agent parity and broader automatic-compaction acceptance, so it should remain open after this PR.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm --filter @texra/cli typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings remain outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds a new CLI command that interacts with active tool-use flow state and triggers manual compaction/follow-up notifications; failures should be limited to user-facing messaging but could affect active sessions if misrouted.
> 
> **Overview**
> Adds a new `/compact` slash command to the CLI chat TUI and includes it in the builtin slash-command registry.
> 
> When invoked, the TUI now looks up the active tool-use flow for the current stream, validates that a session exists and the model supports manual compaction, then queues an immediate compaction request and emits the standard follow-up notification; otherwise it prints clear inline error messages. Test coverage is updated to assert `/compact` is registered with the expected description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25713ce3f0290848d8338e324eba1690a5fbb4af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->