### PR TITLE
docs: tighten user-facing pitch and add workflow template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **GPT-5.5 Pro** — OpenAI's GPT-5.5 Pro (`gpt55pro`) is now available in the model catalog as an opt-in choice for the hardest planning, long-horizon, and large-codebase tasks. It extends GPT-5.5 with a 1.05M-token context window and `xhigh` default reasoning effort. Premium pricing ($30/M input, $180/M output) and Ultra-tier only on the relay — enable it from Settings → Models when GPT-5.5 isn't enough.
+- **GPT-5.5 Pro** — OpenAI's GPT-5.5 Pro (`gpt55pro`) is now available in the model catalog as an opt-in choice for the hardest planning, long-horizon, and large-codebase tasks. It extends GPT-5.5 with a 1.05M-token context window and `xhigh` default reasoning effort. Premium pricing ($30/M input, $180/M output); available on premium plans — enable it from Settings → Models when GPT-5.5 isn't enough.
 - **Computer Scientist (ML) multi-agent preset** — a new built-in team preset tuned for empirical ML and CS work pairs a numerics agent for code-driven experiments with a search agent for literature and a review/criticize agent for methodology and baseline scrutiny.
 - **Setup assistant can run terminal commands** — the setup wizard can now hand off sudo prompts and interactive installers to your VS Code terminal instead of stalling on them.
 
@@ -237,7 +237,7 @@ All notable changes to this project will be documented in this file.
 
 - **Better multi-file paper support** — workflow agents handle papers with shared files and bibliographies more reliably.
 - **More flexible arXiv downloads** — downloaded papers can be saved where they fit your project organization.
-- **Remote-agent transparency** — Ultra users can inspect the prompt sent to a remote agent.
+- **Remote-agent transparency** — premium users can inspect the prompt sent to a remote agent.
 - **Settings import** — settings can now be loaded from a saved file.
 
 ### Improvements
@@ -790,9 +790,9 @@ All notable changes to this project will be documented in this file.
 
 - Added **Gemini 3 Flash** (`gemini3f`) to the default models list.
 - Chat and tool-use agents can now be hosted as remote agents.
-- Introduced **Max tier** with access to premium models for subscribed users.
-- Added **Researcher Access Program** (free tier) with budget models including
-  GPT-5 Mini and Nano.
+- Introduced **premium plans** with access to flagship models for subscribers.
+- Added **Researcher Access Program** with complimentary access to budget
+  models including GPT-5 Mini and Nano.
 - Added access expiration system for researcher access program.
 
 ### Bug Fixes
@@ -835,7 +835,7 @@ All notable changes to this project will be documented in this file.
 
 - Added **GPT-5.2** (`gpt52`, `gpt52pro`) to the default model list.
 - Introduced **flexible user groups** with permission-based access control
-  and tier levels (Max/Ultra) for remote agents.
+  and subscription tiers for remote agents.
 - Added a **todo list UI** in the progress view for tool-use agents.
 - Added **Research agent** for analytical derivations and scientific research.
 - Added **Search agent** to the default tool-use agents for web search workflows.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Run history and agent settings are shared between both surfaces.
 
 Four built-in presets cover the most common research disciplines:
 
-| Team | Built for |
-| --- | --- |
-| **Physicist** | Analytical derivations, numerical experiments, literature search, slide drafting |
-| **Mathematician** | Proofs, Lean 4 formalization, research, LaTeX correction |
-| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature, reproducibility |
-| **Lean Project** | Mathlib search, tactic simplification, blueprint-driven formalization |
+| Team                        | Built for                                                                        |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| **Physicist**               | Analytical derivations, numerical experiments, literature search, slide drafting |
+| **Mathematician**           | Proofs, Lean 4 formalization, research, LaTeX correction                         |
+| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature, reproducibility         |
+| **Lean Project**            | Mathlib search, tactic simplification, blueprint-driven formalization            |
 
 Pick a team in **Settings → Multi-Agent**, or with `texra multi-agent
 run <preset>`. Or define your own roster in YAML.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TeXRA: Multi-Agent AI Research Assistant for Theorists
