### PR TITLE
docs: relocate CLI checkout instructions out of the public guide

### DIFF
--- a/docs/dev/texra-cli-checkout.md
+++ b/docs/dev/texra-cli-checkout.md
@@ -1,0 +1,106 @@
+# TeXRA CLI — Checkout Workflow
+
+Developer-only notes for running the `texra` CLI from a local repository
+checkout. These instructions assume read access to the TeXRA source tree and
+are not part of the public CLI guide (`docs/guide/texra-cli.md`) because the
+repository is not open source.
+
+## Install From a Checkout
+
+To track unreleased changes, clone the repository, install workspace
+dependencies, build the CLI package, and link the bundled CLI binary into the
+global pnpm bin directory:
+
+```bash
+corepack pnpm install
+corepack pnpm --filter @texra-ai/cli build
+corepack pnpm setup    # one-time; then restart your shell or source its rc file
+PNPM_BIN="$(corepack pnpm bin -g)"
+mkdir -p "$PNPM_BIN"
+ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_BIN/texra"
+```
+
+The linked binary takes precedence over a globally-installed npm copy, so `texra`
+now runs your local build.
+
+## Shell Completion
+
+TeXRA can print completion scripts for Bash, Zsh, and Fish:
+
+```bash
+texra completion bash >> ~/.bashrc
+texra completion zsh > "${fpath[1]}/_texra"
+texra completion fish > ~/.config/fish/completions/texra.fish
+```
+
+Restart the shell, or source the file you updated. Completion includes
+subcommands, flags, enum values such as `--output-format text|json|ndjson`,
+agent names for `texra run <TAB>`, and model names for `--model <TAB>`.
+
+Agent and model completion call back into `texra agents list` and
+`texra models list`, so they reflect the current checkout. Disable those
+dynamic lookups in slow shells with:
+
+```bash
+export TEXRA_COMPLETION_DYNAMIC=0
+```
+
+The linked command points to `packages/cli/dist/bin/texra.js`. Rebuild after
+changing CLI code or shared runtime code:
+
+```bash
+corepack pnpm --filter @texra-ai/cli build
+```
+
+The symlink is used instead of `pnpm link --global` because the CLI package
+still has workspace-only dependencies, while the built binary is self-contained.
+
+## Run Without Linking
+
+After building, the generated binary can also be run directly:
+
+```bash
+node packages/cli/dist/bin/texra.js --help
+node packages/cli/dist/bin/texra.js agents list
+```
+
+Run a workflow agent from a project directory:
+
+```bash
+node packages/cli/dist/bin/texra.js run polish --input paper.tex --output paper.polished.tex --print
+```
+
+Pass read-only context files with repeated `--context` flags. The agent can
+read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
+documents for the selected inputs:
+
+```bash
+node packages/cli/dist/bin/texra.js run firstread --input appendices.tex --context Draft0.tex --context refs.bib
+```
+
+Pass multiple inputs with repeated `--input` flags, a directory, or a glob.
+Directory inputs expand recursively to `.tex` files. Multi-input runs can copy
+their generated artifacts to a directory with `--output-dir`; relative document
+paths are preserved under that directory:
+
+```bash
+node packages/cli/dist/bin/texra.js run firstread --input Draft0.tex --input appendices.tex --output-dir flagged
+node packages/cli/dist/bin/texra.js run logic --input 'paper/**/*.tex' --output-dir logic-pass
+```
+
+Workflow agents always write generated files into the execution's run-storage
+directory first. In text mode, TeXRA prints a filesystem path: the copied path
+when `--output` or `--output-dir` is used, otherwise the final generated file in
+run storage.
+
+With `--output`, TeXRA also copies the final artifact to the requested
+filesystem destination. JSON and NDJSON output keep `outputs[]` as the
+run-storage source of truth (`relativePath`, `absolutePath`, and `location`),
+include `runDirectory`, include `copiedOutput` or `copiedOutputs` when a
+filesystem copy was written, and report `terminalStatus` for the completed run.
+
+## Remove the Linked Command
+
+```bash
+rm "$(corepack pnpm bin -g)/texra"
+```

