### PR TITLE
fix(cli): fail fast on `--output <dir>` or `--output <file>/out.tex`

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -61,6 +61,49 @@ export async function assertOutputDirAvailable(
   }
 }
 
+/**
+ * Single-file twin of {@link assertOutputDirAvailable}: `--output` must end at
+ * a path the workflow can write a file to. The path doesn't need to exist
+ * (we `mkdir -p` the parent and create the file during the run), but pointing
+ * `--output` at an existing directory or through a file-typed parent component
+ * blows up at copy time after the full agent run (`EISDIR` / `EEXIST`).
+ *
+ * `ENOENT` → return (file will be created). `ENOTDIR` (parent component is a
+ * file) → Usage error. Other stat errors propagate.
+ */
+export async function assertOutputFileAvailable(
+  outputFile: string | undefined,
+  cwd: string,
+): Promise<void> {
+  if (!outputFile) return;
+  const target = path.isAbsolute(outputFile)
+    ? outputFile
+    : path.join(cwd, outputFile);
+  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
+  try {
+    stats = await fs.stat(target);
+  } catch (error: unknown) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (code === 'ENOENT') {
+      return;
+    }
+    if (code === 'ENOTDIR') {
+      throw new CliUsageError(
+        `--output: a parent path component is a file: ${target}`,
+      );
+    }
+    throw error;
+  }
+  if (stats.isDirectory()) {
+    throw new CliUsageError(
+      `--output is a directory; use --output-dir or pick a file path: ${target}`,
+    );
+  }
+}
+
 export type CliWorkflowRunResult = Extract<
   CliRunResult,
   { category: 'workflow' }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -51,6 +51,7 @@ import {
 } from './_helpers/workflowInputs';
 import {
   assertOutputDirAvailable,
+  assertOutputFileAvailable,
   expectedOutputFilesForOutputDir,
   formatWorkflowTextResult,
   resolveWorkflowOutput,
@@ -90,6 +91,10 @@ async function runWorkflowAgent(
   // Reject `--output-dir <path>` early when the path already points at a
   // non-directory (else we'd run the full workflow and EEXIST at the end).
   await assertOutputDirAvailable(init.outputDir, runContext.cwd);
+  // Same fast-fail for `--output <path>`: existing directory or file-typed
+  // parent component blows up at copy time (`EISDIR` / `EEXIST`) after the
+  // full agent run otherwise.
+  await assertOutputFileAvailable(init.output, runContext.cwd);
   const inputFiles = await expandWorkflowInputSpecs(
     init.inputFiles,
     runContext.cwd,

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { CliUsageError } from '../../../packages/cli/src/runtime/cliContext';
-import { assertOutputDirAvailable } from '../../../packages/cli/src/commands/_helpers/workflowOutput';
+import {
+  assertOutputDirAvailable,
+  assertOutputFileAvailable,
+} from '../../../packages/cli/src/commands/_helpers/workflowOutput';
 
 describe('assertOutputDirAvailable', () => {
   it('no-ops when --output-dir was not passed', async () => {
@@ -114,4 +117,87 @@ describe('assertOutputDirAvailable', () => {
       }
     },
   );
+});
+
+describe('assertOutputFileAvailable', () => {
+  it('no-ops when --output was not passed', async () => {
+    await expect(
+      assertOutputFileAvailable(undefined, tmpdir()),
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts a path that does not exist yet (writer creates the file)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outfile-'));
+    try {
+      await expect(
+        assertOutputFileAvailable(join(root, 'out.tex'), root),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts an existing file (the writer overwrites)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outfile-'));
+    try {
+      const target = join(root, 'existing.tex');
+      await writeFile(target, 'old content');
+      await expect(
+        assertOutputFileAvailable(target, root),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --output pointing at an existing directory', async () => {
+    // Previously: workflow ran ~19s, then EISDIR on copyfile at the end
+    // (exit 1). The fast path now refuses with a Usage error (exit 2) and
+    // hints at --output-dir.
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outfile-'));
+    try {
+      const dirPath = join(root, 'sub');
+      await mkdir(dirPath);
+      await expect(
+        assertOutputFileAvailable(dirPath, root),
+      ).rejects.toBeInstanceOf(CliUsageError);
+      await expect(
+        assertOutputFileAvailable(dirPath, root),
+      ).rejects.toThrow(/--output is a directory.*use --output-dir/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --output whose parent path component is a file (ENOTDIR)', async () => {
+    // Previously: workflow ran ~40s, then EEXIST on mkdir of the parent
+    // (exit 1). `mkdir -p` can't recover this — the parent IS a file.
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outfile-'));
+    try {
+      const filePath = join(root, 'not-a-dir');
+      await writeFile(filePath, 'just a file');
+      const through = join(filePath, 'out.tex');
+      await expect(
+        assertOutputFileAvailable(through, root),
+      ).rejects.toBeInstanceOf(CliUsageError);
+      await expect(
+        assertOutputFileAvailable(through, root),
+      ).rejects.toThrow(/parent path component is a file/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a relative --output against cwd before stat-ing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'texra-cli-outfile-'));
+    try {
+      const dirPath = join(root, 'rel-dir');
+      await mkdir(dirPath);
+      await expect(
+        assertOutputFileAvailable('rel-dir', root),
+      ).rejects.toThrow(/--output is a directory/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -161,9 +161,9 @@ describe('assertOutputFileAvailable', () => {
       await expect(
         assertOutputFileAvailable(dirPath, root),
       ).rejects.toBeInstanceOf(CliUsageError);
-      await expect(
-        assertOutputFileAvailable(dirPath, root),
-      ).rejects.toThrow(/--output is a directory.*use --output-dir/);
+      await expect(assertOutputFileAvailable(dirPath, root)).rejects.toThrow(
+        /--output is a directory.*use --output-dir/,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -180,9 +180,9 @@ describe('assertOutputFileAvailable', () => {
       await expect(
         assertOutputFileAvailable(through, root),
       ).rejects.toBeInstanceOf(CliUsageError);
-      await expect(
-        assertOutputFileAvailable(through, root),
-      ).rejects.toThrow(/parent path component is a file/);
+      await expect(assertOutputFileAvailable(through, root)).rejects.toThrow(
+        /parent path component is a file/,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -193,9 +193,9 @@ describe('assertOutputFileAvailable', () => {
     try {
       const dirPath = join(root, 'rel-dir');
       await mkdir(dirPath);
-      await expect(
-        assertOutputFileAvailable('rel-dir', root),
-      ).rejects.toThrow(/--output is a directory/);
+      await expect(assertOutputFileAvailable('rel-dir', root)).rejects.toThrow(
+        /--output is a directory/,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

`texra run … --output <path>` previously paid the full agent run before failing at copy time when `<path>` was wrong:

| Invocation | Before | After |
|---|---|---|
| `texra run -i in.tex --output /tmp/some-dir` (existing directory; typo of `--output-dir`) | run, then `EISDIR: copyfile …` exit 1 | `--output is a directory; use --output-dir or pick a file path: …` exit 2 |
| `texra run -i in.tex --output /tmp/file.txt/out.tex` (a parent path component is a file) | run, then `EEXIST: mkdir '/tmp/file.txt'` exit 1 | `--output: a parent path component is a file: …` exit 2 |

Same fail-late pattern as `--output-dir` had before PR #4438. This adds the file twin.

Closes #4439.

## Changes

- `packages/cli/src/commands/_helpers/workflowOutput.ts`: new `assertOutputFileAvailable(outputFile, cwd)` next to `assertOutputDirAvailable`. ENOENT → return; ENOTDIR → `CliUsageError`; other stat errors propagate. Existing-directory case throws `CliUsageError` with the `--output-dir` hint.
- `packages/cli/src/commands/workflow.ts`: call the new helper right after `assertOutputDirAvailable`, before any IO.
- `src/test-kernel/cli/OutputGuards.vitest.mts` (renamed from `OutputDirGuard.vitest.mts`): 6 new cases — no-flag, nonexistent path, existing file (overwrite), existing directory rejected, ENOTDIR rejected, relative path resolved against cwd.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/` → 290/290 (6 new)
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probes:
  - `texra run correct -i probe.tex --output /tmp/some-dir` → `--output is a directory; use --output-dir or pick a file path: /tmp/some-dir`, exit 2
  - `texra run correct -i probe.tex --output /tmp/file.txt/out.tex` → `--output: a parent path component is a file: …`, exit 2
  - `--output <new-file>` and `--output <new-deep-path>` → unchanged

## Verification commands

```sh
cd packages/cli && npm run bundle
mkdir -p /tmp/some-dir && echo > /tmp/probe.tex
node dist/bin/texra.js run correct -i /tmp/probe.tex --output /tmp/some-dir; echo "exit=$?"
echo file > /tmp/probe-file.txt
node dist/bin/texra.js run correct -i /tmp/probe.tex --output /tmp/probe-file.txt/out.tex; echo "exit=$?"
npx vitest run src/test-kernel/cli/OutputGuards.vitest.mts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds early CLI validation for `--output` path edge cases and corresponding tests, without changing workflow execution behavior or output copying logic for valid paths.
> 
> **Overview**
> **Fails fast for invalid `--output` destinations.** Adds `assertOutputFileAvailable()` to preflight `--output` so the CLI returns a `CliUsageError` when the target is an existing directory or when a parent path component is a file (while still allowing missing paths and existing files).
> 
> Wires this check into `texra run` alongside the existing `--output-dir` guard, and adds a dedicated Vitest suite covering the new `--output` cases (nonexistent path, existing file, existing directory, ENOTDIR parent, and relative-path resolution).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5d3d836c88e4cd5911acd1bd519d72b213f4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->