### PR TITLE
refactor(model-handlers): drop redundant casts & pass-through closures

### DIFF
--- a/src/agent/modelHandlers/anthropicDocumentHandling.ts
+++ b/src/agent/modelHandlers/anthropicDocumentHandling.ts
@@ -14,9 +14,9 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type {
   DocumentBlockParam,
   ContentBlockParam,
+  MessageParam,
 } from '@anthropic-ai/sdk/resources/messages';
 import type { BetaRequestDocumentBlock } from '@anthropic-ai/sdk/resources/beta/messages';
-import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 
 /**
  * Extracts all document blocks from a content block array, including those
@@ -33,11 +33,8 @@ export function extractDocumentBlocks(
       documents.push(block);
     } else if (block.type === 'tool_result' && Array.isArray(block.content)) {
       for (const nested of block.content) {
-        if (
-          nested.type === 'document' &&
-          (nested as DocumentBlockParam).source
-        ) {
-          documents.push(nested as DocumentBlockParam);
+        if (nested.type === 'document' && nested.source) {
+          documents.push(nested);
         }
       }
     }

--- a/src/agent/modelHandlers/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropicTools.ts
@@ -57,12 +57,17 @@ export async function uploadToolAttachments(
   attachments: ToolFileAttachment[],
   logger: AgentLogger,
   uploadedPdfPageCounts: Map<string, number>,
-  getTrackedPdfPageCount: () => number,
-  getMaxPdfPages: () => number,
+  maxPdfPages: number,
 ): Promise<UploadToolAttachmentsResult> {
   const uploaded: UploadedAnthropicAttachment[] = [];
   const unsupported: ToolFileAttachment[] = [];
   const pageLimitExceeded: ToolFileAttachment[] = [];
+
+  const trackedPdfPageCount = (): number => {
+    let total = 0;
+    for (const count of uploadedPdfPageCounts.values()) total += count;
+    return total;
+  };
 
   for (const attachment of attachments) {
     const mimeType = attachment.mimeType ?? 'application/octet-stream';
@@ -90,7 +95,7 @@ export async function uploadToolAttachments(
     let pdfPageCount = 0;
     if (isPdf) {
       pdfPageCount = await countPdfPagesFromBuffer(buffer);
-      if (getTrackedPdfPageCount() + pdfPageCount > getMaxPdfPages()) {
+      if (trackedPdfPageCount() + pdfPageCount > maxPdfPages) {
         pageLimitExceeded.push(attachment);
         buffer.fill(0);
         buffer = undefined;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -229,7 +229,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (!Array.isArray(contentBlocks)) continue;
 
       for (const block of extractDocumentBlocks(contentBlocks)) {
-        const source = (block as DocumentBlockParam).source as
+        const source = block.source as
           | { type: string; file_id?: string }
           | undefined;
         if (source?.type === 'file' && source.file_id) {
@@ -1883,8 +1883,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         attachments,
         this.logger,
         this.uploadedPdfPageCounts,
-        () => this.getTrackedPdfPageCount(),
-        () => this.getMaxPdfPages(),
+        this.getMaxPdfPages(),
       );
       uploadedAttachments = uploadResult.uploaded;
       unsupportedAttachments.push(...uploadResult.unsupported);


### PR DESCRIPTION
Follow-up simplification to #4249.

- `anthropicDocumentHandling.ts`: merged a split `@anthropic-ai/sdk/resources/messages` import; removed two `as DocumentBlockParam` casts now that the SDK `tool_result` nested union narrows after the `type === 'document'` guard.
- `anthropicTools.ts`: `uploadToolAttachments` takes a plain `maxPdfPages: number` plus a local `trackedPdfPageCount()` that sums the `uploadedPdfPageCounts` map it already receives, instead of two injected getter closures.
- `modelHandlerAnthropic.ts`: dropped a redundant cast in `pruneTrackedPdfPages` and updated the call site to pass `maxPdfPages` directly.

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Anthropic handler types/signatures; behavior should be unchanged but touches attachment upload/page-limit enforcement and document block extraction used across tool results.
> 
> **Overview**
> **Refactors Anthropic model handler utilities** to rely on SDK type narrowing instead of explicit `as DocumentBlockParam` casts when extracting nested `document` blocks (including inside `tool_result`).
> 
> **Simplifies tool attachment uploads** by changing `uploadToolAttachments` to accept a plain `maxPdfPages` number and computing tracked PDF pages from the provided `uploadedPdfPageCounts` map, with the Anthropic handler call site updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb068360da5f668f36ba2e44ff99647df58d010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->