### PR TITLE
feat(cli): add texra-local for running the latest local CLI build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,20 @@ npm run typecheck
 
 Alternatively, use `npm run compile:safe` which runs type checking before building.
 
+### Local CLI (`texra-local`)
+
+To run your locally-built CLI alongside a globally-installed published `texra`:
+
+```bash
+npm run texra-local:build   # bundle the CLI + copy resources/docs into packages/cli/dist
+npm run texra-local:link    # symlink `texra-local` into ~/.local/bin (one-time)
+```
+
+`texra-local` is a symlink to `packages/cli/dist/bin/texra.js`, which each build
+overwrites in place — so it always runs your latest local build, no relinking
+needed. Re-run `texra-local:build` to refresh. Override the install dir with
+`TEXRA_LOCAL_BIN_DIR=/some/dir npm run texra-local:link`.
+
 ### Legacy Webpack Builds
 
 The original webpack-based commands are still available:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "check:desktop-package": "node scripts/verify-desktop-package.mjs",
     "check:cli-architecture": "corepack pnpm --filter @texra-ai/cli check:architecture",
     "check:cli-orchestration-manifest": "node scripts/check-cli-orchestration-manifest.mjs",
+    "texra-local:build": "corepack pnpm --filter @texra-ai/cli run bundle && corepack pnpm --filter @texra-ai/cli run copy:resources && corepack pnpm --filter @texra-ai/cli run copy:docs",
+    "texra-local:link": "node scripts/link-texra-local.mjs",
     "check:desktop-installers": "node scripts/verify-desktop-installer-artifacts.mjs",
     "sync:remote-agents": "node scripts/sync-remote-agents.mjs -o docs/supabase/SYNC_REFERENCE_AGENTS.sql",
     "check:remote-agents": "node scripts/sync-remote-agents.mjs --check"

--- a/scripts/link-texra-local.mjs
+++ b/scripts/link-texra-local.mjs
@@ -14,6 +14,7 @@
 import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(

--- a/scripts/link-texra-local.mjs
+++ b/scripts/link-texra-local.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+// Create (or refresh) a `texra-local` command that always runs this repo's
+// locally-built CLI, so it can coexist with a globally-installed published
+// `texra`. It's a symlink to the bundled `dist/bin/texra.js`, which each CLI
+// build overwrites in place — so rebuilding the CLI updates `texra-local`
+// automatically, no relinking needed.
+//
+//   node scripts/link-texra-local.mjs           # link into ~/.local/bin
+//   TEXRA_LOCAL_BIN_DIR=/some/dir node scripts/link-texra-local.mjs
+//
+// Refresh the build it points at with: npm run texra-local:build
+
+import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const target = path.join(repoRoot, 'packages/cli/dist/bin/texra.js');
+const binDir = process.env.TEXRA_LOCAL_BIN_DIR
+  ? path.resolve(process.env.TEXRA_LOCAL_BIN_DIR)
+  : path.join(homedir(), '.local/bin');
+const linkPath = path.join(binDir, 'texra-local');
+
+// `lstatSync` (unlike `existsSync`) doesn't follow symlinks, so it sees a
+// dangling link too — clear whatever is there before relinking.
+function pathPresent(p) {
+  try {
+    lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+mkdirSync(binDir, { recursive: true });
+if (pathPresent(linkPath)) rmSync(linkPath);
+symlinkSync(target, linkPath);
+
+console.log(`Linked texra-local -> ${target}`);
+
+if (!existsSync(target)) {
+  console.warn(
+    '\nThe target build does not exist yet — run `npm run texra-local:build` ' +
+      'before invoking texra-local.',
+  );
+}
+
+const pathDirs = (process.env.PATH ?? '').split(path.delimiter);
+if (!pathDirs.includes(binDir)) {
+  console.warn(
+    `\n${binDir} is not on your PATH. Add it (e.g. in your shell rc):\n` +
+      `  export PATH="${binDir}:$PATH"`,
+  );
+}


### PR DESCRIPTION
## Summary

Adds a `texra-local` command that always runs this repo's locally-built CLI, so it can coexist with a globally-installed published `texra` (no clobbering the npm install).

`texra-local` is a **symlink** to `packages/cli/dist/bin/texra.js`. Each CLI build overwrites that file in place, so the symlink always points at your latest local build — no relinking after a rebuild.

## Usage

```bash
npm run texra-local:build   # bundle the CLI + copy resources/docs into packages/cli/dist
npm run texra-local:link    # symlink texra-local into ~/.local/bin (one-time)

texra-local --version       # runs the local build
texra --version             # still the globally-installed published one
```

Refresh by re-running `texra-local:build`. Override the install dir with `TEXRA_LOCAL_BIN_DIR=/some/dir npm run texra-local:link`.

## Changes

- **`scripts/link-texra-local.mjs`** — idempotent symlink creator. Resolves the repo's dist bin from the script's own location, replaces any prior link, and warns when the build is missing or the bin dir isn't on PATH. Defaults to `~/.local/bin`; overridable via `TEXRA_LOCAL_BIN_DIR`.
- **`package.json`** — `texra-local:build` (fast bundle + resource/doc copy, no typecheck) and `texra-local:link`.
- **`CLAUDE.md`** — documents the workflow under Development Commands.

## Notes

- `~/.local/bin` is a no-sudo PATH dir; the script warns (doesn't fail) if it isn't on PATH.
- `scripts/` isn't covered by `npm run lint` (consistent with the other root `scripts/*.mjs`), so the script doesn't go through eslint — same as existing scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only symlink and npm scripts; no changes to shipped extension, desktop, or CLI runtime behavior in production installs.
> 
> **Overview**
> Adds a **`texra-local`** developer workflow so you can run the repo’s bundled CLI next to a globally installed **`texra`**, without replacing the published install.
> 
> **`npm run texra-local:build`** bundles `@texra-ai/cli` and copies resources/docs into `packages/cli/dist`. **`npm run texra-local:link`** (via new **`scripts/link-texra-local.mjs`**) creates an idempotent symlink **`texra-local` → `packages/cli/dist/bin/texra.js`** in `~/.local/bin` (or **`TEXRA_LOCAL_BIN_DIR`**). Rebuilds overwrite the target in place, so the link stays current without relinking. The script warns if the build is missing or the bin dir isn’t on **`PATH`**. **`CLAUDE.md`** documents the flow under Development Commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efcc925f023ef6bb8740f24359f08da172ccf51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->