### PR TITLE
fix(cli): guard optional model fields in `models show` output

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -81,9 +81,10 @@ function formatModelDetails(entry: ModelAccessEntry): string {
   const lines: string[] = [];
   lines.push(`id: ${model.value}`);
   lines.push(`label: ${model.label}`);
-  lines.push(`provider: ${model.provider}`);
+  if (model.provider) lines.push(`provider: ${model.provider}`);
   lines.push(`status: ${status}`);
-  lines.push(`availability: ${model.availabilityLabel}`);
+  if (model.availabilityLabel)
+    lines.push(`availability: ${model.availabilityLabel}`);
   if (model.context) lines.push(`context: ${model.context}`);
   if (model.cost) lines.push(`cost: ${model.cost}`);
   if (model.hint) {


### PR DESCRIPTION
## Summary

`texra models show <id>` printed literal `provider: undefined` and `availability: undefined` for models without a config entry, because `formatModelDetails` interpolated `model.provider` and `model.availabilityLabel` unconditionally even though both are optional in `ModelOptionDataSchema`.

This guards both fields with `if` checks so they're omitted when absent — matching how `context`, `cost`, and `hint` are already handled in the same function.

## Testing
- `pnpm --filter @texra/cli typecheck` — clean
- `prettier --check` / `eslint` on the changed file — clean

Closes #4411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI text-formatting change that only affects `texra models show` human-readable output, with no impact on JSON/NDJSON or backend behavior.
> 
> **Overview**
> Fixes `texra models show` text output to **omit optional fields** when unset. `formatModelDetails` now only prints `provider` and `availability` lines when `model.provider` / `model.availabilityLabel` are present, avoiding `undefined` in the displayed details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f89eb2d6dc86f3b116fdc23e11529e82785e4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->