### PR TITLE
refactor(lean): dedupe LSP session start/teardown plumbing

### DIFF
--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -59,30 +59,50 @@ export function createDirectLspLeanAdapter(
     return getOrStartSession(root);
   }
 
+  /**
+   * Register an in-flight start so concurrent callers join the same promise,
+   * dropping the session on failure and clearing the in-flight slot once it
+   * settles.
+   */
+  function trackStart(
+    root: string,
+    session: LeanSession | undefined,
+    start: Promise<LeanSession>,
+  ): Promise<LeanSession> {
+    sessionStarts.set(root, start);
+    void start
+      .catch(() => {
+        if (session && sessions.get(root) === session) {
+          sessions.delete(root);
+        }
+      })
+      .finally(() => {
+        if (sessionStarts.get(root) === start) {
+          sessionStarts.delete(root);
+        }
+      });
+    return start;
+  }
+
+  /** Dispose every session and clear all tracking. */
+  async function disposeAll(): Promise<void> {
+    const all = [...sessions.values()];
+    sessions.clear();
+    sessionStarts.clear();
+    await Promise.all(all.map((session) => session.dispose()));
+  }
+
   function getOrStartSession(root: string): Promise<LeanSession> {
     const inFlight = sessionStarts.get(root);
     if (inFlight) return inFlight;
 
     const existing = sessions.get(root);
     if (existing) {
-      const ready = existing
-        .ensureReady()
-        .then(() => existing)
-        .catch((error) => {
-          if (sessions.get(root) === existing) {
-            sessions.delete(root);
-          }
-          throw error;
-        });
-      sessionStarts.set(root, ready);
-      void ready
-        .catch(() => undefined)
-        .finally(() => {
-          if (sessionStarts.get(root) === ready) {
-            sessionStarts.delete(root);
-          }
-        });
-      return ready;
+      return trackStart(
+        root,
+        existing,
+        existing.ensureReady().then(() => existing),
+      );
     }
 
     return startFreshSession(root);
@@ -99,43 +119,26 @@ export function createDirectLspLeanAdapter(
       },
     });
     sessions.set(root, session);
