### PR TITLE
fix(auth): block disposable email subdomains

### DIFF
--- a/src/test-kernel/auth/EmailPolicy.vitest.ts
+++ b/src/test-kernel/auth/EmailPolicy.vitest.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkEmailDomain } from '../../../supabase/functions/_shared/emailPolicy';
+
+describe('checkEmailDomain', () => {
+  it('blocks disposable email domains exactly', () => {
+    expect(checkEmailDomain('user@mailinator.com')).toMatchObject({
+      allowed: false,
+      reason: 'disposable-domain:mailinator.com',
+    });
+  });
+
+  it('blocks subdomains of disposable email domains', () => {
+    expect(checkEmailDomain('user@inbound.mailinator.com')).toMatchObject({
+      allowed: false,
+      reason: 'disposable-domain:mailinator.com',
+    });
+  });
+
+  it('blocks subdomains of privacy-relay email domains', () => {
+    expect(checkEmailDomain('user@relay.proton.me')).toMatchObject({
+      allowed: false,
+      reason: 'privacy-relay-domain:proton.me',
+    });
+  });
+
+  it('does not block unrelated domains that merely contain a listed domain', () => {
+    expect(checkEmailDomain('user@mailinator.com.example.org')).toEqual({
+      allowed: true,
+    });
+    expect(checkEmailDomain('user@notmailinator.com')).toEqual({
+      allowed: true,
+    });
+  });
+
+  it('normalizes domain case and whitespace before matching', () => {
+    expect(checkEmailDomain('user@ InboxBear.com ')).toMatchObject({
+      allowed: false,
+      reason: 'disposable-domain:inboxbear.com',
+    });
+  });
+});

--- a/supabase/functions/_shared/emailPolicy.ts
+++ b/supabase/functions/_shared/emailPolicy.ts
@@ -60,6 +60,23 @@ function normalizeDomain(email: string): string | null {
     .toLowerCase();
 }
 
+function findBlockedDomain(
+  domain: string,
+  blockedDomains: ReadonlySet<string>,
+): string | null {
+  let candidate = domain;
+
+  while (candidate) {
+    if (blockedDomains.has(candidate)) return candidate;
+
+    const dot = candidate.indexOf('.');
+    if (dot < 0) return null;
+    candidate = candidate.slice(dot + 1);
+  }
+
+  return null;
+}
+
 export function checkEmailDomain(email: string): EmailPolicyDecision {
   const domain = normalizeDomain(email);
   if (!domain) {
@@ -71,24 +88,29 @@ export function checkEmailDomain(email: string): EmailPolicyDecision {
     };
   }
 
-  if (DISPOSABLE_EMAIL_DOMAINS.has(domain)) {
+  const disposableDomain = findBlockedDomain(domain, DISPOSABLE_EMAIL_DOMAINS);
+  if (disposableDomain) {
     return {
       allowed: false,
-      reason: `disposable-domain:${domain}`,
+      reason: `disposable-domain:${disposableDomain}`,
       userMessage:
-        `Sign-up is restricted: "${domain}" is a disposable / temporary email provider. ` +
+        `Sign-up is restricted: "${disposableDomain}" is a disposable / temporary email provider. ` +
         'Please sign in with a GitHub account that uses your primary institutional, ' +
         'employer, or long-term personal email address. ' +
         'If you believe this is in error, contact contact@texra.ai.',
     };
   }
 
-  if (PRIVACY_RELAY_EMAIL_DOMAINS.has(domain)) {
+  const privacyRelayDomain = findBlockedDomain(
+    domain,
+    PRIVACY_RELAY_EMAIL_DOMAINS,
+  );
+  if (privacyRelayDomain) {
     return {
       allowed: false,
-      reason: `privacy-relay-domain:${domain}`,
+      reason: `privacy-relay-domain:${privacyRelayDomain}`,
       userMessage:
-        `Sign-up via "${domain}" is currently not accepted for the Researcher ` +
+        `Sign-up via "${privacyRelayDomain}" is currently not accepted for the Researcher ` +
         'Access Program due to repeated abuse. Please sign in with a GitHub ' +
         'account that uses your primary institutional or long-term personal ' +
         'email address. If this is your only email and you are a legitimate ' +


### PR DESCRIPTION
## Summary

- Block subdomains of disposable and privacy-relay email providers, not only exact provider domains.
- Add regression coverage for exact matches, subdomain matches, and unrelated suffixes that should remain allowed.

## Validation

- `npm run test:kernel -- src/test-kernel/auth/EmailPolicy.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; two pre-existing warnings in unrelated files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens sign-up gating in shared auth email policy; incorrect suffix matching could block legitimate domains, though new tests target false-positive cases.
> 
> **Overview**
> Sign-up email policy now treats **subdomains** of blocked disposable and privacy-relay providers the same as the root domain (e.g. `inbound.mailinator.com` is blocked via `mailinator.com`), using suffix walking in `findBlockedDomain` instead of exact hostname lookup only.
> 
> Rejection reasons and user-facing copy reference the **matched list entry** (the provider domain), not only the full host. New kernel tests cover exact blocks, subdomain blocks, domains that must stay allowed, and case/whitespace normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d03faaa06223accde8ef3a23cc0e3fe62a21042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->