### PR TITLE
fix(settings): defer model controller wiring + restructure history layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.38.1] - 2026-05-25
+
+### Bug Fixes
+
+- **Settings view tabs load correctly again** — Models, History, Agents, LaTeX, Memory, and approval settings now populate on first open.
+
+### Improvements
+
+- **Cleaner history rows** — each entry now puts the metadata (timestamp, agent, model, inputs) and action buttons on top, keeps Context / Config visible inline, and collapses very long instruction prompts behind a "Show full instructions" toggle.
+
 ## [0.38.0] - 2026-05-24
 
 ### Features

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -144,6 +144,7 @@ import { buildToolDashboardItems } from './utils/toolDashboardData';
 import { AgentHandlers } from './handlers/agentHandlers';
 import { LatexSettingsHandlers } from './handlers/latexSettingsHandlers';
 import type { SettingsMemoryController } from '@controllers/settingsView/SettingsMemoryController';
+import type { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
 import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 
 // Re-use the shared type helper for extracting specific message types.
@@ -228,15 +229,6 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
   }));
 }
 
-const modelSelectionController = createModelSelectionController(
-  { workspaceState: workspaceSM, globalState: globalSM },
-  {
-    useIncludedAccess: () =>
-      getServerSideKeyService().getUseIncludedModelAccess(),
-    getUserTier: () => getServerSideKeyService().getUserTier() ?? undefined,
-  },
-);
-
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
@@ -246,6 +238,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly agentHandlers: AgentHandlers;
   private readonly latexHandlers: LatexSettingsHandlers;
   private readonly memoryController: SettingsMemoryController;
+  private readonly modelSelectionController: SettingsModelSelectionController;
   private readonly profileKeyController: SettingsProfileKeyController;
 
   /** Used by handleExportChat to locate the bundled HTML export assets. */
@@ -269,6 +262,18 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       prompt: new VscodePromptHost(),
       setMemoryEnabled: setToolUseMemoryEnabled,
     });
