### PR TITLE
refactor(cli-tui): dedupe slash-command context & unnest task output

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -177,6 +177,38 @@ export function computePickerListLayout({
   };
 }
 
+function TaskOutput({
+  childStreamId,
+  tailLines,
+  visibleTail,
+  visibleLineCount,
+}: {
+  readonly childStreamId: StreamTabId | undefined;
+  readonly tailLines: readonly string[];
+  readonly visibleTail: readonly string[];
+  readonly visibleLineCount: number;
+}): React.JSX.Element | null {
+  if (tailLines.length > 0) {
+    if (visibleLineCount <= 0) return null;
+    return (
+      <>
+        {visibleTail.map((line, index) => (
+          <Text key={`${index}:${line}`} dimColor>
+            {line}
+          </Text>
+        ))}
+      </>
+    );
+  }
+  if (visibleLineCount === 0) return null;
+  if (childStreamId) {
+    return (
+      <Text dimColor>Open the task stream to see its live transcript.</Text>
+    );
+  }
+  return <Text dimColor>No output captured yet.</Text>;
+}
+
 function TaskDetailView({
   availableRows,
   item,

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -297,18 +297,12 @@ function TaskDetailView({
       ) : null}
       <Box flexDirection="column" marginTop={layout.compact ? 0 : 1}>
         <Text bold>Output:</Text>
-        {item.tailLines.length > 0 && visibleLineCount > 0 ? (
-          visibleTail.map((line, index) => (
-            <Text key={`${index}:${line}`} dimColor>
-              {line}
-            </Text>
-          ))
-        ) : item.tailLines.length > 0 ||
-          visibleLineCount === 0 ? null : item.childStreamId ? (
-          <Text dimColor>Open the task stream to see its live transcript.</Text>
-        ) : (
-          <Text dimColor>No output captured yet.</Text>
-        )}
+        <TaskOutput
+          childStreamId={item.childStreamId}
+          tailLines={item.tailLines}
+          visibleTail={visibleTail}
+          visibleLineCount={visibleLineCount}
+        />
       </Box>
       {layout.showHints ? (
         <Box marginTop={layout.compact ? 0 : 1}>

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -612,6 +612,20 @@ export async function runChat(
   const setApprovalPolicy = (policy: CliApprovalPolicy): void => {
     activeApprovalPolicy = policy;
   };
+  // The slash-command context is identical at every call site; build it once
+  // lazily so the closures it captures (interruptActive, resetSessionForClear,
+  // startAgentRun) are all defined before the first use.
+  const slashCommandContext = (): SlashCommandContext => ({
+    session,
+    initialAgent: agent,
+    initialModel: model,
+    interruptActive,
+    requestInputExit: () => requestInputExit?.(),
+    getApprovalPolicy,
+    setApprovalPolicy,
+    resetSession: resetSessionForClear,
+    startStoredExecution: startAgentRun,
+  });
   await loadAgents();
   cliState.sessionMeta.set({
     agent,
@@ -757,17 +771,7 @@ export async function runChat(
   registerBuiltinSlashCommands({
     canSelectAgent: () => !session.runPromise,
     onAgentSelect: (nextAgent) =>
-      applyInitialCliAgentSelection(nextAgent, {
-        session,
-        initialAgent: agent,
-        initialModel: model,
-        interruptActive,
-        requestInputExit: () => requestInputExit?.(),
-        getApprovalPolicy,
-        setApprovalPolicy,
-        resetSession: resetSessionForClear,
-        startStoredExecution: startAgentRun,
-      }),
+      applyInitialCliAgentSelection(nextAgent, slashCommandContext()),
     getApprovalPolicy,
     onApprovalPolicySelect: (policy) => {
       setApprovalPolicy(policy);
@@ -777,34 +781,13 @@ export async function runChat(
     },
     canSelectModel: () => !session.runPromise,
     onModelSelect: (nextModel) =>
-      applyInitialCliModelSelection(nextModel, {
-        session,
-        initialAgent: agent,
-        initialModel: model,
-        interruptActive,
-        requestInputExit: () => requestInputExit?.(),
-        getApprovalPolicy,
-        setApprovalPolicy,
-        resetSession: resetSessionForClear,
-        startStoredExecution: startAgentRun,
-      }),
+      applyInitialCliModelSelection(nextModel, slashCommandContext()),
     onApiModeSelect: applyCliApiModeSelection,
     onMemorySelect: showCliMemoryPreview,
     onMemoryError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },
-    onResumeSelect: (id) =>
-      resumeStoredExecution(id, {
-        session,
-        initialAgent: agent,
-        initialModel: model,
-        interruptActive,
-        requestInputExit: () => requestInputExit?.(),
-        getApprovalPolicy,
-        setApprovalPolicy,
-        resetSession: resetSessionForClear,
-        startStoredExecution: startAgentRun,
-      }),
+    onResumeSelect: (id) => resumeStoredExecution(id, slashCommandContext()),
     onResumeError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },
@@ -828,19 +811,7 @@ export async function runChat(
   };
 
   const handleSubmittedLine = async (line: string): Promise<void> => {
-    if (
-      await handleTuiSlashCommand(line, {
-        session,
-        initialAgent: agent,
-        initialModel: model,
-        interruptActive,
-        requestInputExit: () => requestInputExit?.(),
-        getApprovalPolicy,
-        setApprovalPolicy,
-        resetSession: resetSessionForClear,
-        startStoredExecution: startAgentRun,
-      })
-    ) {
+    if (await handleTuiSlashCommand(line, slashCommandContext())) {
       return;
     }
     if (!session.runPromise) {


### PR DESCRIPTION
Follow-up simplification to #4251.

- `runChatTui.tsx`: extracted a single `slashCommandContext()` builder reused by the four call sites that previously spelled out the same nine fields. It's a function so the captured closures (`interruptActive`, `resetSessionForClear`, `startAgentRun`, `requestInputExit`) resolve at call time, preserving lazy binding.
- `ChildControlPicker.tsx`: replaced the four-level nested ternary in `TaskDetailView`'s output section with a `TaskOutput` component using early-return branches (identical logic).

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI TUI wiring and rendering; behavior should remain the same but regressions could show up in slash-command handling or task output display edge cases.
> 
> **Overview**
> Refactors the CLI TUI slash-command plumbing by introducing a lazily-built `slashCommandContext()` and reusing it across built-in slash command registration and input handling, removing repeated inline context objects.
> 
> Simplifies task detail output rendering in `ChildControlPicker` by extracting the nested ternary into a `TaskOutput` component with early-return branches, keeping the same display logic while improving readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78caadc1c59ced943484ffc3ed2284112644c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->