### PR TITLE
fix(cli): echo slash commands and compact transcript rows

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -72,14 +72,14 @@ function TranscriptEntry({
   switch (entry.role) {
     case 'user':
       return (
-        <Box marginBottom={1} paddingX={1}>
+        <Box paddingX={1}>
           <Text dimColor>› </Text>
           <Text>{entry.text}</Text>
         </Box>
       );
     case 'error':
       return (
-        <Box marginBottom={1} paddingX={1}>
+        <Box paddingX={1}>
           <Text color="red">! </Text>
           <Text color="red">{entry.text}</Text>
         </Box>
@@ -129,6 +129,12 @@ export function estimateTranscriptEntryRows(
   if (entry.role === 'assistant') {
     const rendered = renderAnsiMarkdown(entry.text, { width });
     return Math.max(1, rendered.split('\n').length) + 1;
+  }
+  // User / error rows render without a trailing margin (compact mode) so
+  // chat-heavy sessions don't burn half the viewport on blank gaps. Keep
+  // the estimate in sync with the rendered height to avoid wasted budget.
+  if (entry.role === 'user' || entry.role === 'error') {
+    return estimateWrappedRows(entry.text, width);
   }
 
   return estimateWrappedRows(entry.text, width) + 1;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -131,10 +131,11 @@ export function estimateTranscriptEntryRows(
     return Math.max(1, rendered.split('\n').length) + 1;
   }
   // User / error rows render without a trailing margin (compact mode) so
-  // chat-heavy sessions don't burn half the viewport on blank gaps. Keep
-  // the estimate in sync with the rendered height to avoid wasted budget.
+  // chat-heavy sessions don't burn half the viewport on blank gaps. Their
+  // box uses `paddingX={1}` (2 cols) and a 2-col prefix (`› ` / `! `), so
+  // long text wraps to `width - 4` — keep the estimate in sync.
   if (entry.role === 'user' || entry.role === 'error') {
-    return estimateWrappedRows(entry.text, width);
+    return estimateWrappedRows(entry.text, Math.max(1, width - 4));
   }
 
   return estimateWrappedRows(entry.text, width) + 1;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -438,9 +438,11 @@ async function handleTuiSlashCommand(
   const rest = parsed.remainder.trim();
   // Echo the slash input into the transcript so the user can see what they
   // typed. Slash commands don't go through the agent run, so the usual
-  // USER_MESSAGE stream-log entry is never produced. Skip the echo for /clear
-  // (it resets the transcript) and exits (the TUI is tearing down).
-  if (command !== 'clear' && command !== 'exit' && command !== 'quit') {
+  // USER_MESSAGE stream-log entry is never produced. Skip the echo for the
+  // exit commands (the TUI is tearing down); /clear still echoes because
+  // resetSessionForClear refuses while a run is active and surfaces an
+  // error — without the echo the user wouldn't see what triggered it.
+  if (command !== 'exit' && command !== 'quit') {
     appendLocalUserTranscript(line.trim());
   }
   switch (command) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -85,6 +85,7 @@ import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
+  appendLocalUserTranscript,
   moveLocalTranscriptToStream,
 } from './state/transcript';
 import {
@@ -435,6 +436,13 @@ async function handleTuiSlashCommand(
 
   const command = parsed.name.toLowerCase();
   const rest = parsed.remainder.trim();
+  // Echo the slash input into the transcript so the user can see what they
+  // typed. Slash commands don't go through the agent run, so the usual
+  // USER_MESSAGE stream-log entry is never produced. Skip the echo for /clear
+  // (it resets the transcript) and exits (the TUI is tearing down).
+  if (command !== 'clear' && command !== 'exit' && command !== 'quit') {
+    appendLocalUserTranscript(line.trim());
+  }
   switch (command) {
     case 'help': {
       const commands = listSlashCommands()

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -59,8 +59,12 @@ export function appendLocalErrorTranscript(text: string): void {
   appendLocalTranscriptEntry('error', text);
 }
 
+export function appendLocalUserTranscript(text: string): void {
+  appendLocalTranscriptEntry('user', text);
+}
+
 function appendLocalTranscriptEntry(
-  role: 'assistant' | 'error',
+  role: 'assistant' | 'error' | 'user',
   text: string,
 ): void {
   const normalized = normalizeTranscriptText(text);


### PR DESCRIPTION
## Summary

Two small CLI TUI fixes:

1. **Echo slash commands into the transcript** (closes #4330). Slash commands like `/status`, `/auth`, `/agent` never go through the agent run, so the usual `USER_MESSAGE` stream-log entry is never produced — the typed line was effectively invisible. Now a `›`-prefixed entry is appended via a new `appendLocalUserTranscript()` helper. `/exit` and `/quit` skip the echo (the TUI is tearing down); `/clear` still echoes because the reset is refused while a run is active, so the user needs to see what triggered the error.

2. **Compact short transcript rows** (closes #4326). User and error rows no longer carry `marginBottom={1}`, so chat-heavy sessions stop burning half the viewport on blank gaps between short turns. `estimateTranscriptEntryRows` is updated to match — including the 4-col overhead from `paddingX={1}` plus the 2-col prefix (`› ` / `! `) so wrapping is not undercounted (caught by Cursor Bugbot review).

## Out of scope

- Issue #4327 (multi-agent preset gaps) is fixed by #4328, already merged.
- Issue #4329 (Mac Option-key labels) remains open; the original attempt was reverted because the label change broke a literal assertion in `StatusBar.vitest.mts`. A future PR can address it without touching the test, e.g. via a footer hint or terminal-capability detection.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/` → 232/232 pass
- `corepack pnpm --filter @texra/cli typecheck` → clean
- `corepack pnpm run lint` → 0 errors

https://claude.ai/code/session_01SG9rdD6jLqnPUvg3ZqMGxx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes to the chat TUI transcript rendering and local transcript utilities; main risk is minor row-height misestimation causing visual clipping/scroll issues.
> 
> **Overview**
> **Improves chat TUI transcript readability and density.** User and error transcript rows no longer render with a trailing bottom margin, and row-height estimation is updated to match the new wrapping behavior so viewport calculations stay accurate.
> 
> **Makes slash commands visible in the conversation flow.** Slash-command input is now echoed into the transcript via a new `appendLocalUserTranscript()` helper (excluding `/exit` and `/quit`), since these commands bypass the normal user-message stream log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856413ea354f8efe1e904d3b143ffab0f9152de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->