### PR TITLE
fix(cli): render chat in primary buffer so history lands in native scrollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **Scroll back through the full chat history** — the CLI chat now renders to your terminal's primary screen and commits finalized messages to native scrollback. Two-finger swipe (or mouse wheel) scrolls up through every past message; selection, copy, and Cmd+F all work. Long replies are no longer collapsed behind a `⋯ N earlier entries hidden` marker.
 - **CLI chat stays pinned during long output** — the chat header, input, and status rows now stay visible while long replies and tool output stream in the terminal.
 
 ## [0.37.9] - 2026-05-18

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,14 +1,14 @@
 // Ink TUI root: conversation, optional side column, status, approval modal,
 // and input bar. Tab / Shift-Tab cycles focus across subagent streams.
 
-import { Box, Text, useInput, useWindowSize } from 'ink';
+import { Box, Static, Text, useInput, useWindowSize } from 'ink';
 import { useState } from 'react';
 
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
 import { REVERSE_SEARCH_ROWS } from './input/ReverseSearch';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ChildControlPicker } from './modals/ChildControlPicker';
-import { ConversationPane } from './panes/ConversationPane';
+import { ConversationPane, TranscriptEntry } from './panes/ConversationPane';
 import { HeaderPane } from './panes/HeaderPane';
 import { InputBar } from './panes/InputBar';
 import { StatusBar } from './panes/StatusBar';
