### PR TITLE
fix(cli): advertise Ctrl-J newline in chat footer (closes #4399)

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -130,6 +130,7 @@ function statusBarBindings(modifierLabel: string): readonly string[] {
     '[/status]details',
     '[/model]models',
     '[/api]api',
+    '[Ctrl-J]newline',
     '[Ctrl-C]stop',
   ];
 }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -36,6 +36,9 @@ describe('CLI StatusBar display model', () => {
     expect(display.right).toBeUndefined();
     expect(display.bindings).toContain('[/api]api');
     expect(display.bindings).toContain('[/model]models');
+    // [Ctrl-J]newline must be visible — the binding exists in BaseTextInput
+    // (see #4399) but used to be discoverable only via source diving.
+    expect(display.bindings).toContain('[Ctrl-J]newline');
     expect(display.bindings).not.toContain('[Alt-s]subagents');
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
   });


### PR DESCRIPTION
## Summary

Surfaces `[Ctrl-J]newline` in the chat composer's footer chip strip so the multi-line binding is discoverable. Closes #4399.

`Ctrl-J` already inserts a literal newline (`packages/cli/src/chat/tui/input/BaseTextInput.tsx:91-94` — "kills the legacy `/multi` ceremony"), but the footer jumped from `[/api]api` to `[Ctrl-C]stop` with no hint that newlines existed. New users had to source-dive to find the binding. This PR adds one chip next to `[Ctrl-C]stop` so the two Ctrl bindings are visually grouped.

## Issue acceptance gates

Closes #4399.

- [x] A new `texra chat` session shows a footer chip naming the newline binding.
- [x] Pressing `Ctrl-J` in the composer inserts a literal newline without submitting (already true; behavior unchanged).

## Single source of truth

`statusBarBindings()` in `packages/cli/src/chat/tui/panes/StatusBar.tsx` remains the only source for the chip strip. No new helper, no parallel string.

## Duplication and abstraction budget

One line added to the existing chip array, one line added to the existing StatusBar test. No new module.

## Host impact

Extension: none.

Desktop: none.

CLI: footer chip strip has one additional segment when `Ctrl-J` is the active newline binding.

## Scheduled refactoring

None. The optional follow-up suggested in #4399 (accepting Shift-Enter or `\<Enter>` as aliases to match Codex / Claude Code muscle memory) is a separate change and intentionally not bundled here.

## Validation

- `corepack pnpm --filter @texra/cli typecheck` ✓
- `corepack pnpm --filter @texra/cli bundle` ✓
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts` ✓
- Full kernel suite: 208 files, 1033 tests ✓
- Manual TUI repro (pty replay):

  ```
   [Tab]streams  [Option-1..9]focus  [Option-p]tasks  [/status]details  [/model]models  [/api]api  [Ctrl-J]newline  [Ctrl-C]stop
  ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new status bar hint string and a matching test assertion, with no behavioral changes to input handling or session state.
> 
> **Overview**
> The chat TUI status bar now advertises the existing multi-line compose shortcut by adding a `"[Ctrl-J]newline"` binding to the footer bindings list.
> 
> The StatusBar display-model test is updated to assert the new binding is present, ensuring the shortcut remains discoverable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77be2674d1456ff5d26eab1b30d51384a3000933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->