--- a/docs/dev/texra-cli-checkout.md
+++ b/docs/dev/texra-cli-checkout.md
@@ -5,6 +5,9 @@ checkout. These instructions assume read access to the TeXRA source tree and
 are not part of the public CLI guide (`docs/guide/texra-cli.md`) because the
 repository is not open source.
 
+For end-user CLI usage (`texra run`, `texra completion`, workspace defaults,
+history, tools), see the [public CLI guide](../guide/texra-cli.md).
+
 ## Install From a Checkout
 
 To track unreleased changes, clone the repository, install workspace
@@ -23,28 +26,6 @@ ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_BIN/texra"
 The linked binary takes precedence over a globally-installed npm copy, so `texra`
 now runs your local build.
 
-## Shell Completion
-
-TeXRA can print completion scripts for Bash, Zsh, and Fish:
-
-```bash
-texra completion bash >> ~/.bashrc
-texra completion zsh > "${fpath[1]}/_texra"
-texra completion fish > ~/.config/fish/completions/texra.fish
-```
-
-Restart the shell, or source the file you updated. Completion includes
-subcommands, flags, enum values such as `--output-format text|json|ndjson`,
-agent names for `texra run <TAB>`, and model names for `--model <TAB>`.
-
-Agent and model completion call back into `texra agents list` and
-`texra models list`, so they reflect the current checkout. Disable those
-dynamic lookups in slow shells with:
-
-```bash
-export TEXRA_COMPLETION_DYNAMIC=0
-```
-
 The linked command points to `packages/cli/dist/bin/texra.js`. Rebuild after
 changing CLI code or shared runtime code:
 
@@ -55,49 +36,39 @@ corepack pnpm --filter @texra-ai/cli build
 The symlink is used instead of `pnpm link --global` because the CLI package
 still has workspace-only dependencies, while the built binary is self-contained.
 
+Shell-completion dynamic lookups (`texra agents list`, `texra models list`)
+reflect the current checkout. Disable them in slow shells with
+`export TEXRA_COMPLETION_DYNAMIC=0` — see the public guide for the completion
+install steps themselves.
+
 ## Run Without Linking
 
-After building, the generated binary can also be run directly:
+After building, the generated binary can also be run directly without the
+symlink:
 
 ```bash
 node packages/cli/dist/bin/texra.js --help
 node packages/cli/dist/bin/texra.js agents list
-```
-
-Run a workflow agent from a project directory:
-
-```bash
 node packages/cli/dist/bin/texra.js run polish --input paper.tex --output paper.polished.tex --print
 ```
 
-Pass read-only context files with repeated `--context` flags. The agent can
-read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
-documents for the selected inputs:
+All flags from the public guide work the same way — substitute
+`node packages/cli/dist/bin/texra.js` for `texra` in any example.
+
+## Validation
+
+The CLI build performs type checking, architecture checks, bundling, and
+resource copying:
 
 ```bash
-node packages/cli/dist/bin/texra.js run firstread --input appendices.tex --context Draft0.tex --context refs.bib
+corepack pnpm --filter @texra-ai/cli build
 ```
 
-Pass multiple inputs with repeated `--input` flags, a directory, or a glob.
-Directory inputs expand recursively to `.tex` files. Multi-input runs can copy
-their generated artifacts to a directory with `--output-dir`; relative document
-paths are preserved under that directory:
+For a deterministic local run check that does not require provider credentials:
 
 ```bash
-node packages/cli/dist/bin/texra.js run firstread --input Draft0.tex --input appendices.tex --output-dir flagged
-node packages/cli/dist/bin/texra.js run logic --input 'paper/**/*.tex' --output-dir logic-pass
+corepack pnpm --filter @texra-ai/cli validate:run
 ```
