### PR TITLE
docs: add TeXRA Scientific Skills and Lean Skills sections

### DIFF
--- a/docs/guide/open-source.md
+++ b/docs/guide/open-source.md
@@ -154,7 +154,7 @@ The capabilities that power TeXRA, packaged as portable agent skills. **texra-sc
 
 ### Quick Start
 
-```bash
+```text
 # Claude Code
 /plugin marketplace add texra-ai/texra-scientific-skills
 ```
@@ -162,7 +162,7 @@ The capabilities that power TeXRA, packaged as portable agent skills. **texra-sc
 Skills use the standardized `SKILL.md` format and can also be installed via Codex or by symlinking individual skill directories into your agent's skills location.
 
 ::: tip Use Case
-These skills bring TeXRA's research workflows to any agent system that supports the `SKILL.md` format — bring scientific writing, review, and figure creation into your own AI assistant.
+These skills bring TeXRA's research workflows to any agent system that supports the `SKILL.md` format, so your own AI assistant can draft, review, and illustrate scientific work.
 :::
 
 [GitHub Repository](https://github.com/texra-ai/texra-scientific-skills)
@@ -187,7 +187,7 @@ These skills bring TeXRA's research workflows to any agent system that supports 
 
 ### Quick Start
 
-```bash
+```text
 # Claude Code
 /plugin marketplace add texra-ai/texra-lean-skills
 ```

--- a/docs/guide/open-source.md
+++ b/docs/guide/open-source.md
@@ -131,8 +131,79 @@ mcp-server-mathematica powers TeXRA's mathematical verification capabilities. It
 
 ---
 
+## TeXRA Scientific Skills
+
+**A collection of agent skills for scientific writing, peer review, and figure creation.**
+
+[![GitHub](https://img.shields.io/github/stars/texra-ai/texra-scientific-skills)](https://github.com/texra-ai/texra-scientific-skills)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/texra-ai/texra-scientific-skills/blob/main/LICENSE)
+
+The capabilities that power TeXRA, packaged as portable agent skills. **texra-scientific-skills** distributes specialized skills for working with LaTeX manuscripts, mathematical content, and scientific communication, usable as Claude Code plugins or Codex skill bundles.
+
+### Skills
+
+- **Inline Paper Critic** — adds compile-safe review comments to LaTeX manuscripts
+- **Literature Search** — discovers and synthesizes academic sources with proper grounding
+- **Manuscript Review** — audits technical documents for mathematical accuracy and consistency
+- **Math OCR** — converts handwritten math into LaTeX
+- **Mathematical Enhancer** — improves proofs, derivations, and mathematical clarity
+- **Scientific Presenter** — creates presentations and Beamer decks
+- **Scientific Simplifier** — streamlines code, LaTeX, and writing while preserving meaning
+- **TikZ Figure Builder** — creates and refines scientific diagrams with iterative compilation
+- **Writing Commenter** — provides inline editorial feedback
+
+### Quick Start
+
+```bash
+# Claude Code
+/plugin marketplace add texra-ai/texra-scientific-skills
+```
+
+Skills use the standardized `SKILL.md` format and can also be installed via Codex or by symlinking individual skill directories into your agent's skills location.
+
+::: tip Use Case
+These skills bring TeXRA's research workflows to any agent system that supports the `SKILL.md` format — bring scientific writing, review, and figure creation into your own AI assistant.
+:::
+
+[GitHub Repository](https://github.com/texra-ai/texra-scientific-skills)
+
+---
+
+## TeXRA Lean Skills
+
+**Agent skills for Lean 4 and Mathlib formalization work.**
+
+[![GitHub](https://img.shields.io/github/stars/texra-ai/texra-lean-skills)](https://github.com/texra-ai/texra-lean-skills)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/texra-ai/texra-lean-skills/blob/main/LICENSE)
+
+**texra-lean-skills** helps AI agents assist with mathematical formalization in Lean 4, bridging informal mathematics and formal code. Distributed as a Claude Code plugin or Codex skills bundle following the standard skill format.
+
+### Skills
+
+- **lean-blueprint** — authors and maintains documents connecting informal mathematics to Lean declarations
+- **lean-proof-assistant** — develops and debugs Lean proofs with goal inspection and lemma search
+- **lean-search** — locates existing Lean 4 and Mathlib lemmas, APIs, and formalization patterns
+- **lean-simplifier** — refactors code toward Mathlib-quality style while preserving meaning
+
+### Quick Start
+
+```bash
+# Claude Code
+/plugin marketplace add texra-ai/texra-lean-skills
+```
+
+Skills can also be installed via Codex or by symlinking individual skill directories into your agent's skills location.
+
+::: tip Use Case
+If you formalize mathematics in Lean 4, these skills let AI assistants search Mathlib, draft and debug proofs, and keep blueprints in sync with formal declarations.
+:::
+
+[GitHub Repository](https://github.com/texra-ai/texra-lean-skills)
+
+---
+
 ## Contributing
 
-Both projects are MIT-licensed and welcome contributions. If you find a bug, want to add a model to llm-zoo, or want to extend the Mathematica tools — open an issue or submit a pull request on the respective GitHub repository.
+All of these projects are MIT-licensed and welcome contributions. If you find a bug, want to add a model to llm-zoo, extend the Mathematica tools, or contribute a new agent skill — open an issue or submit a pull request on the respective GitHub repository.
 
 - [texra-ai on GitHub](https://github.com/texra-ai)


### PR DESCRIPTION
## Summary

Added documentation for two new open-source projects to the guide: **TeXRA Scientific Skills** and **TeXRA Lean Skills**. These are collections of portable agent skills for scientific writing, peer review, figure creation, and Lean 4 formalization work. Updated the Contributing section to reflect the expanded project ecosystem.

## Changes

- **TeXRA Scientific Skills**: New section documenting 9 specialized skills (Inline Paper Critic, Literature Search, Manuscript Review, Math OCR, Mathematical Enhancer, Scientific Presenter, Scientific Simplifier, TikZ Figure Builder, Writing Commenter) with quick start instructions and use case guidance.

- **TeXRA Lean Skills**: New section documenting 4 Lean 4 formalization skills (lean-blueprint, lean-proof-assistant, lean-search, lean-simplifier) with quick start instructions and use case guidance.

- **Contributing section**: Updated to reference all projects in the ecosystem and mention agent skills as a contribution avenue.

## Validation

Documentation-only change. No code or tests affected.

https://claude.ai/code/session_01QzWxupQwyCdKPCtNKbh2wb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `docs/guide/open-source.md`; no runtime, auth, or data paths affected.
> 
> **Overview**
> The open-source guide now documents **TeXRA Scientific Skills** and **TeXRA Lean Skills** alongside `llm-zoo` and the Mathematica MCP server.
> 
> **TeXRA Scientific Skills** is described as nine portable `SKILL.md` skills (writing, review, literature, Math OCR, TikZ, etc.) with Claude Code marketplace install and Codex/symlink options. **TeXRA Lean Skills** covers four Lean 4/Mathlib skills (blueprint, proof assistant, search, simplifier) with the same install pattern.
> 
> The **Contributing** blurb now refers to the full ecosystem and mentions contributing new agent skills, not only the two original projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3577d8194300cbbc617a65d46324f2bc3e49b0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->