### PR TITLE
fix(cli): route subagent follow-ups to active child

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -143,6 +143,14 @@ export function chatTuiCanStartRootRun(session: {
   return !session.runPromise || session.runCompleted;
 }
 
+export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
+  const activeStreamId = cliState.activeStreamId.get();
+  if (!activeStreamId) return undefined;
+  return cliState.parentStream.get().has(activeStreamId)
+    ? activeStreamId
+    : undefined;
+}
+
 interface SlashCommandContext {
   readonly session: TuiSession;
   readonly initialAgent: string;
@@ -837,7 +845,8 @@ export async function runChat(
     if (await handleTuiSlashCommand(line, slashCommandContext())) {
       return;
     }
-    if (chatTuiCanStartRootRun(session)) {
+    const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
+    if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
       startSession(line);
       return;
     }
@@ -846,17 +855,27 @@ export async function runChat(
     // p-queue serializes work but doesn't have an "await predicate" primitive,
     // so the task itself waits for the stream id via a tiny poll loop.
     void followUpQueue.add(async () => {
+      let followUpTarget = childFollowUpTarget;
       while (
-        session.streamId === undefined &&
+        !followUpTarget &&
         !session.stopRequested &&
         !session.runCompleted
       ) {
         await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        followUpTarget = session.streamId;
       }
-      if (!session.streamId || session.stopRequested) return;
-      const result = await sendFollowUp(session.streamId, line);
+      if (!followUpTarget || session.stopRequested) return;
+      const result = await sendFollowUp(followUpTarget, line);
       if (result.status === 'no_session') {
-        session.stopRequested = true;
+        // Child stream ids are keys in parentStream; the root session id is not.
+        if (followUpTarget === session.streamId) {
+          session.stopRequested = true;
+        } else {
+          appendLocalAssistantTranscript(
+            'The selected subagent is no longer accepting follow-ups.',
+            followUpTarget,
+          );
+        }
       }
     });
   };

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -51,8 +51,11 @@ export function appendAssistantTranscriptIfMissing(
   });
 }
 
-export function appendLocalAssistantTranscript(text: string): void {
-  appendLocalTranscriptEntry('assistant', text);
+export function appendLocalAssistantTranscript(
+  text: string,
+  streamId?: StreamTabId,
+): void {
+  appendLocalTranscriptEntry('assistant', text, streamId);
 }
 
 export function appendLocalErrorTranscript(text: string): void {
@@ -66,11 +69,13 @@ export function appendLocalUserTranscript(text: string): void {
 function appendLocalTranscriptEntry(
   role: 'assistant' | 'error' | 'user',
   text: string,
+  explicitStreamId?: StreamTabId,
 ): void {
   const normalized = normalizeTranscriptText(text);
   if (!normalized) return;
 
-  const streamId = cliState.activeStreamId.get() ?? CLI_LOCAL_STREAM_ID;
+  const streamId =
+    explicitStreamId ?? cliState.activeStreamId.get() ?? CLI_LOCAL_STREAM_ID;
   if (!cliState.activeStreamId.get()) cliState.activeStreamId.set(streamId);
   const syntheticAfterSeq =
     AgentLogger.getStreamLogStore().get(streamId)?.head ?? 0;

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -49,6 +49,7 @@ import { renderAnsiMarkdown } from '../../../packages/cli/src/chat/tui/render/an
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanStartRootRun,
+  chatTuiActiveChildFollowUpTarget,
   clearTuiSessionRunState,
 } from '../../../packages/cli/src/chat/tui/runChatTui';
 import { CliExitCode } from '../../../packages/cli/src/runtime/exitCodes';
@@ -308,6 +309,18 @@ describe('CLI TUI row allocation', () => {
     ).toBe(true);
   });
 
+  it('selects the focused child stream as a follow-up target', () => {
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    setParentStream(child1, root);
+
+    cliState.activeStreamId.set(root);
+    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+
+    cliState.activeStreamId.set(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+  });
+
   it('clears stale resume ids when clearing chat session run state', () => {
     const session = {
       streamId: root,
@@ -484,6 +497,20 @@ describe('CLI transcript state', () => {
       'Available commands: /help',
       'Available commands: /help',
     ]);
+  });
+
+  it('can append local assistant output to an explicit stream', () => {
+    cliState.activeStreamId.set(root);
+
+    appendLocalAssistantTranscript('Child stream note.', child1);
+
+    expect(cliState.streams.get().get(root)?.entries ?? []).toEqual([]);
+    expect(
+      cliState.streams
+        .get()
+        .get(child1)
+        ?.entries.map((entry) => entry.text),
+    ).toEqual(['Child stream note.']);
   });
 
   it('adds local runtime errors to the transcript', () => {


### PR DESCRIPTION
## Summary

This fixes the CLI TUI path where submitted text from a focused subagent tab was still sent to the parent conversation. The TUI now detects when the active stream is a child stream and sends ordinary submitted text to that child execution. Root stream behavior is preserved: a new root run starts when the root is idle, and root follow-ups still wait for the root stream id when necessary.

The local transcript helper can also target an explicit stream, so rejected child follow-ups report their warning on the same child stream instead of whichever stream is active when the queued task runs.

Closes #4370.

## Root Cause

The submission handler always called `sendFollowUp(session.streamId, line)`, where `session.streamId` is the parent/root execution. The focused stream id was used for rendering and navigation, but not for choosing the follow-up target.

## Verification

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile`
- `corepack pnpm --filter @texra/cli build`
- Built CLI TUI probe: launched `creator`, approved a `chat` subagent, focused the child tab, submitted `Now reply exactly: followup-ok`, and confirmed the child execution persisted both the initial instruction and the follow-up while the parent execution only recorded the delegation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes the CLI TUI message submission/follow-up routing logic, which can affect where user input is delivered and how sessions stop on follow-up failures.
> 
> **Overview**
> Fixes CLI TUI follow-up routing so normal submitted text targets the **currently focused child (subagent) stream** when that tab is active, instead of always following up on the root session.
> 
> Adds `chatTuiActiveChildFollowUpTarget()` and updates the follow-up queue to wait for an available target (child immediately, otherwise `session.streamId`) and to handle `no_session` differently for child vs root (showing a local warning for stale children rather than stopping the whole session). Also extends `appendLocalAssistantTranscript` to optionally write to an explicit stream and adds/updates Vitest coverage for both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c86090b3c3f6789dd4b19769a44901840fd593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->