### PR TITLE
fix(cli): fail fast on `texra run` usage errors (missing input / agent / category)

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -60,6 +60,11 @@ export async function expandWorkflowInputSpec(
     return matches.sort().map((match) => normalizeCliInputPath(match, cwd));
   }
 
+  // Fail fast with a Usage error (exit 2) instead of paying full platform
+  // init + agent loading just to ENOENT inside the agent run (exit 1).
+  if (!stats) {
+    throw new CliUsageError(`--input: file not found: ${trimmed}`);
+  }
   return [normalizeCliInputPath(trimmed, cwd)];
 }
 

--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -24,9 +24,19 @@ function normalizeCliInputPath(candidate: string, cwd: string): string {
   return absolutePath;
 }
 
+/**
+ * Expand a single user-supplied path spec into the absolute / cwd-relative
+ * paths it resolves to.
+ *
+ * `flagLabel` is the CLI flag name (e.g. `--input`, `--context`) used in
+ * Usage-error messages so a missing file is attributed to the right flag.
+ * Defaults to `--input` for the common case; callers that pass context paths
+ * (multi-agent `--context`) should override.
+ */
 export async function expandWorkflowInputSpec(
   inputSpec: string,
   cwd: string,
+  flagLabel: string = '--input',
 ): Promise<string[]> {
   const trimmed = inputSpec.trim();
   if (!trimmed) return [];
@@ -77,7 +87,7 @@ export async function expandWorkflowInputSpec(
   // Fail fast with a Usage error (exit 2) instead of paying full platform
   // init + agent loading just to ENOENT inside the agent run (exit 1).
   if (!stats) {
-    throw new CliUsageError(`--input: file not found: ${trimmed}`);
+    throw new CliUsageError(`${flagLabel}: file not found: ${trimmed}`);
   }
   return [normalizeCliInputPath(trimmed, cwd)];
 }
@@ -85,10 +95,11 @@ export async function expandWorkflowInputSpec(
 export async function expandWorkflowInputSpecs(
   inputSpecs: readonly string[],
   cwd: string,
+  flagLabel: string = '--input',
 ): Promise<string[]> {
   const expanded = (
     await Promise.all(
-      inputSpecs.map((spec) => expandWorkflowInputSpec(spec, cwd)),
+      inputSpecs.map((spec) => expandWorkflowInputSpec(spec, cwd, flagLabel)),
     )
   ).flat();
   const unique = [...new Set(expanded)];

--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -45,7 +45,21 @@ export async function expandWorkflowInputSpec(
   }
 
   const absolutePath = resolveAgainstCwd(trimmed, cwd);
-  const stats = await fs.stat(absolutePath).catch(() => null);
+  // Only treat true missing-path errors as "file not found"; other failures
+  // (EACCES, EIO, …) are environment problems, not Usage errors, and must
+  // propagate so the user sees the real cause.
+  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
+  try {
+    stats = await fs.stat(absolutePath);
+  } catch (error: unknown) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      throw error;
+    }
+  }
   if (stats?.isDirectory()) {
     const matches = await glob('**/*.tex', {
       cwd: absolutePath,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -223,7 +223,7 @@ async function runMultiAgentPreset(
   const contextFiles = (
     await Promise.all(
       init.contextFiles.map((spec) =>
-        expandWorkflowInputSpec(spec, runContext.cwd),
+        expandWorkflowInputSpec(spec, runContext.cwd, '--context'),
       ),
     )
   ).flat();

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -99,6 +99,19 @@ async function runWorkflowAgent(
     await loadAgents();
     agent = getAgent(init.agent);
   }
+  // Pre-validate the resolved agent so usage errors land before the runtime
+  // host starts: an unknown name or wrong category should be exit 2 (Usage),
+  // not exit 1 (AgentError) raised mid-run.
+  if (!agent) {
+    throw new CliUsageError(
+      `Agent not found: ${init.agent}. Use \`texra agents list\` to see available agents.`,
+    );
+  }
+  if (agent.category !== AgentCategory.Workflow) {
+    throw new CliUsageError(
+      `Agent "${init.agent}" is a ${agent.category} agent; use \`texra chat\` or \`texra multi-agent run\` instead.`,
+    );
+  }
 
   const modelOutputFile =
     init.output && path.isAbsolute(init.output)

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -258,6 +258,20 @@ describe('CLI root argument routing', () => {
     }
   });
 
+  it('rejects a literal --input file that does not exist', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-inputs-'));
+    try {
+      const missing = path.join(root, 'no-such.tex');
+      // Pure path (no glob magic, not a directory) — previously this was
+      // returned as-is and the workflow ran until the agent ENOENT'd.
+      await expect(
+        expandWorkflowInputSpecs([missing], root),
+      ).rejects.toThrow(/--input: file not found/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('reports missing workflow outputs as a failed copy operation', async () => {
     await expect(
       resolveWorkflowOutput(

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -272,6 +272,33 @@ describe('CLI root argument routing', () => {
     }
   });
 
+  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
+  // mode-0 doesn't block stat.
+  const skipPermissionTest =
+    process.platform === 'win32' ||
+    (typeof process.getuid === 'function' && process.getuid() === 0);
+  (skipPermissionTest ? it.skip : it)(
+    'propagates non-ENOENT stat errors instead of misreporting as not-found',
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-perm-'));
+      const blocked = path.join(root, 'blocked');
+      const inner = path.join(blocked, 'paper.tex');
+      try {
+        await fs.mkdir(blocked, { recursive: true });
+        await fs.writeFile(inner, 'draft');
+        // Strip search/execute permission on the parent so stat(inner) fails
+        // with EACCES. The not-found fast path must not swallow this.
+        await fs.chmod(blocked, 0o000);
+        await expect(expandWorkflowInputSpecs([inner], root)).rejects.toThrow(
+          /(EACCES|permission)/i,
+        );
+      } finally {
+        await fs.chmod(blocked, 0o755).catch(() => undefined);
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('reports missing workflow outputs as a failed copy operation', async () => {
     await expect(
       resolveWorkflowOutput(

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -264,9 +264,9 @@ describe('CLI root argument routing', () => {
       const missing = path.join(root, 'no-such.tex');
       // Pure path (no glob magic, not a directory) — previously this was
       // returned as-is and the workflow ran until the agent ENOENT'd.
-      await expect(
-        expandWorkflowInputSpecs([missing], root),
-      ).rejects.toThrow(/--input: file not found/);
+      await expect(expandWorkflowInputSpecs([missing], root)).rejects.toThrow(
+        /--input: file not found/,
+      );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -272,6 +272,21 @@ describe('CLI root argument routing', () => {
     }
   });
 
+  it('attributes the missing-path error to the caller-supplied flag label', async () => {
+    // The helper is shared between --input (texra run, multi-agent run input)
+    // and --context (multi-agent run context). The error must name the flag
+    // the user actually passed, not always say --input.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-flag-'));
+    try {
+      const missing = path.join(root, 'no-such-context.tex');
+      await expect(
+        expandWorkflowInputSpecs([missing], root, '--context'),
+      ).rejects.toThrow(/--context: file not found/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Skip on Windows (no POSIX chmod semantics) and when running as root, where
   // mode-0 doesn't block stat.
   const skipPermissionTest =


### PR DESCRIPTION
## Summary

`texra run` paid the full platform init + agent registry load before discovering three common user errors, and then surfaced them as `AgentError` (exit 1):

| Invocation | Before | After |
|---|---|---|
| `texra run correct -i /tmp/no-such.tex` | init → ENOENT → exit 1 | refuses fast → exit 2 |
| `texra run nonexistent-agent -i …` | init → "Could not find agent" → exit 1 | refuses fast → exit 2 |
| `texra run chat -i …` (tool-use agent) | init → category mismatch → exit 1 | refuses fast → exit 2 |

`AgentError` is reserved for failures during a real run; these are Usage errors (exit 2). Three pre-flight checks now refuse fast and steer the user to the right command for category mismatches.

Closes #4431.

## Changes

- `packages/cli/src/commands/_helpers/workflowInputs.ts`: in `expandWorkflowInputSpec`, after the existing `stat()` for the directory branch, treat a missing literal path as `CliUsageError("--input: file not found: <path>")`. Globs and directories keep their existing handling.
- `packages/cli/src/commands/workflow.ts`: in `runWorkflowAgent`, immediately after the registry-load + remote-fallback lookup, throw:
  - `CliUsageError("Agent not found: X. Use \`texra agents list\` to see available agents.")` if the agent still doesn't resolve.
  - `CliUsageError("Agent \"X\" is a <category> agent; use \`texra chat\` or \`texra multi-agent run\` instead.")` if the resolved agent isn't `AgentCategory.Workflow`.
- `src/test-kernel/cli/CliRootArgs.vitest.mts`: new case `rejects a literal --input file that does not exist` covering the input-spec contract.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 255/255 (1 new)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probes:
  - `texra run correct -i /tmp/no-such.tex` → `--input: file not found: /tmp/no-such.tex` exit 2
  - `texra run nonexistent-agent -i …` → `Agent not found: nonexistent-agent. Use \`texra agents list\` …` exit 2
  - `texra run chat -i …` → `Agent "chat" is a toolUse agent; use \`texra chat\` or \`texra multi-agent run\` instead.` exit 2

## Verification commands

```sh
cd packages/cli && npm run bundle
node dist/bin/texra.js run correct -i /tmp/no-such.tex; echo "exit=$?"
node dist/bin/texra.js run nonexistent-agent -i /etc/hosts; echo "exit=$?"
node dist/bin/texra.js run chat -i /etc/hosts; echo "exit=$?"
npx vitest run src/test-kernel/cli/CliRootArgs.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI preflight validation and error messaging/exit codes, with added tests to lock behavior; main risk is potential behavior change for edge-case path specs or agent selection.
> 
> **Overview**
> **Improves CLI preflight validation for `texra run` and multi-agent runs** so common usage mistakes fail early with `CliUsageError` (exit 2) instead of surfacing later as runtime/agent errors.
> 
> The workflow input expansion helper now rejects missing *literal* files (while preserving glob/dir behavior), attributes not-found errors to the correct flag via a new `flagLabel` parameter (e.g. `--context`), and avoids swallowing non-ENOENT `stat` failures like permission errors.
> 
> `texra run` now validates that the resolved agent exists and is `AgentCategory.Workflow` before starting the runtime host, and new vitest cases cover missing input, flag attribution, and permission-error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a66f067ecc7d86a97f6b58fcd9bd085c9a6679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->