### PR TITLE
feat(auth): block disposable & privacy-relay signups, require 30d-old GitHub

### DIFF
--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -2,7 +2,7 @@
 
 _Effective Date: February 9, 2026_
 
-_Last Updated: February 9, 2026_
+_Last Updated: May 28, 2026_
 
 ---
 
@@ -36,6 +36,12 @@ We reserve all rights not expressly granted in these Terms.
 
 - **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers. See Section 9 for details on how data is handled in this mode.
 - **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. When using this program, requests are routed through a TeXRA-operated relay server (see Section 9 for details). Participation is limited to personal research and academic use, is subject to fair-use limits, and may be modified or discontinued at any time.
+- **Account Integrity**: You may only create and operate one account for your own personal use. To prevent abuse of free and Researcher Access tier resources, sign-up may be restricted by automated checks on the email address and the underlying identity provider account. In particular, we may reject sign-ups that:
+  1. use a disposable, temporary, or throwaway email provider;
+  2. use a privacy / forwarding-only email provider that has been disproportionately associated with abuse;
+  3. authenticate through a third-party identity provider account (e.g., a GitHub account) that was created very recently (typically within the last 30 days) or that otherwise has no meaningful prior history.
+
+  You agree to sign up using your primary institutional, employer, or long-term personal email address and a primary identity-provider account, rather than a newly-created or disposable account. If you have a legitimate need for an exception (for example, you are a researcher whose only available address is a privacy-relay email), you may contact contact@texra.ai to request manual approval.
 
 ## 6. Acceptable Use
 
@@ -49,6 +55,7 @@ You agree not to use the Service to:
 6. Circumvent any access controls, rate limits, or usage restrictions.
 7. Use the Service for automated bulk processing in a manner that abuses third-party API services.
 8. Misrepresent AI-generated content as solely human-authored in contexts where disclosure is required.
+9. Create more than one account, or use disposable, temporary, throwaway, privacy-relay, or other newly-created or pseudonymous email or identity-provider accounts in order to obtain additional free or Researcher Access Program resources, or otherwise to circumvent per-user fair-use limits ("multi-accounting"). Accounts found to engage in such conduct, together with any other accounts we reasonably believe to be operated by the same person, may be suspended or terminated without notice and without refund. Quotas and credits associated with such accounts are forfeit.
 
 ## 7. Intellectual Property
 

--- a/supabase/functions/_shared/emailPolicy.ts
+++ b/supabase/functions/_shared/emailPolicy.ts
@@ -1,25 +1,8 @@
-/**
- * Sign-up policy checks shared across edge functions.
- *
- * Two gates are enforced at the auth-github exchange when a *new* user is
- * about to be created:
- *
- *   1. Email domain is not in a blocklist of disposable / privacy-relay
- *      providers that are routinely used to farm the free tier.
- *   2. The GitHub account is at least MIN_GITHUB_ACCOUNT_AGE_DAYS old.
- *
- * Both checks are intentionally only enforced at user creation. Existing
- * users keep their access regardless of the lists below.
- */
+// Sign-up policy checks enforced at user creation (existing users are never re-checked).
 
 export const MIN_GITHUB_ACCOUNT_AGE_DAYS = 30;
 
-/**
- * Disposable / throwaway mailbox providers.
- *
- * These produce zero legitimate signups in practice and have been observed
- * directly farming the Researcher Access Program.
- */
+// Disposable mailbox providers observed farming the Researcher Access Program.
 const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
   'atomicmail.io',
   'tempmail.com',
@@ -55,12 +38,8 @@ const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
   'trashmail.de',
 ]);
 
-/**
- * Privacy mail providers that, while legitimate, are disproportionately used
- * for free-tier abuse here. Treated the same as disposable for now — see ToS.
- * Kept as a separate list so we can flip it to soft-review later without
- * touching the disposable list.
- */
+// Privacy-relay providers disproportionately used for free-tier abuse.
+// Kept separate from DISPOSABLE so it can be moved to soft-review independently.
 const PRIVACY_RELAY_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
   'protonmail.com',
   'protonmail.ch',
