### PR TITLE
fix(ci): tolerate deleted PR heads in tracker gate

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -65,15 +65,25 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           should_run=true
 
           if [[ "$EVENT_NAME" == pull_request* ]]; then
-            tracker_workflow_changes="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- .github/workflows/issue-tracker.yml)"
-            if [[ -n "$tracker_workflow_changes" ]]; then
-              should_run=false
-              echo "Skipping tracker agent because this PR changes issue-tracker.yml."
-              echo "The Claude action requires workflow content to match the default branch before token exchange."
+            diff_head="$HEAD_SHA"
+            if ! git cat-file -e "$diff_head^{commit}" 2>/dev/null && [[ -n "$MERGE_SHA" ]]; then
+              diff_head="$MERGE_SHA"
+            fi
+
+            if git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null && git cat-file -e "$diff_head^{commit}" 2>/dev/null; then
+              tracker_workflow_changes="$(git diff --name-only "$BASE_SHA" "$diff_head" -- .github/workflows/issue-tracker.yml)"
+              if [[ -n "$tracker_workflow_changes" ]]; then
+                should_run=false
+                echo "Skipping tracker agent because this PR changes issue-tracker.yml."
+                echo "The Claude action requires workflow content to match the default branch before token exchange."
+              fi
+            else
+              echo "::notice::Skipping tracker workflow diff gate because the pull request comparison commits are unavailable."
             fi
           fi
 


### PR DESCRIPTION
## Summary

This PR hardens the issue-tracker workflow gate after a post-merge tracker run failed on #4315.

On `pull_request.closed`, the PR head branch may already be deleted. The workflow currently diffs `base.sha...head.sha` while gating changes to `.github/workflows/issue-tracker.yml`; when the head commit is unavailable, `git diff` fails with `fatal: bad object` and the tracker job fails before it can decide whether to run.

The gate now:

- uses `pull_request.merge_commit_sha` as the comparison head when the original PR head commit is absent;
- checks both comparison commits before diffing;
- emits a notice instead of failing the workflow if GitHub cannot provide a fetchable comparison pair.

## Validation

- `npx prettier --write .github/workflows/issue-tracker.yml`
- `git diff --check`
- Inspected failed tracker log from run `26201970260`, which showed `fatal: bad object d5acc7e076582f4c90792defc0b58bfafa40e16e` in the gate step after PR branch deletion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a GitHub Actions gating script to avoid failing when PR comparison commits are missing; main risk is incorrectly skipping or running the tracker job for some PR events.
> 
> **Overview**
> Hardens the `issue-tracker.yml` “Gate tracker agent” step so PR events don’t fail when the PR head commit is no longer fetchable (e.g., head branch deleted on `pull_request.closed`).
> 
> The gate now prefers `pull_request.merge_commit_sha` when `head.sha` is unavailable, verifies both comparison commits exist before running `git diff`, and emits a `::notice::` (instead of erroring) when the comparison SHAs can’t be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52774574881b64d1e6cd0bd7f2e3c4ebc79d2c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->