-    const start = (async () => {
-      await session.ensureReady();
-      return session;
-    })();
-    sessionStarts.set(root, start);
-    void start
-      .catch(() => {
-        if (sessions.get(root) === session) {
-          sessions.delete(root);
-        }
-      })
-      .finally(() => {
-        if (sessionStarts.get(root) === start) {
-          sessionStarts.delete(root);
-        }
-      });
-    return start;
+    return trackStart(
+      root,
+      session,
+      session.ensureReady().then(() => session),
+    );
   }
 
   function restartSession(root: string): Promise<LeanSession> {
-    const restart = (async () => {
-      const existing = sessions.get(root);
-      if (existing) {
-        sessions.delete(root);
-        await existing.dispose();
-      }
-      return startFreshSession(root);
-    })();
-    sessionStarts.set(root, restart);
-    void restart
-      .catch(() => undefined)
-      .finally(() => {
-        if (sessionStarts.get(root) === restart) {
-          sessionStarts.delete(root);
+    return trackStart(
+      root,
+      undefined,
+      (async () => {
+        const existing = sessions.get(root);
+        if (existing) {
+          sessions.delete(root);
+          await existing.dispose();
         }
-      });
-    return restart;
+        return startFreshSession(root);
+      })(),
+    );
   }
 
   return {
@@ -190,13 +193,9 @@ export function createDirectLspLeanAdapter(
           await Promise.all(roots.map((root) => restartSession(root)));
           return;
         }
-        case 'stop_server': {
-          const all = [...sessions.values()];
-          sessions.clear();
-          sessionStarts.clear();
-          await Promise.all(all.map((session) => session.dispose()));
+        case 'stop_server':
+          await disposeAll();
           return;
-        }
         case 'build':
           await runForAllSessions(sessions, lakeCommand, ['build']);
           return;
@@ -256,10 +255,7 @@ export function createDirectLspLeanAdapter(
     },
 
     async dispose(): Promise<void> {
-      const all = [...sessions.values()];
-      sessions.clear();
-      sessionStarts.clear();
-      await Promise.all(all.map((session) => session.dispose()));
+      await disposeAll();
     },
   };
 

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -149,11 +149,15 @@ export class LeanSession {
       textDocument: { uri: pathToUri(absolute) },
       position: { line, character: column },
     };
-    const rpc = this.rpc;
-    if (this.disposed || !rpc) {
+    return (await this.requireRpc().request(method, params)) as T;
+  }
+
+  /** Return the live JSON-RPC connection, or throw if the session is down. */
+  private requireRpc(): JsonRpcConnection {
+    if (this.disposed || !this.rpc) {
       throw new Error('Lean session is not running');
     }
-    return (await rpc.request(method, params)) as T;
+    return this.rpc;
   }
 
   private async openAndSettle(filePath: string): Promise<string> {
@@ -319,9 +323,7 @@ export class LeanSession {
     absolute: string,
     options: { forceReload: boolean },
   ): Promise<void> {
-    if (this.disposed || !this.rpc) {
-      throw new Error('Lean session is not running');
-    }
+    this.requireRpc();
     let existing = this.openFiles.get(absolute);
     if (existing && !options.forceReload) return;
     const text = await readFile(absolute, 'utf8').catch((error) => {
@@ -331,10 +333,8 @@ export class LeanSession {
     });
     existing = this.openFiles.get(absolute);
     if (existing && !options.forceReload) return;
-    const rpc = this.rpc;
-    if (this.disposed || !rpc) {
-      throw new Error('Lean session is not running');
-    }
+    // Re-check after the await: the session may have been disposed mid-read.
+    const rpc = this.requireRpc();
     const version = (existing?.version ?? 0) + 1;
     if (existing) {
       rpc.notify('textDocument/didChange', {
@@ -397,9 +397,7 @@ export class LeanSession {
     state.diagnostics = params.diagnostics.map(toLeanDiagnostic);
     state.lastDiagnosticsAt = Date.now();
     // Release any waiters — the quiet-window check above re-arms if needed.
-    for (const waiter of state.diagnosticsWaiters.splice(0)) {
-      this.resolveDiagnosticsWaiter(waiter);
-    }
+    this.releaseDiagnosticsWaiters(state);
   }
 
   private releaseAllDiagnosticsWaiters(): void {
@@ -410,15 +408,9 @@ export class LeanSession {
 
   private releaseDiagnosticsWaiters(state: OpenedFile): void {
     for (const waiter of state.diagnosticsWaiters.splice(0)) {
-      this.resolveDiagnosticsWaiter(waiter);
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
     }
-  }
-
-  private resolveDiagnosticsWaiter(
-    waiter: OpenedFile['diagnosticsWaiters'][number],
-  ): void {
-    clearTimeout(waiter.timeout);
-    waiter.resolve();
   }
 }
 


### PR DESCRIPTION
Follow-up simplification to the direct Lean LSP adapter (#4296).

- `directLspAdapter.ts`: extracted `trackStart()` for the in-flight-promise/eviction/clear bookkeeping duplicated across `getOrStartSession`/`startFreshSession`/`restartSession`, and `disposeAll()` for the identical teardown used by `stop_server` and `dispose()`. Synchronous `sessionStarts` ordering preserved.
- `leanSession.ts`: added a `requireRpc()` guard replacing three inlined disposed/rpc checks (post-await re-check retained), and folded the waiter-release chain into `releaseDiagnosticsWaiters`.

JSON-RPC framing, lake commands, and session lifecycle unchanged; `npm run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches direct Lean LSP session lifecycle and RPC/diagnostic gating; behavior should be equivalent but regressions could impact server reuse, restart/stop, or requests during disposal.
> 
> **Overview**
> **Refactors direct Lean LSP session bookkeeping** by extracting `trackStart()` to unify the in-flight `sessionStarts` promise registration, eviction-on-failure, and cleanup used across cached session reuse, fresh starts, and restarts.
> 
> **Dedupes shutdown paths** by adding `disposeAll()` and using it for both `stop_server` and adapter `dispose()`, ensuring session maps and in-flight tracking are cleared consistently.
> 
> **Centralizes session liveness checks** in `LeanSession` via `requireRpc()` (including a post-`await` re-check) and simplifies diagnostics waiter release by inlining timeout clearing + resolve into `releaseDiagnosticsWaiters()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115415abf25d4f8c2b9d3f785f18043a2d590af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->