### PR TITLE
feat(cli): pulse active subagent rows

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -4,6 +4,7 @@
 //
 // The leading numeric index is currently a visual cue only.
 
+import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
@@ -11,21 +12,21 @@ import type { ActiveChildInfo } from '@shared/schemas';
 import { visibleSubagentRows } from '../state/childControls';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import {
+  childStatusColor,
+  childStatusMarker,
+  childStatusPulses,
+} from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
   readonly index: number;
+  readonly pulseOn: boolean;
   readonly tail?: ProcessOutputTail;
 }
 
 const TAIL_LINES = 4;
-
-function statusColor(status: string | undefined): string | undefined {
-  if (!status) return 'green';
-  if (status === 'waiting' || status === 'idle') return 'yellow';
-  if (status === 'error' || status === 'stopped') return 'red';
-  return 'green';
-}
+const PULSE_INTERVAL_MS = 700;
 
 /** Pull the last `TAIL_LINES` non-blank lines from the combined std streams.
  *  The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
@@ -39,13 +40,31 @@ function lastLines(tail: ProcessOutputTail | undefined): string[] {
   return nonBlank.slice(-TAIL_LINES);
 }
 
-function Row({ child, index, tail }: RowProps): React.JSX.Element {
+function usePulse(enabled: boolean): boolean {
+  const [pulseOn, setPulseOn] = useState(true);
+  useEffect(() => {
+    if (!enabled) {
+      setPulseOn(true);
+      return;
+    }
+    const timer = setInterval(
+      () => setPulseOn((value) => !value),
+      PULSE_INTERVAL_MS,
+    );
+    return () => clearInterval(timer);
+  }, [enabled]);
+  return pulseOn;
+}
+
+function Row({ child, index, pulseOn, tail }: RowProps): React.JSX.Element {
   const tailLines = lastLines(tail);
   return (
     <Box flexDirection="column">
       <Box flexDirection="row">
         <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
-        <Text color={statusColor(child.status)}>● </Text>
+        <Text color={childStatusColor(child.status)}>
+          {childStatusMarker(child.status, pulseOn)}
+        </Text>
         <Text>{child.agentName || child.toolName || child.executionId}</Text>
         {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
         {child.elapsed ? <Text dimColor>{` · ${child.elapsed}`}</Text> : null}
@@ -73,9 +92,15 @@ export function SubagentList(
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const activeProcesses = slice?.activeProcesses ?? [];
+  const processOutput = slice?.processOutput;
+  const subagents = slice ? visibleSubagentRows(slice) : [];
+  const pulseOn = usePulse(
+    [...subagents, ...activeProcesses].some((child) =>
+      childStatusPulses(child.status),
+    ),
+  );
   if (!slice) return null;
-  const { activeProcesses, processOutput } = slice;
-  const subagents = visibleSubagentRows(slice);
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
 
@@ -93,7 +118,12 @@ export function SubagentList(
             Subagents
           </Text>
           {subagents.map((child, i) => (
-            <Row key={child.executionId} child={child} index={i} />
+            <Row
+              key={child.executionId}
+              child={child}
+              index={i}
+              pulseOn={pulseOn}
+            />
           ))}
         </Box>
       ) : null}
@@ -107,7 +137,8 @@ export function SubagentList(
               key={child.executionId}
               child={child}
               index={subagents.length + i}
-              tail={processOutput.get(child.executionId)}
+              pulseOn={pulseOn}
+              tail={processOutput?.get(child.executionId)}
             />
           ))}
         </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,0 +1,18 @@
+export function childStatusColor(status: string | undefined): string {
+  if (!status) return 'green';
+  if (status === 'waiting' || status === 'idle') return 'yellow';
+  if (status === 'error' || status === 'stopped') return 'red';
+  return 'green';
+}
+
+export function childStatusPulses(status: string | undefined): boolean {
+  return !status || status === 'running' || status === 'in_progress';
+}
+
+export function childStatusMarker(
+  status: string | undefined,
+  pulseOn: boolean,
+): string {
+  if (!childStatusPulses(status)) return '● ';
+  return pulseOn ? '● ' : '○ ';
+}

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  childStatusColor,
+  childStatusMarker,
+  childStatusPulses,
+} from '../../../packages/cli/src/chat/tui/panes/SubagentListDisplay';
+
+describe('CLI SubagentList display model', () => {
+  it('pulses running statuses', () => {
+    expect(childStatusPulses(undefined)).toBe(true);
+    expect(childStatusPulses('running')).toBe(true);
+    expect(childStatusPulses('in_progress')).toBe(true);
+    expect(childStatusPulses('waiting')).toBe(false);
+  });
+
+  it('alternates the marker only for active rows', () => {
+    expect(childStatusMarker('running', true)).toBe('● ');
+    expect(childStatusMarker('running', false)).toBe('○ ');
+    expect(childStatusMarker('waiting', false)).toBe('● ');
+  });
+
+  it('maps status colors consistently', () => {
+    expect(childStatusColor(undefined)).toBe('green');
+    expect(childStatusColor('running')).toBe('green');
+    expect(childStatusColor('waiting')).toBe('yellow');
+    expect(childStatusColor('stopped')).toBe('red');
+  });
+});


### PR DESCRIPTION
## Summary

- Makes running subagent and process rows pulse in the CLI side panel by alternating the status marker.
- Keeps waiting, idle, stopped, and error rows stable so completed or blocked states remain easy to read.
- Extracts the status display mapping into a small tested helper.

Addresses #4333.

## Verification

- npm run format
- corepack pnpm vitest run src/test-kernel/cli/SubagentListDisplay.vitest.mts --config vitest.config.mjs
- npm run typecheck
- npm run lint -- --quiet
- npm run compile:fast
- corepack pnpm --filter @texra/cli build
- node packages/cli/dist/bin/texra.js chat --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to the CLI TUI rendering; primary risk is minor visual/refresh behavior regressions due to the new interval-based pulsing.
> 
> **Overview**
> **CLI TUI subagent/process rows now visually pulse when active** by alternating the status marker (`●`/`○`) on a timer for `running`/`in_progress` (and unset) statuses, while keeping `waiting`/`idle`/`stopped`/`error` stable.
> 
> Extracts status-to-color/marker/pulsing rules into `SubagentListDisplay.ts` and adds a small `vitest` suite to lock in the mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6687f19a523c094ead555d7318bdc6a18429408d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->