### PR TITLE
feat(cli): open orchestration view by default

### DIFF
--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -20,11 +20,13 @@ const processInputAllowedFiles = new Set([
   // Ink needs the actual `process.stdin` stream object to wire its raw-mode
   // input pipeline; this file is the TUI I/O boundary.
   'packages/cli/src/chat/tui/runChatTui.tsx',
+  'packages/cli/src/orchestration/runOrchestrationTui.tsx',
 ]);
 
 const processTerminalInputAllowedFiles = new Set([
   'packages/cli/src/runtime/cliContext.ts',
   'packages/cli/src/chat/tui/runChatTui.tsx',
+  'packages/cli/src/orchestration/runOrchestrationTui.tsx',
 ]);
 
 const processOutputAllowedFiles = new Set([
@@ -33,6 +35,7 @@ const processOutputAllowedFiles = new Set([
   // Ink mounts onto real `process.stdout`/`process.stderr` streams; the rest
   // of the TUI must keep going through logSinks.
   'packages/cli/src/chat/tui/runChatTui.tsx',
+  'packages/cli/src/orchestration/runOrchestrationTui.tsx',
 ]);
 
 const processOutputPatterns = [

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -61,6 +61,13 @@ export function visibleSelectRange({
   return { start, end: start + visibleCount };
 }
 
+export function selectItemRenderKey<T>(
+  item: SelectItem<T>,
+  index: number,
+): string {
+  return `${index}:${item.label}`;
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const activeIndex = props.items.findIndex(
     (it) => it.value === props.activeValue,
@@ -133,7 +140,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         const tick = active ? '✓' : ' ';
         const numeric = i < 9 ? `${i + 1}.` : '  ';
         return (
-          <Box key={String(item.value)} minWidth={0}>
+          <Box key={selectItemRenderKey(item, i)} minWidth={0}>
             <Box flexShrink={0}>
               <Text color={focused ? 'cyan' : undefined}>
                 {pointer} {tick} {numeric}{' '}

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -100,6 +100,7 @@ import {
   formatCliMultiAgentPresetList,
   readCliMultiAgentPresets,
 } from '../runtime/multiAgentPresets';
+import { buildCliOrchestrationItems } from '../runtime/orchestration';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after
@@ -1430,6 +1431,67 @@ const resumeCommand = defineCommand({
   },
 });
 
+const orchestrationCommand = defineCommand({
+  meta: {
+    name: 'orchestrate',
+    description: 'Choose a chat, resume, or team preset',
+  },
+  args: {
+    ...GLOBAL_ARGS,
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await runOrchestration(context));
+  },
+});
+
+async function runOrchestration(context: CliContext): Promise<number> {
+  const isHeadless =
+    context.mode === 'headless' || context.stdoutIsTty !== true;
+  const dumbTerm = context.termIsDumb === true;
+  if (isHeadless || dumbTerm) {
+    writeTextStderr(
+      isHeadless
+        ? 'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run`, `texra chat`, or a concrete subcommand.'
+        : 'texra orchestrate needs a capable terminal — TERM=dumb strips the cursor controls Ink uses.',
+    );
+    return CliExitCode.Usage;
+  }
+
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+  await loadAgents({ includeRemote: false });
+  const history = await listCliHistoryEntries();
+  const items = buildCliOrchestrationItems({
+    presets: readCliMultiAgentPresets(),
+    history,
+    toolUseAgents: getVisibleAgents(AgentCategory.ToolUse),
+  });
+  const { runOrchestrationTui } =
+    await import('../orchestration/runOrchestrationTui');
+  const action = await runOrchestrationTui(items);
+
+  switch (action.kind) {
+    case 'chat': {
+      const { runChat } = await import('../chat/tui/runChatTui');
+      const result = await runChat(context, {
+        agentOverride: action.agent,
+      });
+      return result.exitCode;
+    }
+    case 'resume':
+      return runResumeExecution(context, action.id);
+    case 'help':
+      await showUsage(rootCommand);
+      return CliExitCode.Success;
+    case 'exit':
+      return CliExitCode.Success;
+  }
+}
+
 async function runResumeExecution(
   context: CliContext,
   id: ExecutionId,
@@ -1587,6 +1649,7 @@ export const rootCommand = defineCommand({
     ...GLOBAL_ARGS,
   },
   subCommands: {
+    orchestrate: orchestrationCommand,
     chat: chatCommand,
     run: runWorkflowCommand,
     resume: resumeCommand,
@@ -1603,14 +1666,15 @@ export const rootCommand = defineCommand({
     version: versionCommand,
     help: helpCommand,
   },
-  // No subcommand on bare `texra`: dispatch to `chat` when both TTYs are
-  // interactive (per docs/prd/cli-tui-ink/10-architecture.md#entrypoint-default);
-  // fall through to the synthetic `help` subcommand otherwise.
-  default: () => {
-    const ambient = readCliAmbientState();
-    return ambient.stdinIsTty && ambient.stdoutIsTty ? 'chat' : 'help';
-  },
+  // No subcommand on bare `texra`: dispatch to the orchestration view when
+  // both TTYs are interactive; fall through to synthetic `help` otherwise.
+  default: defaultRootSubcommand,
 });
+
+export function defaultRootSubcommand(): 'orchestrate' | 'help' {
+  const ambient = readCliAmbientState();
+  return ambient.stdinIsTty && ambient.stdoutIsTty ? 'orchestrate' : 'help';
+}
 
 // Derived from `GLOBAL_ARGS` so adding/renaming a global flag in one place
 // flows through to `reorderGlobalFlags` automatically.

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -1,0 +1,82 @@
+import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
+
+import type {
+  CliOrchestrationAction,
+  CliOrchestrationItem,
+} from '../runtime/orchestration';
+import { Select } from '../chat/tui/ui/Select';
+import { KeyHints } from '../chat/tui/ui/KeyHints';
+
+interface OrchestrationAppProps {
+  readonly items: readonly CliOrchestrationItem[];
+  readonly onResolve: (action: CliOrchestrationAction) => void;
+}
+
+function OrchestrationApp(props: OrchestrationAppProps): React.JSX.Element {
+  const app = useApp();
+  const { rows } = useWindowSize();
+  const maxVisibleItems = Math.max(4, rows - 8);
+
+  const finish = (action: CliOrchestrationAction): void => {
+    props.onResolve(action);
+    app.exit();
+  };
+
+  useInput((input, key) => {
+    if (key.escape || input.toLowerCase() === 'q') {
+      finish({ kind: 'exit' });
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold color="cyan">
+        TeXRA
+      </Text>
+      <Text dimColor>Choose how to start this CLI session.</Text>
+      <Box marginTop={1}>
+        <Select
+          items={props.items}
+          maxVisibleItems={maxVisibleItems}
+          showOverflow={props.items.length > maxVisibleItems}
+          onSelect={finish}
+          onCancel={() => finish({ kind: 'exit' })}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: '1-9/Enter', action: 'open' },
+            { key: 'q/Esc', action: 'exit' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export async function runOrchestrationTui(
+  items: readonly CliOrchestrationItem[],
+): Promise<CliOrchestrationAction> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (action: CliOrchestrationAction): void => {
+      if (settled) return;
+      settled = true;
+      resolve(action);
+    };
+
+    const instance = render(
+      <OrchestrationApp items={items} onResolve={settle} />,
+      {
+        stdout: process.stdout,
+        stderr: process.stderr,
+        stdin: process.stdin,
+      },
+    );
+
+    void instance.waitUntilExit().then(() => settle({ kind: 'exit' }));
+  });
+}

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -35,6 +35,8 @@ export interface CliContext {
   readonly apiMode?: CliApiMode;
   readonly quietLogs?: boolean;
   readonly renderRunProgress?: boolean;
+  readonly stdoutIsTty?: boolean;
+  readonly termIsDumb?: boolean;
   readonly stderrIsTty?: boolean;
   readonly colorEnabled: boolean;
   readonly version: string;
@@ -59,6 +61,7 @@ export interface CliAmbientState {
   readonly stdinIsTty: boolean;
   readonly stdoutIsTty: boolean;
   readonly stderrIsTty: boolean;
+  readonly termIsDumb?: boolean;
   readonly colorEnabled: boolean;
 }
 
@@ -76,6 +79,7 @@ export function readCliAmbientState(): CliAmbientState {
     stdinIsTty,
     stdoutIsTty,
     stderrIsTty,
+    termIsDumb: dumbTerm,
     colorEnabled: stderrIsTty && !noColor && !dumbTerm,
   };
   return cachedAmbient;
@@ -253,6 +257,8 @@ export async function buildCliContext(
     ),
     apiMode,
     quietLogs: init.globalArgs.quiet === true,
+    stdoutIsTty: ambient.stdoutIsTty,
+    termIsDumb: ambient.termIsDumb === true,
     stderrIsTty: ambient.stderrIsTty,
     colorEnabled: ambient.colorEnabled,
     version: await readCliVersion(),

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -1,0 +1,95 @@
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { ExecutionId } from '@shared/schemas';
+
+import type { CliHistoryEntry } from './history';
+import type { CliMultiAgentPreset } from './multiAgentPresets';
+
+export type CliOrchestrationAction =
+  | { readonly kind: 'chat'; readonly agent?: string }
+  | { readonly kind: 'resume'; readonly id: ExecutionId }
+  | { readonly kind: 'help' }
+  | { readonly kind: 'exit' };
+
+export interface CliOrchestrationItem {
+  readonly value: CliOrchestrationAction;
+  readonly label: string;
+  readonly description: string;
+  readonly disabled?: boolean;
+}
+
+export interface BuildCliOrchestrationItemsInput {
+  readonly presets: readonly CliMultiAgentPreset[];
+  readonly history: readonly CliHistoryEntry[];
+  readonly toolUseAgents: readonly AgentEntry[];
+}
+
+const MAX_RECENT_RESUME_ITEMS = 3;
+const MAX_RECENT_AGENT_ITEMS = 3;
+const MAX_PRESET_ITEMS = 6;
+
+export function buildCliOrchestrationItems(
+  input: BuildCliOrchestrationItemsInput,
+): CliOrchestrationItem[] {
+  const items: CliOrchestrationItem[] = [
+    {
+      value: { kind: 'chat' },
+      label: 'New chat',
+      description: 'Start the default tool-use chat',
+    },
+  ];
+
+  items.push(...recentResumeItems(input.history));
+  items.push(...recentAgentItems(input.history, input.toolUseAgents));
+  items.push(...presetItems(input.presets));
+  items.push({
+    value: { kind: 'help' },
+    label: 'Help',
+    description: 'Show CLI commands',
+  });
+  return items;
+}
+
+function recentResumeItems(
+  history: readonly CliHistoryEntry[],
+): CliOrchestrationItem[] {
+  return history.slice(0, MAX_RECENT_RESUME_ITEMS).map((entry) => ({
+    value: { kind: 'resume', id: entry.id },
+    label: `Resume ${entry.id}`,
+    description: `${entry.agent}; ${entry.status}; ${entry.inputBasename}`,
+  }));
+}
+
+function recentAgentItems(
+  history: readonly CliHistoryEntry[],
+  toolUseAgents: readonly AgentEntry[],
+): CliOrchestrationItem[] {
+  const toolUseNames = new Set(toolUseAgents.map((agent) => agent.name));
+  const seen = new Set<string>();
+  const items: CliOrchestrationItem[] = [];
+
+  for (const entry of history) {
+    if (entry.category && entry.category !== AgentCategory.ToolUse) continue;
+    if (!toolUseNames.has(entry.agent) || seen.has(entry.agent)) continue;
+    seen.add(entry.agent);
+    items.push({
+      value: { kind: 'chat', agent: entry.agent },
+      label: `Chat with ${entry.agent}`,
+      description: 'Recent tool-use agent',
+    });
+    if (items.length >= MAX_RECENT_AGENT_ITEMS) break;
+  }
+
+  return items;
+}
+
+function presetItems(
+  presets: readonly CliMultiAgentPreset[],
+): CliOrchestrationItem[] {
+  return presets.slice(0, MAX_PRESET_ITEMS).map((preset) => ({
+    value: { kind: 'help' },
+    label: `Team ${preset.name}`,
+    description: `${preset.source}; workflow:${preset.workflowAgents.length}; tool-use:${preset.toolUseAgents.length}; run pending`,
+    disabled: true,
+  }));
+}

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -6,7 +6,10 @@ import {
   formatModelStatusForCliMode,
   modelSelectWindow,
 } from '../../../packages/cli/src/chat/tui/forms/ModelListForm';
-import { visibleSelectRange } from '../../../packages/cli/src/chat/tui/ui/Select';
+import {
+  selectItemRenderKey,
+  visibleSelectRange,
+} from '../../../packages/cli/src/chat/tui/ui/Select';
 import type { CliModelAccess } from '../../../packages/cli/src/runtime/modelAccess';
 
 function access(
@@ -50,6 +53,23 @@ describe('CLI ModelListForm status text', () => {
         'included',
       ),
     ).toBe('relay: unavailable; api key set');
+  });
+});
+
+describe('Select render keys', () => {
+  it('does not collapse object-valued items to the same React key', () => {
+    const first = selectItemRenderKey(
+      { value: { kind: 'chat' }, label: 'New chat' },
+      0,
+    );
+    const second = selectItemRenderKey(
+      { value: { kind: 'help' }, label: 'Help' },
+      1,
+    );
+
+    expect(first).toBe('0:New chat');
+    expect(second).toBe('1:Help');
+    expect(first).not.toBe(second);
   });
 });
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { ExecutionId } from '@shared/schemas';
+
+import { buildCliOrchestrationItems } from '../../../packages/cli/src/runtime/orchestration';
+import type { CliHistoryEntry } from '../../../packages/cli/src/runtime/history';
+import type { CliMultiAgentPreset } from '../../../packages/cli/src/runtime/multiAgentPresets';
+
+function historyEntry(
+  id: string,
+  overrides: Partial<CliHistoryEntry> = {},
+): CliHistoryEntry {
+  return {
+    id: id as ExecutionId,
+    timestamp: '2026-05-21T00:00:00Z',
+    agent: 'orchestrator',
+    model: 'claude-opus-4-7',
+    status: 'completed',
+    inputBasename: '-',
+    category: AgentCategory.ToolUse,
+    ...overrides,
+  };
+}
+
+function toolUseAgent(name: string): AgentEntry {
+  return {
+    name,
+    description: `${name} agent`,
+    tools: [],
+  } as unknown as AgentEntry;
+}
+
+function preset(overrides: Partial<CliMultiAgentPreset>): CliMultiAgentPreset {
+  return {
+    id: 'physicist',
+    name: 'Physicist',
+    description: 'Physics team',
+    icon: 'codicon-symbol-operator',
+    workflowAgents: ['criticize'],
+    toolUseAgents: ['orchestrator', 'review'],
+    source: 'built-in',
+    ...overrides,
+  };
+}
+
+describe('CLI orchestration items', () => {
+  it('starts with new chat and keeps help as the final active item', () => {
+    const items = buildCliOrchestrationItems({
+      presets: [],
+      history: [],
+      toolUseAgents: [],
+    });
+
+    expect(items.at(0)).toMatchObject({
+      label: 'New chat',
+      value: { kind: 'chat' },
+    });
+    expect(items.at(-1)).toMatchObject({
+      label: 'Help',
+      value: { kind: 'help' },
+    });
+  });
+
+  it('lists recent resumable executions before recent agents', () => {
+    const items = buildCliOrchestrationItems({
+      presets: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', { agent: 'review' }),
+        historyEntry('bbbbbbbbbbbb', { agent: 'orchestrator' }),
+      ],
+      toolUseAgents: [toolUseAgent('review'), toolUseAgent('orchestrator')],
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      'New chat',
+      'Resume aaaaaaaaaaaa',
+      'Resume bbbbbbbbbbbb',
+      'Chat with review',
+      'Chat with orchestrator',
+      'Help',
+    ]);
+  });
+
+  it('filters recent agent entries to known tool-use agents', () => {
+    const items = buildCliOrchestrationItems({
+      presets: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', {
+          agent: 'polish',
+          category: AgentCategory.Workflow,
+        }),
+        historyEntry('bbbbbbbbbbbb', { agent: 'missing' }),
+        historyEntry('cccccccccccc', { agent: 'review' }),
+      ],
+      toolUseAgents: [toolUseAgent('review')],
+    });
+
+    expect(items.map((item) => item.label)).toContain('Chat with review');
+    expect(items.map((item) => item.label)).not.toContain('Chat with polish');
+    expect(items.map((item) => item.label)).not.toContain('Chat with missing');
+  });
+
+  it('lists team presets as disabled until preset execution exists', () => {
+    const items = buildCliOrchestrationItems({
+      presets: [preset({ id: 'physicist' })],
+      history: [],
+      toolUseAgents: [],
+    });
+
+    expect(items.find((item) => item.label === 'Team Physicist')).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        description: 'built-in; workflow:1; tool-use:2; run pending',
+      }),
+    );
+  });
+});

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -50,7 +50,8 @@ _texra() {
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'orchestrate') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -75,7 +76,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -101,6 +102,7 @@ complete -F _texra texra
 
 exports[`CLI shell completion > generates fish completion 1`] = `
 "# fish completion for texra
+complete -c texra -n '__fish_use_subcommand' -a 'orchestrate' -d 'Choose a chat, resume, or team preset'
 complete -c texra -n '__fish_use_subcommand' -a 'chat' -d 'Interactive tool-use chat session'
 complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
 complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Re-run a stored execution config'
@@ -122,6 +124,12 @@ complete -c texra -n '__fish_use_subcommand' -l 'cwd' -r -d 'Working directory t
 complete -c texra -n '__fish_use_subcommand' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_use_subcommand' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_use_subcommand' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
@@ -274,6 +282,7 @@ _texra() {
   [[ -n "\${words[3]}" && "\${words[3]}" != -* ]] && path="$path \${words[3]}"
 
   case "$path" in
+    'orchestrate') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'chat') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
     'run') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--context[Read-only context file passed to the workflow agent]:value:' '-c[Read-only context file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--output-dir[Directory to copy multi-input workflow outputs into]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
     'resume') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
@@ -298,7 +307,7 @@ _texra() {
     'completion') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(chat run resume history agents multi-agent models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help)' ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

Changes bare interactive `texra` from direct single-agent chat into a small orchestration entry view. The view offers:

- new default chat
- recent stored executions for resume
- recent tool-use agents from history
- team presets as visible disabled rows until executable preset semantics land in #4291
- help

`texra chat` remains the direct single-agent chat path, and non-TTY bare `texra --print` still prints synthetic help.

The interactive probe also exposed a shared `Select` rendering defect for object-valued items; this PR fixes the React key generation so object-valued select rows do not emit duplicate `[object Object]` key warnings.

Addresses #4293.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts`
- `corepack pnpm --filter @texra/cli build`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings outside this change remain)
- `node packages/cli/dist/bin/texra.js --print`
- `node packages/cli/dist/bin/texra.js orchestrate --print`
- PTY probe: `node packages/cli/dist/bin/texra.js`, verified the orchestration selector renders and exits with `q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default interactive `texra` behavior and introduces a new Ink-based routing TUI that depends on TTY capabilities; regressions would primarily affect interactive CLI UX and terminal detection/stream handling.
> 
> **Overview**
> **Bare interactive `texra` now opens a new orchestration selector by default** (via `defaultRootSubcommand`), and adds a new `texra orchestrate` subcommand that routes into **chat**, **resume execution**, or **help** based on the selected item.
> 
> Introduces an Ink TUI (`runOrchestrationTui`) and orchestration item builder (`buildCliOrchestrationItems`) that surfaces recent history, recent tool-use agents, and (currently disabled) team presets; adds terminal capability checks (`stdoutIsTty`, `TERM=dumb`) to gate the experience.
> 
> Fixes a shared TUI bug by changing `Select` row React keys to be stable for object-valued items, and updates CLI host-import allowlists plus shell completion snapshots/tests to include `orchestrate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3288614daa42edf2364142984343ddbc05a125a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->