### PR TITLE
test(agent): cover automatic response compaction

### DIFF
--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -1,0 +1,133 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - agent model handlers
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+
+// Type imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
+
+function createLoggerStub(): Partial<AgentLogger> & { streamId: string } {
+  return {
+    streamId: 'test-channel',
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    logProgress: vi.fn(),
+    logContextManagement: vi.fn(),
+    withCurrentGroup: vi.fn(),
+    runWithinCurrentGroup: async <T>(fn: () => T | Promise<T>) => fn(),
+    runWithGroup: async <T>(
+      _groupId: string | undefined,
+      fn: () => T | Promise<T>,
+    ) => fn(),
+  };
+}
+
+function createConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    name: 'gpt-4.1',
+    fullName: 'gpt-4.1',
+    shortName: 'gpt-4.1',
+    label: 'GPT 4.1',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: overrides.maxOutputTokens ?? 100,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: overrides.contextWindow ?? 1000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: false,
+      supportsVision: false,
+      ...(overrides.capabilities ?? {}),
+    },
+    openRouterOnly: overrides.openRouterOnly ?? false,
+  };
+}
+
+function createHandler(): ModelHandlerOpenAIResponse {
+  const handler = new ModelHandlerOpenAIResponse(createConfig());
+  handler.setLogger(createLoggerStub() as unknown as AgentLogger);
+  (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
+    false;
+  return handler;
+}
+
+function createResponse(id: string, inputTokens: number) {
+  return {
+    id,
+    status: 'completed',
+    output: [],
+    output_text: 'ok',
+    usage: { input_tokens: inputTokens },
+  };
+}
+
+function createMessages(count: number): ResponseInputItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    role: 'user',
+    content: `message ${index + 1}`,
+  })) as ResponseInputItem[];
+}
+
+describe('ModelHandlerOpenAIResponse automatic compaction', () => {
+  it('compacts before the next response when prior usage crosses the threshold', async () => {
+    const handler = createHandler();
+    const requests: any[] = [];
+    const compactRequests: any[] = [];
+    const compactedMessages = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'compacted state' }],
+      },
+    ] as unknown as ResponseInputItem[];
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => ({ input_tokens: 100 }),
+        },
+        compact: async (params: any) => {
+          compactRequests.push(params);
+          return {
+            output: compactedMessages,
+            usage: { output_tokens: 100 },
+          };
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          return requests.length === 1
+            ? createResponse('resp-before-threshold', 800)
+            : createResponse('resp-after-compaction', 150);
+        },
+      },
+    };
+    const firstTurnMessages = createMessages(2);
+    const secondTurnMessages = createMessages(3);
+
+    await handler.createResponse({
+      client: client as any,
+      messages: firstTurnMessages,
+      temperature: 0,
+    });
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: secondTurnMessages,
+      temperature: 0,
+    });
+
+    expect(compactRequests).toHaveLength(1);
+    expect(compactRequests[0].input).toEqual(secondTurnMessages);
+    expect(requests).toHaveLength(2);
+    expect(requests[1].previous_response_id).toBeUndefined();
+    expect(requests[1].input).toEqual(compactedMessages);
+    expect(result.updatedMessages).toEqual(compactedMessages);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds active kernel coverage for automatic OpenAI Responses compaction.

The new test drives a real `ModelHandlerOpenAIResponse` instance through two turns with mocked Responses API calls. After the first response reports 800 input tokens in a 1000-token context window, the second turn must call `responses.compact`, submit the compacted messages, avoid carrying the stale `previous_response_id`, and return the compacted message history to the caller.

This strengthens the automatic-compaction evidence requested in #4277. The CLI and headless paths share this model-handler layer through `executeAgent`; the existing CLI `/compact` tests cover manual TUI dispatch into the same flow.

## Checks

- `corepack pnpm vitest run src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts src/test-kernel/cli/CompactionRequest.vitest.mts --config vitest.config.mjs`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js --help`
- `node packages/cli/dist/bin/texra.js chat --help`
- `node packages/cli/dist/bin/texra.js models list --api-mode personal --output-format json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a unit/integration-style test with mocked OpenAI Responses API calls and does not change production logic.
> 
> **Overview**
> Adds a new Vitest (`OpenAIResponseCompaction.vitest.ts`) that drives `ModelHandlerOpenAIResponse.createResponse()` through two turns and asserts **automatic compaction** triggers after high prior `usage.input_tokens`.
> 
> The test verifies the handler calls `responses.compact` before the second request, submits the returned compacted message state, clears any `previous_response_id` carryover, and returns `updatedMessages` reflecting the compacted history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a858b926d3748e79355bdc7aab05950a8862896d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->