### PR TITLE
Add design-mock gallery for UI affordance previews

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -27,6 +27,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement } from '../utils';
+import { toolbarToggleStyles } from '../styles/toolbarToggleStyles';
 import {
   renderProgressBadgeContent,
   getProgressBadgeTitle,
@@ -128,6 +129,7 @@ export class StreamHeader extends LitElement {
     animationStyles,
     commonViewStyles,
     statusIndicatorStyles,
+    toolbarToggleStyles,
     css`
       :host {
         display: block;
@@ -244,36 +246,6 @@ export class StreamHeader extends LitElement {
       .run-button {
         margin-left: var(--wa-space-3xs);
         color: var(--color-success);
-      }
-
-      /* Shared toggle button base */
-      .yolo-toggle-button,
-      .super-yolo-toggle-button {
-        flex-shrink: 0;
-      }
-
-      .yolo-toggle-button.is-active,
-      .super-yolo-toggle-button.is-active {
-        border-radius: var(--border-radius);
-      }
-
-      /* Toggle color per variant */
-      .yolo-toggle-button.is-active {
-        --_toggle-color: var(--color-error);
-      }
-
-      .super-yolo-toggle-button.is-active {
-        --_toggle-color: var(--color-warning);
-      }
-
-      /* Active toggle: color + tinted background. */
-      :is(.yolo-toggle-button, .super-yolo-toggle-button).is-active {
-        color: var(--_toggle-color);
-        background-color: color-mix(
-          in srgb,
-          var(--_toggle-color) 15%,
-          transparent
-        );
       }
 
       .odyssey-chip {

--- a/packages/extension/src/progressView/frontend/styles/toolbarToggleStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolbarToggleStyles.ts
@@ -1,0 +1,28 @@
+// Third-party imports
+import { css } from 'lit';
+
+/** Shared styles for toolbar toggle buttons in stream headers. */
+export const toolbarToggleStyles = css`
+  .yolo-toggle-button,
+  .super-yolo-toggle-button {
+    flex-shrink: 0;
+  }
+
+  .yolo-toggle-button.is-active,
+  .super-yolo-toggle-button.is-active {
+    border-radius: var(--border-radius);
+  }
+
+  .yolo-toggle-button.is-active {
+    --_toggle-color: var(--color-error);
+  }
+
+  .super-yolo-toggle-button.is-active {
+    --_toggle-color: var(--color-warning);
+  }
+
+  :is(.yolo-toggle-button, .super-yolo-toggle-button).is-active {
+    color: var(--_toggle-color);
+    background-color: color-mix(in srgb, var(--_toggle-color) 15%, transparent);
+  }
+`;

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -60,6 +60,7 @@ import './components/FileSelectGroup';
 import './components/BannerGroup';
 import './components/LatexDiffsSection';
 import './components/InstructionPanel';
+import './mocks';
 import {
   ELEMENT_IDS,
   DOCUMENT_FILE_TYPES,
@@ -185,6 +186,16 @@ export class MainApp extends MainAppBase {
   @state() protected override debugMode = false;
   private readonly isGitRepo = signal(true);
   private instructionSaveTimer: number | null = null;
+
+  // Design-mocks toggle. Flip from the webview DevTools console:
+  //   localStorage.setItem('texra-mocks','1'); location.reload();
+  private readonly showMocksGallery: boolean = (() => {
+    try {
+      return localStorage.getItem('texra-mocks') === '1';
+    } catch {
+      return false;
+    }
+  })();
 
   private readonly fileStateContext$ = new Signal.Computed(
     (): FileStateContextValue => ({
@@ -1652,6 +1663,16 @@ export class MainApp extends MainAppBase {
   }
 
   render(): TemplateResult {
+    if (this.showMocksGallery) {
+      return html`
+        <div class="content-wrapper">
+          <div class="main-content">
+            <texra-mocks-gallery></texra-mocks-gallery>
+          </div>
+        </div>
+      `;
+    }
+
     const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
     const fileSelectionClasses = classMap({
       'file-selection-group': true,

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -123,9 +123,7 @@ const MainAppBase = SignalWatcher(
   BaseWebviewApp as unknown as new (...args: any[]) => BaseWebviewApp,
 );
 
-const SHOW_MOCKS_GALLERY =
-  process.env.NODE_ENV === 'development' &&
-  localStorage.getItem('texra-mocks') === '1';
+const ENABLE_MOCKS_GALLERY = process.env.NODE_ENV === 'development';
 
 @customElement('main-app')
 export class MainApp extends MainAppBase {
@@ -328,7 +326,7 @@ export class MainApp extends MainAppBase {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    if (SHOW_MOCKS_GALLERY) {
+    if (ENABLE_MOCKS_GALLERY && localStorage.getItem('texra-mocks') === '1') {
       void import('./mocks');
     }
     this.restorePersistedState();
@@ -1659,7 +1657,7 @@ export class MainApp extends MainAppBase {
   }
 
   render(): TemplateResult {
-    if (SHOW_MOCKS_GALLERY) {
+    if (ENABLE_MOCKS_GALLERY && localStorage.getItem('texra-mocks') === '1') {
       return html`
         <div class="content-wrapper">
           <div class="main-content">

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -60,7 +60,6 @@ import './components/FileSelectGroup';
 import './components/BannerGroup';
 import './components/LatexDiffsSection';
 import './components/InstructionPanel';
-import './mocks';
 import {
   ELEMENT_IDS,
   DOCUMENT_FILE_TYPES,
@@ -123,6 +122,10 @@ type SetMultipleFilesMessage =
 const MainAppBase = SignalWatcher(
   BaseWebviewApp as unknown as new (...args: any[]) => BaseWebviewApp,
 );
+
+const SHOW_MOCKS_GALLERY =
+  process.env.NODE_ENV === 'development' &&
+  localStorage.getItem('texra-mocks') === '1';
 
 @customElement('main-app')
 export class MainApp extends MainAppBase {
@@ -187,10 +190,9 @@ export class MainApp extends MainAppBase {
   private readonly isGitRepo = signal(true);
   private instructionSaveTimer: number | null = null;
 
-  // Design-mocks toggle. Flip from the webview DevTools console:
+  // Dev-only design-mocks toggle. Flip from the webview DevTools console:
   //   localStorage.setItem('texra-mocks','1'); location.reload();
-  private readonly showMocksGallery =
-    localStorage.getItem('texra-mocks') === '1';
+  private readonly showMocksGallery = SHOW_MOCKS_GALLERY;
 
   private readonly fileStateContext$ = new Signal.Computed(
     (): FileStateContextValue => ({
@@ -330,6 +332,9 @@ export class MainApp extends MainAppBase {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (SHOW_MOCKS_GALLERY) {
+      void import('./mocks');
+    }
     this.restorePersistedState();
   }
 

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -185,6 +185,7 @@ export class MainApp extends MainAppBase {
     ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
   );
   @state() protected override debugMode = false;
+  @state() private mocksGalleryLoaded = false;
   private readonly isGitRepo = signal(true);
   private instructionSaveTimer: number | null = null;
 
@@ -327,7 +328,9 @@ export class MainApp extends MainAppBase {
   override connectedCallback(): void {
     super.connectedCallback();
     if (ENABLE_MOCKS_GALLERY && localStorage.getItem('texra-mocks') === '1') {
-      void import('./mocks');
+      void import('./mocks').then(() => {
+        this.mocksGalleryLoaded = true;
+      });
     }
     this.restorePersistedState();
   }
@@ -1657,7 +1660,7 @@ export class MainApp extends MainAppBase {
   }
 
   render(): TemplateResult {
-    if (ENABLE_MOCKS_GALLERY && localStorage.getItem('texra-mocks') === '1') {
+    if (ENABLE_MOCKS_GALLERY && this.mocksGalleryLoaded) {
       return html`
         <div class="content-wrapper">
           <div class="main-content">

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -189,13 +189,8 @@ export class MainApp extends MainAppBase {
 
   // Design-mocks toggle. Flip from the webview DevTools console:
   //   localStorage.setItem('texra-mocks','1'); location.reload();
-  private readonly showMocksGallery: boolean = (() => {
-    try {
-      return localStorage.getItem('texra-mocks') === '1';
-    } catch {
-      return false;
-    }
-  })();
+  private readonly showMocksGallery =
+    localStorage.getItem('texra-mocks') === '1';
 
   private readonly fileStateContext$ = new Signal.Computed(
     (): FileStateContextValue => ({

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -190,10 +190,6 @@ export class MainApp extends MainAppBase {
   private readonly isGitRepo = signal(true);
   private instructionSaveTimer: number | null = null;
 
-  // Dev-only design-mocks toggle. Flip from the webview DevTools console:
-  //   localStorage.setItem('texra-mocks','1'); location.reload();
-  private readonly showMocksGallery = SHOW_MOCKS_GALLERY;
-
   private readonly fileStateContext$ = new Signal.Computed(
     (): FileStateContextValue => ({
       sessionType: this.sessionType.get(),
@@ -1663,7 +1659,7 @@ export class MainApp extends MainAppBase {
   }
 
   render(): TemplateResult {
-    if (this.showMocksGallery) {
+    if (SHOW_MOCKS_GALLERY) {
       return html`
         <div class="content-wrapper">
           <div class="main-content">

--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -1,0 +1,119 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+/**
+ * Visual-only mock of a context window utilization chip. Shows the
+ * percentage of the model's context budget used by the current session,
+ * with a hairline progress bar. No real token counting wired in.
+ */
+@customElement('texra-context-utilization-mock')
+export class ContextUtilizationMock extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .ctx-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+        padding: 2px var(--wa-space-2xs);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-m);
+        background: var(--wa-color-surface-default, transparent);
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+        cursor: default;
+      }
+
+      .ctx-chip__icon {
+        font-size: var(--font-size-icon-sm);
+      }
+
+      .ctx-chip__bar {
+        position: relative;
+        width: 48px;
+        height: 4px;
+        border-radius: 2px;
+        background: var(--wa-color-neutral-fill-quiet);
+        overflow: hidden;
+      }
+
+      .ctx-chip__fill {
+        position: absolute;
+        inset: 0;
+        transform-origin: left center;
+        background: var(--wa-color-brand-fill-loud);
+        transition: transform 0.2s ease;
+      }
+
+      .ctx-chip--warn .ctx-chip__fill {
+        background: var(--wa-color-warning-fill-loud);
+      }
+
+      .ctx-chip--danger {
+        color: var(--wa-color-danger-text-loud);
+      }
+
+      .ctx-chip--danger .ctx-chip__fill {
+        background: var(--wa-color-danger-fill-loud);
+      }
+
+      .ctx-chip__numeric {
+        white-space: nowrap;
+      }
+    `,
+  ];
+
+  /** 0–100. Visual only, no real measurement behind it. */
+  @property({ type: Number }) percent = 12;
+
+  /** Display tokens used; purely cosmetic. */
+  @property({ type: String }) tokens = '24k / 200k';
+
+  override render(): TemplateResult {
+    const clamped = Math.max(0, Math.min(100, this.percent));
+    const tone = clamped >= 90 ? 'danger' : clamped >= 70 ? 'warn' : 'ok';
+    const scale = (clamped / 100).toFixed(3);
+    const title = `Context ${clamped}% used — ${this.tokens}`;
+    return html`
+      <span
+        class=${classMap({
+          'ctx-chip': true,
+          'ctx-chip--warn': tone === 'warn',
+          'ctx-chip--danger': tone === 'danger',
+        })}
+        title=${title}
+        role="img"
+        aria-label=${title}
+      >
+        <wa-icon
+          class="ctx-chip__icon"
+          library=${TEXRA_ICON_LIBRARY}
+          name="chart-pie"
+          variant="solid"
+        ></wa-icon>
+        <span class="ctx-chip__bar" aria-hidden="true">
+          <span
+            class="ctx-chip__fill"
+            style="transform: scaleX(${scale})"
+          ></span>
+        </span>
+        <span class="ctx-chip__numeric">${clamped}%</span>
+      </span>
+    `;
+  }
+}

--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -3,8 +3,10 @@ import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+// Local imports - shared styles and icons
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 

--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -32,7 +32,7 @@ export class ContextUtilizationMock extends LitElement {
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
         background: var(--wa-color-surface-default, transparent);
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         color: var(--wa-color-text-quiet);
         font-variant-numeric: tabular-nums;
         line-height: 1;
@@ -86,15 +86,14 @@ export class ContextUtilizationMock extends LitElement {
 
   override render(): TemplateResult {
     const clamped = Math.max(0, Math.min(100, this.percent));
-    const tone = clamped >= 90 ? 'danger' : clamped >= 70 ? 'warn' : 'ok';
     const scale = (clamped / 100).toFixed(3);
     const title = `Context ${clamped}% used — ${this.tokens}`;
     return html`
       <span
         class=${classMap({
           'ctx-chip': true,
-          'ctx-chip--warn': tone === 'warn',
-          'ctx-chip--danger': tone === 'danger',
+          'ctx-chip--warn': clamped >= 70 && clamped < 90,
+          'ctx-chip--danger': clamped >= 90,
         })}
         title=${title}
         role="img"

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -1,308 +1,111 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
+import { customElement, query, state } from 'lit/decorators.js';
 
-import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/select/select.js';
-import '@awesome.me/webawesome/dist/components/option/option.js';
+// Reuse the production followup component so the mock reflects the real
+// affordance instead of inventing one. The wrapper just feeds it static
+// FollowupOptionsState (agents + models) and a READY-status fixture.
+import '@progressView/frontend/components/WorkflowToolUseFollowupSection';
 
+import type { FollowupOptionsState } from '@progressView/frontend/store';
+import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { selectStyles } from '@shared/styles/selectStyles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
-type Mode = 'chat' | 'agent';
+const SAMPLE_OPTIONS: FollowupOptionsState = {
+  toolUseAgentsData: [
+    {
+      value: 'tooluse-research',
+      label: 'tooluse-research',
+      description: 'Interactive research over the workflow outputs',
+      isToolUse: true,
+    },
+    {
+      value: 'tooluse-revise',
+      label: 'tooluse-revise',
+      description: 'Iteratively revise the revised files',
+      isToolUse: true,
+    },
+    {
+      value: 'tooluse-explain',
+      label: 'tooluse-explain',
+      description: 'Walk through what changed and why',
+      isToolUse: true,
+    },
+  ],
+  modelOptionsData: [
+    {
+      value: 'claude-opus-4-7',
+      label: 'Claude Opus 4.7',
+      provider: 'Anthropic',
+      context: '1M',
+    },
+    {
+      value: 'claude-sonnet-4-6',
+      label: 'Claude Sonnet 4.6',
+      provider: 'Anthropic',
+      context: '200k',
+    },
+    {
+      value: 'claude-haiku-4-5',
+      label: 'Claude Haiku 4.5',
+      provider: 'Anthropic',
+      context: '200k',
+    },
+  ],
+};
+
+const SAMPLE_STATUS: StreamStatus = STREAM_STATUS.READY;
+const SAMPLE_STREAM_MODEL = 'claude-opus-4-7';
 
 /**
- * Visual-only mock of the post-workflow followup controls. Two modes —
- * "chat about the output" and "run another agent on the output" — with
- * a sample list of output files that the followup would inherit.
+ * Static host for the production WorkflowToolUseFollowupSection. Feeds it
+ * a READY status, output-files=true, and a realistic options fixture so
+ * the panel renders fully expanded for screenshots.
  */
 @customElement('texra-followup-controls-mock')
 export class FollowupControlsMock extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    selectStyles,
     css`
       :host {
         display: block;
       }
 
-      .panel {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-s);
+      .frame {
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
+        padding: var(--wa-space-s);
         background: var(--wa-color-surface-default, transparent);
-      }
-
-      .header {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-      }
-
-      .header__title {
-        font-weight: var(--font-weight-medium);
-      }
-
-      .header__caption {
-        font-size: var(--font-size-small);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .files {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--wa-space-3xs);
-      }
-
-      .file-chip {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        padding: 2px var(--wa-space-2xs);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--wa-border-radius-s);
-        font-size: var(--font-size-small);
-        background: var(--wa-color-surface-raised, transparent);
-      }
-
-      .mode-row {
-        display: flex;
-        gap: var(--wa-space-2xs);
-      }
-
-      .mode-btn {
-        flex: 1;
-      }
-
-      .mode-btn::part(base) {
-        justify-content: flex-start;
-        gap: var(--wa-space-2xs);
-      }
-
-      .mode-btn--active::part(base) {
-        background: var(--wa-color-brand-fill-quiet);
-        color: var(--wa-color-brand-on-quiet);
-        border-color: var(--wa-color-brand-border-loud);
-      }
-
-      .form {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-2xs);
-      }
-
-      .form__row {
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-        gap: var(--wa-space-2xs);
-      }
-
-      .form__field {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-3xs);
-        min-width: 0;
-      }
-
-      .form__label {
-        font-size: var(--font-size-small);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .form__textarea {
-        width: 100%;
-        min-height: 64px;
-        font-family: inherit;
-        font-size: var(--font-size);
-        padding: var(--wa-space-2xs);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--wa-border-radius-s);
-        background: var(--wa-color-surface-raised, transparent);
-        color: var(--wa-color-text-normal);
-        resize: vertical;
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-2xs);
-      }
-
-      @media (max-width: 540px) {
-        .form__row {
-          grid-template-columns: minmax(0, 1fr);
-        }
       }
     `,
   ];
 
-  @state() private mode: Mode = 'chat';
+  @state() private options: FollowupOptionsState = SAMPLE_OPTIONS;
+  @query('workflow-tool-use-followup-section')
+  private followupEl?: HTMLElement;
+
+  override async firstUpdated(): Promise<void> {
+    // Wait for the production component + wa-details to upgrade before
+    // forcing the panel open; otherwise the query runs before the shadow
+    // DOM exists and the section stays collapsed in screenshots.
+    await customElements.whenDefined('workflow-tool-use-followup-section');
+    await customElements.whenDefined('wa-details');
+    await Promise.resolve();
+    const details =
+      this.followupEl?.shadowRoot?.querySelector('wa-details');
+    if (details) (details as HTMLElement & { open: boolean }).open = true;
+  }
 
   override render(): TemplateResult {
     return html`
-      <div class="panel">
-        <div class="header">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="check"
-            variant="solid"
-          ></wa-icon>
-          <span class="header__title">Run complete — follow up?</span>
-          <span class="header__caption">
-            Picks up from this run's outputs without re-selecting files.
-          </span>
-        </div>
-
-        <div class="files" aria-label="Output files from previous run">
-          ${this.renderFileChip('manuscript_revised.tex')}
-          ${this.renderFileChip('cover_letter.tex')}
-          ${this.renderFileChip('response_to_reviewers.tex')}
-        </div>
-
-        <div class="mode-row" role="tablist" aria-label="Follow-up mode">
-          ${this.renderModeButton('chat', 'comments', 'Chat about results')}
-          ${this.renderModeButton('agent', 'robot', 'Run another agent')}
-        </div>
-
-        ${this.mode === 'chat'
-          ? this.renderChatForm()
-          : this.renderAgentForm()}
-      </div>
-    `;
-  }
-
-  private renderModeButton(
-    mode: Mode,
-    icon: string,
-    label: string,
-  ): TemplateResult {
-    const active = this.mode === mode;
-    return html`
-      <wa-button
-        class=${classMap({
-          'mode-btn': true,
-          'mode-btn--active': active,
-        })}
-        appearance=${active ? 'outlined' : 'plain'}
-        size="small"
-        role="tab"
-        aria-selected=${active}
-        @click=${() => (this.mode = mode)}
-      >
-        <wa-icon
-          slot="start"
-          library=${TEXRA_ICON_LIBRARY}
-          name=${icon}
-          variant="solid"
-        ></wa-icon>
-        ${label}
-      </wa-button>
-    `;
-  }
-
-  private renderFileChip(name: string): TemplateResult {
-    return html`
-      <span class="file-chip">
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="file"
-          variant="solid"
-        ></wa-icon>
-        ${name}
-      </span>
-    `;
-  }
-
-  private renderChatForm(): TemplateResult {
-    return html`
-      <div class="form">
-        <div class="form__field">
-          <label class="form__label" for="followup-chat-text">
-            Ask about the revision
-          </label>
-          <textarea
-            id="followup-chat-text"
-            class="form__textarea"
-            placeholder="e.g. Summarize what changed in the intro, and flag any leftover TODOs."
-          ></textarea>
-        </div>
-        <div class="actions">
-          <wa-button size="small" appearance="plain">Discard</wa-button>
-          <wa-button size="small" appearance="accent">
-            <wa-icon
-              slot="start"
-              library=${TEXRA_ICON_LIBRARY}
-              name="paper-plane"
-              variant="solid"
-            ></wa-icon>
-            Send
-          </wa-button>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderAgentForm(): TemplateResult {
-    return html`
-      <div class="form">
-        <div class="form__row">
-          <div class="form__field">
-            <label class="form__label" for="followup-agent">Agent</label>
-            <wa-select
-              id="followup-agent"
-              size="small"
-              value="merge"
-              placeholder="Pick an agent"
-            >
-              <wa-option value="merge">merge</wa-option>
-              <wa-option value="polish">polish</wa-option>
-              <wa-option value="reflect">reflect</wa-option>
-              <wa-option value="diff">latexdiff</wa-option>
-            </wa-select>
-          </div>
-          <div class="form__field">
-            <label class="form__label" for="followup-model">Model</label>
-            <wa-select
-              id="followup-model"
-              size="small"
-              value="claude-opus-4-7"
-              placeholder="Pick a model"
-            >
-              <wa-option value="claude-opus-4-7">Claude Opus 4.7</wa-option>
-              <wa-option value="claude-sonnet-4-6">Claude Sonnet 4.6</wa-option>
-              <wa-option value="claude-haiku-4-5">Claude Haiku 4.5</wa-option>
-            </wa-select>
-          </div>
-        </div>
-        <div class="form__field">
-          <label class="form__label" for="followup-agent-text">
-            Instruction (optional)
-          </label>
-          <textarea
-            id="followup-agent-text"
-            class="form__textarea"
-            placeholder="Extra direction for the agent. Output files are inherited automatically."
-          ></textarea>
-        </div>
-        <div class="actions">
-          <wa-button size="small" appearance="plain">Discard</wa-button>
-          <wa-button size="small" appearance="accent">
-            <wa-icon
-              slot="start"
-              library=${TEXRA_ICON_LIBRARY}
-              name="play"
-              variant="solid"
-            ></wa-icon>
-            Run merge
-          </wa-button>
-        </div>
+      <div class="frame">
+        <workflow-tool-use-followup-section
+          .status=${SAMPLE_STATUS}
+          .hasOutputFiles=${true}
+          .options=${this.options}
+          .streamModel=${SAMPLE_STREAM_MODEL}
+        ></workflow-tool-use-followup-section>
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -92,8 +92,7 @@ export class FollowupControlsMock extends LitElement {
     await customElements.whenDefined('workflow-tool-use-followup-section');
     await customElements.whenDefined('wa-details');
     await Promise.resolve();
-    const details =
-      this.followupEl?.shadowRoot?.querySelector('wa-details');
+    const details = this.followupEl?.shadowRoot?.querySelector('wa-details');
     if (details) (details as HTMLElement & { open: boolean }).open = true;
   }
 

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -5,8 +5,10 @@ import { customElement, query, state } from 'lit/decorators.js';
 // Reuse the production followup component so the mock reflects the real
 // affordance instead of inventing one. The wrapper just feeds it static
 // FollowupOptionsState (agents + models) and a READY-status fixture.
+// Side-effect imports - production progress view components
 import '@progressView/frontend/components/WorkflowToolUseFollowupSection';
 
+// Local imports - progress view types and shared styles
 import type { FollowupOptionsState } from '@progressView/frontend/store';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 
 // Reuse the production followup component so the mock reflects the real
 // affordance instead of inventing one. The wrapper just feeds it static
@@ -83,7 +83,7 @@ export class FollowupControlsMock extends LitElement {
     `,
   ];
 
-  @state() private options: FollowupOptionsState = SAMPLE_OPTIONS;
+  private readonly options: FollowupOptionsState = SAMPLE_OPTIONS;
   @query('workflow-tool-use-followup-section')
   private followupEl?: HTMLElement;
 

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -83,7 +83,6 @@ export class FollowupControlsMock extends LitElement {
     `,
   ];
 
-  private readonly options: FollowupOptionsState = SAMPLE_OPTIONS;
   @query('workflow-tool-use-followup-section')
   private followupEl?: HTMLElement;
 
@@ -104,7 +103,7 @@ export class FollowupControlsMock extends LitElement {
         <workflow-tool-use-followup-section
           .status=${SAMPLE_STATUS}
           .hasOutputFiles=${true}
-          .options=${this.options}
+          .options=${SAMPLE_OPTIONS}
           .streamModel=${SAMPLE_STREAM_MODEL}
         ></workflow-tool-use-followup-section>
       </div>

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -1,0 +1,309 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/select/select.js';
+import '@awesome.me/webawesome/dist/components/option/option.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { selectStyles } from '@shared/styles/selectStyles';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+type Mode = 'chat' | 'agent';
+
+/**
+ * Visual-only mock of the post-workflow followup controls. Two modes —
+ * "chat about the output" and "run another agent on the output" — with
+ * a sample list of output files that the followup would inherit.
+ */
+@customElement('texra-followup-controls-mock')
+export class FollowupControlsMock extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    selectStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-s);
+        padding: var(--wa-space-s);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-m);
+        background: var(--wa-color-surface-default, transparent);
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+      }
+
+      .header__title {
+        font-weight: var(--font-weight-medium);
+      }
+
+      .header__caption {
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .files {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--wa-space-3xs);
+      }
+
+      .file-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+        padding: 2px var(--wa-space-2xs);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-s);
+        font-size: var(--font-size-small);
+        background: var(--wa-color-surface-raised, transparent);
+      }
+
+      .mode-row {
+        display: flex;
+        gap: var(--wa-space-2xs);
+      }
+
+      .mode-btn {
+        flex: 1;
+      }
+
+      .mode-btn::part(base) {
+        justify-content: flex-start;
+        gap: var(--wa-space-2xs);
+      }
+
+      .mode-btn--active::part(base) {
+        background: var(--wa-color-brand-fill-quiet);
+        color: var(--wa-color-brand-on-quiet);
+        border-color: var(--wa-color-brand-border-loud);
+      }
+
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+      }
+
+      .form__row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: var(--wa-space-2xs);
+      }
+
+      .form__field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-3xs);
+        min-width: 0;
+      }
+
+      .form__label {
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .form__textarea {
+        width: 100%;
+        min-height: 64px;
+        font-family: inherit;
+        font-size: var(--font-size);
+        padding: var(--wa-space-2xs);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-s);
+        background: var(--wa-color-surface-raised, transparent);
+        color: var(--wa-color-text-normal);
+        resize: vertical;
+      }
+
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--wa-space-2xs);
+      }
+
+      @media (max-width: 540px) {
+        .form__row {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+    `,
+  ];
+
+  @state() private mode: Mode = 'chat';
+
+  override render(): TemplateResult {
+    return html`
+      <div class="panel">
+        <div class="header">
+          <wa-icon
+            library=${TEXRA_ICON_LIBRARY}
+            name="check"
+            variant="solid"
+          ></wa-icon>
+          <span class="header__title">Run complete — follow up?</span>
+          <span class="header__caption">
+            Picks up from this run's outputs without re-selecting files.
+          </span>
+        </div>
+
+        <div class="files" aria-label="Output files from previous run">
+          ${this.renderFileChip('manuscript_revised.tex')}
+          ${this.renderFileChip('cover_letter.tex')}
+          ${this.renderFileChip('response_to_reviewers.tex')}
+        </div>
+
+        <div class="mode-row" role="tablist" aria-label="Follow-up mode">
+          ${this.renderModeButton('chat', 'comments', 'Chat about results')}
+          ${this.renderModeButton('agent', 'robot', 'Run another agent')}
+        </div>
+
+        ${this.mode === 'chat'
+          ? this.renderChatForm()
+          : this.renderAgentForm()}
+      </div>
+    `;
+  }
+
+  private renderModeButton(
+    mode: Mode,
+    icon: string,
+    label: string,
+  ): TemplateResult {
+    const active = this.mode === mode;
+    return html`
+      <wa-button
+        class=${classMap({
+          'mode-btn': true,
+          'mode-btn--active': active,
+        })}
+        appearance=${active ? 'outlined' : 'plain'}
+        size="small"
+        role="tab"
+        aria-selected=${active}
+        @click=${() => (this.mode = mode)}
+      >
+        <wa-icon
+          slot="start"
+          library=${TEXRA_ICON_LIBRARY}
+          name=${icon}
+          variant="solid"
+        ></wa-icon>
+        ${label}
+      </wa-button>
+    `;
+  }
+
+  private renderFileChip(name: string): TemplateResult {
+    return html`
+      <span class="file-chip">
+        <wa-icon
+          library=${TEXRA_ICON_LIBRARY}
+          name="file"
+          variant="solid"
+        ></wa-icon>
+        ${name}
+      </span>
+    `;
+  }
+
+  private renderChatForm(): TemplateResult {
+    return html`
+      <div class="form">
+        <div class="form__field">
+          <label class="form__label" for="followup-chat-text">
+            Ask about the revision
+          </label>
+          <textarea
+            id="followup-chat-text"
+            class="form__textarea"
+            placeholder="e.g. Summarize what changed in the intro, and flag any leftover TODOs."
+          ></textarea>
+        </div>
+        <div class="actions">
+          <wa-button size="small" appearance="plain">Discard</wa-button>
+          <wa-button size="small" appearance="accent">
+            <wa-icon
+              slot="start"
+              library=${TEXRA_ICON_LIBRARY}
+              name="paper-plane"
+              variant="solid"
+            ></wa-icon>
+            Send
+          </wa-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentForm(): TemplateResult {
+    return html`
+      <div class="form">
+        <div class="form__row">
+          <div class="form__field">
+            <label class="form__label" for="followup-agent">Agent</label>
+            <wa-select
+              id="followup-agent"
+              size="small"
+              value="merge"
+              placeholder="Pick an agent"
+            >
+              <wa-option value="merge">merge</wa-option>
+              <wa-option value="polish">polish</wa-option>
+              <wa-option value="reflect">reflect</wa-option>
+              <wa-option value="diff">latexdiff</wa-option>
+            </wa-select>
+          </div>
+          <div class="form__field">
+            <label class="form__label" for="followup-model">Model</label>
+            <wa-select
+              id="followup-model"
+              size="small"
+              value="claude-opus-4-7"
+              placeholder="Pick a model"
+            >
+              <wa-option value="claude-opus-4-7">Claude Opus 4.7</wa-option>
+              <wa-option value="claude-sonnet-4-6">Claude Sonnet 4.6</wa-option>
+              <wa-option value="claude-haiku-4-5">Claude Haiku 4.5</wa-option>
+            </wa-select>
+          </div>
+        </div>
+        <div class="form__field">
+          <label class="form__label" for="followup-agent-text">
+            Instruction (optional)
+          </label>
+          <textarea
+            id="followup-agent-text"
+            class="form__textarea"
+            placeholder="Extra direction for the agent. Output files are inherited automatically."
+          ></textarea>
+        </div>
+        <div class="actions">
+          <wa-button size="small" appearance="plain">Discard</wa-button>
+          <wa-button size="small" appearance="accent">
+            <wa-icon
+              slot="start"
+              library=${TEXRA_ICON_LIBRARY}
+              name="play"
+              variant="solid"
+            ></wa-icon>
+            Run merge
+          </wa-button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -63,13 +63,6 @@ export class MocksGallery extends LitElement {
         margin-bottom: var(--wa-space-2xs);
       }
 
-      .row {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: var(--wa-space-s);
-      }
-
       .header-strip {
         display: flex;
         align-items: center;

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -1,0 +1,203 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+import './YoloToggleMock';
+import './ContextUtilizationMock';
+import './TodoListMock';
+import './FollowupControlsMock';
+import './ProgressBoardLayoutMock';
+
+/**
+ * Static design gallery for proposed UI affordances. All children are
+ * visual-only mocks; nothing here is wired to real state. Mount by
+ * setting `localStorage.setItem('texra-mocks','1')` and reloading the
+ * main webview — see MainApp.ts.
+ */
+@customElement('texra-mocks-gallery')
+export class MocksGallery extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+        padding: var(--wa-space-s);
+      }
+
+      .heading {
+        font-weight: var(--font-weight-medium);
+        font-size: var(--font-size-large);
+        margin-bottom: var(--wa-space-3xs);
+      }
+
+      .subheading {
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+        margin-bottom: var(--wa-space-m);
+      }
+
+      .section {
+        margin-bottom: var(--wa-space-l);
+      }
+
+      .section__title {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+        font-weight: var(--font-weight-medium);
+        margin-bottom: var(--wa-space-3xs);
+      }
+
+      .section__desc {
+        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-small);
+        margin-bottom: var(--wa-space-2xs);
+      }
+
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--wa-space-s);
+      }
+
+      .header-strip {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-m);
+        background: var(--wa-color-surface-default, transparent);
+      }
+
+      .header-strip__label {
+        flex: 1;
+        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-small);
+      }
+    `,
+  ];
+
+  override render(): TemplateResult {
+    return html`
+      <div class="heading">
+        <wa-icon
+          library=${TEXRA_ICON_LIBRARY}
+          name="flask"
+          variant="solid"
+        ></wa-icon>
+        Design mocks
+      </div>
+      <div class="subheading">
+        Static UI previews for proposed affordances. No live wiring — pure
+        screenshots / demo.
+      </div>
+
+      ${this.renderHeaderStrip()} ${this.renderTodoSection()}
+      ${this.renderFollowupSection()} ${this.renderProgressBoardSection()}
+    `;
+  }
+
+  private renderHeaderStrip(): TemplateResult {
+    return html`
+      <div class="section">
+        <div class="section__title">
+          <wa-icon
+            library=${TEXRA_ICON_LIBRARY}
+            name="bolt"
+            variant="solid"
+          ></wa-icon>
+          Launcher header — YOLO toggle + context utilization
+        </div>
+        <div class="section__desc">
+          Hands-free agent execution toggle and a live context-budget chip,
+          shown in the launcher header strip.
+        </div>
+        <div class="header-strip">
+          <span class="header-strip__label">TeXRA</span>
+          <texra-context-utilization-mock
+            percent="12"
+            tokens="24k / 200k"
+          ></texra-context-utilization-mock>
+          <texra-context-utilization-mock
+            percent="72"
+            tokens="144k / 200k"
+          ></texra-context-utilization-mock>
+          <texra-context-utilization-mock
+            percent="93"
+            tokens="186k / 200k"
+          ></texra-context-utilization-mock>
+          <texra-yolo-toggle-mock></texra-yolo-toggle-mock>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTodoSection(): TemplateResult {
+    return html`
+      <div class="section">
+        <div class="section__title">
+          <wa-icon
+            library=${TEXRA_ICON_LIBRARY}
+            name="list-check"
+            variant="solid"
+          ></wa-icon>
+          Todo list on ProgressBoard
+        </div>
+        <div class="section__desc">
+          Live checklist that shows each step transition Pending → In Progress
+          → Completed.
+        </div>
+        <texra-todo-list-mock></texra-todo-list-mock>
+      </div>
+    `;
+  }
+
+  private renderFollowupSection(): TemplateResult {
+    return html`
+      <div class="section">
+        <div class="section__title">
+          <wa-icon
+            library=${TEXRA_ICON_LIBRARY}
+            name="comments"
+            variant="solid"
+          ></wa-icon>
+          Followup task controls
+        </div>
+        <div class="section__desc">
+          After a workflow completes, the followup controls let users chat
+          about the output or hand it to another agent without re-selecting
+          files.
+        </div>
+        <texra-followup-controls-mock></texra-followup-controls-mock>
+      </div>
+    `;
+  }
+
+  private renderProgressBoardSection(): TemplateResult {
+    return html`
+      <div class="section">
+        <div class="section__title">
+          <wa-icon
+            library=${TEXRA_ICON_LIBRARY}
+            name="robot"
+            variant="solid"
+          ></wa-icon>
+          ProgressBoard layout (stream + outputs, no editors)
+        </div>
+        <div class="section__desc">
+          Stream header and live log on the left, the run's output files on
+          the right. Editors live in the host, not the board.
+        </div>
+        <texra-progress-board-layout-mock></texra-progress-board-layout-mock>
+      </div>
+    `;
+  }
+}

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -2,14 +2,17 @@
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+// Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+// Local imports - shared styles and icons
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 // Keep the gallery self-contained: importing this file alone is enough to
 // render every section. ES module dedup makes the second registration path
 // (via ./index.ts) a no-op.
+// Side-effect imports - local mock components
 import './YoloToggleMock';
 import './ContextUtilizationMock';
 import './TodoListMock';

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -156,8 +156,8 @@ export class MocksGallery extends LitElement {
           Todo list on ProgressBoard
         </div>
         <div class="section__desc">
-          Live checklist that shows each step transition Pending → In Progress
-          → Completed.
+          Live checklist that shows each step transition Pending → In Progress →
+          Completed.
         </div>
         <texra-todo-list-mock></texra-todo-list-mock>
       </div>
@@ -176,9 +176,8 @@ export class MocksGallery extends LitElement {
           Followup task controls
         </div>
         <div class="section__desc">
-          After a workflow completes, the followup controls let users chat
-          about the output or hand it to another agent without re-selecting
-          files.
+          After a workflow completes, the followup controls let users chat about
+          the output or hand it to another agent without re-selecting files.
         </div>
         <texra-followup-controls-mock></texra-followup-controls-mock>
       </div>
@@ -197,8 +196,8 @@ export class MocksGallery extends LitElement {
           ProgressBoard layout (stream + outputs, no editors)
         </div>
         <div class="section__desc">
-          Stream header and live log on the left, the run's output files on
-          the right. Editors live in the host, not the board.
+          Stream header and live log on the left, the run's output files on the
+          right. Editors live in the host, not the board.
         </div>
         <texra-progress-board-layout-mock></texra-progress-board-layout-mock>
       </div>

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -7,6 +7,9 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
+// Keep the gallery self-contained: importing this file alone is enough to
+// render every section. ES module dedup makes the second registration path
+// (via ./index.ts) a no-op.
 import './YoloToggleMock';
 import './ContextUtilizationMock';
 import './TodoListMock';
@@ -32,12 +35,12 @@ export class MocksGallery extends LitElement {
 
       .heading {
         font-weight: var(--font-weight-medium);
-        font-size: var(--font-size-large);
+        font-size: var(--font-size-lg);
         margin-bottom: var(--wa-space-3xs);
       }
 
       .subheading {
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         color: var(--wa-color-text-quiet);
         margin-bottom: var(--wa-space-m);
       }
@@ -56,7 +59,7 @@ export class MocksGallery extends LitElement {
 
       .section__desc {
         color: var(--wa-color-text-quiet);
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         margin-bottom: var(--wa-space-2xs);
       }
 
@@ -80,7 +83,7 @@ export class MocksGallery extends LitElement {
       .header-strip__label {
         flex: 1;
         color: var(--wa-color-text-quiet);
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
       }
     `,
   ];
@@ -106,6 +109,11 @@ export class MocksGallery extends LitElement {
   }
 
   private renderHeaderStrip(): TemplateResult {
+    const CHIPS = [
+      { percent: 12, tokens: '24k / 200k' },
+      { percent: 72, tokens: '144k / 200k' },
+      { percent: 93, tokens: '186k / 200k' },
+    ];
     return html`
       <div class="section">
         <div class="section__title">
@@ -122,18 +130,14 @@ export class MocksGallery extends LitElement {
         </div>
         <div class="header-strip">
           <span class="header-strip__label">TeXRA</span>
-          <texra-context-utilization-mock
-            percent="12"
-            tokens="24k / 200k"
-          ></texra-context-utilization-mock>
-          <texra-context-utilization-mock
-            percent="72"
-            tokens="144k / 200k"
-          ></texra-context-utilization-mock>
-          <texra-context-utilization-mock
-            percent="93"
-            tokens="186k / 200k"
-          ></texra-context-utilization-mock>
+          ${CHIPS.map(
+            (c) => html`
+              <texra-context-utilization-mock
+                percent=${c.percent}
+                tokens=${c.tokens}
+              ></texra-context-utilization-mock>
+            `,
+          )}
           <texra-yolo-toggle-mock></texra-yolo-toggle-mock>
         </div>
       </div>

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -9,9 +9,8 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
-// Keep the gallery self-contained: importing this file alone is enough to
-// render every section. ES module dedup makes the second registration path
-// (via ./index.ts) a no-op.
+// Keep the gallery self-contained: importing this file alone registers every
+// child mock custom element used by the sections below.
 // Side-effect imports - local mock components
 import './YoloToggleMock';
 import './ContextUtilizationMock';

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -1,22 +1,30 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 
-// Side-effect imports - Web Awesome components
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/tag/tag.js';
-
-// Reuse the production FileList — it lives INSIDE the conversation column
-// (stacked below the log), matching WorkflowStreamContent's vertical layout.
 // Side-effect imports - production progress view components
 import '@progressView/frontend/components/FileList';
+import '@progressView/frontend/components/StreamHeader';
+import '@progressView/frontend/components/StreamTabs';
+import '@progressView/frontend/components/TaskGroupList';
 
 // Local imports - shared types and styles
-import type { OutputFileInfo } from '@shared/schemas';
+import {
+  AgentCategory,
+  createWorkflowStreamState,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_STATUS,
+  type LogMessageData,
+  type OutputFileInfo,
+  type StreamState,
+  type StreamTabInfo,
+  type TaskGroup,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+const ACTIVE_STREAM_ID = 'polish';
+const BASE_TIME = Date.parse('2026-05-28T16:00:00Z');
 
 /** Realistic OutputFileInfo fixture for the production <file-list>. */
 function mockFile(
@@ -44,73 +52,150 @@ const SAMPLE_FILES: Record<string, OutputFileInfo[]> = {
   ],
 };
 
-/** Sample stream-tabs rail entries — matches what ProgressApp passes
- *  into the right-hand <stream-tabs> in production. */
-const SAMPLE_RAIL: Array<{
-  id: string;
-  label: string;
-  meta: string;
-  status: 'running' | 'ready' | 'finished';
-  icon: string;
-  active?: boolean;
-}> = [
+const SAMPLE_STREAMS: StreamTabInfo[] = [
   {
-    id: 'polish',
-    label: 'manuscript_revised — polish',
-    meta: 'workflow · 02:14',
-    status: 'running',
-    icon: 'pencil',
-    active: true,
+    name: ACTIVE_STREAM_ID,
+    label: 'manuscript_revised.tex - polish workflow',
+    modelLabel: 'Opus 4.7',
+    agent: 'paper-polish',
+    agentCategory: AgentCategory.Workflow,
+    inputFile: 'manuscript.tex',
+    creationTimestamp: BASE_TIME,
+    executionId: 'abc123',
   },
   {
-    id: 'figures',
-    label: 'figures.tex — tikz tighten',
-    meta: 'tool-use · 14m',
-    status: 'finished',
-    icon: 'wand-magic-sparkles',
+    name: 'figures',
+    label: 'figures.tex - tikz tighten',
+    modelLabel: 'Sonnet 4.5',
+    agent: 'latex-fixer',
+    agentCategory: AgentCategory.ToolUse,
+    inputFile: 'figures.tex',
+    creationTimestamp: BASE_TIME - 14 * 60_000,
+    executionId: 'abc124',
   },
   {
-    id: 'review',
-    label: 'reviewer-response — draft',
-    meta: 'workflow · 1h',
-    status: 'finished',
-    icon: 'comments',
+    name: 'review',
+    label: 'reviewer-response - draft',
+    modelLabel: 'Opus 4.7',
+    agent: 'reviewer-response',
+    agentCategory: AgentCategory.Workflow,
+    inputFile: 'response.tex',
+    creationTimestamp: BASE_TIME - 60 * 60_000,
+    executionId: 'abc125',
   },
   {
-    id: 'bib',
+    name: 'bib',
     label: 'bibliography sync',
-    meta: 'tool-use · 3h',
-    status: 'finished',
-    icon: 'book',
+    modelLabel: 'Sonnet 4.5',
+    agent: 'research',
+    agentCategory: AgentCategory.ToolUse,
+    creationTimestamp: BASE_TIME - 3 * 60 * 60_000,
+    executionId: 'abc126',
   },
 ];
 
-const RAIL_STATUS_CLASS: Record<
-  (typeof SAMPLE_RAIL)[number]['status'],
-  string
-> = {
-  running: 'is-running',
-  ready: 'is-ready',
-  finished: 'is-stopped',
-};
+const SAMPLE_TASK_GROUPS: TaskGroup[] = [
+  {
+    id: 'outline',
+    name: 'Analyze manuscript structure',
+    startTime: BASE_TIME + 1_000,
+    endTime: BASE_TIME + 24_000,
+    status: STREAM_STATUS.STOPPED,
+  },
+  {
+    id: 'rewrite',
+    name: 'Polish abstract and introduction',
+    startTime: BASE_TIME + 25_000,
+    status: STREAM_STATUS.RUNNING,
+  },
+];
+
+const SAMPLE_MESSAGES: LogMessageData[] = [
+  {
+    id: 'm1',
+    text: 'Polish the introduction; tighten the abstract.',
+    level: LOG_LEVELS.INFO,
+    timestamp: BASE_TIME + 1_000,
+    messageType: MESSAGE_TYPES.USER_MESSAGE,
+  },
+  {
+    id: 'm2',
+    text: 'Skim outline, identify weak transitions, plan two passes.',
+    level: LOG_LEVELS.INFO,
+    timestamp: BASE_TIME + 7_000,
+    groupId: 'outline',
+    messageType: MESSAGE_TYPES.THINKING,
+  },
+  {
+    id: 'm3',
+    text: 'read_file manuscript.tex (1,824 lines)',
+    level: LOG_LEVELS.INFO,
+    timestamp: BASE_TIME + 14_000,
+    groupId: 'outline',
+    messageType: MESSAGE_TYPES.TOOL_USE,
+  },
+  {
+    id: 'm4',
+    text: 'Applied 4 edits to the opening paragraph.',
+    level: LOG_LEVELS.INFO,
+    timestamp: BASE_TIME + 33_000,
+    groupId: 'rewrite',
+    messageType: MESSAGE_TYPES.TOOL_USE,
+  },
+  {
+    id: 'm5',
+    text: 'Rewriting abstract for tone and length...',
+    level: LOG_LEVELS.INFO,
+    timestamp: BASE_TIME + 41_000,
+    groupId: 'rewrite',
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+  },
+];
+
+const SAMPLE_STREAM_STATES: Map<string, StreamState> = new Map([
+  [
+    ACTIVE_STREAM_ID,
+    createWorkflowStreamState({
+      status: STREAM_STATUS.RUNNING,
+      lastTimestamp: BASE_TIME + 41_000,
+      conversationProgress: { conversationTurns: 2, toolCallCount: 4 },
+      taskGroups: SAMPLE_TASK_GROUPS,
+      files: SAMPLE_FILES,
+    }),
+  ],
+  [
+    'figures',
+    createWorkflowStreamState({
+      status: STREAM_STATUS.STOPPED,
+      lastTimestamp: BASE_TIME - 10 * 60_000,
+    }),
+  ],
+  [
+    'review',
+    createWorkflowStreamState({
+      status: STREAM_STATUS.STOPPED,
+      lastTimestamp: BASE_TIME - 52 * 60_000,
+    }),
+  ],
+  [
+    'bib',
+    createWorkflowStreamState({
+      status: STREAM_STATUS.STOPPED,
+      lastTimestamp: BASE_TIME - 2 * 60 * 60_000,
+    }),
+  ],
+]);
 
 /**
- * Static layout mock of the ProgressBoard split, mirroring production:
- *   - Left column (wide, ~75%): the active stream's conversation —
- *     stream-header → live log → file-list (stacked vertically, as in
- *     WorkflowStreamContent).
- *   - Right column (narrow rail, ~25%): the stream-tabs list of all runs
- *     (active highlighted, finished dimmed). Equivalent to the
- *     `<stream-tabs>` rail in `slot="end"` of `ProgressApp`'s
- *     `wa-split-panel`.
- * Editors are not shown — opening a file is delegated to the host.
+ * Static layout mock of the ProgressBoard split. The fixture data is local,
+ * but the header, log body, output files, and stream rail are the production
+ * Lit components used by the real progress view.
  */
 @customElement('texra-progress-board-layout-mock')
 export class ProgressBoardLayoutMock extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    statusIndicatorStyles,
     css`
       :host {
         display: block;
@@ -119,7 +204,6 @@ export class ProgressBoardLayoutMock extends LitElement {
       .board {
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(200px, 240px);
-        gap: 0;
         min-height: 360px;
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
@@ -133,218 +217,37 @@ export class ProgressBoardLayoutMock extends LitElement {
         }
       }
 
-      .col {
+      .conversation {
         display: flex;
         flex-direction: column;
         min-width: 0;
-      }
-
-      .col--conversation {
         border-right: var(--border-thin) solid var(--color-border);
       }
 
       @media (max-width: 720px) {
-        .col--conversation {
+        .conversation {
           border-right: none;
           border-bottom: var(--border-thin) solid var(--color-border);
         }
       }
 
-      /* ---- Conversation column ---- */
-
-      .stream-header {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding: var(--wa-space-2xs) var(--wa-space-s);
-        border-bottom: var(--border-thin) solid var(--color-border);
-        background: var(--wa-color-surface-raised, transparent);
-      }
-
-      .stream-header__title {
-        font-weight: var(--font-weight-medium);
+      .log-body {
+        min-height: 0;
         flex: 1;
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
 
-      .stream-header__meta {
-        font-size: var(--font-size-sm);
-        color: var(--wa-color-text-quiet);
-        white-space: nowrap;
+      task-group-list {
+        height: 100%;
       }
 
-      .log {
-        flex: 1;
-        overflow: hidden;
-        padding: var(--wa-space-2xs) var(--wa-space-s);
-        font-size: var(--font-size-sm);
-        line-height: 1.45;
-        font-family: var(
-          --wa-font-family-mono,
-          ui-monospace,
-          SFMono-Regular,
-          Menlo,
-          monospace
-        );
-        background: var(--wa-color-surface-default, transparent);
-      }
-
-      .log__line {
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-
-      .log__line--turn {
-        margin-top: var(--wa-space-2xs);
-        font-weight: var(--font-weight-medium);
-        color: var(--wa-color-text-normal);
-      }
-
-      .log__line--tool {
-        color: var(--wa-color-brand-text-loud);
-      }
-
-      .log__line--ok {
-        color: var(--wa-color-success-text-loud);
-      }
-
-      .log__line--info {
-        color: var(--wa-color-text-quiet);
-      }
-
-      .log__cursor::after {
-        content: '▍';
-        margin-left: 2px;
-        color: var(--wa-color-brand-text-loud);
-        animation: blink 1s steps(2) infinite;
-      }
-
-      @keyframes blink {
-        50% {
-          opacity: 0;
-        }
-      }
-
-      /* file-list sits inside the conversation column, separated from the
-         log by a hairline divider — same vertical stacking as
-         WorkflowStreamContent uses in production. */
       .files-block {
         border-top: var(--border-thin) solid var(--color-border);
         padding: var(--wa-space-2xs) var(--wa-space-s) var(--wa-space-xs);
         background: var(--wa-color-surface-raised, transparent);
       }
-
-      /* ---- Stream-tabs rail (right column) ---- */
-
-      .rail {
-        display: flex;
-        flex-direction: column;
-        background: var(--wa-color-surface-default, transparent);
-      }
-
-      .rail__list {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-3xs);
-        padding: var(--wa-space-2xs);
-        flex: 1;
-        min-height: 0;
-        overflow: hidden;
-      }
-
-      .rail__tab {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
-        border: var(--border-thin) solid transparent;
-        border-radius: var(--border-radius);
-        cursor: pointer;
-        min-width: 0;
-      }
-
-      .rail__tab--active {
-        background-color: color-mix(
-          in srgb,
-          var(--wa-color-brand-fill-loud, var(--color-info)) 12%,
-          transparent
-        );
-        border-color: var(--color-border);
-      }
-
-      .rail__tab--finished {
-        opacity: var(--opacity-subtle, 0.62);
-      }
-
-      .rail__icon {
-        flex-shrink: 0;
-        color: var(--wa-color-text-quiet);
-      }
-
-      .rail__tab--active .rail__icon {
-        color: var(--wa-color-brand-text-loud);
-      }
-
-      .rail__body {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        min-width: 0;
-        flex: 1;
-      }
-
-      .rail__label {
-        font-size: var(--font-size-sm);
-        font-weight: var(--font-weight-medium);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .rail__meta {
-        font-size: var(--font-size-xs);
-        color: var(--wa-color-text-quiet);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .rail__status {
-        flex-shrink: 0;
-      }
-
-      .rail__footer {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: var(--wa-space-2xs) var(--wa-space-s);
-        border-top: var(--border-thin) solid var(--color-border);
-        font-size: var(--font-size-xs);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .rail__filter {
-        display: inline-flex;
-        gap: var(--wa-space-3xs);
-      }
-
-      .rail__filter-pill {
-        padding: 0 var(--wa-space-2xs);
-        border-radius: 999px;
-        border: var(--border-thin) solid var(--color-border);
-      }
-
-      .rail__filter-pill--active {
-        background: var(--wa-color-surface-raised, transparent);
-        color: var(--wa-color-text-normal);
-      }
     `,
   ];
 
-  private readonly filesByRound = SAMPLE_FILES;
   @query('file-list') private fileListEl?: HTMLElement;
 
   override async firstUpdated(): Promise<void> {
@@ -361,105 +264,44 @@ export class ProgressBoardLayoutMock extends LitElement {
   }
 
   override render(): TemplateResult {
+    const activeStream = SAMPLE_STREAMS[0];
     return html`
       <div class="board">
-        <div class="col col--conversation">${this.renderConversation()}</div>
-        <div class="col rail">${this.renderRail()}</div>
-      </div>
-    `;
-  }
-
-  private renderConversation(): TemplateResult {
-    return html`
-      <div class="stream-header">
-        <span class="status-indicator is-running" aria-hidden="true"></span>
-        <span class="stream-header__title">
-          manuscript_revised.tex — polish workflow
-        </span>
-        <wa-tag size="small" variant="brand">Running</wa-tag>
-        <span class="stream-header__meta">opus-4.7 · 02:14</span>
-      </div>
-      <div class="log" aria-label="Live log">
-        <div class="log__line log__line--turn">
-          → user: Polish the introduction; tighten the abstract.
+        <div class="conversation">
+          <stream-header
+            .stream=${activeStream}
+            .status=${STREAM_STATUS.RUNNING}
+            .progress=${{
+              conversationTurns: 2,
+              toolCallCount: 4,
+            }}
+            .yoloActive=${true}
+          ></stream-header>
+          <div class="log-body">
+            <task-group-list
+              .groups=${SAMPLE_TASK_GROUPS}
+              .messages=${SAMPLE_MESSAGES}
+              .hasStreams=${true}
+              .streamStatus=${STREAM_STATUS.RUNNING}
+              .messageGeneration=${SAMPLE_MESSAGES.length}
+            ></task-group-list>
+          </div>
+          <div class="files-block">
+            <file-list
+              .filesByRound=${SAMPLE_FILES}
+              .failuresByRound=${{}}
+              .showRoundHeaders=${false}
+            ></file-list>
+          </div>
         </div>
-        <div class="log__line log__line--info">
-          [thinking] Skim outline, identify weak transitions, plan two passes.
-        </div>
-        <div class="log__line log__line--tool">
-          ⚙ read_file manuscript.tex (1,824 lines)
-        </div>
-        <div class="log__line log__line--ok">
-          ✓ extracted 12 sections, 38 paragraphs
-        </div>
-        <div class="log__line log__line--tool">
-          ⚙ edit intro paragraph 1 — clarity pass
-        </div>
-        <div class="log__line log__line--ok">
-          ✓ applied 4 edits, 0 conflicts
-        </div>
-        <div class="log__line log__line--turn">
-          → assistant: Rewriting abstract for tone and length…
-        </div>
-        <div class="log__line log__cursor">
-          Drafting new abstract opening: "We present a unified
-        </div>
-      </div>
-      <div class="files-block">
-        <file-list
-          .filesByRound=${this.filesByRound}
-          .failuresByRound=${{}}
-          .showRoundHeaders=${false}
-        ></file-list>
-      </div>
-    `;
-  }
-
-  private renderRail(): TemplateResult {
-    return html`
-      <div class="rail__list" role="list">
-        ${SAMPLE_RAIL.map((tab) => this.renderRailTab(tab))}
-      </div>
-      <div class="rail__footer">
-        <div class="rail__filter" aria-label="Stream filter">
-          <span class="rail__filter-pill rail__filter-pill--active">All</span>
-          <span class="rail__filter-pill">Workflow</span>
-          <span class="rail__filter-pill">Tool-use</span>
-        </div>
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="trash"
-          variant="solid"
-          aria-hidden="true"
-        ></wa-icon>
-      </div>
-    `;
-  }
-
-  private renderRailTab(tab: (typeof SAMPLE_RAIL)[number]): TemplateResult {
-    const classes = {
-      rail__tab: true,
-      'rail__tab--active': tab.active ?? false,
-      'rail__tab--finished': tab.status === 'finished',
-    };
-    const statusClass = RAIL_STATUS_CLASS[tab.status];
-    return html`
-      <div class=${classMap(classes)} role="listitem">
-        <wa-icon
-          class="rail__icon"
-          library=${TEXRA_ICON_LIBRARY}
-          name=${tab.icon}
-          variant="solid"
-          aria-hidden="true"
-        ></wa-icon>
-        <div class="rail__body">
-          <div class="rail__label">${tab.label}</div>
-          <div class="rail__meta">${tab.meta}</div>
-        </div>
-        <span
-          class="status-indicator rail__status ${statusClass}"
-          aria-hidden="true"
-        ></span>
+        <stream-tabs
+          .streams=${SAMPLE_STREAMS}
+          .activeStreamId=${ACTIVE_STREAM_ID}
+          .filter=${'all'}
+          .streamStates=${SAMPLE_STREAM_STATES}
+          .pendingApprovalStreamIds=${new Set<string>()}
+          .childStreamsByParent=${new Map<string, StreamTabInfo[]>()}
+        ></stream-tabs>
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -343,7 +344,7 @@ export class ProgressBoardLayoutMock extends LitElement {
     `,
   ];
 
-  @state() private filesByRound = SAMPLE_FILES;
+  private readonly filesByRound = SAMPLE_FILES;
   @query('file-list') private fileListEl?: HTMLElement;
 
   override async firstUpdated(): Promise<void> {
@@ -436,16 +437,14 @@ export class ProgressBoardLayoutMock extends LitElement {
   }
 
   private renderRailTab(tab: (typeof SAMPLE_RAIL)[number]): TemplateResult {
-    const classes = [
-      'rail__tab',
-      tab.active ? 'rail__tab--active' : '',
-      tab.status === 'finished' ? 'rail__tab--finished' : '',
-    ]
-      .filter(Boolean)
-      .join(' ');
+    const classes = {
+      rail__tab: true,
+      'rail__tab--active': tab.active ?? false,
+      'rail__tab--finished': tab.status === 'finished',
+    };
     const statusClass = RAIL_STATUS_CLASS[tab.status];
     return html`
-      <div class=${classes} role="listitem">
+      <div class=${classMap(classes)} role="listitem">
         <wa-icon
           class="rail__icon"
           library=${TEXRA_ICON_LIBRARY}

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -5,8 +5,8 @@ import { customElement, query, state } from 'lit/decorators.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 
-// Reuse the production FileList so the right-hand "Run outputs" panel
-// matches the real progress board, not a hand-rolled approximation.
+// Reuse the production FileList — it lives INSIDE the conversation column
+// (stacked below the log), matching WorkflowStreamContent's vertical layout.
 import '@progressView/frontend/components/FileList';
 
 import type { OutputFileInfo } from '@shared/schemas';
@@ -40,13 +40,57 @@ const SAMPLE_FILES: Record<string, OutputFileInfo[]> = {
   ],
 };
 
+/** Sample stream-tabs rail entries — matches what ProgressApp passes
+ *  into the right-hand <stream-tabs> in production. */
+const SAMPLE_RAIL: Array<{
+  id: string;
+  label: string;
+  meta: string;
+  status: 'running' | 'ready' | 'finished';
+  icon: string;
+  active?: boolean;
+}> = [
+  {
+    id: 'polish',
+    label: 'manuscript_revised — polish',
+    meta: 'workflow · 02:14',
+    status: 'running',
+    icon: 'pencil',
+    active: true,
+  },
+  {
+    id: 'figures',
+    label: 'figures.tex — tikz tighten',
+    meta: 'tool-use · 14m',
+    status: 'finished',
+    icon: 'wand-magic-sparkles',
+  },
+  {
+    id: 'review',
+    label: 'reviewer-response — draft',
+    meta: 'workflow · 1h',
+    status: 'finished',
+    icon: 'messages',
+  },
+  {
+    id: 'bib',
+    label: 'bibliography sync',
+    meta: 'tool-use · 3h',
+    status: 'finished',
+    icon: 'book',
+  },
+];
+
 /**
- * Static layout mock of a proposed split ProgressBoard:
- *   - Left column: stream header + live log
- *   - Right column: run's output files (rendered via the production
- *     `<file-list>` so the panel matches the real board)
- * Editors are intentionally not shown — opening a file is delegated to
- * the host (VS Code / desktop).
+ * Static layout mock of the ProgressBoard split, mirroring production:
+ *   - Left column (wide, ~75%): the active stream's conversation —
+ *     stream-header → live log → file-list (stacked vertically, as in
+ *     WorkflowStreamContent).
+ *   - Right column (narrow rail, ~25%): the stream-tabs list of all runs
+ *     (active highlighted, finished dimmed). Equivalent to the
+ *     `<stream-tabs>` rail in `slot="end"` of `ProgressApp`'s
+ *     `wa-split-panel`.
+ * Editors are not shown — opening a file is delegated to the host.
  */
 @customElement('texra-progress-board-layout-mock')
 export class ProgressBoardLayoutMock extends LitElement {
@@ -61,8 +105,8 @@ export class ProgressBoardLayoutMock extends LitElement {
 
       .board {
         display: grid;
-        grid-template-columns: minmax(0, 1.6fr) minmax(220px, 1fr);
-        gap: var(--wa-space-s);
+        grid-template-columns: minmax(0, 1fr) minmax(200px, 240px);
+        gap: 0;
         min-height: 360px;
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
@@ -82,16 +126,18 @@ export class ProgressBoardLayoutMock extends LitElement {
         min-width: 0;
       }
 
-      .col--left {
+      .col--conversation {
         border-right: var(--border-thin) solid var(--color-border);
       }
 
       @media (max-width: 720px) {
-        .col--left {
+        .col--conversation {
           border-right: none;
           border-bottom: var(--border-thin) solid var(--color-border);
         }
       }
+
+      /* ---- Conversation column ---- */
 
       .stream-header {
         display: flex;
@@ -169,23 +215,118 @@ export class ProgressBoardLayoutMock extends LitElement {
         }
       }
 
-      .files-col {
-        padding: var(--wa-space-s);
-        gap: var(--wa-space-2xs);
+      /* file-list sits inside the conversation column, separated from the
+         log by a hairline divider — same vertical stacking as
+         WorkflowStreamContent uses in production. */
+      .files-block {
+        border-top: var(--border-thin) solid var(--color-border);
+        padding: var(--wa-space-2xs) var(--wa-space-s) var(--wa-space-xs);
+        background: var(--wa-color-surface-raised, transparent);
       }
 
-      .files-col__title {
+      /* ---- Stream-tabs rail (right column) ---- */
+
+      .rail {
+        display: flex;
+        flex-direction: column;
+        background: var(--wa-color-surface-default, transparent);
+      }
+
+      .rail__list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-3xs);
+        padding: var(--wa-space-2xs);
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .rail__tab {
         display: flex;
         align-items: center;
-        gap: var(--wa-space-3xs);
-        margin-bottom: var(--wa-space-2xs);
-        font-weight: var(--font-weight-medium);
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        border: var(--border-thin) solid transparent;
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        min-width: 0;
       }
 
-      .files-col__title small {
+      .rail__tab--active {
+        background-color: color-mix(
+          in srgb,
+          var(--wa-color-brand-fill-loud, var(--color-info)) 12%,
+          transparent
+        );
+        border-color: var(--color-border);
+      }
+
+      .rail__tab--finished {
+        opacity: var(--opacity-subtle, 0.62);
+      }
+
+      .rail__icon {
+        flex-shrink: 0;
         color: var(--wa-color-text-quiet);
+      }
+
+      .rail__tab--active .rail__icon {
+        color: var(--wa-color-brand-text-loud);
+      }
+
+      .rail__body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+        flex: 1;
+      }
+
+      .rail__label {
         font-size: var(--font-size-sm);
-        font-weight: var(--font-weight);
+        font-weight: var(--font-weight-medium);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .rail__meta {
+        font-size: var(--font-size-xs);
+        color: var(--wa-color-text-quiet);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .rail__status {
+        flex-shrink: 0;
+      }
+
+      .rail__footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        border-top: var(--border-thin) solid var(--color-border);
+        font-size: var(--font-size-xs);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .rail__filter {
+        display: inline-flex;
+        gap: var(--wa-space-3xs);
+      }
+
+      .rail__filter-pill {
+        padding: 0 var(--wa-space-2xs);
+        border-radius: 999px;
+        border: var(--border-thin) solid var(--color-border);
+      }
+
+      .rail__filter-pill--active {
+        background: var(--wa-color-surface-raised, transparent);
+        color: var(--wa-color-text-normal);
       }
     `,
   ];
@@ -194,8 +335,8 @@ export class ProgressBoardLayoutMock extends LitElement {
   @query('file-list') private fileListEl?: HTMLElement;
 
   override async firstUpdated(): Promise<void> {
-    // Wait for the production <file-list> and wa-details to upgrade so the
-    // imperative open below targets a real shadow tree.
+    // Wait for the production <file-list> and its <wa-details> to upgrade
+    // so the imperative open below targets a real shadow tree.
     await customElements.whenDefined('file-list');
     await customElements.whenDefined('wa-details');
     await Promise.resolve();
@@ -209,13 +350,13 @@ export class ProgressBoardLayoutMock extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="board">
-        <div class="col col--left">${this.renderLeft()}</div>
-        <div class="col files-col">${this.renderRight()}</div>
+        <div class="col col--conversation">${this.renderConversation()}</div>
+        <div class="col rail">${this.renderRail()}</div>
       </div>
     `;
   }
 
-  private renderLeft(): TemplateResult {
+  private renderConversation(): TemplateResult {
     return html`
       <div class="stream-header">
         <span class="status-indicator is-running" aria-hidden="true"></span>
@@ -251,29 +392,71 @@ export class ProgressBoardLayoutMock extends LitElement {
           Drafting new abstract opening: "We present a unified
         </div>
       </div>
+      <div class="files-block">
+        <file-list
+          .filesByRound=${this.filesByRound}
+          .failuresByRound=${{}}
+          .showRoundHeaders=${false}
+        ></file-list>
+      </div>
     `;
   }
 
-  private renderRight(): TemplateResult {
-    const count = Object.values(this.filesByRound).reduce(
-      (n, files) => n + files.length,
-      0,
-    );
+  private renderRail(): TemplateResult {
     return html`
-      <div class="files-col__title">
+      <div class="rail__list" role="list">
+        ${SAMPLE_RAIL.map((tab) => this.renderRailTab(tab))}
+      </div>
+      <div class="rail__footer">
+        <div class="rail__filter" aria-label="Stream filter">
+          <span class="rail__filter-pill rail__filter-pill--active">All</span>
+          <span class="rail__filter-pill">Workflow</span>
+          <span class="rail__filter-pill">Tool-use</span>
+        </div>
         <wa-icon
           library=${TEXRA_ICON_LIBRARY}
-          name="folder"
+          name="trash"
           variant="solid"
+          aria-hidden="true"
         ></wa-icon>
-        Run outputs
-        <small>${count} files</small>
       </div>
-      <file-list
-        .filesByRound=${this.filesByRound}
-        .failuresByRound=${{}}
-        .showRoundHeaders=${false}
-      ></file-list>
+    `;
+  }
+
+  private renderRailTab(
+    tab: (typeof SAMPLE_RAIL)[number],
+  ): TemplateResult {
+    const classes = [
+      'rail__tab',
+      tab.active ? 'rail__tab--active' : '',
+      tab.status === 'finished' ? 'rail__tab--finished' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const statusClass =
+      tab.status === 'running'
+        ? 'is-running'
+        : tab.status === 'finished'
+          ? 'is-ready'
+          : 'is-ready';
+    return html`
+      <div class=${classes} role="listitem">
+        <wa-icon
+          class="rail__icon"
+          library=${TEXRA_ICON_LIBRARY}
+          name=${tab.icon}
+          variant="solid"
+          aria-hidden="true"
+        ></wa-icon>
+        <div class="rail__body">
+          <div class="rail__label">${tab.label}</div>
+          <div class="rail__meta">${tab.meta}</div>
+        </div>
+        <span
+          class="status-indicator rail__status ${statusClass}"
+          aria-hidden="true"
+        ></span>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -1,25 +1,59 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 
+// Reuse the production FileList so the right-hand "Run outputs" panel
+// matches the real progress board, not a hand-rolled approximation.
+import '@progressView/frontend/components/FileList';
+
+import type { OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+/** Realistic OutputFileInfo fixture for the production <file-list>. */
+function mockFile(
+  relative: string,
+  diff: { added: number; removed: number },
+): OutputFileInfo {
+  return {
+    source: relative,
+    location: {
+      kind: 'workspace',
+      absolutePath: `/workspace/${relative}`,
+      relativePath: relative,
+    },
+    round: 1,
+    lineage: null,
+    diff,
+  };
+}
+
+const SAMPLE_FILES: Record<string, OutputFileInfo[]> = {
+  '1': [
+    mockFile('manuscript_revised.tex', { added: 142, removed: 89 }),
+    mockFile('abstract_draft.tex', { added: 18, removed: 0 }),
+    mockFile('change_summary.md', { added: 24, removed: 0 }),
+  ],
+};
 
 /**
  * Static layout mock of a proposed split ProgressBoard:
  *   - Left column: stream header + live log
- *   - Right column: run's output files
+ *   - Right column: run's output files (rendered via the production
+ *     `<file-list>` so the panel matches the real board)
  * Editors are intentionally not shown — opening a file is delegated to
- * the host (VS Code / desktop), keeping the board focused on chat + diffs.
+ * the host (VS Code / desktop).
  */
 @customElement('texra-progress-board-layout-mock')
 export class ProgressBoardLayoutMock extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    statusIndicatorStyles,
     css`
       :host {
         display: block;
@@ -78,41 +112,16 @@ export class ProgressBoardLayoutMock extends LitElement {
       }
 
       .stream-header__meta {
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         color: var(--wa-color-text-quiet);
         white-space: nowrap;
-      }
-
-      .status-dot {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: var(--wa-color-success-fill-loud);
-        box-shadow: 0 0 0 3px var(--wa-color-success-fill-quiet);
-        flex-shrink: 0;
-      }
-
-      .status-dot--running {
-        background: var(--wa-color-brand-fill-loud);
-        box-shadow: 0 0 0 3px var(--wa-color-brand-fill-quiet);
-        animation: pulse 1.8s ease-in-out infinite;
-      }
-
-      @keyframes pulse {
-        0%,
-        100% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0.55;
-        }
       }
 
       .log {
         flex: 1;
         overflow: hidden;
         padding: var(--wa-space-2xs) var(--wa-space-s);
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         line-height: 1.45;
         font-family: var(
           --wa-font-family-mono,
@@ -166,77 +175,36 @@ export class ProgressBoardLayoutMock extends LitElement {
       }
 
       .files-col__title {
-        font-weight: var(--font-weight-medium);
-        margin-bottom: var(--wa-space-2xs);
         display: flex;
         align-items: center;
         gap: var(--wa-space-3xs);
+        margin-bottom: var(--wa-space-2xs);
+        font-weight: var(--font-weight-medium);
       }
 
       .files-col__title small {
-        font-weight: var(--font-weight-normal);
         color: var(--wa-color-text-quiet);
-        font-size: var(--font-size-small);
-      }
-
-      .file-row {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        padding: var(--wa-space-2xs);
-        border-radius: var(--wa-border-radius-s);
-        border: var(--border-thin) solid transparent;
-        cursor: default;
-      }
-
-      .file-row:hover {
-        background: var(--wa-color-neutral-fill-quiet);
-        border-color: var(--color-border);
-      }
-
-      .file-row__icon {
-        font-size: var(--font-size-icon);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .file-row__body {
-        flex: 1;
-        min-width: 0;
-      }
-
-      .file-row__name {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .file-row__meta {
-        font-size: var(--font-size-xs, 11px);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .file-row__diff {
-        font-variant-numeric: tabular-nums;
-        font-size: var(--font-size-small);
-        white-space: nowrap;
-      }
-
-      .file-row__diff .add {
-        color: var(--wa-color-success-text-loud);
-      }
-      .file-row__diff .del {
-        color: var(--wa-color-danger-text-loud);
-      }
-
-      .files-col__hint {
-        margin-top: var(--wa-space-s);
-        padding: var(--wa-space-2xs);
-        border-top: var(--border-thin) dashed var(--color-border);
-        font-size: var(--font-size-small);
-        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight);
       }
     `,
   ];
+
+  @state() private filesByRound = SAMPLE_FILES;
+  @query('file-list') private fileListEl?: HTMLElement;
+
+  override async firstUpdated(): Promise<void> {
+    // Wait for the production <file-list> and wa-details to upgrade so the
+    // imperative open below targets a real shadow tree.
+    await customElements.whenDefined('file-list');
+    await customElements.whenDefined('wa-details');
+    await Promise.resolve();
+    const root = this.fileListEl?.shadowRoot;
+    if (!root) return;
+    for (const det of root.querySelectorAll('wa-details')) {
+      (det as HTMLElement & { open: boolean }).open = true;
+    }
+  }
 
   override render(): TemplateResult {
     return html`
@@ -250,7 +218,7 @@ export class ProgressBoardLayoutMock extends LitElement {
   private renderLeft(): TemplateResult {
     return html`
       <div class="stream-header">
-        <span class="status-dot status-dot--running" aria-hidden="true"></span>
+        <span class="status-indicator is-running" aria-hidden="true"></span>
         <span class="stream-header__title">
           manuscript_revised.tex — polish workflow
         </span>
@@ -287,6 +255,10 @@ export class ProgressBoardLayoutMock extends LitElement {
   }
 
   private renderRight(): TemplateResult {
+    const count = Object.values(this.filesByRound).reduce(
+      (n, files) => n + files.length,
+      0,
+    );
     return html`
       <div class="files-col__title">
         <wa-icon
@@ -295,58 +267,13 @@ export class ProgressBoardLayoutMock extends LitElement {
           variant="solid"
         ></wa-icon>
         Run outputs
-        <small>3 files</small>
+        <small>${count} files</small>
       </div>
-
-      ${this.renderFile({
-        name: 'manuscript_revised.tex',
-        meta: 'edited · 02:14',
-        add: 142,
-        del: 89,
-      })}
-      ${this.renderFile({
-        name: 'abstract_draft.tex',
-        meta: 'new · 02:13',
-        add: 18,
-        del: 0,
-      })}
-      ${this.renderFile({
-        name: 'change_summary.md',
-        meta: 'new · 02:13',
-        add: 24,
-        del: 0,
-      })}
-
-      <div class="files-col__hint">
-        Click to open in the host editor — the board itself doesn't render
-        editors.
-      </div>
-    `;
-  }
-
-  private renderFile(opts: {
-    name: string;
-    meta: string;
-    add: number;
-    del: number;
-  }): TemplateResult {
-    return html`
-      <div class="file-row" tabindex="0">
-        <wa-icon
-          class="file-row__icon"
-          library=${TEXRA_ICON_LIBRARY}
-          name="file"
-          variant="solid"
-        ></wa-icon>
-        <div class="file-row__body">
-          <div class="file-row__name">${opts.name}</div>
-          <div class="file-row__meta">${opts.meta}</div>
-        </div>
-        <div class="file-row__diff">
-          <span class="add">+${opts.add}</span>
-          <span class="del">−${opts.del}</span>
-        </div>
-      </div>
+      <file-list
+        .filesByRound=${this.filesByRound}
+        .failuresByRound=${{}}
+        .showRoundHeaders=${false}
+      ></file-list>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -73,7 +73,7 @@ const SAMPLE_RAIL: Array<{
     label: 'reviewer-response — draft',
     meta: 'workflow · 1h',
     status: 'finished',
-    icon: 'messages',
+    icon: 'comments',
   },
   {
     id: 'bib',

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -423,9 +423,7 @@ export class ProgressBoardLayoutMock extends LitElement {
     `;
   }
 
-  private renderRailTab(
-    tab: (typeof SAMPLE_RAIL)[number],
-  ): TemplateResult {
+  private renderRailTab(tab: (typeof SAMPLE_RAIL)[number]): TemplateResult {
     const classes = [
       'rail__tab',
       tab.active ? 'rail__tab--active' : '',

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -84,6 +84,15 @@ const SAMPLE_RAIL: Array<{
   },
 ];
 
+const RAIL_STATUS_CLASS: Record<
+  (typeof SAMPLE_RAIL)[number]['status'],
+  string
+> = {
+  running: 'is-running',
+  ready: 'is-ready',
+  finished: 'is-stopped',
+};
+
 /**
  * Static layout mock of the ProgressBoard split, mirroring production:
  *   - Left column (wide, ~75%): the active stream's conversation —
@@ -434,12 +443,7 @@ export class ProgressBoardLayoutMock extends LitElement {
     ]
       .filter(Boolean)
       .join(' ');
-    const statusClass =
-      tab.status === 'running'
-        ? 'is-running'
-        : tab.status === 'finished'
-          ? 'is-stopped'
-          : 'is-ready';
+    const statusClass = RAIL_STATUS_CLASS[tab.status];
     return html`
       <div class=${classes} role="listitem">
         <wa-icon

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -1,0 +1,352 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+/**
+ * Static layout mock of a proposed split ProgressBoard:
+ *   - Left column: stream header + live log
+ *   - Right column: run's output files
+ * Editors are intentionally not shown — opening a file is delegated to
+ * the host (VS Code / desktop), keeping the board focused on chat + diffs.
+ */
+@customElement('texra-progress-board-layout-mock')
+export class ProgressBoardLayoutMock extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: minmax(0, 1.6fr) minmax(220px, 1fr);
+        gap: var(--wa-space-s);
+        min-height: 360px;
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-m);
+        background: var(--wa-color-surface-default, transparent);
+        overflow: hidden;
+      }
+
+      @media (max-width: 720px) {
+        .board {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+
+      .col {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+
+      .col--left {
+        border-right: var(--border-thin) solid var(--color-border);
+      }
+
+      @media (max-width: 720px) {
+        .col--left {
+          border-right: none;
+          border-bottom: var(--border-thin) solid var(--color-border);
+        }
+      }
+
+      .stream-header {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        border-bottom: var(--border-thin) solid var(--color-border);
+        background: var(--wa-color-surface-raised, transparent);
+      }
+
+      .stream-header__title {
+        font-weight: var(--font-weight-medium);
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .stream-header__meta {
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+        white-space: nowrap;
+      }
+
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--wa-color-success-fill-loud);
+        box-shadow: 0 0 0 3px var(--wa-color-success-fill-quiet);
+        flex-shrink: 0;
+      }
+
+      .status-dot--running {
+        background: var(--wa-color-brand-fill-loud);
+        box-shadow: 0 0 0 3px var(--wa-color-brand-fill-quiet);
+        animation: pulse 1.8s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.55;
+        }
+      }
+
+      .log {
+        flex: 1;
+        overflow: hidden;
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        font-size: var(--font-size-small);
+        line-height: 1.45;
+        font-family: var(
+          --wa-font-family-mono,
+          ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace
+        );
+        background: var(--wa-color-surface-default, transparent);
+      }
+
+      .log__line {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .log__line--turn {
+        margin-top: var(--wa-space-2xs);
+        font-weight: var(--font-weight-medium);
+        color: var(--wa-color-text-normal);
+      }
+
+      .log__line--tool {
+        color: var(--wa-color-brand-text-loud);
+      }
+
+      .log__line--ok {
+        color: var(--wa-color-success-text-loud);
+      }
+
+      .log__line--info {
+        color: var(--wa-color-text-quiet);
+      }
+
+      .log__cursor::after {
+        content: '▍';
+        margin-left: 2px;
+        color: var(--wa-color-brand-text-loud);
+        animation: blink 1s steps(2) infinite;
+      }
+
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      .files-col {
+        padding: var(--wa-space-s);
+        gap: var(--wa-space-2xs);
+      }
+
+      .files-col__title {
+        font-weight: var(--font-weight-medium);
+        margin-bottom: var(--wa-space-2xs);
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+      }
+
+      .files-col__title small {
+        font-weight: var(--font-weight-normal);
+        color: var(--wa-color-text-quiet);
+        font-size: var(--font-size-small);
+      }
+
+      .file-row {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+        padding: var(--wa-space-2xs);
+        border-radius: var(--wa-border-radius-s);
+        border: var(--border-thin) solid transparent;
+        cursor: default;
+      }
+
+      .file-row:hover {
+        background: var(--wa-color-neutral-fill-quiet);
+        border-color: var(--color-border);
+      }
+
+      .file-row__icon {
+        font-size: var(--font-size-icon);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .file-row__body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .file-row__name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .file-row__meta {
+        font-size: var(--font-size-xs, 11px);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .file-row__diff {
+        font-variant-numeric: tabular-nums;
+        font-size: var(--font-size-small);
+        white-space: nowrap;
+      }
+
+      .file-row__diff .add {
+        color: var(--wa-color-success-text-loud);
+      }
+      .file-row__diff .del {
+        color: var(--wa-color-danger-text-loud);
+      }
+
+      .files-col__hint {
+        margin-top: var(--wa-space-s);
+        padding: var(--wa-space-2xs);
+        border-top: var(--border-thin) dashed var(--color-border);
+        font-size: var(--font-size-small);
+        color: var(--wa-color-text-quiet);
+      }
+    `,
+  ];
+
+  override render(): TemplateResult {
+    return html`
+      <div class="board">
+        <div class="col col--left">${this.renderLeft()}</div>
+        <div class="col files-col">${this.renderRight()}</div>
+      </div>
+    `;
+  }
+
+  private renderLeft(): TemplateResult {
+    return html`
+      <div class="stream-header">
+        <span class="status-dot status-dot--running" aria-hidden="true"></span>
+        <span class="stream-header__title">
+          manuscript_revised.tex — polish workflow
+        </span>
+        <wa-tag size="small" variant="brand">Running</wa-tag>
+        <span class="stream-header__meta">opus-4.7 · 02:14</span>
+      </div>
+      <div class="log" aria-label="Live log">
+        <div class="log__line log__line--turn">
+          → user: Polish the introduction; tighten the abstract.
+        </div>
+        <div class="log__line log__line--info">
+          [thinking] Skim outline, identify weak transitions, plan two passes.
+        </div>
+        <div class="log__line log__line--tool">
+          ⚙ read_file manuscript.tex (1,824 lines)
+        </div>
+        <div class="log__line log__line--ok">
+          ✓ extracted 12 sections, 38 paragraphs
+        </div>
+        <div class="log__line log__line--tool">
+          ⚙ edit intro paragraph 1 — clarity pass
+        </div>
+        <div class="log__line log__line--ok">
+          ✓ applied 4 edits, 0 conflicts
+        </div>
+        <div class="log__line log__line--turn">
+          → assistant: Rewriting abstract for tone and length…
+        </div>
+        <div class="log__line log__cursor">
+          Drafting new abstract opening: "We present a unified
+        </div>
+      </div>
+    `;
+  }
+
+  private renderRight(): TemplateResult {
+    return html`
+      <div class="files-col__title">
+        <wa-icon
+          library=${TEXRA_ICON_LIBRARY}
+          name="folder"
+          variant="solid"
+        ></wa-icon>
+        Run outputs
+        <small>3 files</small>
+      </div>
+
+      ${this.renderFile({
+        name: 'manuscript_revised.tex',
+        meta: 'edited · 02:14',
+        add: 142,
+        del: 89,
+      })}
+      ${this.renderFile({
+        name: 'abstract_draft.tex',
+        meta: 'new · 02:13',
+        add: 18,
+        del: 0,
+      })}
+      ${this.renderFile({
+        name: 'change_summary.md',
+        meta: 'new · 02:13',
+        add: 24,
+        del: 0,
+      })}
+
+      <div class="files-col__hint">
+        Click to open in the host editor — the board itself doesn't render
+        editors.
+      </div>
+    `;
+  }
+
+  private renderFile(opts: {
+    name: string;
+    meta: string;
+    add: number;
+    del: number;
+  }): TemplateResult {
+    return html`
+      <div class="file-row" tabindex="0">
+        <wa-icon
+          class="file-row__icon"
+          library=${TEXRA_ICON_LIBRARY}
+          name="file"
+          variant="solid"
+        ></wa-icon>
+        <div class="file-row__body">
+          <div class="file-row__name">${opts.name}</div>
+          <div class="file-row__meta">${opts.meta}</div>
+        </div>
+        <div class="file-row__diff">
+          <span class="add">+${opts.add}</span>
+          <span class="del">−${opts.del}</span>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -2,13 +2,16 @@
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 
+// Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 
 // Reuse the production FileList — it lives INSIDE the conversation column
 // (stacked below the log), matching WorkflowStreamContent's vertical layout.
+// Side-effect imports - production progress view components
 import '@progressView/frontend/components/FileList';
 
+// Local imports - shared types and styles
 import type { OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
@@ -435,7 +438,7 @@ export class ProgressBoardLayoutMock extends LitElement {
       tab.status === 'running'
         ? 'is-running'
         : tab.status === 'finished'
-          ? 'is-ready'
+          ? 'is-stopped'
           : 'is-ready';
     return html`
       <div class=${classes} role="listitem">

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -69,8 +69,7 @@ export class TodoListMock extends LitElement {
     await customElements.whenDefined('todo-list');
     await customElements.whenDefined('wa-details');
     await Promise.resolve();
-    const details =
-      this.todoListEl?.shadowRoot?.querySelector('wa-details');
+    const details = this.todoListEl?.shadowRoot?.querySelector('wa-details');
     if (details) (details as HTMLElement & { open: boolean }).open = true;
   }
 

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -4,7 +4,10 @@ import { customElement, query, state } from 'lit/decorators.js';
 
 // Reuse the production TodoList component with mock data so the demo
 // reflects the real visual output, not a hand-rolled copy.
+// Side-effect imports - production progress view components
 import '@progressView/frontend/components/TodoList';
+
+// Local imports - shared schemas and styles
 import { TODO_STATUS, type TodoItem } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -1,0 +1,71 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+// Reuse the production TodoList component with mock data so the demo
+// reflects the real visual output, not a hand-rolled copy.
+import '@progressView/frontend/components/TodoList';
+import { TODO_STATUS, type TodoItem } from '@shared/schemas';
+import { designTokens, commonViewStyles } from '@shared/styles';
+
+const SAMPLE_TODOS: TodoItem[] = [
+  {
+    status: TODO_STATUS.COMPLETED,
+    content: 'Read base manuscript and extract section structure',
+    activeForm: 'Reading base manuscript',
+  },
+  {
+    status: TODO_STATUS.COMPLETED,
+    content: 'Sketch reviewer-response outline per comment',
+    activeForm: 'Sketching reviewer-response outline',
+  },
+  {
+    status: TODO_STATUS.IN_PROGRESS,
+    content: 'Draft revised abstract addressing reviewer #2',
+    activeForm: 'Drafting revised abstract',
+  },
+  {
+    status: TODO_STATUS.PENDING,
+    content: 'Refine introduction with new positioning',
+    activeForm: 'Refining introduction',
+  },
+  {
+    status: TODO_STATUS.PENDING,
+    content: 'Update bibliography with three new citations',
+    activeForm: 'Updating bibliography',
+  },
+];
+
+/**
+ * Mock host for the production TodoList component, pre-populated with
+ * sample data so screenshots show a realistic active checklist.
+ */
+@customElement('texra-todo-list-mock')
+export class TodoListMock extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .frame {
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--wa-border-radius-m);
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        background: var(--wa-color-surface-default, transparent);
+      }
+    `,
+  ];
+
+  @state() private todos: TodoItem[] = SAMPLE_TODOS;
+
+  override render(): TemplateResult {
+    return html`
+      <div class="frame">
+        <todo-list .todos=${this.todos}></todo-list>
+      </div>
+    `;
+  }
+}

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 
 // Reuse the production TodoList component with mock data so the demo
 // reflects the real visual output, not a hand-rolled copy.
@@ -62,7 +62,7 @@ export class TodoListMock extends LitElement {
     `,
   ];
 
-  @state() private todos: TodoItem[] = SAMPLE_TODOS;
+  private readonly todos: TodoItem[] = SAMPLE_TODOS;
   @query('todo-list') private todoListEl?: HTMLElement;
 
   override async firstUpdated(): Promise<void> {

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
 
 // Reuse the production TodoList component with mock data so the demo
 // reflects the real visual output, not a hand-rolled copy.
@@ -60,6 +60,19 @@ export class TodoListMock extends LitElement {
   ];
 
   @state() private todos: TodoItem[] = SAMPLE_TODOS;
+  @query('todo-list') private todoListEl?: HTMLElement;
+
+  override async firstUpdated(): Promise<void> {
+    // Production todo-list collapses by default; wait for its shadow DOM
+    // to upgrade, then pre-open the inner wa-details so screenshots show
+    // the checklist instead of the collapsed header.
+    await customElements.whenDefined('todo-list');
+    await customElements.whenDefined('wa-details');
+    await Promise.resolve();
+    const details =
+      this.todoListEl?.shadowRoot?.querySelector('wa-details');
+    if (details) (details as HTMLElement & { open: boolean }).open = true;
+  }
 
   override render(): TemplateResult {
     return html`

--- a/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/TodoListMock.ts
@@ -62,7 +62,6 @@ export class TodoListMock extends LitElement {
     `,
   ];
 
-  private readonly todos: TodoItem[] = SAMPLE_TODOS;
   @query('todo-list') private todoListEl?: HTMLElement;
 
   override async firstUpdated(): Promise<void> {
@@ -79,7 +78,7 @@ export class TodoListMock extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="frame">
-        <todo-list .todos=${this.todos}></todo-list>
+        <todo-list .todos=${SAMPLE_TODOS}></todo-list>
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
@@ -1,0 +1,89 @@
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+/**
+ * Visual-only mock of a header-level YOLO mode toggle. No real wiring —
+ * clicking only flips a local @state so screenshots can show both states.
+ */
+@customElement('texra-yolo-toggle-mock')
+export class YoloToggleMock extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .yolo-toggle {
+        flex-shrink: 0;
+      }
+
+      .yolo-toggle::part(base) {
+        min-height: var(--height-control, 24px);
+        gap: var(--wa-space-3xs);
+        font-size: var(--font-size-small);
+        padding: 0 var(--wa-space-2xs);
+        border-radius: var(--wa-border-radius-m);
+      }
+
+      .yolo-toggle--on::part(base) {
+        background: var(--wa-color-warning-fill-loud);
+        color: var(--wa-color-warning-on-loud);
+      }
+
+      .yolo-toggle--on::part(base):hover {
+        background: var(--wa-color-warning-fill-loud);
+        filter: brightness(1.05);
+      }
+
+      .yolo-toggle__indicator {
+        font-size: var(--font-size-icon-sm);
+      }
+    `,
+  ];
+
+  @state() private active = false;
+
+  override render(): TemplateResult {
+    const label = this.active ? 'YOLO on' : 'YOLO off';
+    const title = this.active
+      ? 'YOLO mode is on — tool-use agents run hands-free'
+      : 'YOLO mode is off — agents pause on each tool call';
+    return html`
+      <wa-button
+        class=${classMap({
+          'yolo-toggle': true,
+          'yolo-toggle--on': this.active,
+        })}
+        appearance=${this.active ? 'accent' : 'plain'}
+        size="small"
+        aria-pressed=${this.active}
+        title=${title}
+        @click=${this.toggle}
+      >
+        <wa-icon
+          slot="start"
+          library=${TEXRA_ICON_LIBRARY}
+          name=${this.active ? 'bolt' : 'shield'}
+          class="yolo-toggle__indicator"
+          variant="solid"
+        ></wa-icon>
+        ${label}
+      </wa-button>
+    `;
+  }
+
+  private toggle = (): void => {
+    this.active = !this.active;
+  };
+}

--- a/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
@@ -7,42 +7,28 @@ import { classMap } from 'lit/directives/class-map.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+// Local imports - progress view styles
+import { toolbarToggleStyles } from '@progressView/frontend/styles/toolbarToggleStyles';
+
 // Local imports - shared styles and controls
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 /**
  * Visual-only mock of a header-level YOLO mode toggle. Mirrors the real
- * `yolo-toggle-button` styling from StreamHeader (icon-only, `is-active`
- * applies a tinted background via color-mix) so the gallery reflects the
- * production toggle, not an invented one. No live wiring — clicking only
- * flips a local @state.
+ * `yolo-toggle-button` styling from StreamHeader so the gallery reflects the
+ * production toggle. No live wiring — clicking only flips a local @state.
  */
 @customElement('texra-yolo-toggle-mock')
 export class YoloToggleMock extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    toolbarToggleStyles,
     css`
       :host {
         display: inline-flex;
         align-items: center;
-      }
-
-      /* Mirror StreamHeader.ts: .yolo-toggle-button + .is-active tint. */
-      .yolo-toggle-button {
-        flex-shrink: 0;
-      }
-
-      .yolo-toggle-button.is-active {
-        --_toggle-color: var(--color-error);
-        border-radius: var(--border-radius);
-        color: var(--_toggle-color);
-        background-color: color-mix(
-          in srgb,
-          var(--_toggle-color) 15%,
-          transparent
-        );
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
@@ -7,11 +7,14 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 /**
- * Visual-only mock of a header-level YOLO mode toggle. No real wiring —
- * clicking only flips a local @state so screenshots can show both states.
+ * Visual-only mock of a header-level YOLO mode toggle. Mirrors the real
+ * `yolo-toggle-button` styling from StreamHeader (icon-only, `is-active`
+ * applies a tinted background via color-mix) so the gallery reflects the
+ * production toggle, not an invented one. No live wiring — clicking only
+ * flips a local @state.
  */
 @customElement('texra-yolo-toggle-mock')
 export class YoloToggleMock extends LitElement {
@@ -24,30 +27,20 @@ export class YoloToggleMock extends LitElement {
         align-items: center;
       }
 
-      .yolo-toggle {
+      /* Mirror StreamHeader.ts: .yolo-toggle-button + .is-active tint. */
+      .yolo-toggle-button {
         flex-shrink: 0;
       }
 
-      .yolo-toggle::part(base) {
-        min-height: var(--height-control, 24px);
-        gap: var(--wa-space-3xs);
-        font-size: var(--font-size-small);
-        padding: 0 var(--wa-space-2xs);
-        border-radius: var(--wa-border-radius-m);
-      }
-
-      .yolo-toggle--on::part(base) {
-        background: var(--wa-color-warning-fill-loud);
-        color: var(--wa-color-warning-on-loud);
-      }
-
-      .yolo-toggle--on::part(base):hover {
-        background: var(--wa-color-warning-fill-loud);
-        filter: brightness(1.05);
-      }
-
-      .yolo-toggle__indicator {
-        font-size: var(--font-size-icon-sm);
+      .yolo-toggle-button.is-active {
+        --_toggle-color: var(--color-error);
+        border-radius: var(--border-radius);
+        color: var(--_toggle-color);
+        background-color: color-mix(
+          in srgb,
+          var(--_toggle-color) 15%,
+          transparent
+        );
       }
     `,
   ];
@@ -55,31 +48,23 @@ export class YoloToggleMock extends LitElement {
   @state() private active = false;
 
   override render(): TemplateResult {
-    const label = this.active ? 'YOLO on' : 'YOLO off';
     const title = this.active
-      ? 'YOLO mode is on — tool-use agents run hands-free'
-      : 'YOLO mode is off — agents pause on each tool call';
+      ? 'Edit auto-accept active — click to resume approval prompts'
+      : 'Skip edit approvals (auto-accept file changes)';
     return html`
-      <wa-button
+      <span
         class=${classMap({
-          'yolo-toggle': true,
-          'yolo-toggle--on': this.active,
+          'yolo-toggle-button': true,
+          'is-active': this.active,
         })}
-        appearance=${this.active ? 'accent' : 'plain'}
-        size="small"
-        aria-pressed=${this.active}
-        title=${title}
         @click=${this.toggle}
       >
-        <wa-icon
-          slot="start"
-          library=${TEXRA_ICON_LIBRARY}
-          name=${this.active ? 'bolt' : 'shield'}
-          class="yolo-toggle__indicator"
-          variant="solid"
-        ></wa-icon>
-        ${label}
-      </wa-button>
+        ${renderIconActionButton({
+          icon: 'shield',
+          label: title,
+          title,
+        })}
+      </span>
     `;
   }
 

--- a/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/YoloToggleMock.ts
@@ -3,9 +3,11 @@ import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+// Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+// Local imports - shared styles and controls
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 

--- a/packages/extension/src/webview/frontend/mocks/index.ts
+++ b/packages/extension/src/webview/frontend/mocks/index.ts
@@ -12,10 +12,5 @@
 // To exit:
 //   localStorage.removeItem('texra-mocks'); location.reload();
 
-// Side-effect imports - mock custom elements
-import './YoloToggleMock';
-import './ContextUtilizationMock';
-import './TodoListMock';
-import './FollowupControlsMock';
-import './ProgressBoardLayoutMock';
+// Side-effect imports - gallery root and its child mock custom elements
 import './MocksGallery';

--- a/packages/extension/src/webview/frontend/mocks/index.ts
+++ b/packages/extension/src/webview/frontend/mocks/index.ts
@@ -12,6 +12,7 @@
 // To exit:
 //   localStorage.removeItem('texra-mocks'); location.reload();
 
+// Side-effect imports - mock custom elements
 import './YoloToggleMock';
 import './ContextUtilizationMock';
 import './TodoListMock';

--- a/packages/extension/src/webview/frontend/mocks/index.ts
+++ b/packages/extension/src/webview/frontend/mocks/index.ts
@@ -1,0 +1,20 @@
+// Registers all design-mock custom elements as a side-effect import.
+// Importing this module makes the following tags available in the DOM:
+//   <texra-yolo-toggle-mock>
+//   <texra-context-utilization-mock>
+//   <texra-todo-list-mock>
+//   <texra-followup-controls-mock>
+//   <texra-progress-board-layout-mock>
+//   <texra-mocks-gallery>
+//
+// To view the gallery in the main webview, open DevTools and run:
+//   localStorage.setItem('texra-mocks', '1'); location.reload();
+// To exit:
+//   localStorage.removeItem('texra-mocks'); location.reload();
+
+import './YoloToggleMock';
+import './ContextUtilizationMock';
+import './TodoListMock';
+import './FollowupControlsMock';
+import './ProgressBoardLayoutMock';
+import './MocksGallery';


### PR DESCRIPTION
## Summary

Adds a static design-mock gallery (`texra-mocks-gallery`) that showcases proposed UI affordances for the TeXRA extension. The gallery includes five reusable mock components:

1. **YoloToggleMock** — Header-level auto-accept toggle (visual-only, no wiring)
2. **ContextUtilizationMock** — Context window budget chip with progress bar
3. **TodoListMock** — Wraps production TodoList with sample checklist data
4. **FollowupControlsMock** — Wraps production WorkflowToolUseFollowupSection with realistic agent/model options
5. **ProgressBoardLayoutMock** — Split-panel layout (stream header + live log on left, output files on right) using production FileList component

The gallery is toggled via `localStorage.setItem('texra-mocks','1')` in the DevTools console and is mounted in MainApp when enabled. All mocks reuse production components where possible to ensure screenshots reflect real affordances rather than hand-rolled approximations.

## Issue acceptance gates

No issue linked. This is a design-system addition for internal UI prototyping and screenshot generation.

## Single source of truth

Each mock component owns its own visual state (e.g., `YoloToggleMock.active`, `ContextUtilizationMock.percent`). Production components (TodoList, FileList, WorkflowToolUseFollowupSection) remain the source of truth for their respective UI patterns; mocks wrap them with fixture data.

## Duplication and abstraction budget

- **Avoided duplication:** TodoListMock, FollowupControlsMock, and ProgressBoardLayoutMock import and wrap production components rather than reimplementing them, ensuring the gallery always reflects real output.
- **New abstraction:** MocksGallery acts as a single entry point for all design mocks, reducing boilerplate in MainApp (one import instead of five).
- **No pass-through layers:** Each mock either renders its own UI (YoloToggleMock, ContextUtilizationMock) or wraps a production component with fixture data (TodoListMock, etc.). No intermediate adapters.

## Host impact

**Extension:** MainApp now conditionally renders `<texra-mocks-gallery>` when `localStorage.texra-mocks === '1'`. No impact on production builds or normal extension behavior.

**Desktop:** None.

**CLI:** None.

## Scheduled refactoring

None.

## Validation

- All new components are Lit elements with proper TypeScript typing and JSDoc comments.
- Mocks reuse production components (FileList, TodoList, WorkflowToolUseFollowupSection) to ensure visual fidelity.
- Gallery is opt-in via localStorage and does not affect normal extension operation.
- No automated tests added (mocks are visual-only fixtures for design review, not functional code).

https://claude.ai/code/session_011dNEBmi3uuNWj93SmuBGLR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gallery is gated on development builds and an explicit localStorage flag; production behavior is unaffected aside from a small CSS refactor in StreamHeader.
> 
> **Overview**
> Adds a **development-only** design gallery (`texra-mocks-gallery`) for static previews of proposed UI (context budget chip, YOLO toggle, todo list, follow-up controls, progress board layout). **MainApp** lazy-loads the mocks module and replaces the launcher UI when `NODE_ENV === 'development'` and `localStorage['texra-mocks'] === '1'`; production builds and normal dev sessions are unchanged.
> 
> Mocks mostly **wrap production Lit components** with fixture data and open collapsed `wa-details` for screenshots; standalone mocks cover the context chip and a clickable YOLO toggle.
> 
> **StreamHeader** YOLO/super-YOLO toggle CSS moves into shared **`toolbarToggleStyles`**, reused by **YoloToggleMock** so gallery styling matches the real header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297422b93704341c6d953e12903ccdda86b4dc49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->