### PR TITLE
test(cli): cover manual compaction request path

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -80,6 +80,7 @@ import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog, syncStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
+import { requestCliCompaction } from './state/compactionRequest';
 import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
@@ -425,37 +426,6 @@ function openCliMemoryListForm(): void {
   });
 }
 
-function requestCliCompaction(): void {
-  const streamId = cliState.activeStreamId.get();
-  if (!streamId) {
-    appendLocalAssistantTranscript(
-      'No active tool-use session found for context compaction.',
-    );
-    return;
-  }
-
-  const flowContext = getToolUseFlowContext(streamId);
-  if (!flowContext) {
-    appendLocalAssistantTranscript(
-      'No active tool-use session found for context compaction.',
-    );
-    return;
-  }
-
-  if (!flowContext.modelHandler.supportsManualCompaction) {
-    appendLocalAssistantTranscript(
-      'Manual context compaction is not available for the current model.',
-    );
-    return;
-  }
-
-  flowContext.requestImmediateCompaction();
-  notifyFollowUpSent(streamId, flowContext.runtimeHost);
-  appendLocalAssistantTranscript(
-    'Context compaction requested. The agent will process it on the next model call.',
-  );
-}
-
 async function handleTuiSlashCommand(
   line: string,
   context: SlashCommandContext,
@@ -569,7 +539,12 @@ async function handleTuiSlashCommand(
       return true;
     }
     case 'compact':
-      requestCliCompaction();
+      requestCliCompaction({
+        streamId: cliState.activeStreamId.get(),
+        getFlowContext: getToolUseFlowContext,
+        notifyFollowUpSent,
+        appendTranscript: appendLocalAssistantTranscript,
+      });
       return true;
     default: {
       const registered = listSlashCommands().find(

--- a/packages/cli/src/chat/tui/state/compactionRequest.ts
+++ b/packages/cli/src/chat/tui/state/compactionRequest.ts
@@ -1,0 +1,57 @@
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { StreamTabId } from '@shared/schemas';
+
+interface CliCompactionFlowContext {
+  readonly modelHandler: {
+    readonly supportsManualCompaction: boolean;
+  };
+  readonly runtimeHost?: AgentRuntimeHost;
+  requestImmediateCompaction(): void;
+}
+
+export interface CliCompactionRequestOptions {
+  readonly streamId: StreamTabId | undefined;
+  readonly getFlowContext: (
+    streamId: StreamTabId,
+  ) => CliCompactionFlowContext | undefined;
+  readonly notifyFollowUpSent: (
+    streamId: StreamTabId,
+    runtimeHost?: AgentRuntimeHost,
+  ) => void;
+  readonly appendTranscript: (message: string) => void;
+}
+
+export function requestCliCompaction({
+  streamId,
+  getFlowContext,
+  notifyFollowUpSent,
+  appendTranscript,
+}: CliCompactionRequestOptions): void {
+  if (!streamId) {
+    appendTranscript(
+      'No active tool-use session found for context compaction.',
+    );
+    return;
+  }
+
+  const flowContext = getFlowContext(streamId);
+  if (!flowContext) {
+    appendTranscript(
+      'No active tool-use session found for context compaction.',
+    );
+    return;
+  }
+
+  if (!flowContext.modelHandler.supportsManualCompaction) {
+    appendTranscript(
+      'Manual context compaction is not available for the current model.',
+    );
+    return;
+  }
+
+  flowContext.requestImmediateCompaction();
+  notifyFollowUpSent(streamId, flowContext.runtimeHost);
+  appendTranscript(
+    'Context compaction requested. The agent will process it on the next model call.',
+  );
+}

--- a/src/test-kernel/cli/CompactionRequest.vitest.mts
+++ b/src/test-kernel/cli/CompactionRequest.vitest.mts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { requestCliCompaction } from '../../../packages/cli/src/chat/tui/state/compactionRequest';
+
+function compactableFlow() {
+  return {
+    modelHandler: { supportsManualCompaction: true },
+    runtimeHost: undefined,
+    requestImmediateCompaction: vi.fn(),
+  };
+}
+
+describe('requestCliCompaction', () => {
+  it('reports a missing active stream without touching follow-up state', () => {
+    const appendTranscript = vi.fn();
+    const getFlowContext = vi.fn();
+    const notifyFollowUpSent = vi.fn();
+
+    requestCliCompaction({
+      streamId: undefined,
+      getFlowContext,
+      notifyFollowUpSent,
+      appendTranscript,
+    });
+
+    expect(getFlowContext).not.toHaveBeenCalled();
+    expect(notifyFollowUpSent).not.toHaveBeenCalled();
+    expect(appendTranscript).toHaveBeenCalledWith(
+      'No active tool-use session found for context compaction.',
+    );
+  });
+
+  it('reports a stale active stream when no flow context is registered', () => {
+    const appendTranscript = vi.fn();
+    const getFlowContext = vi.fn().mockReturnValue(undefined);
+    const notifyFollowUpSent = vi.fn();
+
+    requestCliCompaction({
+      streamId: 'stream-1',
+      getFlowContext,
+      notifyFollowUpSent,
+      appendTranscript,
+    });
+
+    expect(getFlowContext).toHaveBeenCalledExactlyOnceWith('stream-1');
+    expect(notifyFollowUpSent).not.toHaveBeenCalled();
+    expect(appendTranscript).toHaveBeenCalledWith(
+      'No active tool-use session found for context compaction.',
+    );
+  });
+
+  it('reports models that cannot compact manually', () => {
+    const appendTranscript = vi.fn();
+    const flowContext = {
+      modelHandler: { supportsManualCompaction: false },
+      runtimeHost: undefined,
+      requestImmediateCompaction: vi.fn(),
+    };
+    const notifyFollowUpSent = vi.fn();
+
+    requestCliCompaction({
+      streamId: 'stream-1',
+      getFlowContext: vi.fn().mockReturnValue(flowContext),
+      notifyFollowUpSent,
+      appendTranscript,
+    });
+
+    expect(flowContext.requestImmediateCompaction).not.toHaveBeenCalled();
+    expect(notifyFollowUpSent).not.toHaveBeenCalled();
+    expect(appendTranscript).toHaveBeenCalledWith(
+      'Manual context compaction is not available for the current model.',
+    );
+  });
+
+  it('requests compaction and wakes the active tool-use flow', () => {
+    const appendTranscript = vi.fn();
+    const flowContext = compactableFlow();
+    const notifyFollowUpSent = vi.fn();
+
+    requestCliCompaction({
+      streamId: 'stream-1',
+      getFlowContext: vi.fn().mockReturnValue(flowContext),
+      notifyFollowUpSent,
+      appendTranscript,
+    });
+
+    expect(flowContext.requestImmediateCompaction).toHaveBeenCalledOnce();
+    expect(notifyFollowUpSent).toHaveBeenCalledExactlyOnceWith(
+      'stream-1',
+      undefined,
+    );
+    expect(appendTranscript).toHaveBeenCalledWith(
+      'Context compaction requested. The agent will process it on the next model call.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR extracts the CLI TUI manual compaction request logic into a small testable helper and covers the command surface used by `/compact`.

It verifies that the TUI:
- reports when no active tool-use stream exists;
- reports when the selected stream has no live flow context;
- reports models that do not support manual compaction;
- requests compaction and emits the follow-up notification for compactable tool-use flows.

This closes one verification gap from #4277. Automatic compaction remains implemented in the shared model handlers, so the remaining work there is end-to-end evidence across chat/headless runs rather than a separate CLI-only code path.

## Checks

- `corepack pnpm vitest run src/test-kernel/cli/CompactionRequest.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts --config vitest.config.mjs`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors `/compact` handling into a small helper and adds unit coverage; behavior should remain the same aside from improved testability.
> 
> **Overview**
> Refactors the TUI `/compact` slash-command path by extracting the manual compaction request logic from `runChatTui.tsx` into a new `requestCliCompaction` helper (`state/compactionRequest.ts`) with explicit, injectable dependencies.
> 
> Adds Vitest coverage for the helper to verify messaging and side effects for missing/stale streams, unsupported models, and the successful compaction+follow-up notification path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5656e6b9eff15c8dc8aa9cb59f8bd4f5ec4ed8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->