### PR TITLE
fix(cli): activate approval streams when presented

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -54,6 +54,10 @@ export interface PendingApproval {
   readonly decide: (decision: ApprovalDecision) => void;
 }
 
+export interface EnqueueApprovalOptions {
+  readonly onPresent?: () => void;
+}
+
 const CURRENT = signal<PendingApproval | undefined>(undefined);
 const DEPTH = signal<number>(0);
 
@@ -82,6 +86,7 @@ export function getApprovalQueueDepth(): number {
 
 export function enqueueApproval(
   payload: ApprovalPayload,
+  options: EnqueueApprovalOptions = {},
 ): Promise<ApprovalDecision> {
   let resolveOuter!: (decision: ApprovalDecision) => void;
   const outer = new Promise<ApprovalDecision>((resolve) => {
@@ -97,6 +102,12 @@ export function enqueueApproval(
       if (!pendingResolvers.has(resolveOuter)) return;
       await new Promise<void>((advance) => {
         currentAdvance = advance;
+        try {
+          options.onPresent?.();
+        } catch {
+          // Presentation hooks update the surrounding TUI only; approval
+          // resolution must remain available even if focus activation fails.
+        }
         CURRENT.set({
           payload,
           decide: (decision) => {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -40,7 +40,11 @@ import {
 import { setCliApiMode } from '../../../runtime/apiAccessMode';
 import { assertNever } from '../assertNever';
 import { cliState } from './cliState';
-import { enqueueApproval, type ApprovalDecision } from './approvalQueue';
+import {
+  enqueueApproval,
+  type ApprovalDecision,
+  type ApprovalPayload,
+} from './approvalQueue';
 import type { CliContext } from '../../../runtime/cliContext';
 import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
@@ -93,7 +97,7 @@ export function installTuiApprovals(
   setToolEditApprovalHandler(async (request) => {
     let decision: ApprovalDecision | undefined = immediateDecision(context);
     if (!decision) {
-      decision = await enqueueApproval({ kind: 'toolEdit', request });
+      decision = await enqueueTuiApproval({ kind: 'toolEdit', request }, host);
       markIfRejected(context, decision);
     }
     if (
@@ -128,6 +132,7 @@ function routeApproval(
     case 'showBashPermission':
       routeWithPolicy(
         context,
+        host,
         'bash',
         payload as ProgressEventPayloads['showBashPermission'],
         (bashPayload, decision) => {
@@ -145,6 +150,7 @@ function routeApproval(
     case 'showPlanApproval':
       routeWithPolicy(
         context,
+        host,
         'plan',
         payload as ProgressEventPayloads['showPlanApproval'],
         dispatchPlan,
@@ -153,6 +159,7 @@ function routeApproval(
     case 'showAgentProposal':
       routeWithPolicy(
         context,
+        host,
         'proposal',
         payload as ProgressEventPayloads['showAgentProposal'],
         dispatchProposal,
@@ -161,6 +168,7 @@ function routeApproval(
     case 'showRetryRequest':
       routeWithPolicy(
         context,
+        host,
         'retry',
         payload as ProgressEventPayloads['showRetryRequest'],
         dispatchRetry,
@@ -173,12 +181,14 @@ function routeApproval(
       handleExternalInquiry(
         payload as ProgressEventPayloads['showExternalInquiry'],
         context,
+        host,
       );
       return;
     case 'showUserQuestion':
       handleUserQuestion(
         payload as ProgressEventPayloads['showUserQuestion'],
         context,
+        host,
       );
       return;
     default:
@@ -188,6 +198,7 @@ function routeApproval(
 
 function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   context: CliContext,
+  host: CliRuntimeHost,
   kind: K,
   payload: P,
   dispatch: (payload: P, decision: ApprovalDecision) => void,
@@ -210,9 +221,39 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
     Parameters<typeof enqueueApproval>[0],
     { kind: K }
   >;
-  void enqueueApproval(queuePayload).then((decision) => {
+  void enqueueTuiApproval(queuePayload, host).then((decision) => {
     markIfRejected(context, decision);
     dispatch(payload, decision);
+  });
+}
+
+export function approvalPayloadStreamId(
+  payload: ApprovalPayload,
+): string | undefined {
+  switch (payload.kind) {
+    case 'bash':
+    case 'plan':
+    case 'proposal':
+    case 'retry':
+    case 'externalInquiry':
+    case 'userQuestion':
+      return payload.payload.streamId || undefined;
+    case 'toolEdit':
+      return payload.request.streamId || undefined;
+    default:
+      assertNever(payload, 'Unhandled approval payload kind');
+  }
+}
+
+function enqueueTuiApproval(
+  payload: ApprovalPayload,
+  host: CliRuntimeHost,
+): Promise<ApprovalDecision> {
+  return enqueueApproval(payload, {
+    onPresent: () => {
+      const streamId = approvalPayloadStreamId(payload);
+      if (streamId) host.emit('setActiveStream', { streamId });
+    },
   });
 }
 
@@ -285,6 +326,7 @@ async function applyRetryDecision(
 function handleExternalInquiry(
   payload: ProgressEventPayloads['showExternalInquiry'],
   context: CliContext,
+  host: CliRuntimeHost,
 ): void {
   const threadId = payload.threadId;
   if (!threadId) return;
@@ -298,7 +340,7 @@ function handleExternalInquiry(
     void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
     return;
   }
-  void enqueueApproval({ kind: 'externalInquiry', payload }).then(
+  void enqueueTuiApproval({ kind: 'externalInquiry', payload }, host).then(
     (decision) => {
       markIfRejected(context, decision);
       // User-accept with text submits an answer; empty text, reject, and
@@ -323,6 +365,7 @@ function handleExternalInquiry(
 function handleUserQuestion(
   payload: ProgressEventPayloads['showUserQuestion'],
   context: CliContext,
+  host: CliRuntimeHost,
 ): void {
   const policy = immediateDecision(context);
   if (policy) {
@@ -334,22 +377,24 @@ function handleUserQuestion(
     return;
   }
 
-  void enqueueApproval({ kind: 'userQuestion', payload }).then((decision) => {
-    markIfRejected(context, decision);
-    if (decision.accepted && decision.userQuestionAnswers) {
+  void enqueueTuiApproval({ kind: 'userQuestion', payload }, host).then(
+    (decision) => {
+      markIfRejected(context, decision);
+      if (decision.accepted && decision.userQuestionAnswers) {
+        void handleUserQuestionAction({
+          requestId: payload.requestId,
+          action: 'submit',
+          answers: decision.userQuestionAnswers,
+        });
+        return;
+      }
       void handleUserQuestionAction({
         requestId: payload.requestId,
-        action: 'submit',
-        answers: decision.userQuestionAnswers,
+        action: 'skip',
+        feedback: decision.userMessage || 'User question skipped by user.',
       });
-      return;
-    }
-    void handleUserQuestionAction({
-      requestId: payload.requestId,
-      action: 'skip',
-      feedback: decision.userMessage || 'User question skipped by user.',
-    });
-  });
+    },
+  );
 }
 
 function userQuestionFeedback(context: CliContext): string {

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearApprovals,
+  currentApproval,
+  enqueueApproval,
+  type ApprovalPayload,
+} from '../../../packages/cli/src/chat/tui/state/approvalQueue';
+import { approvalPayloadStreamId } from '../../../packages/cli/src/chat/tui/state/subscribeApprovals';
+
+function bashPayload(streamId: string): ApprovalPayload {
+  return {
+    kind: 'bash',
+    payload: {
+      requestId: `bash-${streamId}`,
+      allowBypass: true,
+      streamId,
+      command: 'echo ok',
+    },
+  };
+}
+
+afterEach(() => {
+  clearApprovals();
+});
+
+describe('CLI approval queue', () => {
+  it('activates each approval only when it becomes the foreground modal', async () => {
+    const presented: string[] = [];
+    const first = bashPayload('child-1');
+    const second = bashPayload('child-2');
+
+    const firstResult = enqueueApproval(first, {
+      onPresent: () => presented.push('child-1'),
+    });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(first);
+    });
+    expect(presented).toEqual(['child-1']);
+
+    const secondResult = enqueueApproval(second, {
+      onPresent: () => presented.push('child-2'),
+    });
+    await Promise.resolve();
+    expect(currentApproval.get()?.payload).toBe(first);
+    expect(presented).toEqual(['child-1']);
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(firstResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(second);
+    });
+    expect(presented).toEqual(['child-1', 'child-2']);
+
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(secondResult).resolves.toEqual({ accepted: false });
+    expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('extracts stream ids from every approval payload used by the TUI', () => {
+    expect(approvalPayloadStreamId(bashPayload('child-bash'))).toBe(
+      'child-bash',
+    );
+    expect(
+      approvalPayloadStreamId({
+        kind: 'toolEdit',
+        request: { streamId: 'child-edit' },
+      } as ApprovalPayload),
+    ).toBe('child-edit');
+    expect(
+      approvalPayloadStreamId({
+        kind: 'retry',
+        payload: { streamId: 'child-retry' },
+      } as ApprovalPayload),
+    ).toBe('child-retry');
+    expect(
+      approvalPayloadStreamId({
+        kind: 'externalInquiry',
+        payload: { streamId: '' },
+      } as ApprovalPayload),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

This PR makes CLI TUI approval focus follow the foreground approval modal, not approval-event arrival time.

Previously, approval producers could activate a child stream before its approval reached the serialized TUI queue, and tool-edit approvals did not activate their stream at all. With several subagent approvals queued, the active stream could therefore disagree with the modal currently on screen. The queue now accepts a presentation hook, and the TUI approval adapter uses it to activate the approval's stream exactly when that approval becomes the foreground modal.

This addresses the remaining #4277 subagent-approval interleaving invariant at the state layer: queued approvals no longer steal focus early, and tool-edit/user-question/external-inquiry approvals get the same stream activation behavior as bash/plan/proposal/retry approvals.

## Checks

- `corepack pnpm vitest run src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/ConfirmCardState.vitest.mts --config vitest.config.mjs`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js --help`
- `node packages/cli/dist/bin/texra.js chat --help`
- `node packages/cli/dist/bin/texra.js models list --api-mode personal --output-format json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CLI TUI approval routing/queueing path; mistakes could cause wrong active stream focus or stalled approvals in interactive sessions.
> 
> **Overview**
> Fixes TUI focus/stream activation so the *foreground approval modal* controls the active stream, rather than the arrival time of approval events.
> 
> The approval queue now accepts an `onPresent` hook (guarded against hook failures), and `subscribeApprovals` routes all approval kinds through a shared `enqueueTuiApproval` helper that activates the relevant stream via `setActiveStream` when the queued approval becomes current. Adds a small vitest suite covering presentation ordering and `streamId` extraction across approval payload kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2903f9982ed248564c8b13dbdf6127d5e64308d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->