### PR TITLE
fix(workflow): stop round outputs from corrupting the workspace via symlink chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Workflow rounds no longer overwrite the workspace** — past round 0, a workflow agent's emitted documents were being written through a symlink chain that ended at your live workspace file. The round directory's outputs are now real files owned by the round, and the workspace is unreachable from the backend.
+
 ## [0.38.2] - 2026-05-27
 
 ### Features

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -35,13 +35,10 @@ import {
 } from '@utils/text/xmlUtils';
 
 /**
- * Write an extracted round-output document, replacing any pre-staged symlink
- * placeholder at the destination. Round directories are populated with
- * symlinks to `runDir/original/<rel>` by `ensureMirroredInRoundDir` so
- * compile/latexdiff can resolve transitive `\input` targets — when the
- * agent re-emits a file this round, that placeholder must be promoted to
- * a real file owned by the round. Without this, `fs.writeFile` follows
- * the symlink and clobbers the immutable snapshot.
+ * Write a round-emitted document, promoting any pre-staged symlink at the
+ * destination to a real round-owned file. Round dirs are populated with
+ * symlinks to `runDir/original/<rel>` for `\input` resolution; following
+ * them with `fs.writeFile` would clobber the immutable snapshot.
  */
 async function writeRoundOutput(
   absolutePath: string,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,6 +1,9 @@
+import { promises as fsp } from 'fs';
 import * as path from 'path';
 
 import { XMLParser } from 'fast-xml-parser';
+
+import { isFileNotFoundError } from '@common/errors';
 
 import {
   debugInternal,
@@ -32,6 +35,30 @@ import {
   extractDocument,
   extractDocuments,
 } from '@utils/text/xmlUtils';
+
+/**
+ * Write an extracted round-output document, replacing any pre-staged symlink
+ * placeholder at the destination. Round directories are populated with
+ * symlinks to `runDir/original/<rel>` by `ensureMirroredInRoundDir` so
+ * compile/latexdiff can resolve transitive `\input` targets — when the
+ * agent re-emits a file this round, that placeholder must be promoted to
+ * a real file owned by the round. Without this, `fs.writeFile` follows
+ * the symlink and clobbers the immutable snapshot.
+ */
+async function writeRoundOutput(
+  absolutePath: string,
+  content: string,
+): Promise<void> {
+  try {
+    const stat = await fsp.lstat(absolutePath);
+    if (stat.isSymbolicLink()) {
+      await fsp.unlink(absolutePath);
+    }
+  } catch (error) {
+    if (!isFileNotFoundError(error)) throw error;
+  }
+  await AbsoluteFS.write(absolutePath, content);
+}
 
 /** Global version of DOCUMENT_NAME_REGEX for counting matches */
 const DOCUMENT_NAME_REGEX_GLOBAL = new RegExp(DOCUMENT_NAME_REGEX.source, 'g');
@@ -144,7 +171,7 @@ export class XmlOutputManager {
       const suffix = EXTRACTION_METHOD_MESSAGES[regexResult.method];
       if (suffix)
         logInternal(this.logger, `Recovered ${documentTag} ${suffix}`);
-      await AbsoluteFS.write(texLocation.absolutePath, regexResult.content);
+      await writeRoundOutput(texLocation.absolutePath, regexResult.content);
       return { location: texLocation, sourceName };
     }
     debugInternal(
@@ -157,7 +184,7 @@ export class XmlOutputManager {
 
     const latexDocument = extractContentFromXMLbyTag(root, documentTag);
     if (latexDocument) {
-      await AbsoluteFS.write(texLocation.absolutePath, latexDocument);
+      await writeRoundOutput(texLocation.absolutePath, latexDocument);
       return { location: texLocation, sourceName };
     }
     throw new Error(
@@ -289,7 +316,7 @@ export class XmlOutputManager {
         doc.content.trim(),
         texFile,
       );
-      await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
+      await writeRoundOutput(texLocation.absolutePath, cleanedContent);
       outputFiles.push({
         source,
         round,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,9 +1,6 @@
-import { promises as fsp } from 'fs';
 import * as path from 'path';
 
 import { XMLParser } from 'fast-xml-parser';
-
-import { isFileNotFoundError } from '@common/errors';
 
 import {
   debugInternal,
@@ -16,6 +13,7 @@ import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
 import { WORKFLOW_OUTPUT_BASENAME } from '@agent/output/workflowOutputLayout';
 import { toErrorMessage } from '@common/errors';
+import { platform } from '@platform/platform';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { OutputFileInfo } from '@shared/schemas';
@@ -49,13 +47,8 @@ async function writeRoundOutput(
   absolutePath: string,
   content: string,
 ): Promise<void> {
-  try {
-    const stat = await fsp.lstat(absolutePath);
-    if (stat.isSymbolicLink()) {
-      await fsp.unlink(absolutePath);
-    }
-  } catch (error) {
-    if (!isFileNotFoundError(error)) throw error;
+  if (await AbsoluteFS.isSymbolicLink(absolutePath)) {
+    await platform().fs.delete(absolutePath);
   }
   await AbsoluteFS.write(absolutePath, content);
 }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -34,12 +34,7 @@ import {
   extractDocuments,
 } from '@utils/text/xmlUtils';
 
-/**
- * Write a round-emitted document, promoting any pre-staged symlink at the
- * destination to a real round-owned file. Round dirs are populated with
- * symlinks to `runDir/original/<rel>` for `\input` resolution; following
- * them with `fs.writeFile` would clobber the immutable snapshot.
- */
+/** Delete any pre-staged symlink before writing so the write never follows the link into the immutable snapshot. */
 async function writeRoundOutput(
   absolutePath: string,
   content: string,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -13,7 +13,6 @@ import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
 import { WORKFLOW_OUTPUT_BASENAME } from '@agent/output/workflowOutputLayout';
 import { toErrorMessage } from '@common/errors';
-import { platform } from '@platform/platform';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { OutputFileInfo } from '@shared/schemas';
@@ -40,7 +39,7 @@ async function writeRoundOutput(
   content: string,
 ): Promise<void> {
   if (await AbsoluteFS.isSymbolicLink(absolutePath)) {
-    await platform().fs.delete(absolutePath);
+    await AbsoluteFS.delete(absolutePath);
   }
   await AbsoluteFS.write(absolutePath, content);
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -228,9 +228,12 @@ export class LatexMediaManager {
       await Promise.all(
         deps.map(async (absolutePath) => {
           const depLocation = pathToLocation(absolutePath);
+          const isTex = hasExtension(absolutePath, '.tex');
           try {
-            await this.fileService!.mirrorWorkspaceFile(depLocation);
-            if (hasExtension(absolutePath, '.tex')) {
+            await this.fileService!.mirrorWorkspaceFile(depLocation, {
+              snapshot: isTex,
+            });
+            if (isTex) {
               worklist.push(depLocation);
             }
           } catch (error) {

--- a/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
@@ -280,8 +280,6 @@ describe('accept_run_files progress events', () => {
         writes++;
       };
       WorkspaceFS.delete = async () => undefined;
-      // Source resolves to a symlink in r1/ — the round didn't emit this
-      // file, so accepting it would propagate snapshot content.
       AbsoluteFS.isSymbolicLink = async (target) =>
         target ===
         `${storagePath}/executions/${executionId}/r1/Draft/appendices.tex`;

--- a/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
@@ -31,6 +31,7 @@ describe('accept_run_files progress events', () => {
   let originalWorkspaceWrite: typeof WorkspaceFS.write;
   let originalWorkspaceDelete: typeof WorkspaceFS.delete;
   let originalAbsoluteIsFile: typeof AbsoluteFS.isFile;
+  let originalAbsoluteIsSymbolicLink: typeof AbsoluteFS.isSymbolicLink;
   let originalAbsoluteRead: typeof AbsoluteFS.read;
   let originalFlexibleRead: typeof flexibleFS.read;
 
@@ -43,8 +44,10 @@ describe('accept_run_files progress events', () => {
     originalWorkspaceWrite = WorkspaceFS.write;
     originalWorkspaceDelete = WorkspaceFS.delete;
     originalAbsoluteIsFile = AbsoluteFS.isFile;
+    originalAbsoluteIsSymbolicLink = AbsoluteFS.isSymbolicLink;
     originalAbsoluteRead = AbsoluteFS.read;
     originalFlexibleRead = flexibleFS.read;
+    AbsoluteFS.isSymbolicLink = async () => false;
     cleanupAllApprovals();
   });
 
@@ -57,6 +60,7 @@ describe('accept_run_files progress events', () => {
     WorkspaceFS.write = originalWorkspaceWrite;
     WorkspaceFS.delete = originalWorkspaceDelete;
     AbsoluteFS.isFile = originalAbsoluteIsFile;
+    AbsoluteFS.isSymbolicLink = originalAbsoluteIsSymbolicLink;
     AbsoluteFS.read = originalAbsoluteRead;
     flexibleFS.read = originalFlexibleRead;
     setToolEditApprovalHandler();
@@ -244,6 +248,71 @@ describe('accept_run_files progress events', () => {
       expect(result.isError).toBeUndefined();
       expect(result.output).toContain('No changes to accept');
       expect(result.output).toContain('unchanged: draft.tex');
+      expect(approvals).toBe(0);
+      expect(writes).toBe(0);
+      expect(fallback.events).toEqual([]);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+  });
+
+  it('refuses symlinked run-storage entries so unemitted files cannot be accepted', async () => {
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const fallback = createRecordingHost();
+    const tool = new AcceptRunFilesTool();
+    let approvals = 0;
+    let writes = 0;
+
+    try {
+      setDefaultAgentRuntimeHost(fallback.host);
+      StorageFS.exists = async (target) =>
+        target === `executions/${executionId}` ||
+        target === `executions/${executionId}/r1/Draft/appendices.tex`;
+      StorageFS.fullPath = (target) => `${storagePath}/${target}`;
+      WorkspaceFS.locatePath = (target) => ({
+        kind: 'workspace',
+        absolutePath: `${workspacePath}/${target}`,
+        relativePath: target,
+      });
+      WorkspaceFS.exists = async () => true;
+      WorkspaceFS.read = async () => '';
+      WorkspaceFS.write = async () => {
+        writes++;
+      };
+      WorkspaceFS.delete = async () => undefined;
+      // Source resolves to a symlink in r1/ — the round didn't emit this
+      // file, so accepting it would propagate snapshot content.
+      AbsoluteFS.isSymbolicLink = async (target) =>
+        target ===
+        `${storagePath}/executions/${executionId}/r1/Draft/appendices.tex`;
+      setToolEditApprovalHandler(async () => {
+        approvals++;
+        return { accepted: true };
+      });
+
+      const result = await withRunContext(
+        createRunContext({
+          runtimeHost: fallback.host,
+          streamId,
+          executionId,
+        }),
+        () =>
+          withToolFileInteractionContext({ tracker: {} as never }, () =>
+            tool.call({
+              execution_id: executionId,
+              files: [
+                {
+                  path: 'r1/Draft/appendices.tex',
+                  original: 'Draft/appendices.tex',
+                },
+              ],
+            }),
+          ),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('symlink');
+      expect(result.error).toContain('did not emit');
       expect(approvals).toBe(0);
       expect(writes).toBe(0);
       expect(fallback.events).toEqual([]);

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -78,8 +78,6 @@ describe('round-dir ownership and editable .tex inheritance', () => {
 
     const fileService = new TaskRunFileService('run-1');
 
-    // Editable input: mirror with snapshot=true (the path
-    // mirrorLatexFileDependencies takes for .tex deps).
     await fileService.mirrorWorkspaceFile(
       createWorkspaceLocation(draftAbsolute, 'Draft/Draft.tex'),
       { snapshot: true },
@@ -90,7 +88,6 @@ describe('round-dir ownership and editable .tex inheritance', () => {
       workspaceOriginal,
     );
 
-    // Stage round 1 working tree.
     await fileService.ensureMirroredInRoundDir(1);
 
     const roundFilePath = path.join(
@@ -100,8 +97,6 @@ describe('round-dir ownership and editable .tex inheritance', () => {
       'Draft.tex',
     );
 
-    // Symlink target must point at the immutable snapshot, not at the
-    // workspace mirror that chains back to the user's file.
     const linkStat = await lstat(roundFilePath);
     expect(linkStat.isSymbolicLink()).toBe(true);
     const linkTarget = await readlink(roundFilePath);
@@ -109,15 +104,14 @@ describe('round-dir ownership and editable .tex inheritance', () => {
       snapshotPath,
     );
 
-    // Simulate XmlOutputManager.writeRoundOutput: lstat → unlink-if-symlink
-    // → write. This is the round-N ownership handoff.
+    // Inline the writeRoundOutput contract so the test is host-neutral
+    // (no platform wiring needed) and the ownership handoff is visible.
     const roundOneContent =
       '\\documentclass{article}\\begin{document}round 1\\end{document}\n';
     const pre = await lstat(roundFilePath);
     if (pre.isSymbolicLink()) await unlink(roundFilePath);
     await AbsoluteFS.write(roundFilePath, roundOneContent);
 
-    // r1/Draft/Draft.tex is now a real file owned by round 1.
     const post = await lstat(roundFilePath);
     expect(post.isSymbolicLink()).toBe(false);
     expect(post.isFile()).toBe(true);
@@ -125,12 +119,9 @@ describe('round-dir ownership and editable .tex inheritance', () => {
       roundOneContent,
     );
 
-    // Snapshot is intact — never written through.
     await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
       workspaceOriginal,
     );
-
-    // User's workspace file is untouched.
     await expect(readFile(draftAbsolute, 'utf8')).resolves.toBe(
       workspaceOriginal,
     );
@@ -150,7 +141,6 @@ describe('round-dir ownership and editable .tex inheritance', () => {
 
     const fileService = new TaskRunFileService('run-2');
 
-    // Mirror without snapshot — represents cls/sty/bib/figure deps.
     await fileService.mirrorWorkspaceFile(
       createWorkspaceLocation(stylePath, 'macros.sty'),
     );
@@ -164,7 +154,6 @@ describe('round-dir ownership and editable .tex inheritance', () => {
     const linkStat = await lstat(roundFilePath);
     expect(linkStat.isSymbolicLink()).toBe(true);
     const linkTarget = await readlink(roundFilePath);
-    // Falls through to the workspace mirror at runDir/<rel>.
     expect(path.resolve(path.dirname(roundFilePath), linkTarget)).toBe(
       path.join(getRunDir('run-2'), 'macros.sty'),
     );

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -12,7 +12,7 @@ import {
 import * as os from 'os';
 import * as path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createMemoryStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -55,10 +55,6 @@ async function installPlatform(
 }
 
 describe('round-dir ownership and editable .tex inheritance', () => {
-  beforeEach(() => {
-    // empty
-  });
-
   afterEach(async () => {
     await Promise.all(
       tempDirs

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -1,0 +1,176 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createMemoryStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { createWorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  AbsoluteFS,
+  createWorkspaceLocation,
+  getOriginalSnapshotPath,
+  getRunDir,
+  TaskRunFileService,
+} from '@utils/files';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function installPlatform(
+  workspaceDir: string,
+  storageRoot: string,
+): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(
+    createFakePlatform(
+      { workspacePath: workspaceDir },
+      {
+        fs: nodeFilesystem,
+        workspace: createNodeWorkspace(() => workspaceDir),
+        storage: createWorkspaceStorageProvider(storageRoot, workspaceDir),
+        globalState: createMemoryStore(),
+        workspaceState: createMemoryStore(),
+      },
+    ),
+  );
+}
+
+describe('round-dir ownership and editable .tex inheritance', () => {
+  beforeEach(() => {
+    // empty
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('snapshots editable .tex on mirror, points r<N>/ symlinks at the snapshot, and the round-output write replaces the symlink with a real file leaving snapshot and workspace untouched', async () => {
+    const tempDir = await makeTempDir('texra-round-ownership-');
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const storageRoot = path.join(tempDir, 'storage');
+    const draftDir = path.join(workspaceDir, 'Draft');
+    const draftAbsolute = path.join(draftDir, 'Draft.tex');
+    const workspaceOriginal =
+      '\\documentclass{article}\\begin{document}original\\end{document}\n';
+    await mkdir(draftDir, { recursive: true });
+    await writeFile(draftAbsolute, workspaceOriginal);
+
+    await installPlatform(workspaceDir, storageRoot);
+
+    const fileService = new TaskRunFileService('run-1');
+
+    // Editable input: mirror with snapshot=true (the path
+    // mirrorLatexFileDependencies takes for .tex deps).
+    await fileService.mirrorWorkspaceFile(
+      createWorkspaceLocation(draftAbsolute, 'Draft/Draft.tex'),
+      { snapshot: true },
+    );
+
+    const snapshotPath = getOriginalSnapshotPath('run-1', 'Draft/Draft.tex');
+    await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
+      workspaceOriginal,
+    );
+
+    // Stage round 1 working tree.
+    await fileService.ensureMirroredInRoundDir(1);
+
+    const roundFilePath = path.join(
+      getRunDir('run-1'),
+      'r1',
+      'Draft',
+      'Draft.tex',
+    );
+
+    // Symlink target must point at the immutable snapshot, not at the
+    // workspace mirror that chains back to the user's file.
+    const linkStat = await lstat(roundFilePath);
+    expect(linkStat.isSymbolicLink()).toBe(true);
+    const linkTarget = await readlink(roundFilePath);
+    expect(path.resolve(path.dirname(roundFilePath), linkTarget)).toBe(
+      snapshotPath,
+    );
+
+    // Simulate XmlOutputManager.writeRoundOutput: lstat → unlink-if-symlink
+    // → write. This is the round-N ownership handoff.
+    const roundOneContent =
+      '\\documentclass{article}\\begin{document}round 1\\end{document}\n';
+    const pre = await lstat(roundFilePath);
+    if (pre.isSymbolicLink()) await unlink(roundFilePath);
+    await AbsoluteFS.write(roundFilePath, roundOneContent);
+
+    // r1/Draft/Draft.tex is now a real file owned by round 1.
+    const post = await lstat(roundFilePath);
+    expect(post.isSymbolicLink()).toBe(false);
+    expect(post.isFile()).toBe(true);
+    await expect(readFile(roundFilePath, 'utf8')).resolves.toBe(
+      roundOneContent,
+    );
+
+    // Snapshot is intact — never written through.
+    await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
+      workspaceOriginal,
+    );
+
+    // User's workspace file is untouched.
+    await expect(readFile(draftAbsolute, 'utf8')).resolves.toBe(
+      workspaceOriginal,
+    );
+    const workspaceStat = await stat(draftAbsolute);
+    expect(workspaceStat.size).toBe(workspaceOriginal.length);
+  });
+
+  it('falls through to the workspace symlink for non-snapshotted (read-only) deps', async () => {
+    const tempDir = await makeTempDir('texra-readonly-mirror-');
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const storageRoot = path.join(tempDir, 'storage');
+    const stylePath = path.join(workspaceDir, 'macros.sty');
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(stylePath, '\\newcommand{\\RR}{\\mathbb{R}}\n');
+
+    await installPlatform(workspaceDir, storageRoot);
+
+    const fileService = new TaskRunFileService('run-2');
+
+    // Mirror without snapshot — represents cls/sty/bib/figure deps.
+    await fileService.mirrorWorkspaceFile(
+      createWorkspaceLocation(stylePath, 'macros.sty'),
+    );
+
+    const snapshotPath = getOriginalSnapshotPath('run-2', 'macros.sty');
+    await expect(stat(snapshotPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await fileService.ensureMirroredInRoundDir(1);
+
+    const roundFilePath = path.join(getRunDir('run-2'), 'r1', 'macros.sty');
+    const linkStat = await lstat(roundFilePath);
+    expect(linkStat.isSymbolicLink()).toBe(true);
+    const linkTarget = await readlink(roundFilePath);
+    // Falls through to the workspace mirror at runDir/<rel>.
+    expect(path.resolve(path.dirname(roundFilePath), linkTarget)).toBe(
+      path.join(getRunDir('run-2'), 'macros.sty'),
+    );
+  });
+});

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -342,18 +342,13 @@ Optional:
       const rel = await resolveStoragePath(executionId, runPath);
       if (rel) {
         const abs = StorageFS.fullPath(rel);
-        // Round-dir entries are real files only when the round actually
-        // emitted them; unemitted `\input` targets are symlinks into the
-        // `original/` snapshot (and pre-fix runs may have symlinks chaining
-        // back to the workspace). Refusing symlinks keeps `accept_run_files`
-        // honest — only content the agent owns this run can be promoted to
-        // the workspace.
+        // Symlinks in run storage mean the round didn't emit the file —
+        // it's a stand-in for the `original/` snapshot (or, on pre-fix
+        // runs, the live workspace). Promoting that to the workspace would
+        // propagate non-agent content as if it were agent output.
         if (await AbsoluteFS.isSymbolicLink(abs)) {
           throw new ToolError(
-            `Cannot accept ${runPath} from run ${executionId}: ` +
-              `the run-storage entry is a symlink, meaning this round did ` +
-              `not emit the file. Accepting it would propagate snapshot or ` +
-              `workspace content rather than agent output.`,
+            `Cannot accept ${runPath} from run ${executionId}: the run-storage entry is a symlink, meaning this round did not emit the file. Accepting it would propagate snapshot or workspace content rather than agent output.`,
           );
         }
         return {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -342,6 +342,20 @@ Optional:
       const rel = await resolveStoragePath(executionId, runPath);
       if (rel) {
         const abs = StorageFS.fullPath(rel);
+        // Round-dir entries are real files only when the round actually
+        // emitted them; unemitted `\input` targets are symlinks into the
+        // `original/` snapshot (and pre-fix runs may have symlinks chaining
+        // back to the workspace). Refusing symlinks keeps `accept_run_files`
+        // honest — only content the agent owns this run can be promoted to
+        // the workspace.
+        if (await AbsoluteFS.isSymbolicLink(abs)) {
+          throw new ToolError(
+            `Cannot accept ${runPath} from run ${executionId}: ` +
+              `the run-storage entry is a symlink, meaning this round did ` +
+              `not emit the file. Accepting it would propagate snapshot or ` +
+              `workspace content rather than agent output.`,
+          );
+        }
         return {
           sourceAbsolute: abs,
           sourceLocation: createRunStorageLocation(abs, runPath, executionId),

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -291,52 +291,9 @@ export class TaskRunFileService {
       if (extra) linkTargets.add(extra);
     }
 
-    const captureTasks = baseFiles.map(async (target) => {
-      if (!target || target.kind !== 'workspace') {
-        return;
-      }
-
-      if (shouldSkipRelocation(target.relativePath)) {
-        return;
-      }
-
-      try {
-        const stats = await fs.stat(target.absolutePath);
-        if (!stats.isFile()) {
-          return;
-        }
-
-        const snapshotRelative = path.join('original', target.relativePath);
-        const snapshotPaths = getRunStoragePaths(executionId, snapshotRelative);
-
-        const alreadyCaptured = await fs.stat(snapshotPaths.absolute).then(
-          () => true,
-          (err: unknown) => {
-            if (!isFileNotFoundError(err)) {
-              throw new Error(
-                `Failed to inspect snapshot destination ${snapshotPaths.absolute}: ${toErrorMessage(err)}`,
-                { cause: err },
-              );
-            }
-            return false;
-          },
-        );
-        if (alreadyCaptured) return;
-
-        await ensureParentDir(snapshotPaths.absolute);
-        await fs.copyFile(target.absolutePath, snapshotPaths.absolute);
-      } catch (error) {
-        if (isFileNotFoundError(error)) {
-          return;
-        }
-        throw new Error(
-          `Failed to capture original file ${target}: ${toErrorMessage(error)}`,
-          { cause: error },
-        );
-      }
-    });
-
-    await Promise.all(captureTasks);
+    await Promise.all(
+      baseFiles.map((target) => this.captureOriginalSnapshot(target)),
+    );
 
     await Promise.all(
       [...linkTargets].map(async (candidate) => {
@@ -352,6 +309,55 @@ export class TaskRunFileService {
     );
 
     this.hasPreparedSnapshot = true;
+  }
+
+  /**
+   * Copy a workspace file into `original/<relativePath>` if not already
+   * captured. Snapshots are the execution-owned anchor for editable inputs:
+   * round-dir symlinks point here rather than chaining back to the live
+   * workspace, so an agent write at `r<N>/<relPath>` can never reach the
+   * user's working copy via symlink follow.
+   *
+   * Idempotent. Silently skips non-workspace locations, ignored roots,
+   * non-regular files, and missing sources.
+   */
+  private async captureOriginalSnapshot(target: FileLocation): Promise<void> {
+    if (!target || target.kind !== 'workspace') return;
+    if (shouldSkipRelocation(target.relativePath)) return;
+
+    const executionId = this.metadata.executionId;
+    if (!executionId) return;
+
+    try {
+      const stats = await fs.stat(target.absolutePath);
+      if (!stats.isFile()) return;
+
+      const snapshotRelative = path.join('original', target.relativePath);
+      const snapshotPaths = getRunStoragePaths(executionId, snapshotRelative);
+
+      const alreadyCaptured = await fs.stat(snapshotPaths.absolute).then(
+        () => true,
+        (err: unknown) => {
+          if (!isFileNotFoundError(err)) {
+            throw new Error(
+              `Failed to inspect snapshot destination ${snapshotPaths.absolute}: ${toErrorMessage(err)}`,
+              { cause: err },
+            );
+          }
+          return false;
+        },
+      );
+      if (alreadyCaptured) return;
+
+      await ensureParentDir(snapshotPaths.absolute);
+      await fs.copyFile(target.absolutePath, snapshotPaths.absolute);
+    } catch (error) {
+      if (isFileNotFoundError(error)) return;
+      throw new Error(
+        `Failed to capture original file ${target.absolutePath}: ${toErrorMessage(error)}`,
+        { cause: error },
+      );
+    }
   }
 
   /**
@@ -397,9 +403,16 @@ export class TaskRunFileService {
   /**
    * Ensure a workspace dependency is reachable from run storage via symlink.
    * Takes a FileLocation and creates a symlink in run storage if needed.
+   *
+   * Pass `snapshot: true` for editable inputs (primary inputs, transitive
+   * `\input` targets) so the file is also copied into `original/<relPath>`.
+   * That snapshot becomes the symlink source when staging round dirs, which
+   * keeps editable content reachable from `r<N>/` without the chain ever
+   * touching the live workspace.
    */
   public async mirrorWorkspaceFile(
     location: FileLocation,
+    options: { snapshot?: boolean } = {},
   ): Promise<FileLocation> {
     if (location.kind !== 'workspace') {
       return location;
@@ -420,6 +433,10 @@ export class TaskRunFileService {
     if (!this.mirroredDependencies.has(location.relativePath)) {
       await createSymlink(location, runPaths.absolute);
       this.mirroredDependencies.add(location.relativePath);
+    }
+
+    if (options.snapshot) {
+      await this.captureOriginalSnapshot(location);
     }
 
     return createRunStorageLocation(
@@ -495,7 +512,26 @@ export class TaskRunFileService {
           return;
         }
 
-        const sourceAbsolute = path.join(runDir, relativePath);
+        // Prefer the immutable `original/` snapshot as the symlink source
+        // for editable inputs, so the chain `r<N>/<rel> → original/<rel>`
+        // never reaches the live workspace. Read-only build assets
+        // (cls/sty/bib/figures) have no snapshot and fall through to the
+        // workspace mirror at `runDir/<rel>`, which is correct — those
+        // are never written to.
+        const snapshotAbsolute = path.join(runDir, 'original', relativePath);
+        const workspaceMirrorAbsolute = path.join(runDir, relativePath);
+        let sourceAbsolute = workspaceMirrorAbsolute;
+        try {
+          await fs.stat(snapshotAbsolute);
+          sourceAbsolute = snapshotAbsolute;
+        } catch (error) {
+          if (!isFileNotFoundError(error)) {
+            logger.debug(
+              CHANNEL,
+              `Unable to stat snapshot ${snapshotAbsolute}: ${toErrorMessage(error)}`,
+            );
+          }
+        }
         const destinationAbsolute = path.join(
           runDir,
           destinationSegment,

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -163,6 +163,25 @@ async function ensureParentDir(filePath: string): Promise<void> {
   await fs.mkdir(parentDir, { recursive: true });
 }
 
+/**
+ * Probe whether a previously-captured snapshot exists. Distinct from a
+ * generic existence check because non-ENOENT stat failures must be
+ * surfaced rather than silently treated as "missing" — corrupting that
+ * decision would re-copy over a real snapshot.
+ */
+async function snapshotExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.stat(absolutePath);
+    return true;
+  } catch (error) {
+    if (isFileNotFoundError(error)) return false;
+    throw new Error(
+      `Failed to inspect snapshot destination ${absolutePath}: ${toErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}
+
 async function createSymlink(
   source: FileLocation,
   destination: string,
@@ -322,7 +341,7 @@ export class TaskRunFileService {
    * non-regular files, and missing sources.
    */
   private async captureOriginalSnapshot(target: FileLocation): Promise<void> {
-    if (!target || target.kind !== 'workspace') return;
+    if (target.kind !== 'workspace') return;
     if (shouldSkipRelocation(target.relativePath)) return;
 
     const executionId = this.metadata.executionId;
@@ -335,19 +354,7 @@ export class TaskRunFileService {
       const snapshotRelative = path.join('original', target.relativePath);
       const snapshotPaths = getRunStoragePaths(executionId, snapshotRelative);
 
-      const alreadyCaptured = await fs.stat(snapshotPaths.absolute).then(
-        () => true,
-        (err: unknown) => {
-          if (!isFileNotFoundError(err)) {
-            throw new Error(
-              `Failed to inspect snapshot destination ${snapshotPaths.absolute}: ${toErrorMessage(err)}`,
-              { cause: err },
-            );
-          }
-          return false;
-        },
-      );
-      if (alreadyCaptured) return;
+      if (await snapshotExists(snapshotPaths.absolute)) return;
 
       await ensureParentDir(snapshotPaths.absolute);
       await fs.copyFile(target.absolutePath, snapshotPaths.absolute);

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -163,12 +163,7 @@ async function ensureParentDir(filePath: string): Promise<void> {
   await fs.mkdir(parentDir, { recursive: true });
 }
 
-/**
- * Probe whether a previously-captured snapshot exists. Distinct from a
- * generic existence check because non-ENOENT stat failures must be
- * surfaced rather than silently treated as "missing" — corrupting that
- * decision would re-copy over a real snapshot.
- */
+/** Non-ENOENT stat failures are re-thrown so a permissions error never silently forces a re-copy over a real snapshot. */
 async function snapshotExists(absolutePath: string): Promise<boolean> {
   try {
     await fs.stat(absolutePath);
@@ -331,14 +326,10 @@ export class TaskRunFileService {
   }
 
   /**
-   * Copy a workspace file into `original/<relativePath>` if not already
-   * captured. Snapshots are the execution-owned anchor for editable inputs:
-   * round-dir symlinks point here rather than chaining back to the live
-   * workspace, so an agent write at `r<N>/<relPath>` can never reach the
-   * user's working copy via symlink follow.
-   *
-   * Idempotent. Silently skips non-workspace locations, ignored roots,
-   * non-regular files, and missing sources.
+   * Copy a workspace file into `original/<relativePath>` if not already captured.
+   * Round-dir symlinks point here rather than the live workspace so an agent
+   * write at `r<N>/<relPath>` can never reach the user's working copy.
+   * Idempotent; skips non-workspace, ignored-root, non-regular, and missing sources.
    */
   private async captureOriginalSnapshot(target: FileLocation): Promise<void> {
     if (target.kind !== 'workspace') return;
@@ -411,11 +402,9 @@ export class TaskRunFileService {
    * Ensure a workspace dependency is reachable from run storage via symlink.
    * Takes a FileLocation and creates a symlink in run storage if needed.
    *
-   * Pass `snapshot: true` for editable inputs (primary inputs, transitive
-   * `\input` targets) so the file is also copied into `original/<relPath>`.
-   * That snapshot becomes the symlink source when staging round dirs, which
-   * keeps editable content reachable from `r<N>/` without the chain ever
-   * touching the live workspace.
+   * Pass `snapshot: true` for editable inputs so the file is also copied into
+   * `original/<relPath>`; round-dir symlinks then point there rather than
+   * chaining back to the live workspace.
    */
   public async mirrorWorkspaceFile(
     location: FileLocation,


### PR DESCRIPTION
## Summary

For workflow agents at round >0, `MediaExtractionNode` pre-stages `r<N>/Draft/` with symlinks pointing at `runDir/Draft/<file>` — which is itself a symlink to the user's actual workspace file. `XmlOutputManager` then writes each emitted document via `AbsoluteFS.write` → `fs.writeFile`, which **follows symlinks**. End result: round 1+ output lands in the user's workspace file instead of `r<N>/Draft/<file>`, and the round dir holds stale symlinks where the agent's emission should have been.

Verified concretely in an affected execution: `r1/Draft/Draft.tex` was a symlink chaining `r1/Draft/Draft.tex → runDir/Draft/Draft.tex → /Users/.../TNLean/Draft/Draft.tex` (same inode as the workspace file).

## Fix

Restructure ownership so the chain dead-ends at an execution-owned snapshot, not the workspace:

- **`mirrorWorkspaceFile`** gains an opt-in `snapshot` flag. `mirrorLatexFileDependencies` passes `snapshot: true` for `.tex` deps so every editable input — not just `config.baseFiles` — is copied into `runDir/original/<rel>` at mirror time.
- **`ensureMirroredInRunSubdir`** prefers `runDir/original/<rel>` as the symlink source when staging `r<N>/<rel>`. Read-only build assets (cls/sty/bib/figures) without a snapshot fall through to the workspace mirror as before (they're never written to).
- **`XmlOutputManager.writeRoundOutput`** lstats the destination, unlinks if it's a symlink, then writes. The pre-staged placeholder is promoted into a real file owned by the round — explicit ownership handoff, not a defensive guard.

After this, `r<N>/Draft/<file>` is either:
- a **real file** owned by round N (the agent emitted `<file>` this round), or
- a **symlink to `runDir/original/<file>`** (immutable snapshot — agent didn't re-emit, compile/latexdiff can still resolve `\input` targets).

The workspace file is unreachable from any `r<N>/` symlink chain.

## Test plan

- [x] `npm run typecheck` — passes.
- [x] New regression test `src/test-kernel/utils/RoundDirOwnership.vitest.ts` covers:
  - Editable `.tex` is snapshotted into `original/` on mirror.
  - `r<N>/Draft/<rel>` symlink target resolves to the snapshot, not the workspace mirror.
  - Round-N write replaces the symlink with a real file; snapshot and workspace are byte-for-byte unchanged.
  - Read-only deps (no snapshot) still fall through to the workspace mirror.
- [x] `LatexdiffShadowStorage.vitest.ts` and the wider `src/test-kernel/utils/` suite — pass unchanged.
- [ ] Multi-round workflow agent run end-to-end in the VS Code extension (manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow run-storage mirroring and XML output writes that guard the live workspace; behavior is covered by new integration tests but touches accept-run-files and all multi-round LaTeX workflows.
> 
> **Overview**
> Fixes a bug where **workflow rounds after the first** could **overwrite live workspace `.tex` files** because round outputs were written through symlinks (`r<N>/…` → run mirror → workspace).
> 
> **Run storage** now **snapshots editable `.tex` into `original/`** (optional `mirrorWorkspaceFile({ snapshot: true })`, used when mirroring LaTeX deps) and stages **`r<N>/` symlinks toward `original/`** instead of the workspace chain. **`XmlOutputManager`** uses **`writeRoundOutput`**, which **removes a symlink destination** before writing so emissions become **real round-owned files**. **`accept_run_files`** **rejects symlinked** run-storage paths so accepting a round that never emitted a file cannot promote snapshot/workspace content as agent output.
> 
> Adds **`RoundDirOwnership.vitest.ts`**, an **`accept_run_files` symlink test**, and an **unreleased changelog** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f958130277df473dbdd132d7b17d920164eb55d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->