### PR TITLE
fix(cli): keep retained subagents selectable

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -5,6 +5,7 @@ import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
 import { isPlainReturnInput } from '../input/inputKeys';
+import { mergeChildStreams } from './childStreamMerge';
 import { orderedDescendantsFromSlice } from './focusCycle';
 import type { ProcessOutputTail, StreamSlice } from './cliState';
 
@@ -136,7 +137,7 @@ export function processTailLines(
 export function buildChildControlItems(
   slice: Pick<
     StreamSlice,
-    'activeProcesses' | 'activeSubagents' | 'processOutput'
+    'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
   >,
   mode: ChildControlMode,
   streamsById: ReadonlyMap<
@@ -145,8 +146,8 @@ export function buildChildControlItems(
   > = new Map(),
 ): readonly ChildControlItem[] {
   if (mode === 'subagents') {
-    return slice.activeSubagents.map((child) =>
-      buildSubagentItem(child, streamsById),
+    return mergeChildStreams(slice.childStreams, slice.activeSubagents).map(
+      (child) => buildSubagentItem(child, streamsById),
     );
   }
 

--- a/packages/cli/src/chat/tui/state/childStreamMerge.ts
+++ b/packages/cli/src/chat/tui/state/childStreamMerge.ts
@@ -1,0 +1,14 @@
+// Local imports - shared schemas
+import type { ActiveChildInfo } from '@shared/schemas';
+
+export function mergeChildStreams(
+  current: readonly ActiveChildInfo[],
+  next: readonly ActiveChildInfo[],
+): readonly ActiveChildInfo[] {
+  const byStream = new Map<string, ActiveChildInfo>();
+  for (const child of [...current, ...next]) {
+    const key = child.childStreamId ?? child.executionId;
+    byStream.set(key, child);
+  }
+  return [...byStream.values()];
+}

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -7,7 +7,6 @@ import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
-import type { ActiveChildInfo } from '@shared/schemas';
 import { appendTail } from '@utils/strings/appendTail';
 
 import {
@@ -17,6 +16,7 @@ import {
   setParentStream,
   type ProcessOutputTail,
 } from './cliState';
+import { mergeChildStreams } from './childStreamMerge';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
@@ -30,22 +30,6 @@ type Emit = <K extends ProgressEvent>(
  *  we truncate at the head via the shared `appendTail` helper so the live
  *  pane never grows unbounded. */
 export const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
-
-function mergeChildStreams(
-  current: readonly ActiveChildInfo[],
-  next: readonly ActiveChildInfo[],
-): readonly ActiveChildInfo[] {
-  const byStream = new Map<string, ActiveChildInfo>();
-  for (const child of current) {
-    const key = child.childStreamId ?? child.executionId;
-    byStream.set(key, child);
-  }
-  for (const child of next) {
-    const key = child.childStreamId ?? child.executionId;
-    byStream.set(key, child);
-  }
-  return [...byStream.values()];
-}
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -24,7 +24,10 @@ function tail(stdout: string, stderr = ''): ProcessOutputTail {
 
 function slice(
   overrides: Partial<StreamSlice> = {},
-): Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'processOutput'> &
+): Pick<
+  StreamSlice,
+  'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
+> &
   StreamSlice {
   return {
     streamId: 'root',
@@ -155,6 +158,50 @@ describe('CLI child execution controls', () => {
         label: 'bash',
         command: 'timeout 1800 texra run paper',
         tailLines: ['line one', 'line two'],
+      },
+    ]);
+  });
+
+  it('keeps retained subagent streams selectable after they leave the active list', () => {
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-2',
+          agentName: 'polisher',
+          childStreamId: 'child-b',
+          status: 'running',
+        },
+      ],
+      childStreams: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'completed',
+        },
+        {
+          executionId: 'agent-2',
+          agentName: 'polisher',
+          childStreamId: 'child-b',
+          status: 'waiting',
+        },
+      ],
+    });
+
+    expect(buildChildControlItems(state, 'subagents')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        childStreamId: 'child-a',
+        kind: 'subagent',
+        label: 'critic',
+        description: 'completed',
+      },
+      {
+        executionId: 'agent-2',
+        childStreamId: 'child-b',
+        kind: 'subagent',
+        label: 'polisher',
+        description: 'running',
       },
     ]);
   });


### PR DESCRIPTION
## Summary

The CLI TUI can retain child stream metadata after a subagent leaves the active list, and the status bar can still advertise `Alt-s` in that state. The subagent picker, however, only read `activeSubagents`, so it could open with “No active subagents” even though retained child streams were still available in the stream tabs/focus model.

This changes the subagent picker data source to merge retained `childStreams` with `activeSubagents`, with active rows overriding stale retained metadata for the same child stream. Retained completed or waiting subagent streams remain focusable from `Alt-s`.

This is a small #4277 multi-agent TUI parity slice.

## Tests

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts`
- `pnpm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

`npm run lint` passes with the existing 18 warnings already present on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to CLI TUI picker data sourcing plus refactor of an existing merge helper; behavior change is covered by a focused unit test.
> 
> **Overview**
> The CLI TUI subagent picker now builds its list by **merging retained `childStreams` with `activeSubagents`**, ensuring subagent streams remain selectable even after leaving the active list, with active metadata overriding retained entries.
> 
> The child-stream merge logic was extracted into a shared `mergeChildStreams` helper (used by both the picker and `subscribeRuntimeHost`), and tests were updated/added to assert retained subagents remain visible in `Alt-s` selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2ef3f414a1f54e85d04462280f992f92162b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->