### PR TITLE
refactor(cli): extract joinCwdRelative helper in workflowOutput.ts

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -18,6 +18,11 @@ import {
 } from './terminalStatus';
 import { CliUsageError, type CliContext } from '../../runtime/cliContext';
 
+/** Resolve a user-supplied path against `cwd` when it isn't already absolute. */
+function joinCwdRelative(target: string, cwd: string): string {
+  return path.isAbsolute(target) ? target : path.join(cwd, target);
+}
+
 /**
  * Stat `target` for the output-path guards. Returns `null` when the path
  * doesn't exist yet (the workflow will create it). `ENOTDIR` (a parent path
@@ -49,9 +54,7 @@ export async function assertOutputDirAvailable(
   cwd: string,
 ): Promise<void> {
   if (!outputDir) return;
-  const target = path.isAbsolute(outputDir)
-    ? outputDir
-    : path.join(cwd, outputDir);
+  const target = joinCwdRelative(outputDir, cwd);
   const stats = await probeOutputPath(target, '--output-dir');
   if (stats && !stats.isDirectory()) {
     throw new CliUsageError(`--output-dir is not a directory: ${target}`);
@@ -64,9 +67,7 @@ export async function assertOutputFileAvailable(
   cwd: string,
 ): Promise<void> {
   if (!outputFile) return;
-  const target = path.isAbsolute(outputFile)
-    ? outputFile
-    : path.join(cwd, outputFile);
+  const target = joinCwdRelative(outputFile, cwd);
   const stats = await probeOutputPath(target, '--output');
   if (stats?.isDirectory()) {
     throw new CliUsageError(
@@ -166,9 +167,7 @@ export async function resolveWorkflowOutput(
       ? (options.runDirectory ?? getRunDir(result.executionId))
       : undefined;
   if (outputDir && result.category === AgentCategory.Workflow) {
-    const targetRoot = path.isAbsolute(outputDir)
-      ? outputDir
-      : path.join(context.cwd, outputDir);
+    const targetRoot = joinCwdRelative(outputDir, context.cwd);
     const outputsByRelativePath = new Map<string, OutputFileSummary>();
     for (const output of result.outputs) {
       const relativePath = outputCopyRelativePath(output);
@@ -223,9 +222,7 @@ export async function resolveWorkflowOutput(
     };
   }
 
-  const targetPath = path.isAbsolute(outputFile)
-    ? outputFile
-    : path.join(context.cwd, outputFile);
+  const targetPath = joinCwdRelative(outputFile, context.cwd);
   if (path.resolve(finalOutput.absolutePath) !== path.resolve(targetPath)) {
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.copyFile(finalOutput.absolutePath, targetPath);


### PR DESCRIPTION
## Summary

Pure refactor. No behavior change.

`path.isAbsolute(x) ? x : path.join(cwd, x)` appeared four times in `workflowOutput.ts`:

- `assertOutputDirAvailable`
- `assertOutputFileAvailable`
- the `outputDir` branch in `resolveWorkflowOutput`
- the `outputFile` branch in `resolveWorkflowOutput`

A small private `joinCwdRelative(target, cwd)` captures the intent and collapses the four sites to one expression each (-12, +9 lines net).

The remaining `path.isAbsolute` check inside `resumeWorkflowOutputFile` has different semantics (returns the absolute path directly when absolute, then conditionally joins against `config.workingDirectory`) and is left alone.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/OutputGuards.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts` → 51/51
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI regression — error messages preserved exactly:
  - `texra run … --output <existing-dir>` → `--output is a directory; use --output-dir or pick a file path: …`
  - `texra run … --output <file>/x.tex` → `--output: a parent path component is a file: …`
  - `texra run … --output-dir <file>` → `--output-dir is not a directory: …`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only centralizes repeated path-joining logic; behavior should remain unchanged aside from potential subtle differences in how paths are constructed/resolved.
> 
> **Overview**
> Introduces a small internal helper, `joinCwdRelative()`, to centralize the repeated `path.isAbsolute(...) ? ... : path.join(cwd, ...)` pattern.
> 
> Updates `assertOutputDirAvailable`, `assertOutputFileAvailable`, and `resolveWorkflowOutput` to use this helper when resolving `--output`/`--output-dir` targets relative to the CLI `cwd`, reducing duplication without changing the output-copying behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5a6147df8674c49dbc82d6efefe866559af8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->