### PR TITLE
refactor(auth): tidy tier & server-key services

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -291,7 +291,7 @@ export class ServerSideKeyService {
    * Primes all caches for subsequent sync calls.
    */
   async canUseServerSideKeys(): Promise<boolean> {
-    if (!this.getUseIncludedModelAccess()) {
+    if (!this.useIncludedModelAccess) {
       this.clearAllCaches({ preserveTierCache: this.wasQuotaAutoSwitched() });
       return false;
     }
@@ -327,8 +327,9 @@ export class ServerSideKeyService {
       }
 
       const providers = this.tierService.getProviders();
+      const accessGranted = hasAccess && providers.length > 0;
 
-      if (hasAccess && providers.length > 0) {
+      if (accessGranted) {
         this.accessTimestamp = Date.now();
         this._isCachePrimed = true;
       }
@@ -357,7 +358,7 @@ export class ServerSideKeyService {
         return false;
       }
 
-      return hasAccess && providers.length > 0;
+      return accessGranted;
     })();
 
     return this.accessFetchPromise;
@@ -377,7 +378,7 @@ export class ServerSideKeyService {
 
   shouldUseServerSideKeysSync(provider: string, modelName?: string): boolean {
     if (
-      !this.getUseIncludedModelAccess() ||
+      !this.useIncludedModelAccess ||
       !this.isProviderOnServer(provider) ||
       !this.accessResult
     ) {

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -343,7 +343,6 @@ export class TierService {
    * transient network failure.
    */
   isQuotaExceeded(): boolean {
-    const s = this.spendingStatus;
-    return s !== null && s.remaining <= 0;
+    return this.spendingStatus !== null && this.spendingStatus.remaining <= 0;
   }
 }


### PR DESCRIPTION
Follow-up simplification to #4248.

- `ServerSideKeyService`: internal reads use the `useIncludedModelAccess` field directly (consistent with other internal usages) instead of the public getter; hoisted the duplicated `hasAccess && providers.length > 0` into a single `accessGranted` local.
- `TierService.isQuotaExceeded()`: inlined the cryptic `const s = this.spendingStatus` alias.

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only simplifies internal conditionals and field access without changing auth/tier behavior.
> 
> **Overview**
> Simplifies `ServerSideKeyService` access checks by reading `useIncludedModelAccess` directly (instead of via the getter) and hoisting the repeated `hasAccess && providers.length > 0` condition into a single `accessGranted` variable.
> 
> Tidies `TierService.isQuotaExceeded()` by inlining the temporary `spendingStatus` alias for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2020b757802ec5602e7da85d1a1bbdc0f9ec007a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->