### PR TITLE
refactor(cli): use toErrorMessage in cliContext

### DIFF
--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { toErrorMessage } from '@common/errors/errorMessage';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 import {
@@ -224,7 +225,7 @@ export async function resolveCliCwd(
       throw new CliUsageError(`--cwd: path does not exist: ${requested}`);
     }
     throw new CliUsageError(
-      `--cwd: cannot access ${requested}: ${error instanceof Error ? error.message : String(error)}`,
+      `--cwd: cannot access ${requested}: ${toErrorMessage(error)}`,
     );
   }
   if (!info.isDirectory()) {


### PR DESCRIPTION
## Summary

Tiny cleanup. No behavior change.

`error instanceof Error ? error.message : String(error)` (one inline occurrence in `resolveCliCwd`) is exactly what the existing `toErrorMessage` helper in `@common/errors/errorMessage` does. Use the shared helper for consistency with the rest of CLI code (where `toErrorMessage` is already imported widely — see `runChatTui.tsx`, `history.ts`, `workflow.ts`, etc.).

`+2 / -1`.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/CliContext.vitest.mts` → 14/14
- [x] `cd packages/cli && npm run typecheck` → clean
- [x] `npm run typecheck` (top-level) → exit 0
- [x] `npm run lint` → 0 errors
- [x] Built-CLI: `texra --cwd /no-such agents list` → `--cwd: path does not exist: /no-such` (unchanged; the `cannot access` branch only fires for non-ENOENT/ENOTDIR stat failures like EACCES).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how an unknown error is stringified in the `--cwd` stat failure path, without altering control flow or validation behavior.
> 
> **Overview**
> Replaces an inline `error instanceof Error ? error.message : String(error)` message construction in `resolveCliCwd` with the shared `toErrorMessage` helper for consistent CLI error formatting, and adds the corresponding import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb4e6dc0880cd8d49a41947edb735967c4dfa76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->