### PR TITLE
Consolidate duplicate helpers: capitalize, truncate, isPlainObject

### DIFF
--- a/packages/extension/src/progressView/persistence/mementoMigration.ts
+++ b/packages/extension/src/progressView/persistence/mementoMigration.ts
@@ -12,6 +12,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { isPlainObject } from '@shared/utils/string';
 import { getStreamTabStore, mapStreamTabStorage } from './StreamTabStore';
 import type {
   StreamTabMeta,
@@ -180,9 +181,6 @@ function isNonNullObject(value: unknown): value is Record<string, unknown> {
 function extractTaskStateEntries(
   raw: Record<string, unknown>,
 ): [string, unknown][] {
-  const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-    typeof v === 'object' && v !== null && !Array.isArray(v);
-
   const legacyBuckets = [raw.workflow, raw.toolUse].filter(isPlainObject);
   if (legacyBuckets.length > 0) {
     return legacyBuckets.flatMap((bucket) =>

--- a/src/shared/utils/string.ts
+++ b/src/shared/utils/string.ts
@@ -1,6 +1,4 @@
-export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
+export { capitalize } from '@utils/text/stringUtils';
 
 export function isPlainObject(
   value: unknown,

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -7,7 +7,6 @@
  * paths (PR / repo / issue).
  */
 
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 
 const WEBHOOK_TAG = 'github-webhook-activity';
@@ -65,7 +64,8 @@ export function sections(
 
 export function truncate(s: string | null | undefined, max: number): string {
   const body = (s ?? '').trim();
-  return truncateWithEllipsis(body, max + 1);
+  if (body.length <= max) return body;
+  return body.slice(0, max) + '…';
 }
 
 /** Newest `updated_at` (falling back to `created_at`) in a list, or undefined. */

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -7,6 +7,7 @@
  * paths (PR / repo / issue).
  */
 
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 
 const WEBHOOK_TAG = 'github-webhook-activity';
@@ -64,8 +65,7 @@ export function sections(
 
 export function truncate(s: string | null | undefined, max: number): string {
   const body = (s ?? '').trim();
-  if (body.length <= max) return body;
-  return body.slice(0, max) + '…';
+  return truncateWithEllipsis(body, max + 1);
 }
 
 /** Newest `updated_at` (falling back to `created_at`) in a list, or undefined. */


### PR DESCRIPTION
## Summary

- **`capitalize`** was implemented identically in both `src/shared/utils/string.ts` and `src/utils/text/stringUtils.ts`. Changed `shared/utils/string.ts` to re-export it from `stringUtils` so a single implementation serves all callers — the `@shared/utils/string` import path used by webview code is unchanged.

- **`formatUtils.truncate`** (GitHub event formatters) duplicated the truncation logic already in `truncateWithEllipsis`. Now delegates to it via `truncateWithEllipsis(body, max + 1)`, which produces identical output (`body.slice(0, max) + '…'`).

- **Inline `isPlainObject`** in `mementoMigration.ts` was a byte-for-byte copy of the one in `@shared/utils/string`. Replaced with an import.

## Test plan

- [x] `npm run compile:fast` builds cleanly (all 3 Vite/esbuild targets pass)
- [x] `npm run lint` — no new errors (pre-existing unrelated warning only)
- [x] All existing callers of `capitalize`, `truncate`, and `isPlainObject` continue to import from their existing paths without modification

https://claude.ai/code/session_01SNtmKSGRYpPdEsefCet5jA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNtmKSGRYpPdEsefCet5jA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactors in shared utilities and one-time memento migration parsing, with no auth, data, or API surface changes.
> 
> **Overview**
> Deduplicates small string/object helpers so callers keep the same import paths.
> 
> `@shared/utils/string` now **re-exports `capitalize`** from `@utils/text/stringUtils` instead of defining it again. **`mementoMigration.ts`** drops its inline `isPlainObject` and uses the shared helper from `@shared/utils/string` when parsing legacy task-state buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b0d18a041850efe11c5ca6a13021e6a1ff9d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->