### PR TITLE
refactor(cli): tidy multi-agent preset resolution

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -64,18 +64,6 @@ const cliPlatformLog: LogBackend = {
   },
 };
 
-function createCliLifecycleHost(): LifecycleHost {
-  return createLifecycleHost({
-    onError: (phase, error) => {
-      logAt(
-        'warn',
-        'cli.lifecycle',
-        `${phase} handler failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    },
-  });
-}
-
 function installCliShutdownSignalHandlers(lifecycle: LifecycleHost): void {
   if (shutdownHandlersInstalled) return;
   shutdownHandlersInstalled = true;
@@ -119,7 +107,15 @@ export async function initCliPlatform(
     const stateStores = await createCliStateStores({
       workspacePath: () => cliWorkspaceCwd,
     });
-    const lifecycle = createCliLifecycleHost();
+    const lifecycle = createLifecycleHost({
+      onError: (phase, error) => {
+        logAt(
+          'warn',
+          'cli.lifecycle',
+          `${phase} handler failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    });
     initPlatform({
       config: new CliConfigProvider(configStore),
       globalState: stateStores.globalState,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -243,12 +243,8 @@ function findPreferredRootAgent(
   agents: readonly AgentEntry[],
   presetOrder: readonly string[],
 ): AgentEntry | undefined {
-  const preferredNames = ['orchestrator', 'leanOrchestrator'];
-  for (const preferred of preferredNames) {
-    const entry = agents.find((agent) => agent.name === preferred);
-    if (entry) return entry;
-  }
-  for (const name of presetOrder) {
+  const searchOrder = ['orchestrator', 'leanOrchestrator', ...presetOrder];
+  for (const name of searchOrder) {
     const entry = agents.find((agent) => agent.name === name);
     if (entry) return entry;
   }


### PR DESCRIPTION
Follow-up simplification to the multi-agent preset work (#4311/#4315/#4328).

- `multiAgentPresets.ts`: collapsed the two duplicated lookup loops in `findPreferredRootAgent` into a single ordered search (preferred names prepended to the preset order). Identical resolution order/result.
- `initPlatform.ts`: inlined the single-use `createCliLifecycleHost()` factory into `initCliPlatform` (two-layer-factory-called-once anti-pattern).

Behavior-preserving; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that preserves behavior while removing small helper indirection and consolidating lookup logic. Main risk is an unintended change in agent selection ordering if the combined search order differs from prior expectations.
> 
> **Overview**
> Refactors CLI platform initialization by inlining the single-use `createCliLifecycleHost()` factory and creating the `LifecycleHost` directly inside `initCliPlatform` with the same `onError` logging.
> 
> Tidies multi-agent preset root-agent selection by collapsing two loops in `findPreferredRootAgent` into one ordered search (`['orchestrator','leanOrchestrator', ...presetOrder]`), keeping the effective preference order while reducing duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3ac811543205d4c47ac4b95aae1f28d8153e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->