### PR TITLE
fix(core): make model/auth error messages host-neutral

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -336,7 +336,7 @@ export abstract class ModelHandler<
       // No access token available - shouldUseServerSideKeys() returned true, meaning isEnabled()
       // returned true. Don't fall back to personal keys - throw an actionable error.
       throw new Error(
-        'Unable to authenticate with server. Please sign out and sign back in, or switch to "Use My Own Keys" mode.',
+        'Unable to authenticate with server. Please sign out and sign back in, or switch to personal API keys.',
       );
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -345,7 +345,7 @@ export abstract class ModelHandler<
     if (shouldUseOpenRouter(this.config)) {
       return this.fetchApiKeyOrThrow(
         'openRouter',
-        'Missing API key for OpenRouter. Please set it using the "Set API Key" command.',
+        'Missing API key for OpenRouter. Set your OpenRouter API key to continue.',
       );
     }
 
@@ -359,13 +359,13 @@ export abstract class ModelHandler<
       );
       throw new Error(
         `Model "${this.config.name}" is not available with your current subscription tier. ` +
-          `Switch to "Use My Own Keys" via the TeXRA Profile panel, or select a model included in your tier.`,
+          `Switch to personal API keys, or select a model included in your tier.`,
       );
     }
 
     return this.fetchApiKeyOrThrow(
       this.config.provider.toLowerCase() as ApiProvider,
-      `Missing API key for ${this.config.provider}. Please set it using the "Set API Key" command.`,
+      `Missing API key for ${this.config.provider}. Set your ${this.config.provider} API key to continue.`,
     );
   }
 

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -143,7 +143,7 @@ export async function getApiKey(
   const key = await lookupApiKey(secrets, provider);
   if (!key) {
     throw new Error(
-      `No API key found for ${provider}. Please set it using the "Set API Key" command or ${apiKeyEnvName(provider)} environment variable.`,
+      `No API key found for ${provider}. Set the ${apiKeyEnvName(provider)} environment variable, or configure your ${provider} API key.`,
     );
   }
   return key;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -170,7 +170,7 @@ export async function getModelUnavailableReason(
 
   // Determine the specific reason
   if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
-    return `Model "${model}" requires an OpenRouter API key. Set your OpenRouter key in the extension settings.`;
+    return `Model "${model}" requires an OpenRouter API key.`;
   }
 
   if (availability.kind === 'not-included') {
@@ -181,7 +181,7 @@ export async function getModelUnavailableReason(
   // Personal key mode or unauthenticated — missing provider key
   const providerName =
     PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
-  return `Model "${model}" requires your ${providerName} API key. Set it in the extension settings or enable included access.`;
+  return `Model "${model}" requires your ${providerName} API key. Provide it, or enable included access.`;
 }
 
 /** Build typed model option data for a single model. */


### PR DESCRIPTION
Closes #4478

## What

Reword six user-facing error strings in host-agnostic core so they no longer point at VS Code-only UI ("extension settings", "TeXRA Profile panel", the `"Set API Key"` command). The same messages now read correctly from both the extension and the CLI.

| File | Before | After |
|------|--------|-------|
| `ModelHandler.ts` (tier) | `Switch to "Use My Own Keys" via the TeXRA Profile panel, …` | `Switch to personal API keys, …` |
| `ModelHandler.ts` (OpenRouter / provider key) | `… the "Set API Key" command.` | `Set your … API key to continue.` |
| `apiProviders.ts` | `… the "Set API Key" command or <ENV> environment variable.` | `Set the <ENV> environment variable, or configure your … API key.` |
| `computeModelOptions.ts` (×2) | `… in the extension settings.` | host-neutral wording |

## Why

Found while driving `texra chat` hands-on: a relay user's first message fails and tells them to open a "Profile panel" that doesn't exist in a terminal. Embedding host-specific UI in core also violates the platform-agnosticism rule in CLAUDE.md (core returns host-neutral results; hosts enrich at the command layer).

## Scope notes

- Left `executeAgent.ts`'s `requestShowInstruction` untouched: it already passes structured `actions` for the host to render/interpret, so the host owns that UI.
- Pure string changes; no behavior change. CLI `build` (typecheck + architecture + react-compiler smoke + bundle) passes; verified the new text live in a relay `texra chat` session.

## Verification

Before/after confirmed by reproducing the error in `texra chat --api-mode included`:
```
Model "deepseekT" is not available with your current subscription tier. Switch to personal API keys, or select a model included in your tier.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)