### PR TITLE
feat(cli): run multi-agent presets

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -6,7 +6,9 @@ import { glob, hasMagic } from 'glob';
 
 import {
   getAgent,
+  getToolUseAgents,
   getVisibleAgents,
+  getWorkflowAgents,
   loadAgents,
   type AgentEntry,
 } from '@agent/index';
@@ -98,7 +100,11 @@ import {
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetList,
+  planCliMultiAgentPresetRun,
   readCliMultiAgentPresets,
+  withCliMultiAgentPresetVisibility,
+  type CliMultiAgentPreset,
+  type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
 
@@ -343,11 +349,250 @@ async function runMultiAgentShow(
   return CliExitCode.Success;
 }
 
+const multiAgentRunCommand = defineCommand({
+  meta: { name: 'run', description: 'Run a multi-agent team preset' },
+  args: {
+    ...GLOBAL_ARGS,
+    preset: {
+      type: 'positional',
+      required: true,
+      description: 'Preset id or name from `texra multi-agent list`',
+    },
+    input: {
+      type: 'string',
+      alias: 'i',
+      required: true,
+      description: 'Input file passed to the team orchestrator',
+    },
+    context: {
+      type: 'string',
+      alias: 'c',
+      description: 'Read-only context file passed to the team orchestrator',
+    },
+    agent: {
+      type: 'string',
+      description:
+        'Tool-use agent to start as the team root (defaults to the preset orchestrator)',
+    },
+    model: {
+      type: 'string',
+      alias: 'm',
+      description: 'Model for the root tool-use agent',
+    },
+    instruction: {
+      type: 'string',
+      description: 'Additional instruction for the team orchestrator',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(
+      await runMultiAgentPreset(context, {
+        preset: ctx.args.preset,
+        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
+        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+        agent: optString(ctx.args.agent),
+        model: optString(ctx.args.model),
+        instruction: optString(ctx.args.instruction) ?? '',
+      }),
+    );
+  },
+});
+
+interface MultiAgentRunInit {
+  readonly preset: string;
+  readonly inputFiles: string[];
+  readonly contextFiles: string[];
+  readonly agent?: string;
+  readonly model?: string;
+  readonly instruction: string;
+}
+
+type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
+
+async function runMultiAgentPreset(
+  context: CliContext,
+  init: MultiAgentRunInit,
+): Promise<number> {
+  const model =
+    init.model?.trim() ||
+    context.envModel ||
+    resolveConfiguredModel(context.cliConfig, 'chat') ||
+    CLI_BUILTIN_DEFAULT_MODEL;
+  const renderRunProgress = shouldRenderRunProgress(context);
+  const runContext: CliContext = {
+    ...context,
+    helperModel: model,
+    quietLogs: true,
+    renderRunProgress,
+  };
+  const inputFiles = await expandWorkflowInputSpecs(
+    init.inputFiles,
+    runContext.cwd,
+  );
+  const contextFiles = (
+    await Promise.all(
+      init.contextFiles.map((spec) =>
+        expandWorkflowInputSpec(spec, runContext.cwd),
+      ),
+    )
+  ).flat();
+
+  await initCliPlatform(runContext);
+  installCliApprovalHandlers(runContext);
+  await loadAgents({ includeRemote: false });
+
+  let plan = resolveMultiAgentRunPlan(init);
+  if (!plan.rootAgent && (await getCliAuthProvider().isAuthenticated())) {
+    await loadAgents();
+    plan = resolveMultiAgentRunPlan(init);
+  }
+  if (!plan.rootAgent) {
+    writeTextStderr(
+      `Multi-agent preset "${init.preset}" has no available tool-use agent to run. Use --agent with an installed tool-use agent, or enable a team with an orchestrator.`,
+    );
+    return CliExitCode.Usage;
+  }
+  writeMissingPresetAgents(plan);
+
+  const config: AgentConfigPayload = {
+    agent: plan.rootAgent.name,
+    model,
+    inputFiles,
+    contextFiles,
+    instruction: formatMultiAgentRunInstruction(plan.preset, init),
+    workingDirectory: runContext.cwd,
+    agentCategory: AgentCategory.ToolUse,
+  };
+
+  const executionId = generateExecutionId();
+  const registeredConfig = AgentConfigSchema.parse(config);
+  const runtimeHost = createCliRuntimeHost(runContext);
+  let result: ExecuteAgentResult;
+  try {
+    result = await withCliMultiAgentPresetVisibility(plan, () =>
+      runValidatedExecutionRequest(
+        { config: registeredConfig, executionId },
+        {
+          runtimeHost,
+          enforceCategory: true,
+          registerExecution: true,
+        },
+      ),
+    );
+  } catch (error) {
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+    throw error;
+  } finally {
+    await runtimeHost.close();
+  }
+
+  const terminalStatus = await readCliTerminalStatus(result);
+  if (result.category !== AgentCategory.ToolUse) {
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+    writeTextStderr(
+      `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+    );
+    return CliExitCode.AgentError;
+  }
+  const displayResult: CliToolUseRunResult = {
+    ...result,
+    terminalStatus,
+  };
+  writeMultiAgentRunResult(runContext, plan, displayResult);
+
+  if (terminalStatus === EXECUTION_STATUS.ERROR) {
+    return hasCliApprovalDenied(runContext)
+      ? CliExitCode.ApprovalDenied
+      : CliExitCode.AgentError;
+  }
+  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+    return CliExitCode.Interrupted;
+  }
+  return CliExitCode.Success;
+}
+
+function resolveMultiAgentRunPlan(
+  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
+): CliMultiAgentPresetRunPlan {
+  const preset = findCliMultiAgentPreset(
+    readCliMultiAgentPresets(),
+    init.preset,
+  );
+  if (!preset) {
+    throw new CliUsageError(`Multi-agent preset not found: ${init.preset}`);
+  }
+  return planCliMultiAgentPresetRun(preset, {
+    workflowAgents: getWorkflowAgents(),
+    toolUseAgents: getToolUseAgents(),
+    agentOverride: init.agent,
+  });
+}
+
+function writeMissingPresetAgents(plan: CliMultiAgentPresetRunPlan): void {
+  const missing = [
+    ...plan.missingWorkflowAgents.map((agent) => `workflow:${agent}`),
+    ...plan.missingToolUseAgents.map((agent) => `tool-use:${agent}`),
+  ];
+  if (missing.length === 0) return;
+  writeTextStderr(
+    `WARN preset ${plan.preset.id} references unavailable agents: ${missing.join(', ')}`,
+  );
+}
+
+function formatMultiAgentRunInstruction(
+  preset: CliMultiAgentPreset,
+  init: Pick<MultiAgentRunInit, 'instruction'>,
+): string {
+  const parts = [
+    `Run the "${preset.name}" multi-agent team preset.`,
+    preset.description,
+    'Use the visible workflow and tool-use agents as the team available for delegation.',
+  ];
+  const instruction = init.instruction.trim();
+  if (instruction) {
+    parts.push('Additional user instruction:', instruction);
+  }
+  return parts.join('\n\n');
+}
+
+function writeMultiAgentRunResult(
+  context: CliContext,
+  plan: CliMultiAgentPresetRunPlan,
+  result: CliToolUseRunResult,
+): void {
+  const payload = {
+    preset: {
+      id: plan.preset.id,
+      name: plan.preset.name,
+      source: plan.preset.source,
+    },
+    rootAgent: plan.rootAgent?.name,
+    result,
+  };
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(payload, null, 2));
+  } else if (context.outputFormat === 'ndjson') {
+    writeNdjsonStdout({
+      kind: 'multi-agent-result',
+      ts: new Date().toISOString(),
+      ...payload,
+    });
+  } else {
+    writeTextStdout(
+      result.lastResponse?.trim() ||
+        `${result.status}\nExecution: ${result.executionId}`,
+    );
+  }
+}
+
 const multiAgentCommand = defineCommand({
   meta: { name: 'multi-agent', description: 'Inspect multi-agent teams' },
   subCommands: {
     list: multiAgentListCommand,
     show: multiAgentShowCommand,
+    run: multiAgentRunCommand,
   },
 });
 
@@ -1480,6 +1725,22 @@ async function runOrchestration(context: CliContext): Promise<number> {
       const result = await runChat(context, {
         agentOverride: action.agent,
       });
+      return result.exitCode;
+    }
+    case 'preset': {
+      const plan = resolveMultiAgentRunPlan({ preset: action.preset });
+      if (!plan.rootAgent) {
+        writeTextStderr(
+          `Multi-agent preset "${action.preset}" has no available tool-use agent to start.`,
+        );
+        return CliExitCode.Usage;
+      }
+      const { runChat } = await import('../chat/tui/runChatTui');
+      const result = await withCliMultiAgentPresetVisibility(plan, () =>
+        runChat(context, {
+          agentOverride: plan.rootAgent?.name,
+        }),
+      );
       return result.exitCode;
     }
     case 'resume':

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,5 +1,8 @@
 import { platform } from '@platform/platform';
+import type { AgentEntry } from '@agent/index';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { agentKey } from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
   AgentModePresetSchema,
@@ -10,6 +13,15 @@ export type CliMultiAgentPresetSource = 'built-in' | 'custom';
 
 export interface CliMultiAgentPreset extends AgentModePreset {
   readonly source: CliMultiAgentPresetSource;
+}
+
+export interface CliMultiAgentPresetRunPlan {
+  readonly preset: CliMultiAgentPreset;
+  readonly rootAgent?: AgentEntry;
+  readonly workflowAgentKeys: readonly string[];
+  readonly toolUseAgentKeys: readonly string[];
+  readonly missingWorkflowAgents: readonly string[];
+  readonly missingToolUseAgents: readonly string[];
 }
 
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
@@ -90,11 +102,156 @@ export function cliMultiAgentPresetNdjsonRecords(
   }));
 }
 
+export function planCliMultiAgentPresetRun(
+  preset: CliMultiAgentPreset,
+  options: {
+    readonly workflowAgents: readonly AgentEntry[];
+    readonly toolUseAgents: readonly AgentEntry[];
+    readonly agentOverride?: string;
+  },
+): CliMultiAgentPresetRunPlan {
+  const workflow = resolvePresetAgents(
+    preset.workflowAgents,
+    options.workflowAgents,
+  );
+  const toolUse = resolvePresetAgents(
+    preset.toolUseAgents,
+    options.toolUseAgents,
+  );
+  const overrideAgent = resolveAgentOverride(
+    options.agentOverride,
+    options.toolUseAgents,
+  );
+  const rootAgent =
+    overrideAgent ??
+    selectPresetRootAgent(toolUse.resolved, preset.toolUseAgents);
+  const toolUseAgents = rootAgent
+    ? includeAgent(toolUse.resolved, rootAgent)
+    : toolUse.resolved;
+
+  return {
+    preset,
+    rootAgent,
+    workflowAgentKeys: workflow.resolved.map(toAgentKey),
+    toolUseAgentKeys: toolUseAgents.map(toAgentKey),
+    missingWorkflowAgents: workflow.missing,
+    missingToolUseAgents: toolUse.missing,
+  };
+}
+
+export async function withCliMultiAgentPresetVisibility<T>(
+  plan: CliMultiAgentPresetRunPlan,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const workspaceState = platform().workspaceState;
+  const previousWorkflowAgents = workspaceState.get<string[] | undefined>(
+    WorkspaceStateKey.ENABLED_AGENTS,
+  );
+  const previousToolUseAgents = workspaceState.get<string[] | undefined>(
+    WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+  );
+
+  await workspaceState.update(WorkspaceStateKey.ENABLED_AGENTS, [
+    ...plan.workflowAgentKeys,
+  ]);
+  await workspaceState.update(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS, [
+    ...plan.toolUseAgentKeys,
+  ]);
+
+  try {
+    return await operation();
+  } finally {
+    await workspaceState.update(
+      WorkspaceStateKey.ENABLED_AGENTS,
+      previousWorkflowAgents,
+    );
+    await workspaceState.update(
+      WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      previousToolUseAgents,
+    );
+  }
+}
+
 function withSource(
   preset: AgentModePreset,
   source: CliMultiAgentPresetSource,
 ): CliMultiAgentPreset {
   return { ...preset, source };
+}
+
+function resolvePresetAgents(
+  names: readonly string[],
+  agents: readonly AgentEntry[],
+): { resolved: AgentEntry[]; missing: string[] } {
+  const resolved: AgentEntry[] = [];
+  const missing: string[] = [];
+  for (const name of names) {
+    const entry = agents.find((agent) => agent.name === name);
+    if (entry) {
+      resolved.push(entry);
+    } else {
+      missing.push(name);
+    }
+  }
+  return { resolved, missing };
+}
+
+function resolveAgentOverride(
+  override: string | undefined,
+  agents: readonly AgentEntry[],
+): AgentEntry | undefined {
+  const query = override?.trim();
+  if (!query) return undefined;
+  return agents.find(
+    (agent) => agent.name === query || toAgentKey(agent) === query,
+  );
+}
+
+function selectPresetRootAgent(
+  agents: readonly AgentEntry[],
+  presetOrder: readonly string[],
+): AgentEntry | undefined {
+  const delegatingAgents = agents.filter(agentHasDelegationTools);
+  if (delegatingAgents.length > 0) {
+    return (
+      findPreferredRootAgent(delegatingAgents, presetOrder) ??
+      delegatingAgents[0]
+    );
+  }
+  return agents[0];
+}
+
+function findPreferredRootAgent(
+  agents: readonly AgentEntry[],
+  presetOrder: readonly string[],
+): AgentEntry | undefined {
+  const preferredNames = ['orchestrator', 'leanOrchestrator'];
+  for (const preferred of preferredNames) {
+    const entry = agents.find((agent) => agent.name === preferred);
+    if (entry) return entry;
+  }
+  for (const name of presetOrder) {
+    const entry = agents.find((agent) => agent.name === name);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+function includeAgent(
+  agents: readonly AgentEntry[],
+  rootAgent: AgentEntry,
+): AgentEntry[] {
+  return agents.some((agent) => toAgentKey(agent) === toAgentKey(rootAgent))
+    ? [...agents]
+    : [...agents, rootAgent];
+}
+
+function agentHasDelegationTools(agent: AgentEntry): boolean {
+  return agent.tools?.some((tool) => DELEGATION_TOOLS.has(tool)) ?? false;
+}
+
+function toAgentKey(agent: AgentEntry): string {
+  return agentKey(agent.source, agent.name);
 }
 
 function formatAgentNames(names: readonly string[]): string {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -7,6 +7,7 @@ import type { CliMultiAgentPreset } from './multiAgentPresets';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string }
+  | { readonly kind: 'preset'; readonly preset: string }
   | { readonly kind: 'resume'; readonly id: ExecutionId }
   | { readonly kind: 'help' }
   | { readonly kind: 'exit' };
@@ -87,9 +88,8 @@ function presetItems(
   presets: readonly CliMultiAgentPreset[],
 ): CliOrchestrationItem[] {
   return presets.slice(0, MAX_PRESET_ITEMS).map((preset) => ({
-    value: { kind: 'help' },
+    value: { kind: 'preset', preset: preset.id },
     label: `Team ${preset.name}`,
-    description: `${preset.source}; workflow:${preset.workflowAgents.length}; tool-use:${preset.toolUseAgents.length}; run pending`,
-    disabled: true,
+    description: `${preset.source}; workflow:${preset.workflowAgents.length}; tool-use:${preset.toolUseAgents.length}`,
   }));
 }

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,12 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
 import {
   cliMultiAgentPresets,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetList,
+  planCliMultiAgentPresetRun,
   parseCliCustomAgentPresets,
 } from '../../../packages/cli/src/runtime/multiAgentPresets';
+
+function agent(
+  name: string,
+  category: AgentCategory,
+  tools: string[] = [],
+): AgentEntry {
+  return {
+    name,
+    category,
+    source:
+      category === AgentCategory.ToolUse ? 'builtInToolUse' : 'builtInWorkflow',
+    path: `/agents/${name}.yaml`,
+    tools,
+  };
+}
 
 describe('CLI multi-agent presets', () => {
   it('lists built-in team presets with stable counts', () => {
@@ -63,5 +82,55 @@ describe('CLI multi-agent presets', () => {
     expect(formatCliMultiAgentPresetDetails(preset!)).toContain(
       'Tool-use agents:\n  lean',
     );
+  });
+
+  it('plans a preset run with canonical visibility keys and an orchestrator root', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [
+        agent('criticize', AgentCategory.Workflow),
+        agent('generic', AgentCategory.Workflow),
+        agent('devise', AgentCategory.Workflow),
+        agent('apply', AgentCategory.Workflow),
+      ],
+      toolUseAgents: [
+        agent('review', AgentCategory.ToolUse),
+        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+
+    expect(plan.rootAgent?.name).toBe('orchestrator');
+    expect(plan.workflowAgentKeys).toEqual([
+      'builtInWorkflow:criticize',
+      'builtInWorkflow:generic',
+      'builtInWorkflow:devise',
+      'builtInWorkflow:apply',
+    ]);
+    expect(plan.toolUseAgentKeys).toEqual([
+      'builtInToolUse:orchestrator',
+      'builtInToolUse:review',
+    ]);
+    expect(plan.missingToolUseAgents).toContain('research');
+  });
+
+  it('adds an explicit root override to the visible tool-use team', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse),
+        agent('review', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+      agentOverride: 'review',
+    });
+
+    expect(plan.rootAgent?.name).toBe('review');
+    expect(plan.toolUseAgentKeys).toContain('builtInToolUse:review');
   });
 });

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -102,7 +102,7 @@ describe('CLI orchestration items', () => {
     expect(items.map((item) => item.label)).not.toContain('Chat with missing');
   });
 
-  it('lists team presets as disabled until preset execution exists', () => {
+  it('lists team presets as runnable orchestration actions', () => {
     const items = buildCliOrchestrationItems({
       presets: [preset({ id: 'physicist' })],
       history: [],
@@ -111,8 +111,8 @@ describe('CLI orchestration items', () => {
 
     expect(items.find((item) => item.label === 'Team Physicist')).toEqual(
       expect.objectContaining({
-        disabled: true,
-        description: 'built-in; workflow:1; tool-use:2; run pending',
+        value: { kind: 'preset', preset: 'physicist' },
+        description: 'built-in; workflow:1; tool-use:2',
       }),
     );
   });

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " orchestrate chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show multi-agent run models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -61,9 +61,10 @@ _texra() {
     'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --all' ;;
     'agents') subcommands='list'; flags='' ;;
     'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
-    'multi-agent') subcommands='list show'; flags='' ;;
+    'multi-agent') subcommands='list show run'; flags='' ;;
     'multi-agent list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'multi-agent show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'multi-agent run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --agent --model -m --instruction' ;;
     'models') subcommands='list'; flags='' ;;
     'models list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'login') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --provider --no-browser --select-account --login-hint' ;;
@@ -187,6 +188,7 @@ complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'list' -d 'List multi-agent team presets'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'show' -d 'Show one multi-agent team preset'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'run' -d 'Run a multi-agent team preset'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
@@ -199,6 +201,17 @@ complete -c texra -n '__fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working 
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'input' -s 'i' -r -d 'Input file passed to the team orchestrator'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'context' -s 'c' -r -d 'Read-only context file passed to the team orchestrator'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'agent' -r -d 'Tool-use agent to start as the team root (defaults to the preset orchestrator)'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'model' -s 'm' -r -d 'Model for the root tool-use agent'
+complete -c texra -n '__fish_seen_subcommand_from run' -l 'instruction' -r -d 'Additional instruction for the team orchestrator'
 complete -c texra -n '__fish_seen_subcommand_from models' -a 'list' -d 'List available models'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
@@ -292,9 +305,10 @@ _texra() {
     'history delete') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
     'agents') _values 'subcommands' 'list'; true ;;
     'agents list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
-    'multi-agent') _values 'subcommands' 'list' 'show'; true ;;
+    'multi-agent') _values 'subcommands' 'list' 'show' 'run'; true ;;
     'multi-agent list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'multi-agent show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'multi-agent run') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--input[Input file passed to the team orchestrator]:value:' '-i[Input file passed to the team orchestrator]:value:' '--context[Read-only context file passed to the team orchestrator]:value:' '-c[Read-only context file passed to the team orchestrator]:value:' '--agent[Tool-use agent to start as the team root (defaults to the preset orchestrator)]:value:' '--model[Model for the root tool-use agent]:value:' '-m[Model for the root tool-use agent]:value:' '--instruction[Additional instruction for the team orchestrator]:value:' ;;
     'models') _values 'subcommands' 'list'; true ;;
     'models list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'login') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--provider[OAuth provider: github or google (alternative to positional)]:value:' '--no-browser[Print the sign-in URL instead of opening a browser]' '--select-account[Ask the OAuth provider to show account selection when supported]' '--login-hint[Suggest a specific provider account, such as a GitHub username or Google email]:value:' ;;


### PR DESCRIPTION
## Summary

This PR makes CLI multi-agent presets executable instead of merely inspectable.

- Adds `texra multi-agent run <preset> --input <file>` for headless team runs.
- Resolves a preset into the same workflow/tool-use visibility keys used by the extension, starts an available tool-use orchestrator, and restores the previous visibility state after the run.
- Lets the bare `texra` orchestration view open a team preset directly, entering chat with the preset's orchestrating tool-use agent and the team visible for delegation.
- Adds completion coverage and tests for preset run planning and orchestration rows.

This advances #4291. It does not claim the remaining NDJSON per-child stream-event acceptance item; this PR emits the terminal result record and uses the existing runtime stream surfaces.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/Completion.vitest.mts -u`
- `pnpm run typecheck`
- `corepack pnpm --filter @texra/cli build`
- `npm run compile:fast`
- `npm run lint` (passes with 18 pre-existing warnings)
- `node packages/cli/dist/bin/texra.js multi-agent --help`
- `node packages/cli/dist/bin/texra.js multi-agent run --help`
- `node packages/cli/dist/bin/texra.js multi-agent list --print | head -n 8`
- `node packages/cli/dist/bin/texra.js completion bash | rg "multi-agent run|Run a multi-agent"`
- `git diff --check`
- TTY probe of bare `texra` showing team presets as selectable orchestration actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution path that mutates workspace agent-visibility state and launches tool-use agent runs, so regressions could affect which agents are visible/used during CLI sessions.
> 
> **Overview**
> **Multi-agent presets are now executable from the CLI.** Adds `texra multi-agent run <preset> --input ...` to resolve a preset to an available *tool-use* root agent (with optional `--agent`/`--model`) and run it headlessly, emitting results in text/json/ndjson.
> 
> Introduces preset run planning + temporary visibility scoping (`planCliMultiAgentPresetRun`, `withCliMultiAgentPresetVisibility`) that enables only the preset’s workflow/tool-use agents for the duration of the run, warns on missing agents, and then restores prior visibility.
> 
> Updates the interactive `texra` orchestration menu so team presets are selectable and start a chat with the preset’s resolved root agent, and refreshes shell completion snapshots + adds tests for run planning and orchestration items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5acc7e076582f4c90792defc0b58bfafa40e16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->