### PR TITLE
fix(cli): chat default falls back when history names a missing agent (closes #4397)

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,5 +1,6 @@
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { getAgent, loadAgents } from '@agent/index';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { isNonEmptyString } from '@utils/core/stringCore';
@@ -64,10 +65,22 @@ async function loadUserDefaults(): Promise<PartialDefaults> {
   }
 }
 
+function isResolvableToolUseAgent(name: string | undefined): boolean {
+  if (!name) return false;
+  const entry = getAgent(name);
+  return entry?.category === AgentCategory.ToolUse;
+}
+
 async function loadHistoryDefaults(): Promise<PartialDefaults> {
   try {
+    // Ensure the local registry is populated before validating history names —
+    // otherwise stale rows that name an agent missing from the current install
+    // (e.g. a `bash` row persisted from a process-tracking run) would still
+    // win this tier and the chat session would crash on first submit with
+    // "Could not find agent: <name>".
+    await loadAgents({ includeRemote: false });
     const entries = await listExecutions();
-    const mostRecent = entries
+    const candidates = entries
       .filter(
         (entry) =>
           entry.agentConfig?.agentCategory === AgentCategory.ToolUse &&
@@ -78,7 +91,10 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
       .sort(
         (a, b) =>
           new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-      )[0];
+      );
+    const mostRecent = candidates.find((entry) =>
+      isResolvableToolUseAgent(entry.agentConfig?.agent),
+    );
     if (!mostRecent?.agentConfig) return {};
     return pickDefaults({
       agent: mostRecent.agentConfig.agent,

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -17,6 +17,27 @@ vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),
 }));
 
