### PR TITLE
fix(cli): validate `-m` model up-front so a typo is exit 2, not exit 1

### DIFF
--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -1,0 +1,30 @@
+// Shared validation for the user-supplied `-m` / `--model` flag value used by
+// `texra run` and `texra multi-agent run`. Centralizing the check keeps the
+// error message and the trim/isKnownCliModel contract in one place so the two
+// callers can't drift.
+
+import { CliUsageError } from '../../runtime/cliContext';
+import { isKnownCliModel } from '../../runtime/cliConfig';
+
+/**
+ * Trim and validate an explicit `-m`/`--model` value.
+ *
+ * Returns the trimmed model id when the user passed a known model, `undefined`
+ * when the flag was absent or empty (callers fall through to env / config /
+ * built-in defaults), and throws `CliUsageError` when the user passed an
+ * unknown model id — surfacing the typo as exit 2 (Usage) instead of letting
+ * it become an exit 1 (AgentError) raised mid-run by the runtime's
+ * `MODEL_CONFIGS` lookup.
+ */
+export function assertExplicitModelKnown(
+  model: string | undefined,
+): string | undefined {
+  const trimmed = model?.trim();
+  if (!trimmed) return undefined;
+  if (!isKnownCliModel(trimmed)) {
+    throw new CliUsageError(
+      `Model not found: ${trimmed}. Use \`texra models list\` to see available models.`,
+    );
+  }
+  return trimmed;
+}

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -1,21 +1,7 @@
-// Shared validation for the user-supplied `-m` / `--model` flag value used by
-// `texra run` and `texra multi-agent run`. Centralizing the check keeps the
-// error message and the trim/isKnownCliModel contract in one place so the two
-// callers can't drift.
-
 import { CliUsageError } from '../../runtime/cliContext';
 import { isKnownCliModel } from '../../runtime/cliConfig';
 
