### PR TITLE
feat(skills): expose imported skills to runtime prompts

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -8,6 +8,7 @@ import { initPlatform, tryPlatform } from '@platform/platform';
 
 // Local imports - agent index
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
+import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
 
 // Local imports - auth
 import {
@@ -168,4 +169,11 @@ export async function initCliPlatform(
     });
     bootstrappedResourcesPath = context.resourcesPath;
   }
+
+  setRuntimeSkillSources(
+    defaultSkillSources({
+      cwd: context.cwd,
+      resourcesPath: context.resourcesPath,
+    }),
+  );
 }

--- a/packages/cli/src/runtime/skills.ts
+++ b/packages/cli/src/runtime/skills.ts
@@ -1,6 +1,3 @@
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 // Local imports - skills
 import {
   discoverSkillSources,
@@ -9,14 +6,15 @@ import {
   type SkillSource,
   type SourcedSkill,
 } from '@skills/loadSkills';
+import {
+  defaultSkillSources,
+  type SkillSourceOptions,
+} from '@skills/skillSources';
 
 // Local imports - CLI runtime
 import type { CliContext } from './cliContext';
 
-export interface CliSkillDiscoveryOptions {
-  readonly includeInterop?: boolean;
-  readonly additionalPaths?: readonly string[];
-}
+export type CliSkillDiscoveryOptions = SkillSourceOptions;
 
 interface CliSkillRecord {
   readonly name: string;
@@ -26,86 +24,11 @@ interface CliSkillRecord {
   readonly path: string;
 }
 
-const INTEROP_SKILL_DIRS = ['.claude', '.codex', '.gemini'] as const;
-
-function bundledSkillSources(resourcesPath: string): SkillSource[] {
-  return [
-    {
-      scope: 'bundled',
-      path: path.join(resourcesPath, 'skills'),
-      label: 'bundled',
-    },
-    {
-      scope: 'bundled',
-      path: path.resolve(resourcesPath, '../../..', 'skills'),
-      label: 'bundled source',
-    },
-  ];
-}
-
-function resolveSkillSourcePath(base: string, candidate: string): string {
-  return path.isAbsolute(candidate)
-    ? path.resolve(candidate)
-    : path.resolve(base, candidate);
-}
-
-function uniqueSources(sources: readonly SkillSource[]): SkillSource[] {
-  const unique: SkillSource[] = [];
-  const seen = new Set<string>();
-  for (const source of sources) {
-    const key = path.resolve(source.path);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    unique.push({ ...source, path: key });
-  }
-  return unique;
-}
-
 export function cliSkillSources(
   context: Pick<CliContext, 'cwd' | 'resourcesPath'>,
   options: CliSkillDiscoveryOptions = {},
 ): SkillSource[] {
-  const home = os.homedir();
-  const sources: SkillSource[] = [
-    ...bundledSkillSources(context.resourcesPath),
-    {
-      scope: 'user',
-      path: path.join(home, '.texra', 'skills'),
-      label: 'user',
-    },
-    {
-      scope: 'project',
-      path: path.join(context.cwd, '.texra', 'skills'),
-      label: 'project',
-    },
-  ];
-
-  if (options.includeInterop === true) {
-    for (const dir of INTEROP_SKILL_DIRS) {
-      sources.push(
-        {
-          scope: 'interop',
-          path: path.join(home, dir, 'skills'),
-          label: `${dir} user`,
-        },
-        {
-          scope: 'interop',
-          path: path.join(context.cwd, dir, 'skills'),
-          label: `${dir} project`,
-        },
-      );
-    }
-  }
-
-  for (const candidate of options.additionalPaths ?? []) {
-    sources.push({
-      scope: 'custom',
-      path: resolveSkillSourcePath(context.cwd, candidate),
-      label: 'custom',
-    });
-  }
-
-  return uniqueSources(sources);
+  return defaultSkillSources(context, options);
 }
 
 export function skillListRecord(entry: SourcedSkill): CliSkillRecord {

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -20,6 +20,7 @@
       "@hosts/*": ["../../src/hosts/*"],
       "@utils/*": ["../../src/utils/*"],
       "@logger/*": ["../../src/logger/*"],
+      "@skills/*": ["../../src/skills/*"],
       "@latex": ["../../src/latex"],
       "@latex/*": ["../../src/latex/*"],
       "@commands/*": ["src/commands/*"],

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -147,6 +147,7 @@ const extensionConfig = {
       '@hosts': path.resolve(rootSrc, 'hosts'),
       '@utils': path.resolve(rootSrc, 'utils'),
       '@logger': path.resolve(rootSrc, 'logger'),
+      '@skills': path.resolve(rootSrc, 'skills'),
       '@latex': path.resolve(rootSrc, 'latex'),
       '@commands': path.resolve(packageSrc, 'commands'),
       '@resources': path.resolve(__dirname, 'resources'),

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -8,6 +8,7 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { getConfig } from '@agent/core/config';
+import { loadRuntimeSkillCatalog } from '@skills/runtimeSkills';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { FileListEntry } from '@shared/schemas';
 import { parseFrontmatter } from '@tools/memory/memoryMeta';
@@ -83,6 +84,7 @@ export async function buildUserVars(
     { vars: patternVars, files: patternFiles },
     latexStyleRules,
     attachedMemories,
+    availableSkills,
   ] = await Promise.all([
     getRequiredFileVars(agentSetting, agentPath),
     getPatternBasedFileVars(agentConfig, agentSetting),
@@ -91,6 +93,7 @@ export async function buildUserVars(
       () => '',
     ),
     getAttachedMemories(agentConfig.memories),
+    loadRuntimeSkillCatalog(logger),
   ]);
   allLoadedFiles.push(...requiredFiles);
   allLoadedFiles.push(...patternFiles);
@@ -106,6 +109,7 @@ export async function buildUserVars(
     ...getToolFlags(agentConfig, agentSetting, agentPrompt),
     LATEX_STYLE_RULES: latexStyleRules,
     ATTACHED_MEMORIES: attachedMemories,
+    AVAILABLE_SKILLS: availableSkills,
   };
 
   // Emit aggregated file list if any files were loaded

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,3 +1,5 @@
 export * from './SkillSchema';
 export * from './frontmatter';
 export * from './loadSkills';
+export * from './runtimeSkills';
+export * from './skillSources';

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,0 +1,54 @@
+import type { AgentLogger } from '@logger/AgentLogger';
+
+import {
+  discoverSkillSources,
+  type SkillLoadIssue,
+  type SkillSource,
+  type SourcedSkill,
+} from './loadSkills';
+
+const runtimeSkillSources: SkillSource[] = [];
+
+export function setRuntimeSkillSources(sources: readonly SkillSource[]): void {
+  runtimeSkillSources.length = 0;
+  runtimeSkillSources.push(...sources.map((source) => ({ ...source })));
+}
+
+export function listRuntimeSkillSources(): SkillSource[] {
+  return runtimeSkillSources.map((source) => ({ ...source }));
+}
+
+export function clearRuntimeSkillSources(): void {
+  runtimeSkillSources.length = 0;
+}
+
+function formatSkillIssue(issue: SkillLoadIssue): string {
+  const location = issue.path ? ` (${issue.path})` : '';
+  return `${issue.severity}: ${issue.message}${location}`;
+}
+
+export function formatRuntimeSkillCatalog(
+  skills: readonly SourcedSkill[],
+): string {
+  return skills
+    .map(({ skill, source }) => {
+      const sourceLabel = source.label ?? source.scope;
+      return `- ${skill.name}: ${skill.description}\n  Source: ${sourceLabel}\n  Path: ${skill.path}`;
+    })
+    .join('\n');
+}
+
+export async function loadRuntimeSkillCatalog(
+  logger?: AgentLogger,
+): Promise<string> {
+  const sources = listRuntimeSkillSources();
+  if (sources.length === 0) return '';
+
+  const result = await discoverSkillSources(sources);
+  for (const issue of result.errors) {
+    logger?.warn(`Skill import ${formatSkillIssue(issue)}`);
+  }
+  if (result.skills.length === 0) return '';
+
+  return formatRuntimeSkillCatalog(result.skills);
+}

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -1,0 +1,96 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { SkillSource } from './loadSkills';
+
+export interface SkillSourceContext {
+  readonly cwd: string;
+  readonly resourcesPath: string;
+}
+
+export interface SkillSourceOptions {
+  readonly includeInterop?: boolean;
+  readonly additionalPaths?: readonly string[];
+}
+
+export const INTEROP_SKILL_DIRS = ['.claude', '.codex', '.gemini'] as const;
+
+function bundledSkillSources(resourcesPath: string): SkillSource[] {
+  return [
+    {
+      scope: 'bundled',
+      path: path.join(resourcesPath, 'skills'),
+      label: 'bundled',
+    },
+    {
+      scope: 'bundled',
+      path: path.resolve(resourcesPath, '../../..', 'skills'),
+      label: 'bundled source',
+    },
+  ];
+}
+
+function resolveSkillSourcePath(base: string, candidate: string): string {
+  return path.isAbsolute(candidate)
+    ? path.resolve(candidate)
+    : path.resolve(base, candidate);
+}
+
+function uniqueSources(sources: readonly SkillSource[]): SkillSource[] {
+  const unique: SkillSource[] = [];
+  const seen = new Set<string>();
+  for (const source of sources) {
+    const key = path.resolve(source.path);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push({ ...source, path: key });
+  }
+  return unique;
+}
+
+export function defaultSkillSources(
+  context: SkillSourceContext,
+  options: SkillSourceOptions = {},
+): SkillSource[] {
+  const home = os.homedir();
+  const sources: SkillSource[] = [
+    ...bundledSkillSources(context.resourcesPath),
+    {
+      scope: 'user',
+      path: path.join(home, '.texra', 'skills'),
+      label: 'user',
+    },
+    {
+      scope: 'project',
+      path: path.join(context.cwd, '.texra', 'skills'),
+      label: 'project',
+    },
+  ];
+
+  if (options.includeInterop === true) {
+    for (const dir of INTEROP_SKILL_DIRS) {
+      sources.push(
+        {
+          scope: 'interop',
+          path: path.join(home, dir, 'skills'),
+          label: `${dir} user`,
+        },
+        {
+          scope: 'interop',
+          path: path.join(context.cwd, dir, 'skills'),
+          label: `${dir} project`,
+        },
+      );
+    }
+  }
+
+  for (const candidate of options.additionalPaths ?? []) {
+    sources.push({
+      scope: 'custom',
+      path: resolveSkillSourcePath(context.cwd, candidate),
+      label: 'custom',
+    });
+  }
+
+  return uniqueSources(sources);
+}

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -1,0 +1,94 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildInitialToolUsePrompts } from '@utils/prompt';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  clearRuntimeSkillSources,
+  loadRuntimeSkillCatalog,
+  setRuntimeSkillSources,
+} from '@skills/runtimeSkills';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'texra-runtime-skills-'),
+  );
+  tempRoots.push(root);
+  return root;
+}
+
+async function writeSkill(
+  root: string,
+  name: string,
+  description: string,
+): Promise<string> {
+  const skillDir = path.join(root, name);
+  await fs.mkdir(skillDir, { recursive: true });
+  const skillPath = path.join(skillDir, 'SKILL.md');
+  await fs.writeFile(
+    skillPath,
+    `---\nname: ${name}\ndescription: ${description}\n---\n\nUse ${name} when it applies.\n`,
+  );
+  return skillPath;
+}
+
+beforeEach(async () => {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+});
+
+afterEach(async () => {
+  clearRuntimeSkillSources();
+  await Promise.all(
+    tempRoots.splice(0).map((root) => {
+      return fs.rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe('runtime skills', () => {
+  it('formats configured runtime skills for prompt injection', async () => {
+    const root = await createTempRoot();
+    const skillPath = await writeSkill(
+      root,
+      'manuscript-review',
+      'Review mathematical manuscripts.',
+    );
+    setRuntimeSkillSources([
+      { scope: 'project', path: root, label: 'project' },
+    ]);
+
+    const catalog = await loadRuntimeSkillCatalog();
+
+    expect(catalog).toContain(
+      '- manuscript-review: Review mathematical manuscripts.',
+    );
+    expect(catalog).toContain('Source: project');
+    expect(catalog).toContain(`Path: ${skillPath}`);
+  });
+
+  it('injects the available skill catalog into tool-use instructions', async () => {
+    const prompts = await buildInitialToolUsePrompts(
+      {
+        systemPrompt: 'System.',
+        userPrefix: '',
+        userRequest: 'Please help.',
+      },
+      {
+        AVAILABLE_SKILLS:
+          '- manuscript-review: Review mathematical manuscripts.\n  Source: project\n  Path: /tmp/project/.texra/skills/manuscript-review/SKILL.md',
+      },
+    );
+
+    expect(prompts.instructionSuffix).toContain('<available_skills>');
+    expect(prompts.instructionSuffix).toContain('manuscript-review');
+    expect(prompts.instructionSuffix).toContain(
+      'inspect its SKILL.md at the listed path',
+    );
+  });
+});

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -25,6 +25,12 @@ Do not call tools that are not provided or any multi_tool_use variants.
 Call tools sequentially and wait for the output before calling another.
 For math in responses, use $...$ or \\(...\\) for inline and $$...$$ or \\[...\\] for display math. Wrap LaTeX environments like align or gather inside $$...$$ (e.g., $$\\begin{align}...\\end{align}$$) so they render correctly.
 {% if DEFAULT_BIB_PATH %}The default bibliography file is {{ DEFAULT_BIB_PATH }}. You can grep or read this file to search for citations and references.{% endif %}
+{% if AVAILABLE_SKILLS %}
+<available_skills>
+The following imported skills are available. If one is relevant, inspect its SKILL.md at the listed path before applying it.
+{{ AVAILABLE_SKILLS }}
+</available_skills>
+{% endif %}
 </tool_use_instructions>`;
 
 /** Base memory instructions for all agents with memory enabled. */


### PR DESCRIPTION
## Summary

This PR adds the next runtime integration slice for #4064. The existing skill discovery roots are now shared between the CLI listing command and runtime setup. When the CLI initializes, it registers the default bundled, user, and project skill roots for agent execution.

Agent prompt variable construction now loads those registered skill roots and exposes an `AVAILABLE_SKILLS` catalog. Tool-use prompts include that catalog when present, with each skill name, description, source label, and SKILL.md path so the agent can inspect the skill before applying it.

This intentionally does not add a full skill activation tool or settings UI; those remain separate follow-up work for #4064.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/skills/RuntimeSkills.vitest.mts src/test-kernel/skills/LoadSkills.vitest.mts src/test-kernel/cli/CliSkills.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/skills/RuntimeSkills.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile:fast`
- `npm run compile`
- `corepack pnpm --filter @texra/cli build`
- built CLI probe: project-local `.texra/skills/runtime-demo/SKILL.md` appears in `node packages/cli/dist/bin/texra.js --cwd <tmp> skills list --output-format json` as `scope=project`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime prompt construction by injecting a discovered skill catalog and adds global runtime skill-source state, which can affect agent behavior and prompt size/format across executions.
> 
> **Overview**
> **Exposes discovered skills to agent runtime prompts.** The CLI now registers the default bundled/user/project skill roots at platform init, and the shared skill-root resolution logic was extracted into `@skills/skillSources` for reuse.
> 
> Runtime execution loads the configured skill sources, formats a catalog (name/description/source/path), and injects it into tool-use prompts via a new `AVAILABLE_SKILLS` user var and `<available_skills>` block. Adds `runtimeSkills` state/helpers plus a vitest covering catalog formatting and prompt injection, and wires `@skills` path aliases into the extension build config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e600c04958058fcb76332f9cb777a125ba6c951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->