### PR TITLE
Mark CLI agent commits with the TeXRA author by default

### DIFF
--- a/packages/cli/src/runtime/gitAuthor.ts
+++ b/packages/cli/src/runtime/gitAuthor.ts
@@ -1,0 +1,43 @@
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import {
+  DEFAULT_GIT_AUTHOR_EMAIL,
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_MARK_COMMITS,
+} from '@shared/constants/git';
+import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+
+import type { ConfigProvider } from '@platform/interfaces/config';
+
+/**
+ * Mirror the extension's git-author marking for the CLI: by default, commits
+ * made by spawned `git` processes are attributed to the TeXRA identity so that
+ * agent-authored commits are distinguishable from the user's own.
+ *
+ * Read from `.texra/config.json` (the CLI's platform config) so it can be
+ * turned off or customized without code changes:
+ *
+ * - `texra.git.markCommits` (default `true`) — enable/disable the marking.
+ * - `texra.git.authorName` / `texra.git.authorEmail` — override the identity.
+ */
+export function applyCliGitAuthorConfig(config: ConfigProvider): void {
+  const markCommits = config.get<boolean>(
+    WorkspaceStateKey.GIT_MARK_COMMITS,
+    DEFAULT_GIT_MARK_COMMITS,
+  );
+  if (!markCommits) {
+    setGitAuthorEnv({});
+    return;
+  }
+  const authorName =
+    config.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME, '') ||
+    DEFAULT_GIT_AUTHOR_NAME;
+  const authorEmail =
+    config.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL, '') ||
+    DEFAULT_GIT_AUTHOR_EMAIL;
+  setGitAuthorEnv({
+    GIT_AUTHOR_NAME: authorName,
+    GIT_AUTHOR_EMAIL: authorEmail,
+    GIT_COMMITTER_NAME: authorName,
+    GIT_COMMITTER_EMAIL: authorEmail,
+  });
+}

--- a/packages/cli/src/runtime/gitAuthor.ts
+++ b/packages/cli/src/runtime/gitAuthor.ts
@@ -1,10 +1,7 @@
-import { WorkspaceStateKey } from '@common/state/stateKeys';
 import {
-  DEFAULT_GIT_AUTHOR_EMAIL,
-  DEFAULT_GIT_AUTHOR_NAME,
-  DEFAULT_GIT_MARK_COMMITS,
-} from '@shared/constants/git';
-import { applyGitAuthorSettings } from '@utils/system/gitAuthorSettings';
+  applyGitAuthorSettings,
+  readGitAuthorSettingsFromState,
+} from '@utils/system/gitAuthorSettings';
 
 import type { ConfigProvider } from '@platform/interfaces/config';
 
@@ -22,20 +19,5 @@ import type { ConfigProvider } from '@platform/interfaces/config';
  * - `texra.git.worktreeSupport` (default `false`) — subagent worktree opt-in.
  */
 export function applyCliGitAuthorConfig(config: ConfigProvider): void {
-  applyGitAuthorSettings({
-    markCommits: config.get<boolean>(
-      WorkspaceStateKey.GIT_MARK_COMMITS,
-      DEFAULT_GIT_MARK_COMMITS,
-    ),
-    authorName:
-      config.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME, '') ||
-      DEFAULT_GIT_AUTHOR_NAME,
-    authorEmail:
-      config.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL, '') ||
-      DEFAULT_GIT_AUTHOR_EMAIL,
-    worktreeSupport: config.get<boolean>(
-      WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
-      false,
-    ),
-  });
+  applyGitAuthorSettings(readGitAuthorSettingsFromState(config));
 }

--- a/packages/cli/src/runtime/gitAuthor.ts
+++ b/packages/cli/src/runtime/gitAuthor.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_MARK_COMMITS,
 } from '@shared/constants/git';
-import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+import { applyGitAuthorSettings } from '@utils/system/gitAuthorSettings';
 
 import type { ConfigProvider } from '@platform/interfaces/config';
 
@@ -13,31 +13,29 @@ import type { ConfigProvider } from '@platform/interfaces/config';
  * made by spawned `git` processes are attributed to the TeXRA identity so that
  * agent-authored commits are distinguishable from the user's own.
  *
