### PR TITLE
refactor(scripts): simplify build and verification scripts

### DIFF
--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -73,7 +73,7 @@ function importSources(source) {
   ];
   for (const pattern of patterns) {
     let match;
-    while ((match = pattern.exec(source)) != null) {
+    while ((match = pattern.exec(source)) !== null) {
       sources.push(match[1]);
     }
   }

--- a/packages/cli/scripts/smoke-react-compiler.mjs
+++ b/packages/cli/scripts/smoke-react-compiler.mjs
@@ -21,40 +21,37 @@ import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
 const here = dirname(fileURLToPath(import.meta.url));
 const smokeFile = resolve(here, '../src/chat/tui/App.tsx');
 
-const recorded = {
-  contents: undefined,
-};
-
+let loadHandler;
 const fakeBuildApi = {
   onLoad(_filter, handler) {
-    fakeBuildApi._handler = handler;
+    loadHandler = handler;
   },
 };
 
 const plugin = reactCompilerPlugin();
 plugin.setup(fakeBuildApi);
 
-if (typeof fakeBuildApi._handler !== 'function') {
+if (typeof loadHandler !== 'function') {
   console.error('react-compiler smoke: plugin did not register onLoad hook');
   process.exit(1);
 }
 
 const args = { path: smokeFile, namespace: 'file' };
-const result = await fakeBuildApi._handler(args);
+const result = await loadHandler(args);
 if (!result || typeof result.contents !== 'string') {
   console.error(
     `react-compiler smoke: plugin returned no transformed contents for ${smokeFile}`,
   );
   process.exit(1);
 }
-recorded.contents = result.contents;
+const contents = result.contents;
 
-if (!recorded.contents.includes('react/compiler-runtime')) {
+if (!contents.includes('react/compiler-runtime')) {
   console.error(
     'react-compiler smoke: expected the compiler to import `react/compiler-runtime` (was the compiler skipped?)',
   );
   console.error('---transformed output snippet---');
-  console.error(recorded.contents.slice(0, 800));
+  console.error(contents.slice(0, 800));
   process.exit(1);
 }
 
@@ -76,7 +73,7 @@ function collectBareImports(code) {
 }
 
 const sourceImports = collectBareImports(source);
-const outputImports = collectBareImports(recorded.contents);
+const outputImports = collectBareImports(contents);
 
 const ALLOWLIST = new Set([
   // The compiler adds its runtime.

--- a/scripts/aliasUtils.mjs
+++ b/scripts/aliasUtils.mjs
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 export function loadAliases(rootDir) {
   const tsconfig = readTsconfig(resolve(rootDir, 'tsconfig.json'));

--- a/scripts/aliasUtils.mjs
+++ b/scripts/aliasUtils.mjs
@@ -7,7 +7,7 @@
  * if the two diverge, builds will silently follow the root.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'path';
 
 export function loadAliases(rootDir) {

--- a/scripts/aliases.mjs
+++ b/scripts/aliases.mjs
@@ -3,8 +3,8 @@
  * Single source of truth for esbuild and Vite build configs.
  */
 
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { loadAliases } from './aliasUtils.mjs';
 

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// Node.js imports
 import fs from 'node:fs';
 import process from 'node:process';
 

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -10,6 +10,7 @@ import {
   formatOutput,
   hasExited,
   readPendingExit,
+  readPositiveNumber,
   stopChild,
   waitForClose,
   waitForExit,
@@ -48,11 +49,6 @@ const fatalLogPatterns = [
       /Failed to load URL:.*ERR_FILE_NOT_FOUND|Unable to load preload script|preload\/index\.cjs not found/i,
   },
 ];
-
-function readPositiveNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
 
 function defaultPackagedExecutable() {
   if (process.platform !== 'darwin') return undefined;
@@ -105,7 +101,7 @@ function findFatalLog(output) {
 
 function failIfFatalLog(output) {
   const fatalLog = findFatalLog(output);
-  if (!fatalLog) return false;
+  if (!fatalLog) return;
 
   console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
   console.error(formatOutput(output));

--- a/scripts/smoke-process-utils.mjs
+++ b/scripts/smoke-process-utils.mjs
@@ -42,6 +42,11 @@ export async function waitForExitOrTimeout(exitPromise, timeoutMs) {
   ]);
 }
 
+export function readPositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export async function readPendingExit(exitPromise) {
   const result = await Promise.race([
     exitPromise.then((exit) => ({ exit })),

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -226,7 +226,8 @@ function createAsarAppReader(asarPath) {
       try {
         return statFile(asarPath, candidate).unpacked === true;
       } catch {
-        // Try the next normalized candidate.
+        // statFile throws when the path is not in the archive; try the next
+        // normalized candidate before giving up.
       }
     }
     return false;


### PR DESCRIPTION
Non-behavioral cleanup pass over `packages/cli/scripts/` and repo-root `scripts/`, driven by a parallel `/simplify` review (reuse / quality / efficiency).

## Changes
- **smoke-react-compiler.mjs** — replace the single-field `recorded` wrapper object and the `fakeBuildApi._handler` side-channel with plain closure variables (`loadHandler`, `contents`).
- **check-host-imports.mjs** — strict `!== null` for the `regex.exec` loop guard (`exec` returns `null`, never `undefined`).
- **aliases.mjs / aliasUtils.mjs** — `node:` specifier prefix for built-in imports, matching every other script in the repo.
- **bump-workspace-version.mjs** — drop the redundant `// Node.js imports` what-comment.
- **smoke-desktop-package-launch.mjs** — import the shared `readPositiveNumber` from `smoke-process-utils.mjs` instead of redefining an identical copy; drop the unused `false` return from `failIfFatalLog` (no caller reads it).
- **verify-desktop-package.mjs** — comment now states *why* `statFile` throws (path not in archive) rather than restating control flow.

No behavior changes; `node --check` and Prettier pass on all touched files.

## Reviewed but deliberately not applied
- Sharing the `react-devtools-core` stub path between `build-bundle.mjs` and `build-harness.mjs` — `build-harness.mjs` is untracked WIP on another branch, and exporting a stub path from the React-compiler plugin module leaks an unrelated concern.
- Guarding `stripPattern` with a match check in `check-host-imports.mjs` — premature optimization for a lint script over 3 small files.
- Removing the provably-no-op self-visit in `sync-remote-agents.mjs` `walkParents` — correctness depends on the inheritance callback's guards; left for a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only hygiene with no production code or behavioral changes; smoke and verify paths stay equivalent.
> 
> **Overview**
> Non-behavioral cleanup across `packages/cli/scripts/` and repo-root `scripts/`: simpler smoke-test wiring, shared helpers, and consistent Node import style.
> 
> The React compiler smoke test drops the `recorded` object and `fakeBuildApi._handler` side channel in favor of plain `loadHandler` and `contents`. CLI host-import linting uses `!== null` for `RegExp#exec` loop guards. Alias scripts import built-ins via the `node:` prefix; the workspace version bump script loses a redundant comment.
> 
> Desktop launch smoke imports `readPositiveNumber` from `smoke-process-utils.mjs` instead of a local duplicate, and `failIfFatalLog` no longer returns an unused `false`. A comment in desktop package verification explains why `statFile` failures are retried with alternate ASAR paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c9d77c212de1e4e592ff0ccc1760ab418d1ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->