### PR TITLE
fix(agent): use lineage.diffBase for subagent original-path snapshot

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -76,7 +76,10 @@ function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
           : o.location.absolutePath,
       absolutePath: o.location.absolutePath,
       location: o.location.kind,
-      originalPath: o.lineage?.original?.absolutePath ?? null,
+      originalPath:
+        o.lineage?.diffBase?.absolutePath ??
+        o.lineage?.original?.absolutePath ??
+        null,
       added: o.diff?.added ?? null,
       removed: o.diff?.removed ?? null,
     })),


### PR DESCRIPTION
## Summary

- Fixes #4502. \`executeAgent.toRoundOutputSummary\` now reads \`lineage.diffBase\` (the immutable pre-run snapshot) instead of \`lineage.original\` (which #4500 retargeted to the live workspace file).
- Falls back to \`lineage.original\` when no \`diffBase\` is set, preserving behavior for paths outside the lineage system.

After #4500, in-place workflows that overwrite the workspace file caused two downstream consumers to silently break:
- \`src/tools/subagentDiffs.ts\` — diff content delivered to the orchestrator became empty (diffed the post-run file against itself).
- \`src/tools/subagentResults.ts\` — LLM saw post-run content as \`original=\"…\"\` in the subagent result XML.

Render-side consumers (progress view) continue to read \`lineage.original\` directly so the "Compare with base" button still diffs against the live workspace doc.

## Test plan

- [x] \`pnpm vitest run src/test-kernel/agent\` — 128/128 pass
- [x] \`npm run typecheck\` — clean
- [ ] Manual: run an in-place reflection workflow and confirm subagent diffs are non-empty and reflect real changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field mapping change in output summaries with fallback; no auth, security, or broad architectural impact.
> 
> **Overview**
> **Fixes subagent workflow reporting** after lineage changes that pointed `lineage.original` at the live workspace file during in-place runs.
> 
> `toOutputSummaries` in `executeAgent` now sets `originalPath` from **`lineage.diffBase`** (pre-run snapshot) when present, with a fallback to `lineage.original`. That restores meaningful diffs in `subagentDiffs` and correct `original="…"` metadata in `subagentResults` for orchestrators. UI paths that still read `lineage.original` for “Compare with base” are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e547593ccc6c8ffbc03639393b7900d4cfadfb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->