### PR TITLE
docs: refresh file-selection UI and stale model IDs across guide

### DIFF
--- a/docs/.vitepress/components/FileSelectHero.vue
+++ b/docs/.vitepress/components/FileSelectHero.vue
@@ -1,7 +1,8 @@
 <script setup>
 // File Management product slice: the Launcher's file-selection section with the
-// real Input / Context / Media groups (FILE_SELECT_CONFIGS in store.ts) — Input
-// as a single file, Context in multiple-file mode, Media as a single file.
+// real Input / Context / Media groups (FILE_SELECT_CONFIGS in store.ts). Each
+// group is an ordered list with three header actions — Add opened files, Clear
+// all, Add files.
 import MockupFrame from './MockupFrame.vue';
 </script>
 
@@ -23,7 +24,7 @@ import MockupFrame from './MockupFrame.vue';
           <span class="sec-lbl">Files</span>
         </div>
 
-        <!-- Input — single file -->
+        <!-- Input -->
         <div class="field">
           <div class="frow">
             <span class="f-label"
@@ -35,31 +36,31 @@ import MockupFrame from './MockupFrame.vue';
               Input</span
             >
             <div class="acts">
-              <span class="act" title="Refresh file list"
-                ><wa-icon library="texra" name="refresh"></wa-icon
+              <span class="act" title="Add opened files as input"
+                ><wa-icon library="texra" name="folder-opened"></wa-icon
               ></span>
-              <span class="act" title="Multiple files"
-                ><wa-icon library="texra" name="chevron-down"></wa-icon
+              <span class="act" title="Clear all input files"
+                ><wa-icon library="texra" name="trash"></wa-icon
               ></span>
-              <span class="act" title="Set current file"
-                ><wa-icon library="texra" name="file-code"></wa-icon
-              ></span>
-              <span class="act" title="Clear selection"
-                ><wa-icon library="texra" name="close"></wa-icon
+              <span class="act" title="Add input files"
+                ><wa-icon library="texra" name="add"></wa-icon
               ></span>
             </div>
           </div>
-          <div class="select">
-            <span class="s-val">draft.tex</span>
-            <wa-icon
-              class="s-caret"
-              library="texra"
-              name="chevron-down"
-            ></wa-icon>
+          <div class="flist">
+            <div class="fitem">
+              <wa-icon
+                class="fi-grip"
+                library="texra"
+                name="ellipsis"
+              ></wa-icon>
+              <span class="fi-name">draft.tex</span>
+              <wa-icon class="fi-rm" library="texra" name="trash"></wa-icon>
+            </div>
           </div>
         </div>
 
-        <!-- Context — multiple-file mode, expanded -->
+        <!-- Context -->
         <div class="field">
           <div class="frow">
             <span class="f-label"
@@ -67,14 +68,14 @@ import MockupFrame from './MockupFrame.vue';
               Context</span
             >
             <div class="acts">
-              <span class="act act-on" title="Multiple files"
-                ><wa-icon library="texra" name="chevron-up"></wa-icon
+              <span class="act" title="Add opened files as context"
+                ><wa-icon library="texra" name="folder-opened"></wa-icon
               ></span>
-              <span class="act" title="Add files"
-                ><wa-icon library="texra" name="add"></wa-icon
-              ></span>
-              <span class="act" title="Clear all"
+              <span class="act" title="Clear all context files"
                 ><wa-icon library="texra" name="trash"></wa-icon
+              ></span>
+              <span class="act" title="Add context files"
+                ><wa-icon library="texra" name="add"></wa-icon
               ></span>
             </div>
           </div>
@@ -86,7 +87,7 @@ import MockupFrame from './MockupFrame.vue';
                 name="ellipsis"
               ></wa-icon>
               <span class="fi-name">references.bib</span>
-              <wa-icon class="fi-rm" library="texra" name="dash"></wa-icon>
+              <wa-icon class="fi-rm" library="texra" name="trash"></wa-icon>
             </div>
             <div class="fitem">
               <wa-icon
@@ -95,12 +96,12 @@ import MockupFrame from './MockupFrame.vue';
                 name="ellipsis"
               ></wa-icon>
               <span class="fi-name">preamble.sty</span>
-              <wa-icon class="fi-rm" library="texra" name="dash"></wa-icon>
+              <wa-icon class="fi-rm" library="texra" name="trash"></wa-icon>
             </div>
           </div>
         </div>
 
-        <!-- Media — single file -->
+        <!-- Media -->
         <div class="field">
           <div class="frow">
             <span class="f-label"
