### PR TITLE
fix(cli): fail fast on `--output-dir <file>`, not after the whole run

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -15,7 +15,27 @@ import {
   type CliRunResult,
   type ExecuteAgentResult,
 } from './terminalStatus';
-import type { CliContext } from '../../runtime/cliContext';
+import { CliUsageError, type CliContext } from '../../runtime/cliContext';
+
+/**
+ * `--output-dir` may legitimately not exist yet (the run will `mkdir -p`
+ * later), but if the path exists today and isn't a directory we want to fail
+ * fast as a Usage error (exit 2) instead of running the whole workflow and
+ * blowing up with an EEXIST mkdir error at the very end (exit 1).
+ */
+export async function assertOutputDirAvailable(
+  outputDir: string | undefined,
+  cwd: string,
+): Promise<void> {
+  if (!outputDir) return;
+  const target = path.isAbsolute(outputDir)
+    ? outputDir
+    : path.join(cwd, outputDir);
+  const stats = await fs.stat(target).catch(() => null);
+  if (stats && !stats.isDirectory()) {
+    throw new CliUsageError(`--output-dir is not a directory: ${target}`);
+  }
+}
 
 export type CliWorkflowRunResult = Extract<
   CliRunResult,

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -22,6 +22,13 @@ import { CliUsageError, type CliContext } from '../../runtime/cliContext';
  * later), but if the path exists today and isn't a directory we want to fail
  * fast as a Usage error (exit 2) instead of running the whole workflow and
  * blowing up with an EEXIST mkdir error at the very end (exit 1).
