### PR TITLE
Extract stream write chaining logic into reusable utility

### DIFF
--- a/packages/extension/src/progressView/managers/OutputFilesManager.ts
+++ b/packages/extension/src/progressView/managers/OutputFilesManager.ts
@@ -1,7 +1,10 @@
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@logger';
 import { RoundKeySchema } from '@progressView/persistence/streamTabSchemas';
-import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import {
+  chainStreamWrite,
+  mapToRecord,
+} from '@progressView/persistence/serializationUtils';
 import {
   getStreamTabStore,
   mapStreamTabStorage,
@@ -274,15 +277,6 @@ export class OutputFilesManager {
     writesMap: Map<StreamTabId, Promise<void>>,
     write: () => Promise<void> | void,
   ): void {
-    if (!this.loaded) return;
-    const prev = writesMap.get(stream) ?? Promise.resolve();
-    const next = prev.then(() => {
-      if (!writesMap.has(stream)) return;
-      return write();
-    });
-    writesMap.set(
-      stream,
-      next.catch(() => {}),
-    );
+    chainStreamWrite(stream, this.loaded, writesMap, write);
   }
 }

--- a/packages/extension/src/progressView/managers/OutputFilesManager.ts
+++ b/packages/extension/src/progressView/managers/OutputFilesManager.ts
@@ -1,10 +1,8 @@
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@logger';
 import { RoundKeySchema } from '@progressView/persistence/streamTabSchemas';
