### PR TITLE
fix(cli): bare-array JSON for `texra skills list` (closes #4393)

### DIFF
--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -28,15 +28,16 @@ async function listSkills(
   const result = await readCliSkills(context, options);
 
   if (context.outputFormat === 'json') {
+    // Match the bare-array JSON shape every other `<resource> list` command
+    // emits (agents, models, multi-agent, history, tools). Parse errors are
+    // surfaced on stderr below (same as the text branch) so the stdout
+    // contract stays scriptable with `jq '.[]'`. NDJSON consumers still get
+    // structured `kind: skill-issue` records for the same errors.
+    for (const issue of result.errors) {
+      writeTextStderr(formatCliSkillIssue(issue));
+    }
     writeTextStdout(
-      JSON.stringify(
-        {
-          skills: result.skills.map(skillListRecord),
-          errors: result.errors,
-        },
-        null,
-        2,
-      ),
+      JSON.stringify(result.skills.map(skillListRecord), null, 2),
     );
     return CliExitCode.Success;
   }


### PR DESCRIPTION
## Summary

`texra skills list --output-format json` returns `{"skills": [...], "errors": [...]}` while every other `<resource> list --output-format json` (agents, models, multi-agent, history, tools) returns a bare array. This PR brings `skills list` in line: bare array on stdout, parse errors on stderr — same split the text branch already does.

## Issue acceptance gates

Closes #4393.

- [x] `texra skills list --output-format json` emits a bare JSON array of skill records.
- [x] `texra skills list --output-format ndjson` unchanged (`kind: skill` + `kind: skill-issue` records).
- [x] Skill parse errors continue to surface (stderr for json/text).
- [x] `--quiet` semantics unchanged (issues are warnings, not info logs).

## Single source of truth

`readCliSkills()` (`packages/cli/src/runtime/skills.ts`) still owns the split between successful skill records and parse issues. Only the *encoding* on stdout/stderr for the JSON branch changes; the runtime data model is unchanged.

## Duplication and abstraction budget

No new abstraction. The new JSON branch reuses `formatCliSkillIssue` (already used by the text branch) and `skillListRecord` (already used by all three branches).

## Host impact

Extension: none.

Desktop: none.

CLI: `skills list --output-format json` stdout shape changes from `{skills, errors}` to a bare array. Scripts using `jq '.[]'` (matching every other list command) work now; scripts that explicitly read `.skills` will break — none are in this tree, and the change is documented in the closing issue.

## Scheduled refactoring

None.

## Validation

Inside `packages/cli`:

- `npm run typecheck` ✓
- `npm run check:architecture` ✓
- `npm run bundle` ✓

Manual smoke:

```
$ texra --output-format json skills list | python3 -c "import json,sys; d=json.load(sys.stdin); print(isinstance(d, list), len(d))"
True 13

$ texra --output-format json skills list 2>err.log >/dev/null
# err.log is empty when no parse errors exist; mirrors the text branch's behavior.

$ texra --output-format ndjson skills list | head -1
{"kind":"skill","ts":"…","skill":{…}}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stdout JSON contract for `skills list`, which can break existing scripts that expect `{ skills, errors }`, though logic and NDJSON/text behavior remain the same.
> 
> **Overview**
> Aligns `texra skills list --output-format json` with other `list` commands by emitting a **bare JSON array** of skill records on stdout instead of an object containing `skills` and `errors`.
> 
> Parse issues are no longer included in the JSON payload; they are printed to stderr using `formatCliSkillIssue`, while NDJSON output remains unchanged (skills as `kind: skill` and issues as `kind: skill-issue`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8439262d7927a63e002ce3778905c828640dd2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->