### PR TITLE
refactor(merge): route through texra.execute / runExecution like other agents

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1249,22 +1249,15 @@ export class DesktopProgressBridge {
     baseFile: string,
     editedFile: string,
   ): Promise<void> {
-    const [{ executeAgent }, { getHelperModelName }] = await Promise.all([
-      import('@agent/runtime/executeAgent'),
-      import('@agent/runtime/helperModel'),
-    ]);
-    // Merge runs as a normal workflow agent (merge.yaml): original as the
-    // input file, the partially-edited document as the edited file.
-    await executeAgent(
-      {
+    const { getHelperModelName } = await import('@agent/runtime/helperModel');
+    await this.runExecution({
+      config: {
         agent: 'merge',
         model: getHelperModelName(),
         inputFiles: [baseFile],
         editedFile,
       },
-      undefined,
-      { runtimeHost: this.runtimeHost },
-    );
+    });
   }
 
   private async acceptEditedFile(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1249,8 +1249,12 @@ export class DesktopProgressBridge {
     baseFile: string,
     editedFile: string,
   ): Promise<void> {
-    const { getHelperModelName } = await import('@agent/runtime/helperModel');
-    await this.runExecution({
+    const [{ getHelperModelName }, { validateExecutionRequest }] =
+      await Promise.all([
+        import('@agent/runtime/helperModel'),
+        import('@agent/core/executionRequests'),
+      ]);
+    const validation = validateExecutionRequest({
       config: {
         agent: 'merge',
         model: getHelperModelName(),
@@ -1258,6 +1262,11 @@ export class DesktopProgressBridge {
         editedFile,
       },
     });
+    if (!validation.valid) {
+      await this.showErrorMessage(`Merge: ${validation.message}`);
+      return;
+    }
+    await this.runExecution(validation.request);
   }
 
   private async acceptEditedFile(

--- a/packages/extension/src/commands/agent/mergeCommands.ts
+++ b/packages/extension/src/commands/agent/mergeCommands.ts
@@ -2,9 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { executeAgent } from '@agent/runtime/executeAgent';
 import { getHelperModelName } from '@agent/runtime/helperModel';
-import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 
 const CHANNEL = 'MergeCommands';
@@ -31,17 +29,10 @@ async function handleMerge(
     return;
   }
 
-  // Merge is a normal prompt-driven workflow agent (see merge.yaml); it runs
-  // through the generic agent path with the original as the input file and the
-  // partially-edited document as the edited file.
-  await executeAgent(
-    {
-      agent: 'merge',
-      model: model ?? getHelperModelName(),
-      inputFiles: [baseFile ?? inputFile],
-      editedFile,
-    },
-    undefined,
-    { runtimeHost: extensionAgentRuntimeHost },
-  );
+  await vscode.commands.executeCommand('texra.execute', {
+    agent: 'merge',
+    model: model ?? getHelperModelName(),
+    inputFiles: [baseFile ?? inputFile],
+    editedFile,
+  });
 }

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -402,9 +402,8 @@ export class FileList extends LitElement {
     const location = file.location;
     // Prefer: workspace original → source doc name → run-storage relative path.
     // Use the compact variant so an external location (e.g. a run-storage file
-    // outside the workspace root, like the merge agent's `_full.tex`) shows its
-    // basename instead of a long absolute path; the full path stays in the
-    // tooltip below.
+    // outside the workspace root) shows its basename instead of a long absolute
+    // path; the full path stays in the tooltip below.
     const displayPath =
       this.getCompactDisplayPath(file.lineage?.original) ||
       this.getSourceDisplayPath(file.source) ||


### PR DESCRIPTION
## Summary

Follow-up to #4501. That PR routed `merge` through the generic `executeAgent` layer like every other prompt-driven workflow agent, but the two entry points (VS Code command + desktop bridge) still called `executeAgent` directly with their own runtime-host wiring. `latexFixer` and every other prompt-driven agent go through the shared dispatchers instead — this PR brings `merge` in line.

## Changes

- **`packages/extension/src/commands/agent/mergeCommands.ts`** — `handleMerge` now uses `vscode.commands.executeCommand('texra.execute', {...})` (same shape as `handleFixCompilation`/latexFixer). Drops the direct `executeAgent` + `extensionAgentRuntimeHost` imports.
- **`packages/desktop/src/main/desktopAgentExecution.ts`** — `runMergeFile` now calls `this.runExecution({ config: ... })`, same shape as the main desktop execution path.
- **`packages/extension/src/progressView/frontend/components/FileList.ts`** — drop comment referencing the deleted `_full.tex` layout from #4501.

## What this gains

Routing through the shared dispatchers gives the merge entry points everything other agents already had:

- **Zod validation** via `AgentConfigSchema.parse` (extension side; bad configs now produce a user-visible error message instead of an unhandled rejection).
- **Auto-wired runtime host** — no `extensionAgentRuntimeHost`/`this.runtimeHost` plumbing at call sites.
- **`openFinalOutputIfAvailable` / `openWorkflowOutput`** post-execution hook — the merge output now opens after completion, matching every other workflow agent.
- **`registerExecution`** call — merge runs now appear in execution history.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`pnpm vitest run src/test-kernel/agent src/test-kernel/desktop\` — 420/420 pass
- [ ] Manual: trigger \`texra.merge\` from the extension and confirm output opens
- [ ] Manual: trigger merge from desktop bridge and confirm output opens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors entry-point wiring only; merge behavior stays on the existing merge agent and shared execution stack with added validation.
> 
> **Overview**
> **Merge** no longer calls `executeAgent` directly from the VS Code command or the desktop progress bridge. Both entry points now use the same shared execution dispatch as other workflow agents.
> 
> In the extension, `texra.merge` delegates to **`texra.execute`** with the merge agent config (base/input + `editedFile`), dropping local `extensionAgentRuntimeHost` wiring. On desktop, **`runMergeFile`** builds a request via **`validateExecutionRequest`**, surfaces validation errors to the user, then runs **`runExecution`** (same path as other desktop runs, including post-run output opening and execution registration).
> 
> A small comment tweak in the progress **FileList** UI removes an outdated reference to merge-specific `_full.tex` layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a32176322b4981aa9ba357b6a63f44e3fbaa32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->