@@ -145,8 +124,7 @@ export function checkGitHubAccountAge(
     };
   }
 
-  const ageMs = now.getTime() - created.getTime();
-  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  const ageDays = (now.getTime() - created.getTime()) / 86_400_000;
 
   if (ageDays < MIN_GITHUB_ACCOUNT_AGE_DAYS) {
     const remaining = Math.ceil(MIN_GITHUB_ACCOUNT_AGE_DAYS - ageDays);

--- a/supabase/functions/_shared/emailPolicy.ts
+++ b/supabase/functions/_shared/emailPolicy.ts
@@ -1,0 +1,166 @@
+/**
+ * Sign-up policy checks shared across edge functions.
+ *
+ * Two gates are enforced at the auth-github exchange when a *new* user is
+ * about to be created:
+ *
+ *   1. Email domain is not in a blocklist of disposable / privacy-relay
+ *      providers that are routinely used to farm the free tier.
+ *   2. The GitHub account is at least MIN_GITHUB_ACCOUNT_AGE_DAYS old.
+ *
+ * Both checks are intentionally only enforced at user creation. Existing
+ * users keep their access regardless of the lists below.
+ */
+
+export const MIN_GITHUB_ACCOUNT_AGE_DAYS = 30;
+
+/**
+ * Disposable / throwaway mailbox providers.
+ *
+ * These produce zero legitimate signups in practice and have been observed
+ * directly farming the Researcher Access Program.
+ */
+const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'atomicmail.io',
+  'tempmail.com',
+  'temp-mail.org',
+  'temp-mail.io',
+  '10minutemail.com',
+  '10minutemail.net',
+  'guerrillamail.com',
+  'guerrillamail.net',
+  'guerrillamail.org',
+  'sharklasers.com',
+  'grr.la',
+  'mailinator.com',
+  'mailinator.net',
+  'throwaway.email',
+  'throwawaymail.com',
+  'fakeinbox.com',
+  'yopmail.com',
+  'yopmail.net',
+  'mintemail.com',
+  'dispostable.com',
+  'mailnesia.com',
+  'getairmail.com',
+  'emailondeck.com',
+  'dropmail.me',
+  'maildrop.cc',
+  'getnada.com',
+  'inboxbear.com',
+  'mohmal.com',
+  'tutanota-temp.com',
+  'spambox.us',
+  'trashmail.com',
+  'trashmail.de',
+]);
+
+/**
+ * Privacy mail providers that, while legitimate, are disproportionately used
+ * for free-tier abuse here. Treated the same as disposable for now — see ToS.
+ * Kept as a separate list so we can flip it to soft-review later without
+ * touching the disposable list.
+ */
+const PRIVACY_RELAY_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'protonmail.com',
+  'protonmail.ch',
+  'proton.me',
+  'pm.me',
+]);
+
+export type EmailPolicyDecision =
+  | { allowed: true }
+  | { allowed: false; reason: string; userMessage: string };
+
+function normalizeDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return null;
+  return email
+    .slice(at + 1)
+    .trim()
+    .toLowerCase();
+}
+
+export function checkEmailDomain(email: string): EmailPolicyDecision {
+  const domain = normalizeDomain(email);
+  if (!domain) {
+    return {
+      allowed: false,
+      reason: 'invalid-email',
+      userMessage:
+        'The email address on your GitHub account is malformed. Please set a valid primary email on GitHub and retry.',
+    };
+  }
+
+  if (DISPOSABLE_EMAIL_DOMAINS.has(domain)) {
+    return {
+      allowed: false,
+      reason: `disposable-domain:${domain}`,
+      userMessage:
+        `Sign-up is restricted: "${domain}" is a disposable / temporary email provider. ` +
+        'Please sign in with a GitHub account that uses your primary institutional, ' +
+        'employer, or long-term personal email address. ' +
+        'If you believe this is in error, contact contact@texra.ai.',
+    };
+  }
+
+  if (PRIVACY_RELAY_EMAIL_DOMAINS.has(domain)) {
+    return {
+      allowed: false,
+      reason: `privacy-relay-domain:${domain}`,
+      userMessage:
+        `Sign-up via "${domain}" is currently not accepted for the Researcher ` +
+        'Access Program due to repeated abuse. Please sign in with a GitHub ' +
+        'account that uses your primary institutional or long-term personal ' +
+        'email address. If this is your only email and you are a legitimate ' +
+        'researcher, contact contact@texra.ai for an exception.',
+    };
+  }
+
+  return { allowed: true };
+}
+
+export function checkGitHubAccountAge(
+  githubCreatedAt: string | null | undefined,
+  now: Date = new Date(),
+): EmailPolicyDecision {
+  if (!githubCreatedAt) {
+    return {
+      allowed: false,
+      reason: 'missing-github-created-at',
+      userMessage:
+        'Could not determine your GitHub account creation date. Please retry, ' +
+        'or contact contact@texra.ai if the problem persists.',
+    };
+  }
+
+  const created = new Date(githubCreatedAt);
+  if (Number.isNaN(created.getTime())) {
+    return {
+      allowed: false,
+      reason: 'invalid-github-created-at',
+      userMessage:
+        'Could not parse your GitHub account creation date. Please retry, ' +
+        'or contact contact@texra.ai if the problem persists.',
+    };
+  }
+
+  const ageMs = now.getTime() - created.getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+
+  if (ageDays < MIN_GITHUB_ACCOUNT_AGE_DAYS) {
+    const remaining = Math.ceil(MIN_GITHUB_ACCOUNT_AGE_DAYS - ageDays);
+    return {
+      allowed: false,
+      reason: `github-account-too-young:${ageDays.toFixed(1)}d`,
+      userMessage:
+        `Sign-up requires a GitHub account at least ${MIN_GITHUB_ACCOUNT_AGE_DAYS} days old. ` +
+        `Your GitHub account is currently ${Math.max(0, Math.floor(ageDays))} days old ` +
+        `(please retry in about ${remaining} day${remaining === 1 ? '' : 's'}). ` +
+        'If you are a legitimate researcher and need access sooner, contact ' +
+        'contact@texra.ai for an exception.',
+    };
+  }
+
+  return { allowed: true };
+}

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -306,9 +306,7 @@ app.post('/exchange', async (c) => {
           },
         });
       } else {
-        // New user about to be created — enforce sign-up policy.
-        // Existing users (matched by identity or email above) are not re-checked,
-        // so users that pre-date the policy keep their access.
+        // New user — enforce sign-up policy (existing users are never re-checked).
         const emailDecision = checkEmailDomain(email);
         if (!emailDecision.allowed) {
           console.warn(

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -18,6 +18,10 @@ import { Hono } from 'jsr:@hono/hono@4.12.15';
 import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import { create, getNumericDate } from 'https://deno.land/x/djwt@v3.0.2/mod.ts';
 import { handleCors } from '../_shared/cors.ts';
+import {
+  checkEmailDomain,
+  checkGitHubAccountAge,
+} from '../_shared/emailPolicy.ts';
 
 // =============================================================================
 // Constants
@@ -45,6 +49,7 @@ interface GitHubUser {
   email: string | null;
   avatar_url: string;
   name: string | null;
+  created_at: string;
 }
 
 type Variables = {
@@ -301,6 +306,25 @@ app.post('/exchange', async (c) => {
           },
         });
       } else {
+        // New user about to be created — enforce sign-up policy.
+        // Existing users (matched by identity or email above) are not re-checked,
+        // so users that pre-date the policy keep their access.
+        const emailDecision = checkEmailDomain(email);
+        if (!emailDecision.allowed) {
+          console.warn(
+            `[AUTH] Sign-up rejected for GitHub ${githubUser.login} (${email}): ${emailDecision.reason}`,
+          );
+          return errorResponse(c, emailDecision.userMessage, 403);
+        }
+
+        const ageDecision = checkGitHubAccountAge(githubUser.created_at);
+        if (!ageDecision.allowed) {
+          console.warn(
+            `[AUTH] Sign-up rejected for GitHub ${githubUser.login} (${email}): ${ageDecision.reason}`,
+          );
+          return errorResponse(c, ageDecision.userMessage, 403);
+        }
+
         // Create new user
         const { data: newUser, error } = await supabase.auth.admin.createUser({
           email,


### PR DESCRIPTION
## Summary

- Closes a free-tier abuse pattern where throwaway GitHub + `atomicmail.io` accounts created seconds before sign-up burned ~\$10 of Researcher Access Program credit each via long `remote:orchestrator` loops on Sonnet 4.6. 8 accounts ≈ \$79 burned over 11 days, cadence accelerating.
- Adds two sign-up gates in the `auth-github` edge function (only on **new-user creation** — existing users are unaffected):
  - **Email domain blocklist**: disposable / temporary providers (atomicmail.io, mailinator, guerrillamail, tempmail variants, …) and the Proton family (`protonmail.com`, `protonmail.ch`, `proton.me`, `pm.me`) due to repeated abuse. Rejected with a user-facing message asking for a primary institutional / long-term personal email and pointing at `contact@texra.ai` for exception requests.
  - **Minimum GitHub account age** of 30 days, read from the GitHub `/user` response's `created_at` (no extra API call needed). 7 of 8 observed abuse accounts went GitHub-signup → TeXRA-signup in under 90s; this gate alone closes that vector.
- Lists live in `supabase/functions/_shared/emailPolicy.ts` so the Proton list can be flipped to soft-review later without touching call sites.
- Updates `TERMS_OF_SERVICE.md`:
  - New "Account Integrity" bullet in §5 documenting the sign-up restrictions and the exception process.
  - New §6.9 prohibiting multi-accounting / disposable-email circumvention, with forfeiture of quotas across linked accounts.
  - "Last Updated" bumped to May 28, 2026.

## Tradeoff to be aware of

Blocking the Proton family will reject some legitimate privacy-conscious researchers. The user-facing message and ToS both surface `contact@texra.ai` as the exception channel. If review-volume becomes a problem, flip `PRIVACY_RELAY_EMAIL_DOMAINS` to a soft-review path (allow signup, gate relay until manually approved) — the list is isolated for exactly this reason.

## Test plan

- [ ] Manually call `POST /auth-github/exchange` with a fresh GitHub token whose primary email is on `atomicmail.io` → expect 403 with the disposable-domain message; no Supabase user row created.
- [ ] Same with a Proton email → expect 403 with the privacy-relay message.
- [ ] Same with a normal email but a GitHub account created < 30 days ago → expect 403 with the account-age message.
- [ ] Sign in with an existing TeXRA user whose email is on one of the blocked lists → expect success (no re-check on existing identity / existing email lookup).
- [ ] Sign in with a fresh GitHub + a normal (institutional) email + GH account > 30 days old → expect success and a new row in `auth.users`.
- [ ] `deno check supabase/functions/_shared/emailPolicy.ts` — clean.
- [ ] Confirm pre-existing type errors in `auth-github/index.ts` are unchanged in count (Supabase client returns `never`-typed rows; out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can register via auth-github (including Proton domains) and gates new-user creation in a security-sensitive path; misconfiguration could lock out legitimate researchers until manual exceptions.
> 
> **Overview**
> Adds **sign-up abuse controls** on the GitHub auth exchange path so new accounts cannot be created with throwaway emails, blocked privacy-relay domains, or GitHub accounts younger than 30 days. Checks run only when creating a brand-new user; returning users and email-based account linking are unchanged.
> 
> A shared `emailPolicy` module centralizes disposable and Proton-family domain denylists plus `checkGitHubAccountAge` (using `created_at` from the existing GitHub `/user` response). Rejections return **403** with user-facing copy pointing to `contact@texra.ai` for exceptions.
> 
> **Terms of Service** now documents automated sign-up restrictions under account integrity, adds a multi-accounting prohibition with quota forfeiture, and updates the last-revised date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6005264500d905b6a5cab3c192176b6f6c8aee67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->