### PR TITLE
docs: cut 0.38.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-05-24
+
 ### Features
 
 - **Export chat history as a shareable webpage** — Settings → History gets a new HTML export button alongside Markdown and PDF. The export uses the same markdown / KaTeX / syntax-highlighting pipeline as the in-app webview, ships its own CSS + fonts, and opens straight in your browser so you can share or demo a project run with anyone.


### PR DESCRIPTION
Moves the shipped HTML chat-export feature from `Unreleased` into a dated `## [0.38.0] - 2026-05-24` section, so the changelog matches the `cli-v0.38.0` tag and the imminent `@texra-ai/cli@0.38.0` npm release.

Docs-only; one-line section header.

After this merges, the `cli-v0.38.0` tag will be re-pointed to the merge commit so the release tag includes the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog edit with no runtime or dependency changes.
> 
> **Overview**
> **Changelog only:** adds a dated **`## [0.38.0] - 2026-05-24`** section and moves the **export chat history as a shareable webpage** feature entry out of **`[Unreleased]`** into that release block, aligning the doc with the **`cli-v0.38.0`** tag and **`@texra-ai/cli@0.38.0`** npm release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0244ae46dd779fd0720c0532b1e6636dbcd6bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->