### PR TITLE
fix(cli): orchestrate menu launches team orchestrator instead of research

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -71,7 +71,7 @@ interface MultiAgentRunInit {
   readonly instruction: string;
 }
 
-export function resolveMultiAgentRunPlan(
+function resolveMultiAgentRunPlan(
   init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
 ): CliMultiAgentPresetRunPlan {
   const preset = findCliMultiAgentPreset(

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -88,7 +88,34 @@ export function resolveMultiAgentRunPlan(
   });
 }
 
-function writeMissingPresetAgents(plan: CliMultiAgentPresetRunPlan): void {
+/**
+ * Resolve a preset plan, then — when it still has gaps and the user is
+ * authenticated — perform a remote load and replan. Relay-served premium agents
+ * (the team orchestrator and delegation specialists most presets name) are only
+ * visible after a remote load, so a local-only resolve silently degrades the
+ * team (e.g. falling back to the first plain tool-use agent as root). Both the
+ * headless `multi-agent run` path and the interactive `orchestrate` menu route
+ * through here so they can't drift apart again.
+ *
+ * Assumes local agents are already loaded by the caller.
+ */
+export async function fillMultiAgentRunPlanGaps(
+  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
+): Promise<CliMultiAgentPresetRunPlan> {
+  let plan = resolveMultiAgentRunPlan(init);
+  if (
+    cliMultiAgentPlanHasGaps(plan) &&
+    (await getCliAuthProvider().isAuthenticated())
+  ) {
+    await loadAgents();
+    plan = resolveMultiAgentRunPlan(init);
+  }
+  return plan;
+}
+
+export function writeMissingPresetAgents(
+  plan: CliMultiAgentPresetRunPlan,
+): void {
   const missing = [
     ...plan.missingWorkflowAgents.map((agent) => `workflow:${agent}`),
     ...plan.missingToolUseAgents.map((agent) => `tool-use:${agent}`),
@@ -232,18 +259,7 @@ async function runMultiAgentPreset(
   installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
 
-  let plan = resolveMultiAgentRunPlan(init);
-  // Relay-served premium agents (the team orchestrator and delegation
-  // specialists most presets name) are only visible after a remote load. Fill
-  // any preset gap — not just a missing root — so an authenticated, entitled
-  // user runs the full team instead of a silently degraded one.
-  if (
-    cliMultiAgentPlanHasGaps(plan) &&
-    (await getCliAuthProvider().isAuthenticated())
-  ) {
-    await loadAgents();
-    plan = resolveMultiAgentRunPlan(init);
-  }
+  const plan = await fillMultiAgentRunPlanGaps(init);
   if (!plan.rootAgent) {
     writeTextStderr(
       `Multi-agent preset "${init.preset}" has no available tool-use agent to run. Use --agent with an installed tool-use agent, or enable a team with an orchestrator.`,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -19,7 +19,10 @@ import {
   INTERACTIVE_GLOBAL_ARGS,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
-import { resolveMultiAgentRunPlan } from './multiAgent';
+import {
+  fillMultiAgentRunPlanGaps,
+  writeMissingPresetAgents,
+} from './multiAgent';
 import { runResumeExecution } from './resume';
 import type { CliContext } from '../runtime/cliContext';
 
@@ -61,13 +64,17 @@ async function runOrchestration(context: CliContext): Promise<number> {
       return result.exitCode;
     }
     case 'preset': {
-      const plan = resolveMultiAgentRunPlan({ preset: action.preset });
+      // Match the headless path: load remote premium agents (orchestrator,
+      // delegation specialists) and replan so the team starts with its real
+      // root instead of silently degrading to the first local tool-use agent.
+      const plan = await fillMultiAgentRunPlanGaps({ preset: action.preset });
       if (!plan.rootAgent) {
         writeTextStderr(
           `Multi-agent preset "${action.preset}" has no available tool-use agent to start.`,
         );
         return CliExitCode.Usage;
       }
+      writeMissingPresetAgents(plan);
       const { runChat } = await import('../chat/tui/runChatTui');
       const result = await withCliMultiAgentPresetVisibility(plan, () =>
         runChat(context, {


### PR DESCRIPTION
## Problem

Starting a CLI session from the interactive menu (`texra` → "Team Physicist", etc.) and selecting a built-in team launched the **`research`** tool-use agent (`agent: research`) instead of the team **orchestrator** — a plain, non-delegating chat agent, with no warning.

Fixes #4412.

## Root cause

The interactive `orchestrate` path and the headless `multi-agent run` path had diverged. The headless path loads remote agents and re-plans when the local plan has gaps; the interactive path did not:

- `orchestrate.ts` only ran `loadAgents({ includeRemote: false })`, then resolved the preset against **local-only** agents.
- The `orchestrator` (and other delegation specialists) are **relay-served premium agents**, not shipped locally — so they were dropped as "missing".
- `selectPresetRootAgent` found no delegation-capable agents locally and fell through to `agents[0]` — the first surviving preset agent, `research`.
- That name was baked into `agentOverride` and resolved in `runChatTui` *before* its own remote `loadAgents()`, so the late remote load couldn't change the root.

The headless path already guarded against this (`multiAgent.ts`): replan after a remote load when authenticated, then warn on residual gaps.

## Fix

- Extract the remote-load-and-replan into a shared, exported `fillMultiAgentRunPlanGaps(init)` helper in `multiAgent.ts`.
- Route **both** the headless `multi-agent run` and the interactive `orchestrate` preset case through it, so they can't drift again.
- Surface missing-agent warnings (`writeMissingPresetAgents`) in the interactive path too.

Behavior for unauthenticated users is unchanged (no remote load); they still get the existing "no available tool-use agent" message when a preset has no usable local root.

## Verification

- `npm run typecheck` — passes clean.
- `npx eslint` on both changed files — clean.
- No behavior change to the headless path (logic moved verbatim into the shared helper).

Note: the `packages/cli` package has no existing unit-test harness (no `.test.ts`/`.spec.ts`), and this fix is wiring that requires platform/auth/remote-load mocks, so no unit test is added. Manual verification path: authenticated user, `texra` → select a team → confirm `agent:` is the orchestrator, not `research`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how preset run plans are resolved and when remote agents are loaded, which can affect which agent is selected as the root in both interactive and headless flows. The behavior change is gated on authentication and only triggers when a preset plan has missing agents, limiting blast radius.
> 
> **Overview**
> Fixes interactive `orchestrate` preset launches to match `multi-agent run` behavior by **resolving preset plans, then remote-loading agents and replanning when gaps remain and the user is authenticated**, preventing silent fallback to a local non-orchestrator agent.
> 
> Extracts this logic into a shared `fillMultiAgentRunPlanGaps()` helper and uses it from both commands, and also surfaces `writeMissingPresetAgents()` warnings in the interactive preset path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b067481f209e38862604a03a64899c7e54ace438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->