### PR TITLE
fix(cli): fill multi-agent preset gaps from relay when authenticated

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -448,7 +448,10 @@ async function runMultiAgentPreset(
   // specialists most presets name) are only visible after a remote load. Fill
   // any preset gap — not just a missing root — so an authenticated, entitled
   // user runs the full team instead of a silently degraded one.
-  if (cliMultiAgentPlanHasGaps(plan) && (await getCliAuthProvider().isAuthenticated())) {
+  if (
+    cliMultiAgentPlanHasGaps(plan) &&
+    (await getCliAuthProvider().isAuthenticated())
+  ) {
     await loadAgents();
     plan = resolveMultiAgentRunPlan(init);
   }

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -96,6 +96,7 @@ import {
   readCliHistoryDetails,
 } from '../runtime/history';
 import {
+  cliMultiAgentPlanHasGaps,
   cliMultiAgentPresetNdjsonRecords,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
@@ -443,7 +444,11 @@ async function runMultiAgentPreset(
   await loadAgents({ includeRemote: false });
 
   let plan = resolveMultiAgentRunPlan(init);
-  if (!plan.rootAgent && (await getCliAuthProvider().isAuthenticated())) {
+  // Relay-served premium agents (the team orchestrator and delegation
+  // specialists most presets name) are only visible after a remote load. Fill
+  // any preset gap — not just a missing root — so an authenticated, entitled
+  // user runs the full team instead of a silently degraded one.
+  if (cliMultiAgentPlanHasGaps(plan) && (await getCliAuthProvider().isAuthenticated())) {
     await loadAgents();
     plan = resolveMultiAgentRunPlan(init);
   }

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -102,6 +102,24 @@ export function cliMultiAgentPresetNdjsonRecords(
   }));
 }
 
+/**
+ * True when a planned run is missing any preset member — either no root agent
+ * could be selected, or some workflow/tool-use agents the preset names aren't
+ * resolvable from the loaded registry. Used to decide whether a remote agent
+ * load is worth attempting for an authenticated user (relay-served premium
+ * agents like the orchestrator and delegation specialists are only visible
+ * after a remote load).
+ */
+export function cliMultiAgentPlanHasGaps(
+  plan: CliMultiAgentPresetRunPlan,
+): boolean {
+  return (
+    !plan.rootAgent ||
+    plan.missingWorkflowAgents.length > 0 ||
+    plan.missingToolUseAgents.length > 0
+  );
+}
+
 export function planCliMultiAgentPresetRun(
   preset: CliMultiAgentPreset,
   options: {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -4,6 +4,7 @@ import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
 import {
+  cliMultiAgentPlanHasGaps,
   cliMultiAgentPresets,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
@@ -114,6 +115,58 @@ describe('CLI multi-agent presets', () => {
       'builtInToolUse:review',
     ]);
     expect(plan.missingToolUseAgents).toContain('research');
+  });
+
+  it('flags a gap when the preset has a root but missing members', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    // A local-only registry: `review` can serve as root, but the orchestrator
+    // and the rest of the team are absent. The run should still be treated as
+    // having gaps so an authenticated user triggers a remote load.
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [agent('review', AgentCategory.ToolUse)],
+    });
+
+    expect(plan.rootAgent?.name).toBe('review');
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
+  });
+
+  it('reports no gaps when every preset member resolves', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: preset.toolUseAgents.map((name) =>
+        agent(
+          name,
+          AgentCategory.ToolUse,
+          name === 'leanOrchestrator' ? ['delegate_agent'] : [],
+        ),
+      ),
+    });
+
+    expect(plan.rootAgent?.name).toBe('leanOrchestrator');
+    expect(plan.missingToolUseAgents).toEqual([]);
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
+  });
+
+  it('flags a gap when no root agent can be selected', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [],
+    });
+
+    expect(plan.rootAgent).toBeUndefined();
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
   it('adds an explicit root override to the visible tool-use team', () => {


### PR DESCRIPTION
## Summary

Built-in multi-agent presets reference relay-served premium agents (the team `orchestrator` and delegation specialists like `criticize`, `devise`, `apply`, `search`, `simplifier`, `progressCheck`, `leanOrchestrator`) that aren't bundled with the CLI. `runMultiAgentPreset` only attempted a remote agent load when **no** local tool-use agent could serve as root. If any local agent (e.g. `research`) could be root, the CLI skipped the remote load and ran a **silently degraded team** — missing the orchestrator and most delegation targets — emitting an `unavailable agents` warning even for entitled, signed-in users.

This broadens the remote-load trigger: when authenticated and the plan is missing the root **or** any workflow/tool-use member, load remote agents and re-plan so the full team is filled from the relay. Unentitled / offline users keep the existing warning.

Closes #4327.

## Changes

- New `cliMultiAgentPlanHasGaps(plan)` helper in `packages/cli/src/runtime/multiAgentPresets.ts` — true when the plan has no root or any missing member.
- `runMultiAgentPreset` (`packages/cli/src/commands/root.ts`) now gates the remote load on `cliMultiAgentPlanHasGaps(plan)` instead of `!plan.rootAgent`.
- 3 new vitest cases covering gap detection (root-but-missing-members, no-root, fully-resolved).

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 232/232 pass (3 new)
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe (signed in):
  - Before: `texra multi-agent run physicist -i paper.tex` → `WARN preset physicist references unavailable agents: ...`
  - After: same command → no warning; full team initializes and runs
  - `texra multi-agent run lean-project -i paper.tex` → no warning after fix

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js multi-agent run physicist -i <some.tex>   # no "unavailable agents" warning when signed in
npx vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes when the CLI performs remote agent loading and replanning, which can affect runtime behavior and network usage for authenticated runs.
> 
> **Overview**
> `texra multi-agent run` now attempts a remote agent load for authenticated users whenever the initial preset plan has *any* missing members (not just a missing root), then replans to fill relay-served premium agents and avoid silently degraded teams.
> 
> Adds `cliMultiAgentPlanHasGaps(plan)` to centralize the “missing root or missing preset agents” check, and introduces new vitest coverage for gap detection across root-present/members-missing, fully-resolved, and no-root scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2540a175708299dd2439ff088204e9412ad69f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->