+// Stub the agent registry so chat-defaults validation is hermetic — the real
+// `loadAgents()` reads from disk paths that aren't reliably populated in the
+// test kernel, so we treat a small allowlist of names as "real tool-use
+// agents" and everything else (including the stale `bash` row from #4397) as
+// unresolvable.
+const TOOL_USE_AGENT_FIXTURES = new Set([
+  'research',
+  'review',
+  'chat',
+  'orchestrator',
+  'leanOrchestrator',
+]);
+vi.mock('@agent/index', () => ({
+  loadAgents: vi.fn(async () => {}),
+  getAgent: vi.fn((name: string) =>
+    TOOL_USE_AGENT_FIXTURES.has(name)
+      ? { name, category: 'toolUse' as const }
+      : undefined,
+  ),
+}));
+
 const mockedListExecutions = vi.mocked(listExecutions);
 
 function historyEntry(
@@ -116,6 +137,20 @@ describe('CLI chat defaults', () => {
     await expect(
       resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
     ).resolves.toMatchObject({ agent: 'chat', source: 'builtin' });
+  });
+
+  it('skips a history row whose agent is not in the tool-use registry', async () => {
+    // A stale `bash` row (or any other name not in `getToolUseAgents()`) used
+    // to win this tier and the chat session would then crash on first submit
+    // with "Could not find agent: bash" — see #4397.
+    mockedListExecutions.mockResolvedValueOnce([
+      historyEntry('bash', {}, '2026-05-21T08:02:00.000Z'),
+      historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
+    ]);
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
   });
 
   it('skips a team run to reach an earlier single-agent execution', async () => {

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -140,9 +140,9 @@ describe('CLI chat defaults', () => {
   });
 
   it('skips a history row whose agent is not in the tool-use registry', async () => {
-    // A stale `bash` row (or any other name not in `getToolUseAgents()`) used
-    // to win this tier and the chat session would then crash on first submit
-    // with "Could not find agent: bash" — see #4397.
+    // A stale `bash` row (or any other name not resolved by `getAgent()`)
+    // used to win this tier and the chat session would then crash on first
+    // submit with "Could not find agent: bash" — see #4397.
     mockedListExecutions.mockResolvedValueOnce([
       historyEntry('bash', {}, '2026-05-21T08:02:00.000Z'),
       historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),


### PR DESCRIPTION
## Summary

`loadHistoryDefaults()` picked the most-recent `agentCategory: toolUse` history row and trusted the name. Stale rows that named an agent missing from the current install — most commonly `bash`, written by some past process-tracking run with `agentCategory: "toolUse"` — would win the history tier of `resolveChatDefaults`. The chat session opened with `agent: bash` in the header but `/agent` did not list `bash`, and submitting any message printed `Could not find agent: bash` in the transcript and the run failed.

## Reproducer captured from a pty replay

```
 TeXRA  v0.37.9  relay
 agent: bash · model: gemini31p
 ~/Local/AI-Projects/coauthor
 ! Could not find agent: bash
…
╭─ › <my message>                                                       ╮
```

with history:

```jsonc
// texra history show b9f172ead762 --output-format json | jq .config
{ "agent": "bash", "agentCategory": "toolUse", "instruction": "sleep 60", … }
```

## Fix

`loadHistoryDefaults()` now validates each candidate against the local agent registry via `getAgent(name)?.category === ToolUse`. Loads the registry (local only — remote agents arrive later in the chat-TUI bootstrap) before validation. Unresolvable rows fall through to the next history candidate or, ultimately, to `BUILTIN_DEFAULT_CHAT_AGENT` (`'chat'`).

Mocked the registry in `ChatDefaults.vitest.mts` so the new validation is hermetic — the existing tests that relied on the `'research'`-from-history path keep passing, and a new test pins the regression.

## Issue acceptance gates

Closes #4397.

- [x] Workspace whose most-recent history is `agent: "bash"` opens `texra chat` with `agent: chat` (or the next valid history candidate), not `bash`.
- [x] Workspace whose most-recent history is a real tool-use agent (e.g. `research`) still inherits it — no regression.
- [x] `Could not find agent: bash` no longer fires for this code path.

The complementary fix (writer-side: refuse `agentCategory: toolUse` for non-registered agents so the bad rows stop being written) is left as a follow-up — that's hygiene; this PR makes the reader robust to the bad rows already present in users' storage.

## Single source of truth

`getAgent()` in `src/agent/index/agentRegistry.ts` remains the only resolver. The new validation is a thin wrapper that filters history rows; it does not embed a second name table.

## Duplication and abstraction budget

One new local helper (`isResolvableToolUseAgent`). No new module. Replaces a single-line `.filter(...).sort(...)[0]` with `.filter(...).sort(...).find(isResolvable)`.

## Host impact

Extension: none.

Desktop: none.

CLI: defaults resolution can now return the *next-recent* valid history row instead of the literal most-recent. For an unaffected workspace (all history rows resolve), behavior is identical.

## Scheduled refactoring

Follow-up #4397 sub-task: tighten the history *writer* to refuse `agentCategory: 'toolUse'` for agents that aren't in the registry, so the bad rows stop accumulating.

## Validation

- `corepack pnpm --filter @texra/cli typecheck` ✓
- `corepack pnpm --filter @texra/cli check:architecture` ✓
- `corepack pnpm --filter @texra/cli bundle` ✓
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/ChatDefaults.vitest.mts` ✓ (8/8 including new regression test)
- Full kernel suite: 208 files, 1034 tests ✓
- Manual TUI repro (pty replay) before fix: `agent: bash` → `Could not find agent: bash`.
- Manual TUI repro after fix: `agent: research` (the next-valid history candidate), no crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `resolveChatDefaults()` selects history-based defaults by loading/consulting the agent registry; this could alter default agent selection for some users and adds a startup dependency on registry loading.
> 
> **Overview**
> Fixes `resolveChatDefaults()` history fallback so it no longer blindly trusts the most recent `toolUse` execution.
> 
> `loadHistoryDefaults()` now loads the local agent registry and **skips history rows whose `agent` cannot be resolved as a `ToolUse` agent**, falling through to the next valid execution (or built-in defaults) instead of crashing later.
> 
> Tests are updated to mock the agent registry (`getAgent`/`loadAgents`) and add coverage for the stale/missing-agent case (e.g. `bash`) to prevent regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347fd0b0a960d714d0356c6359bc6308e8a138cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->