### PR TITLE
fix(cli): validate -m model up-front for `texra chat`

### DIFF
--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -7,6 +7,7 @@ import {
   optString,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
+import { assertExplicitModelKnown } from './_helpers/modelArg';
 
 export const chatCommand = defineCommand({
   meta: { name: 'chat', description: 'Interactive tool-use chat session' },
@@ -17,11 +18,12 @@ export const chatCommand = defineCommand({
   },
   async run(ctx) {
     rejectHeadlessOnlyFlags(ctx.rawArgs, 'chat');
+    const modelOverride = assertExplicitModelKnown(optString(ctx.args.model));
     const context = await contextFromArgs(ctx.args);
     const { runChat } = await import('../chat/tui/runChatTui');
     const result = await runChat(context, {
       agentOverride: optString(ctx.args.agent),
-      modelOverride: optString(ctx.args.model),
+      modelOverride,
     });
     setExitCode(result.exitCode);
   },


### PR DESCRIPTION
Closes #4441.

## Summary

`texra run` and `texra multi-agent run` already call `assertExplicitModelKnown` on `-m` (PR #4436), so a typo exits 2 (Usage) immediately with a "Use `texra models list`" hint. `texra chat` was left out of scope and a typo surfaced later as exit 1 (AgentError).

Wire the existing helper at the top of `chatCommand.run` (`packages/cli/src/commands/chat.ts`) so chat matches the others. Validate before `contextFromArgs` so a bogus model fails fast, before any workspace I/O.

`+3 / -1`. Existing `ModelArg.vitest.mts` already covers the helper.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/ModelArg.vitest.mts` → 3/3
- [x] `npm run typecheck` → exit 0
- [x] `npm run lint` → exit 0
- [x] Built-CLI probe:
      `texra chat -m bogus` → `Model not found: bogus. Use \`texra models list\` to see available models.` exit **2** (was: late exit 1).
      `texra chat -m sonnet46T < /dev/null` → reaches the existing "chat requires TTY" branch (unchanged).
      `texra chat -m '   '` → empty after trim, treated as undefined (unchanged).
- [x] Regression: `texra run -m bogus` still exit 2 (unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI input-validation change that fails fast on invalid `-m` values without altering core runtime or data handling.
> 
> **Overview**
> `texra chat` now validates the `-m/--model` override up-front using `assertExplicitModelKnown`, matching the behavior of other commands.
> 
> Unknown model IDs are rejected immediately (before `contextFromArgs`/workspace I/O) with a usage error, and the validated/trimmed model value is passed through to `runChat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852652c3ee16d4bfaf6dfcab33490da4e2f1b401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->