### PR TITLE
fix(settings): helper-model dropdown empty when enabled-models list is empty

### DIFF
--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -62,7 +62,11 @@ export class SettingsModelSelectionController {
   }
 
   getVisibleModels(): string[] {
-    return this.deps.state.getEnabledModels() ?? DEFAULT_MODELS;
+    // Normalize at the single read boundary: an empty persisted list (e.g. the
+    // user disabled every model) falls back to defaults so downstream consumers
+    // — including the helper-model dropdown — never see an empty model set.
+    const enabled = this.deps.state.getEnabledModels();
+    return enabled && enabled.length > 0 ? enabled : DEFAULT_MODELS;
   }
 
   buildSelectionData(): SettingsModelSelectionData {

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -74,6 +74,19 @@ describe('SettingsModelSelectionController', () => {
     expect(state.getHelperModel()).toBe('sonnet46T');
   });
 
+  it('falls back to default models when the persisted enabled list is empty', () => {
+    const controller = new SettingsModelSelectionController({
+      state: createState({ enabledModels: [] }),
+    });
+
+    const enabled = controller
+      .buildSelectionData()
+      .models.filter((model) => model.enabled);
+
+    // An empty persisted list must not blank out the helper-model dropdown.
+    expect(enabled.length).toBeGreaterThan(0);
+  });
+
   it('uses the runtime helper default when no helper model is configured', () => {
     const controller = new SettingsModelSelectionController({
       state: createState({


### PR DESCRIPTION
## Summary

The **Helper model** dropdown in Settings → Models rendered empty (no options, no value). The dropdown only lists models with `enabled: true`, and that flag derives from `getVisibleModels()`:

```ts
return this.deps.state.getEnabledModels() ?? DEFAULT_MODELS;
```

`??` only falls back on null/undefined. If `ENABLED_MODELS` was ever persisted as an empty array `[]` (e.g. the user disabled every model), the empty list passed straight through, every model got `enabled: false`, and the dropdown had nothing to show.

## Fix

Normalize at the single read boundary so an empty list falls back to defaults — all downstream consumers (the dropdown included) always see a non-empty model set:

```ts
const enabled = this.deps.state.getEnabledModels();
return enabled && enabled.length > 0 ? enabled : DEFAULT_MODELS;
```

## Testing
- New regression test in `SettingsModelSelectionController.vitest.ts` asserting an empty persisted list still yields enabled models.
- `pnpm vitest run …SettingsModelSelectionController.vitest.ts` — 4 passed.
- prettier clean.

Closes #4404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small settings normalization change plus a regression test; behavior only differs when `enabledModels` is persisted as an empty array.
> 
> **Overview**
> Fixes an edge case where persisting `enabledModels` as an empty array caused Settings → Models to show *no enabled models* (and an empty helper-model dropdown). `SettingsModelSelectionController.getVisibleModels()` now treats an empty enabled-models list as invalid and falls back to `DEFAULT_MODELS`.
> 
> Adds a regression test to ensure `buildSelectionData()` still returns at least one enabled model when the persisted list is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e6ef886d0001f6b000c7bdce2a45c62fb23ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->