-
-Workflow agents always write generated files into the execution's run-storage
-directory first. In text mode, TeXRA prints a filesystem path: the copied path
-when `--output` or `--output-dir` is used, otherwise the final generated file in
-run storage.
-
-With `--output`, TeXRA also copies the final artifact to the requested
-filesystem destination. JSON and NDJSON output keep `outputs[]` as the
-run-storage source of truth (`relativePath`, `absolutePath`, and `location`),
-include `runDirectory`, include `copiedOutput` or `copiedOutputs` when a
-filesystem copy was written, and report `terminalStatus` for the completed run.
 
 ## Remove the Linked Command
 

--- a/docs/dev/texra-cli-checkout.md
+++ b/docs/dev/texra-cli-checkout.md
@@ -10,9 +10,29 @@ history, tools), see the [public CLI guide](../guide/texra-cli.md).
 
 ## Install From a Checkout
 
-To track unreleased changes, clone the repository, install workspace
-dependencies, build the CLI package, and link the bundled CLI binary into the
-global pnpm bin directory:
+There are two supported paths. Pick based on whether you want the local build to
+**replace** the published `texra` command or sit **alongside** it.
+
+### Side-by-side as `texra-local` (recommended)
+
+Use the maintained workspace scripts. `texra-local:link` symlinks
+`~/.local/bin/texra-local` to `packages/cli/dist/bin/texra.js` once;
+`texra-local:build` overwrites that target in place, so the symlink always
+points at your latest build without relinking:
+
+```bash
+corepack pnpm install
+npm run texra-local:build   # bundle CLI + copy resources/docs into packages/cli/dist
+npm run texra-local:link    # one-time; override the install dir with TEXRA_LOCAL_BIN_DIR=/some/dir
+```
+
+Run with `texra-local` instead of `texra`. Re-run `texra-local:build` to refresh.
+See also the "Local CLI (`texra-local`)" section of `CLAUDE.md`.
+
+### Override the published `texra`
+
+To shadow the npm-installed `texra` command with the local build, link the
+bundled binary into the global pnpm bin directory:
 
 ```bash
 corepack pnpm install
@@ -71,6 +91,14 @@ corepack pnpm --filter @texra-ai/cli validate:run
 ```
 
 ## Remove the Linked Command
+
+For the side-by-side `texra-local` link:
+
+```bash
+rm "${TEXRA_LOCAL_BIN_DIR:-$HOME/.local/bin}/texra-local"
+```
+
+For the global `texra` override:
 
 ```bash
 rm "$(corepack pnpm bin -g)/texra"

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -58,7 +58,7 @@ Node.js 22 or newer):
 npm install -g @texra-ai/cli
 ```
 
-See [TeXRA CLI](./texra-cli.md) for usage and workspace defaults.
+See [TeXRA CLI](./texra-cli.md) for usage, shell completion, and workspace defaults.
 
 ### From VSIX File
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -58,8 +58,7 @@ Node.js 22 or newer):
 npm install -g @texra-ai/cli
 ```
 
-See [TeXRA CLI](./texra-cli.md) for usage, shell completion, and instructions for
-building from a repository checkout if you want to track unreleased changes.
+See [TeXRA CLI](./texra-cli.md) for usage and workspace defaults.
 
 ### From VSIX File
 

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -19,6 +19,64 @@ texra version
 texra agents list
 ```
 
+## Running Agents
+
+Run a workflow agent from a project directory:
+
+```bash
+texra run polish --input paper.tex --output paper.polished.tex --print
+```
+
+Pass read-only context files with repeated `--context` flags. The agent can
+read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
+documents for the selected inputs:
+
+```bash
+texra run firstread --input appendices.tex --context Draft0.tex --context refs.bib
+```
+
+Pass multiple inputs with repeated `--input` flags, a directory, or a glob.
+Directory inputs expand recursively to `.tex` files. Multi-input runs can copy
+their generated artifacts to a directory with `--output-dir`; relative document
+paths are preserved under that directory:
+
+```bash
+texra run firstread --input Draft0.tex --input appendices.tex --output-dir flagged
+texra run logic --input 'paper/**/*.tex' --output-dir logic-pass
+```
+
+Workflow agents always write generated files into the execution's run-storage
+directory first. In text mode, TeXRA prints a filesystem path: the copied path
+when `--output` or `--output-dir` is used, otherwise the final generated file in
+run storage.
+
+With `--output`, TeXRA also copies the final artifact to the requested
+filesystem destination. JSON and NDJSON output keep `outputs[]` as the
+run-storage source of truth (`relativePath`, `absolutePath`, and `location`),
+include `runDirectory`, include `copiedOutput` or `copiedOutputs` when a
+filesystem copy was written, and report `terminalStatus` for the completed run.
+
+## Shell Completion
+
+TeXRA can print completion scripts for Bash, Zsh, and Fish:
+
+```bash
+texra completion bash >> ~/.bashrc
+texra completion zsh > "${fpath[1]}/_texra"
+texra completion fish > ~/.config/fish/completions/texra.fish
+```
+
+Restart the shell, or source the file you updated. Completion includes
+subcommands, flags, enum values such as `--output-format text|json|ndjson`,
+agent names for `texra run <TAB>`, and model names for `--model <TAB>`.
+
+Agent and model completion call back into `texra agents list` and
+`texra models list`. Disable those dynamic lookups in slow shells with:
+
+```bash
+export TEXRA_COMPLETION_DYNAMIC=0
+```
+
 ## Execution History
 
 TeXRA stores completed executions in the workspace run store. List recent runs:
@@ -113,18 +171,3 @@ included relay access. `--api-mode included` keeps the default relay behavior
 when the account is signed in. The accepted aliases match the TUI `/api`
 command: for example, `direct`, `api`, and `byok` select personal API keys,
 while `relay` selects included access.
