### PR TITLE
Fill in 0.38.1 changelog + extract siblingLocation helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-- **Cleaner history rows** — each entry now puts the metadata (timestamp, agent, model, inputs) and action buttons on top, keeps Context / Config visible inline, and collapses very long instruction prompts behind a "Show full instructions" toggle.
-- **Merge shows up on the progress board** — running a merge now creates a normal task entry with progress, logs, and outputs like every other agent, and saves its result under the input filename instead of `_full.tex`.
-- **CLI auth grouped under `texra auth`** — `login`, `logout`, `status`, and `usage` now live under `texra auth` (with `texra login` / `texra logout` kept as top-level shortcuts). Clearer `--approval-policy` help, safer defaults (`texra init` defaults to `ask`), and disambiguated `--output` vs `--output-dir`.
+- **Cleaner history rows** — restructured layout with metadata on top, inline Context/Config, and collapsible long prompts.
+- **Merge shows up on the progress board** — runs now appear as a normal task and save their result under the input filename.
+- **CLI auth grouped under `texra auth`** — `login`, `logout`, `status`, and `usage` now live under `texra auth` (top-level `texra login` / `texra logout` kept as shortcuts). Clearer `--approval-policy` help, safer defaults, and disambiguated `--output` vs `--output-dir`.
 
 ## [0.38.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### CLI
+## [0.38.1] - 2026-05-27
 
-- **Auth commands grouped under `texra auth`** — `login`, `logout`, `status`, and `usage` now live under `texra auth`, with `texra login` / `texra logout` kept as top-level shortcuts. The standalone top-level `texra usage` was removed; use `texra auth usage`.
-- **Inspect stored memories from the terminal** — new `texra memory list` and `texra memory show` mirror the in-chat `/memory` view.
-- **`texra tools show`** is now the canonical per-tool inspector (matching `agents`/`models`), with `texra tools status` kept as an alias.
-- **Clearer, safer help and defaults** — `--approval-policy` now documents that `ask` is the default and that `never` denies every privileged action; `texra init` defaults to `ask` instead of the deny-all `never`; `run --input`/`--context` are marked repeatable and `--output` vs `--output-dir` are disambiguated.
+### Features
 
-## [0.38.1] - 2026-05-25
+- **CLI tools, memory, and init** — new `texra tools` (`list`, `show`, `enable`, `disable`, `install`, `auth`) and `texra memory` (`list`, `show`) command groups, plus a `texra init` wizard that writes `.texra/config.json` and gitignores it. The TUI gets a matching `/tools` slash command.
 
 ### Bug Fixes
 
-- **Settings view tabs load correctly again** — Models, History, Agents, LaTeX, Memory, and approval settings now populate on first open.
+- Bug fixes on settings tabs loading, "Compare with base" diffing against the live workspace file, and progress-log replay preserving initial entries.
 
 ### Improvements
 
 - **Cleaner history rows** — each entry now puts the metadata (timestamp, agent, model, inputs) and action buttons on top, keeps Context / Config visible inline, and collapses very long instruction prompts behind a "Show full instructions" toggle.
+- **Merge shows up on the progress board** — running a merge now creates a normal task entry with progress, logs, and outputs like every other agent, and saves its result under the input filename instead of `_full.tex`.
+- **CLI auth grouped under `texra auth`** — `login`, `logout`, `status`, and `usage` now live under `texra auth` (with `texra login` / `texra logout` kept as top-level shortcuts). Clearer `--approval-policy` help, safer defaults (`texra init` defaults to `ask`), and disambiguated `--output` vs `--output-dir`.
 
 ## [0.38.0] - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TeXRA: Multi-Agent AI Research Assistant for TeX
