### PR TITLE
feat(skills): add skill package discovery

### DIFF
--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -19,6 +19,7 @@
       "@resources/*": ["packages/extension/resources/*"],
       "@model": ["src/model"],
       "@model/*": ["src/model/*"],
+      "@skills/*": ["src/skills/*"],
       "@housekeeping": ["src/housekeeping"],
       "@housekeeping/*": ["src/housekeeping/*"],
       "@progressView/*": ["packages/extension/src/progressView/*"],

--- a/src/skills/SkillSchema.ts
+++ b/src/skills/SkillSchema.ts
@@ -1,0 +1,53 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - utilities
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+export const SKILL_NAME_MAX_LENGTH = 64;
+export const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+
+export const SkillNameSchema = z
+  .string()
+  .transform((name) => collapseWhitespace(name))
+  .refine((name) => name.length > 0, 'Skill name is required')
+  .refine(
+    (name) => name.length <= SKILL_NAME_MAX_LENGTH,
+    `Skill name must be at most ${SKILL_NAME_MAX_LENGTH} characters`,
+  )
+  .refine(
+    (name) => /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(name),
+    'Skill name must contain only lowercase letters, digits, and hyphens',
+  )
+  .refine(
+    (name) => !name.includes('--'),
+    'Skill name must not contain repeated hyphens',
+  );
+
+export const SkillDescriptionSchema = z
+  .string()
+  .transform((description) => collapseWhitespace(description))
+  .refine((description) => description.length > 0, {
+    message: 'Skill description is required',
+  })
+  .refine(
+    (description) => description.length <= SKILL_DESCRIPTION_MAX_LENGTH,
+    `Skill description must be at most ${SKILL_DESCRIPTION_MAX_LENGTH} characters`,
+  );
+
+export const SkillFrontmatterSchema = z.looseObject({
+  name: SkillNameSchema,
+  description: SkillDescriptionSchema,
+});
+
+export const SkillSchema = z.strictObject({
+  name: SkillNameSchema,
+  description: SkillDescriptionSchema,
+  body: z.string().min(1),
+  baseDir: z.string().min(1),
+  path: z.string().min(1),
+  frontmatter: SkillFrontmatterSchema,
+});
+
+export type Skill = z.infer<typeof SkillSchema>;
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;

