### PR TITLE
fix(cli): stop showing "(no output)" for tools with output hidden

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -312,6 +312,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
   const showNoOutput =
+    showOutput &&
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
     visibleOutput.length === 0 &&
     !patchGroups &&


### PR DESCRIPTION
The React ToolRow appended a "(no output)" line for any completed,
non-error tool with an empty visible-output buffer, even when output
was intentionally suppressed (showOutput=false) — as is the case for
ls/glob/read_file/grep, which only render a curated header summary.
Gate showNoOutput on showOutput so it matches the string display-lines
path, which already required it.

https://claude.ai/code/session_01898pty6FFMaF14EcxkwEy5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition UI display fix in the CLI TUI with no auth, data, or API impact.
> 
> **Overview**
> The CLI TUI **`ToolRow`** React renderer no longer shows **“(no output)”** when tool output is intentionally hidden (`showOutput` is false).
> 
> `showNoOutput` is now gated on **`showOutput`**, matching **`universalToolUseDisplayLines`**, so tools like **ls**, **glob**, **read_file**, and **grep** that only show a header summary are not labeled as having no output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db05bf9ed447df48d3ce5ffc21d2be8fda0a403a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->