### PR TITLE
fix(cli): return exit 2 (Usage) for `usage --month <bad-format>`, not 3

### DIFF
--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -14,6 +14,7 @@ import {
 } from '../runtime/logSinks';
 import {
   fetchRelayUsageSummary,
+  parseUtcMonth,
   type RelayUsageSummary,
 } from '../runtime/relayUsage';
 import {
@@ -260,6 +261,19 @@ export const usageCommand = defineCommand({
   },
   async run(ctx) {
     const context = await contextFromArgs(ctx.args);
+    const month = optString(ctx.args.month);
+    // Pre-validate `--month` before any network I/O so a malformed value
+    // yields a Usage error (exit 2), not the catch-all ModelOrNetworkError
+    // (exit 3) that the broader try/catch below would assign.
+    if (month) {
+      try {
+        parseUtcMonth(month);
+      } catch (error) {
+        writeTextStderr(toErrorMessage(error));
+        setExitCode(CliExitCode.Usage);
+        return;
+      }
+    }
     let summary: RelayUsageSummary;
     try {
       await initCliPlatform({ ...context, quietLogs: true });
@@ -271,7 +285,7 @@ export const usageCommand = defineCommand({
       }
       summary = await fetchRelayUsageSummary({
         tier: profile.tier ?? 'free',
-        month: optString(ctx.args.month),
+        month,
       });
     } catch (error) {
       writeTextStderr(toErrorMessage(error));

--- a/src/test-kernel/cli/RelayUsage.vitest.mts
+++ b/src/test-kernel/cli/RelayUsage.vitest.mts
@@ -36,6 +36,21 @@ describe('CLI relay usage ranges', () => {
     expect(range.start.toISOString()).toBe('2026-12-01T00:00:00.000Z');
     expect(range.end.toISOString()).toBe('2027-01-01T00:00:00.000Z');
   });
+
+  it('rejects values that do not match YYYY-MM', () => {
+    // The command handler pre-validates `--month` so a malformed value yields
+    // a Usage error (exit 2), not the catch-all ModelOrNetworkError (exit 3).
+    // This contract is what makes that pre-validation possible.
+    expect(() => parseUtcMonth('not-a-date')).toThrow(/YYYY-MM format/);
+    expect(() => parseUtcMonth('2026/05')).toThrow(/YYYY-MM format/);
+    expect(() => parseUtcMonth('26-05')).toThrow(/YYYY-MM format/);
+    expect(() => parseUtcMonth('2026-5')).toThrow(/YYYY-MM format/);
+  });
+
+  it('rejects month numbers outside 01..12', () => {
+    expect(() => parseUtcMonth('2026-00')).toThrow(/YYYY-MM format/);
+    expect(() => parseUtcMonth('2026-13')).toThrow(/YYYY-MM format/);
+  });
 });
 
 describe('CLI relay usage summary', () => {


### PR DESCRIPTION
## Summary

`texra usage --month not-a-date` exited with code **3** (`ModelOrNetworkError`) for what is clearly a Usage error (exit 2): the command's single broad `try/catch` swallowed both real network failures and `parseUtcMonth()`'s "Expected month in YYYY-MM format." throws.

```
$ texra usage --month not-a-date
Expected month in YYYY-MM format.
$ echo $?
3                  # ← should be 2
```

Pre-validate `--month` in the command handler before any network I/O. Bad format → `CliExitCode.Usage` with the existing message. Real post-validation failures (auth, fetch, relay) keep their `ModelOrNetworkError` code.

Closes #4429.

## Changes

- `packages/cli/src/commands/auth.ts`: in `usageCommand.run`, call `parseUtcMonth(month)` up front when `--month` is present; on throw, write the message and set `CliExitCode.Usage`.
- `src/test-kernel/cli/RelayUsage.vitest.mts`: 2 new parameterized cases for `parseUtcMonth` covering the format-rejection contract the command relies on (malformed strings + month out of range).

## Test plan

- [x] `npx vitest run src/test-kernel/cli/RelayUsage.vitest.mts` → 7/7 (2 new)
- [x] `npx vitest run src/test-kernel/cli/` → 256/256
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe:
  - `texra usage --month not-a-date` → exit 2 (was 3)
  - `texra usage --month 2026-13` → exit 2 (was 3)
  - `texra usage --month 2026-04` → exit 0 (unchanged)

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js usage --month not-a-date; echo "exit=$?"
node dist/bin/texra.js usage --month 2026-13; echo "exit=$?"
node dist/bin/texra.js usage --month 2026-04 >/dev/null; echo "exit=$?"
npx vitest run src/test-kernel/cli/RelayUsage.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI argument validation change that only affects error classification/exit code for invalid `--month` values, plus added unit tests.
> 
> **Overview**
> Fixes `texra usage --month <value>` to **validate the month string before any network/auth work**, so bad formats emit the existing parse error message but exit with `CliExitCode.Usage` (2) instead of the generic `ModelOrNetworkError` (3).
> 
> Adds test coverage asserting `parseUtcMonth` rejects non-`YYYY-MM` inputs and out-of-range months, which the new pre-validation relies on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7fc59f9a6747c617fcd4336b4e687f33dc1d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->