### PR TITLE
fix(cli): promote detached subagent streams

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -185,9 +185,17 @@ export function patchStream(
 
 export function setParentStream(
   childStreamId: StreamTabId,
-  parentStreamId: StreamTabId,
+  parentStreamId: StreamTabId | null | undefined,
 ): void {
   const current = cliState.parentStream.get();
+  // A null parent means the runtime promoted this child to a top-level stream.
+  if (parentStreamId == null || childStreamId === parentStreamId) {
+    if (!current.has(childStreamId)) return;
+    const out = new Map(current);
+    out.delete(childStreamId);
+    cliState.parentStream.set(out);
+    return;
+  }
   if (current.get(childStreamId) === parentStreamId) return;
   const out = new Map(current);
   out.set(childStreamId, parentStreamId);

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -722,11 +722,15 @@ export class DesktopProgressBridge {
       }
       case 'setParentStream': {
         const data = payload as ProgressEventPayloads['setParentStream'];
-        this.parentStreams.set(data.childStreamId, data.parentStreamId);
+        if (data.parentStreamId == null) {
+          this.parentStreams.delete(data.childStreamId);
+        } else {
+          this.parentStreams.set(data.childStreamId, data.parentStreamId);
+        }
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM,
           stream: data.childStreamId,
-          parentStreamId: data.parentStreamId,
+          parentStreamId: data.parentStreamId ?? undefined,
         });
         break;
       }

--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -134,7 +134,7 @@ export class ProgressEventHandler {
           if (this.webviewUpdater.isAvailable()) {
             this.webviewUpdater.updateParentStream(
               childStreamId,
-              parentStreamId,
+              parentStreamId ?? undefined,
             );
           }
         },

--- a/packages/extension/src/progressView/managers/StreamMetaManager.ts
+++ b/packages/extension/src/progressView/managers/StreamMetaManager.ts
@@ -63,8 +63,15 @@ export class StreamMetaManager {
     return this.parentStreamIds.get(stream);
   }
 
-  setParentStream(child: StreamTabId, parent: StreamTabId): void {
-    this.parentStreamIds.set(child, parent);
+  setParentStream(
+    child: StreamTabId,
+    parent: StreamTabId | null | undefined,
+  ): void {
+    if (parent == null) {
+      this.parentStreamIds.delete(child);
+    } else {
+      this.parentStreamIds.set(child, parent);
+    }
     this.save(child);
   }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -233,6 +233,10 @@ export function detachActiveChildren(
       handle.childStreamId !== parentStreamId
     ) {
       handle.detach();
+      runtimeHost.emit('setParentStream', {
+        childStreamId: handle.childStreamId,
+        parentStreamId: null,
+      });
     } else if (handle instanceof ProcessExecutionHandle) {
       handle.terminate();
     }

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -148,7 +148,7 @@ export interface ProgressEventPayloads {
   };
   setParentStream: {
     childStreamId: StreamTabId;
-    parentStreamId: StreamTabId;
+    parentStreamId: StreamTabId | null;
   };
   /** A follow-up message was sent to an active tool-use session.
    *  Listened by blocking tools (e.g. ExecutionsTool wait) to abort early. */

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -92,9 +92,14 @@ describe('executionRegistry', () => {
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',
         'setParentStream',
+        'setParentStream',
         'updateActiveSubagents',
       ]);
       expect(explicit.events[2].payload).toEqual({
+        childStreamId,
+        parentStreamId: null,
+      });
+      expect(explicit.events[3].payload).toEqual({
         parentStreamId,
         children: [],
       });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -98,6 +98,15 @@ describe('cliState Phase 4 fields', () => {
     removeStream(root);
     expect(cliState.parentStream.get().has(child2)).toBe(false);
   });
+
+  it('treats a null-parent update as child promotion to top-level', () => {
+    setParentStream(child1, root);
+    expect(cliState.parentStream.get().get(child1)).toBe(root);
+
+    setParentStream(child1, null);
+
+    expect(cliState.parentStream.get().has(child1)).toBe(false);
+  });
 });
 
 describe('CLI TUI row allocation', () => {

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view frontend
+import { streamLifecycleHandlers } from '@progressView/frontend/slices/streamLifecycleSlice';
 import { streamMetaHandlers } from '@progressView/frontend/slices/streamMetaSlice';
 import {
   createInitialState,
@@ -89,6 +90,15 @@ function dispatch(
   handler?.(message as never, ctx);
 }
 
+function dispatchLifecycle(
+  message: ProgressViewOutboundMessage,
+  ctx: MessageHandlerContext,
+) {
+  const handler = streamLifecycleHandlers[message.command];
+  expect(handler).toBeDefined();
+  handler?.(message as never, ctx);
+}
+
 describe('process output frontend state', () => {
   it('appends output without pruning sibling process entries', () => {
     const streamId = 'stream-a' as StreamTabId;
@@ -141,5 +151,36 @@ describe('process output frontend state', () => {
     const outputs = getState().processOutputs.get(streamId);
     expect(outputs?.has('active-process')).toBe(true);
     expect(outputs?.has('stale-process')).toBe(false);
+  });
+
+  it('clears a stream parent when update parent stream receives null', () => {
+    const parent = 'stream-parent' as StreamTabId;
+    const child = 'stream-child' as StreamTabId;
+    const state = createInitialState();
+    state.streamById.set(parent, {
+      name: parent,
+      label: 'parent',
+      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      creationTimestamp: 1,
+    });
+    state.streamById.set(child, {
+      name: child,
+      label: 'child',
+      agentCategory: AGENT_CATEGORY.TOOL_USE,
+      creationTimestamp: 2,
+      parentStreamId: parent,
+    });
+    const { ctx, getState } = createContext(state);
+
+    dispatchLifecycle(
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM,
+        stream: child,
+        parentStreamId: null,
+      },
+      ctx,
+    );
+
+    expect(getState().streamById.get(child)?.parentStreamId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

When an orchestrator is stopped without killing its children, `detachActiveChildren` promotes each child execution to a top-level stream in the runtime handle. The runtime did not publish the corresponding parent-stream update, so UI consumers could keep a stale child-to-parent edge after the underlying handle had been detached.

This PR makes the runtime emit `setParentStream` with `parentStreamId: null` for each detached child. The CLI TUI, VS Code progress view metadata/frontend, and desktop progress bridge now interpret that null parent as deletion of the parent edge. This keeps the focus/tab graph finite and makes detached child streams behave as top-level streams across hosts.

This is a partial slice of #4277, specifically the detached-child promotion invariant in the multi-agent TUI parity section.

## Tests

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProcessOutputState.vitest.ts`
- `pnpm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

`npm run lint` passes with the existing 18 warnings already present on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-host stream lineage handling (runtime event payloads + three UI consumers), so a mismatch could leave stale parent/child edges or incorrect tab/focus behavior, but changes are small and covered by targeted tests.
> 
> **Overview**
> Fixes detached subagent promotion by having `detachActiveChildren` emit `setParentStream` with `parentStreamId: null` when a child is detached, making the parent-edge removal explicit.
> 
> Updates CLI TUI state, desktop progress bridge, and VS Code progress view metadata to interpret a null/undefined parent as *delete the parent mapping* (promotion to top-level), and adjusts the `ProgressEventBus` type plus adds regression tests to ensure parent edges are cleared correctly across consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ffc9dd6ed1d86be11b5a851821844575692e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->