### PR TITLE
feat(cli): add `texra agents show <name>`

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,11 +1,16 @@
 import { defineCommand } from 'citty';
 
-import { getVisibleAgents, loadAgents } from '@agent/index';
+import { getAgent, getVisibleAgents, loadAgents } from '@agent/index';
+import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeNdjsonStdout, writeTextStdout } from '../runtime/logSinks';
+import {
+  writeNdjsonStdout,
+  writeTextStderr,
+  writeTextStdout,
+} from '../runtime/logSinks';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
@@ -45,6 +50,61 @@ async function listAgents(context: CliContext): Promise<number> {
   return CliExitCode.Success;
 }
 
+function formatAgentDetails(entry: AgentEntry): string {
+  const lines: string[] = [];
+  lines.push(`name: ${entry.name}`);
+  lines.push(`category: ${entry.category}`);
+  lines.push(`source: ${entry.source}`);
+  if (entry.path) lines.push(`path: ${entry.path}`);
+  if (entry.description) {
+    lines.push('');
+    lines.push(entry.description);
+  }
+  if (entry.tools && entry.tools.length > 0) {
+    lines.push('');
+    lines.push(`tools: ${entry.tools.join(', ')}`);
+  }
+  if (entry.defaultOutputFiles && entry.defaultOutputFiles.length > 0) {
+    lines.push(`defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`);
+  }
+  if (entry.visibility && entry.visibility.length > 0) {
+    lines.push(`visibility: ${entry.visibility.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+async function showAgent(context: CliContext, name: string): Promise<number> {
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+  await loadAgents({ includeRemote: false });
+
+  const entry = getAgent(name);
+  if (!entry) {
+    writeTextStderr(`Agent not found: ${name}`);
+    return CliExitCode.Usage;
+  }
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(entry, null, 2));
+    return CliExitCode.Success;
+  }
+
+  if (context.outputFormat === 'ndjson') {
+    writeNdjsonStdout({
+      kind: 'agent',
+      ts: new Date().toISOString(),
+      agent: entry,
+    });
+    return CliExitCode.Success;
+  }
+
+  writeTextStdout(formatAgentDetails(entry));
+  return CliExitCode.Success;
+}
+
 const agentsListCommand = defineCommand({
   meta: { name: 'list', description: 'List available agents' },
   args: {
@@ -56,7 +116,26 @@ const agentsListCommand = defineCommand({
   },
 });
 
+const agentsShowCommand = defineCommand({
+  meta: { name: 'show', description: 'Show one agent' },
+  args: {
+    ...GLOBAL_ARGS,
+    name: {
+      type: 'positional',
+      required: true,
+      description: 'Agent name from `texra agents list`',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await showAgent(context, ctx.args.name));
+  },
+});
+
 export const agentsCommand = defineCommand({
   meta: { name: 'agents', description: 'Inspect TeXRA agents' },
-  subCommands: { list: agentsListCommand },
+  subCommands: {
+    list: agentsListCommand,
+    show: agentsShowCommand,
+  },
 });

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -60,15 +60,21 @@ function formatAgentDetails(entry: AgentEntry): string {
     lines.push('');
     lines.push(entry.description);
   }
+  const metadataLines: string[] = [];
   if (entry.tools && entry.tools.length > 0) {
-    lines.push('');
-    lines.push(`tools: ${entry.tools.join(', ')}`);
+    metadataLines.push(`tools: ${entry.tools.join(', ')}`);
   }
   if (entry.defaultOutputFiles && entry.defaultOutputFiles.length > 0) {
-    lines.push(`defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`);
+    metadataLines.push(
+      `defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`,
+    );
   }
   if (entry.visibility && entry.visibility.length > 0) {
-    lines.push(`visibility: ${entry.visibility.join(', ')}`);
+    metadataLines.push(`visibility: ${entry.visibility.join(', ')}`);
+  }
+  if (metadataLines.length > 0) {
+    lines.push('');
+    lines.push(...metadataLines);
   }
   return lines.join('\n');
 }
@@ -123,7 +129,8 @@ const agentsShowCommand = defineCommand({
     name: {
       type: 'positional',
       required: true,
-      description: 'Agent name from `texra agents list`',
+      description:
+        'Agent name from `texra agents list` (use `source:name` to disambiguate when the same name exists in multiple sources)',
     },
   },
   async run(ctx) {

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " orchestrate chat run resume history history list history show history delete agents agents list skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume history history list history show history delete agents agents list agents show skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -59,8 +59,9 @@ _texra() {
     'history list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history delete') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --all' ;;
-    'agents') subcommands='list'; flags='' ;;
+    'agents') subcommands='list show'; flags='' ;;
     'agents list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'agents show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'skills') subcommands='list'; flags='' ;;
     'skills list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --include-interop --source -s' ;;
     'multi-agent') subcommands='list show run'; flags='' ;;
@@ -179,12 +180,19 @@ complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subco
 complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from history; and __fish_seen_subcommand_from delete' -l 'all' -d 'Delete all stored executions'
 complete -c texra -n '__fish_seen_subcommand_from agents' -a 'list' -d 'List available agents'
+complete -c texra -n '__fish_seen_subcommand_from agents' -a 'show' -d 'Show one agent'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from skills' -a 'list' -d 'List available skills'
 complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
 complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
@@ -311,8 +319,9 @@ _texra() {
     'history list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'history show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'history delete') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--all[Delete all stored executions]' ;;
-    'agents') _values 'subcommands' 'list'; true ;;
+    'agents') _values 'subcommands' 'list' 'show'; true ;;
     'agents list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'agents show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'skills') _values 'subcommands' 'list'; true ;;
     'skills list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--include-interop[Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory]' '--source[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' '-s[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' ;;
     'multi-agent') _values 'subcommands' 'list' 'show' 'run'; true ;;


### PR DESCRIPTION
## Summary

- Add `texra agents show <name>` so an individual agent's metadata (source, path, tools, default output files, visibility, description) is reachable from the terminal without grepping `agents list --output-format json` or opening the YAML on disk.
- Mirrors the existing `multi-agent show` / `history show` / `tools status` pattern.

## Issue acceptance gates

Closes #4391 for the `texra agents show` half. The `texra models show` and shell-completion wiring listed in the issue stay as follow-ups.

- [x] `texra agents show <name>` prints the resolved `AgentEntry` (text, json, ndjson).
- [x] `texra agents show <missing>` exits 2 with a stderr `Agent not found:` message.
- [ ] `texra models show <id>` — follow-up PR.
- [ ] Shell completion of the positional `<name>` — follow-up PR.
- [x] `agents list` and the rest of the CLI surface unchanged.

## Single source of truth

`getAgent()` in `src/agent/index/agentRegistry.ts` remains the only lookup. The new command consumes the same `AgentEntry` shape that `agents list` already emits and adds no parallel agent registry inside the CLI package.

## Duplication and abstraction budget

- No new abstraction. The new `showAgent()` function follows the same shape as `listAgents()` and `runMultiAgentShow()` (text / json / ndjson branches → write → return exit code).
- The text formatter (`formatAgentDetails`) is a local helper, not a new module, because it is only used here and only inspects `AgentEntry` fields.

## Host impact

Extension: none.

Desktop: none.

CLI: new `agents show <name>` subcommand. No change to `agents list`, no new config, no new state.

## Scheduled refactoring

Follow-up #4391 sub-tasks:
- `texra models show <id>` matching JSON/NDJSON shape.
- Wire the positional `<name>` into `_texra_agents` completion in bash/zsh/fish.

## Validation

Inside `packages/cli`:

- `npm run typecheck` ✓
- `npm run check:architecture` ✓
- `npm run bundle` ✓

Manual smoke (from repo root, against the rebuilt `dist/bin/texra.js`):

```
$ node packages/cli/dist/bin/texra.js agents show polish
name: polish
category: workflow
source: builtInWorkflow
path: /Users/.../polish.yaml

Rewrites and restructures text to improve clarity, flow, and readability based on your instructions.

$ node packages/cli/dist/bin/texra.js --output-format json agents show research
{ "name": "research", "source": "builtInToolUse", "category": "toolUse", "tools": [...], ... }

$ node packages/cli/dist/bin/texra.js --output-format ndjson agents show research
{"kind":"agent","ts":"…","agent":{...}}

$ node packages/cli/dist/bin/texra.js agents show nonexistent
Agent not found: nonexistent
$ echo $?
2
```

`validate:run` (which builds + smoke-tests the binary) was not re-run because it requires `TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER` rigging that is unrelated to this command. Happy to run it on request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only CLI subcommand and updates shell-completion snapshots, without changing agent loading/registry behavior or any data writes.
> 
> **Overview**
> Adds a new `texra agents show <name>` subcommand that resolves a single agent via `getAgent()` and prints its `AgentEntry` in **text**, **JSON**, or **NDJSON** (including a human-readable formatter for key metadata). Missing agents now return a usage exit code and emit `Agent not found: …` to stderr.
> 
> Updates generated shell completion snapshots (bash/fish/zsh) to include the new `agents show` subcommand and its flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3dcd2df3c10d6df7158bc3f8ef772d7ae8003a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->