### PR TITLE
fix(agent): dispose run-trace handles on agent launch lifecycle

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -27,6 +27,7 @@ import {
   AgentUsageReporter,
   createRunTrace,
   getStreamTabId,
+  type RunTrace,
 } from '@logger/index';
 import {
   STREAM_STATUS,
@@ -54,6 +55,13 @@ export interface AgentLaunchContext extends AgentCore {
   storageKey: StorageKey;
   parentStage: StageHandle;
   coordinators: RunCoordinators;
+  /**
+   * Dispose the run-trace subscribers (channel sink + transcript recorder)
+   * registered by {@link createRunTrace}. Must be called once at end-of-run
+   * to avoid leaking entries in the module-global `activeFlushers` set and
+   * keeping subscribers attached to the trace emitter.
+   */
+  disposeTrace: () => void;
 }
 
 export interface AgentLaunchInput {
@@ -164,6 +172,7 @@ async function assembleAgentLaunchContext(
   runtimeHost: AgentRuntimeHost,
   reservedStreamId: StreamTabId | undefined,
   onActivated: (streamId: StreamTabId) => void,
+  onRunTraceCreated: (runTrace: RunTrace) => void,
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
   const fullConfig = AgentConfigSchema.parse(configPayload);
@@ -209,6 +218,7 @@ async function assembleAgentLaunchContext(
     getStreamTabId(config.agent, fullConfig.model, { executionId });
 
   const runTrace = createRunTrace(streamId);
+  onRunTraceCreated(runTrace);
   const agentLogger = runTrace.trace;
   const usageReporter = new AgentUsageReporter(
     agentLogger,
@@ -297,6 +307,7 @@ async function assembleAgentLaunchContext(
       proposal: new AgentProposalCoordinator(runtimeHost),
       retry: new RetryRequestCoordinatorImpl(runtimeHost),
     },
+    disposeTrace: runTrace.dispose,
   };
 }
 
@@ -337,6 +348,10 @@ function compensateFailedActivation(args: {
   activatedStreamId?: StreamTabId;
   runtimeHost: AgentRuntimeHost;
   err: unknown;
+  // The run-trace from assembleAgentLaunchContext when it was created before the
+  // throw. Reused for the error log so we don't allocate a second one; outer
+  // catch disposes it after this returns.
+  runTrace?: RunTrace;
 }): void {
   const {
     configPayload,
@@ -344,10 +359,14 @@ function compensateFailedActivation(args: {
     activatedStreamId,
     runtimeHost,
     err,
+    runTrace,
   } = args;
 
   if (activatedStreamId) {
-    createRunTrace(activatedStreamId).trace.logError(
+    // `activatedStreamId` is set only after `runTrace` is created in
+    // `assembleAgentLaunchContext`, so runTrace is always present here in
+    // practice. Guard for defensiveness.
+    runTrace?.trace.logError(
       `Failed to start agent ${configPayload.agent}: ${getSdkErrorMessage(err)}`,
       err,
       { operation: `start ${configPayload.agent}` },
@@ -393,6 +412,10 @@ export async function buildAgentLaunchContext(
   }
 
   let activatedStreamId: StreamTabId | undefined;
+  // Captured so the outer catch can dispose the trace and let
+  // `compensateFailedActivation` reuse it for the failure log. Released to the
+  // returned context on the success path (cleaned up by runFlowWithLifecycle).
+  let runTrace: RunTrace | undefined;
   try {
     return await assembleAgentLaunchContext(
       input,
@@ -402,6 +425,9 @@ export async function buildAgentLaunchContext(
       (streamId) => {
         activatedStreamId = streamId;
       },
+      (rt) => {
+        runTrace = rt;
+      },
     );
   } catch (err) {
     compensateFailedActivation({
@@ -410,7 +436,9 @@ export async function buildAgentLaunchContext(
       activatedStreamId,
       runtimeHost,
       err,
+      runTrace,
     });
+    runTrace?.dispose();
     if (!input.suppressErrorNotification && !(err instanceof ZodError)) {
       runtimeHost.emit('requestShowError', {
         message: toErrorMessage(err),

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -280,6 +280,9 @@ async function runFlowWithLifecycle(
     // Release long-lived resources (e.g., WebSocket connections, keepalive intervals)
     // to prevent leaks when handler instances are discarded after execution.
     ctx.modelHandler.dispose();
+    // Drop the run-trace subscribers (channel sink + transcript recorder) so
+    // they don't pile up across many agent runs.
+    ctx.disposeTrace();
   }
 }
 

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createRunTrace,
+  flushPendingRunTraces,
+  getDefaultStreamLogStore,
+  setDefaultStreamLogStore,
+} from '@logger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+import { MESSAGE_TYPES } from '@shared/schemas';
+
+describe('createRunTrace dispose', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removes the flusher from the global registry on dispose', () => {
+    vi.useFakeTimers();
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const handle = createRunTrace('disposed-stream');
+      const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+
+      stream.append('a');
+      // Chunk is throttled (49ms window) — `flushPendingRunTraces` reaches it
+      // through the module-global `activeFlushers` set.
+      flushPendingRunTraces();
+      expect(store.get('disposed-stream')?.getRange(0)[0]?.text).toBe('a');
+
+      handle.dispose();
+
+      // After dispose: more chunks should not reach the store via the global
+      // flusher (because the flusher was removed from `activeFlushers`).
+      // Append another chunk and confirm `flushPendingRunTraces` doesn't push
+      // it through. The chunk would still flush via its own per-stream timer,
+      // so we verify by sampling before the timer fires.
+      stream.append('b');
+      flushPendingRunTraces();
+      // Only the 'a' chunk should be visible — the 'b' chunk hasn't been
+      // pushed because the flusher was unregistered and the throttled timer
+      // hasn't fired.
+      expect(store.get('disposed-stream')?.getRange(0)[0]?.text).toBe('a');
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('returns the same dispose function across the handle', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const handle = createRunTrace('idempotent-stream');
+      handle.dispose();
+      // Calling dispose again should not throw and should be a no-op.
+      expect(() => handle.dispose()).not.toThrow();
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+});


### PR DESCRIPTION
Addresses two of the three leaks tracked in #4448.

## Summary

\`createRunTrace\` registers two long-lived resources per call: a transcript subscriber attached via \`attachTranscriptRecorder\` and a flusher in the module-global \`activeFlushers\` set. The returned handle includes \`dispose()\` to clean both up. Before this change, the agent-launch call sites kept only \`.trace\` and threw the rest away — every agent run leaked one subscriber and one flusher entry.

**1. Main agent launch path (\`AgentLaunchContext.ts:211\`)**
Capture the full \`RunTrace\` handle, expose \`disposeTrace\` on \`AgentLaunchContext\`, and call it from \`runFlowWithLifecycle\`'s \`finally\` alongside \`modelHandler.dispose()\`.

**2. \`compensateFailedActivation\` double leak (\`AgentLaunchContext.ts:350\`)**
When activation threw after \`createRunTrace\` was already called, compensation created a *second* run trace just for one \`logError\` — both were orphaned. \`buildAgentLaunchContext\` now captures the original trace via an \`onRunTraceCreated\` callback, hands it to \`compensateFailedActivation\` for the error log, then disposes it in the outer catch.

**Item 3 (childStream.ts per-tool-call leak)** is left as a follow-up: it touches three tool call sites (\`bash.ts\`, \`codex.ts\`, \`claudeAgent.ts\`) with custom finalization paths and is worth its own PR.

## Test plan

- [x] \`npm run typecheck\` → exit 0
- [x] \`npm run lint\` → 0 errors
- [x] New focused test: \`npx vitest run src/test-kernel/logger/RunTraceDispose.vitest.ts\` → 2/2 (covers dispose removing the flusher from the global registry + idempotence).
- [x] Regression: \`npx vitest run src/test-kernel/logger/\` → 3 files, 8/8.
- [x] Regression: \`npx vitest run src/test-kernel/agent/runtime/\` → 6 files, 13/13.

Closes #4448 in part — leaves item 3 open for a follow-up PR.

## References

- Tracking issue: #4448
- Parent PR: #4446 (introduced \`createRunTrace\` + \`activeFlushers\`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent execution lifecycle and error-compensation paths; mistakes could drop logs or affect stream status transitions, but changes are narrowly scoped to cleanup behavior.
> 
> **Overview**
> Fixes a run-trace resource leak by keeping the full `createRunTrace` handle during agent launch and exposing `disposeTrace()` on `AgentLaunchContext`, then calling it in `executeAgent`’s `finally` alongside `modelHandler.dispose()`.
> 
> Also avoids a double-allocation on post-activation failures by reusing the original `RunTrace` for error logging in `compensateFailedActivation`, and ensures the trace is disposed in the outer catch when launch fails. Adds a focused vitest verifying `dispose()` unregisters the flusher from the module-global `activeFlushers` set and is idempotent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0371ec043464e42736c13c509d5159061ae6e8b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->