@@ -112,27 +113,27 @@ import MockupFrame from './MockupFrame.vue';
               Media</span
             >
             <div class="acts">
-              <span class="act" title="Refresh file list"
-                ><wa-icon library="texra" name="refresh"></wa-icon
+              <span class="act" title="Add opened files as media"
+                ><wa-icon library="texra" name="folder-opened"></wa-icon
               ></span>
-              <span class="act" title="Multiple files"
-                ><wa-icon library="texra" name="chevron-down"></wa-icon
+              <span class="act" title="Clear all media files"
+                ><wa-icon library="texra" name="trash"></wa-icon
               ></span>
-              <span class="act" title="Set current file"
-                ><wa-icon library="texra" name="file-code"></wa-icon
-              ></span>
-              <span class="act" title="Clear selection"
-                ><wa-icon library="texra" name="close"></wa-icon
+              <span class="act" title="Add media files"
+                ><wa-icon library="texra" name="add"></wa-icon
               ></span>
             </div>
           </div>
-          <div class="select">
-            <span class="s-val">figure1.pdf</span>
-            <wa-icon
-              class="s-caret"
-              library="texra"
-              name="chevron-down"
-            ></wa-icon>
+          <div class="flist">
+            <div class="fitem">
+              <wa-icon
+                class="fi-grip"
+                library="texra"
+                name="ellipsis"
+              ></wa-icon>
+              <span class="fi-name">figure1.pdf</span>
+              <wa-icon class="fi-rm" library="texra" name="trash"></wa-icon>
+            </div>
           </div>
         </div>
       </div>

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -34,7 +34,7 @@ For complex tasks:
 Match model capability to task complexity - overpowered models waste money, underpowered ones produce poor results.
 
 - **Simple tasks** (corrections): Use fast, cheap models (`qwenturbo`, `deepseek`, `haiku45`)
