### PR TITLE
feat(reference-agents): add claude_code tool to orchestrators

### DIFF
--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -196,7 +196,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -312,7 +312,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -22,6 +22,7 @@ settings:
     - ls
     # Codex agent
     - codex
+    - claude_code
     # Lean tools (for quick checks without delegating)
     - lean_diagnostics
     - lean_inspect

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -22,6 +22,7 @@ settings:
     - texcount
     - inquiry
     - codex
+    - claude_code
     # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
     # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
     # Git. When disabled by the user, resolveTools() strips this from the


### PR DESCRIPTION
## Summary

Enables the **orchestrator** and **leanOrchestrator** reference agents to delegate to the **Claude Code** agent (`claude_code`) as a subagent, alongside the existing `codex` tool.

The `claude_code` tool was already registered in the tool registry (`src/tools/registry.ts`) and fully implemented (`src/tools/claudeAgent.ts`), but it was absent from **every** agent's toolset — so it could never actually run as an orchestrated subagent. This adds it to the two orchestrators that already host `codex`, giving them both external-CLI delegation options.

## Changes

- `reference-agents/orchestrator.yaml` — add `claude_code` after `codex`
- `reference-agents/Lean4/leanOrchestrator.yaml` — add `claude_code` after `codex`
- `docs/supabase/SYNC_REFERENCE_AGENTS.sql` — regenerated via `npm run sync:remote-agents` so the `remote_agents.tools` column matches

## Verification

- `npm run check:remote-agents` → SQL up to date ✓
- SQL diff is limited to the two orchestrator `tools` arrays (only `claude_code` added); no other agent rows changed
- No prompt changes needed — the orchestrator discovers `claude_code` from its own tool description, same as `codex`

## Follow-up (Supabase deploy)

The reference agents are served as **remote agents** from Supabase. After merge, the two edited YAMLs must be uploaded to Storage and the SQL applied to the `remote_agents` table for the change to take effect at runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables an additional delegated tool (`claude_code`) for the two orchestrator agents, which can change what external actions they can perform at runtime. Risk is limited to configuration/agent tooling updates, but it expands execution surface area.
> 
> **Overview**
> **Adds `claude_code` as an available tool** for the `orchestrator` and `leanOrchestrator` reference agents, alongside `codex`, so they can delegate to the Claude Code subagent.
> 
> Updates the generated Supabase sync SQL (`SYNC_REFERENCE_AGENTS.sql`) so the `remote_agents.tools` arrays for these two agents include `claude_code`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8815b119faca46758af697d27ae9c5af25039b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->