### PR TITLE
refactor(core): add isModuleNotFoundError predicate

### DIFF
--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -9,6 +9,12 @@ export function isNotADirectoryError(err: unknown): boolean {
   return (err as { code?: string })?.code === 'ENOTDIR';
 }
 
+/** Check if an error is "dynamic import couldn't find the module" (Node + ESM variants). */
+export function isModuleNotFoundError(err: unknown): boolean {
+  const code = (err as { code?: string })?.code;
+  return code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
+}
+
 /** Check if an error represents a "no space left on device" condition. */
 export function isDiskFullError(err: unknown): boolean {
   for (

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -11,6 +11,7 @@ export { toErrorMessage } from './errorMessage';
 export {
   isDiskFullError,
   isFileNotFoundError,
+  isModuleNotFoundError,
   isNotADirectoryError,
 } from './errorPredicates';
 export {

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -18,6 +18,7 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
+import { isModuleNotFoundError } from '@common/errors';
 import { platform } from '@platform/platform';
 import { executeCommandSync } from '@utils/system/execUtils';
 
@@ -52,8 +53,7 @@ export async function importClaudeAgentSdk(): Promise<QueryFn> {
   try {
     mod = await import('@anthropic-ai/claude-agent-sdk');
   } catch (err: unknown) {
-    const code = (err as { code?: string }).code;
-    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    if (isModuleNotFoundError(err)) {
       throw new Error(
         '@anthropic-ai/claude-agent-sdk package not found. Reinstall TeXRA or run corepack pnpm install in the TeXRA workspace.',
       );

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,6 +17,7 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
+import { isModuleNotFoundError } from '@common/errors';
 import { platform } from '@platform/platform';
 import { executeCommandSync } from '@utils/system/execUtils';
 
@@ -43,8 +44,7 @@ export async function importCodexClass(): Promise<CodexConstructor> {
   try {
     mod = await import('@openai/codex-sdk');
   } catch (err: unknown) {
-    const code = (err as { code?: string }).code;
-    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    if (isModuleNotFoundError(err)) {
       throw new Error(
         '@openai/codex-sdk package not found. Install with: npm install -g @openai/codex',
       );


### PR DESCRIPTION
## Summary

Pure refactor. No behavior change. Continues the predicate chain (#4450, #4452).

`claudeAgentImport.ts` and `codexImport.ts` had the same dynamic-import fallback shape:

```ts
const code = (err as { code?: string }).code;
if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
  throw new Error('… package not found. …');
}
throw err;
```

Both ESM and CJS variants of "module not found" needed checking, repeated at two sites. Adds `isModuleNotFoundError(err)` next to the existing `isFileNotFoundError` / `isNotADirectoryError` predicates in `@common/errors/errorPredicates`. Net `+11 / -4`.

## Test plan

- [x] `npx vitest run` → 1084/1084 pass
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors