### PR TITLE
fix(cli): a-z hotkeys for picker items past 9 (closes #4398)

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -9,7 +9,7 @@ import { computeAgentOptionsData } from '@agent/index';
 import type { AgentOptionData } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
-import { Select } from '../ui/Select';
+import { Select, selectHotkeyHint } from '../ui/Select';
 
 export interface AgentListFormProps {
   readonly currentAgent: string;
@@ -262,7 +262,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
-              { key: '1-9', action: 'select' },
+              { key: selectHotkeyHint(items.length), action: 'select' },
             ]}
           />
         ) : (

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -6,7 +6,7 @@ import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
-import { Select } from '../ui/Select';
+import { Select, selectHotkeyHint } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
 import {
   getCliModelAccessList,
@@ -200,7 +200,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
-              { key: '1-9', action: 'select' },
+              { key: selectHotkeyHint(items.length), action: 'select' },
             ]}
           />
         ) : (

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -5,7 +5,8 @@
 // docs/prd/cli-tui-ink/10-architecture.md § Intuitiveness conventions.
 //
 // `↑/↓` walks the rows, Enter calls `onSelect`, Esc calls `onCancel`. Items
-// receive a 1-based numeric prefix so digit shortcuts can jump directly.
+// 1-9 are reachable by digit; items 10-35 by a-z (lowercase). Beyond 35,
+// only arrow-key navigation reaches the row.
 
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
@@ -68,6 +69,33 @@ export function selectItemRenderKey<T>(
   return `${index}:${item.label}`;
 }
 
+const A_LOWERCASE = 'a'.charCodeAt(0);
+const Z_LOWERCASE = 'z'.charCodeAt(0);
+
+/** Map a typed keystroke to a zero-based item index, or undefined if unbound. */
+export function hotkeyIndex(input: string): number | undefined {
+  if (input.length !== 1) return undefined;
+  const digit = Number(input);
+  if (Number.isInteger(digit) && digit >= 1 && digit <= 9) return digit - 1;
+  const code = input.charCodeAt(0);
+  if (code >= A_LOWERCASE && code <= Z_LOWERCASE) return code - A_LOWERCASE + 9;
+  return undefined;
+}
+
+/** Render the leading slot for an item: `1.`-`9.`, `a.`-`z.`, or two spaces. */
+export function selectIndexLabel(index: number): string {
+  if (index < 9) return `${index + 1}.`;
+  if (index < 9 + 26) return `${String.fromCharCode(A_LOWERCASE + index - 9)}.`;
+  return '  ';
+}
+
+/** Footer hint string matching the active hotkey range for a given item count. */
+export function selectHotkeyHint(itemCount: number): string {
+  if (itemCount <= 0) return '';
+  if (itemCount <= 9) return '1-9';
+  return '1-9 a-z';
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const activeIndex = props.items.findIndex(
     (it) => it.value === props.activeValue,
@@ -113,16 +141,15 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       if (choice && !choice.disabled) props.onSelect(choice.value);
       return;
     }
-    // 1-9 digit jumps for direct selection.
-    const digit = Number(input);
-    if (Number.isInteger(digit) && digit >= 1 && digit <= 9) {
-      const idx = digit - 1;
-      if (idx < props.items.length) {
-        const choice = props.items[idx];
-        if (choice && !choice.disabled) {
-          setHighlight(idx);
-          props.onSelect(choice.value);
-        }
+    // 1-9 digit jumps for items 1-9; a-z covers items 10-35 so pickers with
+    // many remote agents (the worst offender is `/agent`, which can list 18+)
+    // do not have a silent number-less tail.
+    const idx = hotkeyIndex(input);
+    if (idx != null && idx < props.items.length) {
+      const choice = props.items[idx];
+      if (choice && !choice.disabled) {
+        setHighlight(idx);
+        props.onSelect(choice.value);
       }
     }
   });
@@ -138,7 +165,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         const active = item.value === props.activeValue;
         const pointer = focused ? '›' : ' ';
         const tick = active ? '✓' : ' ';
-        const numeric = i < 9 ? `${i + 1}.` : '  ';
+        const numeric = selectIndexLabel(i);
         return (
           <Box key={selectItemRenderKey(item, i)} minWidth={0}>
             <Box flexShrink={0}>

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hotkeyIndex,
+  selectHotkeyHint,
+  selectIndexLabel,
+} from '../../../packages/cli/src/chat/tui/ui/Select';
+
+describe('CLI Select hotkey ergonomics', () => {
+  it('maps 1-9 to indices 0-8', () => {
+    expect(hotkeyIndex('1')).toBe(0);
+    expect(hotkeyIndex('9')).toBe(8);
+  });
+
+  it('maps a-z to indices 9-34 so items past 9 stay one-key reachable', () => {
+    expect(hotkeyIndex('a')).toBe(9);
+    expect(hotkeyIndex('z')).toBe(9 + 25);
+  });
+
+  it('rejects keystrokes that do not bind a hotkey', () => {
+    expect(hotkeyIndex('0')).toBeUndefined();
+    expect(hotkeyIndex('A')).toBeUndefined(); // uppercase reserved for shifted shortcuts elsewhere
+    expect(hotkeyIndex('!')).toBeUndefined();
+    expect(hotkeyIndex('')).toBeUndefined();
+    expect(hotkeyIndex('ab')).toBeUndefined();
+  });
+
+  it('renders the leading slot consistently with the bound keystroke', () => {
+    expect(selectIndexLabel(0)).toBe('1.');
+    expect(selectIndexLabel(8)).toBe('9.');
+    expect(selectIndexLabel(9)).toBe('a.');
+    expect(selectIndexLabel(34)).toBe('z.');
+    expect(selectIndexLabel(35)).toBe('  '); // beyond a-z: arrow-key only
+  });
+
+  it('hints just `1-9` for small pickers and `1-9 a-z` once items overflow', () => {
+    expect(selectHotkeyHint(0)).toBe('');
+    expect(selectHotkeyHint(1)).toBe('1-9');
+    expect(selectHotkeyHint(9)).toBe('1-9');
+    expect(selectHotkeyHint(10)).toBe('1-9 a-z');
+    expect(selectHotkeyHint(35)).toBe('1-9 a-z');
+  });
+});


### PR DESCRIPTION
## Summary

`/agent` listed all visible tool-use agents but only the first 9 had a number prefix and a one-key shortcut. Beyond 9 the picker rendered each row with two leading spaces and the footer kept saying `1-9 select` — so on any workspace with ≥10 visible tool-use agents (typical once remote agents load) there was a silent gap between item 9 and the un-numbered tail.

This PR binds items 10-35 to `a-z` (lowercase, ASCII order) and switches the footer hint to `1-9 a-z select` once `items.length` crosses 9. Beyond 35, only arrow-key navigation reaches the row — no current picker is anywhere near that ceiling.

Captured frame from a pty replay against the rebuilt CLI:

```
 ›   1. orchestrator      …
     2. leanOrchestrator  …
   ✓ 3. research          …
     …
     9. lean              …
     a. leanBlueprint     …
     b. leanSearch        …
     c. leanSimplifier    …
     d. numerics          …
     e. presenter         …
     f. progressCheck     …
     g. search            …
     h. setup             …
     i. simplifier        …
 ↑/↓ navigate · 1-9 a-z select · Enter confirm · Esc cancel
```

## Issue acceptance gates

Closes #4398.

- [x] Every visible row in `/agent` has a stable single-key shortcut (1-9, then a-z up to 35 items).
- [x] Footer matches the active range — `1-9` for picker with ≤9 items, `1-9 a-z` for 10+.
- [x] The `✓` marker for the current selection works (already true after #4400 fixed the registry-mismatch crash that was preventing the active row from matching).
- [x] No new abstractions imposed on pickers that fit in 9 items (`/model`, `/approval`, `/api`).

## Single source of truth

Three small helpers on `packages/cli/src/chat/tui/ui/Select.tsx`:

- `hotkeyIndex(input)` — keystroke → zero-based index.
- `selectIndexLabel(index)` — leading-slot label (`1.`-`9.`, `a.`-`z.`, two spaces).
- `selectHotkeyHint(itemCount)` — footer hint string for the active range.

`Select`'s `useInput` dispatch, the row renderer, and every picker form footer route through these so a future picker with >9 items cannot drift its hint string out of sync with its actual bindings.

## Duplication and abstraction budget

- Replaces an inline `Number(input)` digit check + `i < 9 ? \`${i+1}.\` : '  '` inline expression with the three helpers above. Net: ~25 LOC added, 4 LOC inline expressions removed; one new exported surface (`Select`) that already owned the existing 1-9 dispatch.
- Two picker forms (`AgentListForm`, `ModelListForm`) import the hint helper. `ApprovalPolicyForm` has its own static `1-3 select now` string and is intentionally untouched (only 3 items, never overflows).

## Host impact

Extension: none.

Desktop: none.

CLI: `/agent` (and `/model` if ever it grew past 9) now binds items 10-35 to `a-z` and the footer reflects the active range. Items 1-9 keep their existing bindings unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm --filter @texra/cli typecheck` ✓
- `corepack pnpm --filter @texra/cli bundle` ✓
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/SelectHotkeys.vitest.mts` ✓ (new file, 5/5 covering all three helpers + the empty-list edge case)
- Full kernel suite: 208 files, 1037 tests ✓
- Manual TUI repro (pty replay): screenshot above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: contained to CLI TUI selection ergonomics, adding simple key-to-index mapping and hint/label rendering plus tests, with no auth/data-path changes.
> 
> **Overview**
> Extends the CLI TUI `Select` widget so items **10–35** become single-key selectable via **`a`–`z`**, while keeping **`1`–`9`** behavior unchanged; rows now render `a.`-style prefixes and input handling uses a shared `hotkeyIndex()` mapper.
> 
> Updates `/agent` and `/model` footers to display an accurate hotkey hint via `selectHotkeyHint(items.length)`, and adds a new Vitest suite covering the hotkey mapping, label rendering, and hint behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89051066ce36836727bdd848c6b27368df974cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->