### PR TITLE
fix(cli): expose `id` alongside `value` in models JSON/NDJSON output

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,5 +1,7 @@
 import { defineCommand } from 'citty';
 
+import type { ModelOptionData } from '@shared/schemas';
+
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -20,6 +22,18 @@ import type { CliContext } from '../runtime/cliContext';
 
 type ModelAccessList = Awaited<ReturnType<typeof getCliModelAccessList>>;
 type ModelAccessEntry = ModelAccessList[number];
+
+/**
+ * Output projection for JSON/NDJSON: prefix the model record with `id` so the
+ * model id is addressable under the same key (`.id`) as every other CLI
+ * resource (`agents`, `multi-agent`, `history`). `value` is kept for backward
+ * compatibility with existing scripts.
+ */
+export function cliModelRecord(
+  model: ModelOptionData,
+): { id: string } & ModelOptionData {
+  return { id: model.value, ...model };
+}
 
 async function loadModelAccessList(
   context: CliContext,
@@ -44,7 +58,7 @@ async function listModels(context: CliContext): Promise<number> {
   if (context.outputFormat === 'json') {
     writeTextStdout(
       JSON.stringify(
-        result.map(({ model }) => model),
+        result.map(({ model }) => cliModelRecord(model)),
         null,
         2,
       ),
@@ -55,7 +69,7 @@ async function listModels(context: CliContext): Promise<number> {
   if (context.outputFormat === 'ndjson') {
     const ts = new Date().toISOString();
     for (const { model } of result) {
-      writeNdjsonStdout({ kind: 'model', ts, model });
+      writeNdjsonStdout({ kind: 'model', ts, model: cliModelRecord(model) });
     }
     return CliExitCode.Success;
   }
@@ -108,7 +122,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
   }
 
   if (context.outputFormat === 'json') {
-    writeTextStdout(JSON.stringify(entry.model, null, 2));
+    writeTextStdout(JSON.stringify(cliModelRecord(entry.model), null, 2));
     return CliExitCode.Success;
   }
 
@@ -116,7 +130,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
     writeNdjsonStdout({
       kind: 'model',
       ts: new Date().toISOString(),
-      model: entry.model,
+      model: cliModelRecord(entry.model),
     });
     return CliExitCode.Success;
   }

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ModelOptionData } from '@shared/schemas';
+
+import { cliModelRecord } from '../../../packages/cli/src/commands/models';
+
+function model(overrides: Partial<ModelOptionData> = {}): ModelOptionData {
+  return {
+    value: 'sonnet46T',
+    label: 'Sonnet 4.6 (Thinking)',
+    provider: 'anthropic',
+    context: '1.0M',
+    cost: '$3.000/$15.000',
+    hint: '1M context',
+    availability: 'included-access',
+    availabilityLabel: 'Included access',
+    requiresKey: false,
+    disabled: false,
+    ...overrides,
+  } as ModelOptionData;
+}
+
+describe('CLI model JSON record', () => {
+  it('exposes an `id` field aliased to `value` for cross-resource addressability', () => {
+    const record = cliModelRecord(model());
+
+    expect(record.id).toBe('sonnet46T');
+    // `value` is preserved for backward compatibility with existing scripts.
+    expect(record.value).toBe('sonnet46T');
+    // `id` must appear before `value` so callers using `Object.keys()[0]`
+    // (and human readers) see the canonical key first.
+    expect(Object.keys(record)[0]).toBe('id');
+  });
+
+  it('does not drop any of the upstream model fields', () => {
+    const m = model({
+      provider: 'openai',
+      cost: '$1.250/$10.000',
+      availabilityLabel: 'Personal key',
+      requiresKey: true,
+    });
+    const record = cliModelRecord(m);
+
+    for (const key of Object.keys(m)) {
+      expect(record).toHaveProperty(key);
+      expect(record[key as keyof typeof record]).toEqual(
+        m[key as keyof ModelOptionData],
+      );
+    }
+  });
+
+  it('keeps `id` synchronized with `value` even when `value` is mutated upstream', () => {
+    // The projection is pure: mutating the source after the call must not
+    // change either alias. Guards against future shared-reference mistakes.
+    const m = model({ value: 'gpt55' });
+    const record = cliModelRecord(m);
+
+    expect(record).toMatchObject({ id: 'gpt55', value: 'gpt55' });
+  });
+});

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -49,12 +49,16 @@ describe('CLI model JSON record', () => {
     }
   });
 
-  it('keeps `id` synchronized with `value` even when `value` is mutated upstream', () => {
-    // The projection is pure: mutating the source after the call must not
-    // change either alias. Guards against future shared-reference mistakes.
+  it('snapshots the source `value` so post-call mutation does not bleed in', () => {
+    // Guards against a future regression where `cliModelRecord` is rewritten
+    // to return a reference instead of a copy: mutating `m.value` after the
+    // projection must not change the record's `id` or `value`.
     const m = model({ value: 'gpt55' });
     const record = cliModelRecord(m);
 
-    expect(record).toMatchObject({ id: 'gpt55', value: 'gpt55' });
+    (m as { value: string }).value = 'mutated-after-call';
+
+    expect(record.id).toBe('gpt55');
+    expect(record.value).toBe('gpt55');
   });
 });


### PR DESCRIPTION
## Summary

Every other CLI resource exposes its identifier under a uniform key in JSON/NDJSON output (`agents`/`skills`: `name`; `multi-agent`/`history`: `id`), but `texra models list` / `models show` passes the shared `ModelOptionData` shape through unchanged and uses **`value`**. Scripts can't `.[].id` across CLI resources.

Add an additive `id` field at the front of the JSON/NDJSON model record (`{ id: model.value, ...model }`). `value` is preserved for back-compat. Text output is unchanged (already prints `id: <value>`).

Closes #4422.

## Changes

- `packages/cli/src/commands/models.ts`: new `cliModelRecord` projection used by both `list` and `show` JSON/NDJSON paths.
- `src/test-kernel/cli/ModelsRecord.vitest.mts`: 3 new unit cases (id present, value preserved, key order, no fields dropped, projection is pure).

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 264/264 (3 new)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe:
  - `texra models list --output-format json | jq '.[0] | keys[0]'` → `"id"`
  - `texra models show sonnet46T --output-format json | jq '.id'` → `"sonnet46T"` (and `.value` still works)

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js models list --output-format json | python3 -c "import json,sys; d=json.load(sys.stdin); print(list(d[0].keys())[:3])"
# → ['id', 'value', 'label']
node dist/bin/texra.js models show sonnet46T --output-format json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['id'], d['value'])"
# → sonnet46T sonnet46T
npx vitest run src/test-kernel/cli/ModelsRecord.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additive `id` field to CLI `models` JSON/NDJSON output without changing text output or lookup behavior; primary risk is minor breaking expectations for consumers relying on exact JSON shape/order.
> 
> **Overview**
> Aligns `texra models list`/`models show` JSON and NDJSON output with other CLI resources by projecting model records to include an `id` field (aliased from `value`) while keeping `value` for backward compatibility.
> 
> Adds unit tests for the `cliModelRecord` projection to ensure `id` is first, no upstream fields are dropped, and the projection is a copy (insulated from later mutation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77ca12b83d9e46e8447b3ff84eb76c171748bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->