### PR TITLE
fix: normalize anthropic tool schemas

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -28,7 +28,9 @@ logger.initialize(CHANNEL);
 type JSONSchemaObject = Record<string, unknown>;
 
 /**
- * Both OpenAI and Gemini reject function parameter schemas whose top-level
+ * OpenAI, Gemini, and Anthropic all require function parameter schemas whose
+ * top-level node is an object. OpenAI and Gemini also reject schemas whose
+ * top-level
  * node is `oneOf`/`anyOf`/`allOf` (HTTP 400:
  * `schema must have type 'object' and not contain 'oneOf'/'anyOf'/'allOf' at the top level`).
  * Zod v4's `toJSONSchema` emits discriminated unions exactly that way. Flatten
@@ -139,12 +141,9 @@ function stripDollarSchema(schema: JSONSchemaObject): JSONSchemaObject {
 
 /**
  * Converts a Zod schema to JSON Schema, or returns the pre-converted parameters.
- * Used by OpenAI Chat Completions, OpenAI Responses, and Gemini function-calling
+ * Used by OpenAI Chat Completions, OpenAI Responses, Anthropic, and Gemini function-calling
  * converters: top-level discriminated unions are flattened and `$schema` is
  * stripped so the output passes their schema validators.
- * Anthropic bypasses this helper (`toAnthropicTools` calls `toJSONSchema`
- * directly with `reused: 'ref'`) because Anthropic accepts top-level `oneOf`
- * and `$schema`.
  */
 function convertToolSchema(def: ToolDefinition): JSONSchemaObject | null {
   let schema: JSONSchemaObject | null;
@@ -171,15 +170,16 @@ const EMPTY_TOOL_PARAMETERS_SCHEMA: Record<string, unknown> = {
   additionalProperties: false,
 };
 
-function toOpenAIParametersSchema(
+function toObjectParametersSchema(
   schema: Record<string, unknown> | null,
+  provider: string,
 ): Record<string, unknown> {
   if (!schema) return EMPTY_TOOL_PARAMETERS_SCHEMA;
   if (schema.type === 'object') return schema;
   if (schema.type !== undefined) {
     logger.warn(
       CHANNEL,
-      `OpenAI tool parameters must be object schemas; received type "${String(schema.type)}". Falling back to an empty object schema.`,
+      `${provider} tool parameters must be object schemas; received type "${String(schema.type)}". Falling back to an empty object schema.`,
     );
     return EMPTY_TOOL_PARAMETERS_SCHEMA;
   }
@@ -187,7 +187,11 @@ function toOpenAIParametersSchema(
 }
 
 function toOpenAISchemaObject(def: ToolDefinition): Record<string, unknown> {
-  return toOpenAIParametersSchema(convertToolSchema(def));
+  return toObjectParametersSchema(convertToolSchema(def), 'OpenAI');
+}
+
+function toAnthropicInputSchema(def: ToolDefinition): Record<string, unknown> {
+  return toObjectParametersSchema(convertToolSchema(def), 'Anthropic');
 }
 
 // Map local tool names to Anthropic remote tool types.
@@ -337,18 +341,10 @@ export function toAnthropicTools(
       }
     }
 
-    // Use Zod schema with ref support for complex types, else fallback
-    const params = d.zodSchema
-      ? (toJSONSchema(d.zodSchema, {
-          reused: 'ref',
-          unrepresentable: 'any',
-        }) as AnthropicTool['input_schema'])
-      : (d.parameters as AnthropicTool['input_schema'] | undefined);
-
     return {
       name: d.name,
       description: d.description,
-      ...(params ? { input_schema: params } : {}),
+      input_schema: toAnthropicInputSchema(d) as AnthropicTool['input_schema'],
     } as ToolUnion;
   });
 }

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -2,10 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import {
+  toAnthropicTools,
   toOpenAITools,
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
 import type { ToolDefinition } from '@model';
+import { BashTool } from '@tools/bash';
+import { EditFileTool } from '@tools/EditTool';
+import { GlobTool } from '@tools/glob';
+import { GrepTool } from '@tools/grep';
+import { LsTool } from '@tools/ls';
+import { ReadFileTool } from '@tools/ReadTool';
+import { WriteFileTool } from '@tools/WriteTool';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type { FunctionTool } from 'openai/resources/responses/responses';
 
@@ -89,5 +97,87 @@ describe('OpenAI tool conversion', () => {
       properties: {},
       additionalProperties: false,
     });
+  });
+});
+
+describe('Anthropic tool conversion', () => {
+  it('uses an empty object input schema when parameters are omitted', () => {
+    const tools = toAnthropicTools([
+      {
+        name: 'noop',
+        description: 'No parameters',
+      },
+    ]);
+
+    expect(tools[0]).toMatchObject({
+      name: 'noop',
+      input_schema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    });
+  });
+
+  it('flattens discriminated object unions into a typed object schema', () => {
+    const tools = toAnthropicTools([
+      {
+        name: 'inquiry',
+        description: 'Ask or read',
+        zodSchema: z.discriminatedUnion('command', [
+          z.object({
+            command: z.literal('ask'),
+            question: z.string(),
+          }),
+          z.object({
+            command: z.literal('read'),
+            thread_id: z.string(),
+          }),
+        ]),
+      },
+    ]);
+
+    const tool = tools[0] as { input_schema?: Record<string, unknown> };
+    const inputSchema = tool.input_schema;
+
+    expect(inputSchema?.type).toBe('object');
+    expect(inputSchema?.oneOf).toBeUndefined();
+    expect(inputSchema?.anyOf).toBeUndefined();
+    expect(inputSchema?.allOf).toBeUndefined();
+    expect(inputSchema?.$schema).toBeUndefined();
+
+    const properties = inputSchema?.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(properties.command.enum).toEqual(['ask', 'read']);
+    expect(properties.question).toBeDefined();
+    expect(properties.thread_id).toBeDefined();
+    expect(inputSchema?.required).toEqual(['command']);
+  });
+
+  it('emits valid object input schemas for the first CLI chat tools', () => {
+    const definitions = [
+      new BashTool().definition,
+      new ReadFileTool().definition,
+      new WriteFileTool().definition,
+      new EditFileTool().definition,
+      new GlobTool().definition,
+      new GrepTool().definition,
+      new LsTool().definition,
+    ];
+
+    const tools = toAnthropicTools(definitions);
+    const customTools = tools.filter(
+      (
+        tool,
+      ): tool is { name: string; input_schema?: Record<string, unknown> } =>
+        !('type' in tool),
+    );
+
+    expect(customTools.map((tool) => tool.name)).toContain('grep');
+    for (const tool of customTools) {
+      expect(tool.input_schema?.type, tool.name).toBe('object');
+    }
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -168,11 +168,15 @@ describe('Anthropic tool conversion', () => {
     ];
 
     const tools = toAnthropicTools(definitions);
-    const customTools = tools.filter(
-      (
-        tool,
-      ): tool is { name: string; input_schema?: Record<string, unknown> } =>
-        !('type' in tool),
+    const customTools = tools.flatMap((tool) =>
+      'type' in tool
+        ? []
+        : [
+            tool as unknown as {
+              name: string;
+              input_schema: Record<string, unknown>;
+            },
+          ],
     );
 
     expect(customTools.map((tool) => tool.name)).toContain('grep');


### PR DESCRIPTION
## Summary

This PR normalizes Anthropic custom-tool schemas through the same object-schema path used by OpenAI and Gemini.

Anthropic rejects custom tools whose `input_schema` lacks a top-level `type`, for example:

```text
tools.5.custom.input_schema.type: Field required
```

The root cause was that `toAnthropicTools()` bypassed the shared schema normalizer and sent Zod JSON Schema output directly. That left some tools with missing `input_schema`, missing top-level `type`, or top-level union shapes. The converter now always emits an object input schema for non-native Anthropic tools, strips `$schema`, and flattens top-level discriminated unions.

## Validation

- `../../node_modules/.bin/vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts`
- `node ../../node_modules/eslint/bin/eslint.js src/agent/modelHandlers/toolConversion.ts src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts`
- `corepack pnpm --filter @texra/cli typecheck`
- `corepack pnpm --filter texra typecheck`
- `corepack pnpm --filter @texra/cli bundle`
- Live CLI smoke: `texra chat --agent chat --model sonnet46T --api-mode included --approval-policy never`, forced the `grep` tool; the model ran `grep` and answered `PASS`.
- Live CLI smoke with delegation-capable agent: `texra chat --agent setup --model sonnet46T --api-mode included --approval-policy never`; the first Anthropic call succeeded with `delegate_agent` and `delegate_workflow` in the tool list, and the model answered `PASS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that refactors how Anthropic custom tools are selected; no production logic changes, so impact is limited to test behavior and type assertions.
> 
> **Overview**
> Updates the Anthropic tool conversion test to collect *custom (non-native)* tools via `flatMap` instead of a type-guard `filter`, and explicitly asserts that returned custom tools include an `input_schema` object.
> 
> The assertions remain focused on ensuring CLI tools like `grep` produce an `input_schema` with top-level `type: 'object'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d8ad067c4f50d5d36687b81fde70b1021b681f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->