### PR TITLE
release(cli): 0.38.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.38.3] - 2026-05-27
+
+### Features
+
+- **Run tool-use agents headlessly** — new `texra agents run <agent>` command runs a tool-use agent non-interactively with `--instruction`/`--instruction-file`, `--input`, `--context`, and `--output-format`. This powers the TeXRA GitHub code-review action.
+
 ## [0.38.2] - 2026-05-27
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-workspace",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "private": true,
   "packageManager": "pnpm@11.1.1",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra-ai/cli",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/core",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/desktop",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "TeXRA standalone desktop application",
   "author": "TeXRA.ai <contact@texra.ai>",
   "homepage": "https://texra.ai",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"


### PR DESCRIPTION
The `texra agents run` command and the GitHub code-review action were
added after the 0.38.2 release without bumping the version, so no
published CLI contains the command. The action's trusted path installs
the published CLI, which fails with "Unknown command: texra agents run".

Bump the workspace to 0.38.3 so a release including `texra agents run`
can be published.

https://claude.ai/code/session_013fAwEzjsaTtnoaH1tnXgx2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no runtime code changes in the diff.
> 
> **Overview**
> This PR **releases 0.38.3** so the published `@texra-ai/cli` on npm matches code that already includes **`texra agents run`** (added after 0.38.2). Without this bump, installs from the registry still report **Unknown command: texra agents run**, which breaks the GitHub code-review action that relies on the published CLI.
> 
> The diff bumps **`version`** from `0.38.2` to **`0.38.3`** across the root workspace and packages (`@texra-ai/cli`, `@texra/core`, desktop, VS Code extension) and adds a **`CHANGELOG`** entry for **0.38.3** documenting headless tool-use agent runs via `texra agents run` and its flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374cf159238f78d3d631744ebb4f06ea58656ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->