### PR TITLE
fix(cli): /agent picker shows ✓ marker and gives rows 10+ a-z hotkeys

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -191,6 +191,14 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     label: agent.label,
     description: agentDescription(agent),
   }));
+  // The current agent may be stored as a canonical key (`source:name`) or a
+  // bare name; rows are keyed by bare name, so resolve to the matching label
+  // so Select can render the ✓ on the active row.
+  const activeAgent = agents.toolUse.find(
+    (agent) =>
+      agent.value === props.currentAgent || agent.label === props.currentAgent,
+  );
+  const activeValue = activeAgent?.label ?? props.currentAgent;
   const workflowRows = agents.workflow.map((agent) => ({
     name: agent.label,
     description: agentDescription(agent),
@@ -224,7 +232,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         <Text bold>Tool-use agents</Text>
         <Select
           items={items}
-          activeValue={props.currentAgent}
+          activeValue={activeValue}
           maxVisibleItems={selectWindow.maxVisibleItems}
           showOverflow={selectWindow.showOverflow}
           onSelect={(value) => {
@@ -262,7 +270,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
-              { key: '1-9', action: 'select' },
+              { key: '1-9/a-z', action: 'select' },
             ]}
           />
         ) : (

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -158,7 +158,7 @@ export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
         <KeyHints
           hints={[
             { key: 'up/down', action: 'navigate' },
-            { key: '1-9/Enter', action: 'preview' },
+            { key: '1-9/a-z/Enter', action: 'preview' },
             { key: 'Esc', action: 'close' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -200,7 +200,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
-              { key: '1-9', action: 'select' },
+              { key: '1-9/a-z', action: 'select' },
             ]}
           />
         ) : (

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -162,7 +162,7 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: '1-9/Enter', action: 'resume' },
+            { key: '1-9/a-z/Enter', action: 'resume' },
             { key: 'Esc', action: 'close' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -5,7 +5,8 @@
 // docs/prd/cli-tui-ink/10-architecture.md § Intuitiveness conventions.
 //
 // `↑/↓` walks the rows, Enter calls `onSelect`, Esc calls `onCancel`. Items
-// receive a 1-based numeric prefix so digit shortcuts can jump directly.
+// receive a single-key shortcut prefix so the row can be jumped to directly:
+// `1`-`9` for the first nine rows, then `a`-`z` for rows 10-35.
 
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
@@ -68,6 +69,31 @@ export function selectItemRenderKey<T>(
   return `${index}:${item.label}`;
 }
 
+/**
+ * Single-key shortcut for a row: `1`-`9` for the first nine, then `a`-`z` for
+ * rows 10-35. Rows beyond that have no shortcut (undefined).
+ */
+export function selectHotkeyForIndex(index: number): string | undefined {
+  if (index < 0) return undefined;
+  if (index < 9) return String(index + 1);
+  const letterIndex = index - 9;
+  if (letterIndex < 26) return String.fromCharCode(97 + letterIndex);
+  return undefined;
+}
+
+/** Inverse of {@link selectHotkeyForIndex}: maps a typed key to a row index. */
+export function selectIndexForHotkey(input: string): number | undefined {
+  if (input.length !== 1) return undefined;
+  if (input >= '1' && input <= '9') {
+    return input.charCodeAt(0) - '1'.charCodeAt(0);
+  }
+  const lower = input.toLowerCase();
+  if (lower >= 'a' && lower <= 'z') {
+    return 9 + (lower.charCodeAt(0) - 'a'.charCodeAt(0));
+  }
+  return undefined;
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const activeIndex = props.items.findIndex(
     (it) => it.value === props.activeValue,
@@ -113,16 +139,13 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       if (choice && !choice.disabled) props.onSelect(choice.value);
       return;
     }
-    // 1-9 digit jumps for direct selection.
-    const digit = Number(input);
-    if (Number.isInteger(digit) && digit >= 1 && digit <= 9) {
-      const idx = digit - 1;
-      if (idx < props.items.length) {
-        const choice = props.items[idx];
-        if (choice && !choice.disabled) {
-          setHighlight(idx);
-          props.onSelect(choice.value);
-        }
+    // Single-key jumps (1-9, then a-z) for direct selection.
+    const idx = selectIndexForHotkey(input);
+    if (idx != null && idx < props.items.length) {
+      const choice = props.items[idx];
+      if (choice && !choice.disabled) {
+        setHighlight(idx);
+        props.onSelect(choice.value);
       }
     }
   });
@@ -138,12 +161,13 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         const active = item.value === props.activeValue;
         const pointer = focused ? '›' : ' ';
         const tick = active ? '✓' : ' ';
-        const numeric = i < 9 ? `${i + 1}.` : '  ';
+        const hotkey = selectHotkeyForIndex(i);
+        const shortcut = hotkey ? `${hotkey}.` : '  ';
         return (
           <Box key={selectItemRenderKey(item, i)} minWidth={0}>
             <Box flexShrink={0}>
               <Text color={focused ? 'cyan' : undefined}>
-                {pointer} {tick} {numeric}{' '}
+                {pointer} {tick} {shortcut}{' '}
               </Text>
             </Box>
             <Box flexShrink={0} maxWidth={SELECT_LABEL_MAX_COLS}>

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  selectHotkeyForIndex,
+  selectIndexForHotkey,
+} from '../../../packages/cli/src/chat/tui/ui/Select';
+
+describe('Select hotkeys', () => {
+  it('numbers the first nine rows 1-9, then letters a-z for 10-35', () => {
+    expect(selectHotkeyForIndex(0)).toBe('1');
+    expect(selectHotkeyForIndex(8)).toBe('9');
+    expect(selectHotkeyForIndex(9)).toBe('a');
+    expect(selectHotkeyForIndex(10)).toBe('b');
+    expect(selectHotkeyForIndex(34)).toBe('z');
+  });
+
+  it('has no shortcut for rows beyond z or below zero', () => {
+    expect(selectHotkeyForIndex(35)).toBeUndefined();
+    expect(selectHotkeyForIndex(-1)).toBeUndefined();
+  });
+
+  it('maps a typed key back to its row index (round-trip)', () => {
+    for (const index of [0, 8, 9, 10, 34]) {
+      const key = selectHotkeyForIndex(index);
+      expect(key).toBeDefined();
+      expect(selectIndexForHotkey(key as string)).toBe(index);
+    }
+  });
+
+  it('accepts uppercase letters and rejects non-shortcut input', () => {
+    expect(selectIndexForHotkey('A')).toBe(9);
+    expect(selectIndexForHotkey('0')).toBeUndefined();
+    expect(selectIndexForHotkey('')).toBeUndefined();
+    expect(selectIndexForHotkey('ab')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the two UX gaps from #4398 in the `texra chat` slash-form pickers.

## 1. `/agent` now marks the active agent with `✓`

`/model` and `/approval` prefix the current selection with `✓`; `/agent` didn't. The picker rows are keyed by the bare agent name (`agent.label`), but the current agent is frequently stored as a canonical `source:name` key (e.g. `remote:orchestrator`), so `Select`'s strict `value === activeValue` comparison never matched and the tick never rendered.

Resolve the active row against **both** the key and the bare name, then pass the matching label as `activeValue`.

## 2. Rows 10+ now have stable single-key shortcuts

The shared `Select` primitive only numbered and digit-jumped rows 1-9; rows 10+ rendered a blank, unaligned prefix and had no shortcut (the `/agent` picker has 18 tool-use entries). `Select` now labels rows **1-9 then a-z** (covering rows 10-35), handles the matching key presses, and the four list-form footers (`/agent`, `/model`, resume, memory) read `1-9/a-z`.

Because letters only appear at row index ≥ 9, pickers with ≤ 9 rows are visually unchanged.

## Testing
- New `SelectHotkeys.vitest.mts` covering the shortcut mapping + round-trip.
- `pnpm vitest run` SelectHotkeys / AgentListForm / ModelListForm — 14 passed.
- CLI + test-kernel typecheck, prettier — clean.

Closes #4398

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI TUI selection rendering and keyboard shortcuts, plus a small unit test addition.
> 
> **Overview**
> Fixes CLI slash-form pickers by ensuring `/agent` correctly shows the active-row `✓` even when the current agent is stored as a canonical `source:name` key (it now resolves to the matching bare label before passing `activeValue`).
> 
> Extends the shared `Select` component to support stable single-key shortcuts beyond 9 items (*`1`-`9` then `a`-`z` for rows 10–35*), updates list-form key-hint footers to advertise `1-9/a-z`, and adds a focused Vitest suite to cover the hotkey/index mapping round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b92c699861cf3f48fc0437328bdfab1d511e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->