### PR TITLE
fix(cli): clarify interactive and headless statuses

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -598,7 +598,7 @@ export async function runChat(
     // actionable advice is "use `texra run`", not "fix your TERM".
     writeTextStderr(
       isHeadless
-        ? 'texra chat requires an interactive terminal (TTY stdin and stdout). For scripting, --print, or piped output, use `texra run`.'
+        ? 'texra chat requires an interactive terminal (TTY stdin and stdout). For scripting or piped input, use `texra run`.'
         : 'texra chat needs a capable terminal — TERM=dumb strips the cursor controls Ink uses. For non-interactive runs, use `texra run`.',
     );
     return { exitCode: CliExitCode.Usage };

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -16,7 +16,7 @@ import { CliUsageError } from '../../runtime/cliContext';
  * narrow enough for `defineCommand<const T>` to expose the per-option literal
  * on `ctx.args[...]`. Adding a new global flag is a one-line change here.
  */
-export const GLOBAL_ARGS: {
+type CliGlobalArgsDef = {
   print: { type: 'boolean'; alias: 'p'; description: string };
   quiet: { type: 'boolean'; alias: 'q'; description: string };
   cwd: { type: 'string'; description: string };
@@ -31,7 +31,9 @@ export const GLOBAL_ARGS: {
     options: CliApprovalPolicy[];
     description: string;
   };
-} = {
+};
+
+export const GLOBAL_ARGS: CliGlobalArgsDef = {
   print: {
     type: 'boolean',
     alias: 'p',
@@ -63,6 +65,21 @@ export const GLOBAL_ARGS: {
   },
 };
 
+/**
+ * Flags that are meaningful for commands which necessarily own the terminal.
+ * In particular, `chat` and `orchestrate` cannot honor `--print` or
+ * `--output-format`; scripts should use a concrete headless command instead.
+ */
+export const INTERACTIVE_GLOBAL_ARGS: Omit<
+  CliGlobalArgsDef,
+  'print' | 'output-format'
+> = {
+  quiet: GLOBAL_ARGS.quiet,
+  cwd: GLOBAL_ARGS.cwd,
+  'api-mode': GLOBAL_ARGS['api-mode'],
+  'approval-policy': GLOBAL_ARGS['approval-policy'],
+};
+
 // Derived from `GLOBAL_ARGS` so adding/renaming a global flag in one place
 // flows through to `reorderGlobalFlags` automatically.
 export const GLOBAL_VALUE_FLAGS = new Set<string>(
@@ -82,6 +99,24 @@ export const GLOBAL_BOOL_FLAGS = new Set<string>(
 
 export function optString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
+}
+
+export function rejectHeadlessOnlyFlags(
+  rawArgs: readonly string[],
+  commandName: string,
+): void {
+  const headlessOnly = rawArgs.some(
+    (arg) =>
+      arg === '--print' ||
+      arg === '-p' ||
+      arg === '--output-format' ||
+      arg.startsWith('--output-format='),
+  );
+  if (!headlessOnly) return;
+
+  throw new CliUsageError(
+    `texra ${commandName} is interactive and does not support --print or --output-format. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,
+  );
 }
 
 export function collectStringFlagValues(

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -7,12 +7,20 @@ export type ExecuteAgentResult = Awaited<
   ReturnType<typeof runValidatedExecutionRequest>
 >;
 
-export type CliRunResult = ExecuteAgentResult & {
+type CliRunResultFor<T extends ExecuteAgentResult> = Omit<T, 'status'> & {
+  status: ExecutionStatus;
+  endGroupStatus: T['status'];
   terminalStatus: ExecutionStatus;
   runDirectory?: string;
   copiedOutput?: string;
   copiedOutputs?: string[];
 };
+
+export type CliRunResult = ExecuteAgentResult extends infer T
+  ? T extends ExecuteAgentResult
+    ? CliRunResultFor<T>
+    : never
+  : never;
 
 function isExecutionStatus(
   value: string | undefined,
@@ -31,6 +39,25 @@ export function cliTerminalStatus(
   if (isExecutionStatus(storedTerminalStatus)) return storedTerminalStatus;
   if (result.status === 'error') return EXECUTION_STATUS.ERROR;
   return EXECUTION_STATUS.COMPLETED;
+}
+
+export function createCliRunResult<T extends ExecuteAgentResult>(
+  result: T,
+  terminalStatus: ExecutionStatus,
+  extras: {
+    readonly runDirectory?: string;
+    readonly copiedOutput?: string;
+    readonly copiedOutputs?: string[];
+  } = {},
+): T extends ExecuteAgentResult ? CliRunResultFor<T> : never {
+  const { status: endGroupStatus, ...rest } = result;
+  return {
+    ...rest,
+    status: terminalStatus,
+    endGroupStatus,
+    terminalStatus,
+    ...extras,
+  } as T extends ExecuteAgentResult ? CliRunResultFor<T> : never;
 }
 
 export async function readCliTerminalStatus(

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -11,6 +11,7 @@ import { getRunDir } from '@utils/files';
 
 import {
   cliTerminalStatus,
+  createCliRunResult,
   type CliRunResult,
   type ExecuteAgentResult,
 } from './terminalStatus';
@@ -87,10 +88,7 @@ export async function resolveWorkflowOutput(
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
       return {
         copiedOutput: undefined,
-        displayResult: {
-          ...result,
-          terminalStatus,
-        },
+        displayResult: createCliRunResult(result, terminalStatus),
       };
     }
     if (outputDir) {
@@ -105,13 +103,10 @@ export async function resolveWorkflowOutput(
     }
   }
 
-  const baseResult: CliRunResult = {
-    ...result,
-    terminalStatus,
-    ...(result.category === AgentCategory.Workflow
-      ? { runDirectory: options.runDirectory ?? getRunDir(result.executionId) }
-      : {}),
-  };
+  const runDirectory =
+    result.category === AgentCategory.Workflow
+      ? (options.runDirectory ?? getRunDir(result.executionId))
+      : undefined;
   if (outputDir && result.category === AgentCategory.Workflow) {
     const targetRoot = path.isAbsolute(outputDir)
       ? outputDir
@@ -144,20 +139,30 @@ export async function resolveWorkflowOutput(
       );
     }
 
-    const displayResult: CliRunResult = {
-      ...baseResult,
+    const displayResult = createCliRunResult(result, terminalStatus, {
+      runDirectory,
       copiedOutputs,
-    };
+    });
     return { copiedOutput: undefined, displayResult };
   }
 
   if (!outputFile || result.category !== AgentCategory.Workflow) {
-    return { copiedOutput: undefined, displayResult: baseResult };
+    return {
+      copiedOutput: undefined,
+      displayResult: createCliRunResult(result, terminalStatus, {
+        runDirectory,
+      }),
+    };
   }
 
   const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
-    return { copiedOutput: undefined, displayResult: baseResult };
+    return {
+      copiedOutput: undefined,
+      displayResult: createCliRunResult(result, terminalStatus, {
+        runDirectory,
+      }),
+    };
   }
 
   const targetPath = path.isAbsolute(outputFile)
@@ -168,10 +173,10 @@ export async function resolveWorkflowOutput(
     await fs.copyFile(finalOutput.absolutePath, targetPath);
   }
 
-  const displayResult: CliRunResult = {
-    ...baseResult,
+  const displayResult = createCliRunResult(result, terminalStatus, {
+    runDirectory,
     copiedOutput: targetPath,
-  };
+  });
   return { copiedOutput: targetPath, displayResult };
 }
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2,16 +2,21 @@ import { defineCommand } from 'citty';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
-import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
+import {
+  INTERACTIVE_GLOBAL_ARGS,
+  optString,
+  rejectHeadlessOnlyFlags,
+} from './_helpers/globalArgs';
 
 export const chatCommand = defineCommand({
   meta: { name: 'chat', description: 'Interactive tool-use chat session' },
   args: {
-    ...GLOBAL_ARGS,
+    ...INTERACTIVE_GLOBAL_ARGS,
     agent: { type: 'string', description: 'Tool-use agent for the session' },
     model: { type: 'string', alias: 'm', description: 'Model for the session' },
   },
   async run(ctx) {
+    rejectHeadlessOnlyFlags(ctx.rawArgs, 'chat');
     const context = await contextFromArgs(ctx.args);
     const { runChat } = await import('../chat/tui/runChatTui');
     const result = await runChat(context, {

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -51,6 +51,7 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import {
+  createCliRunResult,
   readCliTerminalStatus,
   type CliRunResult,
   type ExecuteAgentResult,
@@ -294,10 +295,10 @@ async function runMultiAgentPreset(
     );
     return CliExitCode.AgentError;
   }
-  const displayResult: CliToolUseRunResult = {
-    ...result,
+  const displayResult: CliToolUseRunResult = createCliRunResult(
+    result,
     terminalStatus,
-  };
+  );
   writeMultiAgentRunResult(runContext, plan, displayResult);
 
   if (terminalStatus === EXECUTION_STATUS.ERROR) {

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -15,7 +15,10 @@ import { buildCliOrchestrationItems } from '../runtime/orchestration';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
-import { GLOBAL_ARGS } from './_helpers/globalArgs';
+import {
+  INTERACTIVE_GLOBAL_ARGS,
+  rejectHeadlessOnlyFlags,
+} from './_helpers/globalArgs';
 import { resolveMultiAgentRunPlan } from './multiAgent';
 import { runResumeExecution } from './resume';
 import type { CliContext } from '../runtime/cliContext';
@@ -27,7 +30,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
   if (isHeadless || dumbTerm) {
     writeTextStderr(
       isHeadless
-        ? 'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run`, `texra chat`, or a concrete subcommand.'
+        ? 'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run` or a concrete subcommand.'
         : 'texra orchestrate needs a capable terminal — TERM=dumb strips the cursor controls Ink uses.',
     );
     return CliExitCode.Usage;
@@ -91,9 +94,10 @@ export const orchestrationCommand = defineCommand({
     description: 'Choose a chat, resume, or team preset',
   },
   args: {
-    ...GLOBAL_ARGS,
+    ...INTERACTIVE_GLOBAL_ARGS,
   },
   async run(ctx) {
+    rejectHeadlessOnlyFlags(ctx.rawArgs, 'orchestrate');
     const context = await contextFromArgs(ctx.args);
     setExitCode(await runOrchestration(context));
   },

--- a/packages/cli/src/runtime/globalArgs.ts
+++ b/packages/cli/src/runtime/globalArgs.ts
@@ -6,7 +6,7 @@ import type { CliOutputFormat } from './cliConfig';
 import type { CliGlobalArgs } from './cliContext';
 
 /**
- * Shape produced by citty's parser for the four global flags after each
+ * Shape produced by citty's parser for the shared global flags after each
  * subcommand inlines them with `type: 'enum'` + literal `options`. Subcommand
  * definitions in `commands/root.ts` re-declare these args inline (not via a
  * spread) so citty's `defineCommand<const T>` generic preserves the enum

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -22,6 +22,7 @@ import {
   resumeWorkflowOutputFile,
   resolveWorkflowOutput,
 } from '../../../packages/cli/src/commands/root';
+import { rejectHeadlessOnlyFlags } from '../../../packages/cli/src/commands/_helpers/globalArgs';
 import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -212,6 +213,18 @@ describe('CLI root argument routing', () => {
         'i',
       ),
     ).toEqual(['Draft0.tex', 'appendices.tex']);
+  });
+
+  it('rejects headless-only flags on interactive command bodies', () => {
+    expect(() => rejectHeadlessOnlyFlags(['--print'], 'chat')).toThrow(
+      'texra chat is interactive',
+    );
+    expect(() =>
+      rejectHeadlessOnlyFlags(['--output-format=json'], 'orchestrate'),
+    ).toThrow('texra orchestrate is interactive');
+    expect(() =>
+      rejectHeadlessOnlyFlags(['--approval-policy', 'ask'], 'chat'),
+    ).not.toThrow();
   });
 
   it('expands workflow input directories and globs relative to cwd', async () => {

--- a/src/test-kernel/cli/Completion.vitest.mts
+++ b/src/test-kernel/cli/Completion.vitest.mts
@@ -5,6 +5,7 @@ import {
   CLI_COMPLETION_SHELLS,
   generateCompletionScript,
 } from '../../../packages/cli/src/runtime/completion';
+import { collectCommands } from '../../../packages/cli/src/runtime/completionCommandTree';
 
 describe('CLI shell completion', () => {
   for (const shell of CLI_COMPLETION_SHELLS) {
@@ -21,5 +22,20 @@ describe('CLI shell completion', () => {
     expect(bash).toContain('TEXRA_COMPLETION_DYNAMIC');
     expect(bash).toContain('texra agents list --quiet');
     expect(bash).toContain('texra models list --quiet');
+  });
+
+  it('does not offer headless-only flags on interactive commands', async () => {
+    const commands = await collectCommands(rootCommand);
+    const flagsFor = (path: string) =>
+      commands
+        .find((command) => command.path.join(' ') === path)
+        ?.flags.map((flag) => flag.name);
+
+    expect(flagsFor('chat')).not.toContain('print');
+    expect(flagsFor('chat')).not.toContain('output-format');
+    expect(flagsFor('orchestrate')).not.toContain('print');
+    expect(flagsFor('orchestrate')).not.toContain('output-format');
+    expect(flagsFor('run')).toContain('print');
+    expect(flagsFor('run')).toContain('output-format');
   });
 });

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -113,6 +113,9 @@ describe('CLI workflow output resolution', () => {
     );
 
     expect(displayResult).toMatchObject({
+      status: EXECUTION_STATUS.COMPLETED,
+      endGroupStatus: END_GROUP_STATUS.STOPPED,
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
       copiedOutputs: [join(cwd, 'out', 'a.tex'), join(cwd, 'out', 'b.tex')],
     });
     await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -51,8 +51,8 @@ _texra() {
   path="$(_texra_completion_path)"
   case "$path" in
     '') subcommands='orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
-    'orchestrate') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
-    'chat') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --agent --model -m' ;;
+    'orchestrate') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy' ;;
+    'chat') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history') subcommands='list show delete'; flags='' ;;
@@ -128,17 +128,13 @@ complete -c texra -n '__fish_use_subcommand' -l 'cwd' -r -d 'Working directory t
 complete -c texra -n '__fish_use_subcommand' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_use_subcommand' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_use_subcommand' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
 complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from orchestrate' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
-complete -c texra -n '__fish_seen_subcommand_from chat' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
-complete -c texra -n '__fish_seen_subcommand_from chat' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'agent' -r -d 'Tool-use agent for the session'
 complete -c texra -n '__fish_seen_subcommand_from chat' -l 'model' -s 'm' -r -d 'Model for the session'
@@ -307,8 +303,8 @@ _texra() {
   [[ -n "\${words[3]}" && "\${words[3]}" != -* ]] && path="$path \${words[3]}"
 
   case "$path" in
-    'orchestrate') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
-    'chat') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
+    'orchestrate') true; _arguments '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'chat') true; _arguments '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
     'run') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--context[Read-only context file passed to the workflow agent]:value:' '-c[Read-only context file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--output-dir[Directory to copy multi-input workflow outputs into]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
     'resume') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'history') _values 'subcommands' 'list' 'show' 'delete'; true ;;


### PR DESCRIPTION
## Summary

This PR fixes the CLI inconsistencies found during a built-CLI audit.

- Splits interactive command flags from the broader global flag set so `texra chat` and `texra orchestrate` no longer advertise `--print` or `--output-format`.
- Rejects headless-only flags explicitly when they are routed to interactive commands.
- Normalizes public CLI run results so `status` is the terminal execution status (`completed`, `interrupted`, or `error`) and the internal stream finalization state is exposed separately as `endGroupStatus`.

Closes #4367.

## Verification

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile`
- `corepack pnpm --filter @texra/cli build`
- `node packages/cli/dist/bin/texra.js chat --help`
- `printf ... | node packages/cli/dist/bin/texra.js --cwd <tmp> chat -p --agent chat --model deepseekT --output-format json --approval-policy never` exits with code 2 and a direct usage error.
- Live workflow probe: `node packages/cli/dist/bin/texra.js --cwd <tmp> run correct --input packages/extension/resources/examples/draft.tex --output corrected.tex --model deepseekT --instruction ... --output-format json --approval-policy never -p` completed and returned `status: "completed"`, `endGroupStatus: "stopped"`, and `terminalStatus: "completed"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public CLI contract: interactive commands now reject previously-accepted headless flags, and JSON/text result objects now repurpose `status` and add `endGroupStatus`, which could break scripts parsing output.
> 
> **Overview**
> **Clarifies interactive vs headless CLI behavior.** `texra chat` and `texra orchestrate` now only expose an interactive-safe subset of global flags (hiding `--print`/`--output-format` from help and shell completion) and explicitly throw a `CliUsageError` if those headless-only flags are passed.
> 
> **Normalizes run result status fields.** CLI run results are reshaped so `status` reflects the terminal execution status (`completed`/`interrupted`/`error`), while the underlying stream finalization status is preserved separately as `endGroupStatus`; helpers (`createCliRunResult`) are adopted in workflow output resolution and `multi-agent` output, and related tests/snapshots are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7b416911821f41e521f95c43466cd084e04cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->