### PR TITLE
refactor(cli): consolidate TUI/state helpers and exit-code mapping

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -220,22 +220,33 @@ export function App(props: AppProps): React.JSX.Element {
     hasTodosPlanPanel,
     rows: transcriptRows,
   });
-  const foregroundSurface = pending ? (
-    <ApprovalModal pending={pending} availableRows={foregroundRows} />
-  ) : childControlMode ? (
-    <ChildControlPicker
-      activeStreamId={activeStreamId}
-      availableRows={foregroundRows}
-      mode={childControlMode}
-      onClose={() => setChildControlMode(undefined)}
-      onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
-      onKillExecution={props.onKillExecution}
-      slice={activeSlice}
-      streams={streams}
-    />
-  ) : activeForm ? (
-    activeForm.render(() => cliState.activeForm.set(undefined), foregroundRows)
-  ) : null;
+  function renderForegroundSurface(): React.ReactNode {
+    if (pending) {
+      return <ApprovalModal pending={pending} availableRows={foregroundRows} />;
+    }
+    if (childControlMode) {
+      return (
+        <ChildControlPicker
+          activeStreamId={activeStreamId}
+          availableRows={foregroundRows}
+          mode={childControlMode}
+          onClose={() => setChildControlMode(undefined)}
+          onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
+          onKillExecution={props.onKillExecution}
+          slice={activeSlice}
+          streams={streams}
+        />
+      );
+    }
+    if (activeForm) {
+      return activeForm.render(
+        () => cliState.activeForm.set(undefined),
+        foregroundRows,
+      );
+    }
+    return null;
+  }
+  const foregroundSurface = renderForegroundSurface();
 
   const focusShortcutsActive = appFocusShortcutsActive({
     inputDisabled,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -30,6 +30,19 @@ function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
   cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), [key]: value });
 }
 
+/** Run a select handler (sync or async) and close the form with the selected
+ *  value once it settles, routing any rejection to `onError` first. */
+function settleThenDone<T>(
+  result: void | Promise<void>,
+  value: T,
+  onDone: (value: T) => void,
+  onError?: ErrorHandler,
+): void {
+  void Promise.resolve(result)
+    .catch((error: unknown) => onError?.(error))
+    .finally(() => onDone(value));
+}
+
 export function registerBuiltinSlashCommands(options?: {
   onAgentSelect?: AgentSelectHandler;
   canSelectAgent?: () => boolean;
@@ -63,11 +76,9 @@ export function registerBuiltinSlashCommands(options?: {
         currentAgent={current}
         availableRows={props.availableRows}
         selectable={selectable}
-        onSelect={(value) => {
-          void Promise.resolve(onAgentSelect(value)).finally(() =>
-            props.onDone(value),
-          );
-        }}
+        onSelect={(value) =>
+          settleThenDone(onAgentSelect(value), value, props.onDone)
+        }
         onClose={() => props.onDone(undefined)}
       />
     );
@@ -78,11 +89,9 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <ApiModeForm
         currentMode={current}
-        onSelect={(value) => {
-          void Promise.resolve(onApiModeSelect(value)).finally(() =>
-            props.onDone(value),
-          );
-        }}
+        onSelect={(value) =>
+          settleThenDone(onApiModeSelect(value), value, props.onDone)
+        }
         onCancel={() => props.onDone(undefined)}
       />
     );
@@ -93,11 +102,9 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <ApprovalPolicyForm
         currentPolicy={current}
-        onSelect={(value) => {
-          void Promise.resolve(onApprovalPolicySelect?.(value)).finally(() =>
-            props.onDone(value),
-          );
-        }}
+        onSelect={(value) =>
+          settleThenDone(onApprovalPolicySelect?.(value), value, props.onDone)
+        }
         onCancel={() => props.onDone(undefined)}
       />
     );
@@ -112,11 +119,9 @@ export function registerBuiltinSlashCommands(options?: {
         apiMode={cliState.sessionMeta.get().apiMode}
         availableRows={props.availableRows}
         selectable={selectable}
-        onSelect={(value) => {
-          void Promise.resolve(onModelSelect(value)).finally(() =>
-            props.onDone(value),
-          );
-        }}
+        onSelect={(value) =>
+          settleThenDone(onModelSelect(value), value, props.onDone)
+        }
         onClose={() => props.onDone(undefined)}
       />
     );
@@ -126,11 +131,14 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <MemoryListForm
         availableRows={props.availableRows}
-        onSelect={(value) => {
-          void Promise.resolve(onMemorySelect?.(value))
-            .catch((error: unknown) => onMemoryError?.(error))
-            .finally(() => props.onDone(value));
-        }}
+        onSelect={(value) =>
+          settleThenDone(
+            onMemorySelect?.(value),
+            value,
+            props.onDone,
+            onMemoryError,
+          )
+        }
         onClose={() => props.onDone(undefined)}
       />
     );
@@ -140,11 +148,9 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <ResumeListForm
         availableRows={props.availableRows}
-        onSelect={(id) => {
-          void Promise.resolve(onResumeSelect?.(id))
-            .catch((error: unknown) => onResumeError?.(error))
-            .finally(() => props.onDone(id));
-        }}
+        onSelect={(id) =>
+          settleThenDone(onResumeSelect?.(id), id, props.onDone, onResumeError)
+        }
         onClose={() => props.onDone(undefined)}
       />
     );

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -9,7 +9,8 @@ import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
 
