### PR TITLE
test(cli): cover ndjson subagent progress

### DIFF
--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -178,6 +178,66 @@ describe('CLI run progress renderer', () => {
     expect(output).toContain('polish paper.tex · 0s');
   });
 
+  it('writes subagent progress events to stdout in ndjson mode', async () => {
+    let output = '';
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((
+      chunk: string | Uint8Array,
+      ...args: unknown[]
+    ) => {
+      output += String(chunk);
+      const callback = args.find(
+        (arg): arg is (error?: Error | null) => void =>
+          typeof arg === 'function',
+      );
+      callback?.();
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const host = createCliRuntimeHost(
+        context({ outputFormat: 'ndjson', renderRunProgress: false }),
+      );
+      host.emit('updateActiveSubagents', {
+        parentStreamId: 'parent-stream',
+        children: [
+          {
+            executionId: 'child-execution',
+            childStreamId: 'child-stream',
+            agentName: 'review',
+            status: 'running',
+          },
+        ],
+      });
+      await host.close();
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const records = output
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'updateActiveSubagents',
+        payload: {
+          parentStreamId: 'parent-stream',
+          children: [
+            {
+              executionId: 'child-execution',
+              childStreamId: 'child-stream',
+              agentName: 'review',
+              status: 'running',
+            },
+          ],
+        },
+      }),
+    ]);
+  });
+
   it('maps the global quiet flag into CLI context args', () => {
     expect(
       pickGlobalArgs({


### PR DESCRIPTION
## Summary

This PR adds focused regression coverage for the remaining `texra multi-agent run --output-format ndjson` streaming guarantee from #4291.

The CLI runtime host already writes progress events to stdout in NDJSON mode. This test now exercises the real runtime host with an `updateActiveSubagents` event and asserts that the emitted record preserves the child execution id, child stream id, agent name, status, and parent stream id.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `pnpm run typecheck`
- `npm run lint` (passes with 18 pre-existing warnings)
- `node packages/cli/dist/bin/texra.js multi-agent run --help | sed -n '1,80p'`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that validates existing NDJSON progress emission behavior without modifying runtime logic.
> 
> **Overview**
> Adds a new Vitest case that runs a real `createCliRuntimeHost` in `ndjson` mode, emits an `updateActiveSubagents` event, and asserts the stdout NDJSON record contains the expected `kind/event/payload` fields (including parent stream and child execution/stream IDs, agent name, and status).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41b0643fc808a0bb4755b3f14f70353d414fd6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->