### PR TITLE
feat(cli): ctrl+t transcript viewer, GFM ANSI tables, settled-prefix scrollback, serialized approvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ packages/desktop/playwright-report/
 
 # External design references cloned locally; do not vendor them into TeXRA.
 references/openrouter-skills/
+
+.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "node-pandoc": "^0.3.0",
     "openai": "^6.39.0",
     "p-map": "^7.0.4",
+    "p-queue": "^9.3.0",
     "pdf2pic": "^3.2.0",
     "perfect-debounce": "^2.1.0",
     "postal-mime": "^2.7.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
     "@texra/core": "workspace:*",
     "@types/markdown-it": "^14.1.2",
     "@types/react": "^19.2.15",
+    "@types/semver": "^7.7.1",
     "babel-plugin-react-compiler": "^1.0.0",
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
@@ -71,9 +72,11 @@
     "picocolors": "^1.1.1",
     "react": "^19.2.0",
     "semver": "^7.8.1",
-    "@types/semver": "^7.7.1",
     "string-width": "^8.0.0",
     "typescript": "^6.0.3",
     "wrap-ansi": "^10.0.0"
+  },
+  "dependencies": {
+    "cli-table3": "^0.6.5"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
+    "cli-table3": "^0.6.5",
     "diff": "^9.0.0",
     "esbuild": "^0.28.0",
     "ink": "^7.0.4",
@@ -75,8 +76,5 @@
     "string-width": "^8.0.0",
     "typescript": "^6.0.3",
     "wrap-ansi": "^10.0.0"
-  },
-  "dependencies": {
-    "cli-table3": "^0.6.5"
   }
 }

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -1,0 +1,108 @@
+// Full-output transcript viewer (ctrl+t).
+//
+// The finalized scrollback and live region only ever show a head+tail slice of
+// tool output (see toolRenderers `elideOutputLines`). This foreground surface
+// renders the active stream's entries untruncated and scrollable so the user
+// can read everything the `… +N lines` marker collapsed.
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { Box, Text, useInput } from 'ink';
+
+import { KeyHints } from '../ui/KeyHints';
+import { transcriptToLines } from '../state/transcriptLines';
+import type { StreamSlice } from '../state/cliState';
+
+export interface TranscriptViewerProps {
+  readonly slice: StreamSlice | undefined;
+  readonly width: number;
+  readonly availableRows: number;
+  readonly onClose: () => void;
+}
+
+export function TranscriptViewer({
+  slice,
+  width,
+  availableRows,
+  onClose,
+}: TranscriptViewerProps): React.JSX.Element {
+  const lines = useMemo(
+    () => transcriptToLines(slice, Math.max(1, width)),
+    // Key on slice.entries, not the whole slice: syncStreamLog hands back a
+    // fresh slice object every ~16ms tick, but the entries array stays the
+    // same reference when nothing was promoted. Keying on entries skips the
+    // O(N) re-flatten on status-only ticks during streaming.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [slice?.entries, width],
+  );
+  // Reserve one row for the footer hint strip.
+  const viewRows = Math.max(1, availableRows - 1);
+  const maxOffset = Math.max(0, lines.length - viewRows);
+  // Open pinned to the bottom — the latest output is what the user just asked
+  // to inspect.
+  const [offset, setOffset] = useState(maxOffset);
+  // While at the bottom, follow new output as it streams in (mid-run); once the
+  // user scrolls up, hold position so reading isn't yanked. Scrolling back to
+  // the bottom re-arms following.
+  const [followBottom, setFollowBottom] = useState(true);
+
+  function scrollTo(next: number): void {
+    const clamped = Math.max(0, Math.min(maxOffset, next));
+    setOffset(clamped);
+    setFollowBottom(clamped >= maxOffset);
+  }
+
+  // React to content growth / resize: follow the tail when armed, otherwise
+  // just clamp so the offset never points past the end.
+  useEffect(() => {
+    setOffset((current) =>
+      followBottom ? maxOffset : Math.min(current, maxOffset),
+    );
+  }, [maxOffset, followBottom]);
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === 't')) onClose();
+    else if (key.downArrow) scrollTo(offset + 1);
+    else if (key.upArrow) scrollTo(offset - 1);
+    else if (key.pageDown) scrollTo(offset + viewRows);
+    else if (key.pageUp) scrollTo(offset - viewRows);
+    else if (input === 'g') scrollTo(0);
+    else if (input === 'G') scrollTo(maxOffset);
+  });
+
+  const visible = lines.slice(offset, offset + viewRows);
+  const lastVisibleLine = Math.min(lines.length, offset + viewRows);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box flexDirection="column" overflowY="hidden">
+        {lines.length === 0 ? (
+          <Text dimColor>(no transcript yet)</Text>
+        ) : (
+          // Ink collapses an empty-string Text to zero height; the space keeps
+          // blank separator rows between entries visible.
+          visible.map((line, index) => (
+            <Text key={offset + index} wrap="truncate-end">
+              {line || ' '}
+            </Text>
+          ))
+        )}
+      </Box>
+      <KeyHints
+        confirmCancel={false}
+        hints={[
+          { key: '↑/↓', action: 'scroll' },
+          { key: 'PgUp/PgDn', action: 'page' },
+          { key: 'g/G', action: 'top/bottom' },
+          {
+            key: 'Esc',
+            action:
+              lines.length > 0
+                ? `close (${lastVisibleLine}/${lines.length})`
+                : 'close',
+          },
+        ]}
+      />
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -20,6 +20,11 @@ export interface TranscriptViewerProps {
   readonly onClose: () => void;
 }
 