-import { visibleSubagentRows } from '../state/childControls';
+import { processTailLines } from '../state/childControls';
+import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import {
@@ -28,18 +29,6 @@ interface RowProps {
 const TAIL_LINES = 4;
 const PULSE_INTERVAL_MS = 700;
 
-/** Pull the last `TAIL_LINES` non-blank lines from the combined std streams.
- *  The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
- *  this is bounded work. */
-function lastLines(tail: ProcessOutputTail | undefined): string[] {
-  if (!tail) return [];
-  const nonBlank = `${tail.stdout}\n${tail.stderr}`
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.length > 0);
-  return nonBlank.slice(-TAIL_LINES);
-}
-
 function usePulse(enabled: boolean): boolean {
   const [pulseOn, setPulseOn] = useState(true);
   useEffect(() => {
@@ -57,7 +46,9 @@ function usePulse(enabled: boolean): boolean {
 }
 
 function Row({ child, index, pulseOn, tail }: RowProps): React.JSX.Element {
-  const tailLines = lastLines(tail);
+  // The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
+  // pulling the last `TAIL_LINES` non-blank lines is bounded work.
+  const tailLines = processTailLines(tail).slice(-TAIL_LINES);
   return (
     <Box flexDirection="column">
       <Box flexDirection="row">

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -5,7 +5,7 @@ import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
 import { isPlainReturnInput } from '../input/inputKeys';
-import { visibleSubagentRows as mergeVisibleSubagentRows } from './childStreamMerge';
+import { visibleSubagentRows } from './childStreamMerge';
 import { orderedDescendantsFromSlice } from './focusCycle';
 import type { ProcessOutputTail, StreamSlice } from './cliState';
 
@@ -159,12 +159,6 @@ export function buildChildControlItems(
       buildProcessItem(child, slice.processOutput.get(child.executionId)),
     ),
   ];
-}
-
-export function visibleSubagentRows(
-  slice: Pick<StreamSlice, 'activeSubagents' | 'childStreams'>,
-): readonly ActiveChildInfo[] {
-  return mergeVisibleSubagentRows(slice.activeSubagents, slice.childStreams);
 }
 
 export function hasChildExecutionRows(

--- a/packages/cli/src/chat/tui/state/childStreamMerge.ts
+++ b/packages/cli/src/chat/tui/state/childStreamMerge.ts
@@ -1,29 +1,30 @@
 // Local imports - shared schemas
 import type { ActiveChildInfo } from '@shared/schemas';
 
+function childKey(child: ActiveChildInfo): string {
+  return child.childStreamId ?? child.executionId;
+}
+
 export function mergeChildStreams(
   current: readonly ActiveChildInfo[],
   next: readonly ActiveChildInfo[],
 ): readonly ActiveChildInfo[] {
   const byStream = new Map<string, ActiveChildInfo>();
   for (const child of [...current, ...next]) {
-    const key = child.childStreamId ?? child.executionId;
-    byStream.set(key, child);
+    byStream.set(childKey(child), child);
   }
   return [...byStream.values()];
 }
 
-export function visibleSubagentRows(
-  activeSubagents: readonly ActiveChildInfo[],
-  retainedChildStreams: readonly ActiveChildInfo[],
-): readonly ActiveChildInfo[] {
-  const activeKeys = new Set(
-    activeSubagents.map((child) => child.childStreamId ?? child.executionId),
-  );
+/** Active subagents followed by any retained child streams that are no longer
+ *  active — so completed/waiting subagent pages stay listed and addressable. */
+export function visibleSubagentRows(slice: {
+  readonly activeSubagents: readonly ActiveChildInfo[];
+  readonly childStreams: readonly ActiveChildInfo[];
+}): readonly ActiveChildInfo[] {
+  const activeKeys = new Set(slice.activeSubagents.map(childKey));
   return [
-    ...activeSubagents,
-    ...retainedChildStreams.filter(
-      (child) => !activeKeys.has(child.childStreamId ?? child.executionId),
-    ),
+    ...slice.activeSubagents,
+    ...slice.childStreams.filter((child) => !activeKeys.has(childKey(child))),
   ];
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -91,14 +91,16 @@ export interface StreamSlice {
   readonly bypass: BypassState;
 }
 
-const SESSION_META = signal<SessionMeta>({
+const EMPTY_SESSION_META: SessionMeta = {
   agent: '',
   model: '',
   cwd: '',
   apiMode: 'personal',
   canDelegate: false,
   version: '',
-});
+};
+
+const SESSION_META = signal<SessionMeta>(EMPTY_SESSION_META);
 
 const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
@@ -224,14 +226,8 @@ export function removeStream(streamId: StreamTabId): void {
 }
 
 function defaultSessionMeta(): SessionMeta {
-  return {
-    agent: '',
-    model: '',
-    cwd: '',
-    apiMode: 'personal',
-    canDelegate: false,
-    version: SESSION_META.get().version,
-  };
+  // Preserve the resolved CLI version across resets; everything else clears.
+  return { ...EMPTY_SESSION_META, version: SESSION_META.get().version };
 }
 
 export function resetCliState(sessionMeta = defaultSessionMeta()): void {

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -22,7 +22,10 @@ export function orderedDescendantsFromSlice(
 ): StreamTabId[] {
   if (!slice) return [];
   const out: StreamTabId[] = [];
-  for (const child of [...visibleSubagentRows(slice), ...slice.activeProcesses]) {
+  for (const child of [
+    ...visibleSubagentRows(slice),
+    ...slice.activeProcesses,
+  ]) {
     if (child.childStreamId) out.push(child.childStreamId);
   }
   return [...new Set(out)];

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -22,10 +22,7 @@ export function orderedDescendantsFromSlice(
 ): StreamTabId[] {
   if (!slice) return [];
   const out: StreamTabId[] = [];
-  for (const child of [
-    ...visibleSubagentRows(slice.activeSubagents, slice.childStreams),
-    ...slice.activeProcesses,
-  ]) {
+  for (const child of [...visibleSubagentRows(slice), ...slice.activeProcesses]) {
     if (child.childStreamId) out.push(child.childStreamId);
   }
   return [...new Set(out)];

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -3,6 +3,10 @@ import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
+import { hasCliApprovalDenied } from '../../runtime/approvalAdapter';
+import { CliExitCode } from '../../runtime/exitCodes';
+import type { CliContext } from '../../runtime/cliContext';
+
 export type ExecuteAgentResult = Awaited<
   ReturnType<typeof runValidatedExecutionRequest>
 >;
@@ -58,6 +62,23 @@ export function createCliRunResult<T extends ExecuteAgentResult>(
     terminalStatus,
     ...extras,
   } as T extends ExecuteAgentResult ? CliRunResultFor<T> : never;
+}
+
+/** Map a terminal execution status to the CLI process exit code, treating an
+ *  approval-denied error distinctly from a generic agent error. */
+export function terminalStatusExitCode(
+  terminalStatus: ExecutionStatus,
+  context: CliContext,
+): number {
+  if (terminalStatus === EXECUTION_STATUS.ERROR) {
+    return hasCliApprovalDenied(context)
+      ? CliExitCode.ApprovalDenied
+      : CliExitCode.AgentError;
+  }
+  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+    return CliExitCode.Interrupted;
+  }
+  return CliExitCode.Success;
 }
 
 export async function readCliTerminalStatus(

--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -5,10 +5,14 @@ import { glob, hasMagic } from 'glob';
 
 import { CliUsageError } from '../../runtime/cliContext';
 
-function normalizeCliInputPath(candidate: string, cwd: string): string {
-  const absolutePath = path.isAbsolute(candidate)
+function resolveAgainstCwd(candidate: string, cwd: string): string {
+  return path.isAbsolute(candidate)
     ? path.resolve(candidate)
     : path.resolve(cwd, candidate);
+}
+
+function normalizeCliInputPath(candidate: string, cwd: string): string {
+  const absolutePath = resolveAgainstCwd(candidate, cwd);
   const relativePath = path.relative(cwd, absolutePath);
   if (
     relativePath &&
@@ -28,25 +32,19 @@ export async function expandWorkflowInputSpec(
   if (!trimmed) return [];
 
   if (hasMagic(trimmed)) {
-    const matches = path.isAbsolute(trimmed)
-      ? await glob(trimmed.replaceAll('\\', '/'), {
-          absolute: true,
-          nodir: true,
-        })
-      : await glob(trimmed.replaceAll('\\', '/'), {
-          cwd,
-          absolute: false,
-          nodir: true,
-        });
+    const isAbsolute = path.isAbsolute(trimmed);
+    const matches = await glob(trimmed.replaceAll('\\', '/'), {
+      cwd: isAbsolute ? undefined : cwd,
+      absolute: isAbsolute,
+      nodir: true,
+    });
     if (matches.length === 0) {
       throw new CliUsageError(`No input files matched: ${trimmed}`);
     }
     return matches.sort().map((match) => normalizeCliInputPath(match, cwd));
   }
 
-  const absolutePath = path.isAbsolute(trimmed)
-    ? path.resolve(trimmed)
-    : path.resolve(cwd, trimmed);
+  const absolutePath = resolveAgainstCwd(trimmed, cwd);
   const stats = await fs.stat(absolutePath).catch(() => null);
   if (stats?.isDirectory()) {
     const matches = await glob('**/*.tex', {

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -16,10 +16,7 @@ import {
   CLI_BUILTIN_DEFAULT_MODEL,
   resolveConfiguredModel,
 } from '../runtime/cliConfig';
-import {
-  hasCliApprovalDenied,
-  installCliApprovalHandlers,
-} from '../runtime/approvalAdapter';
+import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -53,6 +50,7 @@ import {
 import {
   createCliRunResult,
   readCliTerminalStatus,
+  terminalStatusExitCode,
   type CliRunResult,
   type ExecuteAgentResult,
 } from './_helpers/terminalStatus';
@@ -301,15 +299,7 @@ async function runMultiAgentPreset(
   );
   writeMultiAgentRunResult(runContext, plan, displayResult);
 
-  if (terminalStatus === EXECUTION_STATUS.ERROR) {
-    return hasCliApprovalDenied(runContext)
-      ? CliExitCode.ApprovalDenied
-      : CliExitCode.AgentError;
-  }
-  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-    return CliExitCode.Interrupted;
-  }
-  return CliExitCode.Success;
+  return terminalStatusExitCode(terminalStatus, runContext);
 }
 
 const multiAgentListCommand = defineCommand({

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -7,10 +7,7 @@ import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 
-import {
-  hasCliApprovalDenied,
-  installCliApprovalHandlers,
-} from '../runtime/approvalAdapter';
+import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
 import { readCliHistoryConfig, parseCliHistoryId } from '../runtime/history';
 import { initCliPlatform } from '../runtime/initPlatform';
@@ -28,6 +25,7 @@ import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
 import {
   readCliTerminalStatus,
+  terminalStatusExitCode,
   type CliRunResult,
   type ExecuteAgentResult,
 } from './_helpers/terminalStatus';
@@ -110,15 +108,7 @@ export async function runResumeExecution(
     writeTextStdout(displayResult.status);
   }
 
-  if (terminalStatus === EXECUTION_STATUS.ERROR) {
-    return hasCliApprovalDenied(runContext)
-      ? CliExitCode.ApprovalDenied
-      : CliExitCode.AgentError;
-  }
-  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-    return CliExitCode.Interrupted;
-  }
-  return CliExitCode.Success;
+  return terminalStatusExitCode(terminalStatus, runContext);
 }
 
 export const resumeCommand = defineCommand({

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -14,10 +14,7 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
-import {
-  hasCliApprovalDenied,
-  installCliApprovalHandlers,
-} from '../runtime/approvalAdapter';
+import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliUsageError } from '../runtime/cliContext';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
@@ -43,6 +40,7 @@ import {
 import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
 import {
   readCliTerminalStatus,
+  terminalStatusExitCode,
   type CliRunResult,
   type ExecuteAgentResult,
 } from './_helpers/terminalStatus';
@@ -177,15 +175,7 @@ async function runWorkflowAgent(
     writeTextStdout(result.status);
   }
 
-  if (terminalStatus === EXECUTION_STATUS.ERROR) {
-    return hasCliApprovalDenied(runContext)
-      ? CliExitCode.ApprovalDenied
-      : CliExitCode.AgentError;
-  }
-  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-    return CliExitCode.Interrupted;
-  }
-  return CliExitCode.Success;
+  return terminalStatusExitCode(terminalStatus, runContext);
 }
 
 export const runWorkflowCommand = defineCommand({

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -12,8 +12,8 @@ import {
   hasChildExecutionRows,
   nextPickerIndex,
   numericFocusTarget,
-  visibleSubagentRows,
 } from '../../../packages/cli/src/chat/tui/state/childControls';
+import { visibleSubagentRows } from '../../../packages/cli/src/chat/tui/state/childStreamMerge';
 import { NO_BYPASS } from '../../../packages/cli/src/chat/tui/state/cliState';
 import type {
   ProcessOutputTail,

--- a/src/tools/odyssey/odysseyStore.ts
+++ b/src/tools/odyssey/odysseyStore.ts
@@ -66,7 +66,7 @@ function readIndex(): StreamTabId[] {
   if (!state) return [];
   const raw = state.get<unknown>(INDEX_KEY);
   return Array.isArray(raw)
-    ? (raw.filter((v) => typeof v === 'string') as string[])
+    ? raw.filter((v): v is StreamTabId => typeof v === 'string')
     : [];
 }
 


### PR DESCRIPTION
## Summary

A set of no-behavior-change cleanups that were sitting uncommitted on a stale local `main`. The base was 48 commits behind and one file (`commands/root.ts`) had since been split into per-command modules upstream, so these were rebased onto current `main` and re-targeted to the new layout. The one local edit already covered upstream (`PlanTool.ts` → `toErrorMessage`) was dropped.

## Changes
- **TUI state**: move `visibleSubagentRows` into `childStreamMerge` with a slice-based signature + shared `childKey` helper; remove the `childControls` re-export wrapper (callers/test updated).
- **SubagentList**: use the existing `processTailLines` instead of a local `lastLines`.
- **cliState**: extract `EMPTY_SESSION_META` and reuse it in `defaultSessionMeta`.
- **odysseyStore**: replace `as string[]` cast with an `is StreamTabId` type guard.
- **registerBuiltins**: collapse the repeated promise-settle blocks into a `settleThenDone` helper.
- **App**: extract `renderForegroundSurface()` from the nested ternary.
- **Exit codes**: add `terminalStatusExitCode` to `_helpers/terminalStatus` and call it from `multiAgent`/`resume`/`workflow`, removing three identical blocks; factor `resolveAgainstCwd` in `workflowInputs` and simplify the glob options.

## Verification
- `npm run typecheck` — clean
- `npx vitest run src/test-kernel/cli` — 39 files, 248 tests pass
- `eslint` on changed files — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on deduplication and readability; behavior should be unchanged, but subtle ordering/visibility and exit-code mapping regressions are possible in edge cases (retained child streams, approval-denied errors).
> 
> **Overview**
> Refactors the CLI TUI state helpers by moving `visibleSubagentRows` into `childStreamMerge` with a slice-based signature and shared keying, updating all callers/tests accordingly, and reusing the shared `processTailLines` helper in `SubagentList`.
> 
> Simplifies UI/control flow by extracting `renderForegroundSurface()` from `App`’s nested ternary and consolidating repeated “promise settle then close form” logic into `settleThenDone` for builtin slash-command forms.
> 
> Centralizes CLI process exit-code selection via a new `terminalStatusExitCode()` helper and switches `workflow`, `resume`, and `multi-agent` commands to use it; also cleans up path/glob handling in workflow input expansion, session-meta reset defaults, and a safer `StreamTabId` type guard in `odysseyStore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49eeefd37aa470e6af506d2dc9f0f7107890eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->