### PR TITLE
fix(cli): collapse subagent follow-up XML in the chat transcript

### DIFF
--- a/packages/cli/src/chat/tui/state/subagentFollowup.ts
+++ b/packages/cli/src/chat/tui/state/subagentFollowup.ts
@@ -15,6 +15,18 @@ function innerTag(xml: string, tag: string): string | undefined {
   return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1]?.trim();
 }
 
+// `<message>` bodies are escapeText()'d by the producer; decode for display.
+// `&amp;` last so an escaped `&lt;` never double-decodes.
+function decodeXmlEntities(text: string): string {
+  if (!text.includes('&')) return text;
+  return text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}
+
 function progressDetail(xml: string): string {
   switch (attr(xml, 'type')) {
     case 'started':
@@ -68,6 +80,8 @@ export function summarizeSubagentFollowup(text: string): string {
 
   // <subagent-error>
   const wall = innerTag(trimmed, 'wall-time');
+  const message = innerTag(trimmed, 'message');
   const retryable = attr(trimmed, 'retryable') === 'true';
-  return `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
+  const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
+  return message ? `${head}\n${decodeXmlEntities(message)}` : head;
 }

--- a/packages/cli/src/chat/tui/state/subagentFollowup.ts
+++ b/packages/cli/src/chat/tui/state/subagentFollowup.ts
@@ -1,0 +1,73 @@
+// Subagent progress/result/error blocks (produced by src/tools/subagentResults.ts)
+// are FollowUpQueue messages addressed to the orchestrator *model*, injected
+// into the conversation as user turns. Rendering the raw XML in the human
+// transcript is noise — the orchestrator's own prose already narrates the
+// outcome — so collapse each block to a terse status line. Text that is not a
+// subagent block passes through unchanged.
+
+const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
+
+function attr(xml: string, name: string): string | undefined {
+  return new RegExp(`\\b${name}="([^"]*)"`).exec(xml)?.[1];
+}
+
+function innerTag(xml: string, tag: string): string | undefined {
+  return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1]?.trim();
+}
+
+function progressDetail(xml: string): string {
+  switch (attr(xml, 'type')) {
+    case 'started':
+      return 'started';
+    case 'overview': {
+      const calls = attr(xml, 'tool-calls');
+      const cost = attr(xml, 'cost');
+      const parts: string[] = [];
+      if (calls) parts.push(`${calls} tool call${calls === '1' ? '' : 's'}`);
+      if (cost) parts.push(`$${cost}`);
+      return parts.length > 0 ? parts.join(' · ') : 'working';
+    }
+    case 'round': {
+      const current = attr(xml, 'current');
+      const total = attr(xml, 'total');
+      return current && total ? `round ${current}/${total}` : 'working';
+    }
+    case 'plan':
+      return attr(xml, 'status') === 'cleared'
+        ? 'plan cleared'
+        : `plan · ${attr(xml, 'steps') ?? '0'} steps`;
+    case 'todos':
+      return `todos · ${attr(xml, 'completed') ?? '0'} done, ${attr(xml, 'active') ?? '0'} active, ${attr(xml, 'pending') ?? '0'} pending`;
+    default:
+      return 'working';
+  }
+}
+
+/**
+ * Collapse a subagent follow-up XML block into a one-line (or, for results,
+ * status + response) human-readable summary. Returns `text` unchanged when it
+ * is not a subagent block.
+ */
+export function summarizeSubagentFollowup(text: string): string {
+  const trimmed = text.trim();
+  if (!SUBAGENT_TAG_RE.test(trimmed)) return text;
+
+  const agent = attr(trimmed, 'agent') ?? 'subagent';
+
+  if (trimmed.startsWith('<subagent-progress')) {
+    return `⟳ ${agent} · ${progressDetail(trimmed)}`;
+  }
+
+  if (trimmed.startsWith('<subagent-result')) {
+    const status = attr(trimmed, 'status') ?? 'completed';
+    const wall = innerTag(trimmed, 'wall-time');
+    const response = innerTag(trimmed, 'response');
+    const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
+    return response ? `${head}\n${response}` : head;
+  }
+
+  // <subagent-error>
+  const wall = innerTag(trimmed, 'wall-time');
+  const retryable = attr(trimmed, 'retryable') === 'true';
+  return `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -14,6 +14,7 @@ import { normalizeToolUseData } from '@shared/toolUse';
 
 import { appendCliApiSwitchHint } from '../../../runtime/approvalAdapter';
 import { cliState, patchStream, type ConversationEntry } from './cliState';
+import { summarizeSubagentFollowup } from './subagentFollowup';
 import { isFinalTranscriptStatus } from './transcript';
 
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
@@ -173,7 +174,7 @@ function renderLogEntry(
     role === 'error'
       ? appendCliApiSwitchHint(text)
       : role === 'user'
-        ? stripOrchestratorFollowup(text)
+        ? summarizeSubagentFollowup(stripOrchestratorFollowup(text))
         : text;
   // Assistant entries defer finalization (see comment above); inherit
   // from `prev` so re-syncs after finalize don't de-finalize and drop

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeSubagentFollowup } from '../../../packages/cli/src/chat/tui/state/subagentFollowup';
+
+describe('summarizeSubagentFollowup', () => {
+  it('passes non-subagent text through unchanged', () => {
+    expect(summarizeSubagentFollowup('hello world')).toBe('hello world');
+    expect(
+      summarizeSubagentFollowup(
+        '<orchestrator-followup>x</orchestrator-followup>',
+      ),
+    ).toBe('<orchestrator-followup>x</orchestrator-followup>');
+  });
+
+  it('summarizes a started progress block', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-progress id="abc" agent="research" type="started" />',
+      ),
+    ).toBe('⟳ research · started');
+  });
+
+  it('summarizes an overview progress block with tool calls and cost', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-progress id="abc" agent="research" type="overview" tool-calls="1" files-changed="none" cost="0.0007" />',
+      ),
+    ).toBe('⟳ research · 1 tool call · $0.0007');
+  });
+
+  it('pluralizes tool calls', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-progress id="abc" agent="research" type="overview" tool-calls="3" files-changed="none" />',
+      ),
+    ).toBe('⟳ research · 3 tool calls');
+  });
+
+  it('summarizes a round progress block', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-progress id="abc" agent="numerics" type="round" current="2" total="5">\n<file path="a.tex" />\n</subagent-progress>',
+      ),
+    ).toBe('⟳ numerics · round 2/5');
+  });
+
+  it('summarizes a completed result with wall time and response', () => {
+    const xml = [
+      '<subagent-result id="abc" agent="research" category="toolUse" status="completed">',
+      '<wall-time>2sec</wall-time>',
+      '<response>',
+      '91 .ts files found.',
+      '</response>',
+      '</subagent-result>',
+    ].join('\n');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '✓ research completed · 2sec\n91 .ts files found.',
+    );
+  });
+
+  it('summarizes a result without a response body', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-result id="abc" agent="review" category="toolUse" status="stopped"><wall-time>5sec</wall-time></subagent-result>',
+      ),
+    ).toBe('✓ review stopped · 5sec');
+  });
+
+  it('summarizes a retryable error block', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-error id="abc" agent="lean" retryable="true"><wall-time>1sec</wall-time></subagent-error>',
+      ),
+    ).toBe('✗ lean failed · 1sec (retryable)');
+  });
+});

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -66,11 +66,19 @@ describe('summarizeSubagentFollowup', () => {
     ).toBe('✓ review stopped · 5sec');
   });
 
-  it('summarizes a retryable error block', () => {
+  it('summarizes a retryable error block without a message', () => {
     expect(
       summarizeSubagentFollowup(
         '<subagent-error id="abc" agent="lean" retryable="true"><wall-time>1sec</wall-time></subagent-error>',
       ),
     ).toBe('✗ lean failed · 1sec (retryable)');
+  });
+
+  it('preserves and decodes the error message', () => {
+    expect(
+      summarizeSubagentFollowup(
+        '<subagent-error id="abc" agent="lean" retryable="false"><wall-time>1sec</wall-time><message>rate limit: &lt;tokens&gt; &amp; retries exhausted</message></subagent-error>',
+      ),
+    ).toBe('✗ lean failed · 1sec\nrate limit: <tokens> & retries exhausted');
   });
 });


### PR DESCRIPTION
Closes #4480

## Problem

When an orchestrating agent delegates to a subagent in `texra chat`, the transcript rendered raw model-directed XML. Observed hands-on (`texra chat --agent creator` → `research` subagent):

```
 › <subagent-progress id="7e37b819c562" agent="research" type="started" />
 › <subagent-progress id="7e37b819c562" agent="research" type="overview" tool-calls="1" files-changed="none" cost="0.0007" />
 › <subagent-result id="7e37b819c562" agent="research" category="toolUse" status="completed">
   <wall-time>2sec</wall-time>
   <response>
   The glob found **91 TypeScript files**…
   </response>
   </subagent-result>
```

These blocks (`src/tools/subagentResults.ts`) are **FollowUpQueue messages for the orchestrator model**, injected as user turns — not meant for the human.

## Fix

Add `summarizeSubagentFollowup` and apply it to user-role entries at the existing rendering boundary in `subscribeStreamLog.ts`, right after `stripOrchestratorFollowup` (same precedent). Each block collapses to a terse status line:

```
⟳ research · started
⟳ research · 1 tool call · $0.0007
✓ research completed · 2sec
  91 .ts files found.        ← <response> body kept for results
```

Rendering-only — the XML still reaches the model unchanged via FollowUpQueue.

## After (live)

Driving the same delegation now shows, in the research stream:
```
 › ⟳ research · started
 › ⟳ research · 1 tool call · $0.0005
 › ✓ research completed · 23sec
```
No raw XML anywhere.

## Notes / scope

- Isolated to the CLI renderer. The extension webview (`progressView/.../UserMessage.ts`) also surfaces these via a styled "structured-delivery" bubble (markdown, `html:false`) rather than a per-type pretty-printer, so I did not try to unify both surfaces here — a shared cross-host formatter could be a follow-up. Kept minimal per "don't overengineer".
- Entries keep `role: 'user'` (still prefixed `›`); only the text is cleaned. Re-styling these as a distinct row type is a possible follow-up.
- 8 unit tests cover started/overview (incl. pluralization)/round progress, completed/stopped results, and a retryable error. All 307 CLI kernel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the CLI TUI transcript path with no auth, persistence, or model message changes.
> 
> **Overview**
> **CLI chat transcripts** no longer show raw `<subagent-progress>`, `<subagent-result>`, and `<subagent-error>` XML for orchestrator follow-ups. A new `summarizeSubagentFollowup` helper turns those blocks into short status lines (progress, completion with optional `<response>` body, or failure with decoded error text); everything else is unchanged.
> 
> The formatter runs in `subscribeStreamLog` on **user-role** stream log text, immediately after `stripOrchestratorFollowup`—display only; the model still receives the full XML via the follow-up queue. Unit tests cover progress variants, results, errors, and pass-through behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c5f4530cc611840fc69f19db5f2c61ade6dc3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->