### PR TITLE
refactor(cli-runtime): tidy supabase auth & history formatting

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -154,8 +154,7 @@ export function cliHistoryNdjsonRecords(
 export function formatCliHistoryDetailsText(
   details: CliHistoryDetails,
 ): string {
-  const config = details.config;
-  const meta = details.meta;
+  const { config, meta } = details;
   const lines = [
     `Execution: ${details.id}`,
     `Status: ${meta?.terminalStatus ?? EXECUTION_STATUS.COMPLETED}`,

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -155,7 +155,6 @@ export async function getCliAuthProfile(): Promise<CliAuthProfile> {
 }
 
 export async function getCliStoredAuthProfile(): Promise<CliAuthProfile> {
-  initializeCliSupabaseAuth();
   const session = await getCliSupabaseAuthCoordinator().loadSession();
   if (!session) return { authenticated: false };
   return {

--- a/packages/cli/src/runtime/supabaseAuthBrowser.ts
+++ b/packages/cli/src/runtime/supabaseAuthBrowser.ts
@@ -13,16 +13,21 @@ export function openBrowser(
   log: LogBackend | undefined,
   manualBrowserHint: string,
 ): Promise<void> {
-  const command =
-    process.platform === 'darwin'
-      ? 'open'
-      : process.platform === 'win32'
-        ? 'cmd'
-        : 'xdg-open';
-  const args =
-    process.platform === 'win32'
-      ? ['/d', '/s', '/c', `start "" "${quoteWindowsStartUrl(url)}"`]
-      : [url];
+  let command: string;
+  let args: string[];
+  switch (process.platform) {
+    case 'darwin':
+      command = 'open';
+      args = [url];
+      break;
+    case 'win32':
+      command = 'cmd';
+      args = ['/d', '/s', '/c', `start "" "${quoteWindowsStartUrl(url)}"`];
+      break;
+    default:
+      command = 'xdg-open';
+      args = [url];
+  }
 
   return new Promise((resolve, reject) => {
     let child: ChildProcess;


### PR DESCRIPTION
Follow-up simplification to #4253.

- `supabaseAuthBrowser.ts`: replaced the platform-select nested ternary with a `switch (process.platform)` (identical darwin/win32/default behavior).
- `supabaseAuth.ts`: removed a redundant `initializeCliSupabaseAuth()` call in `getCliStoredAuthProfile()` (the following `getCliSupabaseAuthCoordinator()` already initializes). Left the analogous call in `getCliAuthProfile()` intact — it must run before the preceding `isAuthenticated()` check.
- `history.ts`: destructured `{ config, meta }` in one line.

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that should be behavior-preserving; main risk is minor platform-specific browser-launch edge cases and auth session initialization ordering.
> 
> **Overview**
> Refactors small pieces of CLI runtime code for readability and reduced redundancy.
> 
> `openBrowser` now uses a `switch` on `process.platform` instead of nested ternaries (same darwin/win32/default behavior), `getCliStoredAuthProfile` drops a redundant `initializeCliSupabaseAuth()` call by relying on `getCliSupabaseAuthCoordinator()` to initialize, and `formatCliHistoryDetailsText` simplifies local variables via destructuring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b07e06432512da6262326630ff6fbd07c1efd6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->