- * Read from `.texra/config.json` (the CLI's platform config) so it can be
- * turned off or customized without code changes:
+ * The extension reads these from workspace state; the CLI reads the same keys
+ * from `.texra/config.json` (the CLI's platform config) so they can be turned
+ * off or customized without code changes:
  *
  * - `texra.git.markCommits` (default `true`) — enable/disable the marking.
  * - `texra.git.authorName` / `texra.git.authorEmail` — override the identity.
+ * - `texra.git.worktreeSupport` (default `false`) — subagent worktree opt-in.
  */
 export function applyCliGitAuthorConfig(config: ConfigProvider): void {
-  const markCommits = config.get<boolean>(
-    WorkspaceStateKey.GIT_MARK_COMMITS,
-    DEFAULT_GIT_MARK_COMMITS,
-  );
-  if (!markCommits) {
-    setGitAuthorEnv({});
-    return;
-  }
-  const authorName =
-    config.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME, '') ||
-    DEFAULT_GIT_AUTHOR_NAME;
-  const authorEmail =
-    config.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL, '') ||
-    DEFAULT_GIT_AUTHOR_EMAIL;
-  setGitAuthorEnv({
-    GIT_AUTHOR_NAME: authorName,
-    GIT_AUTHOR_EMAIL: authorEmail,
-    GIT_COMMITTER_NAME: authorName,
-    GIT_COMMITTER_EMAIL: authorEmail,
+  applyGitAuthorSettings({
+    markCommits: config.get<boolean>(
+      WorkspaceStateKey.GIT_MARK_COMMITS,
+      DEFAULT_GIT_MARK_COMMITS,
+    ),
+    authorName:
+      config.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME, '') ||
+      DEFAULT_GIT_AUTHOR_NAME,
+    authorEmail:
+      config.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL, '') ||
+      DEFAULT_GIT_AUTHOR_EMAIL,
+    worktreeSupport: config.get<boolean>(
+      WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+      false,
+    ),
   });
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -29,6 +29,7 @@ import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter'
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
 // Local imports - CLI runtime
+import { applyCliGitAuthorConfig } from './gitAuthor';
 import { getCliSecrets } from './cliSecrets';
 import { writeTextStderr } from './logSinks';
 import { workspaceCliConfigPath } from './cliConfig';
@@ -140,8 +141,9 @@ export async function initCliPlatform(
         );
       },
     });
+    const config = new JsonConfigProvider({ workspace: configStore });
     initPlatform({
-      config: new JsonConfigProvider({ workspace: configStore }),
+      config,
       globalState: stateStores.globalState,
       workspaceState: stateStores.workspaceState,
       fs: nodeFilesystem,
@@ -159,6 +161,10 @@ export async function initCliPlatform(
     const leanAdapter = createDirectLspLeanAdapter();
     setLeanLanguageServices(leanAdapter);
     lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
+
+    // Attribute agent-authored commits to the TeXRA identity by default;
+    // configurable via `.texra/config.json` `texra.git.markCommits`.
+    applyCliGitAuthorConfig(config);
   }
 
   if (!serverSideKeysInitialized) {

--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -1,3 +1,6 @@
+// Local imports - shared state keys (canonical git-author key names)
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+
 // Local imports - shared core schema
 import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
 
@@ -19,8 +22,8 @@ export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   // Git commit-author marking is stored as workspace state in the VS Code
   // extension, but the CLI reads it from `.texra/config.json`. Recognize the
   // keys here so they don't warn as unknown.
-  'texra.git.markCommits',
-  'texra.git.authorName',
-  'texra.git.authorEmail',
-  'texra.git.worktreeSupport',
+  WorkspaceStateKey.GIT_MARK_COMMITS,
+  WorkspaceStateKey.GIT_AUTHOR_NAME,
+  WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+  WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
 ]);

--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -16,4 +16,10 @@ import { CLI_SETTING_PATHS } from './cliSettings';
 export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   ...CORE_SETTING_PATHS.map((path) => `texra.${path}`),
   ...CLI_SETTING_PATHS.map((path) => `texra.${path}`),
+  // Git commit-author marking is stored as workspace state in the VS Code
+  // extension, but the CLI reads it from `.texra/config.json`. Recognize the
+  // keys here so they don't warn as unknown.
+  'texra.git.markCommits',
+  'texra.git.authorName',
+  'texra.git.authorEmail',
 ]);

--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -22,4 +22,5 @@ export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   'texra.git.markCommits',
   'texra.git.authorName',
   'texra.git.authorEmail',
+  'texra.git.worktreeSupport',
 ]);


### PR DESCRIPTION
Apply the git author/committer identity in the CLI platform init the
same way the VS Code extension does at activation, so commits made by
spawned git processes are attributed to texra-ai. Defaults on and is
configurable via .texra/config.json (texra.git.markCommits, plus
authorName/authorEmail overrides).

https://claude.ai/code/session_01PWGvC99t2da1H93H38Vuw7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only how spawned git processes set author/committer env vars; default-on but opt-out via config, with no auth or data-path changes.
> 
> **Overview**
> The CLI now applies the same **git author/committer marking** as the VS Code extension during platform init, so commits from spawned `git` processes are attributed to the TeXRA identity by default and stay distinguishable from the user’s commits.
> 
> Settings are read from `.texra/config.json` via the shared `readGitAuthorSettingsFromState` / `applyGitAuthorSettings` helpers (`texra.git.markCommits`, optional name/email overrides, `texra.git.worktreeSupport`). Those keys are added to `KNOWN_TEXRA_KEYS` so they are not flagged as unknown when validating config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fe18a46bcfadabf8fbb20b0e603b537ddcc32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->