### PR TITLE
fix(cli): allow fresh chat after terminal failure

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -136,6 +136,13 @@ export function chatTuiCanInterruptActiveRun(session: {
   );
 }
 
+export function chatTuiCanStartRootRun(session: {
+  readonly runPromise: Promise<unknown> | undefined;
+  readonly runCompleted: boolean;
+}): boolean {
+  return !session.runPromise || session.runCompleted;
+}
+
 interface SlashCommandContext {
   readonly session: TuiSession;
   readonly initialAgent: string;
@@ -160,7 +167,7 @@ function applyInitialCliAgentSelection(
   agentName: string,
   context: SlashCommandContext,
 ): void {
-  if (context.session.runPromise) {
+  if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
       'Agent changes are only available before the first message. Start a new chat with texra --agent=<name> to choose a different root agent.',
     );
@@ -177,7 +184,7 @@ function applyInitialCliAgentSelection(
 }
 
 function openCliAgentListForm(context: SlashCommandContext): void {
-  const selectable = !context.session.runPromise;
+  const selectable = chatTuiCanStartRootRun(context.session);
   cliState.activeForm.set({
     commandName: 'agent',
     render: (close, availableRows) => (
@@ -199,7 +206,7 @@ async function applyInitialCliModelSelection(
   model: string,
   context: SlashCommandContext,
 ): Promise<void> {
-  if (context.session.runPromise) {
+  if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
       'Model changes are only available before the first message. Start a new chat with texra --model=<name> to choose a different root model.',
     );
@@ -219,7 +226,7 @@ async function applyInitialCliModelSelection(
 }
 
 function openCliModelListForm(context: SlashCommandContext): void {
-  const selectable = !context.session.runPromise;
+  const selectable = chatTuiCanStartRootRun(context.session);
   cliState.activeForm.set({
     commandName: 'model',
     render: (close, availableRows) => (
@@ -368,7 +375,7 @@ async function resumeStoredExecution(
   id: ExecutionId,
   context: SlashCommandContext,
 ): Promise<void> {
-  if (context.session.runPromise) {
+  if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
       'Finish the active chat before resuming a stored execution.',
     );
@@ -463,7 +470,7 @@ async function handleTuiSlashCommand(
       context.requestInputExit();
       return true;
     case 'agent':
-      if (context.session.runPromise && rest) {
+      if (!chatTuiCanStartRootRun(context.session) && rest) {
         appendLocalAssistantTranscript(
           'The agent is fixed for this chat session. Start a new chat to use a different agent.',
         );
@@ -710,6 +717,12 @@ export async function runChat(
   };
 
   const startAgentRun = (config: AgentConfigPayload): void => {
+    followUpQueue.clear();
+    session.streamId = undefined;
+    session.runCompleted = false;
+    session.stopRequested = false;
+    session.runExitCode = CliExitCode.Success;
+
     const currentModel = config.model;
     const sessionContext = currentSessionContext(currentModel);
     cliState.sessionMeta.set({
@@ -779,7 +792,7 @@ export async function runChat(
 
   // Pre-register the slash commands the input palette uses.
   registerBuiltinSlashCommands({
-    canSelectAgent: () => !session.runPromise,
+    canSelectAgent: () => chatTuiCanStartRootRun(session),
     onAgentSelect: (nextAgent) =>
       applyInitialCliAgentSelection(nextAgent, slashCommandContext()),
     getApprovalPolicy,
@@ -789,7 +802,7 @@ export async function runChat(
         `Approval mode set to ${formatApprovalPolicy(policy)}.`,
       );
     },
-    canSelectModel: () => !session.runPromise,
+    canSelectModel: () => chatTuiCanStartRootRun(session),
     onModelSelect: (nextModel) =>
       applyInitialCliModelSelection(nextModel, slashCommandContext()),
     onApiModeSelect: applyCliApiModeSelection,
@@ -824,7 +837,7 @@ export async function runChat(
     if (await handleTuiSlashCommand(line, slashCommandContext())) {
       return;
     }
-    if (!session.runPromise) {
+    if (chatTuiCanStartRootRun(session)) {
       startSession(line);
       return;
     }

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -48,6 +48,7 @@ import {
 import { renderAnsiMarkdown } from '../../../packages/cli/src/chat/tui/render/ansiMarkdown';
 import {
   chatTuiCanInterruptActiveRun,
+  chatTuiCanStartRootRun,
   clearTuiSessionRunState,
 } from '../../../packages/cli/src/chat/tui/runChatTui';
 import { CliExitCode } from '../../../packages/cli/src/runtime/exitCodes';
@@ -280,6 +281,29 @@ describe('CLI TUI row allocation', () => {
         runCompleted: false,
         runPromise,
         streamId: root,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows a fresh root run after a terminal chat failure', () => {
+    const runPromise = Promise.resolve();
+
+    expect(
+      chatTuiCanStartRootRun({
+        runCompleted: false,
+        runPromise: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      chatTuiCanStartRootRun({
+        runCompleted: false,
+        runPromise,
+      }),
+    ).toBe(false);
+    expect(
+      chatTuiCanStartRootRun({
+        runCompleted: true,
+        runPromise,
       }),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Treats a completed chat run as inactive when deciding whether a new prompt should start a fresh root run.
- Re-enables root agent/model selection and stored-execution resume after a terminal chat failure, while keeping active runs protected.
- Clears queued follow-ups and stale run flags when starting the replacement run.

Closes #4347.

## Verification

- npm run format
- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts --config vitest.config.mjs
- npm run typecheck
- npm run lint -- --quiet
- npm run compile:fast
- corepack pnpm --filter @texra/cli build
- node packages/cli/dist/bin/texra.js chat --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adjusts TUI run lifecycle gating and resets run state, which can affect when new root runs vs follow-ups are started and when agent/model selection is allowed.
> 
> **Overview**
> Fixes `texra chat` so a *completed* (including terminal error) run is treated as inactive, allowing a new prompt to start a fresh root run and re-enabling root agent/model selection and `/resume` after failure.
> 
> Introduces `chatTuiCanStartRootRun` and replaces prior `runPromise` checks across slash commands and submission handling; starting a new agent run now clears queued follow-ups and resets key session run flags before launching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4345c9f8e021df98b763364ef02670e13d2d0e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->