--- a/src/skills/frontmatter.ts
+++ b/src/skills/frontmatter.ts
@@ -1,0 +1,48 @@
+// Third-party imports
+import * as yaml from 'yaml';
+
+// Local imports - utilities
+import { normalizeLineEndings } from '@utils/text/stringUtils';
+
+export interface ExtractedFrontmatter {
+  frontmatter: unknown;
+  body: string;
+}
+
+/**
+ * Extract strict YAML frontmatter from a SKILL.md file.
+ *
+ * Both delimiters must be `---` on their own line. The returned body is
+ * trimmed because an empty skill body is not useful to the runtime.
+ */
+export function extractFrontmatter(content: string): ExtractedFrontmatter {
+  const lines = normalizeLineEndings(content).split('\n');
+  if (lines[0] !== '---') {
+    throw new Error('SKILL.md must start with YAML frontmatter');
+  }
+
+  const closeIndex = lines.findIndex((line, index) => {
+    return index > 0 && line === '---';
+  });
+  if (closeIndex < 0) {
+    throw new Error('SKILL.md frontmatter is missing a closing delimiter');
+  }
+
+  const frontmatterText = lines.slice(1, closeIndex).join('\n');
+  const body = lines
+    .slice(closeIndex + 1)
+    .join('\n')
+    .trim();
+  if (!body) {
+    throw new Error('SKILL.md body must be non-empty');
+  }
+
+  try {
+    return {
+      frontmatter: yaml.parse(frontmatterText),
+      body,
+    };
+  } catch (err) {
+    throw new Error(`Invalid SKILL.md frontmatter: ${String(err)}`);
+  }
+}

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,0 +1,3 @@
+export * from './SkillSchema';
+export * from './frontmatter';
+export * from './loadSkills';

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -1,0 +1,329 @@
+// Standard library imports
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+// Third-party imports
+import { ZodError } from 'zod';
+
+// Local imports - skill parsing
+import {
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SkillNameSchema,
+  SkillSchema,
+  type Skill,
+} from './SkillSchema';
+import { extractFrontmatter } from './frontmatter';
+
+// Local imports - utilities
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+export type SkillIssueSeverity = 'error' | 'warning';
+
+export type SkillIssueCode =
+  | 'duplicate_name'
+  | 'duplicate_realpath'
+  | 'invalid_frontmatter'
+  | 'invalid_name'
+  | 'missing_description'
+  | 'name_mismatch'
+  | 'read_error';
+
+export interface SkillLoadIssue {
+  severity: SkillIssueSeverity;
+  code: SkillIssueCode;
+  message: string;
+  path?: string;
+  name?: string;
+}
+
+export interface DiscoverSkillsResult {
+  skills: Skill[];
+  errors: SkillLoadIssue[];
+}
+
+interface LoadedSkill {
+  skill?: Skill;
+  errors: SkillLoadIssue[];
+}
+
+function issue(
+  severity: SkillIssueSeverity,
+  code: SkillIssueCode,
+  message: string,
+  options: { path?: string; name?: string } = {},
+): SkillLoadIssue {
+  return { severity, code, message, ...options };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstZodMessage(error: ZodError): string {
+  return error.issues[0]?.message ?? 'Invalid skill metadata';
+}
+
+function normalizeSkillName(
+  frontmatter: Record<string, unknown>,
+  directoryName: string,
+  skillPath: string,
+): { name?: string; errors: SkillLoadIssue[] } {
+  const errors: SkillLoadIssue[] = [];
+  const rawName = frontmatter.name;
+  const candidate = typeof rawName === 'string' ? rawName : directoryName;
+  const parsed = SkillNameSchema.safeParse(candidate);
+
+  if (parsed.success) {
+    const name = parsed.data;
+    if (typeof rawName === 'string' && name !== directoryName) {
+      errors.push(
+        issue(
+          'warning',
+          'name_mismatch',
+          `Skill name "${name}" does not match directory "${directoryName}"`,
+          { path: skillPath, name },
+        ),
+      );
+    }
+    return { name, errors };
+  }
+
+  if (rawName !== undefined) {
+    errors.push(
+      issue(
+        'warning',
+        'invalid_name',
+        `Ignoring invalid skill name: ${firstZodMessage(parsed.error)}`,
+        { path: skillPath },
+      ),
+    );
+  }
+
+  const fallback = SkillNameSchema.safeParse(directoryName);
+  if (fallback.success) {
+    return { name: fallback.data, errors };
+  }
+
+  errors.push(
+    issue(
+      'error',
+      'invalid_name',
+      `Directory name cannot be used as a skill name: ${firstZodMessage(
+        fallback.error,
+      )}`,
+      { path: skillPath },
+    ),
+  );
+  return { errors };
+}
+
+function normalizeSkillDescription(
+  frontmatter: Record<string, unknown>,
+  skillPath: string,
+  name: string,
+): { description?: string; errors: SkillLoadIssue[] } {
+  const errors: SkillLoadIssue[] = [];
+  const rawDescription = frontmatter.description;
+  if (typeof rawDescription !== 'string') {
+    errors.push(
+      issue('error', 'missing_description', 'Skill description is required', {
+        path: skillPath,
+        name,
+      }),
+    );
+    return { errors };
+  }
+
+  const description = collapseWhitespace(rawDescription);
+  if (!description) {
+    errors.push(
+      issue('error', 'missing_description', 'Skill description is required', {
+        path: skillPath,
+        name,
+      }),
+    );
+    return { errors };
+  }
+
+  if (description.length > SKILL_DESCRIPTION_MAX_LENGTH) {
+    errors.push(
+      issue(
+        'warning',
+        'invalid_frontmatter',
+        `Skill description exceeds ${SKILL_DESCRIPTION_MAX_LENGTH} characters and was truncated`,
+        { path: skillPath, name },
+      ),
+    );
+    return {
+      description: description.slice(0, SKILL_DESCRIPTION_MAX_LENGTH),
+      errors,
+    };
+  }
+
+  return { description, errors };
+}
+
+async function loadSkillDirectory(
+  skillDir: string,
+  directoryName: string,
+): Promise<LoadedSkill> {
+  const skillPath = path.join(skillDir, 'SKILL.md');
+
+  try {
+    const content = await fs.readFile(skillPath, 'utf8');
+    const { frontmatter, body } = extractFrontmatter(content);
+    if (!isRecord(frontmatter)) {
+      return {
+        errors: [
+          issue(
+            'error',
+            'invalid_frontmatter',
+            'SKILL.md frontmatter must be a YAML object',
+            { path: skillPath },
+          ),
+        ],
+      };
+    }
+
+    const nameResult = normalizeSkillName(
+      frontmatter,
+      directoryName,
+      skillPath,
+    );
+    const errors = [...nameResult.errors];
+    if (!nameResult.name) return { errors };
+
+    const descriptionResult = normalizeSkillDescription(
+      frontmatter,
+      skillPath,
+      nameResult.name,
+    );
+    errors.push(...descriptionResult.errors);
+    if (!descriptionResult.description) return { errors };
+
+    const normalizedFrontmatter = {
+      ...frontmatter,
+      name: nameResult.name,
+      description: descriptionResult.description,
+    };
+    const skill = SkillSchema.parse({
+      name: nameResult.name,
+      description: descriptionResult.description,
+      body,
+      baseDir: skillDir,
+      path: skillPath,
+      frontmatter: normalizedFrontmatter,
+    });
+
+    return { skill, errors };
+  } catch (err) {
+    return {
+      errors: [
+        issue(
+          'error',
+          err instanceof Error &&
+            (err.message.startsWith('Invalid SKILL.md') ||
+              err.message.startsWith('SKILL.md'))
+            ? 'invalid_frontmatter'
+            : 'read_error',
+          err instanceof Error ? err.message : String(err),
+          { path: skillPath },
+        ),
+      ],
+    };
+  }
+}
+
+/**
+ * Discover one-level `SKILL.md` packages below `root`.
+ *
+ * Missing roots are treated as empty because user and project skill directories
+ * are optional. Per-skill failures are reported and do not abort discovery.
+ */
+export async function discoverSkills(
+  root: string,
+): Promise<DiscoverSkillsResult> {
+  const skills: Skill[] = [];
+  const errors: SkillLoadIssue[] = [];
+  const seenNames = new Set<string>();
+  const seenRealPaths = new Set<string>();
+
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { skills, errors };
+    }
+
+    errors.push(
+      issue(
+        'error',
+        'read_error',
+        err instanceof Error ? err.message : String(err),
+        {
+          path: root,
+        },
+      ),
+    );
+    return { skills, errors };
+  }
+
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+    const skillDir = path.join(root, entry.name);
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    let realSkillPath: string;
+    try {
+      realSkillPath = await fs.realpath(skillPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        errors.push(
+          issue(
+            'warning',
+            'read_error',
+            err instanceof Error ? err.message : String(err),
+            { path: skillPath },
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (seenRealPaths.has(realSkillPath)) {
+      errors.push(
+        issue(
+          'warning',
+          'duplicate_realpath',
+          `Skipping duplicate skill path ${realSkillPath}`,
+          { path: skillPath },
+        ),
+      );
+      continue;
+    }
+    seenRealPaths.add(realSkillPath);
+
+    const loaded = await loadSkillDirectory(skillDir, entry.name);
+    errors.push(...loaded.errors);
+    if (!loaded.skill) continue;
+
+    if (seenNames.has(loaded.skill.name)) {
+      errors.push(
+        issue(
+          'warning',
+          'duplicate_name',
+          `Skipping duplicate skill name "${loaded.skill.name}"`,
+          { path: loaded.skill.path, name: loaded.skill.name },
+        ),
+      );
+      continue;
+    }
+
+    seenNames.add(loaded.skill.name);
+    skills.push(loaded.skill);
+  }
+
+  return { skills, errors };
+}

--- a/src/test-kernel/skills/LoadSkills.vitest.mts
+++ b/src/test-kernel/skills/LoadSkills.vitest.mts
@@ -1,0 +1,191 @@
+// Standard library imports
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - skills
+import { discoverSkills } from '@skills/loadSkills';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-skills-'));
+  tempRoots.push(root);
+  return root;
+}
+
+async function writeSkill(
+  root: string,
+  dirName: string,
+  frontmatter: string,
+  body = 'Use this skill carefully.',
+): Promise<string> {
+  const skillDir = path.join(root, dirName);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, 'SKILL.md'),
+    `---\n${frontmatter.trim()}\n---\n\n${body}\n`,
+  );
+  return skillDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => {
+      return fs.rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe('discoverSkills', () => {
+  it('loads valid SKILL.md packages', async () => {
+    const root = await createTempRoot();
+    await writeSkill(
+      root,
+      'manuscript-review',
+      `
+name: manuscript-review
+description: Reviews mathematical manuscripts for correctness and exposition.
+`,
+      'Read the paper and report substantial mathematical issues.',
+    );
+
+    const result = await discoverSkills(root);
+
+    expect(result.errors).toEqual([]);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]).toMatchObject({
+      name: 'manuscript-review',
+      description:
+        'Reviews mathematical manuscripts for correctness and exposition.',
+      body: 'Read the paper and report substantial mathematical issues.',
+    });
+  });
+
+  it('rejects skills without descriptions', async () => {
+    const root = await createTempRoot();
+    await writeSkill(root, 'missing-description', 'name: missing-description');
+
+    const result = await discoverSkills(root);
+
+    expect(result.skills).toEqual([]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'missing_description',
+      }),
+    );
+  });
+
+  it('loads name-mismatched skills with a warning', async () => {
+    const root = await createTempRoot();
+    await writeSkill(
+      root,
+      'directory-name',
+      `
+name: frontmatter-name
+description: A skill whose declared name differs from its directory.
+`,
+    );
+
+    const result = await discoverSkills(root);
+
+    expect(result.skills.map((skill) => skill.name)).toEqual([
+      'frontmatter-name',
+    ]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'name_mismatch',
+        name: 'frontmatter-name',
+      }),
+    );
+  });
+
+  it('reports invalid YAML frontmatter without aborting discovery', async () => {
+    const root = await createTempRoot();
+    await writeSkill(
+      root,
+      'valid-skill',
+      `
+name: valid-skill
+description: A valid skill.
+`,
+    );
+    const invalidDir = path.join(root, 'invalid-skill');
+    await fs.mkdir(invalidDir);
+    await fs.writeFile(
+      path.join(invalidDir, 'SKILL.md'),
+      `---\nname: : bad\n---\n\nBody\n`,
+    );
+
+    const result = await discoverSkills(root);
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(['valid-skill']);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_frontmatter',
+      }),
+    );
+  });
+
+  it('deduplicates symlinked skill packages by real path', async () => {
+    const root = await createTempRoot();
+    const actualDir = await writeSkill(
+      root,
+      'actual-skill',
+      `
+name: actual-skill
+description: A skill reached through a real directory and a symlink.
+`,
+    );
+    await fs.symlink(actualDir, path.join(root, 'linked-skill'), 'dir');
+
+    const result = await discoverSkills(root);
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(['actual-skill']);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'duplicate_realpath',
+      }),
+    );
+  });
+
+  it('keeps the first skill when names collide', async () => {
+    const root = await createTempRoot();
+    await writeSkill(
+      root,
+      'alpha',
+      `
+name: repeated-name
+description: The first skill with this name.
+`,
+    );
+    await writeSkill(
+      root,
+      'beta',
+      `
+name: repeated-name
+description: The second skill with this name.
+`,
+    );
+
+    const result = await discoverSkills(root);
+
+    expect(result.skills.map((skill) => skill.description)).toEqual([
+      'The first skill with this name.',
+    ]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'duplicate_name',
+        name: 'repeated-name',
+      }),
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@resources/*": ["packages/extension/resources/*"],
       "@model": ["src/model"],
       "@model/*": ["src/model/*"],
+      "@skills/*": ["src/skills/*"],
       "@housekeeping": ["src/housekeeping"],
       "@housekeeping/*": ["src/housekeeping/*"],
       "@progressView/*": ["packages/extension/src/progressView/*"],


### PR DESCRIPTION
## Summary

Adds the host-agnostic foundation for importing `SKILL.md` packages, addressing the first concrete slice of #4064:

- add `src/skills/` schemas for skill names, descriptions, and loaded skill records
- add strict YAML frontmatter extraction for `SKILL.md`
- add one-level skill discovery with realpath deduplication, first-wins name collisions, and per-skill warning/error reporting
- add `@skills/*` path alias for the new host-neutral module
- add kernel coverage for valid imports, missing descriptions, name mismatches, invalid YAML, symlink deduplication, and duplicate names

This does not yet inject skills into agent prompts or expose a skill tool; those should follow as narrower PRs on top of this loader.

## Validation

- `corepack pnpm vitest run src/test-kernel/skills/LoadSkills.vitest.mts --config vitest.config.mjs`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run compile:fast`

Refs #4064

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new filesystem/YAML parsing and normalization logic for discovering skills, which could surface unexpected errors or edge cases across platforms despite test coverage.
> 
> **Overview**
> Adds a new host-agnostic `src/skills` module to discover one-level `SKILL.md` skill packages, including strict YAML frontmatter extraction, Zod-based validation/normalization of names and descriptions, and structured warning/error reporting.
> 
> Discovery deduplicates by `realpath` (symlink-safe) and skips duplicate skill names with first-wins behavior. Adds the `@skills/*` TS path alias and Vitest coverage for success and key failure/dedup scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17bfeac8bf56ea0f1f0798b12a9dda8e244ec4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->