### PR TITLE
fix(cli): open resume picker from slash palette

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,10 +1,13 @@
 // Registers the slash commands the input palette surfaces.
 
+import type { ExecutionId } from '@shared/schemas';
+
 import { ApiModeForm } from '../forms/ApiModeForm';
 import { AgentListForm } from '../forms/AgentListForm';
 import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
+import { ResumeListForm } from '../forms/ResumeListForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 import type { CliApiMode } from '../../../runtime/apiAccessMode';
@@ -17,6 +20,7 @@ type ApprovalPolicySelectHandler = (
 type ModelSelectHandler = (value: string) => void | Promise<void>;
 type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
+type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
 
 function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
@@ -36,6 +40,8 @@ export function registerBuiltinSlashCommands(options?: {
   onApiModeSelect?: ApiModeSelectHandler;
   onMemorySelect?: MemorySelectHandler;
   onMemoryError?: ErrorHandler;
+  onResumeSelect?: ResumeSelectHandler;
+  onResumeError?: ErrorHandler;
 }): void {
   const onAgentSelect: AgentSelectHandler =
     options?.onAgentSelect ?? ((value) => patchSessionMeta('agent', value));
@@ -46,6 +52,8 @@ export function registerBuiltinSlashCommands(options?: {
     options?.onApiModeSelect ?? ((value) => patchSessionMeta('apiMode', value));
   const onMemorySelect = options?.onMemorySelect;
   const onMemoryError = options?.onMemoryError;
+  const onResumeSelect = options?.onResumeSelect;
+  const onResumeError = options?.onResumeError;
 
   function AgentListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = cliState.sessionMeta.get().agent;
@@ -128,6 +136,20 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
+  function ResumeListFormAdapter(props: SlashFormProps): React.JSX.Element {
+    return (
+      <ResumeListForm
+        availableRows={props.availableRows}
+        onSelect={(id) => {
+          void Promise.resolve(onResumeSelect?.(id))
+            .catch((error: unknown) => onResumeError?.(error))
+            .finally(() => props.onDone(id));
+        }}
+        onClose={() => props.onDone(undefined)}
+      />
+    );
+  }
+
   registerSlashCommand({
     name: 'help',
     description: 'Show available slash commands',
@@ -171,6 +193,7 @@ export function registerBuiltinSlashCommands(options?: {
   registerSlashCommand({
     name: 'resume',
     description: 'Resume a previous session',
+    formComponent: ResumeListFormAdapter,
   });
   registerSlashCommand({
     name: 'memory',

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -818,6 +818,21 @@ export async function runChat(
     onMemoryError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },
+    onResumeSelect: (id) =>
+      resumeStoredExecution(id, {
+        session,
+        initialAgent: agent,
+        initialModel: model,
+        interruptActive,
+        requestInputExit: () => requestInputExit?.(),
+        getApprovalPolicy,
+        setApprovalPolicy,
+        resetSession: resetSessionForClear,
+        startStoredExecution: startAgentRun,
+      }),
+    onResumeError: (error) => {
+      appendLocalAssistantTranscript(toErrorMessage(error));
+    },
   });
 
   const startSession = (instruction: string): void => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -28,6 +28,7 @@ describe('slashRegistry', () => {
         'approval',
         'yolo',
         'status',
+        'resume',
         'memory',
         'compact',
       ]),
@@ -52,6 +53,12 @@ describe('slashRegistry', () => {
     expect(listSlashCommands().find((cmd) => cmd.name === 'memory')).toEqual(
       expect.objectContaining({
         description: 'List stored memories',
+        formComponent: expect.any(Function),
+      }),
+    );
+    expect(listSlashCommands().find((cmd) => cmd.name === 'resume')).toEqual(
+      expect.objectContaining({
+        description: 'Resume a previous session',
         formComponent: expect.any(Function),
       }),
     );


### PR DESCRIPTION
## Summary

Selecting `/resume` from the CLI slash palette now opens the same stored-execution picker as typing `/resume` and pressing Enter. Previously `/resume` was registered as a plain slash command, so palette selection only completed text, unlike other picker commands such as `/model`, `/agent`, `/approval`, and `/memory`.

This is a small #4277 parity polish for the in-TUI resume workflow.

## Tests

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ResumeListForm.vitest.mts`
- `corepack pnpm --filter @texra/cli build`
- Built CLI TUI probe: `node packages/cli/dist/bin/texra.js chat`, typed `/res`, pressed Enter on the slash palette, verified `/resume` picker opened directly.
- `pnpm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

`npm run lint` passes with the existing 18 warnings already present on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX parity change that wires the existing `/resume` picker into the slash palette; no auth/data-path logic changes beyond invoking the existing resume flow and surfacing errors.
> 
> **Overview**
> **Enables `/resume` in the slash-command palette to open the stored-execution picker** (like other picker-style commands), by registering `/resume` with a `formComponent` and adding a `ResumeListForm` adapter.
> 
> `runChatTui` now provides `onResumeSelect`/`onResumeError` handlers so selecting a prior execution from the palette routes through the existing `resumeStoredExecution` path, and tests assert `/resume` is registered as a structured-form command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd39b386b32d4bbd395c8d9f2287460c8ced82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->