### PR TITLE
fix(cli): ignore closed stdout pipes

### DIFF
--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -3,9 +3,13 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { runCli } from '../commands/root';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeTextStderr } from '../runtime/logSinks';
+import {
+  installCliPipeErrorHandlers,
+  writeTextStderr,
+} from '../runtime/logSinks';
 
 try {
+  installCliPipeErrorHandlers();
   const result = await runCli();
   process.exitCode = result.exitCode;
 } catch (error) {

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -7,6 +7,34 @@ const closed = { stdout: false, stderr: false };
 
 type StreamKey = 'stdout' | 'stderr';
 
+export function isCliPipeClosureError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED';
+}
+
+let pipeErrorHandlersInstalled = false;
+
+export function installCliPipeErrorHandlers(): void {
+  if (pipeErrorHandlersInstalled) return;
+  pipeErrorHandlersInstalled = true;
+
+  process.stdout.on('error', (error) => {
+    if (isCliPipeClosureError(error)) {
+      closed.stdout = true;
+      return;
+    }
+    throw error;
+  });
+  process.stderr.on('error', (error) => {
+    if (isCliPipeClosureError(error)) {
+      closed.stderr = true;
+      return;
+    }
+    throw error;
+  });
+}
+
 // CLI output is best effort: throwing from an async write callback would bypass
 // the command error boundary and can crash the process.
 function writeRaw(key: StreamKey, text: string): void {

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCliPipeClosureError } from '../../../packages/cli/src/runtime/logSinks';
+
+describe('CLI log sinks', () => {
+  it('recognizes pipe closure errors as non-fatal output events', () => {
+    expect(
+      isCliPipeClosureError(
+        Object.assign(new Error('write EPIPE'), {
+          code: 'EPIPE',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isCliPipeClosureError(
+        Object.assign(new Error('stream destroyed'), {
+          code: 'ERR_STREAM_DESTROYED',
+        }),
+      ),
+    ).toBe(true);
+    expect(isCliPipeClosureError(new Error('disk full'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This fixes normal shell-pipeline use where a TeXRA CLI command writes to stdout after the downstream consumer has already closed the pipe. The CLI now installs stdout/stderr error handlers at startup and treats pipe-closure errors as non-fatal output events.

Closes #4372.

## Root Cause

The low-level write helpers caught synchronous write failures and write-callback errors, but Node can also emit `error` on the stdout stream after a pipe closes. Without a listener, Node reports the event as uncaught and prints a stack trace.

## Verification

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/LogSinks.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile`
- `corepack pnpm --filter @texra/cli build`
- Built CLI probe: `set -o pipefail; node packages/cli/dist/bin/texra.js agents list | head -n 1` exits 0 and emits no stderr stack trace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to CLI output handling to ignore `EPIPE`/`ERR_STREAM_DESTROYED`, with a focused unit test added; primary impact is on how the process behaves under piped output.
> 
> **Overview**
> Improves CLI robustness in shell pipelines by installing startup `stdout`/`stderr` `error` handlers and treating `EPIPE`/`ERR_STREAM_DESTROYED` as normal pipe-closure events (marking the stream closed instead of crashing).
> 
> Adds `isCliPipeClosureError`/`installCliPipeErrorHandlers` to `logSinks` and calls the installer from the CLI entrypoint, plus a small Vitest to validate the error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe080b6f3058865f47a4c2197afa43387a13c7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->