### PR TITLE
fix(cli): restore Ctrl+C in the chat TUI under the Kitty protocol

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -2,7 +2,7 @@
 // todos panels at the bottom, then status, approval modal, and input bar.
 // Tab / Shift-Tab cycles focus across subagent streams.
 
-import { Box, useInput, useStdin, useWindowSize } from 'ink';
+import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
 import { useEffect, useState } from 'react';
 
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
@@ -19,6 +19,7 @@ import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
 import {
+  isKittyCtrlC,
   isKittyKeypadEnter,
   metaChordDigit,
   metaChordInput,
@@ -197,15 +198,18 @@ export function App(props: AppProps): React.JSX.Element {
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
   const reverseSearchOpen = useSignal(cliState.reverseSearchOpen);
   const { columns, rows } = useWindowSize();
+  const { exit } = useApp();
   const [childControlMode, setChildControlMode] = useState<
     ChildControlMode | undefined
   >(undefined);
 
-  // The Kitty disambiguate flag makes keypad Enter a distinct key that Ink's
-  // `useInput` never surfaces (see isKittyKeypadEnter). Re-dispatch it on Ink's
-  // own input channel as a plain Enter (CR) so every submit/confirm path that
-  // keys off `key.return` keeps working. Inert when the protocol is off — the
-  // sequence simply never arrives.
+  // The Kitty disambiguate flag remaps two keys onto CSI-u sequences that the
+  // TUI's normal paths don't see, so we patch them on Ink's own input channel:
+  //   • keypad Enter (kpenter) — useInput surfaces no field for it; re-dispatch
+  //     as a plain Enter (CR) so submit/confirm keeps working.
+  //   • Ctrl+C — arrives as a CSI-u sequence, not the \x03 that Ink's
+  //     exitOnCtrlC watches for; call exit() to reproduce that same shutdown.
+  // Both are inert when the protocol is off — the sequences never arrive.
   const stdin = useStdin();
   useEffect(() => {
     const emitter = (
@@ -213,12 +217,15 @@ export function App(props: AppProps): React.JSX.Element {
     ).internal_eventEmitter;
     if (!emitter) return;
     const onInput = (data: string): void => {
-      if (isKittyKeypadEnter(data))
+      if (isKittyKeypadEnter(data)) {
         emitter.emit('input', String.fromCharCode(13));
+      } else if (isKittyCtrlC(data)) {
+        exit();
+      }
     };
     emitter.on('input', onInput);
     return () => emitter.off('input', onInput);
-  }, [stdin]);
+  }, [stdin, exit]);
   const foregroundOpen =
     pending !== undefined ||
     activeForm !== undefined ||

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -69,3 +69,14 @@ const KITTY_KEYPAD_ENTER = new Set([
 export function isKittyKeypadEnter(data: string): boolean {
   return KITTY_KEYPAD_ENTER.has(data);
 }
+
+// Under the same disambiguate flag, Ctrl+C is reported as a CSI-u sequence
+// (codepoint 99 = "c", modifier 5 = ctrl) instead of the raw \x03 byte that
+// would raise SIGINT — so the TUI's SIGINT-based interrupt/exit never fires.
+// App.tsx re-raises SIGINT when it sees this. Matches only the unmodified
+// Ctrl+C (no shift/alt), leaving other Ctrl+Shift/Alt+C combos untouched.
+const KITTY_CTRL_C = `${String.fromCharCode(27)}[99;5u`;
+
+export function isKittyCtrlC(data: string): boolean {
+  return data === KITTY_CTRL_C;
+}

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -9,6 +9,7 @@ import {
   insertText,
 } from '@cli/chat/tui/input/textInputEditing';
 import {
+  isKittyCtrlC,
   isKittyKeypadEnter,
   isPlainReturnInput,
   isShiftReturnInput,
@@ -46,6 +47,14 @@ describe('CLI TUI text input editing', () => {
     expect(isKittyKeypadEnter('\r')).toBe(false);
     expect(isKittyKeypadEnter(`${ESC}[13u`)).toBe(false);
     expect(isKittyKeypadEnter(`${ESC}[57414;5u`)).toBe(false);
+  });
+
+  it('recognizes the Kitty Ctrl+C sequence for re-raising SIGINT', () => {
+    expect(isKittyCtrlC(`${ESC}[99;5u`)).toBe(true);
+    // Raw \x03, plain c, and other modifiers (e.g. Ctrl+Shift+C = ;6) must not match.
+    expect(isKittyCtrlC(String.fromCharCode(3))).toBe(false);
+    expect(isKittyCtrlC('c')).toBe(false);
+    expect(isKittyCtrlC(`${ESC}[99;6u`)).toBe(false);
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {


### PR DESCRIPTION
## Problem

Ctrl+C stopped working in `texra chat` on Kitty-capable terminals (regression from #4517).

Enabling the Kitty keyboard protocol's `disambiguateEscapeCodes` flag (needed to distinguish Shift+Enter) also makes the terminal report **Ctrl+C as a CSI-u sequence** — `ESC[99;5u` (codepoint 99 = `c`, modifier 5 = ctrl) — instead of the raw `\x03` byte. Ink's `exitOnCtrlC` only watches for `\x03`, and `useInput` swallows the parsed `c`+ctrl, so Ctrl+C silently did nothing.

(This is the same class of issue as the keypad-Enter fix that shipped with #4517 — the disambiguate flag remaps several keys onto CSI-u sequences the normal paths don't see.)

## Fix

Detect the Ctrl+C sequence on Ink's input channel (the same `internal_eventEmitter` listener already used for keypad Enter) and call `useApp().exit()`, which reproduces Ink's `exitOnCtrlC` shutdown exactly.

- Matches only **unmodified** Ctrl+C (`ESC[99;5u`), so Ctrl+Shift/Alt+C combos pass through untouched.
- Inert when the protocol is off — the sequence never arrives, so legacy Ctrl+C (`\x03` → Ink `exitOnCtrlC`) is completely unchanged.
- Uses `exit()` rather than re-raising SIGINT: in raw mode the TUI's Ctrl+C is driven by Ink's `exitOnCtrlC` (single-press exit), not `process.on('SIGINT')` (which only fires on real OS signals), so `exit()` is the faithful match.

## Testing

- **Unit**: `isKittyCtrlC` matches `ESC[99;5u`, rejects raw `\x03`, plain `c`, and other modifiers (`ESC[99;6u`).
- **Over a real TTY (tmux)**: sending the raw `ESC[99;5u` bytes now exits the chat (previously did nothing); legacy `C-c` still exits; normal typing is unaffected.
- eslint ✓, vitest ✓.

## Verified

- `packages/cli/src/chat/tui/App.tsx` — emitter listener now handles both kpenter (→ CR) and Kitty Ctrl+C (→ `exit()`).
- `packages/cli/src/chat/tui/input/inputKeys.ts` — `isKittyCtrlC` sequence matcher.
- Ink 7.0.4 `components/App.js` — confirmed `exitOnCtrlC` keys off `input === '\x03'`; `useApp().exit()` is the same `handleExit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted input-layer fix with tests; no auth, data, or API surface changes.
> 
> **Overview**
> Restores **Ctrl+C quit** in the chat TUI when the **Kitty keyboard protocol** is on. With `disambiguateEscapeCodes`, the terminal sends **`ESC[99;5u`** instead of **`\x03`**, so Ink’s **`exitOnCtrlC`** never runs and Ctrl+C did nothing.
> 
> The same **`internal_eventEmitter`** hook that re-dispatches keypad Enter now also detects that sequence via **`isKittyCtrlC`** and calls **`useApp().exit()`**, matching Ink’s normal Ctrl+C shutdown. Only unmodified Ctrl+C is handled; legacy **`\x03`** behavior is unchanged when the protocol is off.
> 
> Unit tests cover **`isKittyCtrlC`** (accepts **`ESC[99;5u`**, rejects raw ETX, plain `c`, and other modifiers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4708c568f9cf7ab063f25baea6bde2d50de755e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->