-/**
- * Trim and validate an explicit `-m`/`--model` value.
- *
- * Returns the trimmed model id when the user passed a known model, `undefined`
- * when the flag was absent or empty (callers fall through to env / config /
- * built-in defaults), and throws `CliUsageError` when the user passed an
- * unknown model id — surfacing the typo as exit 2 (Usage) instead of letting
- * it become an exit 1 (AgentError) raised mid-run by the runtime's
- * `MODEL_CONFIGS` lookup.
- */
+/** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
 export function assertExplicitModelKnown(
   model: string | undefined,
 ): string | undefined {

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -14,7 +14,6 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError } from '../runtime/cliContext';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  isKnownCliModel,
   resolveConfiguredModel,
 } from '../runtime/cliConfig';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
@@ -43,6 +42,7 @@ import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
+import { assertExplicitModelKnown } from './_helpers/modelArg';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
@@ -205,16 +205,10 @@ async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
-  const explicitModel = init.model?.trim();
   // Validate the explicit `-m` value up-front so a typo is a Usage error
-  // (exit 2), not a mid-run "Model not found in MODEL_CONFIGS" AgentError
-  // (exit 1). Env / workspace-config / built-in fallbacks already warn on
-  // their own and are left alone here.
-  if (explicitModel && !isKnownCliModel(explicitModel)) {
-    throw new CliUsageError(
-      `Model not found: ${explicitModel}. Use \`texra models list\` to see available models.`,
-    );
-  }
+  // (exit 2), not a mid-run AgentError (exit 1). Env / config / built-in
+  // fallbacks already warn on their own and are left alone.
+  const explicitModel = assertExplicitModelKnown(init.model);
   const model =
     explicitModel ||
     context.envModel ||

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -205,9 +205,6 @@ async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
-  // Validate the explicit `-m` value up-front so a typo is a Usage error
-  // (exit 2), not a mid-run AgentError (exit 1). Env / config / built-in
-  // fallbacks already warn on their own and are left alone.
   const explicitModel = assertExplicitModelKnown(init.model);
   const model =
     explicitModel ||

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -14,6 +14,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError } from '../runtime/cliContext';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
+  isKnownCliModel,
   resolveConfiguredModel,
 } from '../runtime/cliConfig';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
@@ -204,8 +205,18 @@ async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
+  const explicitModel = init.model?.trim();
+  // Validate the explicit `-m` value up-front so a typo is a Usage error
+  // (exit 2), not a mid-run "Model not found in MODEL_CONFIGS" AgentError
+  // (exit 1). Env / workspace-config / built-in fallbacks already warn on
+  // their own and are left alone here.
+  if (explicitModel && !isKnownCliModel(explicitModel)) {
+    throw new CliUsageError(
+      `Model not found: ${explicitModel}. Use \`texra models list\` to see available models.`,
+    );
+  }
   const model =
-    init.model?.trim() ||
+    explicitModel ||
     context.envModel ||
     resolveConfiguredModel(context.cliConfig, 'chat') ||
     CLI_BUILTIN_DEFAULT_MODEL;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -67,9 +67,6 @@ async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
 ): Promise<number> {
-  // Validate the explicit `-m` value up-front so a typo is a Usage error
-  // (exit 2), not a mid-run AgentError (exit 1). Env / config / built-in
-  // fallbacks already warn on their own and are left alone.
   const explicitModel = assertExplicitModelKnown(init.model);
   const model =
     explicitModel ||

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -18,7 +18,6 @@ import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliUsageError } from '../runtime/cliContext';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  isKnownCliModel,
   resolveConfiguredModel,
 } from '../runtime/cliConfig';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -33,6 +32,7 @@ import { createCliRuntimeHost } from '../runtime/runtimeHost';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
+import { assertExplicitModelKnown } from './_helpers/modelArg';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
@@ -67,16 +67,10 @@ async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
 ): Promise<number> {
-  const explicitModel = init.model?.trim();
   // Validate the explicit `-m` value up-front so a typo is a Usage error
-  // (exit 2), not a mid-run "Model not found in MODEL_CONFIGS" AgentError
-  // (exit 1). Env / workspace-config / built-in fallbacks already emit
-  // warnings on their own and are left alone here.
-  if (explicitModel && !isKnownCliModel(explicitModel)) {
-    throw new CliUsageError(
-      `Model not found: ${explicitModel}. Use \`texra models list\` to see available models.`,
-    );
-  }
+  // (exit 2), not a mid-run AgentError (exit 1). Env / config / built-in
+  // fallbacks already warn on their own and are left alone.
+  const explicitModel = assertExplicitModelKnown(init.model);
   const model =
     explicitModel ||
     context.envModel ||

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -18,6 +18,7 @@ import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliUsageError } from '../runtime/cliContext';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
+  isKnownCliModel,
   resolveConfiguredModel,
 } from '../runtime/cliConfig';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -66,8 +67,18 @@ async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
 ): Promise<number> {
+  const explicitModel = init.model?.trim();
+  // Validate the explicit `-m` value up-front so a typo is a Usage error
+  // (exit 2), not a mid-run "Model not found in MODEL_CONFIGS" AgentError
+  // (exit 1). Env / workspace-config / built-in fallbacks already emit
+  // warnings on their own and are left alone here.
+  if (explicitModel && !isKnownCliModel(explicitModel)) {
+    throw new CliUsageError(
+      `Model not found: ${explicitModel}. Use \`texra models list\` to see available models.`,
+    );
+  }
   const model =
-    init.model?.trim() ||
+    explicitModel ||
     context.envModel ||
     resolveConfiguredModel(context.cliConfig, 'run') ||
     CLI_BUILTIN_DEFAULT_MODEL;

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -23,6 +23,7 @@ import {
   resolveWorkflowOutput,
 } from '../../../packages/cli/src/commands/root';
 import { rejectHeadlessOnlyFlags } from '../../../packages/cli/src/commands/_helpers/globalArgs';
+import { isKnownCliModel } from '../../../packages/cli/src/runtime/cliConfig';
 import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -430,14 +431,7 @@ describe('CLI root argument routing', () => {
 });
 
 describe('CLI model flag validation contract', () => {
-  it('classifies built-in models as known and bogus names as unknown', async () => {
-    // `texra run -m X` and `texra multi-agent run -m X` validate the explicit
-    // `-m` value via this predicate before any platform init, so a typo is
-    // surfaced as a Usage error (exit 2) instead of an AgentError (exit 1)
-    // raised mid-run by the runtime's `MODEL_CONFIGS` lookup.
-    const { isKnownCliModel } =
-      await import('../../../packages/cli/src/runtime/cliConfig');
-
+  it('classifies built-in models as known and bogus names as unknown', () => {
     expect(isKnownCliModel('sonnet46T')).toBe(true);
     expect(isKnownCliModel('deepseekT')).toBe(true);
     expect(isKnownCliModel('nonexistent-model-xyz')).toBe(false);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -429,6 +429,23 @@ describe('CLI root argument routing', () => {
   });
 });
 
+describe('CLI model flag validation contract', () => {
+  it('classifies built-in models as known and bogus names as unknown', async () => {
+    // `texra run -m X` and `texra multi-agent run -m X` validate the explicit
+    // `-m` value via this predicate before any platform init, so a typo is
+    // surfaced as a Usage error (exit 2) instead of an AgentError (exit 1)
+    // raised mid-run by the runtime's `MODEL_CONFIGS` lookup.
+    const { isKnownCliModel } = await import(
+      '../../../packages/cli/src/runtime/cliConfig'
+    );
+
+    expect(isKnownCliModel('sonnet46T')).toBe(true);
+    expect(isKnownCliModel('deepseekT')).toBe(true);
+    expect(isKnownCliModel('nonexistent-model-xyz')).toBe(false);
+    expect(isKnownCliModel('')).toBe(false);
+  });
+});
+
 describe('CLI login arguments', () => {
   it('prefers explicit provider flags over positional providers', () => {
     expect(resolveLoginProvider('google', 'github')).toBe('github');

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -435,9 +435,8 @@ describe('CLI model flag validation contract', () => {
     // `-m` value via this predicate before any platform init, so a typo is
     // surfaced as a Usage error (exit 2) instead of an AgentError (exit 1)
     // raised mid-run by the runtime's `MODEL_CONFIGS` lookup.
-    const { isKnownCliModel } = await import(
-      '../../../packages/cli/src/runtime/cliConfig'
-    );
+    const { isKnownCliModel } =
+      await import('../../../packages/cli/src/runtime/cliConfig');
 
     expect(isKnownCliModel('sonnet46T')).toBe(true);
     expect(isKnownCliModel('deepseekT')).toBe(true);

--- a/src/test-kernel/cli/ModelArg.vitest.mts
+++ b/src/test-kernel/cli/ModelArg.vitest.mts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { CliUsageError } from '../../../packages/cli/src/runtime/cliContext';
+import { assertExplicitModelKnown } from '../../../packages/cli/src/commands/_helpers/modelArg';
+
+describe('assertExplicitModelKnown', () => {
+  it('returns undefined when no model flag was passed', () => {
+    expect(assertExplicitModelKnown(undefined)).toBeUndefined();
+    expect(assertExplicitModelKnown('')).toBeUndefined();
+    expect(assertExplicitModelKnown('   ')).toBeUndefined();
+  });
+
+  it('returns the trimmed value for a known model id', () => {
+    expect(assertExplicitModelKnown('sonnet46T')).toBe('sonnet46T');
+    expect(assertExplicitModelKnown('  deepseekT  ')).toBe('deepseekT');
+  });
+
+  it('throws a CliUsageError for an unknown model id', () => {
+    // The thrown error is what makes the typo surface as exit 2 (Usage)
+    // instead of an exit 1 (AgentError) raised mid-run by the runtime's
+    // MODEL_CONFIGS lookup. The message must name the model and steer the
+    // user to `texra models list`.
+    expect(() => assertExplicitModelKnown('nonexistent-model-xyz')).toThrow(
+      CliUsageError,
+    );
+    expect(() => assertExplicitModelKnown('nonexistent-model-xyz')).toThrow(
+      /Model not found: nonexistent-model-xyz/,
+    );
+    expect(() => assertExplicitModelKnown('nonexistent-model-xyz')).toThrow(
+      /texra models list/,
+    );
+  });
+});

--- a/src/test-kernel/cli/ModelArg.vitest.mts
+++ b/src/test-kernel/cli/ModelArg.vitest.mts
@@ -16,10 +16,6 @@ describe('assertExplicitModelKnown', () => {
   });
 
   it('throws a CliUsageError for an unknown model id', () => {
-    // The thrown error is what makes the typo surface as exit 2 (Usage)
-    // instead of an exit 1 (AgentError) raised mid-run by the runtime's
-    // MODEL_CONFIGS lookup. The message must name the model and steer the
-    // user to `texra models list`.
     expect(() => assertExplicitModelKnown('nonexistent-model-xyz')).toThrow(
       CliUsageError,
     );


### PR DESCRIPTION
## Summary

`texra run -m bogus -i …` and `texra multi-agent run <preset> -m bogus -i …` paid the full platform init + agent registry load + runtime-host startup before the runtime's `MODEL_CONFIGS` lookup threw "Model X not found in MODEL_CONFIGS" — and surfaced it as `AgentError` (exit 1). A typo'd model name is plainly a Usage error (exit 2).

```
$ texra run correct -i probe.tex -m nonexistent-model
ready · 0s
ERROR Model nonexistent-model not found in MODEL_CONFIGS
$ echo $?
1                  # ← should be 2
```

Both `runWorkflowAgent` and `runMultiAgentPreset` now check the explicit `-m` value against `isKnownCliModel` before any side effects. Unknown → `CliUsageError` with exit 2 and a hint to `texra models list`. Env / workspace-config / built-in fallbacks are unchanged (they already warn on their own).

Closes #4435.

## Changes

- `packages/cli/src/commands/workflow.ts`: pre-validate `init.model?.trim()` via `isKnownCliModel`; throw `CliUsageError("Model not found: <name>. Use \`texra models list\` to see available models.")` if unknown.
- `packages/cli/src/commands/multiAgent.ts`: identical guard in `runMultiAgentPreset`.
- `src/test-kernel/cli/CliRootArgs.vitest.mts`: new "CLI model flag validation contract" describe block asserting `isKnownCliModel` accepts known model ids and rejects bogus / empty strings — the predicate both fixes rely on.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 255/255 (1 new)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probes:
  - `texra run correct -i probe.tex -m nonexistent-model` → `Model not found: nonexistent-model. Use \`texra models list\` to see available models.` exit 2
  - `texra multi-agent run lean-project -i probe.tex -m nonexistent-model` → same message, exit 2
  - Valid models continue to run unchanged

## Verification commands

```sh
cd packages/cli && npm run bundle
echo test > /tmp/probe.tex
node dist/bin/texra.js run correct -i /tmp/probe.tex -m bogus; echo "exit=$?"
node dist/bin/texra.js multi-agent run lean-project -i /tmp/probe.tex -m bogus; echo "exit=$?"
npx vitest run src/test-kernel/cli/CliRootArgs.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds early CLI validation and a new helper around existing `isKnownCliModel`, primarily changing error classification/message for invalid `-m` values without affecting model fallback resolution.
> 
> **Overview**
> Adds upfront validation for an explicitly provided `-m/--model` in `texra run` and `texra multi-agent run`, so unknown model IDs now fail immediately with a `CliUsageError` (usage exit code) and a hint to run `texra models list`, instead of surfacing later as a runtime `AgentError`.
> 
> Introduces `assertExplicitModelKnown` helper and adds/updates Vitest coverage for the `isKnownCliModel` contract and the new helper’s trim/unknown-model behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e08dd3b01d262bea9363a3cb2ba270bff75156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->