### PR TITLE
perf(skills): gate runtime skill catalog load on ToolUse agents

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -93,7 +93,12 @@ export async function buildUserVars(
       () => '',
     ),
     getAttachedMemories(agentConfig.memories),
-    loadRuntimeSkillCatalog(logger),
+    // AVAILABLE_SKILLS is only substituted into TOOL_USE_INSTRUCTIONS, so the
+    // catalog (a multi-source readdir + per-skill realpath/read/parse) is dead
+    // work for workflow agents — gate it on the ToolUse category.
+    agentSetting.agentCategory === AgentCategory.ToolUse
+      ? loadRuntimeSkillCatalog(logger)
+      : Promise.resolve(''),
   ]);
   allLoadedFiles.push(...requiredFiles);
   allLoadedFiles.push(...patternFiles);


### PR DESCRIPTION
## Summary

Follow-up from #4362. `buildUserVars` (`src/agent/utils/userVars.ts`) called `loadRuntimeSkillCatalog(logger)` unconditionally on every invocation. But `AVAILABLE_SKILLS` is only substituted inside `TOOL_USE_INSTRUCTIONS` — for workflow agents the rendered catalog lands in `userVars` and is never read by any prompt template.

So every workflow-agent launch performed a multi-source `readdir` plus per-skill `realpath`/`readFile`/Zod-parse for nothing.

## Fix

Gate the load on `agentSetting.agentCategory === AgentCategory.ToolUse` (the same guard already used at `userVars.ts:238` and `:503`). Workflow agents resolve to `''`, which is exactly the value `loadRuntimeSkillCatalog` returns when there are no skills — so there's no behavioral change to the rendered prompt, only the elimination of dead I/O.

## Testing
- Root `tsc --noEmit` — clean.
- prettier / eslint on the changed file — clean.

(No vitest harness exists for `buildUserVars`; the empty-string result is identical to the prior unused value, and root typecheck guards the conditional.)

Closes #4365

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization: it only changes when `loadRuntimeSkillCatalog` runs, and preserves the `AVAILABLE_SKILLS` value (`''`) for non-ToolUse agents, so prompt output should be unchanged aside from avoiding unnecessary I/O.
> 
> **Overview**
> Avoids unnecessary runtime skill discovery for workflow agents by only loading the `AVAILABLE_SKILLS` catalog when `agentSetting.agentCategory === AgentCategory.ToolUse` in `buildUserVars`.
> 
> Workflow agents now resolve `AVAILABLE_SKILLS` to an empty string via a resolved promise, eliminating dead filesystem reads/parsing while keeping tool-use prompt rendering behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfbed910cb6ef3a1175967e7c851f56e790e619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->