-- **Complex tasks** (transformations): Use powerful models (`opus47`, `gpt54`)
+- **Complex tasks** (transformations): Use powerful models (`opus47T`, `gpt55`, `gemini31p`)
 - **Reasoning-heavy**: Use thinking models (`sonnet46T`, `opus47T`, `deepseekT`)
 
 See the [AI Models Guide](./models.md) for detailed comparisons.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -69,7 +69,7 @@ Configure how TeXRA connects to AI model providers:
 - `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled. Defaults to the built-in proxy when unset.
   - ⚠️ **Security Warning:** When using a proxy, ensure you trust the proxy server as it will receive your API keys. Only use proxies from trusted sources.
 - `useOpenAIResponsesAPI`: Use OpenAI's Responses API instead of Chat Completions when available
-- `gpt5ReasoningSummary`: Request reasoning summaries from the GPT-5 family, including GPT-5.4 and GPT-5.4 Pro (requires verified account and user tier)
+- `gpt5ReasoningSummary`: Request reasoning summaries from the GPT-5 family, including GPT-5.5 and GPT-5.5 Pro (requires verified account and user tier)
 
 | Provider         | Proxy path                  | Supported |
 | ---------------- | --------------------------- | --------- |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,8 +20,10 @@ The **Dashboard** is your one-stop shop for managing everything in TeXRA. Open i
 - **Agents** - Turn agents on or off for the current workspace. Agents that support multiple output files are marked with a badge.
 - **Multi-Agent** - Configure multi-agent orchestration and presets.
 - **Tools** - Manage tool-use agent capabilities and approval settings.
+- **Integrations** - Set up third-party coding agents (OpenAI Codex, Claude Code) that TeXRA can hand off to. See [Agent Integrations](./agent-integrations.md).
 - **Git** - Set a GitHub personal access token (required for the `github_subscription` tool) and optionally attribute TeXRA commits to a custom author.
 - **LaTeX** - Configure LaTeX formatting, diff, and TikZ settings.
+- **Odyssey** - Monitor long-running multi-agent jobs from the orchestrator.
 
 ::: tip
 Many connection and model settings are configured through VS Code's standard settings. The Dashboard tabs provide convenient access to agent, model, and tool configuration.

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -51,38 +51,31 @@ The TeXRA interface provides a streamlined way to select and manage files using 
 
 <FileSelectHero />
 
-<p class="hero-caption">Each category is a dropdown with quick controls — set the current file, clear it, refresh the list, or switch to multiple-file mode (shown here for Context).</p>
+<p class="hero-caption">Each category holds an ordered list of files with three quick actions in the header.</p>
 
-### Single File Selection
+### File List Controls
 
-For each file category, you can select a single file using the dropdown menu. The interface provides several helpful options:
+Each category — Input, Context, and Media — manages a list of files (a single-file workflow is just a list of length one). The header exposes three buttons:
 
-- **Current Button** (<wa-icon library="texra" name="file-code"></wa-icon>): Select the currently open file in VS Code
-- **Empty Button** (<wa-icon library="texra" name="close"></wa-icon>): Clear the current selection
-- **Multiple Toggle** (▼): Switch to multiple file selection mode
-- **Refresh Button** (<wa-icon library="texra" name="refresh"></wa-icon> icon next to label): Update the file list
+- **Add opened files** (<wa-icon library="texra" name="folder-opened"></wa-icon>): Append every editor tab whose extension matches the category to the list.
+- **Clear all files** (<wa-icon library="texra" name="trash"></wa-icon>): Empty the list.
+- **Add files** (<wa-icon library="texra" name="add"></wa-icon>): Open a file picker to append files.
 
-### Multiple File Selection
+You can also **drag-and-drop files** from the OS file manager (or from VS Code's Explorer) onto a category to add them.
 
-For projects requiring multiple files, enable the multiple file selection mode:
+Inside the list:
 
-1. Click the "▼" toggle next to the file category
-2. The multiple selection panel will expand
-3. Use the "Add" button (<wa-icon library="texra" name="add"></wa-icon>) to add files via a file picker
-4. Remove files with the "-" button next to each file
-5. Reorder files by dragging and dropping
-6. Clear the entire list using the "Empty List" button (<wa-icon library="texra" name="trash"></wa-icon>)
+- Each file row has a small trash icon to remove just that file.
+- Drag a row by its grip handle to reorder files. Input files are sent to the agent in this order.
 
-Multiple file selection is particularly useful for:
+The list is the only mode — there is no separate "single file" view. To work with one file, just keep the list at length one.
+
+This works well for:
 
 - Processing multiple chapters of a book
 - Working with documents split across multiple files
 - Batch processing similar documents
 - Including multiple reference materials
-
-### Adding Opened Files
-
-The "Add Opened Files" button (<wa-icon library="texra" name="folder-opened"></wa-icon>) available for the Input, Context, and Media categories allows you to quickly add all currently open files in your VS Code editor (that match the allowed file types) to the respective multiple file list. This is useful when you have already opened the relevant files for your project.
 
 ### Output Files
 

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -44,7 +44,7 @@ EOF
 
 1. Open `draft.tex`.
 2. Click the TeXRA icon in the activity bar.
-3. With `draft.tex` open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section.
+3. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick `draft.tex` from the file picker.
 4. Pick **polish** under Agent. Pick **sonnet46T** under Model (or any
    available model).
 5. Type an instruction:

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -44,8 +44,8 @@ EOF
 
 1. Open `draft.tex`.
 2. Click the TeXRA icon in the activity bar.
-3. In the sidebar, click **Current** next to **Input**.
-4. Pick **polish** under Agent. Pick **sonnet46** under Model (or any
+3. With `draft.tex` open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section.
+4. Pick **polish** under Agent. Pick **sonnet46T** under Model (or any
    available model).
 5. Type an instruction:
    > Tighten the prose. Preserve all math and citations.

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -46,7 +46,7 @@ See the [LaTeX Diff guide](./latex-diff.md) for the full workflow.
 
 **Enabling `texcount`:**
 
-1. **For context:** toggle <wa-icon library="texra" name="symbol-numeric"></wa-icon> **Attach TeX Count** in the Tool Configuration dropdown — see [File Management](./file-management.md#tool-config-dropdown).
+1. **For context:** toggle <wa-icon library="texra" name="symbol-numeric"></wa-icon> **Attach TeX Count** in the Tool Configuration dropdown — see [Configuration](./configuration.md#agent-execution-settings-webview-interface).
 2. **As a tool:** tool-use agents can invoke `texcount` directly to analyse files on demand.
 
 **Modes:**

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -15,7 +15,7 @@ Working with multiple files is often necessary when:
 
 The TeXRA UI provides dedicated sections for managing multiple input files.
 
-- **Input Files**: Use the "▼" toggle to add multiple source files. These are typically concatenated and provided as context to the selected agent. For editing agents, the expected output filenames are the selected input filenames in the same order.
+- **Input Files**: Each Input row is an ordered list — use **Add files** (<wa-icon library="texra" name="add"></wa-icon>), **Add opened files** (<wa-icon library="texra" name="folder-opened"></wa-icon>), or drag-and-drop to append sources. They are concatenated and provided as context to the selected agent. For editing agents, the expected output filenames are the selected input filenames in the same order.
 - **Fixed Outputs**: Agents that create files with names not determined by the inputs declare those filenames in `settings.defaultOutputFiles`.
 
 _(See [File Management](./file-management.md) for general UI controls.)_

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -65,7 +65,7 @@ Run **TeXRA: Create Sample Project** from the Command Palette to add a ready-mad
 
 ### Step 2: Select Files
 
-1. With your document open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section. You can also drag-and-drop files onto a section or use <wa-icon library="texra" name="add"></wa-icon> **Add files** to pick from a dialog.
+1. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick your document from the file picker. You can also drag-and-drop it from the OS file manager. If you have several `.tex` files open and want them all, use <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** — it appends every editor tab whose extension matches.
 2. (Optional) Use the same buttons in **Context** or **Media** to add reference, auxiliary, or figure files.
 
 ::: tip Onboarding Prompt

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -65,8 +65,8 @@ Run **TeXRA: Create Sample Project** from the Command Palette to add a ready-mad
 
 ### Step 2: Select Files
 
-1. In the TeXRA panel, click the "Current" button next to "Input" to set your active document as the input file
-2. (Optional) Add reference, auxiliary, or figure files if needed for your task
+1. With your document open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section. You can also drag-and-drop files onto a section or use <wa-icon library="texra" name="add"></wa-icon> **Add files** to pick from a dialog.
+2. (Optional) Use the same buttons in **Context** or **Media** to add reference, auxiliary, or figure files.
 
 ::: tip Onboarding Prompt
 The first time you choose an input file, TeXRA shows a tooltip explaining the selector.
@@ -74,7 +74,7 @@ Select **Never remind again** to hide it permanently.
 :::
 
 ::: info Multiple Files
-For complex documents with multiple input files, use the "Multiple" dropdown to select additional files.
+Each category holds an ordered list — add as many files as the task needs and drag rows to reorder them.
 :::
 
 ### Step 3: Choose Agent and Model
@@ -276,7 +276,7 @@ Here are some common tasks you can try with TeXRA:
 ### Converting a Paper to Slides
 
 - **Agent**: `paper2slide`
-- **Model**: `sonnet46T`, `opus47`, or `gpt54`
+- **Model**: `sonnet46T`, `opus47T`, or `gpt55`
 - **Instruction**: "Convert this paper into presentation slides using the beamer template. Create approximately 12-15 slides highlighting the key points, methodology, and results."
 
 ### Improving Writing Style

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -48,7 +48,7 @@ Because these are tool-use agents, they can compile the figure and inspect the r
 ### Creating New Figures
 
 1. Select a tool-use agent — `research` or `presenter` (<wa-icon library="texra" name="sparkle"></wa-icon>).
-2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet46T`, `opus47T`, `gpt54`, or `gemini31p` are good choices for complex drawings.
+2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet46T`, `opus47T`, `gpt55`, or `gemini31p` are good choices for complex drawings.
 3. Provide a detailed description of the figure you want.
 4. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -291,7 +291,6 @@ to confirm available models, and `texra tools status` to check tool availability
    - Use relative paths within the workspace
 
 3. **File list not updating**:
-   - Click the refresh icon next to the file type
    - Restart VS Code if file lists remain outdated
    - Check file extension settings to ensure your files are included:
 
@@ -299,10 +298,10 @@ to confirm available models, and `texra tools status` to check tool availability
    "texra.files.included.inputExtensions": [".txt", ".tex", ".md"]
    ```
 
