### PR TITLE
Extract external binary resolution utilities to shared module

### DIFF
--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -18,9 +18,12 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
-import { platform } from '@platform/platform';
 import { isModuleNotFoundError } from '@common/errors';
 import { executeCommandSync } from '@utils/system/execUtils';
+import {
+  getPackagedElectronResourcesPath,
+  pathExists,
+} from './support/externalBinaryUtils';
 
 type QueryFn = (params: {
   prompt: string | AsyncIterable<unknown>;
@@ -28,10 +31,6 @@ type QueryFn = (params: {
 }) => AsyncGenerator<unknown, void>;
 
 type PlatformInfo = { pkgs: readonly string[] };
-type ElectronProcess = NodeJS.Process & {
-  defaultApp?: boolean;
-  resourcesPath?: string;
-};
 
 // ---------------------------------------------------------------------------
 // SDK import
@@ -226,13 +225,6 @@ async function findClaudeBinaryInElectronResources(
   return undefined;
 }
 
-function getPackagedElectronResourcesPath(): string | undefined {
-  const electronProcess = process as ElectronProcess;
-  if (electronProcess.versions.electron == null) return undefined;
-  if (electronProcess.defaultApp === true) return undefined;
-  return electronProcess.resourcesPath;
-}
-
 /**
  * Resolve the native Claude binary from a directory that contains (or nests)
  * the platform-specific package. Returns the binary path if found, or
@@ -258,9 +250,3 @@ async function resolveClaudeBinary(
   return undefined;
 }
 
-async function pathExists(target: string): Promise<boolean> {
-  return platform()
-    .fs.stat(target)
-    .then(() => true)
-    .catch(() => false);
-}

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -249,4 +249,3 @@ async function resolveClaudeBinary(
   }
   return undefined;
 }
-

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -265,4 +265,3 @@ async function resolveCodexBinaryFromPlatformPackage(
   );
   return (await pathExists(binary)) ? binary : undefined;
 }
-

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,16 +17,15 @@
 import { createRequire } from 'module';
 import * as path from 'path';
 
-import { platform } from '@platform/platform';
 import { isModuleNotFoundError } from '@common/errors';
 import { executeCommandSync } from '@utils/system/execUtils';
+import {
+  getPackagedElectronResourcesPath,
+  pathExists,
+} from './support/externalBinaryUtils';
 
 type CodexConstructor = new (options?: any) => any;
 type PlatformInfo = { pkg: string; triple: string };
-type ElectronProcess = NodeJS.Process & {
-  defaultApp?: boolean;
-  resourcesPath?: string;
-};
 
 // ---------------------------------------------------------------------------
 // SDK import
@@ -224,13 +223,6 @@ export async function findCodexBinaryInElectronResources(
   );
 }
 
-function getPackagedElectronResourcesPath(): string | undefined {
-  const electronProcess = process as ElectronProcess;
-  if (electronProcess.versions.electron == null) return undefined;
-  if (electronProcess.defaultApp === true) return undefined;
-  return electronProcess.resourcesPath;
-}
-
 /**
  * Resolve the native Codex binary from a directory that contains (or nests)
  * the platform-specific package.  Returns the binary path if found, or
@@ -274,9 +266,3 @@ async function resolveCodexBinaryFromPlatformPackage(
   return (await pathExists(binary)) ? binary : undefined;
 }
 
-async function pathExists(target: string): Promise<boolean> {
-  return platform()
-    .fs.stat(target)
-    .then(() => true)
-    .catch(() => false);
-}

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -9,7 +9,7 @@
 
 import { platform } from '@platform/platform';
 
-export type ElectronProcess = NodeJS.Process & {
+type ElectronProcess = NodeJS.Process & {
   defaultApp?: boolean;
   resourcesPath?: string;
 };

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared utilities for locating external CLI binaries shipped as npm platform
+ * packages (e.g. @anthropic-ai/claude-agent-sdk-*, @openai/codex-*).
+ *
+ * Both the Claude Code and Codex tool implementations follow the same
+ * 4-strategy resolution pattern and require identical Electron-detection and
+ * path-existence helpers. Centralising them here prevents silent drift.
+ */
+
+import { platform } from '@platform/platform';
+
+export type ElectronProcess = NodeJS.Process & {
+  defaultApp?: boolean;
+  resourcesPath?: string;
+};
+
+/**
+ * Returns Electron's `process.resourcesPath` when running inside a packaged
+ * Electron application. Returns `undefined` in development mode
+ * (`defaultApp === true`) and in non-Electron runtimes (VS Code extension
+ * host, plain Node.js).
+ */
+export function getPackagedElectronResourcesPath(): string | undefined {
+  const electronProcess = process as ElectronProcess;
+  if (electronProcess.versions.electron == null) return undefined;
+  if (electronProcess.defaultApp === true) return undefined;
+  return electronProcess.resourcesPath;
+}
+
+/**
+ * Check whether a file-system path exists using the platform FS abstraction.
+ * Returns `true` if `stat()` succeeds, `false` on any error (including ENOENT).
+ */
+export async function pathExists(target: string): Promise<boolean> {
+  return platform()
+    .fs.stat(target)
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
## Summary

Centralizes duplicate binary resolution logic from `claudeAgentImport.ts` and `codexImport.ts` into a new shared utility module `externalBinaryUtils.ts`. Both files implement identical 4-strategy resolution patterns for locating external CLI binaries shipped as npm platform packages, requiring the same Electron-detection and path-existence helpers.

## Issue acceptance gates

N/A — This is a refactoring to prevent silent drift between two parallel implementations.

## Single source of truth

`src/tools/support/externalBinaryUtils.ts` now owns:
- `getPackagedElectronResourcesPath()` — Electron runtime detection
- `pathExists()` — Platform-abstracted filesystem checks
- `ElectronProcess` type definition

## Duplication and abstraction budget

**Removed duplication:**
- `getPackagedElectronResourcesPath()` function (identical in both files)
- `pathExists()` function (identical in both files)
- `ElectronProcess` type definition (identical in both files)

**Abstraction invariant:** The module owns the contract for detecting packaged Electron environments and checking path existence using the platform FS abstraction. This prevents divergence as the Claude and Codex tool implementations evolve independently.

## Host impact

Extension: No behavioral change; refactored imports only.

Desktop: No behavioral change; refactored imports only.

CLI: N/A

## Scheduled refactoring

None — This completes the deduplication.

## Validation

- No functional changes; code is moved verbatim
- Both `claudeAgentImport.ts` and `codexImport.ts` import from the new shared module
- Existing type checking and linting will verify correctness of imports

https://claude.ai/code/session_0138Bqp3T5VynRPTi2X7dVRU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Verbatim move of helpers with import-only call-site updates; no change to resolution order or runtime behavior.
> 
> **Overview**
> Moves duplicated **Electron packaged-app detection** and **path existence** helpers out of `claudeAgentImport.ts` and `codexImport.ts` into a new shared module `src/tools/support/externalBinaryUtils.ts`.
> 
> Both import modules now use **`getPackagedElectronResourcesPath`** and **`pathExists`** from that file instead of maintaining identical local copies (including the shared `ElectronProcess` typing). **Binary lookup strategies and SDK import logic are unchanged**—this is consolidation only, to keep Claude and Codex resolvers aligned as they evolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42b3d8d3de628d6623a1efe3eb1eddf58cea078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->