### PR TITLE
fix(cli): don't seed chat default agent from multi-agent team runs

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -471,6 +471,7 @@ async function runMultiAgentPreset(
     instruction: formatMultiAgentRunInstruction(plan.preset, init),
     workingDirectory: runContext.cwd,
     agentCategory: AgentCategory.ToolUse,
+    cliMultiAgentPresetId: plan.preset.id,
   };
 
   const executionId = generateExecutionId();

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -69,7 +69,11 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
     const entries = await listExecutions();
     const mostRecent = entries
       .filter(
-        (entry) => entry.agentConfig?.agentCategory === AgentCategory.ToolUse,
+        (entry) =>
+          entry.agentConfig?.agentCategory === AgentCategory.ToolUse &&
+          // A multi-agent team run's root is an orchestrator agent, not a
+          // sensible default for a plain single-agent chat session.
+          !entry.agentConfig?.cliMultiAgentPresetId,
       )
       .sort(
         (a, b) =>

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -25,6 +25,13 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   workingDirectory: z.string().nullish(),
   /** CLI-only workspace copy target for `texra run --output`, preserved for resume. */
   cliOutputFile: z.string().nullish(),
+  /**
+   * CLI-only marker: the multi-agent team preset id this execution was launched
+   * from (`texra multi-agent run <preset>`). Used so a team run — whose root is
+   * an orchestrator agent — is not inferred as the default agent for a plain
+   * `texra chat` session. Preserved across resume.
+   */
+  cliMultiAgentPresetId: z.string().nullish(),
 });
 
 /**

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -19,10 +19,7 @@ vi.mock('@agent/storage', () => ({
 
 const mockedListExecutions = vi.mocked(listExecutions);
 
-function historyEntry(
-  agent: string,
-  overrides: Record<string, unknown> = {},
-) {
+function historyEntry(agent: string, overrides: Record<string, unknown> = {}) {
   return {
     timestamp: new Date().toISOString(),
     agentConfig: {
@@ -107,7 +104,9 @@ describe('CLI chat defaults', () => {
     // whose root is the team orchestrator. It must not become the default
     // agent for a plain `texra chat` — fall back to the built-in instead.
     mockedListExecutions.mockResolvedValueOnce([
-      historyEntry('leanOrchestrator', { cliMultiAgentPresetId: 'lean-project' }),
+      historyEntry('leanOrchestrator', {
+        cliMultiAgentPresetId: 'lean-project',
+      }),
     ]);
 
     await expect(

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { listExecutions } from '@agent/storage';
+
 import {
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
@@ -13,6 +16,23 @@ import {
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),
 }));
+
+const mockedListExecutions = vi.mocked(listExecutions);
+
+function historyEntry(
+  agent: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    timestamp: new Date().toISOString(),
+    agentConfig: {
+      agent,
+      model: 'sonnet46T',
+      agentCategory: AgentCategory.ToolUse,
+      ...overrides,
+    },
+  } as unknown as Awaited<ReturnType<typeof listExecutions>>[number];
+}
 
 vi.mock('@utils/files/storageFS', () => ({
   GlobalStorageFS: {
@@ -72,6 +92,41 @@ describe('CLI chat defaults', () => {
       model: 'sonnet46T',
       source: 'mixed',
     });
+  });
+
+  it('inherits the agent from the most recent single-agent tool-use execution', async () => {
+    mockedListExecutions.mockResolvedValueOnce([historyEntry('research')]);
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
+  });
+
+  it('does not inherit the orchestrator from a multi-agent team run', async () => {
+    // A `texra multi-agent run physicist` is stored as a tool-use execution
+    // whose root is the team orchestrator. It must not become the default
+    // agent for a plain `texra chat` — fall back to the built-in instead.
+    mockedListExecutions.mockResolvedValueOnce([
+      historyEntry('leanOrchestrator', { cliMultiAgentPresetId: 'lean-project' }),
+    ]);
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({ agent: 'chat', source: 'builtin' });
+  });
+
+  it('skips a team run to reach an earlier single-agent execution', async () => {
+    mockedListExecutions.mockResolvedValueOnce([
+      historyEntry('orchestrator', {
+        cliMultiAgentPresetId: 'physicist',
+        // newer timestamp so it would win if not filtered
+      }),
+      historyEntry('research'),
+    ]);
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
   });
 
   it('uses prefixed command-specific workspace defaults', async () => {

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -19,9 +19,13 @@ vi.mock('@agent/storage', () => ({
 
 const mockedListExecutions = vi.mocked(listExecutions);
 
-function historyEntry(agent: string, overrides: Record<string, unknown> = {}) {
+function historyEntry(
+  agent: string,
+  overrides: Record<string, unknown> = {},
+  timestamp = '2026-05-21T08:00:00.000Z',
+) {
   return {
-    timestamp: new Date().toISOString(),
+    timestamp,
     agentConfig: {
       agent,
       model: 'sonnet46T',
@@ -116,11 +120,14 @@ describe('CLI chat defaults', () => {
 
   it('skips a team run to reach an earlier single-agent execution', async () => {
     mockedListExecutions.mockResolvedValueOnce([
-      historyEntry('orchestrator', {
-        cliMultiAgentPresetId: 'physicist',
-        // newer timestamp so it would win if not filtered
-      }),
-      historyEntry('research'),
+      historyEntry(
+        'orchestrator',
+        {
+          cliMultiAgentPresetId: 'physicist',
+        },
+        '2026-05-21T08:02:00.000Z',
+      ),
+      historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
     ]);
 
     await expect(


### PR DESCRIPTION
## Summary

`texra chat` infers its default agent from the most recent tool-use execution (`loadHistoryDefaults`). A `texra multi-agent run <preset>` is stored as a tool-use execution whose root is the team **orchestrator** (e.g. `leanOrchestrator`, `orchestrator`), so after running any preset a plain `texra chat` silently booted with the orchestrator as its default agent — not a sensible solo-chat default, and often a remote/premium agent the user never picked for chat.

Tag preset runs with a CLI-only `cliMultiAgentPresetId` marker on the stored `AgentConfig` (mirrors the existing `cliOutputFile` CLI-only field) and skip tagged executions when inferring the chat default. Single-agent `chat`/`run` history still seeds the default. Pre-existing untagged runs self-heal as newer executions replace them.

Closes #4341.

## Changes

- `src/agent/core/AgentConfig.ts`: add optional CLI-only `cliMultiAgentPresetId` field.
- `packages/cli/src/commands/root.ts`: set `cliMultiAgentPresetId: plan.preset.id` on multi-agent run configs.
- `packages/cli/src/runtime/chatDefaults.ts`: `loadHistoryDefaults` skips entries carrying the marker.
- `src/test-kernel/cli/ChatDefaults.vitest.mts`: 3 new cases (inherit single-agent, skip team run → builtin, skip team run → reach earlier single-agent).

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 235/235 (3 new)
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI PTY probe: with only a tagged team run in history, `texra chat` boots `agent: chat` (was `agent: leanOrchestrator` before the fix); the stored config carries `cliMultiAgentPresetId: lean-project`.

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js multi-agent run lean-project -i some.tex   # interrupt early
node dist/bin/texra.js chat   # header shows `agent: chat`, not the orchestrator
npx vitest run src/test-kernel/cli/ChatDefaults.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a CLI-only config marker and filters history-based defaults to avoid selecting multi-agent orchestrator runs; behavior change is limited to chat default inference.
> 
> **Overview**
> Fixes `texra chat` default-agent inference so it **ignores multi-agent team runs** whose stored root agent is an orchestrator.
> 
> This introduces a CLI-only `cliMultiAgentPresetId` field on `AgentConfig`, sets it when launching `texra multi-agent run`, and updates `loadHistoryDefaults` to skip tagged executions when picking the most recent tool-use run. Tests add coverage for inheriting from single-agent history while skipping tagged team runs (including falling back to builtin or selecting an earlier untagged run).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a317912e31ee728d9cc30699ace851348d9d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->