### PR TITLE
fix(agents): guard INPUT_FILES join against null/absent in prompts

### DIFF
--- a/packages/extension/resources/agents/polish.yaml
+++ b/packages/extension/resources/agents/polish.yaml
@@ -62,7 +62,7 @@ prompts:
 
       Output further enhanced and complete versions of all \LaTeX documents in the format below, incorporating the fixes above. Include all the changes you added in the previous step. Only modify sections explicitly mentioned in the instruction, unless changes in one section directly necessitate adjustments in another for consistency. Did later documents receive less attention than earlier ones? Re-read the last document now.
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/packages/extension/resources/docs/agent-creation/workflow_schema.md
+++ b/packages/extension/resources/docs/agent-creation/workflow_schema.md
@@ -61,7 +61,8 @@ Workflow agent prompts receive:
 - `{{ INSTRUCTION }}` — the user's free-text instruction for this run
 - `{{ INPUT_FILES }}` — ordered list of input filenames. Editing agents should
   output one document for each input, preserving the same names and order. Use
-  `{{ INPUT_FILES | join(", ") }}` for a human-readable list.
+  `{{ INPUT_FILES | default([], true) | join(", ") }}` for a human-readable list
+  (guards against null/absent `INPUT_FILES` so the prompt renders safely).
 - `{{ OUTPUT_FILES }}` — ordered list of declared generated filenames. This is
   only populated when the agent has explicit `outputFiles` or
   `settings.defaultOutputFiles`.

--- a/reference-agents/apply.yaml
+++ b/reference-agents/apply.yaml
@@ -108,7 +108,7 @@ prompts:
 
       Verify before output: all fixes are correct, logical flow is preserved (no notation used before defined), and the document is complete. Cross-document consistency must hold (aligned notation, consistent definitions, matching results). Match the document's existing comment style (\criticize / \todo / \comment / %) when annotating changes.
 
-      Output the final revised documents in the following order: {{ INPUT_FILES | join(', ') }}.
+      Output the final revised documents in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/criticize.yaml
+++ b/reference-agents/criticize.yaml
@@ -135,7 +135,7 @@ prompts:
       </instruction>
       If no specific instruction is given, apply your full critical scrutiny to all mathematical content.
 
-      The output documents should use the selected input filenames in this order: {{ INPUT_FILES | join(', ') }}.
+      The output documents should use the selected input filenames in this order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       FIRST PHASE - DERIVATION EXPANSION: First, create an expanded version showing all mathematical steps explicitly. This is your working document where you verify every claim.
 
@@ -340,7 +340,7 @@ prompts:
 
       Remember: Focus on the crucial points that matter most. Quality over quantity---better to identify 5 critical issues than 50 minor ones. If appendix errors invalidate main results, that's severity 5. Be harsh on what matters, lenient on what doesn't. Identify issues that cascade between documents. If one paper's errors invalidate others, that's severity 5. Be strategic about comment placement to maximize clarity.
 
-      Ensure that the output documents use the selected input filenames in this order: {{ INPUT_FILES | join(', ') }}.
+      Ensure that the output documents use the selected input filenames in this order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/devise.yaml
+++ b/reference-agents/devise.yaml
@@ -185,7 +185,7 @@ prompts:
 
       Then, following your plan in the scratchpad, please output revised version(s) of the LaTeX document(s) that transform the fully derived mathematical drafts into polished scientific papers with an appropriate level of detail. Focus on addressing the original instruction while maintaining scientific clarity and proper motivation. Remember, the goal is not to show every mathematical step unless specifically required by the instruction, but to present the mathematics in a way that best serves the scientific content.
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}.
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/elevate.yaml
+++ b/reference-agents/elevate.yaml
@@ -266,7 +266,7 @@ prompts:
 
       The goal is writing that makes a reviewer think: ``This is a well-written, important paper.''
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/enhance.yaml
+++ b/reference-agents/enhance.yaml
@@ -405,7 +405,7 @@ prompts:
         The finite-time bound from the main text now gives...
         \criticize{Enhancement: Using strengthened result from main text \cref{thm:main}. Previous version only had asymptotic bound.}{3}{5}
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/generic.yaml
+++ b/reference-agents/generic.yaml
@@ -79,7 +79,7 @@ prompts:
     - |
       Now critically reflect on the work you've just completed across all documents and output a further refined version. Check for accuracy, notation consistency within and across documents, structural coherence, formatting issues, and clarity. Include all the work from the previous step plus the new refinements.
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/logic.yaml
+++ b/reference-agents/logic.yaml
@@ -302,7 +302,7 @@ prompts:
 
       Remember: If appendix derivations are questionable, add comments in the main text where those results are used, warning about the shaky foundation. Be proactive with improvements that don't cross section boundaries, delete substantial content, or require cross-document coordination; leave major reorganization and cross-document changes as issue comments for the human to decide.
 
-      Did later documents receive less attention than earlier ones? Re-read the last document now. Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}.
+      Did later documents receive less attention than earlier ones? Re-read the last document now. Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       <documents>
       {% for output in INPUT_FILES %}

--- a/reference-agents/notation.yaml
+++ b/reference-agents/notation.yaml
@@ -264,7 +264,7 @@ prompts:
 
       Remember: Be proactive with local notation improvements (within sections, 2-5 equations), but document all non-trivial changes with comments. Leave systemic and cross-document notation changes as issue comments for the human to decide, but ALWAYS provide graceful solutions that minimize changes.
 
-      Ensure that the output documents are in the following order: {{ INPUT_FILES | join(', ') }}.
+      Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}.
 
       <documents>
       {% for output in INPUT_FILES %}


### PR DESCRIPTION
## Summary

Workflow agent prompts render `{{ INPUT_FILES | join(', ') }}` to tell the model the expected output document order. If `INPUT_FILES` is ever absent or nulled by an upstream code path, `join` raises and the whole prompt render fails.

This wraps those expressions with the Jinja `default([], true)` filter so the list renders empty (harmless) instead of erroring, across all affected prompts:

- `packages/extension/resources/agents/polish.yaml`
- `reference-agents/{apply,criticize,devise,elevate,enhance,generic,logic,notation}.yaml`

The `criticize.yaml` prompt has two such expressions; both are guarded.

`workflow_schema.md` is updated to document the guarded form as the recommended pattern.

## Behavior

- Normal case (INPUT_FILES populated): identical output to before.
- Edge case (INPUT_FILES null/absent): renders an empty list instead of throwing.

No code paths, return values, or non-template behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-template-only change with identical behavior when INPUT_FILES is populated; no auth, data, or runtime logic paths affected.
> 
> **Overview**
> Workflow agent prompts that tell the model the expected **output document order** used `{{ INPUT_FILES | join(', ') }}`, which can **break prompt rendering** when `INPUT_FILES` is missing or null.
> 
> This PR switches those lines to **`{{ INPUT_FILES | default([], true) | join(', ') }}`** in **`polish.yaml`**, eight **`reference-agents`** YAMLs (**`criticize`** has two occurrences), and documents the guarded pattern in **`workflow_schema.md`**.
> 
> When **`INPUT_FILES`** is set, behavior is unchanged; when it is absent, the order line becomes an empty list instead of throwing during template render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa277e891950b4fd48bec7ff08c99113b6fcbd8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->