### PR TITLE
feat(quota): show monthly percentages instead of USD amounts

### DIFF
--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -4,12 +4,16 @@ import { formatCliApiMode, getCliApiMode } from './apiAccessMode';
 import { fetchRelayUsageSummary, type RelayUsageSummary } from './relayUsage';
 import { getCliAuthProfile } from './supabaseAuth';
 
-function formatUsd(value: number): string {
-  return value.toFixed(2);
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0%';
+  if (value < 1) return '<1%';
+  return `${value.toFixed(1)}%`;
 }
 
 export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
-  return `relay usage: $${formatUsd(summary.costUsd)} / $${formatUsd(summary.limitUsd)} (${summary.usagePercent.toFixed(1)}%), $${formatUsd(summary.remainingUsd)} remaining`;
+  const used = formatPercent(summary.usagePercent);
+  const remaining = formatPercent(Math.max(0, 100 - summary.usagePercent));
+  return `relay usage this month: ${used} used, ${remaining} remaining`;
 }
 
 export async function loadCliApiStatusLines(): Promise<string[]> {

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -10,10 +10,10 @@ import { profileViewStyles } from './styles';
 
 const WARNING_THRESHOLD_PCT = 80;
 
-function formatUsd(value: number): string {
-  if (!Number.isFinite(value)) return '$0.00';
-  if (value >= 100) return `$${value.toFixed(0)}`;
-  return `$${value.toFixed(2)}`;
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0%';
+  if (value < 1) return '<1%';
+  return `${Math.round(value)}%`;
 }
 
 type QuotaState = 'ok' | 'warning' | 'exhausted';
@@ -128,9 +128,7 @@ export class RelayQuotaMeter extends LitElement {
       <div class="quota-meter" data-state=${state}>
         <div class="quota-row">
           <span class="quota-label">Relay usage this month</span>
-          <span class="quota-amount"
-            >${formatUsd(s.currentSpend)} / ${formatUsd(s.limit)}</span
-          >
+          <span class="quota-amount">${formatPercent(percent)} used</span>
         </div>
         <div
           class="quota-bar"

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -24,7 +24,7 @@ describe('CLI API status text', () => {
     };
 
     expect(formatRelayUsageStatus(summary)).toBe(
-      'relay usage: $42.00 / $300.00 (14.0%), $258.00 remaining',
+      'relay usage this month: 14.0% used, 86.0% remaining',
     );
   });
 });


### PR DESCRIPTION
Replaces the "$1.25 / $10.00" style readout in the Settings → Models
quota meter and CLI relay-usage status with a percent-of-monthly-quota
readout, so users see how much of the month they've used at a glance
without translating dollar amounts in their head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX-only change that alters displayed quota text in the CLI and extension without changing quota calculation or enforcement logic.
> 
> **Overview**
> Updates relay quota readouts to show **monthly percent used/remaining** instead of USD amounts.
> 
> In the CLI, `formatRelayUsageStatus` now reports `relay usage this month: X% used, Y% remaining` with new percent formatting (including `<1%` handling), and the corresponding test expectation is updated. In the extension’s `RelayQuotaMeter`, the header value switches from `$spent / $limit` to a rounded `% used` display while keeping the existing progress bar and warning/exhausted behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb6ccb45449c319b3aff558f4b273d34c10f70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->