-4. **Multiple file selection issues**:
-   - Verify the multiple selection panel is expanded
-   - Try adding files one by one instead of in bulk
-   - Check the browser console for any JavaScript errors
+4. **File selection issues**:
+   - Try adding files one by one with the picker instead of dragging in bulk
+   - If a file does not appear after dropping, confirm its extension is in the category's allowed-extensions setting
+   - Check the developer console (`Developer: Open Webview Developer Tools`) for any errors
 
 ## Output File Issues
 

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -50,7 +50,7 @@ texra run polish --input intro.tex --output intro.polished.tex
 
 1. Open `intro.tex`.
 2. Click the TeXRA icon in the activity bar.
-3. With `intro.tex` open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section.
+3. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick `intro.tex` from the file picker.
 4. Pick **polish** as the agent. Pick a model.
 5. Type the instruction. Press **Execute**.
 6. When the run completes, open the diff from the **Progress Board**.

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -50,7 +50,7 @@ texra run polish --input intro.tex --output intro.polished.tex
 
 1. Open `intro.tex`.
 2. Click the TeXRA icon in the activity bar.
-3. In the sidebar, click **Current** next to **Input**.
+3. With `intro.tex` open in the editor, click <wa-icon library="texra" name="folder-opened"></wa-icon> **Add opened files** in the **Input** section.
 4. Pick **polish** as the agent. Pick a model.
 5. Type the instruction. Press **Execute**.
 6. When the run completes, open the diff from the **Progress Board**.

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -12,7 +12,7 @@ agent in `texra chat`.
 ## <wa-icon library="texra" name="rocket"></wa-icon> Quick Task: Add a Figure Caption
 
 1. Select the `polish` agent from the agent dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>).
