### PR TITLE
chore: bump version to 0.37.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-workspace",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "private": true,
   "packageManager": "pnpm@11.1.1",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/cli",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/core",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/desktop",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "description": "TeXRA standalone desktop application",
   "author": "TeXRA.ai <contact@texra.ai>",
   "homepage": "https://texra.ai",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"


### PR DESCRIPTION
Manually bumps the workspace package manifests from 0.37.9 to 0.37.10.

The automated **Version Bump on Release** workflow failed for the v0.37.9 release ("Unable to locate executable file: pnpm" — missing `pnpm/action-setup` step before `setup-node`). That workflow has since been fixed in `55dfe6b20`, but the fix landed after the release event, so this bump never ran automatically. This PR restores the expected post-release version state.

Bumped: root + cli, core, desktop, extension packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a manifest-only version bump with no runtime logic changes; impact is limited to packaging/publishing metadata.
> 
> **Overview**
> Updates the workspace and package manifests to version `0.37.10` (from `0.37.9`) across the root `package.json` and the `@texra/cli`, `@texra/core`, `@texra/desktop`, and VS Code extension (`texra`) packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd0a2983d034b375152bc7844ba9f098dfed39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->