### PR TITLE
fix(cli): resolve follow-up CLI and runtime issues

### DIFF
--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -138,6 +138,27 @@ The interactive chat also accepts `/resume`. With no id it prints recent
 executions; with an id it starts from the stored execution configuration. A
 missing or malformed id exits with code 2 in headless commands.
 
+## Tools and Integrations
+
+The CLI can inspect the same external agent integrations shown in the extension
+settings:
+
+```bash
+texra tools list
+texra tools status codex
+texra tools disable codex
+texra tools enable codex
+texra tools install codex
+texra tools auth codex
+```
+
+`tools list` reports each integration id, name, category, enabled state, and
+detection result. Use `--output-format json` or `--output-format ndjson` for
+scripts. `tools install <id>` prints the install guide and registered command;
+it only runs the command when passed `--run`. In the interactive TUI, `/tools`
+opens the same integration list and toggles integrations that support enabling
+or disabling.
+
 ## Workspace Defaults
 
 The CLI reads optional, non-secret defaults from `.texra/config.json` in the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,8 +13,10 @@ import { loadAliasEntries } from './scripts/aliasUtils.mjs';
 const INTERNAL_ALIAS_NAMES = [
   'agent',
   'auth',
+  'cli',
   'commands',
   'common',
+  'desktop',
   'eventBus',
   'explorer',
   'frontend',
@@ -364,6 +366,7 @@ export default tseslint.config(
       'packages/extension/src/**/*.ts',
       'packages/desktop/src/**/*.ts',
       'packages/cli/src/**/*.ts',
+      'packages/cli/src/**/*.tsx',
     ],
     extends: [...tseslint.configs.recommended],
     languageOptions: {

--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -21,6 +21,7 @@ const processInputAllowedFiles = new Set([
   // input pipeline; this file is the TUI I/O boundary.
   'packages/cli/src/chat/tui/runChatTui.tsx',
   'packages/cli/src/orchestration/runOrchestrationTui.tsx',
+  'packages/cli/src/init/runInitWizard.tsx',
 ]);
 
 const processTerminalInputAllowedFiles = new Set([
@@ -36,6 +37,7 @@ const processOutputAllowedFiles = new Set([
   // of the TUI must keep going through logSinks.
   'packages/cli/src/chat/tui/runChatTui.tsx',
   'packages/cli/src/orchestration/runOrchestrationTui.tsx',
+  'packages/cli/src/init/runInitWizard.tsx',
 ]);
 
 const processOutputPatterns = [

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -18,7 +18,7 @@ import { SubagentList } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
-import { metaChordInput } from './input/inputKeys';
+import { metaChordDigit, metaChordInput } from './input/inputKeys';
 import {
   hasChildExecutionRows,
   numericFocusTarget,
@@ -284,8 +284,8 @@ export function App(props: AppProps): React.JSX.Element {
         setChildControlMode('tasks');
         return;
       }
-      const digit = Number(input);
-      if (Number.isInteger(digit) && digit >= 1 && digit <= 9) {
+      const digit = metaChordDigit(input, key);
+      if (digit !== undefined) {
         const target = numericFocusTarget(activeSlice, digit - 1);
         if (target) cliState.activeStreamId.set(target);
       }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -18,6 +18,7 @@ import { SubagentList } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
+import { metaChordInput } from './input/inputKeys';
 import {
   hasChildExecutionRows,
   numericFocusTarget,
@@ -271,8 +272,9 @@ export function App(props: AppProps): React.JSX.Element {
 
   useInput(
     (input, key) => {
-      if (!key.meta) return;
-      const lower = input.toLowerCase();
+      const metaInput = metaChordInput(input, key);
+      if (!metaInput) return;
+      const lower = metaInput.toLowerCase();
       if (lower === 's') {
         if (!subagentControlsAvailable) return;
         setChildControlMode('subagents');

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -8,6 +8,7 @@ import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
+import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 import type { CliApiMode } from '../../../runtime/apiAccessMode';
@@ -156,6 +157,15 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
+  function ToolsListFormAdapter(props: SlashFormProps): React.JSX.Element {
+    return (
+      <ToolsListForm
+        availableRows={props.availableRows}
+        onClose={() => props.onDone(undefined)}
+      />
+    );
+  }
+
   registerSlashCommand({
     name: 'help',
     description: 'Show available slash commands',
@@ -205,6 +215,11 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'memory',
     description: 'List stored memories',
     formComponent: MemoryListFormAdapter,
+  });
+  registerSlashCommand({
+    name: 'tools',
+    description: 'List or toggle external integrations',
+    formComponent: ToolsListFormAdapter,
   });
   registerSlashCommand({
     name: 'compact',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,5 +1,7 @@
 // Registers the slash commands the input palette surfaces.
 
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import type { CliApprovalPolicy } from '@cli/runtime/approvalPolicy';
 import type { ExecutionId } from '@shared/schemas';
 
 import { ApiModeForm } from '../forms/ApiModeForm';
@@ -11,8 +13,6 @@ import { ResumeListForm } from '../forms/ResumeListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
-import type { CliApiMode } from '../../../runtime/apiAccessMode';
-import type { CliApprovalPolicy } from '../../../runtime/approvalPolicy';
 
 type AgentSelectHandler = (value: string) => void | Promise<void>;
 type ApprovalPolicySelectHandler = (

--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from 'ink';
 import { useEffect, useState } from 'react';
 
-import { type CliApiMode } from '../../../runtime/apiAccessMode';
-import { loadCliApiStatusLines } from '../../../runtime/apiStatus';
+import { type CliApiMode } from '@cli/runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 

--- a/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'ink';
 
-import type { CliApprovalPolicy } from '../../../runtime/approvalPolicy';
+import type { CliApprovalPolicy } from '@cli/runtime/approvalPolicy';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -5,13 +5,13 @@ import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
-import type { MemoryViewItem } from '@shared/schemas';
-import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
-
 import {
   CLI_MEMORY_LIST_LIMIT,
   cliMemoryItemDescription,
-} from '../../../runtime/memory';
+} from '@cli/runtime/memory';
+import type { MemoryViewItem } from '@shared/schemas';
+import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
+
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -6,16 +6,13 @@ import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
-import { Select } from '../ui/Select';
-import { KeyHints } from '../ui/KeyHints';
 import {
   getCliModelAccessList,
   type CliModelAccess,
-} from '../../../runtime/modelAccess';
-import {
-  formatCliApiMode,
-  type CliApiMode,
-} from '../../../runtime/apiAccessMode';
+} from '@cli/runtime/modelAccess';
+import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
+import { Select } from '../ui/Select';
+import { KeyHints } from '../ui/KeyHints';
 
 export interface ModelListFormProps {
   readonly currentModel: string;

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -65,6 +65,8 @@ export function formatModelStatusForCliMode(
       return 'relay: included';
     case 'not-included':
       return 'relay: not included';
+    case 'relay-quota-exhausted':
+      return 'relay: quota exhausted';
     case 'provider-key':
       return 'relay: unavailable; api key set';
     case 'openrouter-key':

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -5,12 +5,12 @@ import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
-import type { ExecutionId } from '@shared/schemas';
-
 import {
   listCliHistoryEntries,
   type CliHistoryEntry,
-} from '../../../runtime/history';
+} from '@cli/runtime/history';
+import type { ExecutionId } from '@shared/schemas';
+
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -1,0 +1,160 @@
+// `/tools` form. It mirrors `texra tools list` inside an active TUI session
+// and toggles integrations that are marked toggleable in EXTERNAL_TOOL_DEFS.
+
+import { Box, Text, useInput } from 'ink';
+import { Spinner } from '@inkjs/ui';
+import { useEffect, useState } from 'react';
+
+import {
+  readCliToolStatuses,
+  setCliToolEnabled,
+  type CliToolStatusRecord,
+} from '../../../runtime/tools';
+import { KeyHints } from '../ui/KeyHints';
+import { Select } from '../ui/Select';
+
+export interface ToolsListFormProps {
+  readonly availableRows?: number;
+  readonly onClose: () => void;
+}
+
+interface ToolsFrameProps {
+  readonly color: string;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}
+
+function ToolsFrame(props: ToolsFrameProps): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={props.color}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={props.color}>
+        {props.title}
+      </Text>
+      {props.children}
+    </Box>
+  );
+}
+
+function yesNo(value: boolean | null): string {
+  if (value == null) return '-';
+  return value ? 'yes' : 'no';
+}
+
+function toolDescription(tool: CliToolStatusRecord): string {
+  const enabled = `enabled ${yesNo(tool.enabled)}`;
+  const detected = `detected ${yesNo(tool.detected)}`;
+  const status = tool.statusLabel ?? tool.status;
+  return `${enabled}; ${detected}; ${status}`;
+}
+
+function toolsSelectWindow({
+  availableRows,
+  itemCount,
+}: {
+  readonly availableRows: number | undefined;
+  readonly itemCount: number;
+}): {
+  readonly maxVisibleItems: number | undefined;
+  readonly showOverflow: boolean;
+} {
+  if (availableRows == null) {
+    return { maxVisibleItems: undefined, showOverflow: false };
+  }
+  const selectRows = Math.max(1, availableRows - 5);
+  if (itemCount <= selectRows) {
+    return { maxVisibleItems: itemCount, showOverflow: false };
+  }
+  if (selectRows < 3) {
+    return { maxVisibleItems: selectRows, showOverflow: false };
+  }
+  return { maxVisibleItems: selectRows - 2, showOverflow: true };
+}
+
+export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
+  const [tools, setTools] = useState<readonly CliToolStatusRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useInput((_input, key) => {
+    if ((loading || error) && key.escape) props.onClose();
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void readCliToolStatuses()
+      .then((list) => {
+        if (cancelled) return;
+        setTools(list);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <ToolsFrame color="cyan" title="/tools">
+        <Spinner label="Checking tool integrations..." />
+      </ToolsFrame>
+    );
+  }
+
+  if (error) {
+    return (
+      <ToolsFrame color="red" title="/tools - error">
+        <Text>{error}</Text>
+      </ToolsFrame>
+    );
+  }
+
+  const selectWindow = toolsSelectWindow({
+    availableRows: props.availableRows,
+    itemCount: tools.length,
+  });
+  const items = tools.map((tool) => ({
+    value: tool.id,
+    label: tool.name,
+    description: toolDescription(tool),
+    disabled: !tool.toggleable || tool.comingSoon,
+  }));
+
+  return (
+    <ToolsFrame color="cyan" title="/tools">
+      <Text dimColor>Toggle available external integrations.</Text>
+      <Select
+        items={items}
+        maxVisibleItems={selectWindow.maxVisibleItems}
+        showOverflow={selectWindow.showOverflow}
+        onSelect={(id) => {
+          const tool = tools.find((candidate) => candidate.id === id);
+          if (!tool || tool.enabled == null) return;
+          void setCliToolEnabled(id, !tool.enabled)
+            .then(() => readCliToolStatuses())
+            .then(setTools);
+        }}
+        onCancel={props.onClose}
+      />
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: 'Enter', action: 'toggle' },
+            { key: 'Esc', action: 'close' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </ToolsFrame>
+  );
+}

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -6,10 +6,11 @@ import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
 import {
+  formatCliBoolean,
   readCliToolStatuses,
   setCliToolEnabled,
   type CliToolStatusRecord,
-} from '../../../runtime/tools';
+} from '@cli/runtime/tools';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 
@@ -40,14 +41,9 @@ function ToolsFrame(props: ToolsFrameProps): React.JSX.Element {
   );
 }
 
-function yesNo(value: boolean | null): string {
-  if (value == null) return '-';
-  return value ? 'yes' : 'no';
-}
-
 function toolDescription(tool: CliToolStatusRecord): string {
-  const enabled = `enabled ${yesNo(tool.enabled)}`;
-  const detected = `detected ${yesNo(tool.detected)}`;
+  const enabled = `enabled ${formatCliBoolean(tool.enabled)}`;
+  const detected = `detected ${formatCliBoolean(tool.detected)}`;
   const status = tool.statusLabel ?? tool.status;
   return `${enabled}; ${detected}; ${status}`;
 }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -17,7 +17,7 @@ import {
   insertText,
   type TextEdit,
 } from './textInputEditing';
-import { isPlainReturnInput } from './inputKeys';
+import { isPlainReturnInput, metaChordInput } from './inputKeys';
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -134,7 +134,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       // Drop unhandled control/meta combos; pass printable input through.
-      if (key.ctrl || key.meta || !input) return;
+      if (key.ctrl || key.meta || metaChordInput(input, key) || !input) return;
       applyEdit(insertText(value, cursor, input));
     },
     { isActive: focus },

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -7,9 +7,9 @@
 import { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
-import type { InputHistory } from '../history/inputHistory';
 import { KeyHints } from '../ui/KeyHints';
 import { BaseTextInput } from './BaseTextInput';
+import type { InputHistory } from '../history/inputHistory';
 
 export interface ReverseSearchProps {
   readonly history: InputHistory;

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -4,10 +4,21 @@ export interface ReturnKeyInput {
   readonly meta?: boolean;
 }
 
+export function metaChordInput(
+  input: string,
+  key: Pick<ReturnKeyInput, 'ctrl' | 'meta'>,
+): string | undefined {
+  if (key.ctrl) return undefined;
+  if (key.meta && input) return input;
+  return input.startsWith('\u001B') && input.length > 1
+    ? input.slice(1)
+    : undefined;
+}
+
 export function isPlainReturnInput(
   input: string,
   key: ReturnKeyInput,
 ): boolean {
-  if (key.ctrl || key.meta) return false;
+  if (key.ctrl || key.meta || metaChordInput(input, key)) return false;
   return key.return === true || input === '\r' || input === '\n';
 }

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -15,6 +15,18 @@ export function metaChordInput(
     : undefined;
 }
 
+export function metaChordDigit(
+  input: string,
+  key: Pick<ReturnKeyInput, 'ctrl' | 'meta'>,
+): number | undefined {
+  const chord = metaChordInput(input, key);
+  if (!chord) return undefined;
+  const digit = Number(chord);
+  return Number.isInteger(digit) && digit >= 1 && digit <= 9
+    ? digit
+    : undefined;
+}
+
 export function isPlainReturnInput(
   input: string,
   key: ReturnKeyInput,

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -17,9 +17,9 @@ import {
   type ChildControlItem,
   type ChildControlMode,
 } from '../state/childControls';
-import type { StreamSlice } from '../state/cliState';
 import { KeyHints } from '../ui/KeyHints';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
+import type { StreamSlice } from '../state/cliState';
 
 export interface ChildControlPickerProps {
   readonly activeStreamId: StreamTabId | undefined;

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -6,12 +6,12 @@ import { Box, Text, type BoxProps } from 'ink';
 import { useInput } from 'ink';
 
 import { confirmCardKeyAction, confirmCardKeyHints } from './ConfirmCardState';
+import { BaseTextInput } from '../input/BaseTextInput';
+import { KeyHints } from '../ui/KeyHints';
 import type {
   ApprovalBypassKind,
   ApprovalDecision,
 } from '../state/approvalQueue';
-import { BaseTextInput } from '../input/BaseTextInput';
-import { KeyHints } from '../ui/KeyHints';
 
 export interface ConfirmCardProps {
   readonly borderStyle: BoxProps['borderStyle'];

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -3,9 +3,9 @@ import { Box, Text, useInput } from 'ink';
 
 import type { ExternalInquiryPermission } from '@shared/schemas';
 
-import type { ApprovalDecision } from '../state/approvalQueue';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { KeyHints } from '../ui/KeyHints';
+import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface ExternalInquiryProps {
   readonly payload: ExternalInquiryPermission;

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -3,8 +3,8 @@ import { ConfirmInput } from '@inkjs/ui';
 
 import type { PlanApprovalPermission } from '@shared/schemas';
 
-import type { ApprovalDecision } from '../state/approvalQueue';
 import { KeyHints } from '../ui/KeyHints';
+import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface PlanApprovalProps {
   readonly payload: PlanApprovalPermission;

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from 'ink';
 
+import { isCliApiSwitchableRetry } from '@cli/runtime/approvalAdapter';
 import type { RetryPermission } from '@shared/schemas';
 
-import { isCliApiSwitchableRetry } from '../../../runtime/approvalAdapter';
 import { ConfirmCard } from './ConfirmCard';
 import type { ApprovalDecision } from '../state/approvalQueue';
 

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
+import { parseUserQuestionAnswer } from '@cli/runtime/userQuestionAnswer';
 import type {
   UserQuestionAnswers,
   UserQuestionPermission,
@@ -13,12 +14,11 @@ import {
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
-import type { ApprovalDecision } from '../state/approvalQueue';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isPlainReturnInput } from '../input/inputKeys';
 import { Select } from '../ui/Select';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
-import { parseUserQuestionAnswer } from '../../../runtime/userQuestionAnswer';
+import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface UserQuestionProps {
   readonly payload: UserQuestionPermission;

--- a/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
+++ b/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
@@ -12,7 +12,7 @@
 // Multiplexer-aware DCS wrapping for tmux/screen is deferred per
 // docs/prd/cli-tui-ink/30-reference.md#16-risks (R9).
 
-import { writeRawStdout } from '../../../runtime/logSinks';
+import { writeRawStdout } from '@cli/runtime/logSinks';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 
 export type NotificationKind = 'agentFinished' | 'approvalNeeded';

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
+import { writeTextStderr } from '@cli/runtime/logSinks';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { SlashPalette } from '../commands/SlashPalette';
 import { matchSlashCommands, parseSlashInput } from '../commands/slashRegistry';
-import type { InputHistory } from '../history/inputHistory';
-import { writeTextStderr } from '../../../runtime/logSinks';
 import { cliState } from '../state/cliState';
+import type { InputHistory } from '../history/inputHistory';
 
 export interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter. */

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { useEffect, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
+import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import type { StreamTabId } from '@shared/schemas';
 import { safeHomedir } from '@utils/system/platformPaths';
 
@@ -18,7 +19,6 @@ import {
 } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import { TranscriptEntry } from './TranscriptEntry';
-import { shortCliApiMode } from '../../../runtime/apiAccessMode';
 
 export type StaticTranscriptItem =
   | {

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   STREAM_STATUS,
   type ConversationProgress,
@@ -18,7 +19,6 @@ import {
   type BypassState,
 } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
-import { shortCliApiMode } from '../../../runtime/apiAccessMode';
 
 type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
 

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -7,10 +7,10 @@ import { Box, Text } from 'ink';
 
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
-import type { ConversationEntry } from '../state/cliState';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
+import type { ConversationEntry } from '../state/cliState';
 
 function ProcessEntryRow({
   process,

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -153,12 +153,17 @@ function outputDisplayLines(toolUse: NormalizedToolUse): string[] {
 
 export function universalToolUseDisplayLines(
   toolUse: NormalizedToolUse,
-  options: { readonly displayName?: string } = {},
+  options: {
+    readonly displayName?: string;
+    readonly showOutput?: boolean;
+  } = {},
 ): readonly string[] {
   const patchLines = toolUsePatchDisplayLines(toolUse);
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
-  const outputLines = outputDisplayLines(toolUse);
+  const outputLines =
+    options.showOutput === true ? outputDisplayLines(toolUse) : [];
   const showNoOutput =
+    options.showOutput === true &&
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
     outputLines.length === 0 &&
     patchLines.length === 0 &&
@@ -268,6 +273,7 @@ interface ToolRowProps {
   readonly fallbackName?: string;
   readonly previewColor?: 'cyan';
   readonly showPatch?: boolean;
+  readonly showOutput?: boolean;
   readonly showExitCode?: boolean;
   readonly preferInputPreview?: boolean;
 }
@@ -277,6 +283,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     toolUse,
     previewColor,
     showPatch = false,
+    showOutput = false,
     showExitCode = false,
     preferInputPreview = false,
   } = props;
@@ -298,9 +305,9 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     return {
       patchGroups: showPatch ? toolUsePatchGroups(toolUse) : undefined,
       preview: previewText,
-      visibleOutput: visibleOutputLines(toolUse),
+      visibleOutput: showOutput ? visibleOutputLines(toolUse) : [],
     };
-  }, [toolUse, showPatch, preferInputPreview]);
+  }, [toolUse, showPatch, showOutput, preferInputPreview]);
 
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
@@ -344,12 +351,19 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
 export function UniversalToolRow({
   toolUse,
   displayName,
+  showOutput,
 }: {
   readonly toolUse: NormalizedToolUse;
   readonly displayName?: string;
+  readonly showOutput?: boolean;
 }): React.JSX.Element {
   return (
-    <ToolRow toolUse={toolUse} displayName={displayName} showPatch={true} />
+    <ToolRow
+      toolUse={toolUse}
+      displayName={displayName}
+      showPatch={true}
+      showOutput={showOutput}
+    />
   );
 }
 
@@ -363,6 +377,7 @@ function BashToolRow({
       toolUse={toolUse}
       fallbackName="bash"
       previewColor="cyan"
+      showOutput={true}
       showExitCode={true}
       preferInputPreview={true}
     />
@@ -398,11 +413,13 @@ const mcpRenderer: ToolRenderer = {
     <UniversalToolRow
       toolUse={toolUse}
       displayName={displayMcpToolName(toolUse.toolName)}
+      showOutput={true}
     />
   ),
   displayLines: (toolUse) =>
     universalToolUseDisplayLines(toolUse, {
       displayName: displayMcpToolName(toolUse.toolName),
+      showOutput: true,
     }),
 };
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -8,8 +8,8 @@
 import { render } from 'ink';
 import PQueue from 'p-queue';
 
-import { getAgent, loadAgents } from '@agent/index';
 import { getDefaultStreamLogStore } from '@transcript';
+import { getAgent, loadAgents } from '@agent/index';
 import { type AgentConfigPayload } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
@@ -26,40 +26,40 @@ import {
   getInterruptible,
   getToolUseFlowContext,
 } from '@agent/toolUse/ToolUseAgentRegistry';
-import { toErrorMessage } from '@common/errors/errorMessage';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
-import {
-  STREAM_STATUS,
-  type ExecutionId,
-  type StreamTabId,
-} from '@shared/schemas';
-import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
-import { generateExecutionId } from '@utils/core/executionId';
-
-import { type CliContext, readCliVersion } from '../../runtime/cliContext';
-import { hasCliApprovalDenied } from '../../runtime/approvalAdapter';
+import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
+import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import {
   formatCliApiMode,
   getCliApiMode,
   parseCliApiMode,
   setCliApiMode,
   type CliApiMode,
-} from '../../runtime/apiAccessMode';
-import { loadCliApiStatusLines } from '../../runtime/apiStatus';
-import { resolveChatDefaults } from '../../runtime/chatDefaults';
-import { CliExitCode } from '../../runtime/exitCodes';
-import { initCliPlatform, setCliHelperModel } from '../../runtime/initPlatform';
-import { createCliRuntimeHost } from '../../runtime/runtimeHost';
-import { writeTextStderr } from '../../runtime/logSinks';
+} from '@cli/runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
+import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
+import { writeTextStderr } from '@cli/runtime/logSinks';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
-} from '../../runtime/approvalPolicy';
-import { parseCliHistoryId, readCliHistoryConfig } from '../../runtime/history';
+} from '@cli/runtime/approvalPolicy';
+import { parseCliHistoryId, readCliHistoryConfig } from '@cli/runtime/history';
 import {
   formatCliMemoryList,
   formatCliMemoryPreview,
-} from '../../runtime/memory';
+} from '@cli/runtime/memory';
+import { toErrorMessage } from '@common/errors/errorMessage';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
+import { generateExecutionId } from '@utils/core/executionId';
+
 import { App } from './App';
 import { AgentListForm } from './forms/AgentListForm';
 import { ApiModeForm } from './forms/ApiModeForm';
@@ -115,7 +115,7 @@ export interface ClearableTuiSessionState {
   stopRequested: boolean;
 }
 
-interface TuiSession extends ClearableTuiSessionState {}
+type TuiSession = ClearableTuiSessionState;
 
 export function clearTuiSessionRunState(
   session: ClearableTuiSessionState,
@@ -647,7 +647,7 @@ export async function runChat(
     initialAgent: agent,
     initialModel: model,
     interruptActive,
-    requestInputExit: () => requestInputExit?.(),
+    requestInputExit,
     getApprovalPolicy,
     setApprovalPolicy,
     resetSession: resetSessionForClear,
@@ -689,8 +689,6 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
-  let requestInputExit: (() => void) | undefined;
-
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
@@ -963,11 +961,11 @@ export async function runChat(
     interruptActive();
     exitNow(129);
   };
-  requestInputExit = () => {
+  function requestInputExit(): void {
     removeProcessHandlers();
     clearPendingExit();
     ink.unmount();
-  };
+  }
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);
   process.on('SIGHUP', handleSighup);

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -10,6 +10,7 @@
 import { signal, type Signal } from '@lit-labs/signals';
 import PQueue from 'p-queue';
 
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type {
   AgentProposalPermission,
   BashPermission,
@@ -20,7 +21,6 @@ import type {
   UserQuestionPermission,
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
-import type { CliApiMode } from '../../../runtime/apiAccessMode';
 
 export type ApprovalBypassKind = 'toolEdit' | 'superYolo';
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -7,6 +7,7 @@
 
 import { signal, type Signal } from '@lit-labs/signals';
 
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type {
   ActiveChildInfo,
   ConversationProgress,
@@ -17,7 +18,6 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
-import type { CliApiMode } from '../../../runtime/apiAccessMode';
 
 export interface ConversationEntry {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -19,6 +19,15 @@ import {
   resolveProposal,
   triggerRetry,
 } from '@agent/runtime/runCoordinators';
+import {
+  denyMessage,
+  immediateDecision,
+  immediateDecisionForApproval,
+  markApprovalDenied,
+} from '@cli/runtime/approvalAdapter';
+import { setCliApiMode } from '@cli/runtime/apiAccessMode';
+import type { CliContext } from '@cli/runtime/cliContext';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
@@ -31,13 +40,6 @@ import {
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
-import {
-  denyMessage,
-  immediateDecision,
-  immediateDecisionForApproval,
-  markApprovalDenied,
-} from '../../../runtime/approvalAdapter';
-import { setCliApiMode } from '../../../runtime/apiAccessMode';
 import { assertNever } from '../assertNever';
 import { cliState } from './cliState';
 import {
@@ -45,8 +47,6 @@ import {
   type ApprovalDecision,
   type ApprovalPayload,
 } from './approvalQueue';
-import type { CliContext } from '../../../runtime/cliContext';
-import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
 type Emit = <K extends ProgressEvent>(
   event: K,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -3,6 +3,7 @@
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
@@ -18,7 +19,6 @@ import {
 } from './cliState';
 import { mergeChildStreams } from './childStreamMerge';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
-import type { CliRuntimeHost } from '../../../runtime/runtimeHost';
 
 type Emit = <K extends ProgressEvent>(
   event: K,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -78,6 +78,12 @@ export function stripOrchestratorFollowup(text: string): string {
   return match?.[1]?.trim() ?? text;
 }
 
+export function isSubagentContinuationMessage(text: string): boolean {
+  return /^<subagent-(progress|result)(?:\s[^>]*)?(?:\/>|>[\s\S]*<\/subagent-\1>)$/.test(
+    text.trim(),
+  );
+}
+
 // `normalizeToolUseData` is dominated by a Zod parse + YAML stringify
 // of `entry.data`. `StreamLog.update` spreads its patch into a fresh
 // `data` object every tick, so reference equality is a reliable signal

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -3,6 +3,7 @@
 // panels and modals; tool rows render inline alongside assistant prose.
 
 import { getDefaultStreamLogStore } from '@transcript';
+import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
 import { flushPendingRunTraces } from '@logger';
 import {
   MESSAGE_TYPES,
@@ -12,7 +13,6 @@ import {
 } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 
-import { appendCliApiSwitchHint } from '../../../runtime/approvalAdapter';
 import { cliState, patchStream, type ConversationEntry } from './cliState';
 import { summarizeSubagentFollowup } from './subagentFollowup';
 import { isFinalTranscriptStatus } from './transcript';
@@ -76,12 +76,6 @@ export function stripOrchestratorFollowup(text: string): string {
     /^<orchestrator-followup>\s*([\s\S]*?)\s*<\/orchestrator-followup>$/,
   );
   return match?.[1]?.trim() ?? text;
-}
-
-export function isSubagentContinuationMessage(text: string): boolean {
-  return /^<subagent-(progress|result)(?:\s[^>]*)?(?:\/>|>[\s\S]*<\/subagent-\1>)$/.test(
-    text.trim(),
-  );
 }
 
 // `normalizeToolUseData` is dominated by a Zod parse + YAML stringify

--- a/packages/cli/src/commands/_helpers/context.ts
+++ b/packages/cli/src/commands/_helpers/context.ts
@@ -1,9 +1,6 @@
-import { buildCliContext, type CliContext } from '../../runtime/cliContext';
-import {
-  pickGlobalArgs,
-  type ParsedGlobalArgs,
-} from '../../runtime/globalArgs';
-import { writeTextStderr } from '../../runtime/logSinks';
+import { buildCliContext, type CliContext } from '@cli/runtime/cliContext';
+import { pickGlobalArgs, type ParsedGlobalArgs } from '@cli/runtime/globalArgs';
+import { writeTextStderr } from '@cli/runtime/logSinks';
 
 export async function contextFromArgs(
   args: ParsedGlobalArgs,

--- a/packages/cli/src/commands/_helpers/exitCode.ts
+++ b/packages/cli/src/commands/_helpers/exitCode.ts
@@ -1,4 +1,4 @@
-import { CliExitCode } from '../../runtime/exitCodes';
+import { CliExitCode } from '@cli/runtime/exitCodes';
 
 // One CLI invocation per process — module-level pending exit code is the
 // simplest way to surface handler exit codes back to `bin/texra.ts` after

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -1,12 +1,12 @@
 import {
   CLI_OUTPUT_FORMATS,
   type CliOutputFormat,
-} from '../../runtime/cliConfig';
+} from '@cli/runtime/cliConfig';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
-} from '../../runtime/approvalPolicy';
-import { CliUsageError } from '../../runtime/cliContext';
+} from '@cli/runtime/approvalPolicy';
+import { CliUsageError } from '@cli/runtime/cliContext';
 
 /**
  * Single source of truth for the global flags accepted by every TeXRA

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -1,5 +1,5 @@
-import { CliUsageError } from '../../runtime/cliContext';
-import { isKnownCliModel } from '../../runtime/cliConfig';
+import { CliUsageError } from '@cli/runtime/cliContext';
+import { isKnownCliModel } from '@cli/runtime/cliConfig';
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
 export function assertExplicitModelKnown(

--- a/packages/cli/src/commands/_helpers/remoteAgents.ts
+++ b/packages/cli/src/commands/_helpers/remoteAgents.ts
@@ -1,4 +1,4 @@
-import { getCliAuthProvider } from '../../runtime/supabaseAuth';
+import { getCliAuthProvider } from '@cli/runtime/supabaseAuth';
 
 export async function shouldHonorRemoteAgentPriority(
   agentName: string,

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -1,11 +1,11 @@
 import { getExecutionStore } from '@agent/storage';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 
-import { hasCliApprovalDenied } from '../../runtime/approvalAdapter';
-import { CliExitCode } from '../../runtime/exitCodes';
-import type { CliContext } from '../../runtime/cliContext';
+import type { CliContext } from '@cli/runtime/cliContext';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
 export type ExecuteAgentResult = Awaited<
   ReturnType<typeof runValidatedExecutionRequest>

--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -3,9 +3,8 @@ import * as path from 'node:path';
 
 import { glob, hasMagic } from 'glob';
 
+import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-
-import { CliUsageError } from '../../runtime/cliContext';
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
   return path.isAbsolute(candidate)

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -6,6 +6,7 @@ import type { AgentConfigPayload } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
+import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { getRunDir } from '@utils/files';
@@ -16,7 +17,6 @@ import {
   type CliRunResult,
   type ExecuteAgentResult,
 } from './terminalStatus';
-import { CliUsageError, type CliContext } from '../../runtime/cliContext';
 
 /** Resolve a user-supplied path against `cwd` when it isn't already absolute. */
 function joinCwdRelative(target: string, cwd: string): string {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,199 @@
+import { defineCommand } from 'citty';
+
+import { getVisibleAgents, loadAgents } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
+import { BUILTIN_DEFAULT_CHAT_AGENT } from '../runtime/chatDefaults';
+import { CliExitCode } from '../runtime/exitCodes';
+import { initCliPlatform } from '../runtime/initPlatform';
+import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import { getCliModelAccessList } from '../runtime/modelAccess';
+import {
+  buildInitConfig,
+  configFileExists,
+  ensureTexraGitignored,
+  initConfigPath,
+  writeInitConfig,
+  type InitAnswers,
+  type InitScope,
+} from '../runtime/initConfig';
+
+import { contextFromArgs } from './_helpers/context';
+import { setExitCode } from './_helpers/exitCode';
+import { optString } from './_helpers/globalArgs';
+import type { CliContext } from '../runtime/cliContext';
+
+function resolveScope(value: unknown): InitScope {
+  return value === 'user' ? 'user' : 'workspace';
+}
+
+async function gatherOptions(): Promise<{
+  agents: { name: string; description?: string }[];
+  models: {
+    value: string;
+    label: string;
+    available: boolean;
+    status: string;
+  }[];
+}> {
+  await loadAgents({ includeRemote: false });
+  const agents = getVisibleAgents(AgentCategory.ToolUse).map((agent) => ({
+    name: agent.name,
+    description: agent.description,
+  }));
+  const models = (await getCliModelAccessList()).map((entry) => ({
+    value: entry.model.value,
+    label: entry.model.label ?? entry.model.value,
+    available: entry.available,
+    status: entry.status,
+  }));
+  return { agents, models };
+}
+
+function defaultAnswers(
+  models: { value: string; available: boolean }[],
+): InitAnswers {
+  const firstAvailable = models.find((model) => model.available);
+  return {
+    agent: BUILTIN_DEFAULT_CHAT_AGENT,
+    model: firstAvailable?.value ?? CLI_BUILTIN_DEFAULT_MODEL,
+    approvalPolicy: 'never',
+    outputFormat: 'text',
+  };
+}
+
+function printSummary(
+  filePath: string,
+  answers: InitAnswers,
+  models: { value: string; available: boolean }[],
+): void {
+  const lines = [
+    `Wrote ${filePath}`,
+    `  agent: ${answers.agent}`,
+    `  model: ${answers.model}`,
+    `  approval: ${answers.approvalPolicy}`,
+    `  output: ${answers.outputFormat}`,
+  ];
+  const chosen = models.find((model) => model.value === answers.model);
+  if (chosen && !chosen.available) {
+    lines.push(
+      '',
+      `Note: "${answers.model}" is not usable in the current access mode.`,
+      'Run `texra login` for included relay access, set the provider API key, or run `texra models list` to pick another.',
+    );
+  }
+  lines.push(
+    '',
+    'Next: run `texra` for the launcher, or `texra chat` to start.',
+  );
+  writeTextStdout(lines.join('\n'));
+}
+
+async function runInit(
+  context: CliContext,
+  scope: InitScope,
+  opts: {
+    yes: boolean;
+    force: boolean;
+    gitignore: boolean | undefined;
+  },
+): Promise<number> {
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    skipIncludedModelAccess: true,
+  });
+
+  const filePath = initConfigPath(scope, context.cwd);
+  if (!opts.force && (await configFileExists(filePath))) {
+    writeTextStderr(
+      `Refusing to overwrite existing config at ${filePath}. Re-run with --force to replace it.`,
+    );
+    return CliExitCode.Usage;
+  }
+
+  const { agents, models } = await gatherOptions();
+
+  const interactive =
+    !opts.yes &&
+    context.mode !== 'headless' &&
+    context.stdoutIsTty === true &&
+    context.termIsDumb !== true;
+
+  let answers: InitAnswers;
+  let gitignore: boolean;
+
+  if (interactive) {
+    const { runInitWizard } = await import('../init/runInitWizard');
+    const result = await runInitWizard({ agents, models, scope });
+    if (!result) {
+      writeTextStderr('Cancelled. No config written.');
+      return CliExitCode.Success;
+    }
+    answers = result.answers;
+    gitignore = result.gitignore;
+  } else {
+    answers = defaultAnswers(models);
+    gitignore = opts.gitignore ?? false;
+  }
+
+  await writeInitConfig(filePath, buildInitConfig(answers));
+
+  if (gitignore && scope === 'workspace') {
+    const outcome = await ensureTexraGitignored(context.cwd);
+    if (outcome !== 'present') {
+      writeTextStdout(
+        `${outcome === 'created' ? 'Created' : 'Updated'} .gitignore (.texra/ ignored).`,
+      );
+    }
+  }
+
+  printSummary(filePath, answers, models);
+  return CliExitCode.Success;
+}
+
+export const initCommand = defineCommand({
+  meta: {
+    name: 'init',
+    description: 'Bootstrap a .texra/config.json with sensible defaults',
+  },
+  args: {
+    cwd: {
+      type: 'string',
+      description: 'Working directory to initialize (defaults to $PWD)',
+    },
+    yes: {
+      type: 'boolean',
+      alias: 'y',
+      description: 'Accept defaults non-interactively',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite an existing config file',
+    },
+    gitignore: {
+      type: 'boolean',
+      description: 'Add .texra/ to .gitignore (non-interactive default: false)',
+    },
+    scope: {
+      type: 'enum',
+      options: ['workspace', 'user'],
+      description: 'Write ./.texra (workspace) or ~/.texra (user)',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    const scope = resolveScope(optString(ctx.args.scope));
+    setExitCode(
+      await runInit(context, scope, {
+        yes: ctx.args.yes === true,
+        force: ctx.args.force === true,
+        gitignore:
+          typeof ctx.args.gitignore === 'boolean'
+            ? ctx.args.gitignore
+            : undefined,
+      }),
+    );
+  },
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,17 +16,11 @@ import {
   initConfigPath,
   writeInitConfig,
   type InitAnswers,
-  type InitScope,
 } from '../runtime/initConfig';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
-import { optString } from './_helpers/globalArgs';
 import type { CliContext } from '../runtime/cliContext';
-
-function resolveScope(value: unknown): InitScope {
-  return value === 'user' ? 'user' : 'workspace';
-}
 
 async function gatherOptions(): Promise<{
   agents: { name: string; description?: string }[];
@@ -92,20 +86,18 @@ function printSummary(
 
 async function runInit(
   context: CliContext,
-  scope: InitScope,
   opts: {
     yes: boolean;
     force: boolean;
     gitignore: boolean | undefined;
   },
 ): Promise<number> {
-  await initCliPlatform({
-    ...context,
-    quietLogs: true,
-    skipIncludedModelAccess: true,
-  });
+  // Don't skip included access: model availability must reflect the user's
+  // real access mode (a signed-in relay user has no personal keys but can use
+  // included models), so the picker annotates and defaults correctly.
+  await initCliPlatform({ ...context, quietLogs: true });
 
-  const filePath = initConfigPath(scope, context.cwd);
+  const filePath = initConfigPath(context.cwd);
   if (!opts.force && (await configFileExists(filePath))) {
     writeTextStderr(
       `Refusing to overwrite existing config at ${filePath}. Re-run with --force to replace it.`,
@@ -126,7 +118,7 @@ async function runInit(
 
   if (interactive) {
     const { runInitWizard } = await import('../init/runInitWizard');
-    const result = await runInitWizard({ agents, models, scope });
+    const result = await runInitWizard({ agents, models });
     if (!result) {
       writeTextStderr('Cancelled. No config written.');
       return CliExitCode.Success;
@@ -140,7 +132,7 @@ async function runInit(
 
   await writeInitConfig(filePath, buildInitConfig(answers));
 
-  if (gitignore && scope === 'workspace') {
+  if (gitignore) {
     const outcome = await ensureTexraGitignored(context.cwd);
     if (outcome !== 'present') {
       writeTextStdout(
@@ -176,17 +168,11 @@ export const initCommand = defineCommand({
       type: 'boolean',
       description: 'Add .texra/ to .gitignore (non-interactive default: false)',
     },
-    scope: {
-      type: 'enum',
-      options: ['workspace', 'user'],
-      description: 'Write ./.texra (workspace) or ~/.texra (user)',
-    },
   },
   async run(ctx) {
     const context = await contextFromArgs(ctx.args);
-    const scope = resolveScope(optString(ctx.args.scope));
     setExitCode(
-      await runInit(context, scope, {
+      await runInit(context, {
         yes: ctx.args.yes === true,
         force: ctx.args.force === true,
         gitignore:

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -29,6 +29,7 @@ import { completionCommand } from './completion';
 import { doctorCommand } from './doctor';
 import { helpCommand } from './help';
 import { historyCommand } from './history';
+import { initCommand } from './init';
 import { modelsCommand } from './models';
 import { multiAgentCommand } from './multiAgent';
 import { orchestrationCommand } from './orchestrate';
@@ -63,6 +64,7 @@ export const rootCommand = defineCommand({
     chat: chatCommand,
     run: runWorkflowCommand,
     resume: resumeCommand,
+    init: initCommand,
     history: historyCommand,
     agents: agentsCommand,
     skills: skillsCommand,

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -35,6 +35,7 @@ import { multiAgentCommand } from './multiAgent';
 import { orchestrationCommand } from './orchestrate';
 import { resumeCommand } from './resume';
 import { skillsCommand } from './skills';
+import { toolsCommand } from './tools';
 import { versionCommand } from './version';
 import { runWorkflowCommand } from './workflow';
 
@@ -68,6 +69,7 @@ export const rootCommand = defineCommand({
     history: historyCommand,
     agents: agentsCommand,
     skills: skillsCommand,
+    tools: toolsCommand,
     'multi-agent': multiAgentCommand,
     models: modelsCommand,
     login: loginCommand,

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -1,0 +1,262 @@
+import { spawn } from 'node:child_process';
+
+import { defineCommand } from 'citty';
+
+import { toErrorMessage } from '@common/errors';
+
+import { CliExitCode } from '../runtime/exitCodes';
+import { initCliPlatform } from '../runtime/initPlatform';
+import {
+  writeNdjsonStdout,
+  writeTextStderr,
+  writeTextStdout,
+} from '../runtime/logSinks';
+import {
+  findCliToolDef,
+  formatCliToolList,
+  formatCliToolStatus,
+  readCliToolStatus,
+  readCliToolStatuses,
+  setCliToolEnabled,
+} from '../runtime/tools';
+
+import { contextFromArgs } from './_helpers/context';
+import { setExitCode } from './_helpers/exitCode';
+import { GLOBAL_ARGS } from './_helpers/globalArgs';
+import type { CliContext } from '../runtime/cliContext';
+
+async function withCliPlatform<T>(
+  context: CliContext,
+  work: () => Promise<T>,
+): Promise<T> {
+  await initCliPlatform({ ...context, quietLogs: true });
+  return work();
+}
+
+async function listTools(context: CliContext): Promise<number> {
+  const records = await withCliPlatform(context, readCliToolStatuses);
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(records, null, 2));
+    return CliExitCode.Success;
+  }
+
+  if (context.outputFormat === 'ndjson') {
+    const ts = new Date().toISOString();
+    for (const tool of records) {
+      writeNdjsonStdout({ kind: 'tool-status', ts, tool });
+    }
+    return CliExitCode.Success;
+  }
+
+  writeTextStdout(formatCliToolList(records));
+  return CliExitCode.Success;
+}
+
+async function showTool(context: CliContext, id: string): Promise<number> {
+  const record = await withCliPlatform(context, () => readCliToolStatus(id));
+  if (!record) {
+    writeTextStderr(`Tool integration not found: ${id}`);
+    return CliExitCode.Usage;
+  }
+
+  if (context.outputFormat === 'json') {
+    writeTextStdout(JSON.stringify(record, null, 2));
+    return CliExitCode.Success;
+  }
+
+  if (context.outputFormat === 'ndjson') {
+    writeNdjsonStdout({
+      kind: 'tool-status',
+      ts: new Date().toISOString(),
+      tool: record,
+    });
+    return CliExitCode.Success;
+  }
+
+  writeTextStdout(formatCliToolStatus(record));
+  return CliExitCode.Success;
+}
+
+async function toggleTool(
+  context: CliContext,
+  id: string,
+  enabled: boolean,
+): Promise<number> {
+  const ok = await withCliPlatform(context, () =>
+    setCliToolEnabled(id, enabled),
+  );
+  if (!ok) {
+    writeTextStderr(`Tool integration is not toggleable: ${id}`);
+    return CliExitCode.Usage;
+  }
+  writeTextStdout(`${enabled ? 'Enabled' : 'Disabled'} ${id}.`);
+  return CliExitCode.Success;
+}
+
+function formatGuide(id: string, kind: 'install' | 'auth'): string | undefined {
+  const def = findCliToolDef(id);
+  if (!def) return undefined;
+  if (kind === 'install') {
+    const lines = [def.installGuide ?? def.configNotes ?? 'No install guide.'];
+    if (def.installCommand) {
+      lines.push('');
+      lines.push(`Command: ${def.installCommand}`);
+    }
+    if (def.installUrl) {
+      lines.push(`URL: ${def.installUrl}`);
+    }
+    return lines.join('\n');
+  }
+
+  const lines = [def.authNote ?? def.configNotes ?? 'No auth guide.'];
+  if (def.authCommand) {
+    lines.push('');
+    lines.push(`Command: ${def.authCommand}`);
+  }
+  return lines.join('\n');
+}
+
+function shellRun(command: string): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: 'inherit',
+    });
+    child.on('error', () => resolve(CliExitCode.AgentError));
+    child.on('exit', (code) => resolve(code ?? CliExitCode.AgentError));
+  });
+}
+
+async function installTool(
+  context: CliContext,
+  id: string,
+  run: boolean,
+): Promise<number> {
+  await initCliPlatform({ ...context, quietLogs: true });
+  const def = findCliToolDef(id);
+  if (!def) {
+    writeTextStderr(`Tool integration not found: ${id}`);
+    return CliExitCode.Usage;
+  }
+
+  writeTextStdout(formatGuide(id, 'install') ?? '');
+  if (!run) return CliExitCode.Success;
+  if (!def.installCommand) {
+    writeTextStderr(`No install command is registered for ${id}.`);
+    return CliExitCode.Usage;
+  }
+  return shellRun(def.installCommand);
+}
+
+async function authTool(context: CliContext, id: string): Promise<number> {
+  await initCliPlatform({ ...context, quietLogs: true });
+  const def = findCliToolDef(id);
+  if (!def) {
+    writeTextStderr(`Tool integration not found: ${id}`);
+    return CliExitCode.Usage;
+  }
+
+  writeTextStdout(formatGuide(id, 'auth') ?? '');
+  if (!def.authCommand) return CliExitCode.Success;
+  try {
+    return await shellRun(def.authCommand);
+  } catch (error) {
+    writeTextStderr(toErrorMessage(error));
+    return CliExitCode.AgentError;
+  }
+}
+
+const toolsListCommand = defineCommand({
+  meta: { name: 'list', description: 'List external tool integrations' },
+  args: { ...GLOBAL_ARGS },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await listTools(context));
+  },
+});
+
+const toolsStatusCommand = defineCommand({
+  meta: { name: 'status', description: 'Show one tool integration status' },
+  args: {
+    ...GLOBAL_ARGS,
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Tool integration id from `texra tools list`',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await showTool(context, ctx.args.id));
+  },
+});
+
+function toggleCommand(name: 'enable' | 'disable', enabled: boolean) {
+  return defineCommand({
+    meta: {
+      name,
+      description: `${enabled ? 'Enable' : 'Disable'} a tool integration`,
+    },
+    args: {
+      ...GLOBAL_ARGS,
+      id: {
+        type: 'positional',
+        required: true,
+        description: 'Tool integration id from `texra tools list`',
+      },
+    },
+    async run(ctx) {
+      const context = await contextFromArgs(ctx.args);
+      setExitCode(await toggleTool(context, ctx.args.id, enabled));
+    },
+  });
+}
+
+const toolsInstallCommand = defineCommand({
+  meta: { name: 'install', description: 'Show install help for a tool' },
+  args: {
+    ...GLOBAL_ARGS,
+    run: {
+      type: 'boolean',
+      description: 'Run the registered install command after printing it',
+    },
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Tool integration id from `texra tools list`',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await installTool(context, ctx.args.id, ctx.args.run === true));
+  },
+});
+
+const toolsAuthCommand = defineCommand({
+  meta: { name: 'auth', description: 'Run or show auth help for a tool' },
+  args: {
+    ...GLOBAL_ARGS,
+    id: {
+      type: 'positional',
+      required: true,
+      description: 'Tool integration id from `texra tools list`',
+    },
+  },
+  async run(ctx) {
+    const context = await contextFromArgs(ctx.args);
+    setExitCode(await authTool(context, ctx.args.id));
+  },
+});
+
+export const toolsCommand = defineCommand({
+  meta: { name: 'tools', description: 'Inspect external tool integrations' },
+  subCommands: {
+    list: toolsListCommand,
+    status: toolsStatusCommand,
+    enable: toggleCommand('enable', true),
+    disable: toggleCommand('disable', false),
+    install: toolsInstallCommand,
+    auth: toolsAuthCommand,
+  },
+});

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -1,0 +1,292 @@
+// Interactive wizard for `texra init`. A small multi-step picker built on the
+// shared Select primitive (same pattern as runOrchestrationTui): one question
+// per screen, Esc cancels. Returns the collected answers, or `undefined` when
+// the user backs out. Pure config logic lives in runtime/initConfig.
+
+import { render, Box, Text, useApp } from 'ink';
+import { useState } from 'react';
+
+import { KeyHints } from '../chat/tui/ui/KeyHints';
+import { Select } from '../chat/tui/ui/Select';
+import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
+import {
+  CLI_APPROVAL_POLICIES,
+  CLI_OUTPUT_FORMATS,
+  type CliApprovalPolicy,
+  type CliOutputFormat,
+} from '../schemas/cliSettings';
+import type { InitAnswers, InitScope } from '../runtime/initConfig';
+
+export interface InitWizardAgentOption {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export interface InitWizardModelOption {
+  readonly value: string;
+  readonly label: string;
+  readonly available: boolean;
+  readonly status: string;
+}
+
+export interface InitWizardOptions {
+  readonly agents: readonly InitWizardAgentOption[];
+  readonly models: readonly InitWizardModelOption[];
+  readonly scope: InitScope;
+}
+
+export interface InitWizardResult {
+  readonly answers: InitAnswers;
+  readonly gitignore: boolean;
+}
+
+const APPROVAL_DESCRIPTIONS: Record<CliApprovalPolicy, string> = {
+  never: 'never prompt before privileged actions',
+  ask: 'confirm before privileged actions',
+  yolo: 'auto-approve every action',
+};
+
+const OUTPUT_DESCRIPTIONS: Record<CliOutputFormat, string> = {
+  text: 'human-readable text (default)',
+  json: 'a single JSON object',
+  ndjson: 'newline-delimited JSON stream',
+};
+
+type Step = 'agent' | 'model' | 'approval' | 'output' | 'gitignore';
+
+interface Draft {
+  agent?: string;
+  model?: string;
+  approvalPolicy?: CliApprovalPolicy;
+  outputFormat?: CliOutputFormat;
+  gitignore?: boolean;
+}
+
+function stepsForScope(scope: InitScope): readonly Step[] {
+  const base: Step[] = ['agent', 'model', 'approval', 'output'];
+  return scope === 'workspace' ? [...base, 'gitignore'] : base;
+}
+
+function StepFrame(props: {
+  readonly stepNumber: number;
+  readonly stepCount: number;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold color="cyan">
+        texra init
+      </Text>
+      <Text dimColor>
+        Step {props.stepNumber}/{props.stepCount} · {props.title}
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {props.children}
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: 'Enter', action: 'select' },
+            { key: 'Esc', action: 'cancel' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function firstAvailableIndex(models: readonly InitWizardModelOption[]): number {
+  const index = models.findIndex((model) => model.available);
+  return index >= 0 ? index : 0;
+}
+
+interface WizardAppProps {
+  readonly options: InitWizardOptions;
+  readonly onResolve: (result: InitWizardResult | undefined) => void;
+}
+
+function WizardApp(props: WizardAppProps): React.JSX.Element {
+  const app = useApp();
+  const steps = stepsForScope(props.options.scope);
+  const stepCount = steps.length;
+  const [index, setIndex] = useState(0);
+  const [draft, setDraft] = useState<Draft>({});
+  const step = steps[index];
+
+  const cancel = (): void => {
+    props.onResolve(undefined);
+    app.exit();
+  };
+
+  const commit = (patch: Draft): void => {
+    const merged = { ...draft, ...patch };
+    setDraft(merged);
+    if (index + 1 < stepCount) {
+      setIndex(index + 1);
+      return;
+    }
+    // Last step — every field is set by construction of `steps`.
+    if (
+      merged.agent === undefined ||
+      merged.model === undefined ||
+      merged.approvalPolicy === undefined ||
+      merged.outputFormat === undefined
+    ) {
+      cancel();
+      return;
+    }
+    props.onResolve({
+      answers: {
+        agent: merged.agent,
+        model: merged.model,
+        approvalPolicy: merged.approvalPolicy,
+        outputFormat: merged.outputFormat,
+      },
+      gitignore: merged.gitignore ?? false,
+    });
+    app.exit();
+  };
+
+  const stepNumber = index + 1;
+
+  if (step === 'agent') {
+    return (
+      <StepFrame
+        stepNumber={stepNumber}
+        stepCount={stepCount}
+        title="default agent for texra chat"
+      >
+        <Select
+          key={step}
+          items={props.options.agents.map((agent) => ({
+            value: agent.name,
+            label: agent.name,
+            description: agent.description,
+          }))}
+          onSelect={(agent) => commit({ agent })}
+          onCancel={cancel}
+        />
+      </StepFrame>
+    );
+  }
+
+  if (step === 'model') {
+    return (
+      <StepFrame
+        stepNumber={stepNumber}
+        stepCount={stepCount}
+        title="default model"
+      >
+        <Select
+          key={step}
+          initialIndex={firstAvailableIndex(props.options.models)}
+          items={props.options.models.map((model) => ({
+            value: model.value,
+            label: model.label,
+            description: model.available
+              ? model.status
+              : `${model.status} (unavailable now)`,
+          }))}
+          onSelect={(model) => commit({ model })}
+          onCancel={cancel}
+        />
+      </StepFrame>
+    );
+  }
+
+  if (step === 'approval') {
+    return (
+      <StepFrame
+        stepNumber={stepNumber}
+        stepCount={stepCount}
+        title="approval policy"
+      >
+        <Select
+          key={step}
+          items={CLI_APPROVAL_POLICIES.map((policy) => ({
+            value: policy,
+            label: policy,
+            description: APPROVAL_DESCRIPTIONS[policy],
+          }))}
+          onSelect={(approvalPolicy) => commit({ approvalPolicy })}
+          onCancel={cancel}
+        />
+      </StepFrame>
+    );
+  }
+
+  if (step === 'output') {
+    return (
+      <StepFrame
+        stepNumber={stepNumber}
+        stepCount={stepCount}
+        title="default output format"
+      >
+        <Select
+          key={step}
+          items={CLI_OUTPUT_FORMATS.map((format) => ({
+            value: format,
+            label: format,
+            description: OUTPUT_DESCRIPTIONS[format],
+          }))}
+          onSelect={(outputFormat) => commit({ outputFormat })}
+          onCancel={cancel}
+        />
+      </StepFrame>
+    );
+  }
+
+  return (
+    <StepFrame
+      stepNumber={stepNumber}
+      stepCount={stepCount}
+      title="add .texra/ to .gitignore?"
+    >
+      <Select
+        key={step}
+        items={[
+          {
+            value: true,
+            label: 'Yes',
+            description: 'keep local config out of git',
+          },
+          {
+            value: false,
+            label: 'No',
+            description: 'leave .gitignore unchanged',
+          },
+        ]}
+        onSelect={(gitignore) => commit({ gitignore })}
+        onCancel={cancel}
+      />
+    </StepFrame>
+  );
+}
+
+export async function runInitWizard(
+  options: InitWizardOptions,
+): Promise<InitWizardResult | undefined> {
+  return new Promise((resolve) => {
+    let chosen: InitWizardResult | undefined;
+    const record = (result: InitWizardResult | undefined): void => {
+      chosen = result;
+    };
+
+    const instance = render(
+      <WizardApp options={options} onResolve={record} />,
+      {
+        stdout: process.stdout,
+        stderr: process.stderr,
+        stdin: process.stdin,
+      },
+    );
+
+    void instance.waitUntilExit().then(() => {
+      clearTerminalScrollback();
+      resolve(chosen);
+    });
+  });
+}

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -15,7 +15,7 @@ import {
   type CliApprovalPolicy,
   type CliOutputFormat,
 } from '../schemas/cliSettings';
-import type { InitAnswers, InitScope } from '../runtime/initConfig';
+import type { InitAnswers } from '../runtime/initConfig';
 
 export interface InitWizardAgentOption {
   readonly name: string;
@@ -32,7 +32,6 @@ export interface InitWizardModelOption {
 export interface InitWizardOptions {
   readonly agents: readonly InitWizardAgentOption[];
   readonly models: readonly InitWizardModelOption[];
-  readonly scope: InitScope;
 }
 
 export interface InitWizardResult {
@@ -54,17 +53,20 @@ const OUTPUT_DESCRIPTIONS: Record<CliOutputFormat, string> = {
 
 type Step = 'agent' | 'model' | 'approval' | 'output' | 'gitignore';
 
+const STEPS: readonly Step[] = [
+  'agent',
+  'model',
+  'approval',
+  'output',
+  'gitignore',
+];
+
 interface Draft {
   agent?: string;
   model?: string;
   approvalPolicy?: CliApprovalPolicy;
   outputFormat?: CliOutputFormat;
   gitignore?: boolean;
-}
-
-function stepsForScope(scope: InitScope): readonly Step[] {
-  const base: Step[] = ['agent', 'model', 'approval', 'output'];
-  return scope === 'workspace' ? [...base, 'gitignore'] : base;
 }
 
 function StepFrame(props: {
@@ -110,11 +112,10 @@ interface WizardAppProps {
 
 function WizardApp(props: WizardAppProps): React.JSX.Element {
   const app = useApp();
-  const steps = stepsForScope(props.options.scope);
-  const stepCount = steps.length;
+  const stepCount = STEPS.length;
   const [index, setIndex] = useState(0);
   const [draft, setDraft] = useState<Draft>({});
-  const step = steps[index];
+  const step = STEPS[index];
 
   const cancel = (): void => {
     props.onResolve(undefined);

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -1,12 +1,12 @@
 import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
 
+import { Select } from '../chat/tui/ui/Select';
+import { KeyHints } from '../chat/tui/ui/KeyHints';
+import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
 import type {
   CliOrchestrationAction,
   CliOrchestrationItem,
 } from '../runtime/orchestration';
-import { Select } from '../chat/tui/ui/Select';
-import { KeyHints } from '../chat/tui/ui/KeyHints';
-import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
 
 interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -1,0 +1,110 @@
+// Pure helpers for `texra init`: turn collected answers into a canonical
+// `.texra/config.json`, resolve the target path by scope, and keep the
+// workspace config directory out of version control. The interactive wizard
+// (init/runInitWizard) and the command (commands/init) build on these; keeping
+// the logic here makes it unit-testable without a TTY.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import type {
+  CliApprovalPolicy,
+  CliOutputFormat,
+} from '../schemas/cliSettings';
+import {
+  CLI_CONFIG_DIR,
+  CLI_CONFIG_FILE,
+  workspaceCliConfigPath,
+} from './cliConfig';
+
+export type InitScope = 'workspace' | 'user';
+
+export interface InitAnswers {
+  readonly agent: string;
+  readonly model: string;
+  readonly approvalPolicy: CliApprovalPolicy;
+  readonly outputFormat: CliOutputFormat;
+}
+
+/** Canonical config shape written by `texra init` (a subset of CliConfigValues). */
+export interface InitConfigShape {
+  readonly model: string;
+  readonly outputFormat: CliOutputFormat;
+  readonly approvalPolicy: CliApprovalPolicy;
+  readonly chat: { readonly agent: string; readonly model: string };
+}
+
+/** Resolve the config file path for the chosen scope. */
+export function initConfigPath(scope: InitScope, cwd: string): string {
+  return scope === 'user'
+    ? path.join(homedir(), CLI_CONFIG_DIR, CLI_CONFIG_FILE)
+    : workspaceCliConfigPath(cwd);
+}
+
+/** Map wizard answers to the canonical config object. */
+export function buildInitConfig(answers: InitAnswers): InitConfigShape {
+  return {
+    model: answers.model,
+    outputFormat: answers.outputFormat,
+    approvalPolicy: answers.approvalPolicy,
+    chat: { agent: answers.agent, model: answers.model },
+  };
+}
+
+/** Stable, pretty JSON with a trailing newline (matches editor/formatter output). */
+export function serializeInitConfig(config: InitConfigShape): string {
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export async function configFileExists(filePath: string): Promise<boolean> {
+  try {
+    await readFile(filePath, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function writeInitConfig(
+  filePath: string,
+  config: InitConfigShape,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, serializeInitConfig(config), 'utf8');
+}
+
+/**
+ * Return `.gitignore` content with the workspace config dir ignored, or `null`
+ * when it is already covered. Appends a single `.texra/` entry, preserving any
+ * existing content and a single trailing newline.
+ */
+export function gitignoreWithTexra(existing: string): string | null {
+  const entry = `${CLI_CONFIG_DIR}/`;
+  const present = existing
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => line === entry || line === CLI_CONFIG_DIR);
+  if (present) return null;
+  const trimmed = existing.replace(/\n+$/, '');
+  return trimmed.length > 0 ? `${trimmed}\n${entry}\n` : `${entry}\n`;
+}
+
+export type GitignoreOutcome = 'added' | 'present' | 'created';
+
+export async function ensureTexraGitignored(
+  cwd: string,
+): Promise<GitignoreOutcome> {
+  const gitignorePath = path.join(cwd, '.gitignore');
+  let existing = '';
+  let existed = true;
+  try {
+    existing = await readFile(gitignorePath, 'utf8');
+  } catch {
+    existed = false;
+  }
+  const next = gitignoreWithTexra(existing);
+  if (next === null) return 'present';
+  await writeFile(gitignorePath, next, 'utf8');
+  return existed ? 'added' : 'created';
+}

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -5,20 +5,13 @@
 // the logic here makes it unit-testable without a TTY.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import path from 'node:path';
 
 import type {
   CliApprovalPolicy,
   CliOutputFormat,
 } from '../schemas/cliSettings';
-import {
-  CLI_CONFIG_DIR,
-  CLI_CONFIG_FILE,
-  workspaceCliConfigPath,
-} from './cliConfig';
-
-export type InitScope = 'workspace' | 'user';
+import { CLI_CONFIG_DIR, workspaceCliConfigPath } from './cliConfig';
 
 export interface InitAnswers {
   readonly agent: string;
@@ -35,11 +28,12 @@ export interface InitConfigShape {
   readonly chat: { readonly agent: string; readonly model: string };
 }
 
-/** Resolve the config file path for the chosen scope. */
-export function initConfigPath(scope: InitScope, cwd: string): string {
-  return scope === 'user'
-    ? path.join(homedir(), CLI_CONFIG_DIR, CLI_CONFIG_FILE)
-    : workspaceCliConfigPath(cwd);
+/**
+ * Resolve the workspace config file path. (User-scope config lives in global
+ * storage with a different shape and loader; bootstrapping it is a follow-up.)
+ */
+export function initConfigPath(cwd: string): string {
+  return workspaceCliConfigPath(cwd);
 }
 
 /** Map wizard answers to the canonical config object. */

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -7,11 +7,11 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { CLI_CONFIG_DIR, workspaceCliConfigPath } from './cliConfig';
 import type {
   CliApprovalPolicy,
   CliOutputFormat,
 } from '../schemas/cliSettings';
-import { CLI_CONFIG_DIR, workspaceCliConfigPath } from './cliConfig';
 
 export interface InitAnswers {
   readonly agent: string;

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -92,7 +92,7 @@ export async function setCliToolEnabled(
   return true;
 }
 
-function yesNo(value: boolean | null): string {
+export function formatCliBoolean(value: boolean | null): string {
   if (value == null) return '-';
   return value ? 'yes' : 'no';
 }
@@ -107,8 +107,8 @@ export function formatCliToolList(
       record.id,
       record.name,
       record.category,
-      yesNo(record.enabled),
-      yesNo(record.detected),
+      formatCliBoolean(record.enabled),
+      formatCliBoolean(record.detected),
       record.note ?? '',
     ].join('\t'),
   );
@@ -121,8 +121,8 @@ export function formatCliToolStatus(record: CliToolStatusRecord): string {
     `name: ${record.name}`,
     `category: ${record.category}`,
     `status: ${record.status}`,
-    `enabled: ${yesNo(record.enabled)}`,
-    `detected: ${yesNo(record.detected)}`,
+    `enabled: ${formatCliBoolean(record.enabled)}`,
+    `detected: ${formatCliBoolean(record.detected)}`,
   ];
   if (record.statusLabel) lines.push(`statusLabel: ${record.statusLabel}`);
   if (record.note) lines.push(`note: ${record.note}`);

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -1,0 +1,137 @@
+// Local imports - tools
+import {
+  EXTERNAL_TOOL_DEFS,
+  findExternalToolDef,
+  type ExternalToolDef,
+} from '@tools/externalToolDefs';
+import { runExternalToolChecks } from '@tools/toolAvailability';
+
+// Local imports - config
+import { getDisabledToolIds, setToolEnabled } from '@utils/config/constants';
+
+export interface CliToolStatusRecord {
+  readonly id: string;
+  readonly name: string;
+  readonly category: string;
+  readonly enabled: boolean | null;
+  readonly detected: boolean | null;
+  readonly status: string;
+  readonly statusLabel?: string;
+  readonly statusDetail?: string;
+  readonly toggleable: boolean;
+  readonly comingSoon: boolean;
+  readonly installCommand?: string;
+  readonly authCommand?: string;
+  readonly note?: string;
+}
+
+function detectedFromStatus(status: string): boolean | null {
+  if (status === 'available') return true;
+  if (status === 'not-found') return false;
+  return null;
+}
+
+function noteForTool(def: ExternalToolDef, statusLabel?: string): string {
+  return (
+    statusLabel ?? def.authNote ?? def.installCommand ?? def.configNotes ?? ''
+  );
+}
+
+export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
+  const checks = new Map((await runExternalToolChecks()).map((r) => [r.id, r]));
+  const disabledIds = getDisabledToolIds();
+
+  return EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard).map(
+    (def) => {
+      const check = checks.get(def.id);
+      const comingSoon = def.comingSoon === true;
+      const toggleable = def.toggleable === true;
+      const status = check?.status ?? (comingSoon ? 'coming-soon' : 'unknown');
+      return {
+        id: def.id,
+        name: def.name,
+        category: def.category,
+        enabled: toggleable ? !disabledIds.has(def.id) : null,
+        detected: detectedFromStatus(status),
+        status,
+        statusLabel: check?.statusLabel,
+        statusDetail: check?.statusDetail,
+        toggleable,
+        comingSoon,
+        installCommand: def.installCommand,
+        authCommand: def.authCommand,
+        note: noteForTool(def, check?.statusLabel),
+      };
+    },
+  );
+}
+
+export async function readCliToolStatus(
+  id: string,
+): Promise<CliToolStatusRecord | undefined> {
+  return (await readCliToolStatuses()).find((record) => record.id === id);
+}
+
+export function findCliToolDef(id: string): ExternalToolDef | undefined {
+  return findExternalToolDef(id);
+}
+
+export function cliToolIds(): string[] {
+  return EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard).map(
+    (def) => def.id,
+  );
+}
+
+export async function setCliToolEnabled(
+  id: string,
+  enabled: boolean,
+): Promise<boolean> {
+  const def = findExternalToolDef(id);
+  if (!def || !def.toggleable) return false;
+  await setToolEnabled(id, enabled);
+  return true;
+}
+
+function yesNo(value: boolean | null): string {
+  if (value == null) return '-';
+  return value ? 'yes' : 'no';
+}
+
+export function formatCliToolList(
+  records: readonly CliToolStatusRecord[],
+): string {
+  if (records.length === 0) return 'No external tools found.';
+  const header = 'ID\tNAME\tCATEGORY\tENABLED\tDETECTED\tNOTE';
+  const rows = records.map((record) =>
+    [
+      record.id,
+      record.name,
+      record.category,
+      yesNo(record.enabled),
+      yesNo(record.detected),
+      record.note ?? '',
+    ].join('\t'),
+  );
+  return [header, ...rows].join('\n');
+}
+
+export function formatCliToolStatus(record: CliToolStatusRecord): string {
+  const lines: string[] = [
+    `id: ${record.id}`,
+    `name: ${record.name}`,
+    `category: ${record.category}`,
+    `status: ${record.status}`,
+    `enabled: ${yesNo(record.enabled)}`,
+    `detected: ${yesNo(record.detected)}`,
+  ];
+  if (record.statusLabel) lines.push(`statusLabel: ${record.statusLabel}`);
+  if (record.note) lines.push(`note: ${record.note}`);
+  if (record.installCommand)
+    lines.push(`installCommand: ${record.installCommand}`);
+  if (record.authCommand) lines.push(`authCommand: ${record.authCommand}`);
+  if (record.statusDetail) {
+    lines.push('');
+    lines.push(record.statusDetail);
+  }
+  return lines.join('\n');
+}

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -301,6 +301,9 @@ export class DesktopProgressBridge {
       if (snapshot.executionId) {
         this.executionIds.set(snapshot.streamId, snapshot.executionId);
       }
+      if (snapshot.parentStreamId) {
+        this.parentStreams.set(snapshot.streamId, snapshot.parentStreamId);
+      }
     }
   }
 
@@ -335,6 +338,8 @@ export class DesktopProgressBridge {
         STREAM_STATUS.STOPPED,
       description: this.descriptions.get(streamId) ?? restored?.description,
       executionId: this.executionIds.get(streamId) ?? restored?.executionId,
+      parentStreamId:
+        this.parentStreams.get(streamId) ?? restored?.parentStreamId,
       creationTimestamp: this.getCreationTimestamp(streamId),
       lastTimestamp:
         this.streamLogs.getLastTimestamp(streamId) ?? restored?.lastTimestamp,
@@ -541,6 +546,7 @@ export class DesktopProgressBridge {
       },
       creationTimestamp: snapshot.creationTimestamp,
       executionId: snapshot.executionId,
+      parentStreamId: snapshot.parentStreamId,
       description: snapshot.description,
     });
   }
@@ -735,6 +741,7 @@ export class DesktopProgressBridge {
           stream: data.childStreamId,
           parentStreamId: data.parentStreamId ?? undefined,
         });
+        this.persistStreamSnapshot(data.childStreamId);
         break;
       }
       case 'updateActiveSubagents':

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -12,6 +12,7 @@ import { createWorkspaceStorageProvider } from '@platform/defaults/workspaceStor
 import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { registerAgentFeatures } from '@agent/features';
+import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
@@ -20,7 +21,6 @@ import { ElectronSecrets } from './electronSecrets.js';
 import { repairLaunchPath } from './pathFix.js';
 import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
 import { showSecretStorageWarningDialog } from './secretStorageWarningDialog.js';
-import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '../../workspacePath.js';
 
 // Type imports - platform
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -4,8 +4,8 @@ import { join, resolve } from 'node:path';
 import { app } from 'electron';
 
 import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
-import { getWorkspacePathInput } from '../../workspacePath.js';
-export { hasWorkspacePath } from '../../workspacePath.js';
+import { getWorkspacePathInput } from '@desktop/workspacePath.js';
+export { hasWorkspacePath } from '@desktop/workspacePath.js';
 
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;

--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -44,7 +44,9 @@
         "node_modules/@openrouter/sdk/esm/models/index.d.ts"
       ],
       "@controllers/*": ["src/controllers/*"],
-      "@test/*": ["src/test/*"]
+      "@test/*": ["src/test/*"],
+      "@cli/*": ["packages/cli/src/*"],
+      "@desktop/*": ["packages/desktop/src/*"]
     }
   }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -605,6 +605,17 @@
         }
       },
       {
+        "title": "Skills",
+        "properties": {
+          "texra.skills.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Discover imported skills and expose them to tool-use agent prompts",
+            "scope": "resource"
+          }
+        }
+      },
+      {
         "title": "Tool Use Agents",
         "properties": {
           "texra.toolUse.requireEditApproval": {

--- a/packages/extension/src/commands/history/htmlExport/htmlFormatter.ts
+++ b/packages/extension/src/commands/history/htmlExport/htmlFormatter.ts
@@ -88,9 +88,11 @@ const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
 
 function safeUrl(raw: string): string | null {
   const trimmed = raw.trim();
-  // Empty / anchor-only / root-relative — no scheme to abuse.
+  // Empty / anchor-only / root-relative — no scheme to abuse. Protocol-
+  // relative URLs (`//example.com`) must still go through scheme validation.
   if (trimmed === '') return null;
-  if (trimmed.startsWith('#') || trimmed.startsWith('/')) return trimmed;
+  if (trimmed.startsWith('#')) return trimmed;
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed;
   let url: URL;
   try {
     url = new URL(trimmed);

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -58,7 +58,7 @@ export class PlanView extends LitElement {
         border-bottom: var(--border-thin) solid var(--color-border);
       }
 
-      .plan-collapsible::part(body) {
+      .plan-body {
         max-height: var(--height-xlarge);
         overflow-y: auto;
       }
@@ -216,13 +216,15 @@ export class PlanView extends LitElement {
         @wa-show=${this.handleShow}
         @wa-hide=${this.handleHide}
       >
-        <div class="plan-summary">${this.plan.summary}</div>
-        <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
-          ${repeat(
-            this.plan.steps,
-            (_step, index) => index,
-            (step, index) => this.renderStep(step, index),
-          )}
+        <div class="plan-body">
+          <div class="plan-summary">${this.plan.summary}</div>
+          <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
+            ${repeat(
+              this.plan.steps,
+              (_step, index) => index,
+              (step, index) => this.renderStep(step, index),
+            )}
+          </div>
         </div>
       </wa-details>
     `;

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -5,6 +5,7 @@
 
 // Local imports - formatter helpers
 import type { LogMessageData, MessageType } from '@shared/schemas';
+import { isPlainObject } from '@shared/utils/string';
 import { safeFormat, type FormatOptions } from './baseLogFormatter';
 import {
   formatBannerContentTemplate,
@@ -68,6 +69,19 @@ function wrapWithErrorHandling(
   };
 }
 
+/** Name the tool in formatter errors so a bad card is actionable. */
+function getToolUseRenderLabel(message: LogMessageData): string {
+  const data = message.data;
+  if (!isPlainObject(data)) return 'tool use';
+  const toolName =
+    typeof data.toolName === 'string'
+      ? data.toolName
+      : typeof data.tool === 'string'
+        ? data.tool
+        : '';
+  return toolName.trim() ? `tool use (${toolName.trim()})` : 'tool use';
+}
+
 /** Map of message types to their formatter functions. */
 const TEMPLATE_FORMATTERS: Record<string, TemplateFormatterFn | null> = {
   // Collapsible content banners
@@ -75,7 +89,17 @@ const TEMPLATE_FORMATTERS: Record<string, TemplateFormatterFn | null> = {
   scratchpad: wrapWithErrorHandling(formatBannerContentTemplate, 'scratchpad'),
 
   // Tool/search/fetch results
-  toolUse: wrapWithErrorHandling(formatToolUseTemplate, 'tool use'),
+  toolUse: (message, options) => {
+    const label = getToolUseRenderLabel(message);
+    const result = safeFormat(
+      () => formatToolUseTemplate(message, options),
+      label,
+    );
+    if (!result.ok) {
+      return formatRenderError(label, result.error);
+    }
+    return result.value;
+  },
   webSearch: wrapWithErrorHandling(formatWebSearchTemplate, 'web search'),
   webFetch: wrapWithErrorHandling(formatWebFetchTemplate, 'web fetch'),
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -203,12 +203,19 @@ type ToolSectionOptions = {
 /**
  * Build a tool section with appropriate code highlighting based on tool type.
  */
+function toolDisplayText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
 function buildToolSection(
   label: string,
-  text: string,
+  text: unknown,
   options: ToolSectionOptions = {},
 ): TemplateResult {
   const { toolName = '', language: contentLanguage, extraClass = '' } = options;
+  const displayText = toolDisplayText(text);
 
   // Determine language: tool config > content metadata > plaintext
   const toolLanguage = TOOL_OUTPUT_LANGUAGES.get(toolName);
@@ -216,24 +223,24 @@ function buildToolSection(
   const shouldHighlight = language && language !== 'plaintext';
 
   const content = shouldHighlight
-    ? buildCodeBlock(text, {
+    ? buildCodeBlock(displayText, {
         language,
         className: extraClass,
         showLanguage: true,
         showCopy: true,
       })
-    : wrapInPre(text, extraClass);
+    : wrapInPre(displayText, extraClass);
 
   return buildToolUseSection(label, content);
 }
 
 /** Build a read-only terminal section for shell output. */
-function buildTerminalSection(label: string, text: string): TemplateResult {
+function buildTerminalSection(label: string, text: unknown): TemplateResult {
   return buildToolUseSection(
     label,
     html`<terminal-output
       class="tool-output-terminal"
-      .text=${text}
+      .text=${toolDisplayText(text)}
     ></terminal-output>`,
   );
 }
@@ -308,13 +315,18 @@ function buildFileContentSections(ctx: ToolSectionContext): TemplateResult[] {
   if (!filePath) return [];
   const writeInput = input as WriteInput;
   const contentLanguage = getLanguageFromPath(filePath);
-  return [
+  const sections = [
     buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
-    buildToolSection('', writeInput.content, {
-      toolName,
-      language: contentLanguage,
-    }),
   ];
+  if (typeof writeInput.content === 'string') {
+    sections.push(
+      buildToolSection('', writeInput.content, {
+        toolName,
+        language: contentLanguage,
+      }),
+    );
+  }
+  return sections;
 }
 
 function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -381,7 +381,11 @@ export class ModelSelectionList extends LitElement {
           @change=${this.handleHelperModelChange}
         >
           ${enabledModels.map(
-            (m) => html`<wa-option value=${m.name}> ${m.name} </wa-option>`,
+            (m) => html`
+              <wa-option value=${m.name}>
+                ${m.label === m.name ? m.name : `${m.label} (${m.name})`}
+              </wa-option>
+            `,
           )}
         </wa-select>
       </div>

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -15,6 +15,7 @@ import { toErrorMessage } from '@common/errors';
 import { workspaceSM } from '@common/state';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
+  DEFAULT_LATEX_SETTINGS_STATUS,
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
   type LatexSettingsStatus,
@@ -95,8 +96,21 @@ export class LatexSettingsHandlers {
       !this.latexSettingsCache ||
       now - this.latexSettingsCache.timestamp >= LATEX_SETTINGS_CACHE_TTL
     ) {
+      let settings: LatexSettingsStatus;
+      try {
+        settings = await this.toolingController.detectStatus();
+      } catch (error) {
+        this.ctx.logger.error(
+          this.ctx.channel,
+          `Failed to load LaTeX settings status: ${toErrorMessage(error)}`,
+        );
+        settings = {
+          ...DEFAULT_LATEX_SETTINGS_STATUS,
+          platform: normalizePlatform(process.platform),
+        };
+      }
       this.latexSettingsCache = {
-        settings: await this.toolingController.detectStatus(),
+        settings,
         timestamp: now,
       };
     }

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -913,6 +913,17 @@
         },
         {
           "properties": {
+            "texra.skills.enabled": {
+              "default": true,
+              "description": "Discover imported skills and expose them to tool-use agent prompts",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "Skills"
+        },
+        {
+          "properties": {
             "texra.toolUse.persistence.enabled": {
               "default": true,
               "description": "Persist tool-use conversations across VS Code restarts",

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -324,6 +324,13 @@ export abstract class ModelHandler<
       ? await serverSideKeyService.canUseServerSideKeys()
       : false;
 
+    if (useIncludedAccess && serverSideKeyService.wasQuotaAutoSwitched()) {
+      throw new Error(
+        `Model "${this.config.name}" cannot use the TeXRA relay because your monthly relay quota is exhausted. ` +
+          `Switch to "Use My Own Keys" via the TeXRA Profile panel, or wait for the next quota period.`,
+      );
+    }
+
     // Use centralized check to ensure consistency with getBaseUrl()
     if (this.shouldUseServerSideKeys()) {
       const accessToken = await SupabaseClient.getAccessToken();

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -324,7 +324,9 @@ export abstract class ModelHandler<
       ? await serverSideKeyService.canUseServerSideKeys()
       : false;
 
-    if (useIncludedAccess && serverSideKeyService.wasQuotaAutoSwitched()) {
+    const relayQuotaExhausted =
+      useIncludedAccess && serverSideKeyService.wasQuotaAutoSwitched();
+    if (relayQuotaExhausted) {
       throw new Error(
         `Model "${this.config.name}" cannot use the TeXRA relay because your monthly relay quota is exhausted. ` +
           `Switch to "Use My Own Keys" via the TeXRA Profile panel, or wait for the next quota period.`,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -95,8 +95,10 @@ export async function buildUserVars(
     getAttachedMemories(agentConfig.memories),
     // AVAILABLE_SKILLS is only substituted into TOOL_USE_INSTRUCTIONS, so the
     // catalog (a multi-source readdir + per-skill realpath/read/parse) is dead
-    // work for workflow agents — gate it on the ToolUse category.
-    agentSetting.agentCategory === AgentCategory.ToolUse
+    // work for workflow agents. The settings toggle gives users a hard off
+    // switch that skips discovery and leaves AVAILABLE_SKILLS empty.
+    agentSetting.agentCategory === AgentCategory.ToolUse &&
+    getConfig<boolean>('texra.skills.enabled', true)
       ? loadRuntimeSkillCatalog(logger)
       : Promise.resolve(''),
   ]);

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -218,6 +218,10 @@ export class ServerSideKeyService {
     return this.quotaAutoSwitchActive && !this.useIncludedModelAccess;
   }
 
+  isRelayQuotaExceeded(): boolean {
+    return this.tierService.isQuotaExceeded();
+  }
+
   async setUseIncludedModelAccess(
     value: boolean,
     cacheOptions: ClearServerSideKeyCachesOptions = {},

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -128,12 +128,12 @@ async function resolveModelAvailability(
       : AVAILABILITY_STATUS['missing-key'];
   }
 
-  if (canUseIncludedAccessForModel(model, config, ctx)) {
-    return AVAILABILITY_STATUS['included-access'];
-  }
-
   if (ctx.relayQuotaExhausted) {
     return AVAILABILITY_STATUS['relay-quota-exhausted'];
+  }
+
+  if (canUseIncludedAccessForModel(model, config, ctx)) {
+    return AVAILABILITY_STATUS['included-access'];
   }
 
   // Fall back to personal API keys when the user opted out of included access
@@ -164,7 +164,8 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
     hasOpenRouter,
     hasServerAccess,
     relayQuotaExhausted:
-      useIncludedAccess && serverSideKeyService.isRelayQuotaExceeded(),
+      serverSideKeyService.wasQuotaAutoSwitched() ||
+      (useIncludedAccess && serverSideKeyService.isRelayQuotaExceeded()),
     useOpenRouter: getUseOpenRouter(),
     useIncludedAccess,
     serverSideKeyService,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -58,6 +58,12 @@ const AVAILABILITY_STATUS: Record<
     available: false,
     requiresKey: false,
   },
+  'relay-quota-exhausted': {
+    kind: 'relay-quota-exhausted',
+    label: 'Relay quota exhausted',
+    available: false,
+    requiresKey: false,
+  },
 };
 
 /** Check whether a model is available through a personal provider or OpenRouter key. */
@@ -90,6 +96,7 @@ async function getPersonalAccessKindForModel(
 interface ModelAvailabilityContext {
   hasOpenRouter: boolean;
   hasServerAccess: boolean;
+  relayQuotaExhausted: boolean;
   useOpenRouter: boolean;
   useIncludedAccess: boolean;
   serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
@@ -125,6 +132,10 @@ async function resolveModelAvailability(
     return AVAILABILITY_STATUS['included-access'];
   }
 
+  if (ctx.relayQuotaExhausted) {
+    return AVAILABILITY_STATUS['relay-quota-exhausted'];
+  }
+
   // Fall back to personal API keys when the user opted out of included access
   // OR they aren't authenticated for it (avoids showing every model as
   // disabled for unauthenticated users with the default setting).
@@ -151,6 +162,10 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
   return {
     hasOpenRouter,
     hasServerAccess,
+    relayQuotaExhausted:
+      serverSideKeyService.wasQuotaAutoSwitched() ||
+      (serverSideKeyService.getUseIncludedModelAccess() &&
+        serverSideKeyService.isRelayQuotaExceeded()),
     useOpenRouter: getUseOpenRouter(),
     useIncludedAccess: serverSideKeyService.getUseIncludedModelAccess(),
     serverSideKeyService,
@@ -176,6 +191,10 @@ export async function getModelUnavailableReason(
   if (availability.kind === 'not-included') {
     // User has server access but model isn't available on their tier
     return `Model "${model}" is not available with your current subscription tier. Upgrade your plan or switch to a different model.`;
+  }
+
+  if (availability.kind === 'relay-quota-exhausted') {
+    return `Model "${model}" is unavailable because your monthly TeXRA relay quota is exhausted. Switch to personal API keys or wait for the next quota period.`;
   }
 
   // Personal key mode or unauthenticated — missing provider key

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -155,6 +155,7 @@ async function resolveModelAvailability(
 
 async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
   const serverSideKeyService = getServerSideKeyService();
+  const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
   const [hasOpenRouter, hasServerAccess] = await Promise.all([
     apiKeyExists(platform().secrets, 'openRouter'),
     serverSideKeyService.canUseServerSideKeys(),
@@ -163,11 +164,9 @@ async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
     hasOpenRouter,
     hasServerAccess,
     relayQuotaExhausted:
-      serverSideKeyService.wasQuotaAutoSwitched() ||
-      (serverSideKeyService.getUseIncludedModelAccess() &&
-        serverSideKeyService.isRelayQuotaExceeded()),
+      useIncludedAccess && serverSideKeyService.isRelayQuotaExceeded(),
     useOpenRouter: getUseOpenRouter(),
-    useIncludedAccess: serverSideKeyService.getUseIncludedModelAccess(),
+    useIncludedAccess,
     serverSideKeyService,
   };
 }

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -238,6 +238,9 @@ export const DEFAULT_CORE_SETTINGS = {
     saveDebugObjects: false,
     saveInputPrompt: false,
   },
+  skills: {
+    enabled: true,
+  },
   toolUse: {
     requireEditApproval: true,
     requireBashApproval: true,
@@ -477,6 +480,11 @@ export const CoreSettingsShape = {
         .prefault(DEFAULT_CORE_SETTINGS.debug.saveInputPrompt),
     })
     .prefault(DEFAULT_CORE_SETTINGS.debug),
+  skills: z
+    .strictObject({
+      enabled: z.boolean().prefault(DEFAULT_CORE_SETTINGS.skills.enabled),
+    })
+    .prefault(DEFAULT_CORE_SETTINGS.skills),
   toolUse: z
     .strictObject({
       requireEditApproval: z
@@ -561,6 +569,7 @@ export const CORE_SETTING_PATHS = [
   'logger.debugMode',
   'debug.saveDebugObjects',
   'debug.saveInputPrompt',
+  'skills.enabled',
   'toolUse.requireEditApproval',
   'toolUse.requireBashApproval',
   'toolUse.persistence.enabled',

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -78,6 +78,7 @@ export const ModelAvailabilityKindSchema = z.enum([
   'openrouter-key',
   'missing-key',
   'not-included',
+  'relay-quota-exhausted',
 ]);
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
 

--- a/src/shared/schemas/streamRestoration.ts
+++ b/src/shared/schemas/streamRestoration.ts
@@ -46,6 +46,8 @@ export const RestoredStreamSnapshotSchema = z.object({
   description: z.string().optional(),
   /** Execution id for storage lookup (powers resume / transcript view). */
   executionId: ExecutionIdSchema.optional(),
+  /** Parent stream id for subagent streams, if this row is nested. */
+  parentStreamId: StreamTabIdSchema.optional(),
   /** Original creation timestamp (ms since epoch). */
   creationTimestamp: z.number(),
   /** Last activity timestamp (ms since epoch) — used to sort the rail. */

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -132,6 +132,7 @@ describe('ServerSideKeyService quota fallback', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(service.getUseIncludedModelAccess()).toBe(false);
     expect(service.wasQuotaAutoSwitched()).toBe(true);
+    expect(service.isRelayQuotaExceeded()).toBe(true);
 
     await service.setUseIncludedModelAccess(true);
 

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentSelectWindow } from '../../../packages/cli/src/chat/tui/forms/AgentListForm';
+import { agentSelectWindow } from '@cli/chat/tui/forms/AgentListForm';
 
 describe('CLI AgentListForm row budget', () => {
   it('windows long agent lists inside the available foreground rows', () => {

--- a/src/test-kernel/cli/AgentProposal.vitest.mts
+++ b/src/test-kernel/cli/AgentProposal.vitest.mts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { agentProposalCategoryLabel } from '@cli/chat/tui/modals/AgentProposalDisplay';
 import { AGENT_CATEGORY } from '@shared/schemas';
-
-import { agentProposalCategoryLabel } from '../../../packages/cli/src/chat/tui/modals/AgentProposalDisplay';
 
 describe('CLI AgentProposal display model', () => {
   it('uses human-facing category labels', () => {

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -12,8 +12,8 @@ import {
   _ansiMarkdownStatsForTests,
   _resetAnsiMarkdownForTests,
   renderAnsiMarkdown,
-} from '../../../packages/cli/src/chat/tui/render/ansiMarkdown';
-import { wrapAnsiToWidth } from '../../../packages/cli/src/chat/tui/render/ansiWrap';
+} from '@cli/chat/tui/render/ansiMarkdown';
+import { wrapAnsiToWidth } from '@cli/chat/tui/render/ansiWrap';
 
 function displayWidthForTest(line: string): number {
   let width = 0;

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatRelayUsageStatus } from '../../../packages/cli/src/runtime/apiStatus';
-import type { RelayUsageSummary } from '../../../packages/cli/src/runtime/relayUsage';
+import { formatRelayUsageStatus } from '@cli/runtime/apiStatus';
+import type { RelayUsageSummary } from '@cli/runtime/relayUsage';
 
 describe('CLI API status text', () => {
   it('shows relay quota usage as a percentage', () => {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   appendCliApiSwitchHint,
   formatRetryRequestMessage,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
-} from '../../../packages/cli/src/runtime/approvalAdapter';
-import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+} from '@cli/runtime/approvalAdapter';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { CliContext } from '@cli/runtime/cliContext';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -5,8 +5,8 @@ import {
   currentApproval,
   enqueueApproval,
   type ApprovalPayload,
-} from '../../../packages/cli/src/chat/tui/state/approvalQueue';
-import { approvalPayloadStreamId } from '../../../packages/cli/src/chat/tui/state/subscribeApprovals';
+} from '@cli/chat/tui/state/approvalQueue';
+import { approvalPayloadStreamId } from '@cli/chat/tui/state/subscribeApprovals';
 
 function bashPayload(streamId: string): ApprovalPayload {
   return {

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -5,13 +5,12 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { listExecutions } from '@agent/storage';
-import { AgentCategory } from '@agent/core/AgentDataclass';
-
 import {
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
-} from '../../../packages/cli/src/runtime/chatDefaults';
+} from '@cli/runtime/chatDefaults';
+import { listExecutions } from '@agent/storage';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -5,20 +5,20 @@ import { describe, expect, it } from 'vitest';
 import {
   computePickerListLayout,
   computeTaskDetailLayout,
-} from '../../../packages/cli/src/chat/tui/modals/ChildControlPicker';
+} from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
   childPickerKeyAction,
   hasChildExecutionRows,
   nextPickerIndex,
   numericFocusTarget,
-} from '../../../packages/cli/src/chat/tui/state/childControls';
-import { visibleSubagentRows } from '../../../packages/cli/src/chat/tui/state/childStreamMerge';
-import { NO_BYPASS } from '../../../packages/cli/src/chat/tui/state/cliState';
+} from '@cli/chat/tui/state/childControls';
+import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
+import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
 import type {
   ProcessOutputTail,
   StreamSlice,
-} from '../../../packages/cli/src/chat/tui/state/cliState';
+} from '@cli/chat/tui/state/cliState';
 
 function tail(stdout: string, stderr = ''): ProcessOutputTail {
   return { stdout, stderr };

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -8,8 +8,8 @@ import {
   buildCliContext,
   CliUsageError,
   resolveCliCwd,
-} from '../../../packages/cli/src/runtime/cliContext';
-import { loadWorkspaceCliConfig } from '../../../packages/cli/src/runtime/cliConfig';
+} from '@cli/runtime/cliContext';
+import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
 
 const ambient = {
   isCi: true,

--- a/src/test-kernel/cli/CliMemory.vitest.mts
+++ b/src/test-kernel/cli/CliMemory.vitest.mts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import type { MemoryViewItem } from '@shared/schemas';
-
 import {
   cliMemoryItemDescription,
   formatCliMemoryList,
   resolveCliMemoryStoragePath,
-} from '../../../packages/cli/src/runtime/memory';
-import { memorySelectWindow } from '../../../packages/cli/src/chat/tui/forms/MemoryListForm';
+} from '@cli/runtime/memory';
+import { memorySelectWindow } from '@cli/chat/tui/forms/MemoryListForm';
+import type { MemoryViewItem } from '@shared/schemas';
 
 const item: MemoryViewItem = {
   displayPath: '/memories/project.md',

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -161,6 +161,10 @@ describe('CLI root argument routing', () => {
         helpCommand: 'texra skills',
       },
     );
+    await expect(detectUnknownCliCommand(['tools', 'bogus'])).resolves.toEqual({
+      typedCommand: 'texra tools bogus',
+      helpCommand: 'texra tools',
+    });
   });
 
   it('formats unknown command usage guidance', () => {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -4,9 +4,6 @@ import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
-
 import {
   cliTerminalStatus,
   collectStringFlagValues,
@@ -21,10 +18,12 @@ import {
   resolveLoginProvider,
   resumeWorkflowOutputFile,
   resolveWorkflowOutput,
-} from '../../../packages/cli/src/commands/root';
-import { rejectHeadlessOnlyFlags } from '../../../packages/cli/src/commands/_helpers/globalArgs';
-import { isKnownCliModel } from '../../../packages/cli/src/runtime/cliConfig';
-import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+} from '@cli/commands/root';
+import { rejectHeadlessOnlyFlags } from '@cli/commands/_helpers/globalArgs';
+import { isKnownCliModel } from '@cli/runtime/cliConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
+import type { CliContext } from '@cli/runtime/cliContext';
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   return {

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -9,7 +9,7 @@ import {
   formatCliSkillList,
   readCliSkills,
   skillListRecord,
-} from '../../../packages/cli/src/runtime/skills';
+} from '@cli/runtime/skills';
 
 const tempRoots: string[] = [];
 

--- a/src/test-kernel/cli/CliStateStores.vitest.mts
+++ b/src/test-kernel/cli/CliStateStores.vitest.mts
@@ -4,9 +4,8 @@ import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { createCliStateStores } from '@cli/runtime/cliStateStores';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
-
-import { createCliStateStores } from '../../../packages/cli/src/runtime/cliStateStores';
 
 describe('CLI state stores', () => {
   it('persists workspace state across store instances', async () => {

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   cliToolIds,
+  formatCliBoolean,
   formatCliToolList,
   formatCliToolStatus,
   type CliToolStatusRecord,
-} from '../../../packages/cli/src/runtime/tools';
+} from '@cli/runtime/tools';
 
 function record(
   overrides: Partial<CliToolStatusRecord> = {},
@@ -31,6 +32,12 @@ describe('CLI tools runtime', () => {
     expect(cliToolIds()).toEqual(
       expect.arrayContaining(['codex', 'claude-agent', 'external-inquiry']),
     );
+  });
+
+  it('formats nullable booleans consistently', () => {
+    expect(formatCliBoolean(true)).toBe('yes');
+    expect(formatCliBoolean(false)).toBe('no');
+    expect(formatCliBoolean(null)).toBe('-');
   });
 
   it('formats tool list rows for text output', () => {

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cliToolIds,
+  formatCliToolList,
+  formatCliToolStatus,
+  type CliToolStatusRecord,
+} from '../../../packages/cli/src/runtime/tools';
+
+function record(
+  overrides: Partial<CliToolStatusRecord> = {},
+): CliToolStatusRecord {
+  return {
+    id: 'codex',
+    name: 'OpenAI Codex CLI',
+    category: 'ai-agents',
+    enabled: true,
+    detected: false,
+    status: 'not-found',
+    toggleable: true,
+    comingSoon: false,
+    note: 'npm install -g @openai/codex',
+    installCommand: 'npm install -g @openai/codex',
+    authCommand: 'codex login',
+    ...overrides,
+  };
+}
+
+describe('CLI tools runtime', () => {
+  it('exposes external tool definition ids', () => {
+    expect(cliToolIds()).toEqual(
+      expect.arrayContaining(['codex', 'claude-agent', 'external-inquiry']),
+    );
+  });
+
+  it('formats tool list rows for text output', () => {
+    expect(formatCliToolList([record()])).toContain(
+      'codex\tOpenAI Codex CLI\tai-agents\tyes\tno\tnpm install -g @openai/codex',
+    );
+  });
+
+  it('formats detailed tool status for text output', () => {
+    expect(
+      formatCliToolStatus(record({ statusDetail: 'Codex not found.' })),
+    ).toContain('authCommand: codex login\n\nCodex not found.');
+  });
+});

--- a/src/test-kernel/cli/CompactionRequest.vitest.mts
+++ b/src/test-kernel/cli/CompactionRequest.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { requestCliCompaction } from '../../../packages/cli/src/chat/tui/state/compactionRequest';
+import { requestCliCompaction } from '@cli/chat/tui/state/compactionRequest';
 
 function compactableFlow() {
   return {

--- a/src/test-kernel/cli/Completion.vitest.mts
+++ b/src/test-kernel/cli/Completion.vitest.mts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { rootCommand } from '../../../packages/cli/src/commands/root';
+import { rootCommand } from '@cli/commands/root';
 import {
   CLI_COMPLETION_SHELLS,
   generateCompletionScript,
-} from '../../../packages/cli/src/runtime/completion';
-import { collectCommands } from '../../../packages/cli/src/runtime/completionCommandTree';
+} from '@cli/runtime/completion';
+import { collectCommands } from '@cli/runtime/completionCommandTree';
 
 describe('CLI shell completion', () => {
   for (const shell of CLI_COMPLETION_SHELLS) {

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   confirmCardKeyAction,
   confirmCardKeyHints,
-} from '../../../packages/cli/src/chat/tui/modals/ConfirmCardState';
+} from '@cli/chat/tui/modals/ConfirmCardState';
 
 describe('CLI confirm-card key handling', () => {
   it('keeps y/n and escape approval behavior', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,26 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import {
-  STREAM_STATUS,
-  type NormalizedToolUse,
-  type StreamTabId,
-} from '@shared/schemas';
-
-import { splitTranscriptEntries } from '../../../packages/cli/src/chat/tui/panes/transcriptEntries';
+import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
   selectPendingEntriesForViewport,
-} from '../../../packages/cli/src/chat/tui/panes/ConversationPane';
+} from '@cli/chat/tui/panes/ConversationPane';
 import {
   cliState,
   patchStream,
   resetCliState,
   type ConversationEntry,
   type StreamSlice,
-} from '../../../packages/cli/src/chat/tui/state/cliState';
-import { finalizeAssistantTranscriptEntries } from '../../../packages/cli/src/chat/tui/state/transcript';
-import { subscribeStreamStatus } from '../../../packages/cli/src/chat/tui/state/subscribeStreamStatus';
+} from '@cli/chat/tui/state/cliState';
+import { finalizeAssistantTranscriptEntries } from '@cli/chat/tui/state/transcript';
+import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  STREAM_STATUS,
+  type NormalizedToolUse,
+  type StreamTabId,
+} from '@shared/schemas';
 
 const STREAM_ID = 'cli-test-stream' as StreamTabId;
 const SESSION_META = {

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   boundedDiffDisplayLines,
   buildHunks,
-} from '../../../packages/cli/src/chat/tui/render/DiffView';
+} from '@cli/chat/tui/render/DiffView';
 
 describe('CLI diff display', () => {
   it('keeps the overflow marker inside the total display budget', () => {

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -5,9 +5,9 @@ import {
   doctorExitCode,
   doctorNdjsonRecords,
   formatDoctorText,
-} from '../../../packages/cli/src/runtime/doctor';
-import { CliExitCode } from '../../../packages/cli/src/runtime/exitCodes';
-import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+} from '@cli/runtime/doctor';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import type { CliContext } from '@cli/runtime/cliContext';
 
 const context: CliContext = {
   cwd: '/workspace',

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -41,7 +41,7 @@ import {
   preflightCliHistoryDeleteAll,
   readCliHistoryConfig,
   readCliHistoryDetails,
-} from '../../../packages/cli/src/runtime/history';
+} from '@cli/runtime/history';
 
 const config = {
   agent: 'correct',

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -8,7 +8,7 @@ import {
   initConfigPath,
   serializeInitConfig,
   type InitAnswers,
-} from '../../../packages/cli/src/runtime/initConfig';
+} from '@cli/runtime/initConfig';
 
 const ANSWERS: InitAnswers = {
   agent: 'chat',

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -1,0 +1,73 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildInitConfig,
+  gitignoreWithTexra,
+  initConfigPath,
+  serializeInitConfig,
+  type InitAnswers,
+} from '../../../packages/cli/src/runtime/initConfig';
+
+const ANSWERS: InitAnswers = {
+  agent: 'chat',
+  model: 'deepseekT',
+  approvalPolicy: 'ask',
+  outputFormat: 'json',
+};
+
+describe('buildInitConfig', () => {
+  it('maps answers to the canonical config shape', () => {
+    expect(buildInitConfig(ANSWERS)).toEqual({
+      model: 'deepseekT',
+      outputFormat: 'json',
+      approvalPolicy: 'ask',
+      chat: { agent: 'chat', model: 'deepseekT' },
+    });
+  });
+});
+
+describe('serializeInitConfig', () => {
+  it('produces pretty JSON with a trailing newline', () => {
+    const text = serializeInitConfig(buildInitConfig(ANSWERS));
+    expect(text.endsWith('\n')).toBe(true);
+    expect(JSON.parse(text)).toEqual(buildInitConfig(ANSWERS));
+    expect(text).toContain('  "chat": {');
+  });
+});
+
+describe('initConfigPath', () => {
+  it('resolves the workspace path under cwd', () => {
+    expect(initConfigPath('workspace', '/projects/paper')).toBe(
+      path.join('/projects/paper', '.texra', 'config.json'),
+    );
+  });
+
+  it('resolves the user path under the home directory', () => {
+    expect(initConfigPath('user', '/projects/paper')).toBe(
+      path.join(homedir(), '.texra', 'config.json'),
+    );
+  });
+});
+
+describe('gitignoreWithTexra', () => {
+  it('appends .texra/ to a non-empty file', () => {
+    expect(gitignoreWithTexra('node_modules\ndist\n')).toBe(
+      'node_modules\ndist\n.texra/\n',
+    );
+  });
+
+  it('creates content from an empty file', () => {
+    expect(gitignoreWithTexra('')).toBe('.texra/\n');
+  });
+
+  it('returns null when .texra/ is already ignored', () => {
+    expect(gitignoreWithTexra('node_modules\n.texra/\n')).toBeNull();
+  });
+
+  it('treats a bare .texra entry as already ignored', () => {
+    expect(gitignoreWithTexra('.texra\n')).toBeNull();
+  });
+});

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -1,4 +1,3 @@
-import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -40,14 +39,8 @@ describe('serializeInitConfig', () => {
 
 describe('initConfigPath', () => {
   it('resolves the workspace path under cwd', () => {
-    expect(initConfigPath('workspace', '/projects/paper')).toBe(
+    expect(initConfigPath('/projects/paper')).toBe(
       path.join('/projects/paper', '.texra', 'config.json'),
-    );
-  });
-
-  it('resolves the user path under the home directory', () => {
-    expect(initConfigPath('user', '/projects/paper')).toBe(
-      path.join(homedir(), '.texra', 'config.json'),
     );
   });
 });

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCliPipeClosureError } from '../../../packages/cli/src/runtime/logSinks';
+import { isCliPipeClosureError } from '@cli/runtime/logSinks';
 
 describe('CLI log sinks', () => {
   it('recognizes pipe closure errors as non-fatal output events', () => {

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveLoginProvider } from '../../../packages/cli/src/commands/root';
+import { resolveLoginProvider } from '@cli/commands/root';
 
 describe('CLI login arguments (texra login)', () => {
   it('defaults texra login to GitHub sign-in', () => {

--- a/src/test-kernel/cli/ModelArg.vitest.mts
+++ b/src/test-kernel/cli/ModelArg.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { CliUsageError } from '../../../packages/cli/src/runtime/cliContext';
-import { assertExplicitModelKnown } from '../../../packages/cli/src/commands/_helpers/modelArg';
+import { CliUsageError } from '@cli/runtime/cliContext';
+import { assertExplicitModelKnown } from '@cli/commands/_helpers/modelArg';
 
 describe('assertExplicitModelKnown', () => {
   it('returns undefined when no model flag was passed', () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -1,16 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ModelOptionData } from '@shared/schemas';
-
 import {
   formatModelStatusForCliMode,
   modelSelectWindow,
-} from '../../../packages/cli/src/chat/tui/forms/ModelListForm';
+} from '@cli/chat/tui/forms/ModelListForm';
 import {
   selectItemRenderKey,
   visibleSelectRange,
-} from '../../../packages/cli/src/chat/tui/ui/Select';
-import type { CliModelAccess } from '../../../packages/cli/src/runtime/modelAccess';
+} from '@cli/chat/tui/ui/Select';
+import type { ModelOptionData } from '@shared/schemas';
+import type { CliModelAccess } from '@cli/runtime/modelAccess';
 
 function access(
   model: Partial<ModelOptionData>,

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -54,6 +54,22 @@ describe('CLI ModelListForm status text', () => {
       ),
     ).toBe('relay: unavailable; api key set');
   });
+
+  it('distinguishes exhausted relay quota from tier exclusion', () => {
+    expect(
+      formatModelStatusForCliMode(
+        access(
+          {
+            availability: 'relay-quota-exhausted',
+            availabilityLabel: 'Relay quota exhausted',
+            disabled: true,
+          },
+          'relay quota exhausted',
+        ),
+        'included',
+      ),
+    ).toBe('relay: quota exhausted');
+  });
 });
 
 describe('Select render keys', () => {

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { cliModelRecord } from '@cli/commands/models';
 import type { ModelOptionData } from '@shared/schemas';
-
-import { cliModelRecord } from '../../../packages/cli/src/commands/models';
 
 function model(overrides: Partial<ModelOptionData> = {}): ModelOptionData {
   return {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AgentEntry } from '@agent/index';
-import { AgentCategory } from '@agent/core/AgentDataclass';
-
 import {
   cliMultiAgentPlanHasGaps,
   cliMultiAgentPresets,
@@ -11,7 +8,9 @@ import {
   formatCliMultiAgentPresetList,
   planCliMultiAgentPresetRun,
   parseCliCustomAgentPresets,
-} from '../../../packages/cli/src/runtime/multiAgentPresets';
+} from '@cli/runtime/multiAgentPresets';
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 function agent(
   name: string,

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@shared/schemas';
 
-import { buildCliOrchestrationItems } from '../../../packages/cli/src/runtime/orchestration';
-import type { CliHistoryEntry } from '../../../packages/cli/src/runtime/history';
-import type { CliMultiAgentPreset } from '../../../packages/cli/src/runtime/multiAgentPresets';
+import type { CliHistoryEntry } from '@cli/runtime/history';
+import type { CliMultiAgentPreset } from '@cli/runtime/multiAgentPresets';
 
 function historyEntry(
   id: string,

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -4,11 +4,11 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { CliUsageError } from '../../../packages/cli/src/runtime/cliContext';
+import { CliUsageError } from '@cli/runtime/cliContext';
 import {
   assertOutputDirAvailable,
   assertOutputFileAvailable,
-} from '../../../packages/cli/src/commands/_helpers/workflowOutput';
+} from '@cli/commands/_helpers/workflowOutput';
 
 describe('assertOutputDirAvailable', () => {
   it('no-ops when --output-dir was not passed', async () => {

--- a/src/test-kernel/cli/RelayUsage.vitest.mts
+++ b/src/test-kernel/cli/RelayUsage.vitest.mts
@@ -7,7 +7,7 @@ import {
   parseUtcMonth,
   summarizeRelayUsage,
   type RelayUsageRow,
-} from '../../../packages/cli/src/runtime/relayUsage';
+} from '@cli/runtime/relayUsage';
 
 function row(input: Partial<RelayUsageRow>): RelayUsageRow {
   return {

--- a/src/test-kernel/cli/ResumeListForm.vitest.mts
+++ b/src/test-kernel/cli/ResumeListForm.vitest.mts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resumeEntryDescription,
   resumeSelectWindow,
-} from '../../../packages/cli/src/chat/tui/forms/ResumeListForm';
+} from '@cli/chat/tui/forms/ResumeListForm';
 
 describe('CLI ResumeListForm row budget', () => {
   it('windows long execution lists inside the available foreground rows', () => {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { AgentCategory } from '@agent/core/AgentDataclass';
-
-import { pickGlobalArgs } from '../../../packages/cli/src/runtime/globalArgs';
+import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,
   shouldRenderRunProgress,
-} from '../../../packages/cli/src/runtime/runProgressRenderer';
-import { createCliRuntimeHost } from '../../../packages/cli/src/runtime/runtimeHost';
-import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+} from '@cli/runtime/runProgressRenderer';
+import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { CliContext } from '@cli/runtime/cliContext';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   selectHotkeyForIndex,
   selectIndexForHotkey,
-} from '../../../packages/cli/src/chat/tui/ui/Select';
+} from '@cli/chat/tui/ui/Select';
 
 describe('Select hotkeys', () => {
   it('numbers the first nine rows 1-9, then letters a-z for 10-35', () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -9,8 +9,8 @@ import {
   registerSlashCommand,
   slashPickIntent,
   unregisterSlashCommand,
-} from '../../../packages/cli/src/chat/tui/commands/slashRegistry';
-import { registerBuiltinSlashCommands } from '../../../packages/cli/src/chat/tui/commands/registerBuiltins';
+} from '@cli/chat/tui/commands/slashRegistry';
+import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { STREAM_STATUS } from '@shared/schemas';
-
 import {
   buildStatusBarDisplay,
   defaultShortcutModifierLabel,
   statusBarSegmentText,
-} from '../../../packages/cli/src/chat/tui/panes/StatusBar';
-import { NO_BYPASS } from '../../../packages/cli/src/chat/tui/state/cliState';
+} from '@cli/chat/tui/panes/StatusBar';
+import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
+import { STREAM_STATUS } from '@shared/schemas';
 
 describe('CLI StatusBar display model', () => {
   it('keeps idle state compact and omits static agent/model names', () => {

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -1,19 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
+import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
+import {
+  streamTabSegmentText,
+  streamTabsDisplayItems,
+} from '@cli/chat/tui/panes/StreamTabsStrip';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
-
-import {
-  NO_BYPASS,
-  type StreamSlice,
-} from '../../../packages/cli/src/chat/tui/state/cliState';
-import {
-  streamTabSegmentText,
-  streamTabsDisplayItems,
-} from '../../../packages/cli/src/chat/tui/panes/StreamTabsStrip';
 
 function streamId(value: string): StreamTabId {
   return value as StreamTabId;

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { summarizeSubagentFollowup } from '../../../packages/cli/src/chat/tui/state/subagentFollowup';
+import { summarizeSubagentFollowup } from '@cli/chat/tui/state/subagentFollowup';
 
 describe('summarizeSubagentFollowup', () => {
   it('passes non-subagent text through unchanged', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -4,7 +4,7 @@ import {
   childStatusColor,
   childStatusMarker,
   childStatusPulses,
-} from '../../../packages/cli/src/chat/tui/panes/SubagentListDisplay';
+} from '@cli/chat/tui/panes/SubagentListDisplay';
 
 describe('CLI SubagentList display model', () => {
   it('pulses running statuses', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -7,11 +7,12 @@ import {
   deleteToEnd,
   deleteToStart,
   insertText,
-} from '../../../packages/cli/src/chat/tui/input/textInputEditing';
+} from '@cli/chat/tui/input/textInputEditing';
 import {
   isPlainReturnInput,
+  metaChordDigit,
   metaChordInput,
-} from '../../../packages/cli/src/chat/tui/input/inputKeys';
+} from '@cli/chat/tui/input/inputKeys';
 
 describe('CLI TUI text input editing', () => {
   it('recognizes normalized and raw Enter without stealing Ctrl-J', () => {
@@ -28,6 +29,13 @@ describe('CLI TUI text input editing', () => {
     expect(metaChordInput('\u001Bp', {})).toBe('p');
     expect(metaChordInput('\u001B3', {})).toBe('3');
     expect(metaChordInput('p', { ctrl: true, meta: true })).toBeUndefined();
+  });
+
+  it('parses Option/Alt digit shortcuts after chord normalization', () => {
+    expect(metaChordDigit('3', { meta: true })).toBe(3);
+    expect(metaChordDigit('\u001B3', {})).toBe(3);
+    expect(metaChordDigit('\u001Bp', {})).toBeUndefined();
+    expect(metaChordDigit('\u001B0', {})).toBeUndefined();
   });
 
   it('inserts pasted multi-line text without submitting embedded newlines', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -8,7 +8,10 @@ import {
   deleteToStart,
   insertText,
 } from '../../../packages/cli/src/chat/tui/input/textInputEditing';
-import { isPlainReturnInput } from '../../../packages/cli/src/chat/tui/input/inputKeys';
+import {
+  isPlainReturnInput,
+  metaChordInput,
+} from '../../../packages/cli/src/chat/tui/input/inputKeys';
 
 describe('CLI TUI text input editing', () => {
   it('recognizes normalized and raw Enter without stealing Ctrl-J', () => {
@@ -17,6 +20,14 @@ describe('CLI TUI text input editing', () => {
     expect(isPlainReturnInput('\n', {})).toBe(true);
     expect(isPlainReturnInput('j', { ctrl: true })).toBe(false);
     expect(isPlainReturnInput('\n', { ctrl: true })).toBe(false);
+    expect(isPlainReturnInput('\u001Bp', {})).toBe(false);
+  });
+
+  it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {
+    expect(metaChordInput('p', { meta: true })).toBe('p');
+    expect(metaChordInput('\u001Bp', {})).toBe('p');
+    expect(metaChordInput('\u001B3', {})).toBe('3');
+    expect(metaChordInput('p', { ctrl: true, meta: true })).toBeUndefined();
   });
 
   it('inserts pasted multi-line text without submitting embedded newlines', () => {

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -117,7 +117,20 @@ describe('CLI tool renderer registry', () => {
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● CustomTool (paper.tex)",
-        "⎿ (no output)",
+      ]
+    `);
+  });
+
+  it('keeps read_file rows compact instead of printing file contents', () => {
+    const entry = toolUse(
+      'read_file',
+      { path: 'paper.tex' },
+      { outputText: 'Large file contents\nwith many lines' },
+    );
+
+    expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
+      [
+        "● read_file (paper.tex)",
       ]
     `);
   });

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -2,13 +2,13 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
-import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
-
-// Local imports - CLI TUI rendering
 import {
   pickToolRenderer,
   toolUseDisplayLines,
-} from '../../../packages/cli/src/chat/tui/panes/toolRenderers';
+} from '@cli/chat/tui/panes/toolRenderers';
+import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+
+// Local imports - CLI TUI rendering
 
 function toolUse(
   toolName: string,

--- a/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
+++ b/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { toolUsePatchDisplayLines } from '@cli/chat/tui/panes/ToolUseRow';
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
-
-import { toolUsePatchDisplayLines } from '../../../packages/cli/src/chat/tui/panes/ToolUseRow';
 
 function toolUse(
   toolName: string,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -32,6 +32,7 @@ import {
   nextFocusForward,
 } from '../../../packages/cli/src/chat/tui/state/focusCycle';
 import {
+  isSubagentContinuationMessage,
   stripOrchestratorFollowup,
   syncStreamLog,
 } from '../../../packages/cli/src/chat/tui/state/subscribeStreamLog';
@@ -356,6 +357,50 @@ describe('CLI transcript state', () => {
     expect(stripOrchestratorFollowup('ordinary user text')).toBe(
       'ordinary user text',
     );
+  });
+
+  it('recognizes subagent continuation protocol messages', () => {
+    expect(
+      isSubagentContinuationMessage(
+        '<subagent-progress id="abc" agent="review" type="started" />',
+      ),
+    ).toBe(true);
+    expect(
+      isSubagentContinuationMessage(
+        '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
+      ),
+    ).toBe(true);
+    expect(
+      isSubagentContinuationMessage(
+        'The subagent-result tag is mentioned in prose.',
+      ),
+    ).toBe(false);
+  });
+
+  it('suppresses subagent protocol continuations from the visible transcript', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('Please solve the problem.', {
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+      });
+      logger.info(
+        '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
+        { messageType: MESSAGE_TYPES.USER_MESSAGE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'Please solve the problem.',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
   });
 
   it('mirrors error log entries into the transcript', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -7,12 +7,6 @@ import {
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-import { createRunTrace } from '@logger';
-import {
-  MESSAGE_TYPES,
-  STREAM_STATUS,
-  type StreamTabId,
-} from '@shared/schemas';
 
 import {
   cliState,
@@ -20,50 +14,55 @@ import {
   removeStream,
   resetCliState,
   setParentStream,
-} from '../../../packages/cli/src/chat/tui/state/cliState';
+} from '@cli/chat/tui/state/cliState';
 import {
   allocateMiddleRows,
   allocateSidePanelRows,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
-} from '../../../packages/cli/src/chat/tui/App';
+} from '@cli/chat/tui/App';
 import {
   nextFocusBack,
   nextFocusForward,
-} from '../../../packages/cli/src/chat/tui/state/focusCycle';
+} from '@cli/chat/tui/state/focusCycle';
 import {
-  isSubagentContinuationMessage,
   stripOrchestratorFollowup,
   syncStreamLog,
-} from '../../../packages/cli/src/chat/tui/state/subscribeStreamLog';
-import { wrapRuntimeHost } from '../../../packages/cli/src/chat/tui/state/subscribeRuntimeHost';
+} from '@cli/chat/tui/state/subscribeStreamLog';
+import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
   COMPLETED_PROCESS_TAIL_LINES,
   buildCompletedProcessTranscript,
   completedProcessDisplayLines,
   isCompletedProcessError,
-} from '../../../packages/cli/src/chat/tui/state/completedProcessTranscript';
+} from '@cli/chat/tui/state/completedProcessTranscript';
 import {
   estimateTranscriptEntryRows,
   selectPendingEntriesForViewport,
   splitTranscriptEntries,
-} from '../../../packages/cli/src/chat/tui/panes/ConversationPane';
-import { renderAnsiMarkdown } from '../../../packages/cli/src/chat/tui/render/ansiMarkdown';
+} from '@cli/chat/tui/panes/ConversationPane';
+import { renderAnsiMarkdown } from '@cli/chat/tui/render/ansiMarkdown';
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanStartRootRun,
   chatTuiActiveChildFollowUpTarget,
   clearTuiSessionRunState,
-} from '../../../packages/cli/src/chat/tui/runChatTui';
-import { CliExitCode } from '../../../packages/cli/src/runtime/exitCodes';
+} from '@cli/chat/tui/runChatTui';
+import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
   CLI_LOCAL_STREAM_ID,
   moveLocalTranscriptToStream,
-} from '../../../packages/cli/src/chat/tui/state/transcript';
-import type { CliRuntimeHost } from '../../../packages/cli/src/runtime/runtimeHost';
+} from '@cli/chat/tui/state/transcript';
+import { createRunTrace } from '@logger';
+import {
+  MESSAGE_TYPES,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;
@@ -359,25 +358,7 @@ describe('CLI transcript state', () => {
     );
   });
 
-  it('recognizes subagent continuation protocol messages', () => {
-    expect(
-      isSubagentContinuationMessage(
-        '<subagent-progress id="abc" agent="review" type="started" />',
-      ),
-    ).toBe(true);
-    expect(
-      isSubagentContinuationMessage(
-        '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
-      ),
-    ).toBe(true);
-    expect(
-      isSubagentContinuationMessage(
-        'The subagent-result tag is mentioned in prose.',
-      ),
-    ).toBe(false);
-  });
-
-  it('suppresses subagent protocol continuations from the visible transcript', () => {
+  it('summarizes subagent protocol continuations in the visible transcript', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
     setDefaultStreamLogStore(store);
@@ -397,6 +378,7 @@ describe('CLI transcript state', () => {
       const entries = cliState.streams.get().get(root)?.entries ?? [];
       expect(entries.map((entry) => entry.text)).toEqual([
         'Please solve the problem.',
+        '✓ review completed',
       ]);
     } finally {
       setDefaultStreamLogStore(previousStore);

--- a/src/test-kernel/cli/UserQuestionAnswer.vitest.ts
+++ b/src/test-kernel/cli/UserQuestionAnswer.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseUserQuestionAnswer } from '../../../packages/cli/src/runtime/userQuestionAnswer';
+import { parseUserQuestionAnswer } from '@cli/runtime/userQuestionAnswer';
 
 const question = {
   question: 'How long should this take?',

--- a/src/test-kernel/cli/UserQuestionState.vitest.mts
+++ b/src/test-kernel/cli/UserQuestionState.vitest.mts
@@ -5,7 +5,7 @@ import {
   updateUserQuestionAnswers,
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
-} from '../../../packages/cli/src/chat/tui/modals/UserQuestionState';
+} from '@cli/chat/tui/modals/UserQuestionState';
 
 const question = {
   question: 'Which path should the agent take?',

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -4,11 +4,11 @@ import { tmpdir } from 'node:os';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { resolveWorkflowOutput } from '@cli/commands/root';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 
-import { resolveWorkflowOutput } from '../../../packages/cli/src/commands/root';
-import type { CliContext } from '../../../packages/cli/src/runtime/cliContext';
+import type { CliContext } from '@cli/runtime/cliContext';
 
 type WorkflowResult = Parameters<typeof resolveWorkflowOutput>[2];
 

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " orchestrate chat run resume history history list history show history delete agents agents list agents show skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list models show login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume init history history list history show history delete agents agents list agents show skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list models show login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -44,17 +44,19 @@ _texra() {
   case "$prev" in
     --output-format) COMPREPLY=( $(compgen -W 'text json ndjson' -- "$cur") ); return ;;
     --approval-policy) COMPREPLY=( $(compgen -W 'never ask yolo' -- "$cur") ); return ;;
+    --scope) COMPREPLY=( $(compgen -W 'workspace user' -- "$cur") ); return ;;
     --model|-m) COMPREPLY=( $(compgen -W "$(_texra_models)" -- "$cur") ); return ;;
     --agent) COMPREPLY=( $(compgen -W "$(_texra_agents)" -- "$cur") ); return ;;
   esac
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'orchestrate') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy' ;;
     'chat') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'init') subcommands=''; flags='--cwd --yes -y --force --gitignore --scope' ;;
     'history') subcommands='list show delete'; flags='' ;;
     'history list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -81,7 +83,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -121,6 +123,7 @@ complete -c texra -n '__fish_use_subcommand' -a 'orchestrate' -d 'Choose a chat,
 complete -c texra -n '__fish_use_subcommand' -a 'chat' -d 'Interactive tool-use chat session'
 complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
 complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Re-run a stored execution config'
+complete -c texra -n '__fish_use_subcommand' -a 'init' -d 'Bootstrap a .texra/config.json with sensible defaults'
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'
 complete -c texra -n '__fish_use_subcommand' -a 'agents' -d 'Inspect TeXRA agents'
 complete -c texra -n '__fish_use_subcommand' -a 'skills' -d 'Inspect TeXRA skills'
@@ -168,6 +171,11 @@ complete -c texra -n '__fish_seen_subcommand_from resume' -l 'cwd' -r -d 'Workin
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
 complete -c texra -n '__fish_seen_subcommand_from resume' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from init' -l 'cwd' -r -d 'Working directory to initialize (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from init' -l 'yes' -s 'y' -d 'Accept defaults non-interactively'
+complete -c texra -n '__fish_seen_subcommand_from init' -l 'force' -d 'Overwrite an existing config file'
+complete -c texra -n '__fish_seen_subcommand_from init' -l 'gitignore' -d 'Add .texra/ to .gitignore (non-interactive default: false)'
+complete -c texra -n '__fish_seen_subcommand_from init' -l 'scope' -r -a 'workspace user' -d 'Write ./.texra (workspace) or ~/.texra (user)'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'list' -d 'List stored executions'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'show' -d 'Show one stored execution'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'delete' -d 'Delete stored executions'
@@ -336,6 +344,7 @@ _texra() {
     'chat') true; _arguments '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
     'run') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--context[Read-only context file passed to the workflow agent]:value:' '-c[Read-only context file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--output-dir[Directory to copy multi-input workflow outputs into]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
     'resume') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'init') true; _arguments '--cwd[Working directory to initialize (defaults to $PWD)]:value:' '--yes[Accept defaults non-interactively]' '-y[Accept defaults non-interactively]' '--force[Overwrite an existing config file]' '--gitignore[Add .texra/ to .gitignore (non-interactive default: false)]' '--scope[Write ./.texra (workspace) or ~/.texra (user)]: :(workspace user)' ;;
     'history') _values 'subcommands' 'list' 'show' 'delete'; true ;;
     'history list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'history show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
@@ -362,7 +371,7 @@ _texra() {
     'completion') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume history agents skills multi-agent models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help)' ;;
   esac
 }
 

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -27,7 +27,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " orchestrate chat run resume init history history list history show history delete agents agents list agents show skills skills list multi-agent multi-agent list multi-agent show multi-agent run models models list models show login logout usage auth auth status auth usage doctor completion version help " in
+    case " orchestrate chat run resume init history history list history show history delete agents agents list agents show skills skills list tools tools list tools status tools enable tools disable tools install tools auth multi-agent multi-agent list multi-agent show multi-agent run models models list models show login logout usage auth auth status auth usage doctor completion version help " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -44,19 +44,18 @@ _texra() {
   case "$prev" in
     --output-format) COMPREPLY=( $(compgen -W 'text json ndjson' -- "$cur") ); return ;;
     --approval-policy) COMPREPLY=( $(compgen -W 'never ask yolo' -- "$cur") ); return ;;
-    --scope) COMPREPLY=( $(compgen -W 'workspace user' -- "$cur") ); return ;;
     --model|-m) COMPREPLY=( $(compgen -W "$(_texra_models)" -- "$cur") ); return ;;
     --agent) COMPREPLY=( $(compgen -W "$(_texra_agents)" -- "$cur") ); return ;;
   esac
 
   path="$(_texra_completion_path)"
   case "$path" in
-    '') subcommands='orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    '') subcommands='orchestrate chat run resume init history agents skills tools multi-agent models login logout usage auth doctor completion version help'; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'orchestrate') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy' ;;
     'chat') subcommands=''; flags='--quiet -q --cwd --api-mode --approval-policy --agent --model -m' ;;
     'run') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --input -i --context -c --output --output-dir --model -m --instruction' ;;
     'resume') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
-    'init') subcommands=''; flags='--cwd --yes -y --force --gitignore --scope' ;;
+    'init') subcommands=''; flags='--cwd --yes -y --force --gitignore' ;;
     'history') subcommands='list show delete'; flags='' ;;
     'history list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'history show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -66,6 +65,13 @@ _texra() {
     'agents show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'skills') subcommands='list'; flags='' ;;
     'skills list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --include-interop --source -s' ;;
+    'tools') subcommands='list status enable disable install auth'; flags='' ;;
+    'tools list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'tools status') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'tools enable') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'tools disable') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
+    'tools install') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy --run' ;;
+    'tools auth') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'multi-agent') subcommands='list show run'; flags='' ;;
     'multi-agent list') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'multi-agent show') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
@@ -83,7 +89,7 @@ _texra() {
     'completion') subcommands=''; flags='--print -p --quiet -q --cwd --api-mode --output-format --approval-policy' ;;
     'version') subcommands=''; flags='' ;;
     'help') subcommands=''; flags='' ;;
-    *) subcommands='orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
+    *) subcommands='orchestrate chat run resume init history agents skills tools multi-agent models login logout usage auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then
@@ -127,6 +133,7 @@ complete -c texra -n '__fish_use_subcommand' -a 'init' -d 'Bootstrap a .texra/co
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'
 complete -c texra -n '__fish_use_subcommand' -a 'agents' -d 'Inspect TeXRA agents'
 complete -c texra -n '__fish_use_subcommand' -a 'skills' -d 'Inspect TeXRA skills'
+complete -c texra -n '__fish_use_subcommand' -a 'tools' -d 'Inspect external tool integrations'
 complete -c texra -n '__fish_use_subcommand' -a 'multi-agent' -d 'Inspect multi-agent teams'
 complete -c texra -n '__fish_use_subcommand' -a 'models' -d 'Inspect TeXRA models'
 complete -c texra -n '__fish_use_subcommand' -a 'login' -d 'Sign in to TeXRA for included access'
@@ -175,7 +182,6 @@ complete -c texra -n '__fish_seen_subcommand_from init' -l 'cwd' -r -d 'Working 
 complete -c texra -n '__fish_seen_subcommand_from init' -l 'yes' -s 'y' -d 'Accept defaults non-interactively'
 complete -c texra -n '__fish_seen_subcommand_from init' -l 'force' -d 'Overwrite an existing config file'
 complete -c texra -n '__fish_seen_subcommand_from init' -l 'gitignore' -d 'Add .texra/ to .gitignore (non-interactive default: false)'
-complete -c texra -n '__fish_seen_subcommand_from init' -l 'scope' -r -a 'workspace user' -d 'Write ./.texra (workspace) or ~/.texra (user)'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'list' -d 'List stored executions'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'show' -d 'Show one stored execution'
 complete -c texra -n '__fish_seen_subcommand_from history' -a 'delete' -d 'Delete stored executions'
@@ -222,6 +228,49 @@ complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcom
 complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'include-interop' -d 'Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory'
 complete -c texra -n '__fish_seen_subcommand_from skills; and __fish_seen_subcommand_from list' -l 'source' -s 's' -r -d 'Additional skill root to scan; may be repeated and is resolved relative to --cwd'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'list' -d 'List external tool integrations'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'status' -d 'Show one tool integration status'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'enable' -d 'Enable a tool integration'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'disable' -d 'Disable a tool integration'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'install' -d 'Show install help for a tool'
+complete -c texra -n '__fish_seen_subcommand_from tools' -a 'auth' -d 'Run or show auth help for a tool'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from list' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from status' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from enable' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from disable' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from install' -l 'run' -d 'Run the registered install command after printing it'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'print' -s 'p' -d 'Run non-interactively and print the result to stdout'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'quiet' -s 'q' -d 'Suppress progress output and informational logs'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'cwd' -r -d 'Working directory the agent runs against (defaults to $PWD)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'api-mode' -r -d 'API access mode: included (TeXRA relay) or personal (your own API keys)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'output-format' -r -a 'text json ndjson' -d 'Output format for headless runs (default: text)'
+complete -c texra -n '__fish_seen_subcommand_from tools; and __fish_seen_subcommand_from auth' -l 'approval-policy' -r -a 'never ask yolo' -d 'When to ask before privileged tool actions (default: never)'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'list' -d 'List multi-agent team presets'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'show' -d 'Show one multi-agent team preset'
 complete -c texra -n '__fish_seen_subcommand_from multi-agent' -a 'run' -d 'Run a multi-agent team preset'
@@ -344,7 +393,7 @@ _texra() {
     'chat') true; _arguments '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--agent[Tool-use agent for the session]:value:' '--model[Model for the session]:value:' '-m[Model for the session]:value:' ;;
     'run') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--input[Input file passed to the workflow agent]:value:' '-i[Input file passed to the workflow agent]:value:' '--context[Read-only context file passed to the workflow agent]:value:' '-c[Read-only context file passed to the workflow agent]:value:' '--output[Output file path]:value:' '--output-dir[Directory to copy multi-input workflow outputs into]:value:' '--model[Model for the agent]:value:' '-m[Model for the agent]:value:' '--instruction[Instruction passed to the workflow agent]:value:' '1:agent:($(_texra_agents))' ;;
     'resume') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
-    'init') true; _arguments '--cwd[Working directory to initialize (defaults to $PWD)]:value:' '--yes[Accept defaults non-interactively]' '-y[Accept defaults non-interactively]' '--force[Overwrite an existing config file]' '--gitignore[Add .texra/ to .gitignore (non-interactive default: false)]' '--scope[Write ./.texra (workspace) or ~/.texra (user)]: :(workspace user)' ;;
+    'init') true; _arguments '--cwd[Working directory to initialize (defaults to $PWD)]:value:' '--yes[Accept defaults non-interactively]' '-y[Accept defaults non-interactively]' '--force[Overwrite an existing config file]' '--gitignore[Add .texra/ to .gitignore (non-interactive default: false)]' ;;
     'history') _values 'subcommands' 'list' 'show' 'delete'; true ;;
     'history list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'history show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
@@ -354,6 +403,13 @@ _texra() {
     'agents show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:agent:($(_texra_agents))' ;;
     'skills') _values 'subcommands' 'list'; true ;;
     'skills list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--include-interop[Also scan .claude/skills, .codex/skills, and .gemini/skills under the workspace and home directory]' '--source[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' '-s[Additional skill root to scan; may be repeated and is resolved relative to --cwd]:value:' ;;
+    'tools') _values 'subcommands' 'list' 'status' 'enable' 'disable' 'install' 'auth'; true ;;
+    'tools list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'tools status') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'tools enable') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'tools disable') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
+    'tools install') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '--run[Run the registered install command after printing it]' ;;
+    'tools auth') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'multi-agent') _values 'subcommands' 'list' 'show' 'run'; true ;;
     'multi-agent list') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
     'multi-agent show') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' ;;
@@ -371,7 +427,7 @@ _texra() {
     'completion') true; _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:shell:(bash zsh fish)' ;;
     'version') true; true ;;
     'help') true; true ;;
-    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume init history agents skills multi-agent models login logout usage auth doctor completion version help)' ;;
+    *) _arguments '--print[Run non-interactively and print the result to stdout]' '-p[Run non-interactively and print the result to stdout]' '--quiet[Suppress progress output and informational logs]' '-q[Suppress progress output and informational logs]' '--cwd[Working directory the agent runs against (defaults to $PWD)]:value:' '--api-mode[API access mode: included (TeXRA relay) or personal (your own API keys)]:value:' '--output-format[Output format for headless runs (default: text)]: :(text json ndjson)' '--approval-policy[When to ask before privileged tool actions (default: never)]: :(never ask yolo)' '1:command:(orchestrate chat run resume init history agents skills tools multi-agent models login logout usage auth doctor completion version help)' ;;
   esac
 }
 

--- a/src/test-kernel/commands/htmlFormatter.vitest.ts
+++ b/src/test-kernel/commands/htmlFormatter.vitest.ts
@@ -194,4 +194,30 @@ describe('formatChatAsHtml', () => {
     // attempted, just not as a clickable anchor.
     expect(malicious).toContain('javascript:alert');
   });
+
+  it('strips protocol-relative URLs from tool-provided links', () => {
+    const malicious = formatChatAsHtml({
+      ...fixture,
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'web_search_tool_result',
+              content: [
+                {
+                  type: 'web_search_result',
+                  url: '//evil.example.com/path',
+                  title: 'protocol-relative',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(malicious).not.toContain('href="//evil.example.com/path"');
+    expect(malicious).toContain('//evil.example.com/path');
+  });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - progress schemas
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
+import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
 import {
   AGENT_CATEGORY,
   LOG_LEVELS,
@@ -15,7 +16,6 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import { DESKTOP_SHELL_COMMANDS } from '../../../packages/desktop/src/desktopShellMessages';
 
 type Bridge = {
   openFileCompile(filePath: string): Promise<void>;

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -5,13 +5,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 
 // Local imports - command catalog and shared schemas
+import type { DesktopCommandActions } from '@desktop/desktopCommandSurface';
 import { commandCatalogById, type CommandId } from '@shared/commands/catalog';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import type { DesktopCommandActions } from '../../../packages/desktop/src/desktopCommandSurface';
 
 interface DesktopCommandSurfaceModule {
   DESKTOP_LOCAL_COMMANDS: {

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -6,7 +6,7 @@ import {
   installDesktopProtocolCallbackLifecycle,
   parseDesktopProtocolCallback,
   type DesktopProtocolApp,
-} from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+} from '@desktop/main/desktopProtocolCallbacks';
 
 function createFakeProtocolApp(
   overrides: Partial<DesktopProtocolApp> = {},

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -22,6 +22,7 @@ type Snapshot = {
   lastKnownStatus: string;
   description?: string;
   executionId?: string;
+  parentStreamId?: string;
   creationTimestamp: number;
   lastTimestamp?: number;
   persistedAt: number;
@@ -117,6 +118,22 @@ describe('DesktopStreamSnapshot', () => {
     expect(
       reopened.hydrated.every((s) => s.lastKnownStatus === 'stopped'),
     ).toBe(true);
+  });
+
+  it('preserves parent stream links on hydrate', async () => {
+    const { openDesktopStreamSnapshotStore } = await loadModule();
+    const filePath = await tempFilePath();
+
+    const writer = await openDesktopStreamSnapshotStore(filePath);
+    await writer.upsert(
+      makeSnapshot({
+        streamId: 'child@2',
+        parentStreamId: 'parent@1',
+      }),
+    );
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated[0]?.parentStreamId).toBe('parent@1');
   });
 
   it('upsert overwrites an existing snapshot with the same id', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -5,13 +5,13 @@ import * as agentRegistry from '@agent/index/agentRegistry';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { SupabaseSession } from '@auth/SupabaseSession';
 import { setServerSideKeyService } from '@auth/serverKeys';
-import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+import { createDesktopProtocolCallbackRouter } from '@desktop/main/desktopProtocolCallbacks';
 import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
   type DesktopOAuthClient,
   type DesktopAuthProfileData,
-} from '../../../packages/desktop/src/main/desktopSupabaseAuth';
+} from '@desktop/main/desktopSupabaseAuth';
 import type { StateStore } from '@platform/interfaces/state';
 
 function createCoordinator() {

--- a/src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
+++ b/src/test-kernel/desktop/desktopProtocolCallbacks.vitest.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 import {
   installDesktopProtocolCallbackLifecycle,
   type DesktopProtocolApp,
-} from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+} from '@desktop/main/desktopProtocolCallbacks';
 
 type SecondInstanceListener = (
   event: unknown,

--- a/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
+++ b/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'node:assert';
 import { resolve } from 'node:path';
 import { describe, it } from 'vitest';
 
-import { resolveWorkspacePath } from '../../../packages/desktop/src/main/platform/paths';
 import {
   hasResolvedWorkspacePath,
   isNewWindowLaunch,
@@ -10,7 +9,8 @@ import {
   serializeWorkspacePresenceArg,
   withNewWindowWorkspaceArgs,
   withWorkspacePathArg,
-} from '../../../packages/desktop/src/workspacePath';
+} from '@desktop/workspacePath';
+import { resolveWorkspacePath } from '@desktop/main/platform/paths';
 
 describe('desktop workspace path', () => {
   it('resolves CLI workspace path before env and stored workspace', () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -76,11 +76,11 @@ describe('computeModelOptionsData relay quota state', () => {
     expect(model.disabled).toBe(true);
   });
 
-  it('falls back to personal keys after quota auto-switch disables included access', async () => {
+  it('falls back to personal keys when included access is disabled without quota auto-switch', async () => {
     installServerSideKeyService({
       useIncludedAccess: false,
       relayQuotaExceeded: true,
-      quotaAutoSwitched: true,
+      quotaAutoSwitched: false,
     });
 
     const [model] = await computeModelOptionsData();

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  ServerSideKeyService,
+  setServerSideKeyService,
+} from '@auth/serverKeys';
+import { GlobalStateKey } from '@common/state/stateKeys';
+import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
+import {
+  computeModelOptionsData,
+  invalidateModelOptionsCache,
+} from '@model/computeModelOptions';
+
+function installServerSideKeyService(options: {
+  useIncludedAccess: boolean;
+  readonly relayQuotaExceeded: boolean;
+  readonly quotaAutoSwitched: boolean;
+  readonly autoSwitchDuringAccessCheck?: boolean;
+}): void {
+  setServerSideKeyService({
+    canUseServerSideKeys: async () => {
+      if (options.autoSwitchDuringAccessCheck) {
+        options.useIncludedAccess = false;
+      }
+      return false;
+    },
+    getUseIncludedModelAccess: () => options.useIncludedAccess,
+    isRelayQuotaExceeded: () => options.relayQuotaExceeded,
+    wasQuotaAutoSwitched: () => options.quotaAutoSwitched,
+    isProviderOnServer: () => true,
+    canUseModelSync: () => false,
+  } as unknown as ServerSideKeyService);
+}
+
+describe('computeModelOptionsData relay quota state', () => {
+  beforeEach(() => {
+    invalidateApiKeyCache();
+    invalidateModelOptionsCache();
+  });
+
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform({
+        globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
+        secrets: { [apiKeySecretName('openai')]: 'sk-openai' },
+      }),
+    );
+  });
+
+  it('shows relay quota exhaustion while included access remains selected', async () => {
+    installServerSideKeyService({
+      useIncludedAccess: true,
+      relayQuotaExceeded: true,
+      quotaAutoSwitched: false,
+    });
+
+    const [model] = await computeModelOptionsData();
+
+    expect(model.availability).toBe('relay-quota-exhausted');
+    expect(model.disabled).toBe(true);
+  });
+
+  it('preserves the quota label when access check auto-switches included access off', async () => {
+    installServerSideKeyService({
+      useIncludedAccess: true,
+      relayQuotaExceeded: true,
+      quotaAutoSwitched: true,
+      autoSwitchDuringAccessCheck: true,
+    });
+
+    const [model] = await computeModelOptionsData();
+
+    expect(model.availability).toBe('relay-quota-exhausted');
+    expect(model.disabled).toBe(true);
+  });
+
+  it('falls back to personal keys after quota auto-switch disables included access', async () => {
+    installServerSideKeyService({
+      useIncludedAccess: false,
+      relayQuotaExceeded: true,
+      quotaAutoSwitched: true,
+    });
+
+    const [model] = await computeModelOptionsData();
+
+    expect(model.availability).toBe('provider-key');
+    expect(model.disabled).toBe(false);
+  });
+});

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -48,4 +48,29 @@ describe('tool-use formatter', () => {
     expect(title?.textContent).not.toContain('Built Mathlib');
     expect(body?.textContent).toContain('Built Mathlib.Example.Module19');
   });
+
+  it('renders write_file cards even when compact logs omit content', async () => {
+    const { formatLogEntry } =
+      await import('@progressView/frontend/formatters');
+    const { render } = await import('lit');
+    const message: LogMessageData = {
+      id: 'write-file-compact',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'write_file',
+        input: { path: 'src/main.ts' },
+        output: 'Wrote src/main.ts',
+      },
+    };
+
+    const container = document.createElement('div');
+    render(formatLogEntry(message), container);
+
+    expect(container.textContent).toContain('write_file');
+    expect(container.textContent).toContain('src/main.ts');
+    expect(container.textContent).not.toContain('Failed to render');
+  });
 });

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -8,6 +8,7 @@ import { useLitComponentTestDom } from './litComponentTestUtils';
 
 type ModelSelectionListElement = HTMLElement & {
   models: ModelSelectionItem[];
+  helperModel: string;
   providerKeyStatuses: ProviderKeyStatus[];
   updateComplete: Promise<boolean>;
 };
@@ -55,5 +56,23 @@ describe('ModelSelectionList provider key actions', () => {
     setKeyButton!.click();
 
     expect(events).toEqual([{ provider: 'deepseek' }]);
+  });
+
+  it('shows helper model labels together with short ids', async () => {
+    const list = document.createElement(
+      'model-selection-list',
+    ) as ModelSelectionListElement;
+    list.models = [deepseekModel];
+    list.helperModel = 'deepseek';
+    document.body.append(list);
+    await list.updateComplete;
+
+    const helperOption = list.shadowRoot!.querySelector(
+      '.helper-model-select wa-option',
+    );
+
+    expect(helperOption?.textContent?.trim()).toBe(
+      'DeepSeek V4 Flash (deepseek)',
+    );
   });
 });

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -55,4 +55,19 @@ describe('StreamLog', () => {
       'message-2500',
     ]);
   });
+
+  it('does not mark no-op updates dirty', () => {
+    const log = new StreamLog();
+    log.append({
+      id: 'message',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'unchanged',
+      messageType: MESSAGE_TYPES.DEFAULT,
+    });
+
+    expect(log.update('message', { text: 'unchanged' })).toBeUndefined();
+    expect(log.drainDirtyUpdates()).toEqual([]);
+  });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -663,7 +663,7 @@ async function proposeAndExecute(
 // ============================================================================
 
 /** Schema for delegate_workflow tool (document processing). */
-const WorkflowAgentInputSchema = z.object({
+const WorkflowAgentInputSchema = z.strictObject({
   agent: z.string().describe('Name of the workflow agent to execute'),
   model: z
     .string()
@@ -844,7 +844,7 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
 // ============================================================================
 
 /** Schema for delegate_agent tool (tool-use agents). */
-const DelegateAgentInputSchema = z.object({
+const DelegateAgentInputSchema = z.strictObject({
   agent: z
     .string()
     .nullish()

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -54,7 +54,7 @@ const logger = createChannelTrace('InquiryTool');
 // Schemas
 // ============================================================================
 
-const AskSchema = z.object({
+const AskSchema = z.strictObject({
   command: z
     .literal('ask')
     .describe(
@@ -94,7 +94,7 @@ const AskSchema = z.object({
     ),
 });
 
-const ReadSchema = z.object({
+const ReadSchema = z.strictObject({
   command: z
     .literal('read')
     .describe(
@@ -105,7 +105,7 @@ const ReadSchema = z.object({
   thread_id: ExternalInquiryThreadIdSchema.describe('The thread to read.'),
 });
 
-const ListSchema = z.object({
+const ListSchema = z.strictObject({
   command: z
     .literal('list')
     .describe(

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -83,6 +83,14 @@ export class StreamLog {
     if (index === undefined) return undefined;
 
     const current = this.entries[index];
+    if (
+      Object.entries(patch).every(([key, value]) =>
+        Object.is(current[key as keyof StreamLogUpdatePatch], value),
+      )
+    ) {
+      return undefined;
+    }
+
     // Direct merge — no Zod parse. update() is on the streaming hot path
     // (tool output chunks at ~200/sec) and receives trusted data from
     // AgentLogger. Persisted entries are parsed when loaded from storage.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,9 @@
         "node_modules/@openrouter/sdk/esm/models/index.d.ts"
       ],
       "@controllers/*": ["src/controllers/*"],
-      "@test/*": ["src/test/*"]
+      "@test/*": ["src/test/*"],
+      "@cli/*": ["packages/cli/src/*"],
+      "@desktop/*": ["packages/desktop/src/*"]
     },
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Fixes #4377
Fixes #4378
Fixes #4364
Fixes #4405
Fixes #4407
Fixes #4469
Fixes #4465
Fixes #4476
Fixes #4477
Fixes #4480
Fixes #4484
Fixes #4485
Fixes #4487
Refs #4363
Fixes #4483

## What

This PR collects the low-risk follow-up fixes that were open against the CLI, relay model availability, webview URL handling, settings loading, transcript restoration, and tool schemas.

### CLI onboarding and integrations

- Adds `texra init` with an interactive Ink wizard and non-interactive `--yes` path for workspace `.texra/config.json` bootstrap.
- Adds `texra tools list|status|enable|disable|install|auth` plus the `/tools` TUI form.
- Documents third-party tool integrations in the CLI guide.
- Fixes Option/Alt-key handling in the TUI input path.
- Keeps `read_file` and similar tools compact by default while preserving details for shells, MCP tools, errors, and patches.

### Relay and model availability

- Adds an explicit `relay-quota-exhausted` model availability state.
- Makes `texra models list` and `/model` show relay quota exhaustion instead of describing personal-key availability as relay availability.
- Makes runtime model errors distinguish exhausted monthly relay quota from subscription-tier exclusion.

### Runtime and webview fixes

- Rejects protocol-relative URLs in `safeUrl`.
- Makes LaTeX settings status load with a fallback instead of leaving the tab stuck on a spinner.
- Preserves parent stream ids when hydrating desktop stream snapshots.
- Avoids no-op `StreamLog` updates that caused continuous dirty writes.
- Suppresses raw `<subagent-progress>` and `<subagent-result>` protocol messages from the visible CLI transcript while leaving the underlying model transcript intact.
- Changes delegation and external inquiry tool schemas to `z.strictObject()`.
- Adds a `texra.skills.enabled` setting gate for runtime skill catalog loading.

## Notes

- #4465 appears already satisfied on `main`: `docs/.vitepress/config.js` already has `architecture/**` in `srcExclude`, so this branch does not add a duplicate docs-config diff.
- #4471 is an npm release operation, not a code change. `packages/cli/package.json` already declares `@texra-ai/cli` with public `publishConfig`; publishing still needs the release npm credentials/workflow.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/auth/ServerSideKeyService.vitest.ts src/test-kernel/commands/htmlFormatter.vitest.ts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts src/test-kernel/transcript/StreamLog.vitest.ts src/test-kernel/cli/CliTools.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/InitConfig.vitest.mts`
- `npm run typecheck && npm run lint && npm run compile:fast`
- `npm run lint` after the final import-order cleanup

Lint finishes with one pre-existing warning in `src/test-kernel/agent/DeleteExecution.vitest.mts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay/model availability and auth-adjacent error paths plus broad CLI TUI behavior, but changes are mostly additive follow-ups with tests.
> 
> **Overview**
> Adds **`texra init`** (Ink wizard or `--yes`) to write **`.texra/config.json`**, optional **`.gitignore`**, and registers the init wizard at the CLI I/O boundary. Adds **`texra tools`** (`list`, `status`, `enable`/`disable`, `install`, `auth`) plus **`/tools`** in chat, backed by **`@cli/runtime/tools`** and CLI guide docs.
> 
> Introduces a **`relay-quota-exhausted`** availability kind so **`texra models list`**, **`/model`**, and **`ModelHandler`** errors distinguish monthly relay exhaustion from tier exclusion or missing keys. Adds **`texra.skills.enabled`** to skip skill-catalog work when off.
> 
> **TUI:** Option/Alt chords via **`metaChordInput`**; subagent XML collapsed in the visible transcript; tool rows hide bulky output by default (bash/MCP still show output). **Elsewhere:** `@cli` / `@desktop` path aliases and import cleanup; desktop stream snapshots persist **`parentStreamId`**; **`safeUrl`** blocks protocol-relative URLs; LaTeX settings status falls back on load failure; plan panel scroll styling fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a803884436a9749d42eaa0dfd27ce72d12aec8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->