### PR TITLE
fix(cli): clarify agent proposal category label

### DIFF
--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -1,12 +1,12 @@
 import { Box, Text } from 'ink';
 
 import {
-  AGENT_CATEGORY,
   getProposalFileGroups,
   type AgentProposalPermission,
 } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
+import { agentProposalCategoryLabel } from './AgentProposalDisplay';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface AgentProposalProps {
@@ -48,10 +48,8 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
           {props.payload.model}
         </Text>
         <Text>
-          <Text bold>Kind: </Text>
-          {props.payload.agentCategory === AGENT_CATEGORY.WORKFLOW
-            ? 'workflow'
-            : 'tool-use'}
+          <Text bold>Category: </Text>
+          {agentProposalCategoryLabel(props.payload.agentCategory)}
         </Text>
         {props.payload.workingDirectory ? (
           <Text>

--- a/packages/cli/src/chat/tui/modals/AgentProposalDisplay.ts
+++ b/packages/cli/src/chat/tui/modals/AgentProposalDisplay.ts
@@ -1,0 +1,9 @@
+import { AGENT_CATEGORY, type AgentProposalPermission } from '@shared/schemas';
+
+export function agentProposalCategoryLabel(
+  agentCategory: AgentProposalPermission['agentCategory'],
+): string {
+  return agentCategory === AGENT_CATEGORY.WORKFLOW
+    ? 'workflow agent'
+    : 'tool-use agent';
+}

--- a/src/test-kernel/cli/AgentProposal.vitest.mts
+++ b/src/test-kernel/cli/AgentProposal.vitest.mts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { AGENT_CATEGORY } from '@shared/schemas';
+
+import { agentProposalCategoryLabel } from '../../../packages/cli/src/chat/tui/modals/AgentProposalDisplay';
+
+describe('CLI AgentProposal display model', () => {
+  it('uses human-facing category labels', () => {
+    expect(agentProposalCategoryLabel(AGENT_CATEGORY.TOOL_USE)).toBe(
+      'tool-use agent',
+    );
+    expect(agentProposalCategoryLabel(AGENT_CATEGORY.WORKFLOW)).toBe(
+      'workflow agent',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the terse agent proposal field `Kind` with `Category`.
- Renders explicit values such as `tool-use agent` and `workflow agent`, avoiding the observed `tool-usekT` artifact when terminal redraws leave a model suffix behind.
- Adds a focused CLI display-model test for the category labels.

Closes #4343.

## Verification

- npm run format
- corepack pnpm vitest run src/test-kernel/cli/AgentProposal.vitest.mts --config vitest.config.mjs
- npm run typecheck
- npm run lint -- --quiet
- npm run compile:fast
- corepack pnpm --filter @texra/cli build
- node packages/cli/dist/bin/texra.js chat --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CLI TUI display-only wording change plus a small pure helper and a focused unit test; no behavioral, security, or data-handling logic changes.
> 
> **Overview**
> Updates the agent spawn approval modal to show a **Category** field (instead of *Kind*) and to render stable, human-facing labels via a new `agentProposalCategoryLabel` helper (e.g., `tool-use agent`, `workflow agent`).
> 
> Adds a small Vitest test to lock in the category label mapping for `AGENT_CATEGORY.TOOL_USE` and `AGENT_CATEGORY.WORKFLOW`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c429f9d3e3fac12463bf6d6fff9417193b113721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->