+# TeXRA: Multi-Agent AI Research Assistant for Theorists
 
 [![VS Code Marketplace](https://vsmarketplacebadges.dev/version-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![Installs](https://vsmarketplacebadges.dev/installs-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
@@ -6,7 +6,6 @@
 [![Rating](https://vsmarketplacebadges.dev/rating-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
-[![License](https://img.shields.io/badge/license-Proprietary-blue)](https://texra.ai/terms)
 [![npm version](https://img.shields.io/npm/v/@texra-ai/cli?label=%40texra-ai%2Fcli)](https://www.npmjs.com/package/@texra-ai/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@texra-ai/cli)](https://www.npmjs.com/package/@texra-ai/cli)
 
@@ -22,7 +21,7 @@
 > [Buy Me a Coffee](https://buymeacoffee.com/texra.ai) to keep the program
 > open for everyone.
 
-**TeXRA is a multi-agent research assistant for LaTeX — in VS Code and the
+**TeXRA is a multi-agent research assistant for theorists (Physics, Math, CS, Engineering, etc.)— in VS Code and the
 terminal.** Instead of chatting with a single model, you direct an
 **Orchestrator** that delegates to a team of specialists—researchers,
 numericists, reviewers, formalizers, LaTeX fixers, presenters—each with their

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -12,15 +12,14 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
-import { getAcceptedFileTarget } from '@latex/acceptedFileTarget';
+import {
+  getAcceptedFileTarget,
+  siblingLocation,
+  type AcceptedFileTarget,
+} from '@latex/acceptedFileTarget';
 import * as logger from '@logger/logUtils';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latex';
-import {
-  createExternalLocation,
-  createRunStorageLocation,
-  createWorkspaceLocation,
-  flexibleFS,
-} from '@utils/files';
+import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 
 /** Run agent/model/round used to build the legacy postfixed copy name. */
@@ -145,60 +144,44 @@ function buildCopyTarget(
   baseLocation: FileLocation,
   copyMeta: AcceptCopyMeta,
 ): { targetLocation: FileLocation; targetFileName: string } {
-  const ext = path.extname(baseLocation.absolutePath);
+  const parsed = path.parse(baseLocation.absolutePath);
   const stem = legacyWorkflowOutputStem({
-    base: path.parse(baseLocation.absolutePath).name,
+    base: parsed.name,
     agent: copyMeta.agent,
     model: copyMeta.model,
     round: copyMeta.round,
   });
-  const targetFileName = `${stem}${ext}`;
-  const targetAbsolute = path.join(
-    path.dirname(baseLocation.absolutePath),
+  const targetFileName = `${stem}${parsed.ext}`;
+  return {
+    targetLocation: siblingLocation(baseLocation, targetFileName),
     targetFileName,
-  );
-
-  if (baseLocation.kind === 'external') {
-    return {
-      targetLocation: createExternalLocation(targetAbsolute),
-      targetFileName,
-    };
-  }
-
-  const targetRelative = path.join(
-    path.dirname(baseLocation.relativePath),
-    targetFileName,
-  );
-  const targetLocation =
-    baseLocation.kind === 'workspace'
-      ? createWorkspaceLocation(targetAbsolute, targetRelative)
-      : createRunStorageLocation(
-          targetAbsolute,
-          targetRelative,
-          baseLocation.executionId,
-        );
-  return { targetLocation, targetFileName };
+  };
 }
 
 /** Original single-confirm flow used when no run metadata is available. */
 async function confirmReplace(
-  target: ReturnType<typeof getAcceptedFileTarget>,
+  target: AcceptedFileTarget,
   basePath: string,
   editedPath: string,
 ): Promise<boolean> {
   const { targetLocation, targetFileName, isNewFile } = target;
   const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
-  const baseExt = path.extname(basePath).toLowerCase();
-  const editedExt = path.extname(editedPath).toLowerCase();
 
-  const action = targetExists
-    ? 'overwrite existing'
-    : isNewFile
-      ? 'create'
-      : 'overwrite';
-  const extensionNote = isNewFile
-    ? `Extensions differ (${baseExt} vs ${editedExt}). `
-    : '';
+  let action: string;
+  if (targetExists) {
+    action = 'overwrite existing';
+  } else if (isNewFile) {
+    action = 'create';
+  } else {
+    action = 'overwrite';
+  }
+
+  let extensionNote = '';
+  if (isNewFile) {
+    const baseExt = path.extname(basePath).toLowerCase();
+    const editedExt = path.extname(editedPath).toLowerCase();
+    extensionNote = `Extensions differ (${baseExt} vs ${editedExt}). `;
+  }
   const confirmMessage = `${extensionNote}This will ${action} '${targetFileName}' with content from '${path.basename(editedPath)}'. Are you sure?`;
 
   const answer = await vscode.window.showWarningMessage(

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -526,8 +526,7 @@ export class FileList extends LitElement {
     if (loc.kind === 'workspace' || loc.kind === 'runStorage') {
       return loc.relativePath;
     }
-    const normalized = loc.absolutePath.replaceAll('\\', '/');
-    return normalized.slice(normalized.lastIndexOf('/') + 1);
+    return parsePath(loc.absolutePath).basename;
   }
 
   /**

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -18,6 +18,36 @@ export type AcceptedFileTarget = {
   isNewFile: boolean;
 };
 
+/**
+ * Build a FileLocation that sits beside {@link baseLocation} but uses
+ * {@link targetFileName}, preserving the base's location kind (workspace,
+ * runStorage, or external) and propagating its workspace-relative directory.
+ */
+export function siblingLocation(
+  baseLocation: FileLocation,
+  targetFileName: string,
+): FileLocation {
+  const targetAbsolutePath = path.join(
+    path.dirname(baseLocation.absolutePath),
+    targetFileName,
+  );
+  if (baseLocation.kind === 'external') {
+    return createExternalLocation(targetAbsolutePath);
+  }
+  const targetRelativePath = path.join(
+    path.dirname(baseLocation.relativePath),
+    targetFileName,
+  );
+  if (baseLocation.kind === 'workspace') {
+    return createWorkspaceLocation(targetAbsolutePath, targetRelativePath);
+  }
+  return createRunStorageLocation(
+    targetAbsolutePath,
+    targetRelativePath,
+    baseLocation.executionId,
+  );
+}
+
 export function getAcceptedFileTarget(
   baseLocation: FileLocation,
   editedPath: string,
@@ -43,28 +73,10 @@ export function getAcceptedFileTarget(
   const targetFileName = agentSuffix
     ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
     : path.basename(editedPath);
-  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
 
-  if (baseLocation.kind === 'external') {
-    return {
-      targetLocation: createExternalLocation(targetAbsolutePath),
-      targetFileName,
-      isNewFile: true,
-    };
-  }
-
-  const targetRelativePath = path.join(
-    path.dirname(baseLocation.relativePath),
+  return {
+    targetLocation: siblingLocation(baseLocation, targetFileName),
     targetFileName,
-  );
-  const targetLocation =
-    baseLocation.kind === 'workspace'
-      ? createWorkspaceLocation(targetAbsolutePath, targetRelativePath)
-      : createRunStorageLocation(
-          targetAbsolutePath,
-          targetRelativePath,
-          baseLocation.executionId,
-        );
-
-  return { targetLocation, targetFileName, isNewFile: true };
+    isNewFile: true,
+  };
 }


### PR DESCRIPTION
## Summary

- Extract a `siblingLocation()` helper so the new compare-with-base `buildCopyTarget` no longer duplicates the workspace/runStorage/external switch from `getAcceptedFileTarget`. Also reuse `parsePath` in `FileList.getCompactDisplayPath` and split an awkward inline-ternary in `confirmReplace`. All behaviour-preserving.
- Fill in the `[0.38.1]` CHANGELOG section: 0.38.1 was bumped in `package.json` but never tagged, and several user-visible changes have landed since — the compare-with-base + progress-log replay fixes (#4500, #4499), the merge-as-workflow refactor (#4501), and the new CLI tools/memory/init command groups plus auth grouping (#4486, #4498). Bug fixes are collapsed to a single terse line.
- Broaden the README tagline from "for TeX" / "for LaTeX" to "for Theorists (Physics, Math, CS, Engineering, etc.)" and drop the standalone Proprietary license badge.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build:fast` (produces `releases/texra-0.38.1.vsix`)
- [x] `packages/cli` `npm run build`
- [ ] Spot-check the CHANGELOG and README render as intended on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, marketing copy, and internal refactors with no new user-facing accept/compare behavior.
> 
> **Overview**
> Documents **0.38.1** in `CHANGELOG.md` (CLI tools/memory/init, auth grouping, merge on progress board, history UI, and bundled bug-fix notes) and retitles the **Unreleased** section. **README** now positions TeXRA for theorists across disciplines instead of LaTeX-only, and drops the standalone Proprietary license badge.
> 
> Refactors accept/compare paths by adding **`siblingLocation()`** in `acceptedFileTarget.ts` and reusing it from **`getAcceptedFileTarget`** and **`buildCopyTarget`** in compare commands, removing duplicated workspace/runStorage/external branching. **`confirmReplace`** uses explicit branches instead of nested ternaries; **`FileList.getCompactDisplayPath`** uses shared **`parsePath`** for external basenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cd0b9f394392cc21c9e695c7a39f07e6d552e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->