### PR TITLE
refactor(core): use isFileNotFoundError / isNotADirectoryError predicates

### DIFF
--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
+import { isFileNotFoundError } from '@common/errors';
+
 type JsonRecord = Record<string, unknown>;
 
 async function readJsonRecord(filePath: string): Promise<JsonRecord> {
@@ -11,7 +13,7 @@ async function readJsonRecord(filePath: string): Promise<JsonRecord> {
       ? (parsed as JsonRecord)
       : {};
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    if (isFileNotFoundError(error)) return {};
     if (error instanceof SyntaxError) return {};
     throw error;
   }

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -4,15 +4,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { isFileNotFoundError } from '@common/errors';
+
 import {
   FileType,
   type FileSystemProvider,
   type FileStat,
 } from '../interfaces/filesystem';
-
-function isNotFound(err: unknown): boolean {
-  return (err as NodeJS.ErrnoException).code === 'ENOENT';
-}
 
 /**
  * Resolve the target type of a symlink, producing combined bitmasks
@@ -134,7 +132,7 @@ export const nodeFilesystem: FileSystemProvider = {
         });
       }
     } catch (err) {
-      if (!isNotFound(err)) throw err;
+      if (!isFileNotFoundError(err)) throw err;
     }
   },
 
@@ -183,7 +181,7 @@ export const nodeFilesystem: FileSystemProvider = {
           code: 'EEXIST',
         });
       } catch (err) {
-        if (!isNotFound(err)) throw err;
+        if (!isFileNotFoundError(err)) throw err;
       }
     }
     await fs.promises.rename(source, dest);

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+
 /**
  * Allowlist of external filesystem roots that tools may read or write.
  *
@@ -83,8 +85,7 @@ function canonicalise(p: string): string {
       ? fs.realpathSync.native(resolved)
       : fs.realpathSync(resolved);
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+    if (!isFileNotFoundError(err) && !isNotADirectoryError(err)) {
       throw err;
     }
     const parent = path.dirname(resolved);

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -517,11 +517,10 @@ export class TaskRunFileService {
             return;
           }
         } catch (error) {
-          const err = error as NodeJS.ErrnoException;
-          if (err?.code !== 'ENOENT') {
+          if (!isFileNotFoundError(error)) {
             logger.debug(
               CHANNEL,
-              `Unable to stat ${destinationAbsolute}: ${toErrorMessage(err)}`,
+              `Unable to stat ${destinationAbsolute}: ${toErrorMessage(error)}`,
             );
           }
           // ENOENT is the common case — no collision, proceed with the link.


### PR DESCRIPTION
## Summary

Pure refactor. No behavior change. Follow-up to PR #4450, which switched four CLI sites to the named error predicates in `@common/errors`. The same inline `(err as NodeJS.ErrnoException).code === 'ENOENT'` idiom (and its `code !== 'ENOENT' && code !== 'ENOTDIR'` variant) appears in four more spots outside the CLI:

- `src/platform/defaults/nodeFilesystem.ts` — had its own private `isNotFound(err)` helper; replaced with `isFileNotFoundError` and removed the duplicate definition.
- `src/platform/defaults/jsonStore.ts` — inline ENOENT check on config-file reads.
- `src/utils/files/externalRoots.ts` — ENOENT && ENOTDIR canonicalisation guard.
- `src/utils/files/taskRunStorage.ts` — inline ENOENT check inside the run-dir mirror collision probe.

Net `0` lines, but the duplicate `isNotFound` private helper is removed and the intent is named at each site.

## Test plan

- [x] `npx vitest run` → 1084/1084 pass
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that standardizes filesystem error handling by swapping inline `ENOENT`/`ENOTDIR` code checks for shared predicates; behavior should remain the same aside from slightly broader matching (e.g. `FileNotFound`).
> 
> **Overview**
> Replaces scattered inline filesystem error-code checks (and one local `isNotFound` helper) with the shared `@common/errors` predicates `isFileNotFoundError` and `isNotADirectoryError`.
> 
> This refactor touches JSON store reads, the Node filesystem provider’s `delete`/`rename` paths, external-root canonicalisation, and task run-dir mirroring collision probes, improving consistency/readability without intended behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2134ed03b622a61bae1f23bb4161613c9c216700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->