### PR TITLE
fix(tools): dispose run-trace handles for child-stream tool sessions

### DIFF
--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -33,24 +33,29 @@ describe('child stream progress events', () => {
     setDefaultAgentRuntimeHost(fallback.host);
 
     try {
-      const { childStreamId: actualChildStreamId, logger } = createChildStream(
-        executionId,
-        parentStreamId,
-        {
-          runtimeHost: active.host,
-          streamPrefix: 'bash',
-          streamCategory: AgentCategory.ToolUse,
-          agentName: 'test-agent',
-          description: 'Run a background bash command',
-          config,
-          toolName: 'bash',
-        },
-      );
+      const {
+        childStreamId: actualChildStreamId,
+        logger,
+        disposeTrace,
+      } = createChildStream(executionId, parentStreamId, {
+        runtimeHost: active.host,
+        streamPrefix: 'bash',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'test-agent',
+        description: 'Run a background bash command',
+        config,
+        toolName: 'bash',
+      });
 
       expect(actualChildStreamId).toBe(childStreamId);
 
-      finalizeChildStream(childStreamId, executionId, logger, active.host, {
-        autoClose: true,
+      finalizeChildStream({
+        childStreamId,
+        executionId,
+        logger,
+        disposeTrace,
+        runtimeHost: active.host,
+        options: { autoClose: true },
       });
     } finally {
       setDefaultAgentRuntimeHost(previousDefault);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -225,7 +225,7 @@ export class BashTool extends defineTool({
       'process',
     );
 
-    const { childStreamId, logger } = createChildStream(
+    const { childStreamId, logger, disposeTrace } = createChildStream(
       executionId,
       parentStreamId,
       {
@@ -298,14 +298,21 @@ export class BashTool extends defineTool({
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
         unregisterInterruptible(childStreamId);
-        finalizeChildStream(childStreamId, executionId, logger, runtimeHost, {
-          wallTimeMs,
-          error: result.success
-            ? undefined
-            : new ToolError(
-                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
-              ),
-          autoClose: true,
+        finalizeChildStream({
+          childStreamId,
+          executionId,
+          logger,
+          disposeTrace,
+          runtimeHost,
+          options: {
+            wallTimeMs,
+            error: result.success
+              ? undefined
+              : new ToolError(
+                  `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
+                ),
+            autoClose: true,
+          },
         });
 
         const msg = formatBashDelivery(
@@ -322,9 +329,16 @@ export class BashTool extends defineTool({
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         unregisterInterruptible(childStreamId);
-        finalizeChildStream(childStreamId, executionId, logger, runtimeHost, {
-          error: err,
-          autoClose: true,
+        finalizeChildStream({
+          childStreamId,
+          executionId,
+          logger,
+          disposeTrace,
+          runtimeHost,
+          options: {
+            error: err,
+            autoClose: true,
+          },
         });
 
         const msg = formatBashError(executionId, command, err);

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -100,7 +100,11 @@ export function createChildStream(
   if (options.toolName) handle.toolName = options.toolName;
   trackExecution(handle);
 
-  return { childStreamId, logger: runTrace.trace, disposeTrace: runTrace.dispose };
+  return {
+    childStreamId,
+    logger: runTrace.trace,
+    disposeTrace: runTrace.dispose,
+  };
 }
 
 interface FinalizeChildStreamArgs {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -53,7 +53,17 @@ export function createChildStream(
   executionId: ExecutionId,
   parentStreamId: StreamTabId,
   options: CreateChildStreamOptions,
-): { childStreamId: StreamTabId; logger: TexraTrace } {
+): {
+  childStreamId: StreamTabId;
+  logger: TexraTrace;
+  /**
+   * Drop the run-trace subscribers attached by `createRunTrace`. Must be
+   * called once when the child stream finalizes, either via
+   * `finalizeChildStream` (which calls it for you) or directly from a custom
+   * cleanup path.
+   */
+  disposeTrace: () => void;
+} {
   const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
   const { runtimeHost } = options;
 
@@ -78,7 +88,7 @@ export function createChildStream(
     description: truncateWithEllipsis(options.description, 80),
   });
 
-  const logger = createRunTrace(childStreamId).trace;
+  const runTrace = createRunTrace(childStreamId);
   const handle = new AgentExecutionHandle(
     executionId,
     parentStreamId,
@@ -90,17 +100,29 @@ export function createChildStream(
   if (options.toolName) handle.toolName = options.toolName;
   trackExecution(handle);
 
-  return { childStreamId, logger };
+  return { childStreamId, logger: runTrace.trace, disposeTrace: runTrace.dispose };
+}
+
+interface FinalizeChildStreamArgs {
+  childStreamId: StreamTabId;
+  executionId: ExecutionId;
+  logger: TexraTrace;
+  /** From `createChildStream` — releases the run-trace subscribers. */
+  disposeTrace: () => void;
+  runtimeHost: AgentRuntimeHost;
+  options?: FinalizeChildStreamOptions;
 }
 
 /** Finalize a child stream tab and untrack its execution handle. */
-export function finalizeChildStream(
-  childStreamId: StreamTabId,
-  executionId: ExecutionId,
-  logger: TexraTrace,
-  runtimeHost: AgentRuntimeHost,
-  options?: FinalizeChildStreamOptions,
-): void {
+export function finalizeChildStream(args: FinalizeChildStreamArgs): void {
+  const {
+    childStreamId,
+    executionId,
+    logger,
+    disposeTrace,
+    runtimeHost,
+    options,
+  } = args;
   const hasError = options?.error != null || options?.errorMessage != null;
 
   if (options?.errorMessage) {
@@ -127,6 +149,7 @@ export function finalizeChildStream(
     );
   }
   untrackExecution(executionId);
+  disposeTrace();
 
   if (options?.autoClose) {
     runtimeHost.emit('removeStream', { streamId: childStreamId });

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -520,6 +520,7 @@ function startClaudeAgentLoop(params: {
   parentStreamId: StreamTabId;
   executionId: ExecutionId;
   logger: TexraTrace;
+  disposeTrace: () => void;
   initialPrompt: string;
   model: string;
   permissionMode: ClaudeAgentPermissionMode;
@@ -535,6 +536,7 @@ function startClaudeAgentLoop(params: {
     parentStreamId,
     executionId,
     logger,
+    disposeTrace,
     initialPrompt,
     runtimeHost,
   } = params;
@@ -650,6 +652,7 @@ function startClaudeAgentLoop(params: {
       await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
       finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);
+      disposeTrace();
     }
   })();
 }
@@ -747,7 +750,7 @@ async function launchClaudeAgentSession(
     throw new ToolError('Failed to register Claude Code CLI execution.');
   }
 
-  const { childStreamId, logger } = createChildStream(
+  const { childStreamId, logger, disposeTrace } = createChildStream(
     executionId,
     parentStreamId,
     {
@@ -766,6 +769,7 @@ async function launchClaudeAgentSession(
     parentStreamId,
     executionId,
     logger,
+    disposeTrace,
     initialPrompt: input.prompt,
     model,
     permissionMode,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -525,6 +525,7 @@ function startCodexLoop(params: {
   parentStreamId: StreamTabId;
   executionId: ExecutionId;
   logger: TexraTrace;
+  disposeTrace: () => void;
   initialPrompt: string;
   runtimeHost: AgentRuntimeHost;
 }): void {
@@ -534,6 +535,7 @@ function startCodexLoop(params: {
     parentStreamId,
     executionId,
     logger,
+    disposeTrace,
     initialPrompt,
     runtimeHost,
   } = params;
@@ -656,6 +658,7 @@ function startCodexLoop(params: {
       untrackExecution(executionId);
 
       finalizeCodexLoopStatus(childStreamId, runtimeHost);
+      disposeTrace();
     }
   })();
 }
@@ -774,7 +777,7 @@ async function launchCodexSession(
     throw new ToolError('Failed to register Codex execution.');
   }
 
-  const { childStreamId, logger } = createChildStream(
+  const { childStreamId, logger, disposeTrace } = createChildStream(
     executionId,
     parentStreamId,
     {
@@ -794,6 +797,7 @@ async function launchCodexSession(
     parentStreamId,
     executionId,
     logger,
+    disposeTrace,
     initialPrompt: input.prompt,
     runtimeHost,
   });


### PR DESCRIPTION
Closes the remaining item from #4448 (item 3 — \`childStream.ts\` per-tool-call leak).

PR #4457 fixed the agent-launch path; this PR fixes the tool sessions.

## Summary

\`createChildStream\` was discarding the \`dispose\` half of its \`createRunTrace(...)\` handle, so every \`bash\` / \`codex\` / \`claudeAgent\` tool session leaked one transcript subscriber and one \`activeFlushers\` entry. For long sessions or large tool-use orchestrations this accumulates.

Changes:
- \`createChildStream\` returns \`disposeTrace\` alongside \`logger\`.
- \`finalizeChildStream\` takes a named-args object and invokes \`disposeTrace()\` after \`untrackExecution\`. (Switched to named args because the call signature was growing unwieldy as more concerns arrived.)
- \`bash.ts\` (two finalize sites) threads \`disposeTrace\` into both \`finalizeChildStream\` calls.
- \`codex.ts\` adds \`disposeTrace\` to \`startCodexLoop\` params and calls it in the loop's \`finally\`.
- \`claudeAgent.ts\` does the same for \`startClaudeAgentLoop\`.

## Test plan

- [x] \`npm run typecheck\` → exit 0
- [x] \`npm run lint\` → 0 errors
- [x] \`npx vitest run src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts\` → 1/1 (updated to new arg shape).
- [x] Regression: \`npx vitest run src/test-kernel/agent/toolUse/ src/test-kernel/logger/\` → 14 files, 38/38.

## References

- Tracking issue: #4448
- Earlier PR (items 1+2): #4457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches child-stream lifecycle/cleanup for tool sessions by changing `createChildStream`/`finalizeChildStream` contracts and disposal timing; mistakes could drop logs or leave streams incorrectly tracked.
> 
> **Overview**
> Fixes a child-stream leak for tool sessions by returning a `disposeTrace` cleanup handle from `createChildStream` and ensuring `finalizeChildStream` invokes it after `untrackExecution`.
> 
> Updates call sites (e.g. `bash.ts` and tests) to pass the new named-args `finalizeChildStream({ ... })` shape and thread `disposeTrace` through cleanup paths so run-trace subscribers are reliably released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c1275a6f0996bc33c863bf7393692359a1bffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->