### PR TITLE
refactor(cli): use isFileNotFoundError / isNotADirectoryError predicates

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path';
 
 import { glob, hasMagic } from 'glob';
 
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+
 import { CliUsageError } from '../../runtime/cliContext';
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
@@ -62,11 +64,7 @@ export async function expandWorkflowInputSpec(
   try {
     stats = await fs.stat(absolutePath);
   } catch (error: unknown) {
-    const code =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+    if (!isFileNotFoundError(error) && !isNotADirectoryError(error)) {
       throw error;
     }
   }

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -6,6 +6,7 @@ import type { AgentConfigPayload } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { getRunDir } from '@utils/files';
 
@@ -18,18 +19,31 @@ import {
 import { CliUsageError, type CliContext } from '../../runtime/cliContext';
 
 /**
- * `--output-dir` may legitimately not exist yet (the run will `mkdir -p`
- * later), but if the path exists today and isn't a directory we want to fail
- * fast as a Usage error (exit 2) instead of running the whole workflow and
- * blowing up with an EEXIST mkdir error at the very end (exit 1).
- *
- * Only `ENOENT` is treated as "not there yet, mkdir -p will create it".
- * `ENOTDIR` (an intermediate path component is a file — e.g.
- * `--output-dir /tmp/file/sub` where `/tmp/file` is a regular file) is also a
- * Usage error: `mkdir -p` can't fix it, and we'd otherwise pay the full agent
- * run before failing. Other stat errors (EACCES, EIO, …) are environment
- * problems and must propagate with their real cause.
+ * Stat `target` for the output-path guards. Returns `null` when the path
+ * doesn't exist yet (the workflow will create it). `ENOTDIR` (a parent path
+ * component is a file) is surfaced as a Usage error here so callers don't
+ * have to repeat it. Other stat errors propagate with their real cause.
  */
+async function probeOutputPath(
+  target: string,
+  flagLabel: '--output' | '--output-dir',
+): Promise<Awaited<ReturnType<typeof fs.stat>> | null> {
+  try {
+    return await fs.stat(target);
+  } catch (error: unknown) {
+    if (isFileNotFoundError(error)) return null;
+    if (isNotADirectoryError(error)) {
+      throw new CliUsageError(
+        flagLabel === '--output-dir'
+          ? `--output-dir is not a directory (a parent path component is a file): ${target}`
+          : `--output: a parent path component is a file: ${target}`,
+      );
+    }
+    throw error;
+  }
+}
+
+/** `--output-dir <path>` must point at a directory (or not exist yet). */
 export async function assertOutputDirAvailable(
   outputDir: string | undefined,
   cwd: string,
@@ -38,39 +52,13 @@ export async function assertOutputDirAvailable(
   const target = path.isAbsolute(outputDir)
     ? outputDir
     : path.join(cwd, outputDir);
-  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
-  try {
-    stats = await fs.stat(target);
-  } catch (error: unknown) {
-    const code =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-    if (code === 'ENOENT') {
-      return;
-    }
-    if (code === 'ENOTDIR') {
-      throw new CliUsageError(
-        `--output-dir is not a directory (a parent path component is a file): ${target}`,
-      );
-    }
-    throw error;
-  }
-  if (!stats.isDirectory()) {
+  const stats = await probeOutputPath(target, '--output-dir');
+  if (stats && !stats.isDirectory()) {
     throw new CliUsageError(`--output-dir is not a directory: ${target}`);
   }
 }
 
-/**
- * Single-file twin of {@link assertOutputDirAvailable}: `--output` must end at
- * a path the workflow can write a file to. The path doesn't need to exist
- * (we `mkdir -p` the parent and create the file during the run), but pointing
- * `--output` at an existing directory or through a file-typed parent component
- * blows up at copy time after the full agent run (`EISDIR` / `EEXIST`).
- *
- * `ENOENT` → return (file will be created). `ENOTDIR` (parent component is a
- * file) → Usage error. Other stat errors propagate.
- */
+/** `--output <path>` must end at a writable file path (or not exist yet). */
 export async function assertOutputFileAvailable(
   outputFile: string | undefined,
   cwd: string,
@@ -79,25 +67,8 @@ export async function assertOutputFileAvailable(
   const target = path.isAbsolute(outputFile)
     ? outputFile
     : path.join(cwd, outputFile);
-  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
-  try {
-    stats = await fs.stat(target);
-  } catch (error: unknown) {
-    const code =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-    if (code === 'ENOENT') {
-      return;
-    }
-    if (code === 'ENOTDIR') {
-      throw new CliUsageError(
-        `--output: a parent path component is a file: ${target}`,
-      );
-    }
-    throw error;
-  }
-  if (stats.isDirectory()) {
+  const stats = await probeOutputPath(target, '--output');
+  if (stats?.isDirectory()) {
     throw new CliUsageError(
       `--output is a directory; use --output-dir or pick a file path: ${target}`,
     );

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -3,6 +3,7 @@ import { readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 import {
@@ -219,11 +220,7 @@ export async function resolveCliCwd(
   try {
     info = await stat(requested);
   } catch (error: unknown) {
-    const code =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
+    if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
       throw new CliUsageError(`--cwd: path does not exist: ${requested}`);
     }
     throw new CliUsageError(

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -4,6 +4,11 @@ export function isFileNotFoundError(err: unknown): boolean {
   return code === 'ENOENT' || code === 'FileNotFound';
 }
 
+/** Check if an error represents "a parent path component is a file, not a directory". */
+export function isNotADirectoryError(err: unknown): boolean {
+  return (err as { code?: string })?.code === 'ENOTDIR';
+}
+
 /** Check if an error represents a "no space left on device" condition. */
 export function isDiskFullError(err: unknown): boolean {
   for (

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -8,7 +8,11 @@
  */
 export { formatError, formatZodError } from './errorFormatUtils';
 export { toErrorMessage } from './errorMessage';
-export { isDiskFullError, isFileNotFoundError } from './errorPredicates';
+export {
+  isDiskFullError,
+  isFileNotFoundError,
+  isNotADirectoryError,
+} from './errorPredicates';
 export {
   classifyAgentError,
   type AgentErrorKind,


### PR DESCRIPTION
## Summary

Pure refactor. No behavior change.

The error-code extraction pattern

```ts
const code =
  typeof error === 'object' && error !== null && 'code' in error
    ? (error as { code?: unknown }).code
    : undefined;
if (code === 'ENOENT') ...
if (code === 'ENOTDIR') ...
```

was inlined in four spots:

- `packages/cli/src/runtime/cliContext.ts` (`resolveCliCwd`)
- `packages/cli/src/commands/_helpers/workflowInputs.ts` (`expandWorkflowInputSpec`)
- `packages/cli/src/commands/_helpers/workflowOutput.ts` (`assertOutputDirAvailable`)
- `packages/cli/src/commands/_helpers/workflowOutput.ts` (`assertOutputFileAvailable`)

The repo already had `isFileNotFoundError` in `@common/errors/errorPredicates`. This PR:

1. Adds the symmetric `isNotADirectoryError` next to it.
2. Switches all four sites to the named predicates.
3. In `workflowOutput.ts` the two `assertOutput*Available` helpers shared ~70% of their bodies; a small private `probeOutputPath(target, flagLabel)` now does the shared stat + ENOENT/ENOTDIR routing, and each public helper collapses to one stat call plus a tail-end `isDirectory` check.

Net `-25` lines, no API surface change beyond the new predicate.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/ src/test-kernel/agent/` → 409/409
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI regression — every error message and exit code preserved exactly:
  - `texra --cwd /no-such agents list` → `--cwd: path does not exist: /no-such` exit 2
  - `texra run … --output /existing-dir` → `--output is a directory; use --output-dir or pick a file path: …` exit 2
  - `texra run … --output /file.txt/x.tex` → `--output: a parent path component is a file: …` exit 2
  - `texra run … --input /file.txt/x.tex` → `--input: file not found: …` exit 2

## Verification commands

```sh
npx vitest run src/test-kernel/cli/ src/test-kernel/agent/
cd packages/cli && npm run bundle
node dist/bin/texra.js --cwd /no-such agents list; echo "exit=$?"
mkdir -p /tmp/d && echo > /tmp/p.tex && echo file > /tmp/f.txt
node dist/bin/texra.js run correct -i /tmp/p.tex --output /tmp/d; echo "exit=$?"
node dist/bin/texra.js run correct -i /tmp/p.tex --output /tmp/f.txt/x.tex; echo "exit=$?"
```