### PR TITLE
[codex] fix progress log replay and CLI test tooling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
     "vsc-extension-quickstart.md": true // set this to false to include "vsc-extension-quickstart" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  // Use the workspace TypeScript (6.0.3) so the editor matches the build; the
+  // bundled VS Code TS server is older and rejects `ignoreDeprecations: "6.0"`.
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "check:architecture": "node scripts/check-host-imports.mjs",
     "bundle": "node scripts/build-bundle.mjs",
+    "bundle:harness": "node scripts/build-harness.mjs",
     "copy:resources": "node scripts/copy-resources.mjs",
     "copy:docs": "node scripts/copy-docs.mjs",
     "smoke:react-compiler": "node scripts/smoke-react-compiler.mjs",

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Bundles scripts/tui-harness.tsx into dist/bin/tui-harness.js for PTY tests.
+import { chmod } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
+
+const reactDevtoolsStub = fileURLToPath(
+  new URL('./react-devtools-core-stub.mjs', import.meta.url),
+);
+
+const outfile = 'dist/bin/tui-harness.js';
+
+await build({
+  entryPoints: ['scripts/tui-harness.tsx'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  external: ['fsevents'],
+  jsx: 'automatic',
+  loader: { '.tsx': 'tsx', '.ts': 'ts' },
+  alias: { 'react-devtools-core': reactDevtoolsStub },
+  outfile,
+  banner: {
+    js: `import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);`,
+  },
+  plugins: [reactCompilerPlugin()],
+  logLevel: 'info',
+});
+
+await chmod(outfile, 0o755);

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1,0 +1,68 @@
+// Test harness: seed cliState with synthetic finalized entries, render <App />
+// to the real terminal. Used to verify the ConversationPane viewport without
+// needing API access. Exits on Ctrl-C.
+
+import { render } from 'ink';
+import React from 'react';
+
+import { App } from '../src/chat/tui/App';
+import {
+  cliState,
+  patchStream,
+  type ConversationEntry,
+} from '../src/chat/tui/state/cliState';
+
+const STREAM_ID = 'harness-stream-1';
+const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
+
+function makeEntries(count: number): ConversationEntry[] {
+  const entries: ConversationEntry[] = [];
+  for (let i = 1; i <= count; i += 1) {
+    const role = i % 3 === 0 ? 'assistant' : 'user';
+    const text =
+      role === 'user'
+        ? `entry-${i} chat history line to grow the transcript pane`
+        : `assistant reply ${i} - confirming receipt of entry ${i}`;
+    entries.push({
+      id: `entry-${i}`,
+      role,
+      text,
+      finalized: true,
+    });
+  }
+  return entries;
+}
+
+cliState.sessionMeta.set({
+  agent: 'chat',
+  model: 'harness-model',
+  cwd: process.cwd(),
+  apiMode: 'personal',
+  canDelegate: false,
+  version: '0.0.0-harness',
+});
+cliState.activeStreamId.set(STREAM_ID);
+patchStream(STREAM_ID, (slice) => ({
+  ...slice,
+  status: undefined,
+  entries: makeEntries(ENTRY_COUNT),
+}));
+
+const ink = render(
+  <App
+    onSubmit={() => undefined}
+    onKillExecution={() => undefined}
+    canInterruptActiveRun={() => false}
+    onInterruptActive={() => undefined}
+  />,
+  {
+    stdout: process.stdout,
+    stderr: process.stderr,
+    stdin: process.stdin,
+  },
+);
+
+process.on('SIGINT', () => {
+  ink.unmount();
+  process.exit(0);
+});

--- a/packages/extension/src/progressView/managers/WebviewBridge.ts
+++ b/packages/extension/src/progressView/managers/WebviewBridge.ts
@@ -18,6 +18,15 @@ export class WebviewBridge {
   ) {
     this.unsubscribe = this.store.onChange((streamId) => {
       if (streamId !== this.getActiveStream()) return;
+      // A stream is mirrored to the webview only after `syncStream` seeds its
+      // cursor. That call is the registration handshake, run once the webview
+      // knows the stream exists. A run appends its earliest entries (the "Init"
+      // stage and files-loaded logs) during launch, before that handshake;
+      // streaming them here would post a LOG_DELTA the frontend drops (no
+      // streamState yet) while this bridge advances its cursor past them,
+      // losing them until a manual reload. Until then the on-disk log is
+      // authoritative and `syncStream` replays it in full.
+      if (!this.cursors.has(streamId)) return;
       this.changedStreams.add(streamId);
       this.scheduleFlush();
     });
@@ -74,6 +83,11 @@ export class WebviewBridge {
       return;
     }
 
+    // `changedStreams` is a subset of `cursors`: onChange only enqueues a
+    // stream whose cursor is already seeded (the `syncStream` handshake), and
+    // syncStream seeds it before enqueuing. Thus a stream present here has a
+    // cursor here. The `?? 0` is therefore unreachable, kept only to satisfy
+    // the type.
     const cursor = this.cursors.get(activeStream) ?? 0;
     const entries = log.getRange(cursor, log.head);
     const updates = log.drainDirtyUpdates(cursor);

--- a/scripts/desktop-package-targets.d.mts
+++ b/scripts/desktop-package-targets.d.mts
@@ -1,0 +1,1 @@
+export function expectedCodexPlatformKeysFromLabel(label: string): string[];

--- a/src/test-kernel/agent/DeleteExecution.vitest.mts
+++ b/src/test-kernel/agent/DeleteExecution.vitest.mts
@@ -22,6 +22,8 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
   getExecutionStore: vi.fn(() => ({ clear: mocks.clear })),
 }));
 
