### PR TITLE
fix(agent): treat user aborts as cancellations

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -8,6 +8,7 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getConfig } from '@agent/core/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError, toErrorMessage } from '@common/errors';
+import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import type { AgentLogger } from '@logger/AgentLogger';
 import {
   MESSAGE_TYPES,
@@ -201,6 +202,8 @@ export abstract class RetryableInvocationNode<
    *  they need human attention (switching keys, topping up). `userRetryable`
    *  only gates the manual retry UI; auto-retry is a stricter subset. */
   shouldAutoRetry(error: Error): boolean {
+    if (isUserAbort(error)) return false;
+
     const formatted = normalizeProviderError(error);
     if (formatted.isCredentialExhausted) return false;
     if (!formatted.userRetryable) return false;
@@ -301,7 +304,7 @@ export abstract class RetryableInvocationNode<
   ):
     | { kind: 'cancelled' }
     | { kind: 'failed'; message: string; userRetryable?: boolean } {
-    if (this._userCancelled) {
+    if (this._userCancelled || isUserAbort(error)) {
       return { kind: 'cancelled' };
     }
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -1,0 +1,30 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent runtime
+import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
+import type { NonIterableObject } from '@agent/node';
+
+class ExposedRetryNode extends RetryableInvocationNode<
+  unknown,
+  NonIterableObject,
+  never
+> {
+  protected getOperationName(): string {
+    return 'Tool-use call';
+  }
+
+  fallbackFor(error: Error): unknown {
+    return this.getFallbackResult(error);
+  }
+}
+
+describe('RetryState', () => {
+  it('treats user aborts as cancellations instead of failed invocations', () => {
+    const node = new ExposedRetryNode();
+    const abort = new DOMException('Request aborted', 'AbortError');
+
+    expect(node.shouldAutoRetry(abort)).toBe(false);
+    expect(node.fallbackFor(abort)).toEqual({ kind: 'cancelled' });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the tool-use chat failure reported in #4347. A provider or AbortController user-abort during model invocation is now classified as a cancelled invocation rather than a failed invocation. This prevents a normal cancellation from being stored as `lastError`, which previously made `runToolUseFlow` throw `Error executing agent ...: Request aborted` after an otherwise recoverable chat turn.

The retry state also avoids auto-retrying user-aborts, preserving the existing cancellation semantics.

Fixes #4347.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/common/SdkErrorUtils.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to retry/cancellation classification plus a focused unit test; main risk is subtle behavior change in how abort-like errors are surfaced and retried.
> 
> **Overview**
> Updates `RetryableInvocationNode` to detect `isUserAbort(error)` and **(a)** skip auto-retry and **(b)** return a `cancelled` fallback result (instead of `failed`) so aborts don’t get recorded as invocation errors.
> 
> Adds a Vitest unit test asserting that an `AbortError` neither auto-retries nor produces a failure fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92a82f2627db4ea39124993935f67067e2aa085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->