### PR TITLE
fix: keep TeXRA walkthrough discoverable

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -979,7 +979,6 @@
         "id": "texra.gettingStarted",
         "title": "Get started with TeXRA",
         "description": "Get TeXRA up and running in a few minutes. Connect your account, pick your field, and run your first paper through the orchestrator.",
-        "when": "texra.activated",
         "steps": [
           {
             "id": "texra.gettingStarted.setupAssistant",

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -640,14 +640,11 @@ export async function activate(context: vscode.ExtensionContext) {
     mainViewProvider.setProgressViewProvider(progressViewProvider);
   }
 
-  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
-  // / views) on `texra.activated` keeps them hidden until every command handler
-  // is registered. This must run after ALL `registerCommand` calls in this
-  // function (including the late ones for `texra.showMainView` and
-  // `texra.toggleView`), otherwise palette entries can fire before their
-  // handlers exist and produce "command not found" errors. It must also run
-  // BEFORE the welcome walkthrough is opened below, because the walkthrough
-  // itself is gated on `texra.activated`.
+  // Gating commandPalette / keybindings / menus / views on `texra.activated`
+  // keeps them hidden until every command handler is registered. This must run
+  // after ALL `registerCommand` calls in this function (including the late ones
+  // for `texra.showMainView` and `texra.toggleView`), otherwise palette entries
+  // can fire before their handlers exist and produce "command not found" errors.
   await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 
   const welcomeKey = 'texra.welcomeShown';

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1450,8 +1450,7 @@
               "title": "Clean up when you're done"
             }
           ],
-          "title": "Get started with TeXRA",
-          "when": "texra.activated"
+          "title": "Get started with TeXRA"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Remove the `texra.activated` condition from the TeXRA walkthrough contribution so VS Code can list it in **Open Walkthrough...** before the extension activates.
- Keep command, menu, keybinding, and view gating on `texra.activated` unchanged, since those entries still depend on registered command handlers.
- Update the extension package invariant snapshot and the activation comment to match the new boundary.

## Testing

- `npm run format`
- `npm run lint`
- `npm run compile:fast`
- `npm run check:extension-package-invariants`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts VS Code contribution metadata/comments so the onboarding walkthrough is visible before activation, without changing command handlers or runtime logic.
> 
> **Overview**
> Makes the **"Get started with TeXRA"** walkthrough discoverable in VS Code’s *Open Walkthrough…* list by removing its `when: texra.activated` gate from `package.json` (and the package invariants snapshot).
> 
> Keeps `texra.activated` gating for command palette/keybindings/menus/views intact, and updates the activation-time comment in `extension.ts` to reflect that walkthroughs are no longer part of the gated set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c03dfcb8aae718b843028bff987e5e65b3a0659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->