+ *
+ * Only `ENOENT` is treated as "not there yet, mkdir -p will create it".
+ * `ENOTDIR` (an intermediate path component is a file — e.g.
+ * `--output-dir /tmp/file/sub` where `/tmp/file` is a regular file) is also a
+ * Usage error: `mkdir -p` can't fix it, and we'd otherwise pay the full agent
+ * run before failing. Other stat errors (EACCES, EIO, …) are environment
+ * problems and must propagate with their real cause.
  */
 export async function assertOutputDirAvailable(
   outputDir: string | undefined,
@@ -31,8 +38,25 @@ export async function assertOutputDirAvailable(
   const target = path.isAbsolute(outputDir)
     ? outputDir
     : path.join(cwd, outputDir);
-  const stats = await fs.stat(target).catch(() => null);
-  if (stats && !stats.isDirectory()) {
+  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
+  try {
+    stats = await fs.stat(target);
+  } catch (error: unknown) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (code === 'ENOENT') {
+      return;
+    }
+    if (code === 'ENOTDIR') {
+      throw new CliUsageError(
+        `--output-dir is not a directory (a parent path component is a file): ${target}`,
+      );
+    }
+    throw error;
+  }
+  if (!stats.isDirectory()) {
     throw new CliUsageError(`--output-dir is not a directory: ${target}`);
   }
 }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -46,6 +46,7 @@ import {
 } from './_helpers/terminalStatus';
 import { expandWorkflowInputSpecs } from './_helpers/workflowInputs';
 import {
+  assertOutputDirAvailable,
   expectedOutputFilesForOutputDir,
   formatWorkflowTextResult,
   resolveWorkflowOutput,
@@ -81,6 +82,9 @@ async function runWorkflowAgent(
   if (init.output && init.outputDir) {
     throw new CliUsageError('Use either --output or --output-dir, not both.');
   }
+  // Reject `--output-dir <path>` early when the path already points at a
+  // non-directory (else we'd run the full workflow and EEXIST at the end).
+  await assertOutputDirAvailable(init.outputDir, runContext.cwd);
   const inputFiles = await expandWorkflowInputSpecs(
     init.inputFiles,
     runContext.cwd,

--- a/src/test-kernel/cli/OutputDirGuard.vitest.mts
+++ b/src/test-kernel/cli/OutputDirGuard.vitest.mts
@@ -49,9 +49,9 @@ describe('assertOutputDirAvailable', () => {
       await expect(
         assertOutputDirAvailable(filePath, root),
       ).rejects.toBeInstanceOf(CliUsageError);
-      await expect(
-        assertOutputDirAvailable(filePath, root),
-      ).rejects.toThrow(/--output-dir is not a directory/);
+      await expect(assertOutputDirAvailable(filePath, root)).rejects.toThrow(
+        /--output-dir is not a directory/,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/test-kernel/cli/OutputDirGuard.vitest.mts
+++ b/src/test-kernel/cli/OutputDirGuard.vitest.mts
@@ -83,9 +83,9 @@ describe('assertOutputDirAvailable', () => {
       await expect(
         assertOutputDirAvailable(through, root),
       ).rejects.toBeInstanceOf(CliUsageError);
-      await expect(
-        assertOutputDirAvailable(through, root),
-      ).rejects.toThrow(/is not a directory/);
+      await expect(assertOutputDirAvailable(through, root)).rejects.toThrow(
+        /is not a directory/,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -105,9 +105,9 @@ describe('assertOutputDirAvailable', () => {
       try {
         await mkdir(blocked);
         await chmod(blocked, 0o000);
-        await expect(
-          assertOutputDirAvailable(inner, root),
-        ).rejects.toThrow(/(EACCES|permission)/i);
+        await expect(assertOutputDirAvailable(inner, root)).rejects.toThrow(
+          /(EACCES|permission)/i,
+        );
       } finally {
         await chmod(blocked, 0o755).catch(() => undefined);
         await rm(root, { recursive: true, force: true });

--- a/src/test-kernel/cli/OutputDirGuard.vitest.mts
+++ b/src/test-kernel/cli/OutputDirGuard.vitest.mts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -70,4 +70,48 @@ describe('assertOutputDirAvailable', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('rejects an --output-dir whose parent path component is a file (ENOTDIR)', async () => {
+    // `mkdir -p` can't fix this — `/tmp/file/sub` where `/tmp/file` is a
+    // regular file — so previously the fast path treated the stat ENOTDIR as
+    // "doesn't exist yet" and we paid the full agent run before mkdir failed.
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-enotdir-'));
+    try {
+      const filePath = join(root, 'not-a-dir');
+      await writeFile(filePath, 'just a file');
+      const through = join(filePath, 'subdir');
+      await expect(
+        assertOutputDirAvailable(through, root),
+      ).rejects.toBeInstanceOf(CliUsageError);
+      await expect(
+        assertOutputDirAvailable(through, root),
+      ).rejects.toThrow(/is not a directory/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
+  // mode-0 doesn't restrict stat.
+  const skipPermissionTest =
+    process.platform === 'win32' ||
+    (typeof process.getuid === 'function' && process.getuid() === 0);
+  (skipPermissionTest ? it.skip : it)(
+    'propagates non-ENOENT/ENOTDIR stat errors with their original cause',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-perm-'));
+      const blocked = join(root, 'blocked');
+      const inner = join(blocked, 'dir');
+      try {
+        await mkdir(blocked);
+        await chmod(blocked, 0o000);
+        await expect(
+          assertOutputDirAvailable(inner, root),
+        ).rejects.toThrow(/(EACCES|permission)/i);
+      } finally {
+        await chmod(blocked, 0o755).catch(() => undefined);
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/test-kernel/cli/OutputDirGuard.vitest.mts
+++ b/src/test-kernel/cli/OutputDirGuard.vitest.mts
@@ -1,0 +1,73 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { CliUsageError } from '../../../packages/cli/src/runtime/cliContext';
+import { assertOutputDirAvailable } from '../../../packages/cli/src/commands/_helpers/workflowOutput';
+
+describe('assertOutputDirAvailable', () => {
+  it('no-ops when --output-dir was not passed', async () => {
+    await expect(
+      assertOutputDirAvailable(undefined, tmpdir()),
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts a directory that already exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-'));
+    try {
+      const target = join(root, 'flagged');
+      await mkdir(target);
+      await expect(
+        assertOutputDirAvailable(target, root),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a path that does not exist yet (mkdir -p happens later)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-'));
+    try {
+      const target = join(root, 'no-such-yet');
+      await expect(
+        assertOutputDirAvailable(target, root),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a --output-dir that points at a file', async () => {
+    // Previously: the workflow ran for ~38s and EEXIST'd on mkdir at the end
+    // (exit 1). The fast path now refuses with a Usage error (exit 2).
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-'));
+    try {
+      const filePath = join(root, 'oops.txt');
+      await writeFile(filePath, 'not a directory');
+      await expect(
+        assertOutputDirAvailable(filePath, root),
+      ).rejects.toBeInstanceOf(CliUsageError);
+      await expect(
+        assertOutputDirAvailable(filePath, root),
+      ).rejects.toThrow(/--output-dir is not a directory/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a relative --output-dir against cwd before stat-ing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outdir-'));
+    try {
+      const filePath = join(root, 'relative-file.txt');
+      await writeFile(filePath, 'not a dir');
+      // Pass just the basename; the helper joins it with cwd.
+      await expect(
+        assertOutputDirAvailable('relative-file.txt', root),
+      ).rejects.toThrow(/--output-dir is not a directory/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`texra run … --output-dir <path>` previously paid the full agent run before `resolveWorkflowOutput`'s `mkdir -p` failed with `EEXIST: file already exists, mkdir '<path>'` and exit 1. A typo like `--output-dir paper.tex` (a file) wastes minutes of work for what is plainly a Usage error (exit 2).

```
$ texra run correct -i /tmp/probe.tex --output-dir /etc/hosts
[r1] · correct probe.tex · 38s
[r1] · correct probe.tex · stopped · 38s
EEXIST: file already exists, mkdir '/etc/hosts'
$ echo $?
1                  # ← should be 2, and should fail in <1s
```

A new `assertOutputDirAvailable(outputDir, cwd)` helper stats the target up-front: existing non-directory → `CliUsageError` (exit 2). Nonexistent paths are still accepted (`mkdir -p` happens later) and existing directories pass through unchanged.

Closes #4437.

## Changes

- `packages/cli/src/commands/_helpers/workflowOutput.ts`: new `assertOutputDirAvailable(outputDir, cwd)` — async helper that resolves the path against `cwd`, `stat`s it, and throws `CliUsageError("--output-dir is not a directory: <path>")` only when the path already exists and isn't a directory.
- `packages/cli/src/commands/workflow.ts`: call the helper right after the existing `--output`/`--output-dir` mutual-exclusion guard, before any IO. Removed the inline implementation in favor of the testable helper.
- `src/test-kernel/cli/OutputDirGuard.vitest.mts`: 5 cases — no flag, existing dir, nonexistent path, file path rejected with `CliUsageError`, relative path resolved against `cwd`.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 259/259 (5 new)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe:
  - `texra run correct -i probe.tex --output-dir /etc/hosts` → `--output-dir is not a directory: /etc/hosts` exit 2, no agent run started
  - `--output-dir <nonexistent>` and `--output-dir <existing-dir>` continue to work
  - Existing `--output` flag flow unchanged

## Verification commands

```sh
cd packages/cli && npm run bundle
echo test > /tmp/probe.tex
node dist/bin/texra.js run correct -i /tmp/probe.tex --output-dir /etc/hosts; echo "exit=$?"
npx vitest run src/test-kernel/cli/OutputDirGuard.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a preflight `fs.stat` check for `--output-dir` and new tests; behavior change is limited to earlier, clearer failures for invalid output paths.
> 
> **Overview**
> **Fail-fast validation for `--output-dir`.** The CLI now preflights `--output-dir` by resolving it against `cwd` and `stat`-ing it, throwing a `CliUsageError` when the path exists but isn’t a directory (including `ENOTDIR` cases), while still allowing non-existent paths.
> 
> `workflow.ts` calls this guard before expanding inputs / running the agent, and a new Vitest suite (`OutputDirGuard.vitest.mts`) covers success, missing-path, file-path, relative-path, `ENOTDIR`, and permission-error propagation scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a3a231cbe5e03d3966e2c6e2a38f736cd3a2efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->