### PR TITLE
fix(cli): label meta shortcuts as Option on macOS

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 import { Box, Text } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
@@ -41,6 +43,7 @@ export interface StatusBarDisplayInput {
   readonly subagentControlsAvailable: boolean;
   readonly model: string;
   readonly apiMode: string;
+  readonly shortcutModifierLabel?: string;
 }
 
 export interface StatusBarDisplay {
@@ -113,29 +116,36 @@ function roundSegment(
   return turns > 0 ? { text: `r${turns}`, color: 'dim' } : undefined;
 }
 
-const TASKS_BINDING = '[Alt-p]tasks';
-const SUBAGENTS_BINDING = '[Alt-s]subagents';
+export function defaultShortcutModifierLabel(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === 'darwin' ? 'Option' : 'Alt';
+}
 
-const STATUS_BAR_BINDINGS = [
-  '[Tab]streams',
-  '[Alt-1..9]focus',
-  TASKS_BINDING,
-  '[/status]details',
-  '[/model]models',
-  '[/api]api',
-  '[Ctrl-C]stop',
-] as const;
+function statusBarBindings(modifierLabel: string): readonly string[] {
+  return [
+    '[Tab]streams',
+    `[${modifierLabel}-1..9]focus`,
+    `[${modifierLabel}-p]tasks`,
+    '[/status]details',
+    '[/model]models',
+    '[/api]api',
+    '[Ctrl-C]stop',
+  ];
+}
 
 export function statusBarBindingsText(
   subagentControlsAvailable: boolean,
+  modifierLabel = defaultShortcutModifierLabel(),
 ): string {
-  const bindings: string[] = [...STATUS_BAR_BINDINGS];
+  const bindings: string[] = [...statusBarBindings(modifierLabel)];
   if (subagentControlsAvailable) {
-    const tasksIndex = bindings.indexOf(TASKS_BINDING);
+    const tasksBinding = `[${modifierLabel}-p]tasks`;
+    const tasksIndex = bindings.indexOf(tasksBinding);
     bindings.splice(
       tasksIndex >= 0 ? tasksIndex + 1 : bindings.length,
       0,
-      SUBAGENTS_BINDING,
+      `[${modifierLabel}-s]subagents`,
     );
   }
   return bindings.join('  ');
@@ -190,7 +200,10 @@ export function buildStatusBarDisplay(
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
-        : statusBarBindingsText(input.subagentControlsAvailable),
+        : statusBarBindingsText(
+            input.subagentControlsAvailable,
+            input.shortcutModifierLabel,
+          ),
   };
 }
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -4,6 +4,7 @@ import { STREAM_STATUS } from '@shared/schemas';
 
 import {
   buildStatusBarDisplay,
+  defaultShortcutModifierLabel,
   statusBarSegmentText,
 } from '../../../packages/cli/src/chat/tui/panes/StatusBar';
 import { NO_BYPASS } from '../../../packages/cli/src/chat/tui/state/cliState';
@@ -24,6 +25,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       model: 'deepseekT',
       apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
@@ -53,6 +55,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       model: 'deepseekT',
       apiMode: 'relay',
+      shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
@@ -84,6 +87,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       model: 'deepseekT',
       apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
@@ -118,6 +122,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       model: 'deepseekT',
       apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
@@ -128,5 +133,28 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toBe(
       'Resume this session with: texra --resume abc123',
     );
+  });
+
+  it('uses Option labels for meta shortcuts on macOS', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUps: 0,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: defaultShortcutModifierLabel('darwin'),
+    });
+
+    expect(display.bindings).toContain('[Option-1..9]focus');
+    expect(display.bindings).toContain('[Option-p]tasks');
+    expect(display.bindings).toContain('[Option-s]subagents');
   });
 });


### PR DESCRIPTION
## Summary

- Labels terminal meta-key shortcuts as Option on macOS and Alt elsewhere.
- Keeps the existing key handling unchanged; this is a display clarification for Mac users.
- Covers the platform-specific status-bar label with a focused CLI status-bar test.

Closes #4329.

## Verification

- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts --config vitest.config.mjs
- npm run typecheck
- npm run lint -- --quiet
- npm run compile:fast
- corepack pnpm --filter @texra/cli build
- env TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --api-mode personal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes status bar shortcut label text (Option vs Alt) and adds test coverage; no changes to key handling or core CLI behavior.
> 
> **Overview**
> Updates the CLI status bar shortcut legend to use a platform-aware modifier label: **`Option` on macOS** and **`Alt` elsewhere**. This refactors the bindings string generation to be parameterized via `defaultShortcutModifierLabel()`/`statusBarBindingsText()` and threads an optional `shortcutModifierLabel` into `buildStatusBarDisplay`.
> 
> Adds a focused Vitest case asserting the macOS `Option-*` labels and updates existing StatusBar tests to pass the modifier label explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f0d6129e70433dcd9abc13355c0681b5d0425d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->