### PR TITLE
feat(cli): list discovered skills

### DIFF
--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(packageDir, '../..');
 const source = path.resolve(packageDir, '../extension/resources');
 const target = path.resolve(packageDir, 'dist/resources');
 const runtimeResourceEntries = [
@@ -27,3 +28,6 @@ await Promise.all(
     }),
   ),
 );
+await cp(path.join(repoRoot, 'skills'), path.join(target, 'skills'), {
+  recursive: true,
+});

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -108,6 +108,12 @@ import {
   type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
+import {
+  formatCliSkillIssue,
+  formatCliSkillList,
+  readCliSkills,
+  skillListRecord,
+} from '../runtime/skills';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after
@@ -267,6 +273,83 @@ async function listAgents(context: CliContext): Promise<number> {
 const agentsCommand = defineCommand({
   meta: { name: 'agents', description: 'Inspect TeXRA agents' },
   subCommands: { list: agentsListCommand },
+});
+
+const skillsListCommand = defineCommand({
+  meta: { name: 'list', description: 'List available skills' },
+  args: {
+    ...GLOBAL_ARGS,
+    'include-interop': {
+      type: 'boolean',
+      description:
+        'Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory',
+    },
+    source: {
+      type: 'string',
+      alias: 's',
+      description:
+        'Additional skill root to scan; may be repeated and is resolved relative to --cwd',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(
+      await listSkills(context, {
+        includeInterop: ctx.args['include-interop'] === true,
+        additionalPaths: collectStringFlagValues(ctx.rawArgs, 'source', 's'),
+      }),
+    );
+  },
+});
+
+async function listSkills(
+  context: CliContext,
+  options: {
+    readonly includeInterop: boolean;
+    readonly additionalPaths: readonly string[];
+  },
+): Promise<number> {
+  const result = await readCliSkills(context, options);
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(
+      JSON.stringify(
+        {
+          skills: result.skills.map(skillListRecord),
+          errors: result.errors,
+        },
+        null,
+        2,
+      ),
+    );
+    return CliExitCode.Success;
+  }
+
+  if (context.outputFormat === 'ndjson') {
+    const ts = new Date().toISOString();
+    for (const entry of result.skills) {
+      writeNdjsonStdout({
+        kind: 'skill',
+        ts,
+        skill: skillListRecord(entry),
+      });
+    }
+    for (const issue of result.errors) {
+      writeNdjsonStdout({ kind: 'skill-issue', ts, issue });
+    }
+    return CliExitCode.Success;
+  }
+
+  for (const issue of result.errors) {
+    writeTextStderr(formatCliSkillIssue(issue));
+  }
+  writeTextStdout(formatCliSkillList(result.skills));
+  return CliExitCode.Success;
+}
+
+const skillsCommand = defineCommand({
+  meta: { name: 'skills', description: 'Inspect TeXRA skills' },
+  subCommands: { list: skillsListCommand },
 });
 
 const multiAgentListCommand = defineCommand({
@@ -1925,6 +2008,7 @@ export const rootCommand = defineCommand({
     resume: resumeCommand,
     history: historyCommand,
     agents: agentsCommand,
+    skills: skillsCommand,
     'multi-agent': multiAgentCommand,
     models: modelsCommand,
     login: loginCommand,

--- a/packages/cli/src/runtime/completionFish.ts
+++ b/packages/cli/src/runtime/completionFish.ts
@@ -17,8 +17,10 @@ function fishDescription(description: string): string[] {
 
 function fishCondition(path: readonly string[]): string {
   if (path.length === 0) return "-n '__fish_use_subcommand'";
-  const command = path.at(-1) ?? '';
-  return `-n '__fish_seen_subcommand_from ${fishEscape(command)}'`;
+  const pathCondition = path
+    .map((command) => `__fish_seen_subcommand_from ${fishEscape(command)}`)
+    .join('; and ');
+  return `-n '${pathCondition}'`;
 }
 
 export function fishCompletion(commands: readonly CompletionCommand[]): string {

--- a/packages/cli/src/runtime/skills.ts
+++ b/packages/cli/src/runtime/skills.ts
@@ -1,0 +1,141 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Local imports - skills
+import {
+  discoverSkillSources,
+  type DiscoverSkillSourcesResult,
+  type SkillLoadIssue,
+  type SkillSource,
+  type SourcedSkill,
+} from '@skills/loadSkills';
+
+// Local imports - CLI runtime
+import type { CliContext } from './cliContext';
+
+export interface CliSkillDiscoveryOptions {
+  readonly includeInterop?: boolean;
+  readonly additionalPaths?: readonly string[];
+}
+
+interface CliSkillRecord {
+  readonly name: string;
+  readonly description: string;
+  readonly scope: SkillSource['scope'];
+  readonly source: string;
+  readonly path: string;
+}
+
+const INTEROP_SKILL_DIRS = ['.claude', '.codex', '.gemini'] as const;
+
+function bundledSkillSources(resourcesPath: string): SkillSource[] {
+  return [
+    {
+      scope: 'bundled',
+      path: path.join(resourcesPath, 'skills'),
+      label: 'bundled',
+    },
+    {
+      scope: 'bundled',
+      path: path.resolve(resourcesPath, '../../..', 'skills'),
+      label: 'bundled source',
+    },
+  ];
+}
+
+function resolveSkillSourcePath(base: string, candidate: string): string {
+  return path.isAbsolute(candidate)
+    ? path.resolve(candidate)
+    : path.resolve(base, candidate);
+}
+
+function uniqueSources(sources: readonly SkillSource[]): SkillSource[] {
+  const unique: SkillSource[] = [];
+  const seen = new Set<string>();
+  for (const source of sources) {
+    const key = path.resolve(source.path);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push({ ...source, path: key });
+  }
+  return unique;
+}
+
+export function cliSkillSources(
+  context: Pick<CliContext, 'cwd' | 'resourcesPath'>,
+  options: CliSkillDiscoveryOptions = {},
+): SkillSource[] {
+  const home = os.homedir();
+  const sources: SkillSource[] = [
+    ...bundledSkillSources(context.resourcesPath),
+    {
+      scope: 'user',
+      path: path.join(home, '.texra', 'skills'),
+      label: 'user',
+    },
+    {
+      scope: 'project',
+      path: path.join(context.cwd, '.texra', 'skills'),
+      label: 'project',
+    },
+  ];
+
+  if (options.includeInterop === true) {
+    for (const dir of INTEROP_SKILL_DIRS) {
+      sources.push(
+        {
+          scope: 'interop',
+          path: path.join(home, dir, 'skills'),
+          label: `${dir} user`,
+        },
+        {
+          scope: 'interop',
+          path: path.join(context.cwd, dir, 'skills'),
+          label: `${dir} project`,
+        },
+      );
+    }
+  }
+
+  for (const candidate of options.additionalPaths ?? []) {
+    sources.push({
+      scope: 'custom',
+      path: resolveSkillSourcePath(context.cwd, candidate),
+      label: 'custom',
+    });
+  }
+
+  return uniqueSources(sources);
+}
+
+export function skillListRecord(entry: SourcedSkill): CliSkillRecord {
+  return {
+    name: entry.skill.name,
+    description: entry.skill.description,
+    scope: entry.source.scope,
+    source: entry.source.path,
+    path: entry.skill.path,
+  };
+}
+
+export async function readCliSkills(
+  context: Pick<CliContext, 'cwd' | 'resourcesPath'>,
+  options: CliSkillDiscoveryOptions = {},
+): Promise<DiscoverSkillSourcesResult> {
+  return discoverSkillSources(cliSkillSources(context, options));
+}
+
+export function formatCliSkillIssue(issue: SkillLoadIssue): string {
+  const location = issue.path ? ` (${issue.path})` : '';
+  return `${issue.severity}: ${issue.message}${location}`;
+}
+
+export function formatCliSkillList(skills: readonly SourcedSkill[]): string {
+  if (skills.length === 0) return 'No skills found.';
+  return skills
+    .map((entry) => {
+      const record = skillListRecord(entry);
+      return `${record.scope}\t${record.name}\t${record.description}`;
+    })
+    .join('\n');
+}

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -45,6 +45,29 @@ export interface DiscoverSkillsResult {
   errors: SkillLoadIssue[];
 }
 
+export type SkillSourceScope =
+  | 'bundled'
+  | 'user'
+  | 'project'
+  | 'interop'
+  | 'custom';
+
+export interface SkillSource {
+  scope: SkillSourceScope;
+  path: string;
+  label?: string;
+}
+
+export interface SourcedSkill {
+  skill: Skill;
+  source: SkillSource;
+}
+
+export interface DiscoverSkillSourcesResult {
+  skills: SourcedSkill[];
+  errors: SkillLoadIssue[];
+}
+
 interface LoadedSkill {
   skill?: Skill;
   errors: SkillLoadIssue[];
@@ -321,6 +344,67 @@ export async function discoverSkills(
 
     seenNames.add(loaded.skill.name);
     skills.push(loaded.skill);
+  }
+
+  return { skills, errors };
+}
+
+/**
+ * Discover skills from several roots in precedence order.
+ *
+ * The one-root loader remains useful for tests and direct imports. This wrapper
+ * adds the cross-root invariants needed by runtimes: a skill name or canonical
+ * `SKILL.md` file is accepted only from the first source that provides it.
+ */
+export async function discoverSkillSources(
+  sources: readonly SkillSource[],
+): Promise<DiscoverSkillSourcesResult> {
+  const skills: SourcedSkill[] = [];
+  const errors: SkillLoadIssue[] = [];
+  const seenNames = new Set<string>();
+  const seenRealPaths = new Set<string>();
+
+  for (const source of sources) {
+    const result = await discoverSkills(source.path);
+    errors.push(...result.errors);
+
+    for (const skill of result.skills) {
+      let realSkillPath = skill.path;
+      try {
+        realSkillPath = await fs.realpath(skill.path);
+      } catch {
+        // The one-root loader has already read this file. If the path vanishes
+        // between the read and this check, name deduplication still suffices.
+      }
+
+      if (seenRealPaths.has(realSkillPath)) {
+        errors.push(
+          issue(
+            'warning',
+            'duplicate_realpath',
+            `Skipping duplicate skill path ${realSkillPath}`,
+            { path: skill.path, name: skill.name },
+          ),
+        );
+        continue;
+      }
+
+      if (seenNames.has(skill.name)) {
+        errors.push(
+          issue(
+            'warning',
+            'duplicate_name',
+            `Skipping duplicate skill name "${skill.name}"`,
+            { path: skill.path, name: skill.name },
+          ),
+        );
+        continue;
+      }
+
+      seenRealPaths.add(realSkillPath);
+      seenNames.add(skill.name);
+      skills.push({ skill, source });
+    }
   }
 
   return { skills, errors };

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -153,6 +153,12 @@ describe('CLI root argument routing', () => {
         helpCommand: 'texra models',
       },
     );
+    await expect(detectUnknownCliCommand(['skills', 'bogus'])).resolves.toEqual(
+      {
+        typedCommand: 'texra skills bogus',
+        helpCommand: 'texra skills',
+      },
+    );
   });
 
   it('formats unknown command usage guidance', () => {

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -1,0 +1,116 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cliSkillSources,
+  formatCliSkillList,
+  readCliSkills,
+  skillListRecord,
+} from '../../../packages/cli/src/runtime/skills';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-skills-'));
+  tempRoots.push(root);
+  return root;
+}
+
+async function writeSkill(
+  root: string,
+  dirName: string,
+  description: string,
+): Promise<void> {
+  const skillDir = path.join(root, dirName);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${dirName}\ndescription: ${description}\n---\n\nUse ${dirName}.\n`,
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => {
+      return fs.rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe('CLI skills runtime', () => {
+  it('resolves default, interop, and custom skill sources in precedence order', () => {
+    const sources = cliSkillSources(
+      {
+        cwd: '/tmp/project',
+        resourcesPath: '/tmp/resources',
+      },
+      {
+        includeInterop: true,
+        additionalPaths: ['vendor/skills'],
+      },
+    );
+
+    expect(sources.map((source) => source.path)).toEqual(
+      expect.arrayContaining([
+        '/tmp/resources/skills',
+        path.join(os.homedir(), '.texra', 'skills'),
+        '/tmp/project/.texra/skills',
+        path.join(os.homedir(), '.claude', 'skills'),
+        '/tmp/project/.claude/skills',
+        path.join(os.homedir(), '.codex', 'skills'),
+        '/tmp/project/.codex/skills',
+        path.join(os.homedir(), '.gemini', 'skills'),
+        '/tmp/project/.gemini/skills',
+        '/tmp/project/vendor/skills',
+      ]),
+    );
+  });
+
+  it('lists bundled skills before custom duplicate names', async () => {
+    const resources = await createTempRoot();
+    const custom = await createTempRoot();
+    await fs.mkdir(path.join(resources, 'skills'));
+    await writeSkill(
+      path.join(resources, 'skills'),
+      'shared-skill',
+      'The bundled skill.',
+    );
+    await writeSkill(custom, 'shared-skill', 'The custom skill.');
+    await writeSkill(custom, 'custom-only', 'The custom-only skill.');
+
+    const result = await readCliSkills(
+      {
+        cwd: resources,
+        resourcesPath: resources,
+      },
+      {
+        additionalPaths: [custom],
+      },
+    );
+
+    expect(result.skills.map(skillListRecord)).toMatchObject([
+      {
+        name: 'shared-skill',
+        description: 'The bundled skill.',
+        scope: 'bundled',
+      },
+      {
+        name: 'custom-only',
+        description: 'The custom-only skill.',
+        scope: 'custom',
+      },
+    ]);
+    expect(formatCliSkillList(result.skills)).toContain(
+      'bundled\tshared-skill\tThe bundled skill.',
+    );
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        code: 'duplicate_name',
+        name: 'shared-skill',
+      }),
+    );
+  });
+});

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " orchestrate chat run resume history history list history show history delete agents agents list multi-agent multi-agent list multi-agent show multi-agent run models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume history history list history show history delete agents agents list skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -50,7 +50,7 @@ _texra() {
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'orchestrate') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
@@ -61,6 +61,8 @@ _texra() {
     'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --all' ;;
     'agents') subcommands='list'; flags='' ;;
     'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'skills') subcommands='list'; flags='' ;;
+    'skills list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --include-interop --source -s' ;;
     'multi-agent') subcommands='list show run'; flags='' ;;
     'multi-agent list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'multi-agent show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -77,7 +79,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -109,6 +111,7 @@ complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
 complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Re-run a stored execution config'
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'
 complete -c texra -n '__fish_use_subcommand' -a 'agents' -d 'Inspect TeXRA agents'
+complete -c texra -n '__fish_use_subcommand' -a 'skills' -d 'Inspect TeXRA skills'
 complete -c texra -n '__fish_use_subcommand' -a 'multi-agent' -d 'Inspect multi-agent teams'
 complete -c texra -n '__fish_use_subcommand' -a 'models' -d 'Inspect TeXRA models'
 complete -c texra -n '__fish_use_subcommand' -a 'login' -d 'Sign in to TeXRA for included access'
@@ -160,65 +163,74 @@ complete -c texra -n '__fish_seen_subcommand_from resume' -l 'approval-policy' -
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'list' -d 'List stored executions'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'show' -d 'Show one stored execution'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'delete' -d 'Delete stored executions'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from delete' -l 'all' -d 'Delete all stored executions'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'all' -d 'Delete all stored executions'
 complete -c texra -n '__fish_seen_subcommand_from agents' -a 'list' -d 'List available agents'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from skills' -a 'list' -d 'List available skills'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'include-interop' -d 'Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory'
+complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'source' -s 's' -r -d 'Additional skill root to scan; may be repeated and is resolved relative to --cwd'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'list' -d 'List multi-agent team presets'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'show' -d 'Show one multi-agent team preset'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'run' -d 'Run a multi-agent team preset'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'input' -s 'i' -r -d 'Input file passed to the team orchestrator'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'context' -s 'c' -r -d 'Read-only context file passed to the team orchestrator'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'agent' -r -d 'Tool-use agent to start as the team root (defaults to the preset orchestrator)'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'model' -s 'm' -r -d 'Model for the root tool-use agent'
-complete -c texra -n '__fish_seen_subcommand_from run' -l 'instruction' -r -d 'Additional instruction for the team orchestrator'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'input' -s 'i' -r -d 'Input file passed to the team orchestrator'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'context' -s 'c' -r -d 'Read-only context file passed to the team orchestrator'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'agent' -r -d 'Tool-use agent to start as the team root (defaults to the preset orchestrator)'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'model' -s 'm' -r -d 'Model for the root tool-use agent'
+complete -c texra -n '__fish_seen_subcommand_from multi-agent; and __fish_seen_subcommand_from run' -l 'instruction' -r -d 'Additional instruction for the team orchestrator'
 complete -c texra -n '__fish_seen_subcommand_from models' -a 'list' -d 'List available models'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from login' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
@@ -244,19 +256,19 @@ complete -c texra -n '__fish_seen_subcommand_from usage' -l 'approval-policy' -r
 complete -c texra -n '__fish_seen_subcommand_from usage' -l 'month' -r -d 'UTC month to show, formatted as YYYY-MM'
 complete -c texra -n '__fish_seen_subcommand_from auth' -a 'status' -d 'Show TeXRA sign-in status'
 complete -c texra -n '__fish_seen_subcommand_from auth' -a 'usage' -d 'Show relay usage for this account'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from status' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from usage' -l 'month' -r -d 'UTC month to show, formatted as YYYY-MM'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from status' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from usage' -l 'month' -r -d 'UTC month to show, formatted as YYYY-MM'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from doctor' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
@@ -305,6 +317,8 @@ _texra() {
     'history delete') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
     'agents') _values 'subcommands' 'list'; true ;;
     'agents list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'skills') _values 'subcommands' 'list'; true ;;
+    'skills list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--include-interop[Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory]' '--source[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' '-s[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' ;;
     'multi-agent') _values 'subcommands' 'list' 'show' 'run'; true ;;
     'multi-agent list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'multi-agent show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
@@ -321,7 +335,7 @@ _texra() {
     'completion') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume history agents multi-agent models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help)' ;;
   esac
 }
 

--- a/src/test-kernel/skills/LoadSkills.vitest.mts
+++ b/src/test-kernel/skills/LoadSkills.vitest.mts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports - skills
-import { discoverSkills } from '@skills/loadSkills';
+import { discoverSkills, discoverSkillSources } from '@skills/loadSkills';
 
 const tempRoots: string[] = [];
 
@@ -185,6 +185,58 @@ description: The second skill with this name.
         severity: 'warning',
         code: 'duplicate_name',
         name: 'repeated-name',
+      }),
+    );
+  });
+});
+
+describe('discoverSkillSources', () => {
+  it('keeps source precedence across multiple roots', async () => {
+    const bundled = await createTempRoot();
+    const project = await createTempRoot();
+    await writeSkill(
+      bundled,
+      'shared-skill',
+      `
+name: shared-skill
+description: The bundled version.
+`,
+    );
+    await writeSkill(
+      project,
+      'shared-skill',
+      `
+name: shared-skill
+description: The project version.
+`,
+    );
+    await writeSkill(
+      project,
+      'project-only',
+      `
+name: project-only
+description: A project-specific skill.
+`,
+    );
+
+    const result = await discoverSkillSources([
+      { scope: 'bundled', path: bundled },
+      { scope: 'project', path: project },
+    ]);
+
+    expect(result.skills.map(({ skill }) => skill.description)).toEqual([
+      'The bundled version.',
+      'A project-specific skill.',
+    ]);
+    expect(result.skills.map(({ source }) => source.scope)).toEqual([
+      'bundled',
+      'project',
+    ]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'duplicate_name',
+        name: 'shared-skill',
       }),
     );
   });


### PR DESCRIPTION
## Summary

This PR exposes the skills loader through the CLI with `texra skills list`. It lists bundled, user, and project `.texra/skills` roots, with opt-in interop roots for `.claude/skills`, `.codex/skills`, and `.gemini/skills`, plus repeatable `--source` roots for explicit imports.

It also adds cross-root skill deduplication in the host-agnostic loader and fixes fish completion conditions so repeated subcommand names such as `agents list` and `skills list` do not share flags.

Part of #4064.
Closes #4352.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/skills/LoadSkills.vitest.mts src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile:fast`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js skills list --output-format json`
- `node packages/cli/dist/bin/texra.js completion fish | rg "skills; and __fish_seen_subcommand_from list|agents; and __fish_seen_subcommand_from list"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI surface that scans multiple on-disk directories (including optional home/workspace interop locations) and changes skill discovery to dedupe across roots, which could affect what skills are found/precedence and has some filesystem/perf implications.
> 
> **Overview**
> Adds a new `texra skills list` command (text/json/ndjson) that discovers skills from bundled, user, project, optional interop (`.claude/.codex/.gemini`), and repeatable `--source` roots, reporting load issues alongside results.
> 
> Extends the core skills loader with `discoverSkillSources` to enforce cross-root precedence and deduplicate by skill name and real path, and updates packaging to ship the repo `skills` directory in CLI resources.
> 
> Fixes fish shell completion generation to scope flag completions by the full subcommand path (avoiding collisions on repeated names like `list`), and updates completion snapshots/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfb6b0a9d5e803e0f2966f26b0d1f7e46278f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->