+    // Must build inside the constructor: globalSM/workspaceSM are populated
+    // by extension.ts → initializeStateManagers and are still undefined at
+    // module load, so destructuring them at top level captures `undefined`
+    // and every later globalState.get(...) throws.
+    this.modelSelectionController = createModelSelectionController(
+      { workspaceState: workspaceSM, globalState: globalSM },
+      {
+        useIncludedAccess: () =>
+          getServerSideKeyService().getUseIncludedModelAccess(),
+        getUserTier: () => getServerSideKeyService().getUserTier() ?? undefined,
+      },
+    );
     this.profileKeyController = new SettingsProfileKeyController({
       prompt: new VscodePromptHost(),
       externalOpener: new VscodeExternalOpener(),
@@ -867,7 +872,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(
-      buildModelSelectionMessage(modelSelectionController),
+      buildModelSelectionMessage(this.modelSelectionController),
     );
   }
 
@@ -1628,7 +1633,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetModelEnabled(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MODEL_ENABLED>,
   ): Promise<void> {
-    await modelSelectionController.setModelEnabled({
+    await this.modelSelectionController.setModelEnabled({
       modelName: data.modelName,
       enabled: data.enabled,
     });
@@ -1642,14 +1647,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetHelperModel(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_HELPER_MODEL>,
   ): Promise<void> {
-    await modelSelectionController.setHelperModel(data.modelName);
+    await this.modelSelectionController.setHelperModel(data.modelName);
     await this.withActiveWebview((w) => this.sendModelSelectionData(w));
   }
 
   private async handleSetModelReasoningLevel(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MODEL_REASONING_LEVEL>,
   ): Promise<void> {
-    await modelSelectionController.setReasoningLevel({
+    await this.modelSelectionController.setReasoningLevel({
       modelName: data.modelName,
       level: data.level,
     });
@@ -1659,7 +1664,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetPreferShortModelNames(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PREFER_SHORT_MODEL_NAMES>,
   ): Promise<void> {
-    await modelSelectionController.setPreferShortModelNames(data.enabled);
+    await this.modelSelectionController.setPreferShortModelNames(data.enabled);
     await this.withActiveWebview((w) => this.sendModelSelectionData(w));
   }
 

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -28,6 +28,8 @@ import { HistoryViewEvents } from './events';
 
 type ConfigValue = string | number | boolean | string[] | null | undefined;
 
+const LONG_INSTRUCTION_CHARS = 400;
+
 @customElement('history-item')
 export class HistoryItemElement extends LitElement {
   static override styles = [
@@ -202,6 +204,37 @@ export class HistoryItemElement extends LitElement {
     return !Array.isArray(value) || value.length > 0;
   }
 
+  private renderInstructionBlock(
+    instructionText: string | null,
+    titleText: string,
+  ): TemplateResult {
+    const body = instructionText
+      ? html`<div class="markdown-content">
+          ${unsafeHTML(this.renderMarkdown(titleText))}
+        </div>`
+      : html`<span>${titleText}</span>`;
+
+    const isLong =
+      !!instructionText && instructionText.length > LONG_INSTRUCTION_CHARS;
+
+    if (!isLong || !this.item) {
+      return html`<div class="history-title">${body}</div>`;
+    }
+
+    return html`
+      <wa-details
+        class="collapsible instruction-collapsible"
+        summary="Show full instructions"
+        ?open=${this.open}
+        @wa-show=${(e: Event) => this.dispatchToggle(e, true)}
+        @wa-hide=${(e: Event) => this.dispatchToggle(e, false)}
+        data-id=${this.item.id}
+      >
+        <div class="history-title">${body}</div>
+      </wa-details>
+    `;
+  }
+
   private renderConfigSection(
     label: string | TemplateResult,
     entries: Array<[string, ConfigValue]>,
@@ -300,12 +333,8 @@ export class HistoryItemElement extends LitElement {
     return html`
       <div class="list-item history-item">
         <div class="list-item-header">
-          <div class="history-title">
-            ${instructionText
-              ? html`<div class="markdown-content">
-                  ${unsafeHTML(this.renderMarkdown(titleText))}
-                </div>`
-              : html`<span>${titleText}</span>`}
+          <div class="text-secondary meta-strip">
+            ${renderDotMeta(metaParts)}
           </div>
           <div
             class="history-actions action-button-group"
@@ -350,23 +379,14 @@ export class HistoryItemElement extends LitElement {
               : nothing}
           </div>
         </div>
+        ${this.renderInstructionBlock(instructionText, titleText)}
         ${summaryText
           ? html`<div class="history-description">${summaryText}</div>`
           : nothing}
-        <div class="text-secondary meta-strip">${renderDotMeta(metaParts)}</div>
         ${extraDetails.length
-          ? html`
-              <wa-details
-                class="collapsible"
-                summary="More details"
-                ?open=${this.open}
-                @wa-show=${(e: Event) => this.dispatchToggle(e, true)}
-                @wa-hide=${(e: Event) => this.dispatchToggle(e, false)}
-                data-id=${this.item.id}
-              >
-                <div class="history-details extra-details">${extraDetails}</div>
-              </wa-details>
-            `
+          ? html`<div class="history-details extra-details">
+              ${extraDetails}
+            </div>`
           : nothing}
       </div>
     `;


### PR DESCRIPTION
## Summary

- Fix Settings view crash that left tabs (History, Agents, LaTeX, Memory, etc.) empty or stuck loading on first open after install.
- Restructure each History row: meta + actions on top, instruction body collapsed when long, Context/Output/Config sections always visible inline.

## Why the settings panels were empty

`SettingsModelSelectionController` was being constructed at the top of `SettingsViewMessageHandler.ts` (`const modelSelectionController = createModelSelectionController({ globalState: globalSM, ... })`). `globalSM` / `workspaceSM` are `export let` bindings in `src/common/state/stateManager.ts` that stay `undefined` until `initializeStateManagers(context)` runs from `packages/extension/src/extension.ts`. The factory destructured them into a closure at module-load time, capturing `undefined`. Every later `globalState.get(...)` then threw `TypeError: Cannot read properties of undefined (reading 'get')` inside `sendModelSelectionData`, which aborted `sendAllData` before its `Promise.all` could send Memory / History / Agent / LaTeX / approval / odyssey data.

Moved the construction into the `SettingsViewMessageHandler` constructor (same pattern already used for `memoryController`, `profileKeyController`, `agentHandlers`, `latexHandlers`) and added a short WHY comment so the pattern is not silently re-hoisted later.

## History row layout

Re-ordered each row to put the metadata where users expect it and stop hiding the actually-useful sections:

- **Header row**: meta strip on the left (timestamp · category tag · `Agent:` · `Model:` · `Inputs:`) and icon buttons on the right (Delete / Setup / Rerun / Export…).
- **Instruction body**: rendered inline when short; wrapped in a `<wa-details summary="Show full instructions">` when over 400 chars so a giant prompt doesn't dominate the list.
- **Description**: italic short summary line, still shown below the instruction when it differs.
- **Extra details (Context / Output / Config)**: rendered inline at the bottom — no more "More details" collapsible.

Per-item open state and search `forceOpen` continue to work because both key on `item.id`; the only semantic shift is that `this.open` now controls the instruction collapsible rather than the (removed) extra-details collapsible.

## Test plan

- [ ] Reinstall the VSIX from `npm run build:fast`, open a fresh window, open Settings → confirm History, Models, Agents, LaTeX, Memory all render content (no infinite "Loading…").
- [ ] Open a history row with a long instruction → confirm meta+icons sit on top, "Show full instructions" collapses the prompt, Context / Config are visible inline.
- [ ] Search in the History tab for a term that occurs only inside a collapsed long instruction → confirm the row's collapsible opens and the match is scrolled into view.
- [ ] Toggle an item open → reload Settings → confirm open state persists for that item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and initialization-order fix; no auth, security, or data-path changes beyond existing settings state reads.
> 
> **Overview**
> Fixes **Settings** tabs that stayed empty on first open by constructing **`SettingsModelSelectionController`** in **`SettingsViewMessageHandler`**’s constructor (after **`globalSM`** / **`workspaceSM`** are initialized) instead of at module load, so **`sendModelSelectionData`** no longer throws and aborts **`sendAllData`**.
> 
> **History** rows are reordered: metadata and action buttons sit in the header; instructions over 400 characters collapse behind **Show full instructions**; Context / Output / Config render inline without a **More details** wrapper. **CHANGELOG** documents **0.38.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97dc267c446825778514cff453cf4fd95ab5d76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->