### PR TITLE
fix: move Odyssey settings tab to the end + slash palette Enter/Tab semantics

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -63,7 +63,6 @@ export function SlashPalette(
           props.onPick(
             chosen,
             slashPickIntent(
-              props.query,
               chosen,
               isPlainReturnInput(input, key) ? 'enter' : 'tab',
             ),
@@ -97,7 +96,8 @@ export function SlashPalette(
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: 'Tab/Enter', action: 'accept' },
+            { key: 'Enter', action: 'run' },
+            { key: 'Tab', action: 'complete' },
           ]}
           confirmCancel={false}
         />

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -25,6 +25,15 @@ export interface SlashCommand {
    * mounts this component instead of routing through `handler` / the input.
    */
   readonly formComponent?: React.ComponentType<SlashFormProps>;
+  /**
+   * Set for commands that take a free-text inline argument (e.g. `/foo bar`).
+   * When true, Enter in the palette *completes* the command into the input
+   * (with a trailing space) so the user can type the argument, rather than
+   * running it argument-less. No built-in command needs this today — every
+   * arg-taking command uses `formComponent` instead — but it's the hook for
+   * future inline-argument commands. See `slashPickIntent`.
+   */
+  readonly takesArgs?: boolean;
 }
 
 export type SlashPickIntent = 'complete' | 'submit';
@@ -56,18 +65,19 @@ export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
 }
 
 export function slashPickIntent(
-  query: string,
   command: SlashCommand,
   acceptKey: 'enter' | 'tab',
 ): SlashPickIntent {
+  // Tab always just fills the input so the user can keep editing (e.g. add
+  // arguments). Enter runs the highlighted command immediately — except for:
+  //  - commands that mount a structured form, which need the input cleared so
+  //    the form can take over (InputBar handles that branch before reading the
+  //    intent, so 'complete' here is just a safe default for them); and
+  //  - commands that take a free-text inline argument, which complete to
+  //    `/cmd ` so the user can type the argument instead of running blank.
   if (acceptKey !== 'enter') return 'complete';
-  if (command.formComponent) return 'complete';
-
-  const normalized = query.trim().toLowerCase();
-  if (normalized === command.name.toLowerCase()) return 'submit';
-  return command.aliases?.some((alias) => alias.toLowerCase() === normalized)
-    ? 'submit'
-    : 'complete';
+  if (command.formComponent || command.takesArgs) return 'complete';
+  return 'submit';
 }
 
 /**

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -922,15 +922,6 @@ export class SettingsApp extends SettingsAppBase {
             ></wa-icon>
             Memory</wa-tab
           >
-          <wa-tab panel="odyssey"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="compass"
-              variant="solid"
-            ></wa-icon>
-            Odyssey</wa-tab
-          >
           <wa-tab panel="history"
             ><wa-icon
               class="settings-tab-icon"
@@ -1002,6 +993,15 @@ export class SettingsApp extends SettingsAppBase {
               variant="solid"
             ></wa-icon>
             LaTeX</wa-tab
+          >
+          <wa-tab panel="odyssey"
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="compass"
+              variant="solid"
+            ></wa-icon>
+            Odyssey</wa-tab
           >
 
           <wa-tab-panel name="memory">

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -86,7 +86,6 @@ export {
 /** Tab name order - single source of truth for tab indices */
 export const SETTINGS_TAB_ORDER = [
   'MEMORY',
-  'ODYSSEY',
   'HISTORY',
   'MODELS',
   'AGENTS',
@@ -95,6 +94,7 @@ export const SETTINGS_TAB_ORDER = [
   'AI_AGENTS',
   'GIT',
   'LATEX',
+  'ODYSSEY',
 ] as const;
 
 export type SettingsTabName = (typeof SETTINGS_TAB_ORDER)[number];

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -95,14 +95,20 @@ describe('slashRegistry', () => {
     expect(matchSlashCommands('us').map((c) => c.name)).toEqual(['help']);
   });
 
-  it('submits exact no-form commands on Enter and completes partial commands', () => {
+  it('submits no-form commands on Enter and completes on Tab', () => {
     const help = { name: 'help', description: 'show help', aliases: ['h'] };
     registerSlashCommand(help);
 
-    expect(slashPickIntent('help', help, 'enter')).toBe('submit');
-    expect(slashPickIntent('h', help, 'enter')).toBe('submit');
-    expect(slashPickIntent('he', help, 'enter')).toBe('complete');
-    expect(slashPickIntent('help', help, 'tab')).toBe('complete');
+    expect(slashPickIntent(help, 'enter')).toBe('submit');
+    expect(slashPickIntent(help, 'tab')).toBe('complete');
+  });
+
+  it('completes arg-taking commands on Enter so the user can type the argument', () => {
+    const foo = { name: 'foo', description: 'takes args', takesArgs: true };
+    registerSlashCommand(foo);
+
+    expect(slashPickIntent(foo, 'enter')).toBe('complete');
+    expect(slashPickIntent(foo, 'tab')).toBe('complete');
   });
 
   it('does not directly submit structured-form commands from the palette', () => {
@@ -113,7 +119,7 @@ describe('slashRegistry', () => {
     };
     registerSlashCommand(agent);
 
-    expect(slashPickIntent('agent', agent, 'enter')).toBe('complete');
+    expect(slashPickIntent(agent, 'enter')).toBe('complete');
   });
 });
 


### PR DESCRIPTION
Two small UX fixes bundled from local changes.

## 1. Move experimental Odyssey settings tab to the end

The **Odyssey** settings tab is observation-only and experimental, but sat second in the tab bar (right after Memory). Moved to the rear, after LaTeX, so frequently-used tabs (Memory, History, Models, Agents) lead.

- Reorder `ODYSSEY` last in `SETTINGS_TAB_ORDER` (`src/shared/schemas/settingsViewMessages.ts`). The index↔panel mapping is name-based, so tab selection logic is unaffected.
- Move the `<wa-tab panel="odyssey">` block after LaTeX in `SettingsApp.ts`, which controls the visible tab order.

## 2. Slash palette: Enter runs, Tab completes

In the CLI slash palette, **Enter** now runs the highlighted command immediately rather than depending on whether the typed query exactly matched the command name. **Tab** still completes the command into the input for further editing.

- Drop the unused `query` arg from `slashPickIntent`; intent derives purely from the command and accept key.
- Add a `takesArgs` hook on `SlashCommand`: Enter *completes* (not submits) for commands that take a free-text inline argument, so the user can type the argument instead of running blank.
- Update key hints to 'Enter: run' / 'Tab: complete'.
- Update `SlashRegistry` tests for the new two-arg signature and semantics.

## Testing

- `npm run typecheck` — clean.
- `pnpm vitest run src/test-kernel/cli/SlashRegistry.vitest.mts` — 9 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI slash-command execution semantics (Enter now immediately submits non-form commands) which could alter user workflows or trigger unintended command runs; settings tab reorder is low risk UI-only.
> 
> **Overview**
> **CLI slash palette behavior changes:** `slashPickIntent` no longer depends on the typed query; **Enter now immediately `submit`s any non-form command**, while **Tab always `complete`s**, with a new `takesArgs` flag to force Enter to complete (for future inline-argument commands). The palette UI hint text is updated accordingly, and `SlashRegistry` tests are rewritten/expanded to cover the new intent rules.
> 
> **Settings UI reorder:** Moves the `Odyssey` settings tab to the end by reordering `SETTINGS_TAB_ORDER` and relocating the `<wa-tab panel="odyssey">` block after `LaTeX` in `SettingsApp.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7416e4893705e96a46ba526a00b1d2b7806def38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->