+interface ScrollState {
+  readonly offset: number;
+  readonly followBottom: boolean;
+}
+
 export function TranscriptViewer({
   slice,
   width,
@@ -32,7 +37,6 @@ export function TranscriptViewer({
     // fresh slice object every ~16ms tick, but the entries array stays the
     // same reference when nothing was promoted. Keying on entries skips the
     // O(N) re-flatten on status-only ticks during streaming.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [slice?.entries, width],
   );
   // Reserve one row for the footer hint strip.
@@ -40,32 +44,41 @@ export function TranscriptViewer({
   const maxOffset = Math.max(0, lines.length - viewRows);
   // Open pinned to the bottom — the latest output is what the user just asked
   // to inspect.
-  const [offset, setOffset] = useState(maxOffset);
-  // While at the bottom, follow new output as it streams in (mid-run); once the
-  // user scrolls up, hold position so reading isn't yanked. Scrolling back to
-  // the bottom re-arms following.
-  const [followBottom, setFollowBottom] = useState(true);
+  const [{ offset }, setScrollState] = useState<ScrollState>(() => ({
+    offset: maxOffset,
+    followBottom: true,
+  }));
 
-  function scrollTo(next: number): void {
-    const clamped = Math.max(0, Math.min(maxOffset, next));
-    setOffset(clamped);
-    setFollowBottom(clamped >= maxOffset);
+  function clampOffset(next: number): number {
+    return Math.max(0, Math.min(maxOffset, next));
+  }
+
+  function scrollTo(next: number | ((currentOffset: number) => number)): void {
+    setScrollState((current) => {
+      const requested =
+        typeof next === 'function' ? next(current.offset) : next;
+      const offset = clampOffset(requested);
+      return { offset, followBottom: offset >= maxOffset };
+    });
   }
 
   // React to content growth / resize: follow the tail when armed, otherwise
   // just clamp so the offset never points past the end.
   useEffect(() => {
-    setOffset((current) =>
-      followBottom ? maxOffset : Math.min(current, maxOffset),
-    );
-  }, [maxOffset, followBottom]);
+    setScrollState((current) => {
+      const offset = current.followBottom
+        ? maxOffset
+        : Math.min(current.offset, maxOffset);
+      return offset === current.offset ? current : { ...current, offset };
+    });
+  }, [maxOffset]);
 
   useInput((input, key) => {
     if (key.escape || (key.ctrl && input === 't')) onClose();
-    else if (key.downArrow) scrollTo(offset + 1);
-    else if (key.upArrow) scrollTo(offset - 1);
-    else if (key.pageDown) scrollTo(offset + viewRows);
-    else if (key.pageUp) scrollTo(offset - viewRows);
+    else if (key.downArrow) scrollTo((current) => current + 1);
+    else if (key.upArrow) scrollTo((current) => current - 1);
+    else if (key.pageDown) scrollTo((current) => current + viewRows);
+    else if (key.pageUp) scrollTo((current) => current - viewRows);
     else if (input === 'g') scrollTo(0);
     else if (input === 'G') scrollTo(maxOffset);
   });

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -24,6 +24,36 @@ const OUTPUT_CORNER = '⎿';
 const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;
 
+// Tool output can be arbitrarily large (a 50 KB bash dump, a long grep). The
+// finalized `<Static>` scrollback and the live region show a head+tail slice
+// with a `… +N lines` marker; the full text stays on `toolUse.outputText` and
+// is reachable via the ctrl+t transcript viewer. Tune head/tail here.
+const OUTPUT_HEAD_LINES = 6;
+const OUTPUT_TAIL_LINES = 3;
+
+interface ElidedOutput {
+  readonly head: readonly string[];
+  readonly tail: readonly string[];
+  readonly hiddenCount: number;
+}
+
+function elideOutputLines(lines: readonly string[]): ElidedOutput {
+  // Only elide when it actually hides something: head + tail + at least one
+  // collapsed line. Otherwise show everything.
+  if (lines.length <= OUTPUT_HEAD_LINES + OUTPUT_TAIL_LINES) {
+    return { head: lines, tail: [], hiddenCount: 0 };
+  }
+  return {
+    head: lines.slice(0, OUTPUT_HEAD_LINES),
+    tail: lines.slice(lines.length - OUTPUT_TAIL_LINES),
+    hiddenCount: lines.length - OUTPUT_HEAD_LINES - OUTPUT_TAIL_LINES,
+  };
+}
+
+function elisionMarker(hiddenCount: number): string {
+  return `… +${hiddenCount} lines (ctrl + t to view transcript)`;
+}
+
 // Tool inputs vary in shape; show whichever of these "primary" fields
 // exists first. Order matters: earlier keys win.
 const PRIMARY_INPUT_KEYS = [
@@ -35,11 +65,20 @@ const PRIMARY_INPUT_KEYS = [
   'url',
 ] as const;
 
+export interface DisplayLineOptions {
+  /** When false, emit the full output instead of the head+tail slice.
+   *  The transcript viewer (ctrl+t) sets this to show everything. */
+  readonly elide?: boolean;
+}
+
 export interface ToolRenderer {
   readonly key: string;
   matches(toolUse: NormalizedToolUse): boolean;
   render(toolUse: NormalizedToolUse): React.JSX.Element;
-  displayLines(toolUse: NormalizedToolUse): readonly string[];
+  displayLines(
+    toolUse: NormalizedToolUse,
+    options?: DisplayLineOptions,
+  ): readonly string[];
 }
 
 function lastSegmentToolName(toolName: string): string {
@@ -148,10 +187,22 @@ function extractExitCode(toolUse: NormalizedToolUse): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
-function outputDisplayLines(toolUse: NormalizedToolUse): string[] {
-  return visibleOutputLines(toolUse).map((line, index) =>
+function outputDisplayLines(
+  toolUse: NormalizedToolUse,
+  elide = true,
+): string[] {
+  const lines = visibleOutputLines(toolUse);
+  const sliced = elide
+    ? elideOutputLines(lines)
+    : { head: lines, tail: [] as readonly string[], hiddenCount: 0 };
+  const out = sliced.head.map((line, index) =>
     index === 0 ? `${OUTPUT_CORNER} ${line}` : `  ${line}`,
   );
+  if (sliced.hiddenCount > 0) {
+    out.push(`  ${elisionMarker(sliced.hiddenCount)}`);
+  }
+  for (const line of sliced.tail) out.push(`  ${line}`);
+  return out;
 }
 
 export function universalToolUseDisplayLines(
@@ -159,12 +210,15 @@ export function universalToolUseDisplayLines(
   options: {
     readonly displayName?: string;
     readonly showOutput?: boolean;
+    readonly elide?: boolean;
   } = {},
 ): readonly string[] {
   const patchLines = toolUsePatchDisplayLines(toolUse);
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   const outputLines =
-    options.showOutput === true ? outputDisplayLines(toolUse) : [];
+    options.showOutput === true
+      ? outputDisplayLines(toolUse, options.elide ?? true)
+      : [];
   const showNoOutput =
     options.showOutput === true &&
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
@@ -190,9 +244,10 @@ export function universalToolUseDisplayLines(
 
 export function bashToolUseDisplayLines(
   toolUse: NormalizedToolUse,
+  options: { readonly elide?: boolean } = {},
 ): readonly string[] {
   const exitCode = extractExitCode(toolUse);
-  const outputLines = outputDisplayLines(toolUse);
+  const outputLines = outputDisplayLines(toolUse, options.elide ?? true);
   const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
   return [
     formatHeader(toolUse),
@@ -250,11 +305,24 @@ function OutputBlock({
   readonly lines: readonly string[];
 }): React.JSX.Element | null {
   if (lines.length === 0) return null;
+  const { head, tail, hiddenCount } = elideOutputLines(lines);
   return (
     <Box flexDirection="column" paddingLeft={2}>
-      {lines.map((line, index) => (
-        <Box key={index} flexDirection="row" flexWrap="nowrap">
+      {head.map((line, index) => (
+        <Box key={`h${index}`} flexDirection="row" flexWrap="nowrap">
           <Text dimColor>{index === 0 ? `${OUTPUT_CORNER} ` : '  '}</Text>
+          <Text>{line}</Text>
+        </Box>
+      ))}
+      {hiddenCount > 0 && (
+        <Box flexDirection="row" flexWrap="nowrap">
+          <Text dimColor>{'  '}</Text>
+          <Text dimColor>{elisionMarker(hiddenCount)}</Text>
+        </Box>
+      )}
+      {tail.map((line, index) => (
+        <Box key={`t${index}`} flexDirection="row" flexWrap="nowrap">
+          <Text dimColor>{'  '}</Text>
           <Text>{line}</Text>
         </Box>
       ))}
@@ -409,14 +477,16 @@ const editRenderer: ToolRenderer = {
   key: 'edit',
   matches: (toolUse) => toolUsePatchGroups(toolUse) !== undefined,
   render: (toolUse) => <UniversalToolRow toolUse={toolUse} />,
-  displayLines: (toolUse) => universalToolUseDisplayLines(toolUse),
+  displayLines: (toolUse, options) =>
+    universalToolUseDisplayLines(toolUse, { elide: options?.elide }),
 };
 
 const bashRenderer: ToolRenderer = {
   key: 'bash',
   matches: isBashTool,
   render: (toolUse) => <BashToolRow toolUse={toolUse} />,
-  displayLines: bashToolUseDisplayLines,
+  displayLines: (toolUse, options) =>
+    bashToolUseDisplayLines(toolUse, { elide: options?.elide }),
 };
 
 const mcpRenderer: ToolRenderer = {
@@ -429,10 +499,11 @@ const mcpRenderer: ToolRenderer = {
       showOutput={true}
     />
   ),
-  displayLines: (toolUse) =>
+  displayLines: (toolUse, options) =>
     universalToolUseDisplayLines(toolUse, {
       displayName: displayMcpToolName(toolUse.toolName),
       showOutput: true,
+      elide: options?.elide,
     }),
 };
 
@@ -450,9 +521,10 @@ export function pickToolRenderer(
 
 export function toolUseDisplayLines(
   toolUse: NormalizedToolUse,
+  options?: DisplayLineOptions,
 ): readonly string[] {
   return (
-    pickToolRenderer(toolUse)?.displayLines(toolUse) ??
-    universalToolUseDisplayLines(toolUse)
+    pickToolRenderer(toolUse)?.displayLines(toolUse, options) ??
+    universalToolUseDisplayLines(toolUse, { elide: options?.elide })
   );
 }

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -30,6 +30,7 @@ const MAX_ERROR_PREVIEW = 240;
 // is reachable via the ctrl+t transcript viewer. Tune head/tail here.
 const OUTPUT_HEAD_LINES = 6;
 const OUTPUT_TAIL_LINES = 3;
+const OUTPUT_MARKER_LINES = 1;
 
 interface ElidedOutput {
   readonly head: readonly string[];
@@ -38,9 +39,11 @@ interface ElidedOutput {
 }
 
 function elideOutputLines(lines: readonly string[]): ElidedOutput {
-  // Only elide when it actually hides something: head + tail + at least one
-  // collapsed line. Otherwise show everything.
-  if (lines.length <= OUTPUT_HEAD_LINES + OUTPUT_TAIL_LINES) {
+  // Only elide when the head + marker + tail form is shorter than the original.
+  if (
+    lines.length <=
+    OUTPUT_HEAD_LINES + OUTPUT_TAIL_LINES + OUTPUT_MARKER_LINES
+  ) {
     return { head: lines, tail: [], hiddenCount: 0 };
   }
   return {

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -9,7 +9,9 @@
 // `highlight.js` grammars the webview already pulls — keeping fence rendering
 // consistent between hosts without dragging the HTML wrapper through.
 
+import Table from 'cli-table3';
 import { highlight, supportsLanguage } from 'cli-highlight';
+import Token from 'markdown-it/lib/token.mjs';
 import pico from 'picocolors';
 
 import {
@@ -41,7 +43,69 @@ function highlightForTui(code: string, lang: string): string {
   return pico.gray(trimmed);
 }
 
-function configureAnsi(md: MarkdownItInstance): void {
+type ColumnAlign = 'left' | 'center' | 'right';
+
+// markdown-it encodes GFM cell alignment as an inline `text-align` style on the
+// `th`/`td` open token; map it to cli-table3's `colAligns` vocabulary.
+function columnAlign(style: string | null): ColumnAlign {
+  if (style?.includes('right')) return 'right';
+  if (style?.includes('center')) return 'center';
+  return 'left';
+}
+
+const TABLE_MIN_COL_WIDTH = 5;
+// Fallback table width when the caller renders without a known terminal width
+// (the live region and Markdown component both pass one, so this is rare).
+const TABLE_FALLBACK_WIDTH = 80;
+
+// Distribute the available width across columns so the rendered table is never
+// wider than `width` — otherwise the trailing `wrapAnsiToWidth` hard-wrap would
+// shred the box-drawing borders. cli-table3's total width is the sum of the
+// column widths plus one border column per column boundary (numCols + 1).
+// Returns undefined when there isn't room to cap, letting cli-table3 size to
+// content instead.
+function tableColWidths(
+  numCols: number,
+  width: number | undefined,
+): number[] | undefined {
+  const total = Math.floor(width ?? TABLE_FALLBACK_WIDTH);
+  const usable = total - (numCols + 1);
+  if (usable < numCols * TABLE_MIN_COL_WIDTH) return undefined;
+  const base = Math.floor(usable / numCols);
+  const widths = Array.from({ length: numCols }, () => base);
+  // Hand the floor remainder to the leftmost columns so the table fills `width`.
+  let i = 0;
+  for (let remainder = usable - base * numCols; remainder > 0; remainder--)
+    widths[i++ % numCols] += 1;
+  return widths;
+}
+
+// Lay out a parsed markdown table through cli-table3 (borders, per-cell word
+// wrap, column widths) rather than hand-rolling alignment math.
+function renderAnsiTable(
+  head: readonly string[],
+  rows: readonly (readonly string[])[],
+  aligns: readonly ColumnAlign[],
+  width: number | undefined,
+): string {
+  const numCols = Math.max(head.length, ...rows.map((row) => row.length), 1);
+  const table = new Table({
+    head: head.map((cell) => pico.bold(cell)),
+    colWidths: tableColWidths(numCols, width),
+    colAligns: Array.from({ length: numCols }, (_, i) => aligns[i] ?? 'left'),
+    wordWrap: true,
+    // No cli-table3 colorizing — cell content already carries its own ANSI and
+    // the border stays the terminal's default foreground.
+    style: { head: [], border: [] },
+  });
+  for (const row of rows) table.push([...row]);
+  return table.toString();
+}
+
+function configureAnsi(
+  md: MarkdownItInstance,
+  width: number | undefined,
+): void {
   const r = md.renderer.rules;
   let quoteDepth = 0;
   let headingDepth = 0;
@@ -180,12 +244,73 @@ function configureAnsi(md: MarkdownItInstance): void {
   r.text = (tokens, idx) => styleHeadingText(tokens[idx]?.content ?? '');
   r.image = (tokens, idx) => pico.dim(`[image: ${tokens[idx]?.content ?? ''}]`);
 
+  // The table-family tokens (table_open … table_close) have no ANSI rules, so
+  // we collapse each table's token range into a single pre-rendered
+  // `ansi_table` token before the default render loop runs — otherwise the
+  // in-cell `inline` tokens would stream into the output and the table tags
+  // would fall through to markdown-it's default HTML renderer.
+  r.ansi_table = (tokens, idx) => `${tokens[idx]?.content ?? ''}\n\n`;
+
+  // The submodule's renderer typings narrow tokens to `unknown[]` and omit
+  // `renderInline`; recover the real shapes locally.
+  const renderInline = (
+    md.renderer as unknown as {
+      renderInline(tokens: Token[], options: unknown, env: unknown): string;
+    }
+  ).renderInline.bind(md.renderer);
   const render = md.renderer.render.bind(md.renderer);
-  md.renderer.render = (tokens, options, env) => {
+  md.renderer.render = (rawTokens, options, env) => {
     quoteDepth = 0;
     headingDepth = 0;
+    const tokens = rawTokens as Token[];
+    const collapsed: Token[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i]?.type !== 'table_open') {
+        collapsed.push(tokens[i]!);
+        continue;
+      }
+      const head: string[] = [];
+      const rows: string[][] = [];
+      const aligns: ColumnAlign[] = [];
+      let cells: string[] = [];
+      let inHeader = false;
+      let col = 0;
+      let j = i + 1;
+      for (; j < tokens.length && tokens[j]?.type !== 'table_close'; j++) {
+        const token = tokens[j]!;
+        switch (token.type) {
+          case 'thead_open':
+            inHeader = true;
+            break;
+          case 'thead_close':
+            inHeader = false;
+            break;
+          case 'tr_open':
+            cells = [];
+            col = 0;
+            break;
+          case 'tr_close':
+            if (inHeader) head.push(...cells);
+            else rows.push(cells);
+            break;
+          case 'th_open':
+          case 'td_open': {
+            if (inHeader) aligns[col] = columnAlign(token.attrGet('style'));
+            col++;
+            break;
+          }
+          case 'inline':
+            cells.push(renderInline(token.children ?? [], options, env));
+            break;
+        }
+      }
+      const tableToken = new Token('ansi_table', '', 0);
+      tableToken.content = renderAnsiTable(head, rows, aligns, width);
+      collapsed.push(tableToken);
+      i = j; // land on table_close; the loop's i++ skips it
+    }
     try {
-      return render(tokens, options, env);
+      return render(collapsed, options, env);
     } finally {
       quoteDepth = 0;
       headingDepth = 0;
@@ -198,6 +323,11 @@ function formatAnsiLatexReference(refType: string, label: string): string {
 }
 
 let cachedProcessor: MarkdownProcessor | null = null;
+// Table layout needs the terminal width baked into the renderer (the shared
+// processor caches by content only), so the processor is bound to one width
+// and rebuilt when the width changes — a rare event (resize), unlike the
+// per-delta streaming calls the cache exists to serve.
+let cachedWidth: number | undefined;
 
 export interface RenderAnsiMarkdownOptions {
   readonly width?: number;
@@ -212,15 +342,16 @@ export function renderAnsiMarkdown(
   content: string,
   options: RenderAnsiMarkdownOptions = {},
 ): string {
-  if (!cachedProcessor) {
+  if (!cachedProcessor || cachedWidth !== options.width) {
     const renderer = createMarkdownRenderer({
       highlight: highlightForTui,
-      configure: configureAnsi,
+      configure: (md) => configureAnsi(md, options.width),
     });
     cachedProcessor = createMarkdownProcessor({
       renderer,
       formatLatexReference: formatAnsiLatexReference,
     });
+    cachedWidth = options.width;
   }
   return wrapAnsiToWidth(cachedProcessor(content), options.width, {
     preserveMarkdownPrefix: true,
@@ -230,6 +361,7 @@ export function renderAnsiMarkdown(
 /** Test seam: drop the cached processor so tests can re-init cleanly. */
 export function _resetAnsiMarkdownForTests(): void {
   cachedProcessor = null;
+  cachedWidth = undefined;
 }
 
 /** Test seam: returns cache hit/miss counters for the active processor. */

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -130,6 +130,11 @@ const ACTIVE_FORM = signal<ActiveSlashForm | undefined>(undefined);
 const SLASH_PALETTE_OPEN = signal<boolean>(false);
 const REVERSE_SEARCH_OPEN = signal<boolean>(false);
 
+/** True while the ctrl+t full-output transcript viewer owns the screen. The
+ *  viewer shows the active stream's tool output untruncated and scrollable;
+ *  the finalized scrollback and live region only ever show a head+tail slice. */
+const TRANSCRIPT_VIEWER_OPEN = signal<boolean>(false);
+
 const PENDING_EXIT_HINT = signal<boolean>(false);
 const PENDING_EXIT_RESUME_ID = signal<string | undefined>(undefined);
 
@@ -145,6 +150,7 @@ export const cliState = {
   activeForm: ACTIVE_FORM as Signal.State<ActiveSlashForm | undefined>,
   slashPaletteOpen: SLASH_PALETTE_OPEN as Signal.State<boolean>,
   reverseSearchOpen: REVERSE_SEARCH_OPEN as Signal.State<boolean>,
+  transcriptViewerOpen: TRANSCRIPT_VIEWER_OPEN as Signal.State<boolean>,
   pendingExitHint: PENDING_EXIT_HINT as Signal.State<boolean>,
   pendingExitResumeId: PENDING_EXIT_RESUME_ID as Signal.State<
     string | undefined
@@ -238,6 +244,7 @@ export function resetCliState(sessionMeta = defaultSessionMeta()): void {
   cliState.activeForm.set(undefined);
   cliState.slashPaletteOpen.set(false);
   cliState.reverseSearchOpen.set(false);
+  cliState.transcriptViewerOpen.set(false);
   cliState.pendingExitHint.set(false);
   cliState.pendingExitResumeId.set(undefined);
   for (const resetHook of RESET_HOOKS) resetHook();

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -7,6 +7,7 @@ import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
 import { flushPendingRunTraces } from '@logger';
 import {
   MESSAGE_TYPES,
+  TOOL_USE_STATUS,
   type NormalizedToolUse,
   type StreamLogEntry,
   type StreamTabId,
@@ -119,22 +120,29 @@ function logEntryRole(
   return 'assistant';
 }
 
+function renderLogEntryText(
+  role: ConversationEntry['role'],
+  text: string,
+): string {
+  switch (role) {
+    case 'error':
+      return appendCliApiSwitchHint(text);
+    case 'user':
+      return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
+    default:
+      return text;
+  }
+}
+
 function renderLogEntry(
   entry: StreamLogEntry,
   prev: ConversationEntry | undefined,
-  finalizeDeferred: boolean,
 ): ConversationEntry | null {
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
     // Cache hit: same `data` reference as last sync, no re-normalize.
-    // Still honor a pending finalize — otherwise a tool row whose payload
-    // stopped changing before the stream went idle would never promote
-    // into `<Static>` scrollback and would vanish per splitTranscriptEntries.
+    // Promotion to `<Static>` is decided later by `finalizeSettledPrefix`
+    // over the ordered slice, so a cache hit just returns `prev` as-is.
     if (prev?.toolUse && toolUseSourceCache.get(prev) === entry.data) {
-      if (finalizeDeferred && !prev.finalized) {
-        const promoted = { ...prev, finalized: true };
-        toolUseSourceCache.set(promoted, entry.data);
-        return promoted;
-      }
       return prev;
     }
 
@@ -142,17 +150,16 @@ function renderLogEntry(
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
     if (!toolUse) return null;
-    // Defer finalization to `finalizeAssistantTranscriptEntries`. A
-    // fast-completing tool would otherwise jump into `<Static>`
-    // scrollback while preceding assistant text from the same turn is
-    // still streaming, reversing the visible order (Static items are
-    // append-only). Inherit the prior flag so a sync tick that fires
-    // after the finalize step doesn't roll the entry back to false.
+    // Never finalize here. `finalizeSettledPrefix` promotes a tool row only
+    // once it completes AND every entry before it has promoted, so a
+    // fast tool can't jump ahead of still-streaming assistant text in
+    // `<Static>` (which is append-only). Inherit the prior flag so a sync
+    // tick can't roll an already-promoted entry back to false.
     const next: ConversationEntry = {
       id: entry.id,
       role: 'tool',
       text: '',
-      finalized: finalizeDeferred || (prev?.finalized ?? false),
+      finalized: prev?.finalized ?? false,
       toolUse,
     };
     if (prev && entriesEqual(prev, next)) {
@@ -170,20 +177,12 @@ function renderLogEntry(
 
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
-  const renderedText =
-    role === 'error'
-      ? appendCliApiSwitchHint(text)
-      : role === 'user'
-        ? summarizeSubagentFollowup(stripOrchestratorFollowup(text))
-        : text;
-  // Assistant entries defer finalization (see comment above); inherit
-  // from `prev` so re-syncs after finalize don't de-finalize and drop
-  // the entry from `splitTranscriptEntries` once status flips to
-  // WAITING.
-  const finalized =
-    role === 'assistant'
-      ? finalizeDeferred || (prev?.finalized ?? false)
-      : true;
+  const renderedText = renderLogEntryText(role, text);
+  // Assistant text is promoted by `finalizeSettledPrefix` once the model
+  // moves on to a later entry; inherit the prior flag here so a re-sync
+  // can't de-finalize an already-promoted block. User/error rows can't
+  // change after they appear, so they finalize immediately.
+  const finalized = role === 'assistant' ? (prev?.finalized ?? false) : true;
   const next: ConversationEntry = {
     id: entry.id,
     role,
@@ -191,6 +190,65 @@ function renderLogEntry(
     finalized,
   };
   return prev && entriesEqual(prev, next) ? prev : next;
+}
+
+// An entry is "settled" once its content can no longer change, so it is
+// safe to print once into `<Static>` scrollback:
+//   - user / error / process: fixed the moment they appear.
+//   - assistant: frozen once the model emits a later entry (more text or a
+//     tool call). The trailing block may still be streaming.
+//   - tool: frozen once its result lands (status COMPLETED).
+function isSettledEntry(
+  entry: ConversationEntry,
+  index: number,
+  entries: readonly ConversationEntry[],
+): boolean {
+  switch (entry.role) {
+    case 'user':
+    case 'error':
+    case 'process':
+      return true;
+    case 'tool':
+      return entry.toolUse?.status === TOOL_USE_STATUS.COMPLETED;
+    case 'assistant':
+      return index < entries.length - 1;
+  }
+}
+
+// Promote the contiguous leading run of settled entries to `finalized`, so
+// completed parts of a round flow into `<Static>` scrollback as the round
+// progresses instead of piling up in the bounded live pane (where the
+// viewport would clip the round's earlier content). Only a contiguous
+// prefix is promoted: `<Static>` is append-only, so an entry must not
+// finalize while any earlier entry is still pending, or insertion order
+// would reverse. When the stream reaches a final status every remaining
+// entry settles, including the trailing live block.
+export function finalizeSettledPrefix(
+  entries: readonly ConversationEntry[],
+  streamFinal: boolean,
+): ConversationEntry[] {
+  let result: ConversationEntry[] | undefined;
+  let sealed = false; // hit the first still-pending entry in this round
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (!entry || entry.finalized) continue;
+    if (!streamFinal && (sealed || !isSettledEntry(entry, index, entries))) {
+      sealed = true;
+      continue;
+    }
+    if (!result) result = [...entries];
+    const promoted: ConversationEntry = { ...entry, finalized: true };
+    // Carry the WeakMap cache key onto the clone so the tool fast-path in
+    // `renderLogEntry` keeps hitting after promotion.
+    if (entry.role === 'tool') {
+      const cached = toolUseSourceCache.get(entry);
+      if (cached !== undefined) toolUseSourceCache.set(promoted, cached);
+    }
+    result[index] = promoted;
+  }
+  // No promotions: hand back the input as-is. The caller's `changed` check
+  // is element-wise, so the same reference is safe and skips a per-tick copy.
+  return result ?? (entries as ConversationEntry[]);
 }
 
 // Coalesce bursts into a single render without visibly delaying the
@@ -246,15 +304,11 @@ export function syncStreamLog(streamId: StreamTabId): void {
   patchStream(streamId, (slice) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
     const syntheticEntries = slice.entries.filter((entry) => entry.synthetic);
-    const finalizeDeferred = isFinalTranscriptStatus(slice.status);
+    const streamFinal = isFinalTranscriptStatus(slice.status);
     const logEntries: { entry: StreamLogEntry; rendered: ConversationEntry }[] =
       [];
     for (const entry of responses) {
-      const rendered = renderLogEntry(
-        entry,
-        existing.get(entry.id),
-        finalizeDeferred,
-      );
+      const rendered = renderLogEntry(entry, existing.get(entry.id));
       if (!rendered) continue;
       logEntries.push({ entry, rendered });
     }
@@ -269,10 +323,11 @@ export function syncStreamLog(streamId: StreamTabId): void {
 
     for (const [index, entry] of syntheticEntries.entries()) {
       if (entry.syntheticKind !== 'local') {
+        const entryTextTrimmed = entry.text.trim();
         const duplicate = logCandidates.some(
           (candidate) =>
             candidate.rendered.role === entry.role &&
-            candidate.rendered.text.trim() === entry.text.trim(),
+            candidate.rendered.text.trim() === entryTextTrimmed,
         );
         if (duplicate) continue;
       }
@@ -284,12 +339,16 @@ export function syncStreamLog(streamId: StreamTabId): void {
       });
     }
 
-    const next = candidates
+    const ordered = candidates
       .sort(
         (left, right) =>
           left.sortSeq - right.sortSeq || left.tieBreak - right.tieBreak,
       )
       .map((candidate) => candidate.rendered);
+    // Promote the settled prefix only after sorting: "is there a later
+    // entry" and Static append order are both defined on the final stream
+    // order, not the per-entry render order.
+    const next = finalizeSettledPrefix(ordered, streamFinal);
 
     const changed =
       slice.entries.length !== next.length ||

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -1,0 +1,53 @@
+// Flatten a stream's conversation entries into full-fidelity plain-text lines
+// for the ctrl+t transcript viewer. Unlike the finalized scrollback and the
+// live region — which slice tool output to a head+tail preview — this renders
+// every line so the viewer is the place to read the complete output.
+
+import { wrapAnsiToWidth } from '../render/ansiWrap';
+import { completedProcessDisplayLines } from './completedProcessTranscript';
+import { toolUseDisplayLines } from '../panes/toolRenderers';
+import type { ConversationEntry, StreamSlice } from './cliState';
+
+function wrap(text: string, cols: number, prefix = ''): string[] {
+  const width = Math.max(1, cols - prefix.length);
+  return wrapAnsiToWidth(text, width)
+    .split('\n')
+    .map(
+      (line, index) =>
+        `${index === 0 ? prefix : ' '.repeat(prefix.length)}${line}`,
+    );
+}
+
+function entryLines(entry: ConversationEntry, cols: number): readonly string[] {
+  switch (entry.role) {
+    case 'tool':
+      return entry.toolUse
+        ? toolUseDisplayLines(entry.toolUse, { elide: false })
+        : [];
+    case 'process':
+      return entry.process ? completedProcessDisplayLines(entry.process) : [];
+    case 'user':
+      return wrap(entry.text, cols, '› ');
+    case 'error':
+      return wrap(entry.text, cols, '! ');
+    default:
+      return wrap(entry.text, cols);
+  }
+}
+
+/** Render the active slice into a flat line array with a blank separator
+ *  between entries. Returns an empty array when there is nothing to show. */
+export function transcriptToLines(
+  slice: StreamSlice | undefined,
+  cols: number,
+): readonly string[] {
+  if (!slice) return [];
+  const out: string[] = [];
+  for (const entry of slice.entries) {
+    const lines = entryLines(entry, cols);
+    if (lines.length === 0) continue;
+    if (out.length > 0) out.push('');
+    out.push(...lines);
+  }
+  return out;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       p-map:
         specifier: ^7.0.4
         version: 7.0.4
+      p-queue:
+        specifier: ^9.3.0
+        version: 9.3.0
       pdf2pic:
         specifier: ^3.2.0
         version: 3.2.0
@@ -326,6 +329,10 @@ importers:
         version: 1.21.2
 
   packages/cli:
+    dependencies:
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -1098,6 +1105,10 @@ packages:
 
   '@clack/prompts@1.0.1':
     resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -3008,6 +3019,10 @@ packages:
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
@@ -7194,6 +7209,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -9403,6 +9421,12 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   cli-spinners@3.4.0: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cli-truncate@2.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,10 +329,6 @@ importers:
         version: 1.21.2
 
   packages/cli:
-    dependencies:
-      cli-table3:
-        specifier: ^0.6.5
-        version: 0.6.5
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -370,6 +366,9 @@ importers:
       cli-highlight:
         specifier: ^2.1.11
         version: 2.1.11
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
       diff:
         specifier: ^9.0.0
         version: 9.0.0

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -200,6 +200,32 @@ describe('renderAnsiMarkdown', () => {
     }
   });
 
+  it('renders GFM pipe tables as a box-drawing table, not raw HTML', () => {
+    _resetAnsiMarkdownForTests();
+    const md = '| Dimension | Workflow |\n|---|---|\n| Output | Rewrites |';
+    const out = renderAnsiMarkdown(md);
+    const plain = stripAnsi(out);
+    // The cells render…
+    expect(plain).toContain('Dimension');
+    expect(plain).toContain('Rewrites');
+    // …inside an actual table, with no markdown-it HTML fallback leaking.
+    expect(plain).toMatch(/[┌┬┐├┼┤└┴┘─│]/);
+    expect(plain).not.toContain('<table>');
+    expect(plain).not.toContain('<td>');
+    expect(plain).not.toContain('<th>');
+  });
+
+  it('keeps a table within the requested width', () => {
+    _resetAnsiMarkdownForTests();
+    const md =
+      '| Col A | Col B | Col C |\n|---|---|---|\n' +
+      '| a fairly long cell value | another long one | third column here |';
+    const out = renderAnsiMarkdown(md, { width: 40 });
+    for (const line of stripAnsi(out).split('\n')) {
+      expect(displayWidthForTest(line)).toBeLessThanOrEqual(40);
+    }
+  });
+
   it('memoises identical inputs (second call hits the cache)', () => {
     _resetAnsiMarkdownForTests();
     const first = renderAnsiMarkdown('# Title\n\nParagraph.');

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -94,6 +94,53 @@ describe('CLI tool renderer registry', () => {
     `);
   });
 
+  it('elides long bash output to a head+tail slice with a line marker', () => {
+    const entry = toolUse(
+      'bash',
+      { command: 'seq 20' },
+      {
+        headerSummary: 'seq 20',
+        outputText: Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join(
+          '\n',
+        ),
+      },
+    );
+
+    expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
+      [
+        "● bash (seq 20)",
+        "⎿ line 1",
+        "  line 2",
+        "  line 3",
+        "  line 4",
+        "  line 5",
+        "  line 6",
+        "  … +11 lines (ctrl + t to view transcript)",
+        "  line 18",
+        "  line 19",
+        "  line 20",
+      ]
+    `);
+  });
+
+  it('shows the full bash output when elision is disabled (transcript viewer)', () => {
+    const entry = toolUse(
+      'bash',
+      { command: 'seq 12' },
+      {
+        headerSummary: 'seq 12',
+        outputText: Array.from({ length: 12 }, (_, i) => `line ${i + 1}`).join(
+          '\n',
+        ),
+      },
+    );
+
+    const full = toolUseDisplayLines(entry, { elide: false });
+    expect(full).toHaveLength(13); // header + 12 output lines, no marker
+    expect(full.some((line) => line.includes('ctrl + t'))).toBe(false);
+    expect(full.at(-1)).toBe('  line 12');
+  });
+
   it('preserves MCP server names as server/tool labels', () => {
     const entry = toolUse(
       'mcp:slack:send',

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -123,6 +123,24 @@ describe('CLI tool renderer registry', () => {
     `);
   });
 
+  it('keeps short bash output whole when elision would not reduce height', () => {
+    const entry = toolUse(
+      'bash',
+      { command: 'seq 10' },
+      {
+        headerSummary: 'seq 10',
+        outputText: Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join(
+          '\n',
+        ),
+      },
+    );
+
+    const lines = toolUseDisplayLines(entry);
+    expect(lines).toHaveLength(11);
+    expect(lines.some((line) => line.includes('ctrl + t'))).toBe(false);
+    expect(lines.at(-1)).toBe('  line 10');
+  });
+
   it('shows the full bash output when elision is disabled (transcript viewer)', () => {
     const entry = toolUse(
       'bash',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -26,6 +26,7 @@ import {
   nextFocusForward,
 } from '@cli/chat/tui/state/focusCycle';
 import {
+  finalizeSettledPrefix,
   stripOrchestratorFollowup,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
@@ -343,6 +344,71 @@ describe('CLI TUI row allocation', () => {
       runCompleted: false,
       stopRequested: false,
     });
+  });
+});
+
+describe('finalizeSettledPrefix', () => {
+  const tool = (id: string, status: 'in_progress' | 'completed') =>
+    ({
+      id,
+      role: 'tool',
+      text: '',
+      finalized: false,
+      toolUse: {
+        parsed: {},
+        toolName: 'Bash',
+        errorText: '',
+        outputText: '',
+        userInstructionText: '',
+        input: {},
+        isError: false,
+        isUserFeedback: false,
+        headerSummary: '',
+        status,
+      },
+    }) as const;
+  const assistant = (id: string) =>
+    ({ id, role: 'assistant', text: id, finalized: false }) as const;
+  const finalizedIds = (
+    entries: readonly { id: string; finalized: boolean }[],
+  ) => entries.filter((entry) => entry.finalized).map((entry) => entry.id);
+
+  it('finalizes an assistant block once the model moves on to a tool call', () => {
+    const out = finalizeSettledPrefix(
+      [assistant('a1'), tool('t1', 'completed'), assistant('a2')],
+      false,
+    );
+    // a1 settled (later entry exists), t1 settled (completed), a2 is the
+    // live tail and stays pending.
+    expect(finalizedIds(out)).toEqual(['a1', 't1']);
+  });
+
+  it('keeps the in-flight tail pending while the stream runs', () => {
+    const out = finalizeSettledPrefix([assistant('a1')], false);
+    expect(finalizedIds(out)).toEqual([]);
+  });
+
+  it('does not promote past a still-running tool (preserves Static order)', () => {
+    const out = finalizeSettledPrefix(
+      [assistant('a1'), tool('t1', 'in_progress'), tool('t2', 'completed')],
+      false,
+    );
+    // t1 is still running: t2 must wait behind it even though it completed,
+    // or it would print above t1 in append-only scrollback.
+    expect(finalizedIds(out)).toEqual(['a1']);
+  });
+
+  it('finalizes every remaining entry once the stream reaches a final status', () => {
+    const out = finalizeSettledPrefix(
+      [assistant('a1'), tool('t1', 'in_progress'), assistant('a2')],
+      true,
+    );
+    expect(finalizedIds(out)).toEqual(['a1', 't1', 'a2']);
+  });
+
+  it('returns the same entries when nothing newly settles', () => {
+    const entries = [assistant('a1')];
+    expect(finalizeSettledPrefix(entries, false)).toBe(entries);
   });
 });
 

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -11,6 +11,8 @@
  * domain-specific result fields (e.g. tool-edit appliedContent / userPatch).
  */
 
+import PQueue from 'p-queue';
+
 import type { StreamTabId } from '@shared/schemas';
 
 export interface PendingApproval<R extends { accepted: boolean }> {
@@ -43,7 +45,8 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
 ): StreamApprovalController<R> {
   const pending = new Map<string, PendingApproval<R>>();
   const bypassedByStream = new Map<StreamTabId, boolean>();
-  let queue: Promise<void> = Promise.resolve();
+  // Serialize approvals so only one prompt is in flight at a time.
+  const queue = new PQueue({ concurrency: 1 });
 
   function rejectMatching(streamId?: StreamTabId): void {
     for (const entry of pending.values()) {
@@ -70,13 +73,10 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     setBypass(streamId, enabled) {
       bypassedByStream.set(streamId, enabled);
     },
-    enqueue(run) {
-      const operation = queue.then(run);
-      queue = operation.then(
-        () => {},
-        () => {},
-      );
-      return operation;
+    enqueue<T>(run: () => Promise<T>): Promise<T> {
+      // `add` widens to `T | void` to cover abort via signal/timeout; we pass
+      // neither, so the task always runs and resolves with `T`.
+      return queue.add(run) as Promise<T>;
     },
     rejectPendingForStream(streamId) {
       rejectMatching(streamId);


### PR DESCRIPTION
## Summary

Four roughly-independent CLI TUI improvements, validated together:

- **ctrl+t transcript viewer** (`TranscriptViewer.tsx` + `transcriptLines.ts`) — the finalized `<Static>` scrollback and the live region show tool output as a head+tail slice with a `… +N lines` marker; this viewer renders the active stream's entries untruncated and scrollable so the marker is reachable.
- **GFM pipe tables → ANSI box-drawing** in the markdown adapter — collapses the `table_open … table_close` token range into a single pre-rendered `ansi_table` token that `cli-table3` lays out (borders, per-cell word wrap, width-capped column widths). Otherwise the trailing `wrapAnsiToWidth` hard-wrap would shred the box-drawing borders.
- **Settled-prefix scrollback** in `subscribeStreamLog.ts` — replaces deferred finalization with `finalizeSettledPrefix`, which promotes only the contiguous leading run of settled entries into `<Static>`. A fast-completing tool no longer jumps ahead of still-streaming assistant text in append-only scrollback.
- **Serialized stream approvals** via `p-queue` in `streamApprovalQueue.ts` — replaces the hand-rolled `Promise.then` chain with a concurrency-1 PQueue so only one approval prompt is in flight at a time. `p-queue` is now declared at the workspace root (used by core `src/tools`) in addition to the cli package.

## Validation

- `npm run typecheck` clean.
- All CLI Vitest suites pass: 348 tests / 48 files. New tests cover table rendering + width clamping (`AnsiMarkdown.vitest.mts`), head+tail elision with marker + full-output mode (`ToolRenderers.vitest.mts`), and `finalizeSettledPrefix` cases (`TuiStateAndFocus.vitest.mts`).
- Pre-commit Prettier hook clean.

## Notes

- The duplicated color-helper portions (`runtime/style.ts`, `doctor.ts`/`updateChecker.ts` colorization, `CliStyle.vitest.mts`) were already shipped via #4527 and have been dropped from the diff via rebase.
- The auto-merged `toolRenderers.tsx` integrates #4527's patch-line coloring + #4529's "no output" fix with the new head+tail elision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Transcript finalization and scrollback ordering logic changed in ways that affect visible message order; approval serialization is refactored but should remain one-at-a-time.
> 
> **Overview**
> This PR tightens the **CLI TUI** in four areas that ship together.
> 
> **Tool output** in scrollback and the live pane is now a **head/tail preview** with a `… +N lines (ctrl + t to view transcript)` marker; full text stays on the tool row and is shown in a new **ctrl+t** scrollable viewer (`TranscriptViewer`, `transcriptLines`, `transcriptViewerOpen` state).
> 
> **Markdown in the terminal** gains **GFM pipe tables** as ANSI box-drawing via `cli-table3`, with tables collapsed to a custom `ansi_table` token and column widths tied to terminal width (processor cache rebuilds on width change).
> 
> **Scrollback ordering** replaces per-entry deferred finalization with **`finalizeSettledPrefix`**: only a contiguous prefix of “settled” entries promotes into append-only `<Static>`, so a finished tool cannot appear above still-streaming assistant text; everything flushes when the stream hits a final status.
> 
> **Approvals** use a **concurrency-1 `p-queue`** instead of a hand-rolled promise chain in `streamApprovalQueue` (also adds root `p-queue` and ignores `.pnpm-store`).
> 
> Tests cover table rendering, elision/full-output modes, and settled-prefix rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb922b7dd9d5140326c20f6a4b1015f2d7f9b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->