### PR TITLE
refactor(agent-runtime): dedupe workflow flow-result construction

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -7,7 +7,10 @@ import {
   runToolUseFlow,
   type IToolUseSession,
 } from '@agent/implementations/flows/tooluse';
-import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
+import {
+  runReflectionFlow,
+  type RunReflectionFlowResult,
+} from '@agent/implementations/flows/reflection/runReflectionFlow';
 import {
   type AgentConfig,
   type AgentConfigPayload,
@@ -95,6 +98,22 @@ function toCompileFailureSummaries(
       logAbsolutePath: failure.log.absolutePath,
     })),
   );
+}
+
+/** Build a workflow AgentFlowResult from a reflection flow run. */
+function buildWorkflowFlowResult(
+  result: RunReflectionFlowResult,
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): AgentFlowResult {
+  return {
+    category: 'workflow',
+    status: result.status,
+    outputs: toOutputSummaries(result.roundOutputs),
+    compileFailures: toCompileFailureSummaries(result.roundOutputs),
+    executionId,
+    streamId,
+  };
 }
 
 /** Create an onRoundCompleted callback that feeds progress into the execution registry and orchestrator. */
@@ -369,6 +388,8 @@ export async function executeAgent(
     const { setting, streamId, config } = ctx;
     const { agent: agentName } = config;
     const { isSubagent } = options;
+    const category =
+      setting.agentCategory === AgentCategory.ToolUse ? 'toolUse' : 'workflow';
 
     // Fire-and-forget: generate AI session description from the user's instruction.
     // Triggered at the start so cancelled/errored sessions still get descriptions.
@@ -476,22 +497,12 @@ export async function executeAgent(
             parentStage: ctx.parentStage,
             onRoundCompleted,
           });
-          return {
-            category: 'workflow' as const,
-            status: result.status,
-            outputs: toOutputSummaries(result.roundOutputs),
-            compileFailures: toCompileFailureSummaries(result.roundOutputs),
-            executionId: ctx.executionId,
-            streamId,
-          };
+          return buildWorkflowFlowResult(result, ctx.executionId, streamId);
         });
       },
       {
         isSubagent,
-        category:
-          setting.agentCategory === AgentCategory.ToolUse
-            ? 'toolUse'
-            : 'workflow',
+        category,
         parentStreamId: options.parentStreamId,
         onCompleted: options.onCompleted,
         onError: options.onError,
@@ -547,14 +558,7 @@ export async function executeMergeAgent(
             ctx.runtimeHost,
           ),
         });
-        return {
-          category: 'workflow' as const,
-          status: result.status,
-          outputs: toOutputSummaries(result.roundOutputs),
-          compileFailures: toCompileFailureSummaries(result.roundOutputs),
-          executionId: ctx.executionId,
-          streamId,
-        };
+        return buildWorkflowFlowResult(result, ctx.executionId, streamId);
       });
     }),
   );


### PR DESCRIPTION
Follow-up simplification to #4252.

- Extracted `buildWorkflowFlowResult` for the workflow `AgentFlowResult` literal that was built identically in three places (reflection branch of `executeAgent` and the merge run in `executeMergeAgent`).
- Compute the `'toolUse' | 'workflow'` category once for `runFlowWithLifecycle`'s `options.category`. (The tool-use dispatch branch intentionally keeps the `setting.agentCategory` discriminant so TS narrows the `setting` union.)

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving refactor that only centralizes result object creation and simplifies local category computation without changing execution flow logic.
> 
> **Overview**
> **Refactors workflow execution result wiring** by extracting `buildWorkflowFlowResult` to build the identical workflow `AgentFlowResult` previously constructed inline in multiple reflection-flow call sites (including merge runs).
> 
> Also computes the `'toolUse' | 'workflow'` category once before calling `runFlowWithLifecycle`, reducing repeated conditional logic while keeping tool-use dispatch narrowing intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c57e80632337c8c3f218e295072584e009e11cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->