### PR TITLE
fix(storage): stop persisting toolUse category for unregistered agents

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -349,6 +349,15 @@ export function getAgentsBySource(source: AgentSource): AgentEntry[] {
   return [...cache.values()].filter((e) => e.source === source);
 }
 
+/**
+ * Whether the local registry has been loaded so `getAgent` lookups are
+ * meaningful. Callers that distinguish "agent absent" from "registry not yet
+ * loaded" must check this first — an empty cache looks identical otherwise.
+ */
+export function isAgentRegistryReady(): boolean {
+  return initialized;
+}
+
 /** Refresh the cache. */
 export async function refresh(): Promise<void> {
   initialized = false;

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -54,6 +54,7 @@ export {
   getWorkflowAgents,
   getToolUseAgents,
   getAgentsBySource,
+  isAgentRegistryReady,
   refresh,
   // Typed data options
   computeAgentOptionsData,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -8,10 +8,36 @@
  */
 
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { getAgent, isAgentRegistryReady } from '@agent/index/agentRegistry';
 
 import type { ExecutionId } from '@shared/schemas';
 import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
 import { invalidateListingCache } from './executionListing';
+
+/**
+ * Tool-driven executions (e.g. the `bash` background tool) persist a synthetic
+ * config tagged `agentCategory: ToolUse` with a name that is not a real
+ * tool-use agent. Those rows would otherwise be picked up as chat-session
+ * defaults (see `chatDefaults.loadHistoryDefaults`, which keys off
+ * `agentConfig.agentCategory === ToolUse`). Demote the persisted category to
+ * Workflow for names the loaded registry does not know as tool-use agents so
+ * the rows stop polluting defaults resolution.
+ *
+ * Skipped when the registry is not loaded — an empty registry can't tell
+ * "agent absent" from "not loaded yet", and we must never demote a legitimate
+ * tool-use agent's run. The displayed history category is unaffected: listing
+ * surfaces `meta.category` (e.g. `'process'`) ahead of `config.agentCategory`.
+ */
+export function normalizeWriterCategory(
+  config: AgentConfig,
+  agentName: string,
+): AgentConfig {
+  if (config.agentCategory !== AgentCategory.ToolUse) return config;
+  if (!isAgentRegistryReady()) return config;
+  if (getAgent(agentName)?.category === AgentCategory.ToolUse) return config;
+  return { ...config, agentCategory: AgentCategory.Workflow };
+}
 
 // ---------------------------------------------------------------------------
 // Per-execution write queue — serializes read-modify-write cycles on meta
@@ -70,7 +96,7 @@ export async function registerExecution(
   if (delegationDepth !== undefined) meta.delegationDepth = delegationDepth;
 
   const writes: Promise<void>[] = [
-    store.writeConfig(config),
+    store.writeConfig(normalizeWriterCategory(config, agentName)),
     store.writeMeta(meta),
   ];
 

--- a/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
+++ b/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+
+// Stub the registry so the writer guard is hermetic: `research` is a real
+// tool-use agent; `bash` (a process-tracking name) is not. `ready` flips the
+// loaded state so we can assert the "registry not loaded" escape hatch.
+const state = { ready: true };
+vi.mock('@agent/index/agentRegistry', () => ({
+  isAgentRegistryReady: vi.fn(() => state.ready),
+  getAgent: vi.fn((name: string) =>
+    name === 'research' ? { name, category: AgentCategory.ToolUse } : undefined,
+  ),
+}));
+
+const { normalizeWriterCategory } =
+  await import('../../agent/storage/executionLifecycle');
+
+function config(agent: string, agentCategory: AgentCategory): AgentConfig {
+  return { agent, agentCategory } as AgentConfig;
+}
+
+describe('normalizeWriterCategory', () => {
+  it('demotes a ToolUse config whose agent is not a registered tool-use agent', () => {
+    state.ready = true;
+    const result = normalizeWriterCategory(
+      config('bash', AgentCategory.ToolUse),
+      'bash',
+    );
+    expect(result.agentCategory).toBe(AgentCategory.Workflow);
+  });
+
+  it('leaves a real tool-use agent untouched', () => {
+    state.ready = true;
+    const input = config('research', AgentCategory.ToolUse);
+    expect(normalizeWriterCategory(input, 'research')).toBe(input);
+  });
+
+  it('leaves Workflow configs untouched', () => {
+    state.ready = true;
+    const input = config('bash', AgentCategory.Workflow);
+    expect(normalizeWriterCategory(input, 'bash')).toBe(input);
+  });
+
+  it('does not demote when the registry is not loaded', () => {
+    state.ready = false;
+    const input = config('bash', AgentCategory.ToolUse);
+    expect(normalizeWriterCategory(input, 'bash')).toBe(input);
+  });
+});

--- a/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
+++ b/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
@@ -15,7 +15,7 @@ vi.mock('@agent/index/agentRegistry', () => ({
 }));
 
 const { normalizeWriterCategory } =
-  await import('../../agent/storage/executionLifecycle');
+  await import('@agent/storage/executionLifecycle');
 
 function config(agent: string, agentCategory: AgentCategory): AgentConfig {
   return { agent, agentCategory } as AgentConfig;


### PR DESCRIPTION
## Summary

Follow-up to #4400 / #4397. Tool-driven executions — most notably the `bash` background tool (`src/tools/bash.ts`) — persist a synthetic `AgentConfig` tagged `agentCategory: ToolUse` with a name that is **not** a registered tool-use agent (`bash`, etc.).

`chatDefaults.loadHistoryDefaults` picks the most-recent `agentCategory: ToolUse` history row to seed a chat session, so a stale `bash` row could win the history tier — opening a chat with `agent: bash` that crashes on first submit (`Could not find agent: bash`). #4400 made the *reader* robust to those rows; this is the complementary *writer* fix that stops them being written.

## Fix

`registerExecution` now runs the persisted config through `normalizeWriterCategory`: if the config claims `ToolUse` but the loaded registry doesn't know the name as a tool-use agent, demote the persisted category to `Workflow`. The predicate `getAgent(name)?.category === ToolUse` is the same one the reader uses — single source of truth for "is this a tool-use agent".

Safety:
- **Registry-readiness gated** via a new `isAgentRegistryReady()` export. An empty registry can't distinguish "agent absent" from "not loaded", so when it isn't ready we leave the config untouched — never demoting a legitimate agent's run.
- **History display unaffected**: the listing surfaces `meta.category` (e.g. `'process'` for bash) ahead of `config.agentCategory`, so the demotion only affects defaults resolution.
- `AgentConfig.agentCategory` is a flat `z.enum`, so the one-field correction is schema-valid.

## Testing
- New `ExecutionWriterCategory.vitest.mts` — 4 cases (demote unregistered, leave real tool-use, leave Workflow, skip when registry not loaded).
- `ChatDefaults.vitest.mts` still green (8 passed).
- Root + test-kernel typecheck, prettier, eslint — clean.

Closes #4410

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes persisted `AgentConfig.agentCategory` during execution registration, which can affect downstream defaults selection and history behavior if the registry readiness check is wrong or load timing differs.
> 
> **Overview**
> Prevents tool-driven executions (e.g. `bash`) from being persisted as `agentCategory: ToolUse` when the agent name is not a registered tool-use agent, avoiding these rows being selected later as chat-session defaults.
> 
> This adds `isAgentRegistryReady()` to gate lookups, introduces `normalizeWriterCategory()` in `executionLifecycle`, and applies it during `registerExecution` before writing config; a new Vitest file covers demotion, no-op cases, and the registry-not-loaded escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a762a37a890f2b1901373860e940e705a97ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->