@@ -24,6 +24,7 @@ import {
 } from './state/childControls';
 import { canShowSubagentControls, cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
+import { scrollbackLog } from './state/scrollbackLog';
 import { useSignal } from './state/useSignal';
 import type { InputHistory } from './history/inputHistory';
 
@@ -181,6 +182,7 @@ export function App(props: AppProps): React.JSX.Element {
   const activeForm = useSignal(cliState.activeForm);
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
   const reverseSearchOpen = useSignal(cliState.reverseSearchOpen);
+  const scrollback = useSignal(scrollbackLog);
   const { columns, rows } = useWindowSize();
   const [childControlMode, setChildControlMode] = useState<
     ChildControlMode | undefined
@@ -307,13 +309,29 @@ export function App(props: AppProps): React.JSX.Element {
   );
 
   return (
-    <Box flexDirection="column" height={rows}>
+    <Box flexDirection="column">
+      {/* Finalized history is committed to the terminal's native scrollback
+       *  via `<Static>`: Ink prints each item once, above the live frame, and
+       *  never rewrites it — so the user can scroll/select/copy the full
+       *  conversation with their normal terminal gestures (two-finger swipe,
+       *  Cmd+F). The dynamic frame below is the only region Ink redraws. */}
+      <Static items={scrollback}>
+        {(item) => (
+          <TranscriptEntry
+            key={item.key}
+            entry={item.entry}
+            width={transcriptWidth}
+          />
+        )}
+      </Static>
+      {/* Live frame — redrawn each delta, pinned at the bottom. The rule and
+       *  header delimit committed history (above) from live output (below). */}
       <Box>
         <Text color="cyan">{'─'.repeat(columns)}</Text>
       </Box>
       <HeaderPane />
-      <Box flexDirection="row" flexGrow={1} overflowY="hidden">
-        <Box flexDirection="column" flexGrow={1} overflowY="hidden">
+      <Box flexDirection="row">
+        <Box flexDirection="column" flexGrow={1}>
           {transcriptRows > 0 ? (
             <ConversationPane
               width={transcriptWidth}
@@ -327,12 +345,7 @@ export function App(props: AppProps): React.JSX.Element {
           ) : null}
         </Box>
         {showSideColumn ? (
-          <Box
-            flexDirection="column"
-            minWidth={SIDE_COLUMN_WIDTH}
-            height={transcriptRows}
-            overflowY="hidden"
-          >
+          <Box flexDirection="column" minWidth={SIDE_COLUMN_WIDTH}>
             <SubagentList maxRows={subagentRows} />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -62,7 +62,10 @@ function ProcessEntryRow({
   );
 }
 
-function TranscriptEntry({
+// Renders a single finalized entry. Exported so the App-level `<Static>`
+// scrollback region can render committed history with the same formatting
+// the live region uses once an entry finalizes.
+export function TranscriptEntry({
   entry,
   width,
 }: {
@@ -354,70 +357,58 @@ export interface ConversationPaneProps {
   readonly maxRows?: number;
 }
 
+// Live region only. Finalized history is committed to the App-level
+// `<Static>` scrollback (see `state/scrollbackLog.ts`) so it lands in the
+// terminal's native scrollback and stays readable/scrollable; this pane
+// renders just the in-flight entries for the active stream. It is
+// content-sized — no fixed-height box — so an idle session puts the input
+// bar directly under the history instead of reserving blank rows.
 export function ConversationPane(
   props: ConversationPaneProps = {},
-): React.JSX.Element {
+): React.JSX.Element | null {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
-  const { finalized, pending } = splitTranscriptEntries(entries, slice?.status);
-  const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
-  const { pendingRows, visibleFinalized, visiblePending } =
-    selectConversationEntriesForViewport({
-      finalized,
-      maxRows,
-      pending,
-      width: props.width,
-    });
+  const { pending } = splitTranscriptEntries(entries, slice?.status);
+  if (pending.length === 0) return null;
 
+  // `maxRows` is a *cap* on the live region (so a tool burst can't shove the
+  // input off-screen), not a reserved height.
+  const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
+  const visiblePending = selectPendingEntriesForViewport(
+    pending,
+    Math.max(MIN_PENDING_ROWS, maxRows),
+    props.width,
+  );
+
+  // `pending` interleaves the in-flight assistant entry with tool rows in
+  // stream order — rendering them as separate buckets would flip the visible
+  // order when the model emits text before a tool call.
   return (
-    <Box flexDirection="column" height={maxRows} overflowY="hidden">
-      <Box
-        flexDirection="column"
-        height={visibleFinalized.usedRows}
-        overflowY="hidden"
-      >
-        {visibleFinalized.hiddenCount > 0 ? (
-          <Text dimColor>
-            {`⋯ ${visibleFinalized.hiddenCount} earlier ${
-              visibleFinalized.hiddenCount === 1 ? 'entry' : 'entries'
-            } hidden`}
-          </Text>
-        ) : null}
-        {visibleFinalized.entries.map((entry) => (
-          <TranscriptEntry key={entry.id} entry={entry} width={props.width} />
-        ))}
-      </Box>
-      {/* `pending` interleaves the in-flight assistant entry with tool
-       *  rows in stream order — rendering them as separate buckets would
-       *  flip the visible order when the model emits text before a tool
-       *  call. The explicit height keeps the input bar pinned and prevents
-       *  tool bursts from stealing rows reserved for the footer chrome. */}
-      <Box flexDirection="column" height={pendingRows} overflowY="hidden">
-        {visiblePending.hiddenCount > 0 ? (
-          <Text dimColor>
-            {`⋯ ${visiblePending.hiddenCount} live ${
-              visiblePending.hiddenCount === 1 ? 'entry' : 'entries'
-            } hidden`}
-          </Text>
-        ) : null}
-        {visiblePending.entries.map((entry) => {
-          if (entry.role === 'tool' && entry.toolUse) {
-            return <ToolUseRow key={entry.id} toolUse={entry.toolUse} />;
-          }
-          if (entry.role === 'assistant') {
-            return (
-              <LiveTranscriptEntry
-                key={entry.id}
-                entry={entry}
-                width={props.width}
-              />
-            );
-          }
-          return null;
-        })}
-      </Box>
+    <Box flexDirection="column">
+      {visiblePending.hiddenCount > 0 ? (
+        <Text dimColor>
+          {`⋯ ${visiblePending.hiddenCount} live ${
+            visiblePending.hiddenCount === 1 ? 'entry' : 'entries'
+          } hidden`}
+        </Text>
+      ) : null}
+      {visiblePending.entries.map((entry) => {
+        if (entry.role === 'tool' && entry.toolUse) {
+          return <ToolUseRow key={entry.id} toolUse={entry.toolUse} />;
+        }
+        if (entry.role === 'assistant') {
+          return (
+            <LiveTranscriptEntry
+              key={entry.id}
+              entry={entry}
+              width={props.width}
+            />
+          );
+        }
+        return null;
+      })}
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/HeaderPane.tsx
+++ b/packages/cli/src/chat/tui/panes/HeaderPane.tsx
@@ -1,6 +1,7 @@
-// Sticky header pane — rendered as an Ink component so it pins to the top of
-// the alternate screen for the whole session. Replaces the pre-mount string
-// banner that lived in terminal scrollback and scrolled away.
+// Header pane — rendered at the top of Ink's live frame, just above the live
+// output and below the committed `<Static>` history. It stays pinned with the
+// prompt while finalized history scrolls away into the terminal's native
+// scrollback.
 
 import os from 'node:os';
 import path from 'node:path';

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -76,6 +76,7 @@ import { notify } from './notifications/terminalNotifier';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
 import { installTuiApprovals } from './state/subscribeApprovals';
+import { startScrollbackSync } from './state/scrollbackLog';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog, syncStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
@@ -88,10 +89,7 @@ import {
   appendLocalUserTranscript,
   moveLocalTranscriptToStream,
 } from './state/transcript';
-import {
-  cleanupTerminalModes,
-  enterTerminalFullScreen,
-} from './terminalCleanup';
+import { cleanupTerminalModes } from './terminalCleanup';
 
 export interface ChatResult {
   exitCode: number;
@@ -676,6 +674,9 @@ export async function runChat(
   const disposers: Array<() => void> = [];
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
+  // Commit finalized entries to the append-only `<Static>` scrollback log as
+  // streams change, so history lands in the terminal's native scrollback.
+  disposers.push(startScrollbackSync());
 
   const session: TuiSession = {
     streamId: undefined,
@@ -880,7 +881,9 @@ export async function runChat(
     });
   };
 
-  enterTerminalFullScreen();
+  // Render in the primary buffer (no alternate screen) so finalized history
+  // committed via `<Static>` accumulates in the terminal's native scrollback
+  // and stays scrollable/selectable after the session ends.
   const ink = render(
     <App
       onSubmit={handleSubmit}

--- a/packages/cli/src/chat/tui/state/scrollbackLog.ts
+++ b/packages/cli/src/chat/tui/state/scrollbackLog.ts
@@ -1,0 +1,86 @@
+// Append-only scrollback log for the Ink `<Static>` history region.
+//
+// Ink 7's `<Static>` only ever renders items appended to the end of its
+// `items` array (`items.slice(index)` with a monotonically climbing
+// `index`). Swapping in a different array — e.g. when Tab switches the
+// active stream — prints nothing new and strands the previous lines in
+// scrollback. So the transcript that backs `<Static>` must be ONE
+// append-only list merged across every stream; per-stream switching only
+// drives the live (dynamic) region, never the committed history.
+//
+// Finalized entries are immutable (assistant text is frozen by
+// `finalizeAssistantTranscriptEntries`, tool rows finalize with their final
+// state at end-of-stream), so committing them once is safe.
+
+import { signal, Signal } from '@lit-labs/signals';
+
+import type { StreamTabId } from '@shared/schemas';
+
+import {
+  cliState,
+  registerCliStateResetHook,
+  type ConversationEntry,
+} from './cliState';
+
+export interface ScrollbackItem {
+  /** Stable React key — the entry id, which is unique across streams. */
+  readonly key: string;
+  /** Stream the entry belongs to (used to label sub-agent history). */
+  readonly streamId: StreamTabId;
+  readonly entry: ConversationEntry;
+}
+
+// Typed as a mutable array (not `readonly`) to satisfy Ink's `<Static>`
+// `items: T[]` prop without copying the whole history every render. The
+// array is only ever *replaced* (never mutated in place), so the
+// append-only invariant still holds.
+const SCROLLBACK = signal<ScrollbackItem[]>([]);
+
+/** The committed, append-only finalized transcript across all streams. */
+export const scrollbackLog = SCROLLBACK as Signal.State<ScrollbackItem[]>;
+
+// Entry ids already committed. Keyed by `entry.id` alone (not
+// `streamId:id`) so re-parenting a local entry into its real stream via
+// `moveLocalTranscriptToStream` — which keeps the id but changes the stream —
+// does not commit it twice.
+const committedIds = new Set<string>();
+
+/** Commit any newly-finalized entries to the append-only log, preserving
+ *  insertion order. Cheap and idempotent: each entry is appended at most
+ *  once. Iterates streams in Map order, then entries in stream order, which
+ *  matches arrival order in the common single-stream case. */
+export function syncScrollbackFromStreams(): void {
+  const streams = cliState.streams.get();
+  let next: ScrollbackItem[] | undefined;
+  for (const [streamId, slice] of streams) {
+    for (const entry of slice.entries) {
+      if (!entry.finalized) continue;
+      if (committedIds.has(entry.id)) continue;
+      committedIds.add(entry.id);
+      (next ??= [...SCROLLBACK.get()]).push({
+        key: entry.id,
+        streamId,
+        entry,
+      });
+    }
+  }
+  if (next) SCROLLBACK.set(next);
+}
+
+/** Begin committing finalized entries to the scrollback log as streams
+ *  change. Returns a disposer. Mirrors the `Signal.subtle.Watcher`
+ *  re-arm pattern in `useSignal`. */
+export function startScrollbackSync(): () => void {
+  syncScrollbackFromStreams();
+  const watcher = new Signal.subtle.Watcher(() => {
+    syncScrollbackFromStreams();
+    watcher.watch();
+  });
+  watcher.watch(cliState.streams);
+  return () => watcher.unwatch(cliState.streams);
+}
+
+registerCliStateResetHook(() => {
+  committedIds.clear();
+  SCROLLBACK.set([]);
+});

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -1,21 +1,14 @@
 import { writeSync } from 'node:fs';
 
-const ENTER_TERMINAL_FULL_SCREEN = '\x1b[?1049h\x1b[2J\x1b[H';
+// Resets input/display modes the session may have enabled. `?1049l` (leave
+// alternate screen) is kept defensively even though the CLI now renders in
+// the primary buffer — it is a no-op if no alternate screen was entered.
 const RESET_TERMINAL_MODES =
   '\x1b[?1000;1003;1006l\x1b[?1049l\x1b[<u\x1b[?2004l\x1b[?25h';
 const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';
 
 export interface CleanupTerminalModesOptions {
   readonly clearItermProgress?: boolean;
-}
-
-export function enterTerminalFullScreen(): void {
-  try {
-    writeSync(1, ENTER_TERMINAL_FULL_SCREEN);
-  } catch {
-    // Startup cannot surface terminal-mode failures usefully; Ink will still
-    // render in the primary buffer.
-  }
 }
 
 export function cleanupTerminalModes(

--- a/src/test-kernel/cli/ScrollbackLog.vitest.ts
+++ b/src/test-kernel/cli/ScrollbackLog.vitest.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { StreamTabId } from '@shared/schemas';
+
+import {
+  cliState,
+  patchStream,
+  resetCliState,
+  type ConversationEntry,
+} from '../../../packages/cli/src/chat/tui/state/cliState';
+import {
+  scrollbackLog,
+  syncScrollbackFromStreams,
+} from '../../../packages/cli/src/chat/tui/state/scrollbackLog';
+
+const ROOT = 'root-stream' as StreamTabId;
+const CHILD = 'child-stream' as StreamTabId;
+
+function entry(
+  id: string,
+  text: string,
+  finalized: boolean,
+): ConversationEntry {
+  return { id, role: 'assistant', text, finalized };
+}
+
+function append(streamId: StreamTabId, ...entries: ConversationEntry[]): void {
+  patchStream(streamId, (slice) => ({
+    ...slice,
+    entries: [...slice.entries, ...entries],
+  }));
+}
+
+function logTexts(): string[] {
+  return scrollbackLog.get().map((item) => item.entry.text);
+}
+
+describe('CLI scrollback log (Static history backing store)', () => {
+  afterEach(() => {
+    resetCliState();
+    syncScrollbackFromStreams();
+  });
+
+  it('commits only finalized entries, in stream order', () => {
+    append(ROOT, entry('a', 'first', true), entry('b', 'in-flight', false));
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual(['first']);
+  });
+
+  it('is append-only: committed entries are never dropped or reordered as new ones finalize', () => {
+    append(ROOT, entry('a', 'first', true));
+    syncScrollbackFromStreams();
+    const firstRef = scrollbackLog.get();
+
+    append(ROOT, entry('b', 'second', true));
+    syncScrollbackFromStreams();
+
+    expect(logTexts()).toEqual(['first', 'second']);
+    // New array reference (so `<Static>` sees a change) but the existing
+    // item objects are reused, preserving identity for already-printed rows.
+    expect(scrollbackLog.get()).not.toBe(firstRef);
+    expect(scrollbackLog.get()[0]).toBe(firstRef[0]);
+  });
+
+  it('commits each entry exactly once even when re-synced repeatedly', () => {
+    append(ROOT, entry('a', 'first', true));
+    syncScrollbackFromStreams();
+    syncScrollbackFromStreams();
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual(['first']);
+  });
+
+  it('does not double-commit when an entry is re-parented to another stream (same id)', () => {
+    // Mirrors moveLocalTranscriptToStream: the entry keeps its id but moves
+    // streams. Dedup is keyed by entry.id, so it must not appear twice.
+    append(ROOT, entry('shared-id', 'hello', true));
+    syncScrollbackFromStreams();
+
+    // Re-parent: same id now lives under CHILD too.
+    append(CHILD, entry('shared-id', 'hello', true));
+    syncScrollbackFromStreams();
+
+    expect(logTexts()).toEqual(['hello']);
+  });
+
+  it('merges finalized entries across streams into one linear log', () => {
+    append(ROOT, entry('r1', 'root-1', true));
+    append(CHILD, entry('c1', 'child-1', true));
+    syncScrollbackFromStreams();
+    // Both present; root stream (inserted first) precedes the child.
+    expect(logTexts()).toEqual(['root-1', 'child-1']);
+  });
+
+  it('promotes an entry once it transitions to finalized', () => {
+    append(ROOT, entry('a', 'streaming…', false));
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual([]);
+
+    // Finalize in place (new object, same id) as finalizeAssistantTranscriptEntries does.
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      entries: slice.entries.map((e) =>
+        e.id === 'a' ? { ...e, finalized: true } : e,
+      ),
+    }));
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual(['streaming…']);
+  });
+
+  it('clears on session reset', () => {
+    append(ROOT, entry('a', 'first', true));
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual(['first']);
+
+    resetCliState();
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual([]);
+    // A fresh entry with a previously-seen id still commits after reset.
+    cliState.activeStreamId.set(ROOT);
+    append(ROOT, entry('a', 'reborn', true));
+    syncScrollbackFromStreams();
+    expect(logTexts()).toEqual(['reborn']);
+  });
+});


### PR DESCRIPTION
## What this fixes

The CLI chat collapses history so fast that nothing older than a few rows is readable — and the terminal's own scroll-up is dead while the chat is running. Reported as a release blocker.

The root cause is two compounding properties:

1. **The chat enters the terminal alternate screen** — `terminalCleanup.ts` unconditionally writes `\x1b[?1049h` from `runChatTui.tsx` before `render()`. The alt screen disables the terminal's *own* scrollback by design (Ink's own docs say so).
2. **The conversation pane clips finalized entries to a viewport tail** — `selectFinalizedEntriesForViewport` keeps only the last entries that fit `maxRows` and replaces the rest with `⋯ N earlier entries hidden`, with no scroll offset and no key handler to walk backwards.

So neither native nor in-app history reach existed. #4160 partially helped by capping the live streaming region, but the underlying alt-screen-plus-clipped-viewport problem was untouched.

## The fix (native scrollback via Ink 7 `<Static>`)

Ink 7 made this the idiomatic path: `alternateScreen` is a first-class render option (default off), and `<Static>` is purpose-built to commit immutable items to the terminal's real scrollback. The intent was already in the codebase — `transcriptEntries.ts` and `ConversationPane.vitest.ts` both reference `<Static>` scrollback by name.

- **`state/scrollbackLog.ts` (new)** — append-only signal of finalized entries, merged across all streams. Dedup keyed by `entry.id` so `moveLocalTranscriptToStream` (re-parents an entry; keeps the id) doesn't double-commit. `Signal.subtle.Watcher` on `cliState.streams` triggers `syncScrollbackFromStreams`.
- **`App.tsx`** — renders `<Static items={scrollback}>` at the top of the tree; drops `height={rows}` from the root and the fixed-height side-column reservation so the live frame is content-sized.
- **`panes/ConversationPane.tsx`** — pending/live-only and content-sized; no clipped finalized viewport, no fixed-height box reserving blank rows. Exports `TranscriptEntry` so `<Static>` can render committed history with the same formatting. The pure `select*` / `estimate*` helpers are kept exported so `TuiStateAndFocus.vitest.mts` still has its guards.
- **`runChatTui.tsx`** — removes `enterTerminalFullScreen()`; adds `disposers.push(startScrollbackSync())`. The render now lives in the primary buffer.
- **`terminalCleanup.ts`** — drops the now-unused `enterTerminalFullScreen`; the reset string still resets mouse / kitty / bracketed-paste / cursor; `?1049l` kept defensively (no-op when no alt screen was entered).

Result for the user: two-finger trackpad swipe / mouse wheel scrolls through every past message, text selection and copy work, Cmd+F searches the history — exactly the way a normal shell session behaves.

## Verification

- **Type-check** (`packages/cli`): clean.
- **`check:architecture`**: clean.
- **TUI tests**: **54 / 54 pass** — including 7 new `ScrollbackLog.vitest.ts` cases that lock the data layer feeding `<Static>`:
  - commits only finalized entries, in stream order
  - append-only — committed items are never dropped or reordered (existing item identity is preserved)
  - exactly once across repeated sync calls
  - **no double-commit when an entry is re-parented to another stream (same id)**
  - cross-stream merge into one linear log
  - promotion when an entry transitions to `finalized: true`
  - clean reset on session reset
- **PTY smoke** (real `texra chat` under macOS `script`): zero `\x1b[?1049h` in the capture (alt screen is gone). A submitted user line lands once at the top of the capture — committed to scrollback — while the header / input / status live frame redraws below.

## Trade-offs

- **Header stays pinned in the live frame** (above the prompt, below the rule), instead of committing once to `<Static>` as a one-shot banner. Simpler, lower-risk, keeps session context persistently visible. Easy to flip later.
- **Multi-stream Tab switching** only drives the live region. Sub-agent finalized entries interleave into the single linear scrollback in commit order — deliberately no per-stream visual labels in this first cut. If interleaving feels noisy in practice, labeling is a tiny follow-up.
- **`select*` / `estimate*` helpers in `ConversationPane`** are kept exported but unused in production (still exercised by tests). Pruning them belongs in a separate cleanup PR.
- **No mouse-tracking sequences enabled.** Trackpad scroll works through the terminal directly — no `\x1b[?1000/?1006` plumbing, no broken text selection.

## Files

- `packages/cli/src/chat/tui/state/scrollbackLog.ts` (new)
- `packages/cli/src/chat/tui/App.tsx`
- `packages/cli/src/chat/tui/panes/ConversationPane.tsx`
- `packages/cli/src/chat/tui/panes/HeaderPane.tsx` (comment only)
- `packages/cli/src/chat/tui/runChatTui.tsx`
- `packages/cli/src/chat/tui/terminalCleanup.ts`
- `src/test-kernel/cli/ScrollbackLog.vitest.ts` (new)
- `CHANGELOG.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core CLI TUI rendering behavior (switching away from alternate screen and refactoring transcript rendering), which could affect layout, performance, or stream ordering during long/tool-heavy sessions.
> 
> **Overview**
> Enables full terminal-native scrollback for `texra chat` by rendering the Ink TUI in the primary buffer and committing finalized transcript entries via Ink 7’s `<Static>` instead of keeping history in a clipped in-app viewport.
> 
> This introduces a new append-only `scrollbackLog` store synced from finalized stream entries, updates `App` to render committed history above a pinned live frame, and refactors `ConversationPane` to render *live/pending only* (removing the `⋯ N earlier entries hidden` behavior). It also removes the explicit alternate-screen entry helper while keeping defensive terminal mode cleanup, adds sync wiring in `runChatTui`, and includes new unit tests covering scrollback append/dedup/reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa172e096a67254d4cb4474e7f45011ec2934400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->