### PR TITLE
Fix user message visibility in high-contrast VS Code themes

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -149,6 +149,21 @@ export class UserMessage extends LitElement {
       .user-message-timestamp {
         font-size: var(--font-size-xs);
       }
+
+      /*
+       * High-contrast themes: the selection-background fill clashes with the
+       * editor-foreground text (rendering the bubble unreadable) and the panel
+       * border resolves to transparent. Fall back to the editor background plus
+       * a solid contrast border so the message stays visible and delineated.
+       */
+      :host-context(.vscode-high-contrast) .user-message,
+      :host-context(.vscode-high-contrast-light) .user-message {
+        background-color: var(--wa-color-surface-default);
+        border-color: var(
+          --vscode-contrastBorder,
+          var(--wa-color-surface-border)
+        );
+      }
     `,
   ];
 


### PR DESCRIPTION
## Summary

Add CSS styling to ensure user message bubbles remain visible and readable in VS Code's high-contrast themes. In high-contrast modes, the default `selection-background` color clashes with `editor-foreground` text, rendering the message unreadable, and the panel border becomes transparent. This change applies fallback styling that uses the editor background color with a solid contrast border for proper delineation.

## Issue acceptance gates

Fixes user message bubble readability in high-contrast and high-contrast-light VS Code themes.

## Single source of truth

The `UserMessage` component's stylesheet now owns the styling rules for high-contrast theme compatibility via `:host-context()` selectors.

## Duplication and abstraction budget

No duplication introduced. The change is a localized CSS addition specific to the UserMessage component's styling needs.

## Host impact

Extension: User messages in the progress view are now readable in high-contrast VS Code themes.

Desktop: N/A

CLI: N/A

## Scheduled refactoring

None.

## Validation

Visual inspection in VS Code high-contrast and high-contrast-light themes. No automated tests required for CSS styling changes.

https://claude.ai/code/session_01UXeUYMpF6F1zaPCsbSn4yJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CSS in the UserMessage component with no logic, API, or security impact.
> 
> **Overview**
> **User message bubbles** in the progress view now get **theme-specific overrides** when VS Code runs in **high-contrast** or **high-contrast-light** mode.
> 
> Instead of the default selection-colored fill (which can make text unreadable) and a border that may disappear, bubbles use **`--wa-color-surface-default`** for the background and **`--vscode-contrastBorder`** (with a surface-border fallback) so messages stay legible and outlined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac8436218f7a444963b059da72de66207eeb529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->