### PR TITLE
refactor(agent): run merge as a normal prompt-driven workflow agent

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1245,15 +1245,21 @@ export class DesktopProgressBridge {
     baseFile: string,
     editedFile: string,
   ): Promise<void> {
-    const [{ executeMergeAgent }, { getHelperModelName }] = await Promise.all([
+    const [{ executeAgent }, { getHelperModelName }] = await Promise.all([
       import('@agent/runtime/executeAgent'),
       import('@agent/runtime/helperModel'),
     ]);
-    await executeMergeAgent(
-      getHelperModelName(),
-      baseFile,
-      editedFile,
-      this.runtimeHost,
+    // Merge runs as a normal workflow agent (merge.yaml): original as the
+    // input file, the partially-edited document as the edited file.
+    await executeAgent(
+      {
+        agent: 'merge',
+        model: getHelperModelName(),
+        inputFiles: [baseFile],
+        editedFile,
+      },
+      undefined,
+      { runtimeHost: this.runtimeHost },
     );
   }
 

--- a/packages/extension/resources/agents/merge.yaml
+++ b/packages/extension/resources/agents/merge.yaml
@@ -57,7 +57,6 @@ prompts:
 
     Provide your output as complete \LaTeX document{% if INPUT_FILES[1] %}s{% endif %}. Accuracy is paramount - even small discrepancies can affect diff tools.
 
-    {% if INPUT_FILES | length %}
     <documents>
     {% for output in INPUT_FILES %}
     <document name="{{ output }}">
@@ -65,10 +64,3 @@ prompts:
     </document>
     {% endfor %}
     </documents>
-    {% else %}
-    <documents>
-    <document name="_full.tex">
-    % Your merged \LaTeX document here
-    </document>
-    </documents>
-    {% endif %}

--- a/packages/extension/src/commands/agent/mergeCommands.ts
+++ b/packages/extension/src/commands/agent/mergeCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { executeMergeAgent } from '@agent/runtime/executeAgent';
+import { executeAgent } from '@agent/runtime/executeAgent';
 import { getHelperModelName } from '@agent/runtime/helperModel';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
@@ -31,10 +31,17 @@ async function handleMerge(
     return;
   }
 
-  await executeMergeAgent(
-    model ?? getHelperModelName(),
-    baseFile ?? inputFile,
-    editedFile,
-    extensionAgentRuntimeHost,
+  // Merge is a normal prompt-driven workflow agent (see merge.yaml); it runs
+  // through the generic agent path with the original as the input file and the
+  // partially-edited document as the edited file.
+  await executeAgent(
+    {
+      agent: 'merge',
+      model: model ?? getHelperModelName(),
+      inputFiles: [baseFile ?? inputFile],
+      editedFile,
+    },
+    undefined,
+    { runtimeHost: extensionAgentRuntimeHost },
   );
 }

--- a/src/agent/output/workflowOutputLayout.ts
+++ b/src/agent/output/workflowOutputLayout.ts
@@ -4,9 +4,6 @@
  * Current format (runDir-relative):
  *   r{round}/output.<ext>
  *
- * Merge output (single-output, non-round, runDir-relative):
- *   _full.<ext>
- *
  * Legacy format (frozen; pre-r{round}/ refactor):
  *   <inputDir>/<inputBase>_<agentChunk>_r{round}_<normalizedModel>.*
  *
@@ -42,15 +39,6 @@ export function workflowOutputPath(params: {
   round: number;
 }): string {
   return `r${params.round}/${WORKFLOW_OUTPUT_BASENAME}.${params.ext}`;
-}
-
-// ---------------------------------------------------------------------------
-// Merge layout — runDir-relative, fixed basename
-// ---------------------------------------------------------------------------
-
-/** Build the runDir-relative merge output path. */
-export function workflowMergeOutputPath(params: { ext: string }): string {
-  return `_full.${params.ext}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 
 import { writeTerminalStatus } from '@agent/storage';
 import { logSdkError } from '@agent/trace';
-import { createMergeOutputFileLocationGetter } from '@agent/utils/outputFileUtils';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import {
   runToolUseFlow,
@@ -513,59 +512,6 @@ export async function executeAgent(
       },
     );
   });
-}
-
-export async function executeMergeAgent(
-  model: string,
-  inputFile: string,
-  editedFile: string,
-  runtimeHost: AgentRuntimeHost,
-): Promise<void> {
-  const configPayload: AgentConfigPayload = {
-    agent: 'merge',
-    model,
-    inputFiles: [inputFile],
-    editedFile,
-  };
-  const ctx = await buildAgentLaunchContext({
-    configPayload,
-    runtimeHost,
-    taskType: 'Merge task',
-  });
-  const { streamId, executionId } = ctx;
-
-  await withExecutionRunContext(ctx, () =>
-    runFlowWithLifecycle(ctx, streamId, 'merge', async () => {
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
-        runtimeHost: ctx.runtimeHost,
-      });
-
-      const taskStage = logger.openStage(`Task: merge@${model}`);
-      return taskStage.run(async () => {
-        logger.info(`Executing merge with model ${model}`);
-
-        if (!isWorkflowSetting(ctx.setting)) {
-          throw new AgentError('merge agent must be a workflow agent');
-        }
-        const fileService = new TaskRunFileService(executionId);
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...createInterruptCallbacks(),
-          onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
-          setting: ctx.setting,
-          getOutputFileLocation:
-            createMergeOutputFileLocationGetter(fileService),
-          parentStage: ctx.parentStage,
-          onRoundCompleted: createRoundProgressCallback(
-            ctx.executionId,
-            streamId,
-            ctx.runtimeHost,
-          ),
-        });
-        return buildWorkflowFlowResult(result, ctx.executionId, streamId);
-      });
-    }),
-  );
 }
 
 export async function resumeToolUseFromSnapshot(

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -1,12 +1,9 @@
 import * as path from 'path';
 
 import {
-  WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_OUTPUT_BASENAME,
-  workflowMergeOutputPath,
   workflowOutputPath,
 } from '@agent/output/workflowOutputLayout';
-import type { TaskRunFileService, AgentFileLocation } from '@utils/files';
 
 /**
  * Generates a runDir-relative output path under a round subfolder:
@@ -92,34 +89,4 @@ export function getExtractedDocOutputFileName(
       ? `${WORKFLOW_OUTPUT_BASENAME}_extracted`
       : safe.name;
   return path.join(roundDir, safe.dir, `${safeName}${safe.ext}`);
-}
-
-/**
- * Creates a merge-specific output file location getter.
- *
- * Merge is a single-output workflow: the round number is not reflected in
- * the filename and the same location is returned for every round. The
- * merge output lives at the runDir root as `_full.tex`; per-execution
- * isolation keeps it from colliding with other runs.
- *
- * The fileService MUST carry an executionId; the fixed `_full.tex` path
- * relies on run-storage isolation for uniqueness. Without it, every merge
- * in the workspace would clobber the same file.
- *
- * Merge is always a LaTeX workflow, so the output extension is fixed rather
- * than configurable through agent YAML.
- */
-export function createMergeOutputFileLocationGetter(
-  fileService: TaskRunFileService,
-): (round: number) => AgentFileLocation {
-  if (!fileService.hasRunDirectory()) {
-    throw new Error(
-      'createMergeOutputFileLocationGetter requires a TaskRunFileService bound to an executionId; the `_full.tex` path is only collision-safe inside per-execution run storage.',
-    );
-  }
-  const outputPath = workflowMergeOutputPath({
-    ext: WORKFLOW_DOCUMENT_OUTPUT_EXT,
-  });
-  const location = fileService.createLocation(outputPath) as AgentFileLocation;
-  return (_round: number): AgentFileLocation => location;
 }


### PR DESCRIPTION
## Motivation

The `merge` agent had a bespoke code path that no other agent uses:

- **`executeMergeAgent()`** — a dedicated runner that bypassed the generic `executeAgent()`.
- **`createMergeOutputFileLocationGetter`** — forced a round-independent `_full.tex` file at the run-dir root instead of the standard `r{round}/output.tex` layout.

Merge is a plain 1-round workflow agent, so the round-independent output location was never needed — and it actually fought `merge.yaml`, which already names its output document after the input file (`<document name="{{ output }}">`). The bespoke `_full.tex` location is also why the merge output surfaced in the Generated Files list as an `external` location with a long absolute path.

## Change

Route merge through the generic `executeAgent({ agent: 'merge', ... })`, exactly like other prompt-driven agents (e.g. `latexFixer`). The original document becomes `inputFiles[0]`; the partially-edited document becomes `editedFile`.

- `mergeCommands.ts` / desktop `runMergeFile`: call `executeAgent` instead of `executeMergeAgent`.
- Remove `executeMergeAgent`, `createMergeOutputFileLocationGetter`, and the now-unused `workflowMergeOutputPath` (`_full.tex`) layout helper.
- `merge.yaml`: drop the dead `_full.tex` fallback branch — output naming is purely input-driven (the merge button always supplies a base file).

## Behavior change

Merge output moves from `executions/<id>/_full.tex` to the standard `executions/<id>/r0/output.tex`, extracted under the input filename — unifying it with every other workflow agent and making it a proper `runStorage` location. The generic path also adds progress-board wiring (`setTaskState`, ensure-view) that the bespoke path lacked.

## Verification

- `pnpm --recursive typecheck` passes (all four packages, incl. desktop).
- `vitest run src/test-kernel/agent/output` passes (11/11).
- No tests referenced the removed helpers.
- Net: 6 files changed, +25 / −119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where merge artifacts are written (`_full.tex` → `r0/output.tex`) and how they appear in the progress UI, though logic stays in the same `merge` workflow agent.
> 
> **Overview**
> **Merge** now runs through the same **`executeAgent`** path as other workflow agents instead of a dedicated **`executeMergeAgent`** runner.
> 
> VS Code **`texra.merge`** and desktop progress **merge** actions call **`executeAgent({ agent: 'merge', inputFiles: [original], editedFile })`**. The bespoke merge runner, **`createMergeOutputFileLocationGetter`**, and **`workflowMergeOutputPath`** (`_full.<ext>`) helpers are removed so merge uses the standard **`r{round}/output.<ext>`** layout and input-driven names from **`merge.yaml`**.
> 
> **`merge.yaml`** drops the unused **`_full.tex`** output template branch; callers always supply a base input file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9038e184a2017b203a56b1d7765ee852d6f0cc39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->