+// Imported after vi.mock so the mocked ExecutionKVStore is in place.
+// eslint-disable-next-line import/order
 import { deleteExecution } from '@agent/storage/executionListing';
 
 beforeEach(() => {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -6,8 +6,8 @@ import {
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
 } from '@cli/runtime/approvalAdapter';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { CliContext } from '@cli/runtime/cliContext';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { listExecutions } from '@agent/storage';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
 } from '@cli/runtime/chatDefaults';
-import { listExecutions } from '@agent/storage';
-import { AgentCategory } from '@agent/core/AgentDataclass';
 
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   cliTerminalStatus,
   collectStringFlagValues,
@@ -21,9 +22,8 @@ import {
 } from '@cli/commands/root';
 import { rejectHeadlessOnlyFlags } from '@cli/commands/_helpers/globalArgs';
 import { isKnownCliModel } from '@cli/runtime/cliConfig';
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   return {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
@@ -14,7 +15,6 @@ import {
 } from '@cli/chat/tui/state/cliState';
 import { finalizeAssistantTranscriptEntries } from '@cli/chat/tui/state/transcript';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_STATUS,
   type NormalizedToolUse,

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -32,6 +32,8 @@ vi.mock('@utils/files/taskRunStorage', () => ({
   resolveStoragePath: vi.fn(async () => undefined),
 }));
 
+// Imported after vi.mock so the mocked dependencies are in place.
+// eslint-disable-next-line import/order
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -8,8 +8,8 @@ import {
   selectItemRenderKey,
   visibleSelectRange,
 } from '@cli/chat/tui/ui/Select';
-import type { ModelOptionData } from '@shared/schemas';
 import type { CliModelAccess } from '@cli/runtime/modelAccess';
+import type { ModelOptionData } from '@shared/schemas';
 
 function access(
   model: Partial<ModelOptionData>,

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   cliMultiAgentPlanHasGaps,
   cliMultiAgentPresets,
@@ -9,8 +11,6 @@ import {
   planCliMultiAgentPresetRun,
   parseCliCustomAgentPresets,
 } from '@cli/runtime/multiAgentPresets';
-import type { AgentEntry } from '@agent/index';
-import { AgentCategory } from '@agent/core/AgentDataclass';
 
 function agent(
   name: string,

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import type { ExecutionId } from '@shared/schemas';
+import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 
 import type { CliHistoryEntry } from '@cli/runtime/history';
 import type { CliMultiAgentPreset } from '@cli/runtime/multiAgentPresets';
+import type { ExecutionId } from '@shared/schemas';
 
 function historyEntry(
   id: string,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,
   shouldRenderRunProgress,
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -56,13 +56,13 @@ import {
   CLI_LOCAL_STREAM_ID,
   moveLocalTranscriptToStream,
 } from '@cli/chat/tui/state/transcript';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { createRunTrace } from '@logger';
 import {
   MESSAGE_TYPES,
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
-import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -4,11 +4,10 @@ import { tmpdir } from 'node:os';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { resolveWorkflowOutput } from '@cli/commands/root';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
-
+import { resolveWorkflowOutput } from '@cli/commands/root';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 
 type WorkflowResult = Parameters<typeof resolveWorkflowOutput>[2];
 

--- a/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
@@ -6,7 +6,6 @@ import {
   normalizeMetafilePath,
   resolveMetafileImportPath,
 } from '../../../scripts/desktop-package-metafile-paths.mjs';
-// @ts-expect-error verifier helper is JavaScript.
 import { expectedCodexPlatformKeysFromLabel } from '../../../scripts/desktop-package-targets.mjs';
 
 describe('desktop package verifier metafile paths', () => {

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -47,6 +47,7 @@ describe('WebviewBridge', () => {
       () => activeStream,
     );
 
+    bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', 'active log', 100));
     await vi.advanceTimersByTimeAsync(20);
 


### PR DESCRIPTION
## Summary

This PR keeps the progress-view webview bridge from advancing a stream cursor before the webview has registered that stream. Without that guard, early launch entries such as the init stage and file-loading logs can be sent as a delta before the frontend has stream state, then skipped until a manual reload.

It also adds a small CLI TUI harness for terminal viewport checks, makes the harness bundle script explicit, adds a declaration file for the desktop package target helper, and cleans up import-order/type-check issues in the affected test files. The workspace settings now point VS Code at the workspace TypeScript SDK, so editor diagnostics use the same TypeScript version as the build.

## Validation

- `prettier --write` on changed files
- `git diff --check`
- `npm run lint`
- `npm --prefix packages/cli run bundle:harness`
- `tsc --noEmit`
- `tsc --noEmit -p tsconfig.test-kernel.json`
- `tsc --noEmit -p packages/cli/tsconfig.json`
- `tsc --noEmit -p packages/extension/tsconfig.json`
- `vitest run --config vitest.config.mjs` on the touched test suites

`npm run typecheck` and `npm run compile:fast` were not usable in the auxiliary PR worktree because `pnpm` attempted to re-create the symlinked dependency tree non-interactively. The equivalent TypeScript checks were run directly instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The WebviewBridge change affects how progress logs reach the VS Code webview at run start; incorrect behavior would show missing early logs, but the fix is narrowly scoped to pre-handshake events.
> 
> **Overview**
> Fixes a **progress-view** race where `WebviewBridge` could advance its log cursor before the webview registered the active stream, so early run logs (init / files loaded) were dropped until reload. **`onChange` now ignores streams until `syncStream` seeds the cursor**, with comments documenting the handshake.
> 
> Adds a **CLI Ink TUI harness** (`tui-harness.tsx`, `build-harness.mjs`, `bundle:harness`) to render synthetic transcript rows in a real terminal for viewport/PTY checks; the harness binary is **excluded from the published CLI package**.
> 
> **Editor/tooling:** VS Code uses `typescript.tsdk` from `node_modules` (TS 6.0.3). Adds `scripts/desktop-package-targets.d.mts` and tightens test-kernel imports/mocks (`syncStream` in `WebviewBridge` tests, post-`vi.mock` imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d696774700937cf6f9bd8d2288c317fdae49cf85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->