+# TeXRA
 
 [![VS Code Marketplace](https://vsmarketplacebadges.dev/version-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![Installs](https://vsmarketplacebadges.dev/installs-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
@@ -9,225 +9,120 @@
 [![npm version](https://img.shields.io/npm/v/@texra-ai/cli?label=%40texra-ai%2Fcli)](https://www.npmjs.com/package/@texra-ai/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@texra-ai/cli)](https://www.npmjs.com/package/@texra-ai/cli)
 
-> **🎓 Free for Researchers!** TeXRA offers a **Researcher Access Program** with
-> complimentary access to budget-friendly models from OpenAI, DeepSeek, Gemini,
-> and more—plus a hosted **Orchestrator** and a roster of remote specialist
-> agents. Sign in through the Profile view to get started—no API keys
-> required.
->
-> The relay runs on sponsor credits. If TeXRA helps your research, please
-> consider supporting it via
-> [GitHub Sponsors](https://github.com/sponsors/texra-ai) or
-> [Buy Me a Coffee](https://buymeacoffee.com/texra.ai) to keep the program
-> open for everyone.
+A LaTeX research assistant for VS Code and the terminal. Multi-agent
+workflows for writing, reviewing, formalizing, and rendering academic
+work — with every change returned as a diff you approve.
 
-**TeXRA is a multi-agent research assistant for theorists (Physics, Math, CS,
-Engineering, etc.).** Instead of chatting with a single model, you direct an
-**Orchestrator** that delegates to a team of specialists—researchers,
-numericists, reviewers, formalizers, LaTeX fixers, presenters—each with their
-own tools, prompts, and model. The result is a coordinated lab that drafts,
-reviews, computes, and formalizes rigorous scientific work alongside its LaTeX,
-code, figures, and PRs.
-
-### One assistant, two surfaces
-
-The same agents, account, and model providers are available wherever you work:
-
-|               | **VS Code extension**                                                                                                                         | **Terminal CLI**                                          |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| Best for      | Interactive writing, side-by-side diffs, figure previews                                                                                      | Scripts, CI, remote/headless machines, the keyboard-first |
-| Install       | [Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra) / [Open VSX](https://open-vsx.org/extension/texra-ai/texra) | `npm install -g @texra-ai/cli`                            |
-| Drive it with | Sidebar chat + the **progress board**                                                                                                         | `texra chat` (TUI) and `texra run` (headless)             |
-
-Pick whichever fits the moment—both run the same teams on the same `.tex`
-projects. The deeper walkthroughs live at
-[texra.ai](https://texra.ai) and the
-[full documentation](https://texra.ai/guide/).
-
-## Why TeXRA
-
-- **Orchestrator-first** – the **Orchestrator** decomposes your task,
-  delegates to specialists in parallel, captures their outputs as diffs, and
-  presents proposals you approve before they touch your files. Follow-ups
-  during delegation are queued, sub-agent runs can be inspected, waited on,
-  resumed, or terminated, and the orchestrator builds long-term memory across
-  sessions.
-- **Curated team presets** – switch to **Physicist**, **Mathematician**,
-  **Computer Scientist (ML)**, or **Lean Project** in one click from the
-  Multi-Agent settings tab, or with `texra multi-agent run <preset>` in the
-  terminal. Each preset is a preconfigured roster of workflow and tool-use
-  agents tuned for that discipline; you can also save your own.
-- **A full cast of specialists** – locally bundled tool-use agents include
-  `research`, `numerics`, `review`, `presenter`, `latexFixer`, `latexDiff`,
-  `creator`, `lean`, `chat`, and the **Setup Wizard** (`setup`); workflow
-  agents include `correct`, `polish`, `merge`, `ocr`, `transcribe_audio`,
-  `paper2slide`, and `paper2poster`. Signing in unlocks remote specialists—
-  `orchestrator`, `search`, `simplifier`, `criticize`, `devise`, `apply`,
-  `generic`, `progressCheck`, and the Lean `leanOrchestrator` /
-  `leanBlueprint` / `leanSearch` / `leanSimplifier` line.
-- **Tools that touch your project** – tool-use agents read and edit
-  workspace files, run shell commands, drive LaTeX builds, work with Git and
-  GitHub PR subscriptions, and can delegate reasoning turns to the Codex
-  CLI—each tool call gated by per-stream approval (with an optional YOLO
-  bypass).
-- **Live, persistent runs** – watch reasoning, tool calls, sub-agent file
-  diffs, and per-run token usage and cost stream in real time—on the VS Code
-  **progress board** or in the `texra chat` terminal UI. Each surface saves its
-  runs so you can reopen and resume them later: via **Show Agent Execution
-  History** and **Resume Tool-Use Agent** in VS Code, or `texra history` and
-  `texra resume <id>` in the terminal. Finished outputs can be archived into
-  the workspace's `History/` directory.
-- **Odyssey mode (experimental)** – let a tool-use agent run a long task to
-  completion on its own. A configurable budget auto-pauses the run for your
-  approval before going further, and a dedicated panel shows progress so
-  you can step in at any time. Off by default; enable it with the
-  `texra.experimental.odyssey.enabled` VS Code setting.
-- **Model flexibility with guardrails** – mix and match per agent: OpenAI
-  (incl. GPT-5.5 and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google
-  Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen (DashScope),
-  Zhipu GLM, MiniMax, OpenRouter, and custom endpoints—with context
-  management, retry/backoff, parallel-tool-call limits, and cost monitoring
-  all configurable.
-
-## Built-in Agent Teams
-
-| Team                        | What the team does                                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **Physicist**               | Analytical derivations, numerical experiments, literature search, slide drafting, and critical review. |
-| **Mathematician**           | Proofs, Lean 4 formalization, research, and LaTeX correction.                                          |
-| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature search, critical review, and reproducibility.  |
-| **Lean Project**            | Lean 4 projects—theorem search, tactic simplification, and blueprint-driven formalization.             |
-
-Switch teams from the Multi-Agent tab in Settings (or `texra multi-agent` in
-the terminal), or build your own roster of workflow and tool-use agents. Teams
-that include remote specialists (e.g. the
-Orchestrator, `search`, `simplifier`) require sign-in or your own API keys
-configured for the providers those agents use.
-
-## Quick Start
-
-Both surfaces share the same sign-in and agents, so set up whichever you'll
-use—or both.
-
-### In VS Code
-
-1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
-   or [Open VSX](https://open-vsx.org/extension/texra-ai/texra).
-2. Launch the **Setup Wizard**. Pick whichever is easiest:
-   - Click the **🚀 TeXRA: Get Started** pill in the status bar (shown
-     automatically until you sign in or add an API key).
-   - Click **Run the setup assistant agent** in the Getting Started banner
-     at the top of the TeXRA sidebar.
-   - Open VS Code's **Welcome / Walkthroughs** page and pick **TeXRA:
-     Getting Started** — Step 1 is a one-click button.
-   - Or, from the command palette, run
-     **`TeXRA: Run Setup Assistant Agent (Setup Wizard)`**.
-
-   The Setup Wizard diagnoses your environment, installs missing LaTeX
-   tooling, helps you sign in or add an API key, and verifies you're ready
-   to run agents—asking before every command and explaining what it's
-   doing. It can hand off interactive `sudo` prompts and installers to your
-   VS Code terminal.
-
-3. Pick an agent **team** in Settings → Multi-Agent (Physicist,
-   Mathematician, CS/ML, or Lean Project), or stay with the default lineup.
-4. Open the TeXRA sidebar, select the **Orchestrator** (or any agent),
-   describe your task, and approve the proposals it routes to specialists.
-   Watch progress, file diffs, and live reasoning on the **progress board**,
-   and follow up at any time—messages are queued for whichever sub-agent
-   needs them.
-
-New here? Use the **Create Sample Project** button in the Getting Started
-banner (also available as `TeXRA: Create Sample Project` from the command
-palette) to spin up a fully configured workspace.
-
-### In the terminal
-
-Run the same agents on your `.tex` projects without an editor—ideal for
-scripts, CI, and remote machines.
+## Install
 
 ```sh
-npm install -g @texra-ai/cli   # requires Node.js >= 22
+# VS Code (or Cursor, Windsurf, Antigravity)
+code --install-extension texra-ai.texra
 
-texra login      # Researcher Access sign-in; or set <PROVIDER>_API_KEY and use --api-mode personal
-texra doctor     # verify environment, sign-in, models, and LaTeX tooling
+# Terminal — requires Node.js 22+
+npm install -g @texra-ai/cli
 ```
 
-Then drive a whole research team from the prompt:
+Sign in with GitHub or Google for hosted access (no key management
+required), or set `<PROVIDER>_API_KEY` to use your own credentials.
+
+## Run
+
+In VS Code: open a `.tex` file, click the TeXRA icon, pick
+**Orchestrator** or another agent, type a task. The Setup Wizard runs
+on first launch and checks your environment.
+
+In the terminal:
 
 ```sh
-texra              # interactive launcher: pick a chat, team, or run to resume
-texra chat         # interactive tool-use session (Orchestrator and specialists)
-texra run polish --input paper.tex --output paper.polished.tex --print
+texra chat                                  # interactive tool-use session
+texra run polish --input paper.tex          # one-shot workflow
+texra multi-agent run physicist             # named team
 ```
 
-The CLI exposes the full toolkit—`texra agents`, `models`, `tools`, and
-`multi-agent` to inspect and launch teams; `texra history` and `texra resume`
-to revisit or re-run past work; `texra init` to drop a project `.texra/config.json`.
-For automation, every headless command takes `--output-format json|ndjson` and
-`--approval-policy never|ask|yolo`. Run `texra --help` or see the
-[documentation](https://texra.ai/guide/) for the full command reference.
+Run history and agent settings are shared between both surfaces.
+
+## Teams
+
+Four built-in presets cover the most common research disciplines:
+
+| Team | Built for |
+| --- | --- |
+| **Physicist** | Analytical derivations, numerical experiments, literature search, slide drafting |
+| **Mathematician** | Proofs, Lean 4 formalization, research, LaTeX correction |
+| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature, reproducibility |
+| **Lean Project** | Mathlib search, tactic simplification, blueprint-driven formalization |
+
+Pick a team in **Settings → Multi-Agent**, or with `texra multi-agent
+run <preset>`. Or define your own roster in YAML.
+
+## Agents
+
+**Workflow agents** write to disk and produce reviewable diffs:
+`polish`, `correct`, `merge`, `ocr`, `transcribe_audio`, `paper2slide`,
+`paper2poster`.
+
+**Tool-use agents** work conversationally with file, shell, and search
+access: `research`, `numerics`, `review`, `presenter`, `latexFixer`,
+`latexDiff`, `creator`, `lean`, `chat`, `setup`.
+
+**Hosted specialists** (signed-in users): `orchestrator`, `search`,
+`simplifier`, `criticize`, `devise`, `apply`, `generic`,
+`progressCheck`, and the Lean line — `leanOrchestrator`,
+`leanBlueprint`, `leanSearch`, `leanSimplifier`.
+
+Every tool call is gated by per-stream approval. Optional YOLO mode
+skips approval for autonomous runs.
+
+## Models
+
+Bring your own keys for OpenAI, Anthropic, Google Gemini, DeepSeek,
+xAI Grok, Moonshot Kimi, Alibaba Qwen, Zhipu GLM, MiniMax, OpenRouter,
+or any OpenAI-compatible endpoint. Each agent in a team can run a
+different model — pair a flagship reasoner for orchestration with
+cheaper, faster models for routine sub-tasks.
+
+In the extension, run **`TeXRA: Set API Key`** (stored in VS Code's
+encrypted SecretStorage) or add a workspace `.env`:
+
+```env
+OPENAI_API_KEY=…
+ANTHROPIC_API_KEY=…
+GOOGLE_API_KEY=…
+```
+
+In the CLI, export the same variables in your shell and run with
+`--api-mode personal`.
 
 ## Requirements
 
-- **VS Code** 1.105+ for the extension (also runs in compatible editors such
-  as Cursor, Windsurf, and Google Antigravity), **or Node.js 22+** for the
-  terminal CLI
-- **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX) for compilation and
-  related tooling
-- **Perl** (required by `latexindent` and `latexdiff`)
-- **Optional**: GraphicsMagick/ImageMagick and Ghostscript for PDF and image
-  processing; `git` for repository-aware features; `gh` and a Codex CLI for
-  GitHub PR and Codex integrations; Lean 4 + `lake` for the Lean Project team
+- **VS Code 1.105+** (also runs in Cursor, Windsurf, Antigravity), or
+  **Node.js 22+** for the CLI
+- **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX)
+- **Perl** (for `latexindent` and `latexdiff`)
+- Optional: ImageMagick + Ghostscript (for PDF/image processing),
+  `git`, `gh`, Codex CLI, Lean 4 + `lake`
 
-The Setup Wizard checks for and helps install most of the above for you.
+The Setup Wizard checks for and helps install most of the above.
 
-## Configuring Models
+## Documentation
 
-Sign in to the Researcher Access Program—via the Profile view in VS Code or
-`texra login` in the terminal—to use the hosted Orchestrator and remote
-specialists. To bring your own keys instead, the extension reads them from the
-**`TeXRA: Set API Key`** command (stored in VS Code's encrypted SecretStorage)
-or a workspace `.env` file it loads automatically; the CLI reads the same
-`<PROVIDER>_API_KEY` variables from your environment when run with
-`--api-mode personal`:
+- [Installation](https://texra.ai/guide/installation)
+- [Quick Start](https://texra.ai/guide/quick-start)
+- [Built-in Agents](https://texra.ai/guide/built-in-agents)
+- [Polish a draft](https://texra.ai/guide/workflows/polish-a-draft) — workflow example
+- [Models](https://texra.ai/guide/models)
+- [Custom Agents](https://texra.ai/guide/custom-agents)
 
-```env
-OPENAI_API_KEY=your_openai_key_here
-ANTHROPIC_API_KEY=your_anthropic_key_here
-GOOGLE_API_KEY=your_google_key_here
-DEEPSEEK_API_KEY=your_deepseek_key_here
-XAI_API_KEY=your_xai_key_here
-OPENROUTER_API_KEY=your_openrouter_key_here
-```
+Full docs at [texra.ai/guide](https://texra.ai/guide/).
 
-Other supported providers follow the same `<PROVIDER>_API_KEY` convention:
-`MOONSHOT_API_KEY`, `DASHSCOPE_API_KEY` (Qwen), `MINIMAX_API_KEY`,
-`GLM_API_KEY`. Each
-agent in a team can use a different model, so you can pair a flagship reasoner
-for the orchestrator with cheaper, faster models for routine sub-tasks. See
-the [installation guide](https://texra.ai/guide/installation.html) and the
-[models guide](https://texra.ai/guide/models.html) for details.
+## Support
 
-## Customization
-
-Configure agents, prompts, models, and reliability policy in VS Code settings
-or the unified Settings view (Memory, History, Models, Agents, Multi-Agent,
-Tools, Git, LaTeX tabs). The Multi-Agent tab covers team presets, parallel
-tool-call limits, compaction thresholds, retry/backoff, and the orchestrator
-kill toggle. In the terminal, `texra init` writes a project
-`.texra/config.json` with the same knobs, and any setting can be overridden
-per run with a command-line flag. Power users on either surface can define new
-workflow or tool-use agents in YAML or register new model handlers.
-
-## Support & Feedback
-
-Report issues and feature requests on the
-[GitHub issues page](https://github.com/texra-ai/texra-issues/issues) or email
-[contact@texra.ai](mailto:contact@texra.ai).
+Issues and feature requests: [GitHub](https://github.com/texra-ai/texra-issues/issues).
+Contact: [contact@texra.ai](mailto:contact@texra.ai).
 
 ## License
 
 © TeXRA Team 2025–2026. All rights reserved.
 
-[Terms of Service](https://texra.ai/terms) · [Provider List](https://texra.ai/providers)
+[Terms of Service](https://texra.ai/terms) · [Provider list](https://texra.ai/providers)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ npm install -g @texra-ai/cli
 Sign in with GitHub or Google for hosted access (no key management
 required), or set `<PROVIDER>_API_KEY` to use your own credentials.
 
+### Researcher Access Program
+
+Academic researchers can sign in for complimentary hosted access to
+a curated set of budget-friendly models — enough to run the
+Orchestrator and the full roster of hosted specialists on real work,
+without managing provider keys or paying per-token rates. Sign in
+through the Profile view in VS Code, or `texra login` in the
+terminal.
+
+The program is sustained by the community. If TeXRA helps your
+research, consider supporting it via
+[GitHub Sponsors](https://github.com/sponsors/texra-ai) or
+[Buy Me a Coffee](https://buymeacoffee.com/texra.ai) to keep it open
+for everyone.
+
 ## Run
 
 In VS Code: open a `.tex` file, click the TeXRA icon, pick

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -112,6 +112,7 @@ const baseConfig = {
           items: [
             { text: 'Introduction', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
+            { text: 'First Run', link: '/guide/first-run' },
             { text: 'Quick Start', link: '/guide/quick-start' },
           ],
         },
@@ -131,6 +132,7 @@ const baseConfig = {
         {
           text: 'Workflows',
           items: [
+            { text: 'Polish a Draft', link: '/guide/workflows/polish-a-draft' },
             { text: 'LaTeX Diff', link: '/guide/latex-diff' },
             { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
             { text: 'Research Tools', link: '/guide/research-tools' },

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -1,0 +1,106 @@
+# First run
+
+You have TeXRA installed. This page walks you through running one
+agent — `polish` — on a real `.tex` file. About five minutes,
+side-by-side for the extension and the CLI.
+
+If you don't have TeXRA yet, see [Installation](./installation.md).
+
+## What you'll do
+
+1. Get a sample `.tex` file.
+2. Run the `polish` agent with one instruction.
+3. Read the diff.
+
+## Get a sample file
+
+If you already have a draft you want to polish, skip this step.
+Otherwise:
+
+### In VS Code
+
+Open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run
+**`TeXRA: Create Sample Project`**. This drops a ready-to-run
+workspace at `texra-sample/draft.tex`.
+
+### In the terminal
+
+Any `.tex` file works. If you want a quick test file:
+
+```sh
+cat > draft.tex <<'EOF'
+\documentclass{article}
+\begin{document}
+The proposed method achieves significant improvements over the baseline,
+which is something that is very important for the field, and we will
+demonstrate this in the following sections through various experiments.
+\end{document}
+EOF
+```
+
+## Run polish
+
+### In VS Code
+
+1. Open `draft.tex`.
+2. Click the TeXRA icon in the activity bar.
+3. In the sidebar, click **Current** next to **Input**.
+4. Pick **polish** under Agent. Pick **sonnet46** under Model (or any
+   available model).
+5. Type an instruction:
+   > Tighten the prose. Preserve all math and citations.
+6. Press **Execute**.
+
+The Progress Board opens and streams the run. When it finishes, a
+**diff** icon appears on the completed stream — click it to see what
+changed.
+
+### In the terminal
+
+```sh
+texra run polish \
+  --input draft.tex \
+  --instruction "Tighten the prose. Preserve all math and citations."
+```
+
+The run streams reasoning, tool calls, and the assembled output.
+When it completes, polish has written:
+
+```
+.texra/runs/<run-id>/r0/draft.tex   # First revision
+.texra/runs/<run-id>/r1/draft.tex   # Critique pass
+```
+
+(The input filename is preserved — not `output.tex`.)
+
+To diff against your original:
+
+```sh
+diff -u draft.tex .texra/runs/<run-id>/r1/draft.tex
+```
+
+To write the final result next to your input instead of into task
+storage, add `--output draft.polished.tex` to the command.
+
+## What just happened
+
+Polish ran two passes:
+
+- **Round 0** — read your file, applied your instruction, wrote the
+  first revision.
+- **Round 1** — reread its own Round 0 output, checked for missing
+  math, weakened sentences, generic filler, and out-of-scope changes,
+  then revised again.
+
+Workflow agents like `polish` do not call tools. They read input, run
+their pipeline, and write a diff. The next step up — tool-use agents
+— can read across your project, search literature, compile LaTeX, and
+verify their work; see [Built-in Agents](./built-in-agents.md).
+
+## Next steps
+
+- [**Polish a draft**](./workflows/polish-a-draft.md) — the workflow in depth: rounds, limits, multi-file projects
+- [**Built-in Agents**](./built-in-agents.md) — the full catalog, including `correct`, `research`, `review`, and `lean`
+- [**Models**](./models.md) — choosing a model that matches the work
+- [**TeXRA CLI**](./texra-cli.md) — sign-in, workspace defaults, headless output formats
+- [**LaTeX Diff**](./latex-diff.md) — compiled PDF comparison of revisions

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,35 +1,69 @@
-# Introduction
+# TeXRA
 
-TeXRA is a multi-agent AI system for rigorous scientific work. You direct one orchestrator; it delegates to **specialized agents** — for literature search, manuscript drafting, figure generation, formal verification, and symbolic computation — each grounded in its own tools and model. Every citation is real, every figure compiles, and every edit comes back as a diff you approve. TeXRA runs in two places that share the same agents and run history: the **VS Code extension** and the **`texra` command-line interface**.
+A LaTeX research assistant for VS Code and the terminal. Multi-agent
+workflows for writing, reviewing, formalizing, and rendering academic
+work — with every change returned as a diff you approve.
 
 <GuideIntroHero />
 
 <p class="hero-caption">A single task, split across three specialists in the Progress view — click a delegation to see what it produced.</p>
 
-Prefer the terminal? Install the CLI with `npm install -g @texra-ai/cli` (Node.js 22+) — see [TeXRA CLI](./texra-cli.md).
+## Get started
 
-## Why multi-agent?
+- [**Installation**](./installation.md) — VS Code extension or the `texra` CLI
+- [**First run**](./first-run.md) — open a `.tex` file, watch one agent work
+- [**Quick start**](./quick-start.md) — the longer walkthrough in VS Code
 
-The gap between having a result and having a correct, publishable manuscript is where most research time goes. A 40-page paper where notation must be consistent from Definition 2.1 through Appendix C. A bibliography where every entry is real and every `\cite` key resolves. Commutative diagrams and Feynman diagrams that compile. A literature survey of a field where hundreds of papers appeared this year. A Lean formalization where the proof state needs careful tactic selection.
+## Use it
 
-General-purpose AI tools make this worse, not better:
+| Task | Workflow |
+| --- | --- |
+| Tighten prose in a draft | [Polish a draft](./workflows/polish-a-draft.md) |
+| Fix LaTeX errors and notation | `correct` agent — see [Built-in Agents](./built-in-agents.md) |
+| Search literature, no fabricated citations | `research` — see [Research Tools](./research-tools.md) |
+| Verify proofs and derivations | `review` — see [Built-in Agents](./built-in-agents.md) |
+| Formalize in Lean 4 | [Lean 4 Proofs](./lean.md) |
+| Build slides from a paper | `paper2slide` — see [Built-in Agents](./built-in-agents.md) |
+| Generate TikZ figures | [TikZ Figures](./tikz-figures.md) |
 
-- **Hallucinated citations.** Without grounded search tools, models fabricate references — dangerous in peer-reviewed work, unacceptable in mathematics.
-- **Lost structure.** Chatbots can't reason across theorem environments, `\label`/`\ref` graphs, BibTeX databases, and multi-file projects simultaneously.
-- **No verification.** You get text output with no way to compile, diff, type-check, or audit what changed.
-- **No tool access.** A single prompt can't search Mathlib by type signature, run a WolframScript computation, compile TikZ, and verify the result.
+## Understand the system
 
-Scientific work needs a _system_ of agents — each specialized, each grounded in real tools, each producing verifiable output.
+- [**Built-in Agents**](./built-in-agents.md) — the full catalog
+- [**Agent Architecture**](./agent-architecture.md) — workflow vs. tool-use, reflection, planning
+- [**Models**](./models.md) — picking a model for the job
+- [**Custom Agents**](./custom-agents.md) — define your own in YAML
 
-## The multi-agent approach
+## Why multi-agent
 
-TeXRA solves this with a team of agents that share context and use tools:
+The gap between a result and a publishable manuscript is where most
+research time goes. A 40-page paper where notation must be consistent
+from Definition 2.1 through Appendix C. A bibliography where every
+`\cite` resolves to a real paper. Commutative diagrams that compile.
+A Lean formalization where the proof state needs careful tactic
+selection.
+
+General-purpose chatbots make this worse, not better:
+
+- **Hallucinated citations** — no grounded search means fabricated references.
+- **Lost structure** — one prompt can't reason across theorem environments, `\label`/`\ref` graphs, BibTeX, and multi-file projects at once.
+- **No verification** — text output with no way to compile, diff, or type-check what changed.
+- **No tools** — no Mathlib search by type signature, no WolframScript, no TikZ compile.
+
+TeXRA solves this by splitting the work across agents — each
+specialized, each grounded in real tools, each producing verifiable
+output.
+
+## Two surfaces, one system
+
+The VS Code extension and the `texra` CLI share the same agents, the
+same sign-in, and the same run history. A run started in the CLI shows
+up in the extension's Progress Board, and vice versa.
 
 ```mermaid
 graph TB
     User[User] --> |selects files + agent| Orchestrator[Agent Orchestrator]
     Orchestrator --> WA[Workflow Agents]
-    Orchestrator --> IA[Interactive Agents]
+    Orchestrator --> IA[Tool-use Agents]
 
     WA --> |polish, correct, merge| Output[Versioned Output Files]
     Output --> Diff[Color-Coded Diff]
@@ -43,68 +77,50 @@ graph TB
     Tools --> Shell[Shell Commands]
 ```
 
-### Two types of agents
+**Workflow agents** (`polish`, `correct`, `merge`, `ocr`,
+`transcribe_audio`, `paper2slide`, `paper2poster`) run a structured
+pipeline and write task-scoped output files with diffs.
 
-**Workflow agents** (`polish`, `correct`, `paper2slide`, `paper2poster`, `ocr`, `transcribe_audio`, `merge`) execute structured pipelines:
+**Tool-use agents** (`research`, `numerics`, `review`, `lean`,
+`presenter`, `latexFixer`, `creator`, `chat`, `setup`) work
+conversationally — they read and edit workspace files, search arXiv
+and Crossref, query Mathlib by type signature, compile LaTeX, and run
+WolframScript.
 
-1. Analyze your input files and instructions
-2. Plan and execute changes via LLM calls
-3. Optionally reflect on their output and iterate
-4. Produce task-scoped output files (`r0/output.*`, `r1/output.*`) with diffs
-
-**Interactive agents** include `research`, `numerics`, `review`, `lean`, and `presenter`, which operate conversationally with tool access:
-
-- Read and edit files across your entire workspace
-- Search arXiv, Crossref, and Zotero for references with verified BibTeX
-- Search Mathlib by type signature (Loogle), inspect Lean proof states, check diagnostics
-- Run WolframScript for symbolic and numerical computation
-- Compile LaTeX and visually verify output
-- Maintain persistent context across multi-turn conversations
-
-### Design patterns
-
-The agent system is built on three established AI design patterns:
-
-1. **Reflection** — agents examine their own output to identify errors and inconsistencies, running multiple rounds when rigor demands it
-2. **Tool use** — agents call external tools (compilers, Lean LSP, Loogle, WolframScript, search APIs, file systems) to ground their reasoning in verified data
-3. **Planning** — agents break complex tasks into steps, execute them sequentially, and adapt based on intermediate results
-
-## What you can do
-
-| Task                 | Agent                         | How it works                                                                                                                                                       |
-| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Polish a manuscript  | `polish`                      | Rewrites for clarity and precision, preserving all math environments and cross-references. Outputs a reviewable diff.                                              |
-| Fix LaTeX errors     | `correct`                     | Finds and repairs compilation errors, notation inconsistencies, broken references, and formatting issues across multi-file projects.                               |
-| Generate figures     | `research` / `presenter`      | Tool-use agents write TikZ diagrams — commutative diagrams, Feynman diagrams, phase portraits, lattice structures — then compile and visually verify every figure. |
-| Search literature    | `research`                    | Queries arXiv, Crossref, Zotero. Returns verified citations with BibTeX — no hallucinated references.                                                              |
-| Verify manuscript    | `review`                      | Systematically audits mathematical correctness, derivation soundness, notation consistency, and goal achievement.                                                  |
-| Work with Lean 4     | `lean`                        | Search Mathlib theorems via Loogle by type signature, inspect proof states, check diagnostics, manage builds and cache.                                            |
-| Symbolic computation | `research`                    | Run WolframScript to evaluate integrals, check identities, simplify expressions, or verify numerical results.                                                      |
-| Build slide decks    | `presenter`                   | Reads your paper, drafts a Beamer deck that preserves logical structure — definitions before theorems, diagrams in TikZ. Compiles and checks every page.           |
-| General research     | `research`                    | Open-ended agent with full tool access for any research task.                                                                                                      |
-| Convert formats      | `paper2slide`, `paper2poster` | Transform papers into presentations or posters.                                                                                                                    |
+The system rests on three established AI design patterns: **reflection**
+(agents critique their own output and iterate), **tool use** (agents
+ground their reasoning in verified data from compilers, LSPs, and search
+APIs), and **planning** (agents decompose tasks, execute steps, and
+adapt to intermediate results).
 
 ## Who uses TeXRA
 
-- **Mathematicians** writing papers with complex theorem environments, maintaining notation consistency across long proofs, formalizing results in Lean 4
-- **Theoretical physicists** managing multi-file manuscripts with extensive equation environments, Feynman diagrams, and large bibliographies
-- **Computational scientists** producing papers that combine numerical methods, algorithm descriptions, convergence plots, and reproducible workflows
-- **PhD students** maintaining consistency across thesis chapters, surveying literature in a new subfield, preparing seminar talks from written work
-- **Research groups** collaborating on papers where every change needs to be traceable and auditable by co-authors and referees
+- **Mathematicians** — papers with complex theorem environments, notation consistency across long proofs, Lean 4 formalization.
+- **Theoretical physicists** — multi-file manuscripts with extensive equation environments, Feynman diagrams, large bibliographies.
+- **Computational scientists** — papers combining numerical methods, algorithm descriptions, convergence plots, reproducible workflows.
+- **PhD students** — thesis chapters with consistent notation, literature surveys in new subfields, seminar talks from written work.
+- **Research groups** — collaborations where every change is traceable and auditable by co-authors and referees.
 
 ## Privacy and data handling
 
-All API calls go **directly from your machine** to the model provider you choose (Anthropic, OpenAI, Google, etc.). TeXRA does not operate intermediate servers. Your unpublished proofs, manuscripts, and API keys never leave your machine except to the provider endpoint.
+**Bring-your-own-key mode.** API calls go directly from your machine
+to the model provider you chose. TeXRA does not sit between you and
+the provider. Your unpublished proofs, manuscripts, and API keys
+never leave your machine except to the provider endpoint.
 
-API keys are stored in your operating system's secure credential store — VS Code's built-in Secret Storage in the extension, and the OS keychain (or a local config file) for the CLI. They can also be supplied via environment variables or a `.env` file in your project.
+**Hosted access** (signed in with GitHub or Google). Requests to
+hosted models are proxied through TeXRA's service so we can manage
+provider credentials and quota on your behalf. Switch any run back
+to direct mode with `--api-mode personal` (CLI) or by providing your
+own key in Settings (extension).
 
-## Next steps
+API keys, whichever mode you use, are stored in your operating
+system's secure credential store — VS Code's built-in Secret Storage
+in the extension, the OS keychain (or a local config file) for the
+CLI. They can also be supplied via environment variables or a `.env`
+file in your project.
 
-- [Installation](/guide/installation) — set up TeXRA and its dependencies
-- [TeXRA CLI](/guide/texra-cli) — run agents from the terminal with the `texra` command
-- [Quick Start](/guide/quick-start) — your first agent run in under five minutes
-- [Built-in Agents](/guide/built-in-agents) — the full catalog of available agents
-- [Agent Architecture](/guide/agent-architecture) — how the multi-agent system works under the hood
-- [Custom Agents](/guide/custom-agents) — build your own agents with YAML configuration
+## Support
 
-If you spot a bug, email [contact@texra.ai](mailto:contact@texra.ai) or open an issue on [GitHub](https://github.com/texra-ai/texra-issues).
+Issues and feature requests: [GitHub](https://github.com/texra-ai/texra-issues).
+Contact: [contact@texra.ai](mailto:contact@texra.ai).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -16,15 +16,15 @@ work — with every change returned as a diff you approve.
 
 ## Use it
 
-| Task | Workflow |
-| --- | --- |
-| Tighten prose in a draft | [Polish a draft](./workflows/polish-a-draft.md) |
-| Fix LaTeX errors and notation | `correct` agent — see [Built-in Agents](./built-in-agents.md) |
-| Search literature, no fabricated citations | `research` — see [Research Tools](./research-tools.md) |
-| Verify proofs and derivations | `review` — see [Built-in Agents](./built-in-agents.md) |
-| Formalize in Lean 4 | [Lean 4 Proofs](./lean.md) |
-| Build slides from a paper | `paper2slide` — see [Built-in Agents](./built-in-agents.md) |
-| Generate TikZ figures | [TikZ Figures](./tikz-figures.md) |
+| Task                                       | Workflow                                                      |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| Tighten prose in a draft                   | [Polish a draft](./workflows/polish-a-draft.md)               |
+| Fix LaTeX errors and notation              | `correct` agent — see [Built-in Agents](./built-in-agents.md) |
+| Search literature, no fabricated citations | `research` — see [Research Tools](./research-tools.md)        |
+| Verify proofs and derivations              | `review` — see [Built-in Agents](./built-in-agents.md)        |
+| Formalize in Lean 4                        | [Lean 4 Proofs](./lean.md)                                    |
+| Build slides from a paper                  | `paper2slide` — see [Built-in Agents](./built-in-agents.md)   |
+| Generate TikZ figures                      | [TikZ Figures](./tikz-figures.md)                             |
 
 ## Understand the system
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -254,14 +254,14 @@ set -a; . .env; set +a
 texra doctor
 ```
 
-Prefer not to manage keys at all? Sign in to TeXRA for included relay access:
+Prefer not to manage keys at all? Sign in to TeXRA for included hosted access:
 
 ```bash
 texra login
 texra auth status
 ```
 
-See [TeXRA CLI](./texra-cli.md) for sign-in, workspace defaults, and switching between relay and personal-key access.
+See [TeXRA CLI](./texra-cli.md) for sign-in, workspace defaults, and switching between hosted and personal-key access.
 
 ::: info Getting API Keys
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -128,7 +128,7 @@ Enable the `texra.debug.saveInputPrompt` setting if you want TeXRA to store the 
 
 ### Step 7: Review Results
 
-1. When the agent completes, VS Code will open the generated output file from the run's task storage folder (e.g., `r0/output.tex`).
+1. When the agent completes, VS Code will open the generated output file from the run's task storage folder (e.g., `r0/draft.tex`, preserving the input filename).
 2. Review the changes made by the AI. Remember, it's smart, but hasn't passed its quals yet!
 3. You can compare the original and modified versions using:
    - **ProgressBoard Diff**: Click the <wa-icon library="texra" name="diff-multiple"></wa-icon> Diff button on the completed stream to compare the original file against the generated task-storage output.
@@ -163,7 +163,7 @@ The same agents are one command away from the terminal. After
 `npm install -g @texra-ai/cli` (Node.js 22+):
 
 ```bash
-# Sign in for included relay access, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in your shell:
+# Sign in for included hosted access, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in your shell:
 texra login
 
 # One-shot run (writes output next to the input):
@@ -293,11 +293,12 @@ When TeXRA completes a task, it produces:
 2. **Log Files**: Detailed information about the process
 3. **Diff Files**: Visual comparison between original and modified versions (if applicable)
 
-Output files are saved in the run's task storage folder with a naming pattern:
-`r{round}/output.extension`
+Output files are saved in the run's task storage folder, one per
+round, using the **input filename** as the document name:
+`r{round}/<input-filename>`
 
 For example, if your input file is `paper.tex` and the first round produces TeX, the output path inside task storage is:
-`r0/output.tex`
+`r0/paper.tex`
 
 ## Next Steps
 

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -58,7 +58,7 @@ filesystem copy was written, and report `terminalStatus` for the completed run.
 
 ## Authentication
 
-You can run the CLI either with a TeXRA sign-in (included relay access) or
+You can run the CLI either with a TeXRA sign-in (included hosted access) or
 with your own provider API keys — whichever you prefer.
 
 **Sign in with GitHub or Google** to use included access without managing keys:
@@ -85,7 +85,7 @@ texra run polish --input paper.tex
 ```
 
 If you're signed in **and** want this particular run to use your own key
-instead of relay access, add `--api-mode personal`.
+instead of hosted access, add `--api-mode personal`.
 
 The CLI doesn't read `.env` files automatically. If you already keep keys
 there, load them into the shell first (in bash/zsh: `set -a; . .env; set +a`).
@@ -106,7 +106,7 @@ texra chat --model deepseekT        # override the session model
 ```
 
 Slash commands inside the session: `/tools` lists and toggles integrations,
-`/api` switches between relay and personal-key access, and `/resume` restores a
+`/api` switches between hosted and personal-key access, and `/resume` restores a
 stored execution. Chat requires an interactive terminal — for scripted, non-TTY
 runs use `texra run` with `--print` or `--output-format json|ndjson`.
 
@@ -223,7 +223,7 @@ keys were ignored.
 
 Use `--api-mode personal` or `TEXRA_API_MODE=personal` to force a `run` or
 `chat` invocation to use provider API keys even when the CLI is signed in for
-included relay access. `--api-mode included` keeps the default relay behavior
+included hosted access. `--api-mode included` keeps the default hosted behavior
 when the account is signed in. The accepted aliases match the TUI `/api`
 command: for example, `direct`, `api`, and `byok` select personal API keys,
-while `relay` selects included access.
+while `included` selects hosted access.

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -1,0 +1,103 @@
+# Polish a draft
+
+Rewrite a LaTeX paper for clarity. Keeps math, citations, and structure
+intact. Outputs a reviewable diff.
+
+## What polish does
+
+- Reads your input `.tex` file (and any context files you attach).
+- Produces a revised draft that follows your instruction.
+- Runs a built-in critique pass that rereads its own output and revises it.
+
+Polish is a **workflow agent**: it writes to disk and produces a diff.
+It does not chat, compile LaTeX, or verify citations.
+
+## When to use it
+
+Use polish when the content is in place and the prose needs work.
+
+- Tighten loose paragraphs before submission.
+- Fix repetition, hedging, generic phrasing.
+- Improve flow between sentences and sections.
+
+Don't use polish to add content, change math, or restructure sections.
+For those, use the [Orchestrator](../built-in-agents.md) or the
+`research` agent.
+
+## Run it from the CLI
+
+```sh
+texra run polish \
+  --input intro.tex \
+  --instruction "Tighten prose. Preserve all math and citations."
+```
+
+Each round writes its output into the run's task storage, using the
+**input filename** as the document name:
+
+```
+.texra/runs/<run-id>/r0/intro.tex   # Round 0 — first revision
+.texra/runs/<run-id>/r1/intro.tex   # Round 1 — critique-and-revise pass
+```
+
+To write the final revision next to your input instead:
+
+```sh
+texra run polish --input intro.tex --output intro.polished.tex
+```
+
+## Run it in VS Code
+
+1. Open `intro.tex`.
+2. Click the TeXRA icon in the activity bar.
+3. In the sidebar, click **Current** next to **Input**.
+4. Pick **polish** as the agent. Pick a model.
+5. Type the instruction. Press **Execute**.
+6. When the run completes, open the diff from the **Progress Board**.
+
+Same run, same history, same output files — whichever surface you used.
+
+## Reviewing the output
+
+CLI — diff the rounds against your input:
+
+```sh
+diff -u intro.tex .texra/runs/<run-id>/r0/intro.tex
+diff -u .texra/runs/<run-id>/r0/intro.tex .texra/runs/<run-id>/r1/intro.tex
+```
+
+VS Code — the Progress Board shows side-by-side diffs and lets you accept
+the output back into the workspace.
+
+For a **compiled PDF comparison** (additions in blue, deletions in red),
+use the LaTeXdiff feature in the TeXRA panel. See
+[LaTeX Diff](../latex-diff.md).
+
+## How the critique pass works
+
+After Round 0 produces a revision, polish re-prompts itself to check
+for common failure modes:
+
+- Edits that weakened the original.
+- Mathematical content that went missing.
+- Notation used before being defined.
+- Generic filler ("provides crucial insights into…").
+- Changes outside the scope of your instruction.
+
+The result is written to `r1/`. Use **Round 0 alone** for fast
+iteration. Use **Round 1** when the draft is close to final.
+
+## Limits
+
+- Operates on one revision per input file. For multi-file projects,
+  list each file with `--input` or use the Orchestrator.
+- No tool access — polish cannot compile, search citations, or run code.
+- No new sections, equations, or references — polish only rewrites
+  what is already there.
+
+## See also
+
+- [Built-in agents](../built-in-agents.md) — the full catalog of agents
+- [LaTeX Diff](../latex-diff.md) — compiled PDF comparison of revisions
+- [Models](../models.md) — picking a model for polish
+- [Configuration](../configuration.md) — workspace defaults and reflection


### PR DESCRIPTION
- README: lean, product-first fold; cut donation banner and adjective-heavy
  pitch; install + run come before philosophy.
- docs/guide/index.md: rewritten as a navigable landing page with explicit
  "Get started / Use it / Understand" sections; privacy section now
  distinguishes BYOK (direct to provider) from hosted access (proxied).
- docs/guide/first-run.md (new): five-minute first agent run, extension
  and CLI side-by-side.
- docs/guide/workflows/polish-a-draft.md (new): template for per-workflow
  docs — what / when / CLI / VS Code / review / limits, all factual to
  the actual agent and output paths.
- Scrubbed tier names (Ultra/Max/free tier) from CHANGELOG and "relay
  access" wording from texra-cli, installation, and quick-start in favor
  of "hosted access".
- Fixed stale claim in quick-start that output files are named
  r{N}/output.tex — workflow agents preserve the input filename.
- Registered the new pages in the VitePress sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no runtime, auth, or API behavior changes.
> 
> **Overview**
> This PR **reframes user-facing docs** around a shorter product pitch and clearer onboarding, without changing application code.
> 
> The **README** is trimmed to install → run → teams/agents/models, with the Researcher Access Program called out separately instead of a long feature essay.
> 
> The **docs site** gets a navigable **guide index** (Get started / Use it / Understand), a new **First run** page (five-minute `polish` in VS Code and CLI), and a **Polish a draft** workflow page as a template for per-workflow guides. **VitePress** registers both in the sidebar.
> 
> **Terminology** is aligned across **CHANGELOG**, CLI, installation, and quick-start: tier names like Ultra/Max are softened to “premium” / “hosted access,” and **“relay”** is replaced with **hosted access**. The **privacy** section on the guide index now separates **BYOK (direct to provider)** from **signed-in hosted (proxied)**.
> 
> **Accuracy fix:** workflow output paths are documented as `r{round}/<input-filename>` (e.g. `r0/draft.tex`), not `r0/output.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601a13bd8c1a053f2e4365b9ccf065676acf7d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->