-
-## Validation
-
-The CLI build performs type checking, architecture checks, bundling, and resource
-copying:
-
-```bash
-corepack pnpm --filter @texra-ai/cli build
-```
-
-For a deterministic local run check that does not require provider credentials:
-
-```bash
-corepack pnpm --filter @texra-ai/cli validate:run
-```

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -19,100 +19,6 @@ texra version
 texra agents list
 ```
 
-## Install From a Checkout
-
-To track unreleased changes, clone the repository, install workspace
-dependencies, build the CLI package, and link the bundled CLI binary into the
-global pnpm bin directory:
-
-```bash
-corepack pnpm install
-corepack pnpm --filter @texra-ai/cli build
-corepack pnpm setup    # one-time; then restart your shell or source its rc file
-PNPM_BIN="$(corepack pnpm bin -g)"
-mkdir -p "$PNPM_BIN"
-ln -sf "$(pwd)/packages/cli/dist/bin/texra.js" "$PNPM_BIN/texra"
-```
-
-The linked binary takes precedence over a globally-installed npm copy, so `texra`
-now runs your local build.
-
-## Shell Completion
-
-TeXRA can print completion scripts for Bash, Zsh, and Fish:
-
-```bash
-texra completion bash >> ~/.bashrc
-texra completion zsh > "${fpath[1]}/_texra"
-texra completion fish > ~/.config/fish/completions/texra.fish
-```
-
-Restart the shell, or source the file you updated. Completion includes
-subcommands, flags, enum values such as `--output-format text|json|ndjson`,
-agent names for `texra run <TAB>`, and model names for `--model <TAB>`.
-
-Agent and model completion call back into `texra agents list` and
-`texra models list`, so they reflect the current checkout. Disable those
-dynamic lookups in slow shells with:
-
-```bash
-export TEXRA_COMPLETION_DYNAMIC=0
-```
-
-The linked command points to `packages/cli/dist/bin/texra.js`. Rebuild after
-changing CLI code or shared runtime code:
-
-```bash
-corepack pnpm --filter @texra-ai/cli build
-```
-
-The symlink is used instead of `pnpm link --global` because the CLI package
-still has workspace-only dependencies, while the built binary is self-contained.
-
-## Run Without Linking
-
-After building, the generated binary can also be run directly:
-
-```bash
-node packages/cli/dist/bin/texra.js --help
-node packages/cli/dist/bin/texra.js agents list
-```
-
-Run a workflow agent from a project directory:
-
-```bash
-node packages/cli/dist/bin/texra.js run polish --input paper.tex --output paper.polished.tex --print
-```
-
-Pass read-only context files with repeated `--context` flags. The agent can
-read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
-documents for the selected inputs:
-
-```bash
-node packages/cli/dist/bin/texra.js run firstread --input appendices.tex --context Draft0.tex --context refs.bib
-```
-
-Pass multiple inputs with repeated `--input` flags, a directory, or a glob.
-Directory inputs expand recursively to `.tex` files. Multi-input runs can copy
-their generated artifacts to a directory with `--output-dir`; relative document
-paths are preserved under that directory:
-
-```bash
-node packages/cli/dist/bin/texra.js run firstread --input Draft0.tex --input appendices.tex --output-dir flagged
-node packages/cli/dist/bin/texra.js run logic --input 'paper/**/*.tex' --output-dir logic-pass
-```
-
-Workflow agents always write generated files into the execution's run-storage
-directory first. In text mode, TeXRA prints a filesystem path: the copied path
-when `--output` or `--output-dir` is used, otherwise the final generated file in
-run storage.
-
-With `--output`, TeXRA also copies the final artifact to the requested
-filesystem destination. JSON and NDJSON output keep `outputs[]` as the
-run-storage source of truth (`relativePath`, `absolutePath`, and `location`),
-include `runDirectory`, include `copiedOutput` or `copiedOutputs` when a
-filesystem copy was written, and report `terminalStatus` for the completed run.
-
 ## Execution History
 
 TeXRA stores completed executions in the workspace run store. List recent runs:
@@ -207,12 +113,6 @@ included relay access. `--api-mode included` keeps the default relay behavior
 when the account is signed in. The accepted aliases match the TUI `/api`
 command: for example, `direct`, `api`, and `byok` select personal API keys,
 while `relay` selects included access.
-
-## Remove the Linked Command
-
-```bash
-rm "$(corepack pnpm bin -g)/texra"
-```
 
 ## Validation
 


### PR DESCRIPTION
Move "Install From a Checkout", "Shell Completion", "Run Without Linking",
and "Remove the Linked Command" from docs/guide/texra-cli.md to a new
docs/dev/texra-cli-checkout.md. The public guide is published to
texra.ai; docs/dev/** is excluded from the published site, so these
checkout-only workflows now live with the other internal dev notes
since the repository is not open source.

Also trim the corresponding cross-reference in docs/guide/installation.md
so it no longer points public readers at the removed sections.

https://claude.ai/code/session_012Bk3gEGBPv51Ur8xyjE5Dc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reorganization with no runtime, auth, or data-handling changes.
> 
> **Overview**
> **Checkout-only CLI workflows** are moved out of the published user docs into a new internal guide at `docs/dev/texra-cli-checkout.md`. That doc covers installing from a repo checkout (recommended **`texra-local`** side-by-side vs overriding global **`texra`**), running the bundled binary without linking, validation, and removing links.
> 
> The public **`docs/guide/texra-cli.md`** is refocused on the npm-installed **`texra`** command: checkout install, unlink, and build/validate sections are removed; examples use **`texra`** instead of **`node packages/cli/dist/bin/texra.js`**; shell completion stays but no longer mentions checkout-specific behavior. **`docs/guide/installation.md`** no longer tells public readers to build from a checkout—only usage, completion, and workspace defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35404f6dee1e12d6fa612625461ff509c584529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->