### PR TITLE
refactor(logger): trim dead exports and unused RunTrace.flushPending

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -8,10 +8,6 @@ export {
 } from './TaskState';
 export { UsageLogService } from './UsageLogService';
 export {
-  attachTranscriptRecorder,
-  type TranscriptRecorderHandle,
-} from './TexraTranscriptRecorder';
-export {
   createChannelTrace,
   createRunTrace,
   flushPendingRunTraces,

--- a/src/logger/runTrace.ts
+++ b/src/logger/runTrace.ts
@@ -6,9 +6,9 @@
  *   per-channel debug output (no transcript).
  *
  * - `createRunTrace(streamId, store)` — for agent runs. Attaches BOTH the
- *   channel-output subscriber AND the {@link TexraTranscriptRecorder} that
- *   drives the webview transcript. Returns `{ trace, flushPending,
- *   dispose }` so callers can drain in-flight stream chunks at shutdown.
+ *   channel-output subscriber AND the {@link attachTranscriptRecorder} that
+ *   drives the webview transcript. Returns `{ trace, dispose }` so callers
+ *   can release the subscribers when the run ends.
  *
  * The returned trace is `TexraTrace` (the host-extended surface). SDK
  * consumers that only care about agent-general events can still treat it
@@ -21,10 +21,7 @@ import {
   getDefaultStreamLogStore,
   type StreamLogStore,
 } from './StreamLogStore';
-import {
-  attachTranscriptRecorder,
-  type TranscriptRecorderHandle,
-} from './TexraTranscriptRecorder';
+import { attachTranscriptRecorder } from './TexraTranscriptRecorder';
 import { TexraTraceEmitter } from './TexraTraceEmitter';
 import type { TexraTrace } from './TexraTrace';
 
@@ -41,7 +38,6 @@ export function createChannelTrace(name: string): TexraTrace {
 
 export interface RunTrace {
   readonly trace: TexraTrace;
-  readonly flushPending: () => void;
   readonly dispose: () => void;
 }
 
@@ -60,11 +56,7 @@ export function createRunTrace(
     channel: streamId,
     isAgent: true,
   });
-  const transcript: TranscriptRecorderHandle = attachTranscriptRecorder(
-    trace,
-    streamId,
-    store,
-  );
+  const transcript = attachTranscriptRecorder(trace, streamId, store);
 
   // Centralized registry so the static shutdown hook
   // (`flushPendingRunTraces()`) can drain every in-flight stream buffer.
@@ -72,7 +64,6 @@ export function createRunTrace(
 
   return {
     trace,
-    flushPending: transcript.flushPending,
     dispose: () => {
       activeFlushers.delete(transcript.flushPending);
       transcript.unsubscribe();

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -18,8 +18,8 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
-import { isModuleNotFoundError } from '@common/errors';
 import { platform } from '@platform/platform';
+import { isModuleNotFoundError } from '@common/errors';
 import { executeCommandSync } from '@utils/system/execUtils';
 
 type QueryFn = (params: {

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,8 +17,8 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
-import { isModuleNotFoundError } from '@common/errors';
 import { platform } from '@platform/platform';
+import { isModuleNotFoundError } from '@common/errors';
 import { executeCommandSync } from '@utils/system/execUtils';
 
 type CodexConstructor = new (options?: any) => any;


### PR DESCRIPTION
Follow-up cleanup to #4461 and #4454. Two small pieces of public surface that nothing outside `runTrace.ts` consumes.

## What's removed

### 1. `attachTranscriptRecorder` + `TranscriptRecorderHandle` re-exports

These were exposed from `@logger/index.ts` so callers could attach the transcript recorder manually. After `createRunTrace` became the standard factory, the lower-level API has **zero external callers**:

```
$ grep -rn "attachTranscriptRecorder\|TranscriptRecorderHandle" src packages \
    | grep -v "TexraTranscriptRecorder.ts\|runTrace.ts\|index.ts"
$ # (empty)
```

Removed from the `@logger` barrel. The recorder is still wired up via `createRunTrace` — that's now the single entry point.

### 2. `RunTrace.flushPending` field

`RunTrace` was returning `{ trace, flushPending, dispose }`. The `flushPending` callback was forwarded from the `TranscriptRecorderHandle` and never called by external code — only the internal `activeFlushers` registry references `transcript.flushPending` directly. Dropped from the interface; the destructure in `createRunTrace`'s return object went with it.

```typescript
// Before
export interface RunTrace {
  readonly trace: TexraTrace;
  readonly flushPending: () => void;  // ← unused externally
  readonly dispose: () => void;
}

// After
export interface RunTrace {
  readonly trace: TexraTrace;
  readonly dispose: () => void;
}
```

`flushPendingRunTraces()` still works — it iterates the module-global `activeFlushers` set, not the public `RunTrace` interface.

## Stats

- 4 files changed, +7 / −20 lines
- 2 dead exports removed from `@logger` barrel (`attachTranscriptRecorder`, `TranscriptRecorderHandle`)
- 1 field removed from public `RunTrace` interface (`flushPending`)

## Test plan

- [x] `npm run typecheck` — clean across root, test-kernel, extension, cli
- [x] `corepack pnpm vitest run src/test-kernel` — 1088 pass + 2 skipped (216 test files)
- [x] `npm run lint` — clean (one pre-existing warning unrelated to this PR)

## Notes for reviewers

- This is the third tightening pass on the `@logger/runTrace` surface after #4454 (consolidate channel logging) and #4461 (inline AgentUsageReporter). The current public API for a TeXRA host is now:
  - `createChannelTrace(name)` for module-level debug singletons
  - `createRunTrace(streamId, store?)` for agent runs (returns `{ trace, dispose }`)
  - `flushPendingRunTraces()` for shutdown drain
- The transcript-recorder attachment is now strictly an implementation detail of `createRunTrace` — there's no remaining use case for attaching the recorder to a custom trace.

https://claude.ai/code/session_01MckcFbSMwjEkznYGCYxACT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MckcFbSMwjEkznYGCYxACT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes items from the public `@logger` surface (`attachTranscriptRecorder`, `TranscriptRecorderHandle`, and `RunTrace.flushPending`), which could break any downstream consumers relying on them. Runtime behavior should be unchanged aside from the API shape tightening.
> 
> **Overview**
> Tightens the public logger API by removing the `attachTranscriptRecorder`/`TranscriptRecorderHandle` re-exports from the `@logger` barrel and making transcript attachment an internal detail of `createRunTrace()`.
> 
> Simplifies `RunTrace` to return only `{ trace, dispose }` by dropping the unused `flushPending` field, while keeping shutdown draining via the internal `activeFlushers` set and `flushPendingRunTraces()`. Also includes a no-op import reorder in the Claude/Codex tool import helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcacb2b0443f06e2bec08520a22db8877a55e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->