### PR TITLE
[codex] fix release version bump after patch ten

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump to next version
+      - name: Bump to next package version
         id: bump_version
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -53,7 +53,7 @@ jobs:
           commit-message: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'
           title: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'
           body: |
-            This PR automatically bumps the workspace package manifests to the next patch version after release.
+            This PR automatically bumps the package manifests to the next development version after release.
 
             Release: ${{ github.event.release.name }}
             Tag: ${{ github.event.release.tag_name }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-workspace",
-  "version": "0.37.11",
+  "version": "0.38.0",
   "private": true,
   "packageManager": "pnpm@11.1.1",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/cli",
-  "version": "0.37.11",
+  "version": "0.38.0",
   "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/core",
-  "version": "0.37.11",
+  "version": "0.38.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/desktop",
-  "version": "0.37.11",
+  "version": "0.38.0",
   "description": "TeXRA standalone desktop application",
   "author": "TeXRA.ai <contact@texra.ai>",
   "homepage": "https://texra.ai",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.37.11",
+  "version": "0.38.0",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -14,6 +14,10 @@ const MANIFEST_PATHS = [
 
 const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
 
+// Release trains use patch values 0 through 10; after .10, development moves
+// to the next minor train.
+const MAX_PATCH_VERSION = 10;
+
 function printUsage() {
   console.error(
     [
@@ -22,8 +26,8 @@ function printUsage() {
       '  node scripts/bump-workspace-version.mjs --version <version> [--check]',
       '',
       'Examples:',
-      '  node scripts/bump-workspace-version.mjs --from v0.37.8',
-      '  node scripts/bump-workspace-version.mjs --version 0.37.9 --check',
+      '  node scripts/bump-workspace-version.mjs --from v0.37.10',
+      '  node scripts/bump-workspace-version.mjs --version 0.38.0 --check',
     ].join('\n'),
   );
 }
@@ -77,8 +81,8 @@ function parseVersion(rawVersion, label) {
 
   const [, major, minor, patch] = match;
   return {
-    major,
-    minor,
+    major: Number(major),
+    minor: Number(minor),
     patch: Number(patch),
   };
 }
@@ -87,8 +91,17 @@ function formatVersion(version) {
   return `${version.major}.${version.minor}.${version.patch}`;
 }
 
-function nextPatchVersion(rawVersion) {
+function nextWorkspaceVersion(rawVersion) {
   const version = parseVersion(rawVersion, 'Release tag');
+
+  if (version.patch >= MAX_PATCH_VERSION) {
+    return formatVersion({
+      major: version.major,
+      minor: version.minor + 1,
+      patch: 0,
+    });
+  }
+
   return formatVersion({
     ...version,
     patch: version.patch + 1,
@@ -111,7 +124,7 @@ function main() {
   const args = parseArgs(process.argv.slice(2));
   const newVersion =
     args.version == null
-      ? nextPatchVersion(args.from)
+      ? nextWorkspaceVersion(args.from)
       : normalizeVersion(args.version);
 
   const mismatches = [];


### PR DESCRIPTION
## Summary

Fixes the release version-bump automation so a release tagged `v0.37.10` advances package manifests to `0.38.0`, not `0.37.11`.

The root cause was that the release action called a helper which always computed the next patch version. The helper now encodes the release-train convention that patch values run from 0 through 10, after which development moves to the next minor train.

This also updates the package manifests from `0.37.11` to `0.38.0` and makes the workflow wording say package manifests rather than workspace package manifests.

## Validation

- `node scripts/bump-workspace-version.mjs --from v0.37.10 --check`
- `git diff --check`
- `corepack pnpm --filter texra build:fast`
- `corepack pnpm --filter @texra/cli build`
- `corepack pnpm --filter @texra/desktop build`