-import {
-  chainStreamWrite,
-  mapToRecord,
-} from '@progressView/persistence/serializationUtils';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import { chainStreamWrite } from '@progressView/persistence/writeChaining';
 import {
   getStreamTabStore,
   mapStreamTabStorage,

--- a/packages/extension/src/progressView/managers/StreamMetaManager.ts
+++ b/packages/extension/src/progressView/managers/StreamMetaManager.ts
@@ -13,6 +13,7 @@ import {
   mapStreamTabStorage,
 } from '@progressView/persistence/StreamTabStore';
 import type { StreamTabMeta } from '@progressView/persistence/streamTabSchemas';
+import { chainStreamWrite } from '@progressView/persistence/serializationUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /**
@@ -268,22 +269,10 @@ export class StreamMetaManager {
   // -- Per-stream persistence -------------------------------------------------
 
   private save(stream: StreamTabId): void {
-    if (!this.loaded) return;
-    // Serialize writes per stream to avoid concurrent writes to the same meta.json.
-    // Each new save chains after the previous pending write for that stream.
-    const prev = this.pendingWrites.get(stream) ?? Promise.resolve();
-    const next = prev.then(() => {
-      // Skip write if the stream was evicted while this write was queued.
-      // evict() deletes from pendingWrites, so absence means eviction.
-      if (!this.pendingWrites.has(stream)) return;
+    chainStreamWrite(stream, this.loaded, this.pendingWrites, () => {
       const meta = this.buildMeta(stream);
-      const store = getStreamTabStore(stream);
-      return store.writeMeta(meta);
+      return getStreamTabStore(stream).writeMeta(meta);
     });
-    this.pendingWrites.set(
-      stream,
-      next.catch(() => {}),
-    );
   }
 
   private buildMeta(stream: StreamTabId): StreamTabMeta {

--- a/packages/extension/src/progressView/managers/StreamMetaManager.ts
+++ b/packages/extension/src/progressView/managers/StreamMetaManager.ts
@@ -13,7 +13,7 @@ import {
   mapStreamTabStorage,
 } from '@progressView/persistence/StreamTabStore';
 import type { StreamTabMeta } from '@progressView/persistence/streamTabSchemas';
-import { chainStreamWrite } from '@progressView/persistence/serializationUtils';
+import { chainStreamWrite } from '@progressView/persistence/writeChaining';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /**

--- a/packages/extension/src/progressView/managers/UsageStatsManager.ts
+++ b/packages/extension/src/progressView/managers/UsageStatsManager.ts
@@ -1,6 +1,9 @@
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@logger';
-import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import {
+  chainStreamWrite,
+  mapToRecord,
+} from '@progressView/persistence/serializationUtils';
 import {
   TokenUsageStatsParsingSchema,
   isEmptyUsage,
@@ -108,17 +111,11 @@ export class UsageStatsManager {
   // -- Per-stream persistence -----------------------------------------------
 
   private saveStream(stream: StreamTabId): void {
-    if (!this.loaded) return;
-    const prev = this.pendingWrites.get(stream) ?? Promise.resolve();
-    const next = prev.then(() => {
-      if (!this.pendingWrites.has(stream)) return;
+    chainStreamWrite(stream, this.loaded, this.pendingWrites, () => {
       const data = this.items.get(stream);
-      const store = getStreamTabStore(stream);
-      return store.writeUsageStats(data ? mapToRecord(data) : {});
+      return getStreamTabStore(stream).writeUsageStats(
+        data ? mapToRecord(data) : {},
+      );
     });
-    this.pendingWrites.set(
-      stream,
-      next.catch(() => {}),
-    );
   }
 }

--- a/packages/extension/src/progressView/managers/UsageStatsManager.ts
+++ b/packages/extension/src/progressView/managers/UsageStatsManager.ts
@@ -1,9 +1,7 @@
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@logger';
-import {
-  chainStreamWrite,
-  mapToRecord,
-} from '@progressView/persistence/serializationUtils';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import { chainStreamWrite } from '@progressView/persistence/writeChaining';
 import {
   TokenUsageStatsParsingSchema,
   isEmptyUsage,

--- a/packages/extension/src/progressView/persistence/serializationUtils.ts
+++ b/packages/extension/src/progressView/persistence/serializationUtils.ts
@@ -31,5 +31,8 @@ export function chainStreamWrite<K>(
     if (!pendingWrites.has(stream)) return;
     return write();
   });
-  pendingWrites.set(stream, next.catch(() => {}));
+  pendingWrites.set(
+    stream,
+    next.catch(() => {}),
+  );
 }

--- a/packages/extension/src/progressView/persistence/serializationUtils.ts
+++ b/packages/extension/src/progressView/persistence/serializationUtils.ts
@@ -12,3 +12,24 @@ export function mapToRecord<K extends string | number, V>(
 ): Record<string, V> {
   return Object.fromEntries(Array.from(map, ([k, v]) => [String(k), v]));
 }
+
+/**
+ * Enqueue a serialized async write for `stream`, guarded by the `loaded`
+ * flag. Writes for the same stream are chained so they never execute
+ * concurrently. A write queued after its stream has been evicted (detected
+ * by absence from `pendingWrites`) is silently skipped.
+ */
+export function chainStreamWrite<K>(
+  stream: K,
+  loaded: boolean,
+  pendingWrites: Map<K, Promise<void>>,
+  write: () => Promise<void> | void,
+): void {
+  if (!loaded) return;
+  const prev = pendingWrites.get(stream) ?? Promise.resolve();
+  const next = prev.then(() => {
+    if (!pendingWrites.has(stream)) return;
+    return write();
+  });
+  pendingWrites.set(stream, next.catch(() => {}));
+}

--- a/packages/extension/src/progressView/persistence/serializationUtils.ts
+++ b/packages/extension/src/progressView/persistence/serializationUtils.ts
@@ -12,27 +12,3 @@ export function mapToRecord<K extends string | number, V>(
 ): Record<string, V> {
   return Object.fromEntries(Array.from(map, ([k, v]) => [String(k), v]));
 }
-
-/**
- * Enqueue a serialized async write for `stream`, guarded by the `loaded`
- * flag. Writes for the same stream are chained so they never execute
- * concurrently. A write queued after its stream has been evicted (detected
- * by absence from `pendingWrites`) is silently skipped.
- */
-export function chainStreamWrite<K>(
-  stream: K,
-  loaded: boolean,
-  pendingWrites: Map<K, Promise<void>>,
-  write: () => Promise<void> | void,
-): void {
-  if (!loaded) return;
-  const prev = pendingWrites.get(stream) ?? Promise.resolve();
-  const next = prev.then(() => {
-    if (!pendingWrites.has(stream)) return;
-    return write();
-  });
-  pendingWrites.set(
-    stream,
-    next.catch(() => {}),
-  );
-}

--- a/packages/extension/src/progressView/persistence/writeChaining.ts
+++ b/packages/extension/src/progressView/persistence/writeChaining.ts
@@ -1,0 +1,27 @@
+/**
+ * Per-key serialized async write queue used by the progress-view persistence
+ * managers. Writes for the same key never execute concurrently, and writes
+ * queued after a key is evicted (detected by absence from `pendingWrites`)
+ * are silently skipped.
+ */
+
+/**
+ * Enqueue a serialized async write for `key`, guarded by the `loaded`
+ * flag. Writes for the same key are chained so they never execute
+ * concurrently. A write queued after its key has been evicted (detected
+ * by absence from `pendingWrites`) is silently skipped.
+ */
+export function chainStreamWrite<K>(
+  key: K,
+  loaded: boolean,
+  pendingWrites: Map<K, Promise<void>>,
+  write: () => Promise<void> | void,
+): void {
+  if (!loaded) return;
+  const prev = pendingWrites.get(key) ?? Promise.resolve();
+  const next = prev.then(() => {
+    if (!pendingWrites.has(key)) return;
+    return write();
+  });
+  pendingWrites.set(key, next.catch(() => {}));
+}

--- a/packages/extension/src/progressView/persistence/writeChaining.ts
+++ b/packages/extension/src/progressView/persistence/writeChaining.ts
@@ -23,5 +23,8 @@ export function chainStreamWrite<K>(
     if (!pendingWrites.has(key)) return;
     return write();
   });
-  pendingWrites.set(key, next.catch(() => {}));
+  pendingWrites.set(
+    key,
+    next.catch(() => {}),
+  );
 }

--- a/packages/extension/src/progressView/persistence/writeChaining.ts
+++ b/packages/extension/src/progressView/persistence/writeChaining.ts
@@ -1,15 +1,10 @@
 /**
- * Per-key serialized async write queue used by the progress-view persistence
- * managers. Writes for the same key never execute concurrently, and writes
- * queued after a key is evicted (detected by absence from `pendingWrites`)
- * are silently skipped.
- */
-
-/**
- * Enqueue a serialized async write for `key`, guarded by the `loaded`
- * flag. Writes for the same key are chained so they never execute
- * concurrently. A write queued after its key has been evicted (detected
- * by absence from `pendingWrites`) is silently skipped.
+ * Enqueue a serialized async write for `key`, guarded by `loaded`. Writes
+ * for the same key never execute concurrently — each new write chains
+ * after the previous pending one. A write queued after its key has been
+ * evicted is silently skipped: eviction is signalled by removing the key
+ * from `pendingWrites`, so absence inside the `.then()` callback means
+ * "skip this write."
  */
 export function chainStreamWrite<K>(
   key: K,


### PR DESCRIPTION
## Summary

Extracted the common pattern of chaining async writes per stream into a new `chainStreamWrite` utility function in `serializationUtils.ts`. This eliminates duplication across three manager classes (`UsageStatsManager`, `StreamMetaManager`, `OutputFilesManager`) that all implement identical write-queueing logic.

The utility encapsulates the invariant: writes for the same stream are serialized (never concurrent), writes queued after stream eviction are silently skipped, and the `loaded` flag guards all writes.

## Issue acceptance gates

N/A — refactoring for code quality.

## Single source of truth

`chainStreamWrite` in `@progressView/persistence/serializationUtils` now owns the stream write chaining pattern.

## Duplication and abstraction budget

**Removed duplication:** Three identical ~10-line write-chaining blocks in `UsageStatsManager.saveStream()`, `StreamMetaManager.save()`, and `OutputFilesManager.enqueueStreamWrite()` are replaced with calls to the new utility.

**Abstraction invariant:** `chainStreamWrite` owns the contract that:
- Writes are guarded by the `loaded` flag
- Writes for the same stream are chained via promise sequencing
- Writes queued after stream eviction (detected by absence from `pendingWrites`) are skipped
- Errors in pending writes don't break the chain

## Host impact

Extension: Refactoring only; no behavioral change.

Desktop: N/A

CLI: N/A

## Scheduled refactoring

None.

## Validation

Refactoring is mechanical—the extracted function implements the exact same logic that was duplicated. Existing tests for the three manager classes cover the write-chaining behavior indirectly. No new tests needed; CI should pass.

https://claude.ai/code/session_01Ky2cSneEBDiRDSEccet9XD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication of existing write-serialization logic with no intended behavior change.
> 
> **Overview**
> Introduces **`chainStreamWrite`** in `@progressView/persistence/writeChaining` and routes per-stream disk persistence through it instead of copy-pasted promise chaining in **`UsageStatsManager`**, **`StreamMetaManager`**, and **`OutputFilesManager`**.
> 
> Behavior is unchanged: writes are skipped until **`loaded`**, serialized per stream key, post-eviction writes are dropped when the key is removed from the pending map, and failed writes still use **`.catch(() => {})`** so the chain continues. **`OutputFilesManager`** keeps a small **`chainWrite`** wrapper so its three pending-write maps still share the same helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fc21317bdbe754ea4f90c2085236a687924938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->