### PR TITLE
feat(cli): support Shift+Enter for newline in the chat TUI

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -2,8 +2,8 @@
 // todos panels at the bottom, then status, approval modal, and input bar.
 // Tab / Shift-Tab cycles focus across subagent streams.
 
-import { Box, useInput, useWindowSize } from 'ink';
-import { useState } from 'react';
+import { Box, useInput, useStdin, useWindowSize } from 'ink';
+import { useEffect, useState } from 'react';
 
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
 import { REVERSE_SEARCH_ROWS } from './input/ReverseSearch';
@@ -18,7 +18,11 @@ import { SubagentList } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
-import { metaChordDigit, metaChordInput } from './input/inputKeys';
+import {
+  isKittyKeypadEnter,
+  metaChordDigit,
+  metaChordInput,
+} from './input/inputKeys';
 import {
   hasChildExecutionRows,
   numericFocusTarget,
@@ -28,6 +32,15 @@ import { canShowSubagentControls, cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { useSignal } from './state/useSignal';
 import type { InputHistory } from './history/inputHistory';
+
+// Subset of Ink's internal stdin event emitter (the same channel `useInput`
+// consumes) needed to re-inject a synthesized Enter. Not part of `useStdin`'s
+// public type, so we narrow to just what we touch.
+interface InputEventEmitterLike {
+  emit(event: 'input', data: string): void;
+  on(event: 'input', listener: (data: string) => void): void;
+  off(event: 'input', listener: (data: string) => void): void;
+}
 
 const MIN_TRANSCRIPT_WIDTH = 20;
 const FOREGROUND_TRANSCRIPT_ROWS = 1;
@@ -187,6 +200,25 @@ export function App(props: AppProps): React.JSX.Element {
   const [childControlMode, setChildControlMode] = useState<
     ChildControlMode | undefined
   >(undefined);
+
+  // The Kitty disambiguate flag makes keypad Enter a distinct key that Ink's
+  // `useInput` never surfaces (see isKittyKeypadEnter). Re-dispatch it on Ink's
+  // own input channel as a plain Enter (CR) so every submit/confirm path that
+  // keys off `key.return` keeps working. Inert when the protocol is off — the
+  // sequence simply never arrives.
+  const stdin = useStdin();
+  useEffect(() => {
+    const emitter = (
+      stdin as unknown as { internal_eventEmitter?: InputEventEmitterLike }
+    ).internal_eventEmitter;
+    if (!emitter) return;
+    const onInput = (data: string): void => {
+      if (isKittyKeypadEnter(data))
+        emitter.emit('input', String.fromCharCode(13));
+    };
+    emitter.on('input', onInput);
+    return () => emitter.off('input', onInput);
+  }, [stdin]);
   const foregroundOpen =
     pending !== undefined ||
     activeForm !== undefined ||

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -17,7 +17,11 @@ import {
   insertText,
   type TextEdit,
 } from './textInputEditing';
-import { isPlainReturnInput, metaChordInput } from './inputKeys';
+import {
+  isPlainReturnInput,
+  isShiftReturnInput,
+  metaChordInput,
+} from './inputKeys';
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -88,8 +92,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   useInput(
     (input, key) => {
-      if (key.ctrl && input === 'j') {
-        // Ctrl-J → literal newline (kills the legacy `/multi` ceremony).
+      if ((key.ctrl && input === 'j') || isShiftReturnInput(input, key)) {
+        // Ctrl-J (universal) or Shift+Enter (Kitty-protocol terminals) →
+        // literal newline. Kills the legacy `/multi` ceremony.
         applyEdit(insertText(value, cursor, '\n'));
         return;
       }

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -49,3 +49,18 @@ export function isShiftReturnInput(
   if (key.ctrl || key.meta || key.shift !== true) return false;
   return key.return === true || input === '\r' || input === '\n';
 }
+
+// Under the Kitty disambiguate flag, terminals report keypad Enter as its own
+// key (codepoint 57414, "kpenter") distinct from the main Enter (codepoint 13).
+// Ink parses it but `useInput` surfaces no field for it, so keypad Enter would
+// silently stop submitting once the protocol is on. App.tsx re-dispatches this
+// raw sequence as a plain Enter. Matches only the unmodified form (bare, or the
+// explicit "no modifiers" `;1`) so Ctrl/Alt+keypad-Enter pass through untouched.
+const KITTY_KEYPAD_ENTER = new Set([
+  `${String.fromCharCode(27)}[57414u`,
+  `${String.fromCharCode(27)}[57414;1u`,
+]);
+
+export function isKittyKeypadEnter(data: string): boolean {
+  return KITTY_KEYPAD_ENTER.has(data);
+}

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -2,6 +2,7 @@ export interface ReturnKeyInput {
   readonly return?: boolean;
   readonly ctrl?: boolean;
   readonly meta?: boolean;
+  readonly shift?: boolean;
 }
 
 export function metaChordInput(
@@ -31,6 +32,20 @@ export function isPlainReturnInput(
   input: string,
   key: ReturnKeyInput,
 ): boolean {
-  if (key.ctrl || key.meta || metaChordInput(input, key)) return false;
+  if (key.ctrl || key.meta || key.shift || metaChordInput(input, key))
+    return false;
+  return key.return === true || input === '\r' || input === '\n';
+}
+
+// Shift+Enter → literal newline, the ergonomic twin of Ctrl-J. Ink only
+// reports `key.shift` on Enter when the Kitty keyboard protocol is active
+// (enabled in runChatTui for terminals that support it). On terminals without
+// it, Shift+Enter is byte-identical to Enter and falls through to submit, so
+// Ctrl-J remains the universal fallback.
+export function isShiftReturnInput(
+  input: string,
+  key: ReturnKeyInput,
+): boolean {
+  if (key.ctrl || key.meta || key.shift !== true) return false;
   return key.return === true || input === '\r' || input === '\n';
 }

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -28,12 +28,17 @@ export function metaChordDigit(
     : undefined;
 }
 
+// A return keypress that should act as Enter (submit / confirm / select).
+// Deliberately shift-agnostic: in modals, Select, and the child-control picker
+// Shift+Enter has no newline meaning and must still confirm. The text editor is
+// the only place Shift+Enter differs (→ newline), and it discriminates by
+// testing `isShiftReturnInput` *before* this — so accepting shift here can't
+// make Shift+Enter also submit in the editor.
 export function isPlainReturnInput(
   input: string,
   key: ReturnKeyInput,
 ): boolean {
-  if (key.ctrl || key.meta || key.shift || metaChordInput(input, key))
-    return false;
+  if (key.ctrl || key.meta || metaChordInput(input, key)) return false;
   return key.return === true || input === '\r' || input === '\n';
 }
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@shared/schemas';
 
 import { approvalQueueDepth } from '../state/approvalQueue';
+import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   canShowSubagentControls,
   cliState,
@@ -48,6 +49,9 @@ export interface StatusBarDisplayInput {
   readonly model: string;
   readonly apiMode: string;
   readonly shortcutModifierLabel?: string;
+  /** Advertise Shift+Enter for newline when the Kitty keyboard protocol is
+   *  active; otherwise the universal Ctrl-J is the only reliable binding. */
+  readonly shiftEnterNewline?: boolean;
 }
 
 export interface StatusBarDisplay {
@@ -129,6 +133,7 @@ export function defaultShortcutModifierLabel(
 function statusBarBindings(
   modifierLabel: string,
   hasMultipleStreams: boolean,
+  shiftEnterNewline: boolean,
 ): readonly string[] {
   return [
     // Stream cycling / numeric focus only do something when there is more
@@ -140,7 +145,7 @@ function statusBarBindings(
     '[/status]details',
     '[/model]models',
     '[/api]api',
-    '[Ctrl-J]newline',
+    shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
     '[Ctrl-C]stop',
   ];
 }
@@ -149,9 +154,10 @@ export function statusBarBindingsText(
   subagentControlsAvailable: boolean,
   hasMultipleStreams: boolean,
   modifierLabel = defaultShortcutModifierLabel(),
+  shiftEnterNewline = false,
 ): string {
   const bindings: string[] = [
-    ...statusBarBindings(modifierLabel, hasMultipleStreams),
+    ...statusBarBindings(modifierLabel, hasMultipleStreams, shiftEnterNewline),
   ];
   if (subagentControlsAvailable) {
     const tasksBinding = `[${modifierLabel}-p]tasks`;
@@ -218,6 +224,7 @@ export function buildStatusBarDisplay(
             input.subagentControlsAvailable,
             input.hasMultipleStreams,
             input.shortcutModifierLabel,
+            input.shiftEnterNewline,
           ),
   };
 }
@@ -233,6 +240,7 @@ export function StatusBar(): React.JSX.Element {
   const pendingExitHint = useSignal(cliState.pendingExitHint);
   const pendingExitResumeId = useSignal(cliState.pendingExitResumeId);
   const approvals = useSignal(approvalQueueDepth);
+  const caps = useSignal(terminalCapabilities);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const display = buildStatusBarDisplay({
     status: slice?.status,
@@ -249,6 +257,7 @@ export function StatusBar(): React.JSX.Element {
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
+    shiftEnterNewline: caps.kittyKeyboard,
   });
 
   return (

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -672,7 +672,7 @@ export async function runChat(
   // when `useInput` mounts) caused capability discovery to flip raw mode off
   // ~250ms in, breaking input. Capability-gated notifications fall back to
   // BEL during this window (~250ms typical, hard 250ms cap on no DA1 reply).
-  await discoverTerminalCapabilities({
+  const terminalCaps = await discoverTerminalCapabilities({
     stdin: process.stdin,
     stdout: process.stdout,
   });
@@ -913,6 +913,14 @@ export async function runChat(
       stdout: process.stdout,
       stderr: process.stderr,
       stdin: process.stdin,
+      // Enable the Kitty keyboard protocol (disambiguate flag only) when the
+      // terminal supports it — already confirmed by discoverTerminalCapabilities
+      // above, so use 'enabled' to skip Ink's redundant detection query. This
+      // is what lets Ink distinguish Shift+Enter (newline) from Enter (submit);
+      // plain Enter stays a legacy `\r`, and Ink pops the protocol on unmount.
+      kittyKeyboard: {
+        mode: terminalCaps.kittyKeyboard ? 'enabled' : 'disabled',
+      },
     },
   );
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -39,11 +39,36 @@ describe('CLI StatusBar display model', () => {
     // [Ctrl-J]newline must be visible — the binding exists in BaseTextInput
     // (see #4399) but used to be discoverable only via source diving.
     expect(display.bindings).toContain('[Ctrl-J]newline');
+    expect(display.bindings).not.toContain('[Shift-Enter]newline');
     expect(display.bindings).not.toContain('[Alt-s]subagents');
     // Stream-navigation hints stay hidden in a single-stream chat.
     expect(display.bindings).not.toContain('[Tab]streams');
     expect(display.bindings).not.toContain('[Alt-1..9]focus');
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
+  });
+
+  it('advertises Shift-Enter for newline when the Kitty protocol is active', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUps: 0,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      shiftEnterNewline: true,
+    });
+
+    expect(display.bindings).toContain('[Shift-Enter]newline');
+    expect(display.bindings).not.toContain('[Ctrl-J]newline');
   });
 
   it('shows live running signals and approval depth', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -9,11 +9,14 @@ import {
   insertText,
 } from '@cli/chat/tui/input/textInputEditing';
 import {
+  isKittyKeypadEnter,
   isPlainReturnInput,
   isShiftReturnInput,
   metaChordDigit,
   metaChordInput,
 } from '@cli/chat/tui/input/inputKeys';
+
+const ESC = String.fromCharCode(27);
 
 describe('CLI TUI text input editing', () => {
   it('recognizes normalized and raw Enter without stealing Ctrl-J', () => {
@@ -33,6 +36,15 @@ describe('CLI TUI text input editing', () => {
     expect(isShiftReturnInput('', { return: true })).toBe(false);
     expect(isShiftReturnInput('j', { ctrl: true })).toBe(false);
     expect(isShiftReturnInput('', { return: true, meta: true })).toBe(false);
+  });
+
+  it('recognizes the Kitty keypad-Enter sequence for re-dispatch as Enter', () => {
+    expect(isKittyKeypadEnter(`${ESC}[57414u`)).toBe(true);
+    expect(isKittyKeypadEnter(`${ESC}[57414;1u`)).toBe(true);
+    // Main Enter, plain CR, and modified keypad Enter must not match.
+    expect(isKittyKeypadEnter('\r')).toBe(false);
+    expect(isKittyKeypadEnter(`${ESC}[13u`)).toBe(false);
+    expect(isKittyKeypadEnter(`${ESC}[57414;5u`)).toBe(false);
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -10,6 +10,7 @@ import {
 } from '@cli/chat/tui/input/textInputEditing';
 import {
   isPlainReturnInput,
+  isShiftReturnInput,
   metaChordDigit,
   metaChordInput,
 } from '@cli/chat/tui/input/inputKeys';
@@ -20,8 +21,18 @@ describe('CLI TUI text input editing', () => {
     expect(isPlainReturnInput('\r', {})).toBe(true);
     expect(isPlainReturnInput('\n', {})).toBe(true);
     expect(isPlainReturnInput('j', { ctrl: true })).toBe(false);
+    // Shift+Enter (Kitty protocol) must NOT submit — it inserts a newline.
+    expect(isPlainReturnInput('', { return: true, shift: true })).toBe(false);
     expect(isPlainReturnInput('\n', { ctrl: true })).toBe(false);
     expect(isPlainReturnInput('\u001Bp', {})).toBe(false);
+  });
+
+  it('treats Shift+Enter as a newline, distinct from plain Enter and Ctrl-J', () => {
+    expect(isShiftReturnInput('', { return: true, shift: true })).toBe(true);
+    // Plain Enter, Ctrl-J, and Option+Enter are not Shift+Enter.
+    expect(isShiftReturnInput('', { return: true })).toBe(false);
+    expect(isShiftReturnInput('j', { ctrl: true })).toBe(false);
+    expect(isShiftReturnInput('', { return: true, meta: true })).toBe(false);
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -24,8 +24,9 @@ describe('CLI TUI text input editing', () => {
     expect(isPlainReturnInput('\r', {})).toBe(true);
     expect(isPlainReturnInput('\n', {})).toBe(true);
     expect(isPlainReturnInput('j', { ctrl: true })).toBe(false);
-    // Shift+Enter (Kitty protocol) must NOT submit — it inserts a newline.
-    expect(isPlainReturnInput('', { return: true, shift: true })).toBe(false);
+    // Shift-agnostic: Shift+Enter still confirms in modals/Select. The editor
+    // routes it to a newline by testing isShiftReturnInput first (see below).
+    expect(isPlainReturnInput('', { return: true, shift: true })).toBe(true);
     expect(isPlainReturnInput('\n', { ctrl: true })).toBe(false);
     expect(isPlainReturnInput('\u001Bp', {})).toBe(false);
   });


### PR DESCRIPTION
## Summary

Adds **Shift+Enter** as a newline binding in the `texra chat` / orchestrate TUI, on terminals that support the Kitty keyboard protocol. Enter still submits; Ctrl-J stays the universal fallback.

### Why this is the only way to do bare Shift+Enter

In legacy terminal input mode, Shift+Enter and Enter transmit the *same* byte (`\r`) — they're indistinguishable, which is why Ctrl-J has been the newline binding. The Kitty keyboard protocol's "disambiguate escape codes" mode makes the terminal report Shift+Enter as a distinct `CSI 13;2 u` sequence while leaving plain Enter as `\r`.

The infrastructure was already half-present: `discoverTerminalCapabilities` already detects `kittyKeyboard`, and `RESET_TERMINAL_MODES` already pops the protocol (`\x1b[<u`) — the push was just never wired.

### What changed

- **`runChatTui.tsx`** — pass Ink's `kittyKeyboard: { mode: 'enabled' | 'disabled' }` render option based on the already-detected capability. `'enabled'` (vs `'auto'`) skips Ink's redundant detection query since we've confirmed support. Ink 7.0.4 owns the full lifecycle: enable on mount, parse, pop on unmount — and correctly remaps every other key (verified against Ink's `parse-keypress`/`use-input`).
- **`inputKeys.ts`** — add `isShiftReturnInput` and exclude `key.shift` from `isPlainReturnInput`, so Shift+Enter no longer submits.
- **`BaseTextInput.tsx`** — Shift+Enter inserts `\n` alongside the existing Ctrl-J branch.
- **`StatusBar.tsx`** — hint is capability-aware: `[Shift-Enter]newline` when the protocol is active, `[Ctrl-J]newline` otherwise (advertising Shift+Enter on a terminal where it actually submits would be misleading).

Under the protocol Ink delivers Shift+Enter as `input='\r', key={return:true, shift:true}` and plain Enter as `{return:true, shift:false}` — the distinction is purely `key.shift`.

### Behavior on terminals without the protocol

Nothing changes: `mode:'disabled'`, no protocol bytes are sent, Shift+Enter remains byte-identical to Enter (submits), and Ctrl-J is the newline binding. Graceful degradation.

## Testing

- `TextInputEditing.vitest.mts` — Shift+Enter classified as newline; excluded from submit; distinct from Ctrl-J / Option+Enter.
- `StatusBar.vitest.mts` — hint shows `[Shift-Enter]newline` when `shiftEnterNewline` is set, `[Ctrl-J]newline` otherwise.
- `npm run typecheck` ✅ · eslint ✅ · vitest (14 tests) ✅

## Verified

- `packages/cli/node_modules/.pnpm/ink@7.0.4/.../parse-keypress.js` — codepoint 13 → `name:'return'`, kitty modifiers set `shift`; confirmed the exact `(input, key)` shape.
- `ink.js:742-810` — `kittyKeyboard` is opt-in; `mode:'enabled'` force-enables on TTYs and pops on unmount.
- `terminalCleanup.ts` — `RESET_TERMINAL_MODES` already includes the `\x1b[<u` pop (belt-and-suspenders alongside Ink's own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal input and a narrow Ink internal hook for keypad Enter; behavior is unchanged when Kitty protocol is off.
> 
> **Overview**
> Enables **Shift+Enter** for multiline input in the chat TUI when the terminal supports the Kitty keyboard protocol, while **Enter** still submits and **Ctrl-J** remains the fallback elsewhere.
> 
> **`runChatTui`** turns on Ink’s `kittyKeyboard` mode from existing capability discovery so Shift+Enter can be distinguished from Enter. **`BaseTextInput`** treats Shift+Enter like Ctrl-J (insert `\n`), checking that before submit. **`inputKeys`** adds `isShiftReturnInput` and keypad-Enter detection; plain Enter stays shift-agnostic so modals still confirm on Shift+Enter. **`App`** re-injects Kitty **keypad Enter** as `\r` via Ink’s internal stdin emitter so submit paths keep working. **`StatusBar`** shows `[Shift-Enter]newline` vs `[Ctrl-J]newline` based on protocol support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7713ab3dbdd04e35fba4dfca2028ab78c9580e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->