### PR TITLE
refactor(skills): dedupe error helpers & clarify guards

### DIFF
--- a/src/skills/SkillSchema.ts
+++ b/src/skills/SkillSchema.ts
@@ -27,9 +27,10 @@ export const SkillNameSchema = z
 export const SkillDescriptionSchema = z
   .string()
   .transform((description) => collapseWhitespace(description))
-  .refine((description) => description.length > 0, {
-    message: 'Skill description is required',
-  })
+  .refine(
+    (description) => description.length > 0,
+    'Skill description is required',
+  )
   .refine(
     (description) => description.length <= SKILL_DESCRIPTION_MAX_LENGTH,
     `Skill description must be at most ${SKILL_DESCRIPTION_MAX_LENGTH} characters`,

--- a/src/skills/frontmatter.ts
+++ b/src/skills/frontmatter.ts
@@ -21,9 +21,7 @@ export function extractFrontmatter(content: string): ExtractedFrontmatter {
     throw new Error('SKILL.md must start with YAML frontmatter');
   }
 
-  const closeIndex = lines.findIndex((line, index) => {
-    return index > 0 && line === '---';
-  });
+  const closeIndex = lines.indexOf('---', 1);
   if (closeIndex < 0) {
     throw new Error('SKILL.md frontmatter is missing a closing delimiter');
   }

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -60,6 +60,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isFileNotFound(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
 function firstZodMessage(error: ZodError): string {
   return error.issues[0]?.message ?? 'Invalid skill metadata';
 }
@@ -125,17 +129,9 @@ function normalizeSkillDescription(
 ): { description?: string; errors: SkillLoadIssue[] } {
   const errors: SkillLoadIssue[] = [];
   const rawDescription = frontmatter.description;
-  if (typeof rawDescription !== 'string') {
-    errors.push(
-      issue('error', 'missing_description', 'Skill description is required', {
-        path: skillPath,
-        name,
-      }),
-    );
-    return { errors };
-  }
+  const description =
+    typeof rawDescription === 'string' ? collapseWhitespace(rawDescription) : '';
 
-  const description = collapseWhitespace(rawDescription);
   if (!description) {
     errors.push(
       issue('error', 'missing_description', 'Skill description is required', {
@@ -220,19 +216,32 @@ async function loadSkillDirectory(
   } catch (err) {
     return {
       errors: [
-        issue(
-          'error',
-          err instanceof Error &&
-            (err.message.startsWith('Invalid SKILL.md') ||
-              err.message.startsWith('SKILL.md'))
-            ? 'invalid_frontmatter'
-            : 'read_error',
-          err instanceof Error ? err.message : String(err),
-          { path: skillPath },
-        ),
+        issue('error', skillReadErrorCode(err), errorMessage(err), {
+          path: skillPath,
+        }),
       ],
     };
   }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * `extractFrontmatter` throws plain errors whose messages begin with `SKILL.md`
+ * or `Invalid SKILL.md`. Treat those as malformed frontmatter; anything else
+ * (e.g. a failed `readFile`) is a read error.
+ */
+function skillReadErrorCode(err: unknown): SkillIssueCode {
+  if (
+    err instanceof Error &&
+    (err.message.startsWith('SKILL.md') ||
+      err.message.startsWith('Invalid SKILL.md'))
+  ) {
+    return 'invalid_frontmatter';
+  }
+  return 'read_error';
 }
 
 /**
@@ -253,19 +262,12 @@ export async function discoverSkills(
   try {
     entries = await fs.readdir(root, { withFileTypes: true });
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (isFileNotFound(err)) {
       return { skills, errors };
     }
 
     errors.push(
-      issue(
-        'error',
-        'read_error',
-        err instanceof Error ? err.message : String(err),
-        {
-          path: root,
-        },
-      ),
+      issue('error', 'read_error', errorMessage(err), { path: root }),
     );
     return { skills, errors };
   }
@@ -279,14 +281,11 @@ export async function discoverSkills(
     try {
       realSkillPath = await fs.realpath(skillPath);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      if (!isFileNotFound(err)) {
         errors.push(
-          issue(
-            'warning',
-            'read_error',
-            err instanceof Error ? err.message : String(err),
-            { path: skillPath },
-          ),
+          issue('warning', 'read_error', errorMessage(err), {
+            path: skillPath,
+          }),
         );
       }
       continue;

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -130,7 +130,9 @@ function normalizeSkillDescription(
   const errors: SkillLoadIssue[] = [];
   const rawDescription = frontmatter.description;
   const description =
-    typeof rawDescription === 'string' ? collapseWhitespace(rawDescription) : '';
+    typeof rawDescription === 'string'
+      ? collapseWhitespace(rawDescription)
+      : '';
 
   if (!description) {
     errors.push(


### PR DESCRIPTION
Follow-up simplification to skill package discovery (#4325).

- `loadSkills.ts`: extracted `errorMessage()`, `isFileNotFound()`, and `skillReadErrorCode()` helpers replacing repeated `instanceof Error`/`ENOENT` casts and an inline nested ternary; collapsed the two identical `missing_description` branches in `normalizeSkillDescription`.
- `frontmatter.ts`: replaced the `findIndex((line, i) => i > 0 && line === '---')` closing-delimiter search with `lines.indexOf('---', 1)`.
- `SkillSchema.ts`: normalized one refine to the bare-string message form used elsewhere in the file.

Behavior-preserving (error codes/severities/messages unchanged); `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to skill frontmatter parsing and validation; intended behavior and error messages/codes remain the same, with only minor guard/lookup logic adjustments.
> 
> **Overview**
> **Refactors skill metadata validation/parsing for clarity and deduplication.** `extractFrontmatter` now finds the closing `---` delimiter via `indexOf` instead of a custom `findIndex` predicate.
> 
> `normalizeSkillDescription` in `loadSkills.ts` collapses the previous type-check and empty-check into a single normalization path (non-string becomes empty and triggers the existing `missing_description` error). `SkillDescriptionSchema` also standardizes a `zod` `refine` call to the same message style used elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f07d95134f15157810964696229e117fc392c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->