### PR TITLE
refactor(tools): dedupe claude binary resolution

### DIFF
--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -106,6 +106,10 @@ const PLATFORM_INFO: Record<string, PlatformInfo> = {
   'win32-arm64': { pkgs: ['@anthropic-ai/claude-agent-sdk-win32-arm64'] },
 };
 
+/** Native CLI binary filename for the current platform. */
+const CLAUDE_BINARY_NAME =
+  process.platform === 'win32' ? 'claude.exe' : 'claude';
+
 /** Cached result — found paths are cached; misses are retried. */
 let cachedBinaryPath: string | undefined;
 
@@ -137,7 +141,7 @@ async function findClaudeBinaryPathUncached(): Promise<string | undefined> {
     const result =
       resourcesPath == null
         ? undefined
-        : await findClaudeBinaryInElectronResources(resourcesPath);
+        : await findClaudeBinaryInElectronResources(resourcesPath, info);
     if (result) return result;
   }
 
@@ -207,11 +211,8 @@ async function findClaudeBinaryPathUncached(): Promise<string | undefined> {
  */
 async function findClaudeBinaryInElectronResources(
   resourcesPath: string,
+  info: PlatformInfo,
 ): Promise<string | undefined> {
-  const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
-  if (!info) return undefined;
-
-  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
   for (const pkg of info.pkgs) {
     const platformPkgDir = path.join(
       resourcesPath,
@@ -219,7 +220,7 @@ async function findClaudeBinaryInElectronResources(
       'node_modules',
       ...pkg.split('/'),
     );
-    const binary = path.join(platformPkgDir, binaryName);
+    const binary = path.join(platformPkgDir, CLAUDE_BINARY_NAME);
     if (await pathExists(binary)) return binary;
   }
   return undefined;
@@ -242,11 +243,13 @@ async function resolveClaudeBinary(
   platformInfo: PlatformInfo,
 ): Promise<string | undefined> {
   const req = createRequire(path.join(baseDir, 'package.json'));
-  const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude';
   for (const pkg of platformInfo.pkgs) {
     try {
       const platformPkgJson = req.resolve(`${pkg}/package.json`);
-      const binary = path.join(path.dirname(platformPkgJson), binaryName);
+      const binary = path.join(
+        path.dirname(platformPkgJson),
+        CLAUDE_BINARY_NAME,
+      );
       if (await pathExists(binary)) return binary;
     } catch {
       // Platform package not resolvable


### PR DESCRIPTION
Follow-up simplification to #4247.

- `findClaudeBinaryInElectronResources()` now receives the already-resolved platform `info` from its sole caller instead of re-deriving it via `PLATFORM_INFO[...]` with a redundant guard.
- Hoisted the duplicated `process.platform === 'win32' ? 'claude.exe' : 'claude'` expression to a module-level `CLAUDE_BINARY_NAME` constant.

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only removes duplicated platform/binary-name resolution logic; behavior should remain the same aside from potential edge cases if the shared constants are incorrect.
> 
> **Overview**
> Simplifies Claude CLI binary discovery by hoisting the platform-specific executable name to a shared `CLAUDE_BINARY_NAME` constant and reusing it across resolution strategies.
> 
> Refactors `findClaudeBinaryInElectronResources()` to accept the already-resolved `PlatformInfo` from its caller instead of re-deriving it, removing redundant guards and duplicated logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2578f36bbeee1bb02af01319bc63464fc4878879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->