### PR TITLE
fix(logger): honor terminal status in emitToolUse for fast-tool paths

### DIFF
--- a/src/logger/TexraTraceEmitter.ts
+++ b/src/logger/TexraTraceEmitter.ts
@@ -155,10 +155,24 @@ export class TexraTraceEmitter extends TraceEmitter implements TexraTrace {
   emitToolUse(data: unknown, groupId?: string): ToolStartRef {
     const logId = randomUUID();
     const resolvedGroupId = groupId ?? this.activeStageId();
-    const toolName =
-      (data as { toolName?: string } | null)?.toolName ?? 'unknown';
-    const input = (data as { input?: unknown } | null)?.input;
+    const payload = (data ?? {}) as {
+      toolName?: string;
+      input?: unknown;
+      status?: ToolStatus;
+    };
+    const toolName = payload.toolName ?? 'unknown';
+    const input = payload.input;
     this.toolStart({ logId, toolName, input }, { stageId: resolvedGroupId });
+    // Fast-tool path: callers that pass a terminal `status` need both
+    // start AND end events so the transcript row reaches `completed`/`failed`
+    // instead of dangling in `in_progress`. Forward the full payload (output,
+    // files, isError) as the result patch — `updateToolUse` does the same.
+    if (payload.status && payload.status !== 'in_progress') {
+      this.toolEnd(
+        { logId, status: payload.status, result: payload },
+        { stageId: resolvedGroupId },
+      );
+    }
     return { logId, groupId: resolvedGroupId };
   }
 

--- a/src/test-kernel/logger/EmitToolUseStatus.vitest.ts
+++ b/src/test-kernel/logger/EmitToolUseStatus.vitest.ts
@@ -18,8 +18,8 @@ describe('TexraTraceEmitter.emitToolUse', () => {
 
     trace.emitToolUse({ toolName: 'bash', input: { command: 'ls' } });
 
-    const toolEvents = events.filter((e) =>
-      e.type === 'tool.start' || e.type === 'tool.end',
+    const toolEvents = events.filter(
+      (e) => e.type === 'tool.start' || e.type === 'tool.end',
     );
     expect(toolEvents).toHaveLength(1);
     expect(toolEvents[0]?.type).toBe('tool.start');
@@ -37,8 +37,8 @@ describe('TexraTraceEmitter.emitToolUse', () => {
       status: 'completed',
     });
 
-    const toolEvents = events.filter((e) =>
-      e.type === 'tool.start' || e.type === 'tool.end',
+    const toolEvents = events.filter(
+      (e) => e.type === 'tool.start' || e.type === 'tool.end',
     );
     expect(toolEvents).toHaveLength(2);
     expect(toolEvents[0]?.type).toBe('tool.start');
@@ -63,8 +63,8 @@ describe('TexraTraceEmitter.emitToolUse', () => {
       status: 'failed',
     });
 
-    const toolEvents = events.filter((e) =>
-      e.type === 'tool.start' || e.type === 'tool.end',
+    const toolEvents = events.filter(
+      (e) => e.type === 'tool.start' || e.type === 'tool.end',
     );
     expect(toolEvents).toHaveLength(2);
     if (toolEvents[1]?.type === 'tool.end') {
@@ -82,8 +82,8 @@ describe('TexraTraceEmitter.emitToolUse', () => {
       status: 'in_progress',
     });
 
-    const toolEvents = events.filter((e) =>
-      e.type === 'tool.start' || e.type === 'tool.end',
+    const toolEvents = events.filter(
+      (e) => e.type === 'tool.start' || e.type === 'tool.end',
     );
     expect(toolEvents).toHaveLength(1);
     expect(toolEvents[0]?.type).toBe('tool.start');

--- a/src/test-kernel/logger/EmitToolUseStatus.vitest.ts
+++ b/src/test-kernel/logger/EmitToolUseStatus.vitest.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentEvent } from '@agent/trace';
+import { TexraTraceEmitter } from '@logger/TexraTraceEmitter';
+
+function captureEvents(trace: TexraTraceEmitter): AgentEvent[] {
+  const events: AgentEvent[] = [];
+  trace.subscribe((event) => {
+    events.push(event);
+  });
+  return events;
+}
+
+describe('TexraTraceEmitter.emitToolUse', () => {
+  it('emits only tool.start when no status is passed (slow-tool path)', () => {
+    const trace = new TexraTraceEmitter();
+    const events = captureEvents(trace);
+
+    trace.emitToolUse({ toolName: 'bash', input: { command: 'ls' } });
+
+    const toolEvents = events.filter((e) =>
+      e.type === 'tool.start' || e.type === 'tool.end',
+    );
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.type).toBe('tool.start');
+  });
+
+  it('emits tool.start + tool.end when status is completed (fast-tool path)', () => {
+    const trace = new TexraTraceEmitter();
+    const events = captureEvents(trace);
+
+    trace.emitToolUse({
+      toolName: 'todo_write',
+      input: { items: [] },
+      output: 'ok',
+      isError: false,
+      status: 'completed',
+    });
+
+    const toolEvents = events.filter((e) =>
+      e.type === 'tool.start' || e.type === 'tool.end',
+    );
+    expect(toolEvents).toHaveLength(2);
+    expect(toolEvents[0]?.type).toBe('tool.start');
+    expect(toolEvents[1]?.type).toBe('tool.end');
+    if (toolEvents[1]?.type === 'tool.end') {
+      expect(toolEvents[1].status).toBe('completed');
+      // start and end share the same logId so the transcript can match them
+      const startLogId =
+        toolEvents[0]?.type === 'tool.start' ? toolEvents[0].logId : null;
+      expect(toolEvents[1].logId).toBe(startLogId);
+    }
+  });
+
+  it('emits tool.start + tool.end when status is failed', () => {
+    const trace = new TexraTraceEmitter();
+    const events = captureEvents(trace);
+
+    trace.emitToolUse({
+      toolName: 'bash',
+      input: { command: 'false' },
+      isError: true,
+      status: 'failed',
+    });
+
+    const toolEvents = events.filter((e) =>
+      e.type === 'tool.start' || e.type === 'tool.end',
+    );
+    expect(toolEvents).toHaveLength(2);
+    if (toolEvents[1]?.type === 'tool.end') {
+      expect(toolEvents[1].status).toBe('failed');
+    }
+  });
+
+  it('does not emit tool.end when status is explicitly in_progress', () => {
+    const trace = new TexraTraceEmitter();
+    const events = captureEvents(trace);
+
+    trace.emitToolUse({
+      toolName: 'bash',
+      input: { command: 'sleep' },
+      status: 'in_progress',
+    });
+
+    const toolEvents = events.filter((e) =>
+      e.type === 'tool.start' || e.type === 'tool.end',
+    );
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.type).toBe('tool.start');
+  });
+});


### PR DESCRIPTION
Closes #4449.

## Summary

\`TexraTraceEmitter.emitToolUse\` at \`src/logger/TexraTraceEmitter.ts:155\` was reading only \`toolName\`/\`input\` from the payload and unconditionally calling \`this.toolStart()\`. The fast-tool path in \`src/agent/core/flows/ToolUseCycleFlow.ts:732\` passes \`status: 'completed'\` for tools that finish synchronously, but the start-only emission left those transcript rows dangling in \`in_progress\` forever.

Fix: when the payload carries a terminal \`status\` (\`'completed'\` or \`'failed'\`), emit a matching \`tool.end\` event right after \`tool.start\` with the same \`logId\`, forwarding the full payload (\`toolName\`, \`input\`, \`output\`, \`files\`, \`isError\`) as the result patch — same shape that the slow-tool path produces via \`updateToolUse\`. Payloads with no status or \`status: 'in_progress'\` keep the previous start-only behavior.

\`+17 / -3\` in TexraTraceEmitter.ts plus a new focused test.

## Test plan

- [x] \`npm run typecheck\` → exit 0
- [x] \`npm run lint\` → 0 errors
- [x] New test: \`npx vitest run src/test-kernel/logger/EmitToolUseStatus.vitest.ts\` → 4/4 (no status, completed, failed, in_progress).
- [x] Regression: \`npx vitest run src/test-kernel/logger/ src/test-kernel/agent/\` → 44 files, 131/131.

## References

- Tracking issue: #4449
- Parent PR: #4446
- Review: https://github.com/LionSR/TeXRA/pull/4446#discussion_r3292752299 (Cursor Bugbot, high severity)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-use event emission semantics for fast/synchronous tools by adding an immediate `tool.end`, which could affect any subscribers expecting start-only events or relying on ordering.
> 
> **Overview**
> Fixes fast/synchronous tool calls leaving transcript entries stuck *in progress* by teaching `TexraTraceEmitter.emitToolUse` to emit a matching `tool.end` when the incoming payload includes a terminal `status` (`completed`/`failed`), reusing the same `logId` and forwarding the payload as the end `result`.
> 
> Adds a focused Vitest (`EmitToolUseStatus.vitest.ts`) covering slow-tool (start-only), terminal status (start+end), and explicit `in_progress` (start-only) behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c2024576fd5ebb02466b3210582dc8795a7db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->