### PR TITLE
chore(deps): group Dependabot updates into production/dev batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,19 @@ updates:
     ignore:
       - dependency-name: '@types/node'
       - dependency-name: '@types/vscode'
+    # Aggregate routine updates into as few PRs as possible: one grouped PR for
+    # all production minor/patch bumps, one for all dev minor/patch bumps. Major
+    # bumps stay individual (reviewed one at a time). Replaces the old narrow
+    # eslint/prettier-only group, which the development-dependencies group now
+    # subsumes.
     groups:
-      dev-dependencies:
-        patterns:
-          - '@typescript-eslint/*'
-          - 'eslint*'
-          - 'prettier'
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-dependencies:
+        dependency-type: 'development'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
## What
Adds Dependabot `groups` so routine npm updates arrive as **two grouped PRs per run** instead of one-per-dependency:
- `production-dependencies` — all prod `minor`/`patch` bumps in a single PR
- `development-dependencies` — all dev `minor`/`patch` bumps in a single PR

Major bumps stay **individual** (reviewed one at a time). This replaces the old narrow eslint/prettier-only group, which `development-dependencies` now subsumes.

## Why
Five separate Dependabot PRs (e.g. #4533–#4537) each touch `pnpm-lock.yaml`, so they serialize behind each other's rebases and multiply CI runs. Grouping by dependency-type collapses a typical daily batch from ~5 PRs to ~2, with one lockfile change and one CI run each.

## Notes
- Grouping applies to **future** Dependabot runs; it does not retroactively combine the currently-open PRs.
- `open-pull-requests-limit: 5` and the `@types/node` / `@types/vscode` ignores are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency automation only; no application runtime or security logic changes.
> 
> **Overview**
> **Dependabot** is reconfigured so routine npm updates land in **two grouped PRs** instead of many single-dependency ones: **`production-dependencies`** batches all production **minor/patch** bumps, and **`development-dependencies`** batches all dev **minor/patch** bumps.
> 
> The previous **eslint/prettier/@typescript-eslint**-only group is removed in favor of the broader dev group. **Major** version bumps remain **ungrouped** (one PR each). **`open-pull-requests-limit`**, **`@types/node` / `@types/vscode` ignores**, and the daily schedule are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d09f19f5ccccb3a4f20c5f7a9e664b72ab66a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->