### PR TITLE
fix(cli): expand and validate `texra run --context` paths the same as --input

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -45,7 +45,10 @@ import {
   type CliRunResult,
   type ExecuteAgentResult,
 } from './_helpers/terminalStatus';
-import { expandWorkflowInputSpecs } from './_helpers/workflowInputs';
+import {
+  expandWorkflowInputSpec,
+  expandWorkflowInputSpecs,
+} from './_helpers/workflowInputs';
 import {
   assertOutputDirAvailable,
   expectedOutputFilesForOutputDir,
@@ -91,6 +94,18 @@ async function runWorkflowAgent(
     init.inputFiles,
     runContext.cwd,
   );
+  // `--context` files are optional, so we can't reuse the plural helper
+  // (which errors on an empty result). Expand each spec individually with
+  // the right flag label so a missing context path fails fast as a Usage
+  // error (exit 2) instead of reaching the agent as a raw ENOENT (exit 1),
+  // and so a glob like `refs/*.bib` actually expands.
+  const contextFiles = (
+    await Promise.all(
+      init.contextFiles.map((spec) =>
+        expandWorkflowInputSpec(spec, runContext.cwd, '--context'),
+      ),
+    )
+  ).flat();
   if (init.output && inputFiles.length > 1) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
@@ -127,7 +142,7 @@ async function runWorkflowAgent(
     agent: init.agent,
     model,
     inputFiles,
-    contextFiles: init.contextFiles,
+    contextFiles,
     outputFiles: modelOutputFile ? [modelOutputFile] : [],
     cliOutputFile: init.output,
     instruction: init.instruction,

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -298,11 +298,7 @@ describe('CLI root argument routing', () => {
       await fs.writeFile(path.join(root, 'a.bib'), 'a');
       await fs.writeFile(path.join(root, 'b.bib'), 'b');
       await expect(
-        expandWorkflowInputSpecs(
-          [path.join(root, '*.bib')],
-          root,
-          '--context',
-        ),
+        expandWorkflowInputSpecs([path.join(root, '*.bib')], root, '--context'),
       ).resolves.toEqual(['a.bib', 'b.bib']);
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -288,6 +288,27 @@ describe('CLI root argument routing', () => {
     }
   });
 
+  it('expands a glob --context spec the same way --input does', async () => {
+    // `texra run -c '<glob>'` previously stuffed the literal glob string into
+    // the AgentConfig and failed late with raw ENOENT (exit 1). Routing
+    // through expandWorkflowInputSpecs gives it the same expansion semantics
+    // as `--input` (and surfaces missing-path errors as Usage / exit 2).
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-ctx-'));
+    try {
+      await fs.writeFile(path.join(root, 'a.bib'), 'a');
+      await fs.writeFile(path.join(root, 'b.bib'), 'b');
+      await expect(
+        expandWorkflowInputSpecs(
+          [path.join(root, '*.bib')],
+          root,
+          '--context',
+        ),
+      ).resolves.toEqual(['a.bib', 'b.bib']);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Skip on Windows (no POSIX chmod semantics) and when running as root, where
   // mode-0 doesn't block stat.
   const skipPermissionTest =


### PR DESCRIPTION
## Summary

`texra run` previously passed `--context` values straight to the AgentConfig with no expansion, so two long-standing wrinkles bit together:

| Invocation | Before | After |
|---|---|---|
| `texra run -c <missing>` | ENOENT mid-run → exit 1 | `--context: file not found: <path>` → exit 2 |
| `texra run -c '<glob>'` | literal sent to agent → ENOENT → exit 1 | glob expanded the same way `--input` is |

`texra multi-agent run` already expands `--context` through `expandWorkflowInputSpec`. This brings `texra run` to parity using the `flagLabel` parameter that landed with #4432.

Closes #4433.

## Notes

This supersedes the closed PR #4434, which was auto-closed when its base branch (`cli/run-validate-input-and-agent` from PR #4432) was deleted after squash-merge. The branch was rebased onto current main; the only test that was novel vs main was kept (`expands a glob --context spec the same way --input does`), the other tests already came in via #4432's squash.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/CliRootArgs.vitest.mts` → 34/34 (1 new)
- [x] Built-CLI behavior verified prior to PR #4432's merge (see PR #4434 description for the original probes)

## Verification commands

```sh
cd packages/cli && npm run bundle
echo > /tmp/probe.tex
node dist/bin/texra.js run correct -i /tmp/probe.tex -c /tmp/no-such-refs.bib; echo "exit=$?"
node dist/bin/texra.js run correct -i /tmp/probe.tex -c '/tmp/refs/no-such-*.bib'; echo "exit=$?"
npx vitest run src/test-kernel/cli/CliRootArgs.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to CLI argument preprocessing for `texra run`; main impact is earlier validation/error messaging and glob expansion for `--context` inputs.
> 
> **Overview**
> `texra run` now expands and validates `--context` path specs (including globs) before starting the workflow, matching `--input` semantics and surfacing missing-path issues as `CliUsageError` (exit 2) instead of late ENOENT failures (exit 1).
> 
> The workflow command builds the AgentConfig with the expanded `contextFiles` list, and a new test covers glob expansion for `--context`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b97c41aa83284f99bfd45c0187b9e0086eb83f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->