-2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — e.g. `gpt54`, `sonnet46`, `gemini31p`.
+2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — e.g. `gpt55`, `sonnet46T`, `gemini31p`.
 3. Select your figure in the **Media** (<wa-icon library="texra" name="file-media"></wa-icon>) section.
 4. Type the instruction: "Write a detailed caption for this figure."
 5. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
@@ -21,11 +21,13 @@ agent in `texra chat`.
 
 The main TeXRA panel includes a **Media** section for figure files:
 
-- **Dropdown** (<wa-icon library="texra" name="file-media"></wa-icon>): pick a primary media file from the workspace.
-- **Multiple Toggle** (<wa-icon library="texra" name="list-unordered"></wa-icon>): expand to select multiple files.
 - **Auto Extract Dropdown** (<wa-icon library="texra" name="wand"></wa-icon>): configure automatic figure extraction.
-- **Current Button** (<wa-icon library="texra" name="file-code"></wa-icon>): select the figure currently open in the editor.
-- **Empty Button** (<wa-icon library="texra" name="close"></wa-icon>): clear the selection.
+- **Add opened files** (<wa-icon library="texra" name="folder-opened"></wa-icon>): append every open editor tab whose extension is a configured media type.
+- **Clear all media files** (<wa-icon library="texra" name="trash"></wa-icon>): empty the media list.
+- **Add media files** (<wa-icon library="texra" name="add"></wa-icon>): open a file picker to append figures.
+- **Drag-and-drop** image, PDF, or audio files from anywhere onto the section.
+
+Each file appears as a row with a drag handle (for reordering) and a small trash icon (to remove just that file).
 
 ## <wa-icon library="texra" name="file-symlink-file"></wa-icon> Supported File Types
 
@@ -91,7 +93,7 @@ Retrieves BibTeX records for every citation key found in the document.
 
 When you provide media files, they're handed to the model according to its capabilities:
 
-- **Vision models** (GPT-5.4, Claude 4.6 Sonnet/Opus, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
+- **Vision models** (GPT-5.5, Claude 4.7 Opus / 4.6 Sonnet, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
 - **Audio models**: audio files are uploaded for transcription.
 - **Non-multimodal models**: only filenames are passed as context.
 


### PR DESCRIPTION
The file-selection UI no longer has a single/multiple toggle, "Current"
button, "Refresh" button, or per-category dropdown — each category is an
ordered list with three buttons (Add opened files, Clear all, Add files).
Updated file-management, working-with-figures, quick-start, first-run,
polish-a-draft, troubleshooting, and the FileSelectHero mockup to match
the live UI in FileSelectGroup.ts. Also swept lingering `gpt54`
recommendations to `gpt55`/`opus47T` and corrected the GPT-5.4 reference
in the gpt5ReasoningSummary description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and VitePress mockup changes only; no runtime or product behavior is modified.
> 
> **Overview**
> Documentation is brought in line with the **current Launcher file UI**: Input, Context, and Media are **ordered lists** with header actions **Add opened files**, **Clear all**, and **Add files** (plus drag-and-drop and per-row trash/reorder). Guides that still described **Current**, dropdowns, refresh, and a single/multiple toggle are rewritten—**file-management**, **working-with-figures**, **multiple-output**, **quick-start**, **first-run**, **polish-a-draft**, and **troubleshooting**—and the **FileSelectHero** mockup is updated to match.
> 
> A smaller pass updates **recommended model IDs** (`gpt54` → `gpt55` / `opus47T` where appropriate), **GPT-5.5** wording for `gpt5ReasoningSummary`, and **Dashboard** mentions (**Integrations**, **Odyssey**). **latex-tools** now links **Attach TeX Count** to the configuration webview section instead of file-management.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8b209b4f8cd6b218b3b55ef531ce25a01d93f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->