### PR TITLE
fix(cli): stop approval modals stretching to full terminal height

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -323,7 +323,11 @@ export function App(props: AppProps): React.JSX.Element {
             />
           ) : null}
           {foregroundSurface ? (
-            <Box height={foregroundRows} overflowY="hidden">
+            <Box
+              height={foregroundRows}
+              alignItems="flex-start"
+              overflowY="hidden"
+            >
               {foregroundSurface}
             </Box>
           ) : null}


### PR DESCRIPTION
The foreground surface wrapper is a default row-direction flex container
with a fixed height, so its default alignItems:stretch grew small
approval cards (bash, plan, retry) to fill the whole reserved area.
Pin children to flex-start so each surface hugs its content height;
EditApproval/forms already size themselves via availableRows.

https://claude.ai/code/session_01SxygYFQ78usHY37WhqxgiH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout prop on the CLI TUI foreground container; no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes approval and other foreground overlays stretching to the full height of the reserved middle area in the Ink TUI.
> 
> The wrapper around `foregroundSurface` (approvals, forms, child-control picker) still gets a fixed `height={foregroundRows}`, but **`alignItems` is set to `flex-start`** so children size to their content instead of stretching on the default cross-axis behavior. Modal content that already uses `availableRows` should look compact again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341130d035835beebf8c2144b15c9e5899cb65e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->