### PR TITLE
fix(cli): fail fast when `--cwd <path>` does not exist or is not a directory

### DIFF
--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { readFile, realpath } from 'node:fs/promises';
+import { readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -203,15 +203,37 @@ function pickCliApiMode(
   return undefined;
 }
 
-async function resolveCliCwd(cwdFlag: string | undefined): Promise<string> {
-  const requested = isNonEmptyString(cwdFlag)
-    ? path.resolve(cwdFlag.trim())
-    : process.cwd();
-  try {
-    return await realpath(requested);
-  } catch {
-    return requested;
+export async function resolveCliCwd(
+  cwdFlag: string | undefined,
+): Promise<string> {
+  // When the user did not pass `--cwd`, `process.cwd()` is correct by
+  // construction (the shell can't put us in a directory that doesn't exist).
+  // When `--cwd` IS passed, validate it explicitly: a typo or stale path
+  // should fail loudly instead of silently falling back to the resolved-but-
+  // nonexistent string and running the agent against the wrong workspace.
+  if (!isNonEmptyString(cwdFlag)) {
+    return await realpath(process.cwd()).catch(() => process.cwd());
   }
+  const requested = path.resolve(cwdFlag.trim());
+  let info: Awaited<ReturnType<typeof stat>>;
+  try {
+    info = await stat(requested);
+  } catch (error: unknown) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new CliUsageError(`--cwd: path does not exist: ${requested}`);
+    }
+    throw new CliUsageError(
+      `--cwd: cannot access ${requested}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!info.isDirectory()) {
+    throw new CliUsageError(`--cwd: not a directory: ${requested}`);
+  }
+  return await realpath(requested).catch(() => requested);
 }
 
 export async function buildCliContext(

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { buildCliContext } from '../../../packages/cli/src/runtime/cliContext';
+import {
+  buildCliContext,
+  CliUsageError,
+  resolveCliCwd,
+} from '../../../packages/cli/src/runtime/cliContext';
 import { loadWorkspaceCliConfig } from '../../../packages/cli/src/runtime/cliConfig';
 
 const ambient = {
@@ -57,7 +61,7 @@ describe('CLI context config defaults', () => {
       buildCliContext({
         ambient,
         env: {},
-        globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+        globalArgs: { cwd: tmpdir() },
       }),
     ).resolves.toMatchObject({
       outputFormat: 'text',
@@ -143,7 +147,7 @@ describe('CLI context config defaults', () => {
     const context = await buildCliContext({
       ambient,
       env: { TEXRA_MODEL: 'claude-opus-4-7' },
-      globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+      globalArgs: { cwd: tmpdir() },
     });
 
     expect(context.envModel).toBeUndefined();
@@ -154,7 +158,7 @@ describe('CLI context config defaults', () => {
     const context = await buildCliContext({
       ambient,
       env: { TEXRA_API_MODE: 'direct' },
-      globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+      globalArgs: { cwd: tmpdir() },
     });
 
     expect(context.apiMode).toBe('personal');
@@ -166,7 +170,7 @@ describe('CLI context config defaults', () => {
       env: { TEXRA_API_MODE: 'personal' },
       globalArgs: {
         apiMode: 'included',
-        cwd: '/tmp/no-such-texra-workspace',
+        cwd: tmpdir(),
       },
     });
 
@@ -177,10 +181,52 @@ describe('CLI context config defaults', () => {
     const context = await buildCliContext({
       ambient,
       env: { TEXRA_API_MODE: 'unknown-mode' },
-      globalArgs: { cwd: '/tmp/no-such-texra-workspace' },
+      globalArgs: { cwd: tmpdir() },
     });
 
     expect(context.apiMode).toBeUndefined();
     expect(context.configWarnings?.join('\n')).toContain('TEXRA_API_MODE');
+  });
+});
+
+describe('CLI --cwd validation', () => {
+  it('accepts an existing directory and returns its realpath', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-cwd-'));
+
+    await expect(resolveCliCwd(workspace)).resolves.toBe(
+      await realpath(workspace),
+    );
+  });
+
+  it('rejects a --cwd path that does not exist', async () => {
+    const missing = join(tmpdir(), 'texra-cli-cwd-missing-' + Date.now());
+
+    await expect(resolveCliCwd(missing)).rejects.toBeInstanceOf(CliUsageError);
+    await expect(resolveCliCwd(missing)).rejects.toThrow(/does not exist/);
+  });
+
+  it('rejects a --cwd path that points at a file', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-cwd-'));
+    const filePath = join(workspace, 'config.json');
+    await writeFile(filePath, '{}');
+
+    await expect(resolveCliCwd(filePath)).rejects.toBeInstanceOf(CliUsageError);
+    await expect(resolveCliCwd(filePath)).rejects.toThrow(/not a directory/);
+  });
+
+  it('falls back to process.cwd() when no --cwd flag is given', async () => {
+    // The shell can't put us in a missing directory, so the no-flag path
+    // intentionally skips validation. Trim any platform realpath canonical-
+    // ization for the comparison.
+    const result = await resolveCliCwd(undefined);
+    expect(result).toBe(await realpath(process.cwd()));
+  });
+
+  it('lets a buildCliContext caller surface the --cwd usage error', async () => {
+    const missing = join(tmpdir(), 'texra-cli-cwd-missing-' + Date.now());
+
+    await expect(
+      buildCliContext({ ambient, env: {}, globalArgs: { cwd: missing } }),
+    ).rejects.toBeInstanceOf(CliUsageError);
   });
 });


### PR DESCRIPTION
## Summary

`texra --cwd <path>` silently fell back to a resolved-but-nonexistent string when the path didn't exist or wasn't a directory. The agent then ran against the actual cwd (or a path the platform never read), exit 0, no warning. A typo (`--cwd ./paaper` vs `./paper`) silently went unnoticed.

```
$ texra --cwd /tmp/nonexistent-xyz-123 agents list
workflow	transcribe_audio	...   # ← ran against the wrong workspace
$ echo $?
0
```

`resolveCliCwd` now `stat()`s the requested path when `--cwd` is explicitly given and refuses paths that don't exist or aren't directories with `CliUsageError` (exit 2). Without `--cwd`, behavior is unchanged.

```
$ texra --cwd /tmp/nonexistent-xyz-123 agents list
--cwd: path does not exist: /tmp/nonexistent-xyz-123
$ echo $?
2

$ texra --cwd /etc/hosts agents list
--cwd: not a directory: /etc/hosts
$ echo $?
2
```

Closes #4427.

## Changes

- `packages/cli/src/runtime/cliContext.ts`:
  - `resolveCliCwd` is exported and now validates the path when `--cwd` is provided.
  - `ENOENT`/`ENOTDIR` → `CliUsageError("--cwd: path does not exist: <path>")`.
  - Exists but not a directory → `CliUsageError("--cwd: not a directory: <path>")`.
  - Other I/O errors → `CliUsageError("--cwd: cannot access ...")`.
  - The no-flag path keeps using `process.cwd()` (always valid by construction).
- `src/test-kernel/cli/CliContext.vitest.mts`:
  - 5 existing tests that used a synthetic `/tmp/no-such-texra-workspace` cwd now use `tmpdir()` instead — those tests were exercising apiMode / envModel behavior and never the cwd path.
  - New `CLI --cwd validation` block with 5 cases: accepts existing dir (returns `realpath`), rejects missing path, rejects file path, falls back to `process.cwd()` without a flag, and the buildCliContext caller surfaces the usage error.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 259/259 (5 new in CliContext)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe:
  - `texra --cwd /tmp/no-such-xyz` → `--cwd: path does not exist: /tmp/no-such-xyz`, exit 2
  - `texra --cwd /etc/hosts` → `--cwd: not a directory: /etc/hosts`, exit 2
  - `texra --cwd /tmp agents list` → works (exit 0)

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js --cwd /tmp/no-such-xyz-123 agents list; echo "exit=$?"
node dist/bin/texra.js --cwd /etc/hosts agents list; echo "exit=$?"
node dist/bin/texra.js --cwd /tmp agents list >/dev/null; echo "exit=$?"
npx vitest run src/test-kernel/cli/CliContext.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI behavior to throw `CliUsageError` when `--cwd` is missing/invalid, which could break callers that previously relied on silent fallback behavior. Scope is limited to argument handling and adds targeted tests for the new validation.
> 
> **Overview**
> `--cwd` is now validated in `resolveCliCwd`: when explicitly provided it must exist and be a directory (checked via `stat()`), otherwise the CLI fails fast with a `CliUsageError` instead of continuing with a non-existent path.
> 
> The no-`--cwd` path keeps using `process.cwd()` (with `realpath` canonicalization), and tests were updated to avoid using non-existent paths except for new coverage that asserts the new missing/file-path error cases and propagation through `buildCliContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be1e37df378bb3a6ba700b6fcbf83f82d7a4c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->