### PR TITLE
fix(cli): show retained subagent rows

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -18,6 +18,7 @@ import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
 import {
+  hasChildExecutionRows,
   numericFocusTarget,
   type ChildControlMode,
 } from './state/childControls';
@@ -198,10 +199,7 @@ export function App(props: AppProps): React.JSX.Element {
     activeSlice,
   );
   const hasSubagentPanel =
-    !foregroundOpen &&
-    activeSlice !== undefined &&
-    (activeSlice.activeSubagents.length > 0 ||
-      activeSlice.activeProcesses.length > 0);
+    !foregroundOpen && hasChildExecutionRows(activeSlice);
   const hasTodosPlanPanel =
     !foregroundOpen &&
     activeSlice !== undefined &&

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -8,6 +8,7 @@ import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
 
+import { visibleSubagentRows } from '../state/childControls';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 
@@ -73,8 +74,9 @@ export function SubagentList(
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (!slice) return null;
-  const { activeSubagents, activeProcesses, processOutput } = slice;
-  if (activeSubagents.length === 0 && activeProcesses.length === 0) return null;
+  const { activeProcesses, processOutput } = slice;
+  const subagents = visibleSubagentRows(slice);
+  if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
 
   return (
@@ -85,21 +87,18 @@ export function SubagentList(
       paddingX={1}
       marginBottom={props.maxRows === undefined ? 1 : 0}
     >
-      {activeSubagents.length > 0 ? (
+      {subagents.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>
             Subagents
           </Text>
-          {activeSubagents.map((child, i) => (
+          {subagents.map((child, i) => (
             <Row key={child.executionId} child={child} index={i} />
           ))}
         </Box>
       ) : null}
       {activeProcesses.length > 0 ? (
-        <Box
-          flexDirection="column"
-          marginTop={activeSubagents.length > 0 ? 1 : 0}
-        >
+        <Box flexDirection="column" marginTop={subagents.length > 0 ? 1 : 0}>
           <Text bold dimColor>
             Processes
           </Text>
@@ -107,7 +106,7 @@ export function SubagentList(
             <Row
               key={child.executionId}
               child={child}
-              index={activeSubagents.length + i}
+              index={subagents.length + i}
               tail={processOutput.get(child.executionId)}
             />
           ))}

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -5,7 +5,7 @@ import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
 import { isPlainReturnInput } from '../input/inputKeys';
-import { mergeChildStreams } from './childStreamMerge';
+import { visibleSubagentRows as mergeVisibleSubagentRows } from './childStreamMerge';
 import { orderedDescendantsFromSlice } from './focusCycle';
 import type { ProcessOutputTail, StreamSlice } from './cliState';
 
@@ -146,8 +146,8 @@ export function buildChildControlItems(
   > = new Map(),
 ): readonly ChildControlItem[] {
   if (mode === 'subagents') {
-    return mergeChildStreams(slice.childStreams, slice.activeSubagents).map(
-      (child) => buildSubagentItem(child, streamsById),
+    return visibleSubagentRows(slice).map((child) =>
+      buildSubagentItem(child, streamsById),
     );
   }
 
@@ -159,6 +159,23 @@ export function buildChildControlItems(
       buildProcessItem(child, slice.processOutput.get(child.executionId)),
     ),
   ];
+}
+
+export function visibleSubagentRows(
+  slice: Pick<StreamSlice, 'activeSubagents' | 'childStreams'>,
+): readonly ActiveChildInfo[] {
+  return mergeVisibleSubagentRows(slice.activeSubagents, slice.childStreams);
+}
+
+export function hasChildExecutionRows(
+  slice:
+    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
+    | undefined,
+): boolean {
+  return (
+    slice !== undefined &&
+    (visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0)
+  );
 }
 
 export function numericFocusTarget(

--- a/packages/cli/src/chat/tui/state/childStreamMerge.ts
+++ b/packages/cli/src/chat/tui/state/childStreamMerge.ts
@@ -12,3 +12,18 @@ export function mergeChildStreams(
   }
   return [...byStream.values()];
 }
+
+export function visibleSubagentRows(
+  activeSubagents: readonly ActiveChildInfo[],
+  retainedChildStreams: readonly ActiveChildInfo[],
+): readonly ActiveChildInfo[] {
+  const activeKeys = new Set(
+    activeSubagents.map((child) => child.childStreamId ?? child.executionId),
+  );
+  return [
+    ...activeSubagents,
+    ...retainedChildStreams.filter(
+      (child) => !activeKeys.has(child.childStreamId ?? child.executionId),
+    ),
+  ];
+}

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -12,6 +12,7 @@
 
 import { type StreamTabId } from '@shared/schemas';
 
+import { visibleSubagentRows } from './childStreamMerge';
 import { cliState, type StreamSlice } from './cliState';
 
 export function orderedDescendantsFromSlice(
@@ -22,9 +23,8 @@ export function orderedDescendantsFromSlice(
   if (!slice) return [];
   const out: StreamTabId[] = [];
   for (const child of [
-    ...slice.activeSubagents,
+    ...visibleSubagentRows(slice.activeSubagents, slice.childStreams),
     ...slice.activeProcesses,
-    ...slice.childStreams,
   ]) {
     if (child.childStreamId) out.push(child.childStreamId);
   }

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -9,8 +9,10 @@ import {
 import {
   buildChildControlItems,
   childPickerKeyAction,
+  hasChildExecutionRows,
   nextPickerIndex,
   numericFocusTarget,
+  visibleSubagentRows,
 } from '../../../packages/cli/src/chat/tui/state/childControls';
 import { NO_BYPASS } from '../../../packages/cli/src/chat/tui/state/cliState';
 import type {
@@ -65,11 +67,19 @@ describe('CLI child execution controls', () => {
           childStreamId: 'child-b',
         },
       ],
+      childStreams: [
+        {
+          executionId: 'agent-2',
+          agentName: 'critic',
+          childStreamId: 'child-c',
+        },
+      ],
     });
 
     expect(numericFocusTarget(state, 0)).toBe('child-a');
-    expect(numericFocusTarget(state, 1)).toBe('child-b');
-    expect(numericFocusTarget(state, 2)).toBeUndefined();
+    expect(numericFocusTarget(state, 1)).toBe('child-c');
+    expect(numericFocusTarget(state, 2)).toBe('child-b');
+    expect(numericFocusTarget(state, 3)).toBeUndefined();
   });
 
   it('builds subagent and process picker items with stable labels and tails', () => {
@@ -190,20 +200,76 @@ describe('CLI child execution controls', () => {
 
     expect(buildChildControlItems(state, 'subagents')).toMatchObject([
       {
-        executionId: 'agent-1',
-        childStreamId: 'child-a',
-        kind: 'subagent',
-        label: 'critic',
-        description: 'completed',
-      },
-      {
         executionId: 'agent-2',
         childStreamId: 'child-b',
         kind: 'subagent',
         label: 'polisher',
         description: 'running',
       },
+      {
+        executionId: 'agent-1',
+        childStreamId: 'child-a',
+        kind: 'subagent',
+        label: 'critic',
+        description: 'completed',
+      },
     ]);
+  });
+
+  it('keeps retained subagent streams visible in the side-panel row model', () => {
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-2',
+          agentName: 'polisher',
+          childStreamId: 'child-b',
+          status: 'running',
+        },
+      ],
+      childStreams: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'completed',
+        },
+        {
+          executionId: 'agent-2',
+          agentName: 'polisher',
+          childStreamId: 'child-b',
+          status: 'waiting',
+        },
+      ],
+    });
+
+    expect(visibleSubagentRows(state)).toMatchObject([
+      {
+        executionId: 'agent-2',
+        childStreamId: 'child-b',
+        status: 'running',
+      },
+      {
+        executionId: 'agent-1',
+        childStreamId: 'child-a',
+        status: 'completed',
+      },
+    ]);
+    expect(hasChildExecutionRows(state)).toBe(true);
+  });
+
+  it('opens the child side panel when only retained subagent streams remain', () => {
+    const state = slice({
+      childStreams: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'completed',
+        },
+      ],
+    });
+
+    expect(hasChildExecutionRows(state)).toBe(true);
   });
 
   it('keeps picker key handling independent of Ink rendering', () => {


### PR DESCRIPTION
## Summary

This PR aligns the CLI TUI child-row model across the focus cycle, subagent picker, and side panel.

The side panel previously hid itself when a parent stream had retained child streams but no currently active subagents or processes. That left a child stream focusable through tabs and selectable through `Alt-s`, but absent from the visible child list. The patch moves retained-child merging into a shared helper and uses it for side-panel visibility and row rendering.

This is another #4277 multi-agent TUI parity slice: retained subagent streams remain visible, selectable, and focusable after they leave the active list.

## Checks

- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts --config vitest.config.mjs`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the child-row source of truth used for side-panel rendering and focus ordering, which can affect keyboard navigation and what streams are shown/selected. Risk is limited to CLI TUI state/UI behavior with added test coverage.
> 
> **Overview**
> Aligns the CLI TUI “child execution” row model so **retained subagent child streams** remain visible/usable after leaving `activeSubagents`.
> 
> Side-panel visibility and `SubagentList` rendering now use a shared `visibleSubagentRows`/`hasChildExecutionRows` helper, and the focus-cycle/Alt-number ordering is updated to include retained child streams. Tests are updated/extended to cover the new ordering and side-panel visibility behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e960b0222fa020038749cd765448325a7c3c07c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->