### PR TITLE
fix(cli): expand and validate `texra run --context` paths the same as --input

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -44,7 +44,10 @@ import {
   type CliRunResult,
   type ExecuteAgentResult,
 } from './_helpers/terminalStatus';
-import { expandWorkflowInputSpecs } from './_helpers/workflowInputs';
+import {
+  expandWorkflowInputSpec,
+  expandWorkflowInputSpecs,
+} from './_helpers/workflowInputs';
 import {
   expectedOutputFilesForOutputDir,
   formatWorkflowTextResult,
@@ -85,6 +88,18 @@ async function runWorkflowAgent(
     init.inputFiles,
     runContext.cwd,
   );
+  // `--context` files are optional, so we can't reuse the plural helper
+  // (which errors on an empty result). Expand each spec individually with
+  // the right flag label so a missing context path fails fast as a Usage
+  // error (exit 2) instead of reaching the agent as a raw ENOENT (exit 1),
+  // and so a glob like `refs/*.bib` actually expands.
+  const contextFiles = (
+    await Promise.all(
+      init.contextFiles.map((spec) =>
+        expandWorkflowInputSpec(spec, runContext.cwd, '--context'),
+      ),
+    )
+  ).flat();
   if (init.output && inputFiles.length > 1) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
@@ -121,7 +136,7 @@ async function runWorkflowAgent(
     agent: init.agent,
     model,
     inputFiles,
-    contextFiles: init.contextFiles,
+    contextFiles,
     outputFiles: modelOutputFile ? [modelOutputFile] : [],
     cliOutputFile: init.output,
     instruction: init.instruction,

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -297,11 +297,7 @@ describe('CLI root argument routing', () => {
       await fs.writeFile(path.join(root, 'a.bib'), 'a');
       await fs.writeFile(path.join(root, 'b.bib'), 'b');
       await expect(
-        expandWorkflowInputSpecs(
-          [path.join(root, '*.bib')],
-          root,
-          '--context',
-        ),
+        expandWorkflowInputSpecs([path.join(root, '*.bib')], root, '--context'),
       ).resolves.toEqual(['a.bib', 'b.bib']);
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -274,14 +274,35 @@ describe('CLI root argument routing', () => {
 
   it('attributes the missing-path error to the caller-supplied flag label', async () => {
     // The helper is shared between --input (texra run, multi-agent run input)
-    // and --context (multi-agent run context). The error must name the flag
-    // the user actually passed, not always say --input.
+    // and --context (texra run / multi-agent run context). The error must
+    // name the flag the user actually passed, not always say --input.
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-flag-'));
     try {
       const missing = path.join(root, 'no-such-context.tex');
       await expect(
         expandWorkflowInputSpecs([missing], root, '--context'),
       ).rejects.toThrow(/--context: file not found/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('expands a glob --context spec the same way --input does', async () => {
+    // `texra run -c '<glob>'` previously stuffed the literal glob string into
+    // the AgentConfig and failed late with raw ENOENT (exit 1). Routing
+    // through expandWorkflowInputSpecs gives it the same expansion semantics
+    // as `--input` (and surfaces missing-path errors as Usage / exit 2).
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-ctx-'));
+    try {
+      await fs.writeFile(path.join(root, 'a.bib'), 'a');
+      await fs.writeFile(path.join(root, 'b.bib'), 'b');
+      await expect(
+        expandWorkflowInputSpecs(
+          [path.join(root, '*.bib')],
+          root,
+          '--context',
+        ),
+      ).resolves.toEqual(['a.bib', 'b.bib']);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

`texra run` previously passed `--context` values straight to the AgentConfig with no expansion, so two long-standing wrinkles bit together:

| Invocation | Before | After |
|---|---|---|
| `texra run -c <missing>` | ENOENT mid-run → exit 1 | `--context: file not found: <path>` → exit 2 |
| `texra run -c '<glob>'` | literal sent to agent → ENOENT → exit 1 | glob expanded the same way `--input` is |

`texra multi-agent run` already expands `--context` through `expandWorkflowInputSpec`. This brings `texra run` to parity.

Closes #4433.

## Changes

- `packages/cli/src/commands/workflow.ts`: replace the direct `init.contextFiles` pass-through with a per-spec `expandWorkflowInputSpec(spec, cwd, '--context')` flat-map, then thread the expanded list into the AgentConfig. Per-spec rather than the plural helper because `--context` is optional and the plural helper insists on at least one entry.
- `src/test-kernel/cli/CliRootArgs.vitest.mts`: new case `expands a glob --context spec the same way --input does`; the existing "attributes the missing-path error" case was reworded to call out the texra-run context path too.

## Depends on

PR #4432 (`cli/run-validate-input-and-agent`) — that branch adds the `flagLabel` parameter to `expandWorkflowInputSpec` that this PR uses. Base is `cli/run-validate-input-and-agent`; once that merges to main, this auto-rebases to a clean three-commit diff against `main`.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 258/258 (1 new + 1 reworded)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probes:
  - `texra run correct -i probe.tex -c /tmp/no-such-refs.bib` → `--context: file not found: …` exit 2
  - `texra run correct -i probe.tex -c '/tmp/refs/no-such-*.bib'` → `No input files matched: …` exit 2
  - `texra run correct -i probe.tex` (no `--context`) → unchanged

## Verification commands

```sh
cd packages/cli && npm run bundle
echo > /tmp/probe.tex
node dist/bin/texra.js run correct -i /tmp/probe.tex -c /tmp/no-such-refs.bib; echo "exit=$?"
node dist/bin/texra.js run correct -i /tmp/probe.tex -c '/tmp/refs/no-such-*.bib'; echo "exit=$?"
npx vitest run src/test-kernel/cli/CliRootArgs.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to CLI argument preprocessing for `texra run --context`, improving error handling and glob expansion without touching agent execution logic.
> 
> **Overview**
> `texra run` now expands and validates `--context` file specs (including globs) before starting the agent, mirroring `--input` behavior and surfacing missing paths as `CliUsageError` (exit 2) instead of late ENOENT failures (exit 1).
> 
> Tests are updated to ensure missing `--context` paths are attributed to the correct flag label and to cover glob expansion for context specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02645ee04775a137f2f143f8d24ea6f53eb43e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->