### PR TITLE
fix: distinguish compare and latexdiff icons

### DIFF
--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -80,6 +80,7 @@ import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagn
 import { faMicrophone } from '@fortawesome/free-solid-svg-icons/faMicrophone';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faNoteSticky } from '@fortawesome/free-solid-svg-icons/faNoteSticky';
+import { faNotEqual } from '@fortawesome/free-solid-svg-icons/faNotEqual';
 import { faPalette } from '@fortawesome/free-solid-svg-icons/faPalette';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
@@ -219,6 +220,7 @@ const icons = {
   microphone: faMicrophone,
   minus: faMinus,
   'note-sticky': faNoteSticky,
+  'not-equal': faNotEqual,
   palette: faPalette,
   'paper-plane': faPaperPlane,
   pencil: faPencil,
@@ -280,8 +282,8 @@ const CODICON_ALIASES = {
   'device-camera-video': 'video',
   diff: 'code-compare',
   'diff-added': 'plus',
-  'diff-multiple': 'code-compare',
-  'diff-single': 'code-compare',
+  'diff-multiple': 'not-equal',
+  'diff-single': 'not-equal',
   discard: 'arrow-rotate-left',
   edit: 'pencil',
   error: 'circle-exclamation',


### PR DESCRIPTION
## Summary

- Keep the `diff` icon alias for side-by-side file comparison.
- Add a distinct `not-equal` glyph for the `diff-single` and `diff-multiple` aliases used by LaTeXdiff actions.
- Apply the change through the shared Web Awesome icon registry so the main webview and progress view remain consistent.

## Testing

- `prettier --write src/shared/wa/webAwesomeIcons.ts`
- `eslint src/shared/wa/webAwesomeIcons.ts`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, UI-only change confined to the shared icon registry, with the main impact being different glyphs for existing icon names.
> 
> **Overview**
> Updates the shared Web Awesome icon registry to add the Font Awesome `not-equal` glyph and map the codicon aliases `diff-single` and `diff-multiple` to it, while keeping `diff` mapped to `code-compare` for side-by-side comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b8df724ec644857846d0bde56ea91709fa5af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->