### PR TITLE
fix(reference-agents): address review feedback on claude_code addition

### DIFF
--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -20,7 +20,7 @@ settings:
     - glob
     - grep
     - ls
-    # Codex agent
+    # External CLI agents
     - codex
     - claude_code
     # Lean tools (for quick checks without delegating)
@@ -49,6 +49,8 @@ prompts:
     Choose delegate_agent when the task benefits from interactive tool use. Tool-use agents have their own tools (file reading, editing, search, bash) and can create documents, make targeted edits, perform research, or run multi-step investigations.
 
     {{ CODEX_GUIDANCE }}
+
+    {{ CLAUDE_CODE_GUIDANCE }}
 
     Delegate liberally — long proofs, multi-file refactors, whole-document rewrites, and research belong to specialists. Parallelize independent lemmas by delegating them simultaneously. Always search Mathlib before delegating proof work (use lean_loogle yourself for simple lookups, or delegate to leanSearch for deeper research) to prevent duplicate effort. Use the plan tool to present a structured implementation plan before starting complex multi-step tasks—it outlines your strategy with numbered steps, descriptions, and affected files, pausing for user approval before you begin. Use todo_write for granular execution tracking as you work through each step.
 

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -61,6 +61,8 @@ prompts:
 
     {{ CODEX_GUIDANCE }}
 
+    {{ CLAUDE_CODE_GUIDANCE }}
+
     Thread context across delegations. Attach relevant memory files via the memories parameter (e.g., /memories/conventions.md, /memories/notation.md) so subagents inherit project conventions and accumulated knowledge without you restating them in the instruction. When a task depends on prior agent work, mention the execution IDs and what those agents produced—e.g., "Execution abc123 (correct agent) polished sections 1–3 of paper.tex; execution def456 (derive agent) produced the proof in appendix_proof.tex. Integrate the polished prose with the new proof." Use /executions/current/children to look up IDs of prior runs. Subagents that know the lineage avoid redundant work and stay consistent with earlier outputs.
 
     For workflow proposals, the file parameters serve distinct roles. The inputFile is the primary document whose structure determines the output. Reference files provide guidance or examples without being modified. Auxiliary files supply supplementary content that the agent needs for context but should not modify—this includes preamble files, custom command definitions, and bibliography data. For bibliographies, prefer the compiled .bbl over large .bib files to save context. Media files provide images the agent can reference. Each file should appear in exactly one category—never duplicate a file across multiple parameters.

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -497,6 +497,15 @@ export function getToolFlags(
         'When multiple codex agents need to edit the same files, or when you want to isolate experimental changes, ' +
         'use a git worktree (`git worktree add ../worktree-name branch-name`) and pass its path as working_directory.'
       : '',
+    CLAUDE_CODE_GUIDANCE: agentSetting.tools.some(
+      (t) => t.name === 'claude_code',
+    )
+      ? 'Choose claude_code for coding tasks that benefit from a separate Anthropic Claude Code agent — it runs in its own workspace with independent file editing, search, and shell access. ' +
+        'claude_code is async and multi-turn, mirroring delegate_agent: each call returns an execution ID, and results arrive as follow-up messages that include a session_id. ' +
+        'Pass that session_id back on a later claude_code call to continue the same session — the agent retains full history and file context. ' +
+        'Use permission_mode to control how it handles edits (acceptEdits auto-applies file edits; plan keeps it read-only), and set model and effort to trade off speed against depth. ' +
+        'codex and claude_code are both independent sandboxed coders distinct from the in-process delegate_agent specialists; prefer whichever vendor fits the task, and for parallel or isolated edits run them against a git worktree.'
+      : '',
   };
 
   // Only compute ROUNDS for workflow agents, not tool-use agents


### PR DESCRIPTION
Follow-up to #4401, addressing the two review notes from Cursor Bugbot and the Claude reviewer.

## Review 1 — misleading section comment (Bugbot + Claude, low severity)
`# Codex agent` in `leanOrchestrator.yaml` now sat above both `codex` and the new `claude_code`, implying the Anthropic tool is part of OpenAI Codex.

**Fix:** relabel to `# External CLI agents`. (`orchestrator.yaml` has no such header, so it's untouched.)

## Review 2 — codex/claude_code prompt-guidance asymmetry (Claude reviewer)
`CODEX_GUIDANCE` (`src/agent/utils/userVars.ts`) injects targeted guidance (async/multi-turn, `thread_id` follow-ups, worktree tip) when `codex` is in the toolset. After #4401, `claude_code` shipped with only its schema description and no equivalent guidance — biasing the orchestrator toward codex.

**Fix:** add a parallel `CLAUDE_CODE_GUIDANCE` var, gated on `claude_code` being present, covering its async/multi-turn `session_id` follow-up model, `permission_mode`/`model`/`effort` controls, and how it differs from in-process `delegate_agent` specialists. Reference `{{ CLAUDE_CODE_GUIDANCE }}` right after `{{ CODEX_GUIDANCE }}` in both orchestrator prompts.

## Changes
- `reference-agents/Lean4/leanOrchestrator.yaml` — comment relabel + `{{ CLAUDE_CODE_GUIDANCE }}`
- `reference-agents/orchestrator.yaml` — `{{ CLAUDE_CODE_GUIDANCE }}`
- `src/agent/utils/userVars.ts` — `CLAUDE_CODE_GUIDANCE` UserVar

## Safety / verification
- Nunjucks (`renderPrompt`, `src/utils/prompt/promptUtils.ts`) renders undefined vars as empty string, so `{{ CLAUDE_CODE_GUIDANCE }}` is safe on builds predating the code change (renders empty, no literal, no error) — same pattern as `CODEX_GUIDANCE`.
- `prettier --check` passes on all three files.
- No SQL/`remote_agents.tools` change — the toolset is unchanged; only prompt text and a comment.

## Follow-up (Supabase deploy)
The orchestrator prompts live in Supabase Storage at runtime. After merge, re-upload the two YAMLs to the `agent-configs` bucket so the guidance reaches production (renders empty until the `userVars.ts` change ships in an extension/CLI build).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to prompt/template text and a new gated user-var string, with no toolset, auth, or data-path logic changes.
> 
> **Overview**
> Adds a new `CLAUDE_CODE_GUIDANCE` prompt variable (populated only when `claude_code` is enabled) to provide usage guidance parallel to `CODEX_GUIDANCE`.
> 
> Injects `{{ CLAUDE_CODE_GUIDANCE }}` into both `reference-agents/orchestrator.yaml` and `reference-agents/Lean4/leanOrchestrator.yaml`, and updates the Lean orchestrator tool-list comment to **“External CLI agents”** to avoid implying `claude_code` is part of Codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f291639d2c9f2da507229037286e0eef9d9d4e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->