### PR TITLE
fix(cli): `texra history delete <bad-id>` reports not-found instead of lying

### DIFF
--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -160,11 +160,17 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
 }
 
 /**
- * Delete a single execution and its KV data.
+ * Delete a single execution and its KV data. Returns true if the execution
+ * existed and was removed, false if no such execution was present. The
+ * `clear()` call silently no-ops on a missing directory, so we have to probe
+ * existence ourselves before calling it — otherwise callers can't tell a real
+ * delete apart from a no-op on a typo'd id.
  */
 export async function deleteExecution(
   executionId: ExecutionId,
 ): Promise<boolean> {
+  const existed = await StorageFS.exists(`${EXECUTIONS_DIR}/${executionId}`);
+  if (!existed) return false;
   try {
     await getExecutionStore(executionId).clear();
     invalidateListingCache();

--- a/src/test-kernel/agent/DeleteExecution.vitest.mts
+++ b/src/test-kernel/agent/DeleteExecution.vitest.mts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ExecutionId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  exists: vi.fn(),
+  clear: vi.fn(),
+  invalidateListingCache: vi.fn(),
+}));
+
+vi.mock('@utils/files', async () => {
+  const actual =
+    await vi.importActual<typeof import('@utils/files')>('@utils/files');
+  return {
+    ...actual,
+    StorageFS: { ...actual.StorageFS, exists: mocks.exists },
+  };
+});
+
+vi.mock('@agent/storage/ExecutionKVStore', () => ({
+  EXECUTIONS_DIR: 'executions',
+  getExecutionStore: vi.fn(() => ({ clear: mocks.clear })),
+}));
+
+import { deleteExecution } from '@agent/storage/executionListing';
+
+beforeEach(() => {
+  mocks.exists.mockReset();
+  mocks.clear.mockReset();
+});
+
+describe('deleteExecution', () => {
+  it('returns false without calling clear when the execution directory is missing', async () => {
+    mocks.exists.mockResolvedValue(false);
+    mocks.clear.mockResolvedValue(undefined);
+
+    await expect(deleteExecution('deadbeef0000' as ExecutionId)).resolves.toBe(
+      false,
+    );
+
+    // The probe asked about the right path.
+    expect(mocks.exists).toHaveBeenCalledWith('executions/deadbeef0000');
+    // Critical: clear() must NOT run on a missing id — otherwise the silent
+    // no-op behaviour of `deleteDir` makes us report "Deleted" for typos.
+    expect(mocks.clear).not.toHaveBeenCalled();
+  });
+
+  it('returns true and clears storage when the execution directory exists', async () => {
+    mocks.exists.mockResolvedValue(true);
+    mocks.clear.mockResolvedValue(undefined);
+
+    await expect(deleteExecution('a73039a36ec9' as ExecutionId)).resolves.toBe(
+      true,
+    );
+    expect(mocks.clear).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`deleteExecution(id)` returned `true` unconditionally when the underlying `store.clear()` succeeded — but `KVStore.deleteDir()` silently swallows ENOENT. The net effect: deleting a never-existed id printed `Deleted execution <id>.` and exited 0:

```
$ texra history delete deadbeef0000
Deleted execution deadbeef0000.
$ echo $?
0                  # ← lying success; nothing was actually deleted
```

The CLI handler at `packages/cli/src/commands/history.ts` already has the correct `not found` branch; `deleteExecution` just never returned `false` to trigger it.

Probe the execution directory with `StorageFS.exists` before calling `clear()`. After:

```
$ texra history delete deadbeef0000
Execution not found: deadbeef0000
$ echo $?
2
```

Closes #4444.

## Changes

- `src/agent/storage/executionListing.ts`: `deleteExecution` checks `StorageFS.exists("executions/<id>")` up front. Missing → return false; present → preserve existing clear+return-true path.
- `src/test-kernel/agent/DeleteExecution.vitest.mts`: 2 new unit cases mocking `StorageFS.exists`. Missing → returns false, does NOT call `clear()`. Present → returns true, calls `clear()` exactly once.

## Test plan

- [x] `npx vitest run src/test-kernel/agent/DeleteExecution.vitest.mts` → 2/2
- [x] `npx vitest run src/test-kernel/cli/ src/test-kernel/agent/DeleteExecution.vitest.mts` → 292/292
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI probe:
  - `texra history delete deadbeef0000` → `Execution not found: deadbeef0000`, exit 2
  - `texra history delete <real-id>` → `Deleted execution <real-id>.`, exit 0 (verified with a real id from `history list`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to deletion flow that adds an existence probe and new unit tests; main risk is any mismatch in the probed path vs actual storage layout.
> 
> **Overview**
> Fixes execution deletion to distinguish a real delete from a silent no-op when the execution directory is missing.
> 
> `deleteExecution` now checks `StorageFS.exists` for `executions/<id>` before calling `clear()`, returning `false` immediately on missing IDs, and adds unit tests covering both missing and present directories to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8729d0079bdf4a9ab160b6cb12cd301ba2b64f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->