### PR TITLE
feat(models): add Claude Opus 4.8, bump llm-zoo and Anthropic SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Claude Opus 4.8 support** — the latest Opus 4.8 models (`opus48`, `opus48T`) are available for demanding research and engineering tasks, replacing Opus 4.7 as the default Anthropic model. Opus 4.8 keeps the full 1M context window, adaptive thinking, and native server-side compaction.
+
 ### Bug Fixes
 
 - **Workflow rounds no longer overwrite the workspace** — past round 0, a workflow agent's emitted documents were being written through a symlink chain that ended at your live workspace file. The round directory's outputs are now real files owned by the round, and the workspace is unreachable from the backend.

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -66,7 +66,7 @@ delivery. The new prompt joins that Codex session as the next turn.
 
 | Setting              | Options                                                                                            | Default             | What it controls                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| **Model**            | `Sonnet 4.6`, `Opus 4.7`, `Haiku 4.5`                                                              | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
+| **Model**            | `Sonnet 4.6`, `Opus 4.8`, `Haiku 4.5`                                                              | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
 | **Permission mode**  | `Prompt for risky actions`, `Auto-accept edits`, `Bypass all (dangerous)`, `Plan only (read-only)` | `Auto-accept edits` | How much the Claude Code child process may do before stopping to ask.         |
 | **Reasoning effort** | `Low`, `Medium`, `High`, `Extra high`, `Maximum`                                                   | `High`              | How deeply Claude deliberates before acting.                                  |
 

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -34,8 +34,8 @@ For complex tasks:
 Match model capability to task complexity - overpowered models waste money, underpowered ones produce poor results.
 
 - **Simple tasks** (corrections): Use fast, cheap models (`qwenturbo`, `deepseek`, `haiku45`)
-- **Complex tasks** (transformations): Use powerful models (`opus47T`, `gpt55`, `gemini31p`)
-- **Reasoning-heavy**: Use thinking models (`sonnet46T`, `opus47T`, `deepseekT`)
+- **Complex tasks** (transformations): Use powerful models (`opus48T`, `gpt55`, `gemini31p`)
+- **Reasoning-heavy**: Use thinking models (`sonnet46T`, `opus48T`, `deepseekT`)
 
 See the [AI Models Guide](./models.md) for detailed comparisons.
 

--- a/docs/guide/code-review.md
+++ b/docs/guide/code-review.md
@@ -88,7 +88,7 @@ The built-in defaults:
 | Provider   | Default model  |
 | ---------- | -------------- |
 | DeepSeek   | `deepseekproT` |
-| Anthropic  | `opus47T`      |
+| Anthropic  | `opus48T`      |
 | OpenAI     | `gpt55`        |
 | Google     | `gemini31p`    |
 | OpenRouter | `gptoss`       |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -92,7 +92,7 @@ Configure how TeXRA connects to AI model providers:
 
 Claude Opus 4.8 and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
 
-Opus 4.8 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High). Extra High maps to Anthropic's `max` effort on Opus-tier models.
+Opus 4.8 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High). On Opus 4.8, Extra High maps to Anthropic's `xhigh` ("extra") effort tier, recommended for difficult tasks and long-running work; the earlier Opus 4.6/4.7 models use `max` instead, since they predate the `xhigh`/`max` split.
 
 ### Bibliography Settings
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -90,9 +90,9 @@ Configure how TeXRA connects to AI model providers:
 
 ### Anthropic 1M Context Window
 
-Claude Opus 4.7, Opus 4.6, and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
+Claude Opus 4.8 and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
 
-Opus 4.7 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High). Extra High maps to Anthropic's `max` effort on Opus-tier models.
+Opus 4.8 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High). Extra High maps to Anthropic's `max` effort on Opus-tier models.
 
 ### Bibliography Settings
 

--- a/docs/guide/intelligent-merge.md
+++ b/docs/guide/intelligent-merge.md
@@ -16,7 +16,7 @@ Access the merge functionality via the "LaTeXdiffs" section (<wa-icon library="t
 
 1.  **Select Base File**: Choose the original document you want to merge changes _into_ using the "Base File" dropdown (<wa-icon library="texra" name="file"></wa-icon> Base).
 2.  **Select Edited File**: Choose the document containing the suggested changes using the "Edited File" dropdown (<wa-icon library="texra" name="edit"></wa-icon> Edited).
-3.  **Choose Merge Model**: Select an appropriate language model from the main Model dropdown (<wa-icon library="texra" name="robot"></wa-icon> Model) below the instruction box. Models capable of strong reasoning (like Claude Opus 4.7, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
+3.  **Choose Merge Model**: Select an appropriate language model from the main Model dropdown (<wa-icon library="texra" name="robot"></wa-icon> Model) below the instruction box. Models capable of strong reasoning (like Claude Opus 4.8, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
 4.  **Click Merge**: Press the "Merge" button (<wa-icon library="texra" name="merge"></wa-icon>) located in the "Edited File" row.
 
 ::: info VS Code feature

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -12,18 +12,16 @@ TeXRA supports models from multiple providers. Select models from the dropdown i
 
 | Model ID    | Use Case                              | Cost | Speed  |
 | :---------- | :------------------------------------ | :--- | :----- |
-| `opus47T`   | Top-tier reasoning, long-horizon work | $$$$ | Slow   |
-| `opus47`    | Most capable for agentic coding       | $$$$ | Slow   |
-| `opus46T`   | Complex tasks with reasoning          | $$$$ | Slow   |
-| `opus46`    | High quality, complex tasks           | $$$$ | Slow   |
+| `opus48T`   | Top-tier reasoning, long-horizon work | $$$$ | Slow   |
+| `opus48`    | Most capable for agentic coding       | $$$$ | Slow   |
 | `sonnet46T` | All-rounder with reasoning            | $$$  | Medium |
 | `sonnet46`  | Strong all-rounder                    | $$$  | Medium |
 | `haiku45T`  | Fast with reasoning                   | $$   | Fast   |
 | `haiku45`   | Fast responses                        | $$   | Fast   |
 
-Opus 4.7, Opus 4.6, and Sonnet 4.6 include the full 1M context window at standard pricing — no opt-in or beta header required. Other Claude models use a 200K context window.
+Opus 4.8 and Sonnet 4.6 include the full 1M context window at standard pricing — no opt-in or beta header required. Other Claude models use a 200K context window.
 
-Claude Opus 4.7 uses adaptive thinking only (extended thinking with a manual `budget_tokens` is no longer accepted). TeXRA's reasoning-effort selector maps to Anthropic's effort levels automatically — pick `opus47T` with Extra High effort for the strongest agentic coding and long-horizon tasks. Opus 4.7 also supports high-resolution images (up to 2576px / 3.75MP) for better figure, chart, and screenshot understanding; note that TeXRA downscales images above `texra.maxImageDimension` (default 2000px) before sending, so raise that setting if you want to take full advantage of Opus 4.7's higher limit.
+Claude Opus 4.8 uses adaptive thinking only (extended thinking with a manual `budget_tokens` is no longer accepted). TeXRA's reasoning-effort selector maps to Anthropic's effort levels automatically — pick `opus48T` with Extra High effort for the strongest agentic coding and long-horizon tasks. Opus 4.8 also supports high-resolution images (up to 2576px / 3.75MP) for better figure, chart, and screenshot understanding; note that TeXRA downscales images above `texra.maxImageDimension` (default 2000px) before sending, so raise that setting if you want to take full advantage of Opus 4.8's higher limit.
 
 ## OpenAI Models
 
@@ -107,10 +105,10 @@ GLM models support thinking mode (reasoning is shown inline). The API uses a non
 ## Choosing a Model
 
 - **Simple tasks**: Fast, cheap models (`qwenturbo`, `deepseek`, `haiku45`)
-- **Complex tasks**: Powerful models (`opus47`, `gpt55`, `gemini31p`)
-- **Code-heavy / LaTeX editing**: Strong editing models (`opus47T`, `sonnet46T`, `qwenplus`)
-- **Reasoning-heavy**: Thinking models (`opus47T`, `sonnet46T`, `deepseekT`, `kimi26T`)
-- **Large documents**: High-context models (`gemini31p`, `sonnet46`, `opus47`)
+- **Complex tasks**: Powerful models (`opus48`, `gpt55`, `gemini31p`)
+- **Code-heavy / LaTeX editing**: Strong editing models (`opus48T`, `sonnet46T`, `qwenplus`)
+- **Reasoning-heavy**: Thinking models (`opus48T`, `sonnet46T`, `deepseekT`, `kimi26T`)
+- **Large documents**: High-context models (`gemini31p`, `sonnet46`, `opus48`)
 
 ## Configuration
 
@@ -120,7 +118,7 @@ Customize available models in VS Code Settings under `texra.models`:
 "texra.models": [
   "gemini31p",
   "sonnet46T",
-  "opus47T",
+  "opus48T",
   "gpt55",
   "deepseekT"
 ]

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -276,7 +276,7 @@ Here are some common tasks you can try with TeXRA:
 ### Converting a Paper to Slides
 
 - **Agent**: `paper2slide`
-- **Model**: `sonnet46T`, `opus47T`, or `gpt55`
+- **Model**: `sonnet46T`, `opus48T`, or `gpt55`
 - **Instruction**: "Convert this paper into presentation slides using the beamer template. Create approximately 12-15 slides highlighting the key points, methodology, and results."
 
 ### Improving Writing Style

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -48,7 +48,7 @@ Because these are tool-use agents, they can compile the figure and inspect the r
 ### Creating New Figures
 
 1. Select a tool-use agent — `research` or `presenter` (<wa-icon library="texra" name="sparkle"></wa-icon>).
-2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet46T`, `opus47T`, `gpt55`, or `gemini31p` are good choices for complex drawings.
+2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet46T`, `opus48T`, `gpt55`, or `gemini31p` are good choices for complex drawings.
 3. Provide a detailed description of the figure you want.
 4. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -267,7 +267,7 @@ to confirm available models, and `texra tools status` to check tool availability
 
 3. **Use better models**:
    - Upgrade to more capable models for complex tasks
-   - Try Claude Opus 4.7 or GPT-5.5 for highest quality
+   - Try Claude Opus 4.8 or GPT-5.5 for highest quality
    - Match the model to your specific task
 
 4. **Reference materials**:

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -191,8 +191,8 @@ Available to Ultra tier subscribers only (includes all lower tier models).
 
 | Model Name | Full Name                  | Provider  | Pricing (in/out per 1M) |
 | ---------- | -------------------------- | --------- | ----------------------- |
-| `opus47`   | claude-opus-4-7            | Anthropic | $5.00/$25.00            |
-| `opus47T`  | claude-opus-4-7 (Thinking) | Anthropic | $5.00/$25.00            |
+| `opus48`   | claude-opus-4-8            | Anthropic | $5.00/$25.00            |
+| `opus48T`  | claude-opus-4-8 (Thinking) | Anthropic | $5.00/$25.00            |
 | `gpt55`    | gpt-5.5-2026-04-23         | OpenAI    | $5.00/$30.00            |
 | `gpt55pro` | gpt-5.5-pro-2026-04-23     | OpenAI    | $30.00/$180.00          |
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.153",
-    "@anthropic-ai/sdk": "^0.99.0",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@awesome.me/webawesome": "^3.7.0",
     "@cantoo/pdf-lib": "^2.7.1",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
@@ -147,7 +147,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.17.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.7.0",
+    "llm-zoo": "^1.8.0",
     "lru-cache": "^11.5.1",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.2.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1522,7 +1522,7 @@
   "homepage": "https://texra.ai",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.153",
-    "@anthropic-ai/sdk": "^0.99.0",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@awesome.me/webawesome": "^3.7.0",
     "@cantoo/pdf-lib": "^2.7.1",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
@@ -1557,7 +1557,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.17.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.7.0",
+    "llm-zoo": "^1.8.0",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.2.0",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -5,13 +5,13 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
+import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
   toErrorMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
-import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
 import {
   getAcceptedFileTarget,
   siblingLocation,

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -32,7 +32,7 @@ const SIGNED_IN_SETUP_MODEL = 'gemini31p';
  * agent can actually authenticate with the key it's been given.
  */
 const API_KEY_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
-  anthropic: 'opus47T',
+  anthropic: 'opus48T',
   openai: 'gpt55',
   google: 'gemini31p',
   deepseek: 'deepseekT',

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -69,7 +69,7 @@ const CLAUDE_MODEL_OPTIONS: readonly {
   label: string;
 }[] = [
   { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { value: 'claude-opus-4-8', label: 'Opus 4.8' },
   { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ] as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.153
-        version: 0.3.153(@anthropic-ai/sdk@0.99.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.153(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
-        specifier: ^0.99.0
-        version: 0.99.0(zod@4.4.3)
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@awesome.me/webawesome':
         specifier: ^3.7.0
         version: 3.7.0(@floating-ui/utils@0.2.11)(@types/react@19.2.15)
@@ -123,8 +123,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.7.0
-        version: 1.7.0(zod@4.4.3)
+        specifier: ^1.8.0
+        version: 1.8.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.1
         version: 11.5.1
@@ -422,7 +422,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.153
-        version: 0.3.153(@anthropic-ai/sdk@0.99.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.153(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
@@ -465,10 +465,10 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.153
-        version: 0.3.153(@anthropic-ai/sdk@0.99.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.153(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
-        specifier: ^0.99.0
-        version: 0.99.0(zod@4.4.3)
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@awesome.me/webawesome':
         specifier: ^3.7.0
         version: 3.7.0(@floating-ui/utils@0.2.11)(@types/react@19.2.15)
@@ -572,8 +572,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.7.0
-        version: 1.7.0(zod@4.4.3)
+        specifier: ^1.8.0
+        version: 1.8.0(zod@4.4.3)
       mark.js:
         specifier: ^8.11.1
         version: 8.11.1
@@ -835,8 +835,8 @@ packages:
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.99.0':
-    resolution: {integrity: sha512-vdicFA9YjtvgpG8rxp39hqW4oxpkdRGPTq0QEts5TZhr2GkLozDduK/GiXrLQ7PzrKYBtIkQFdRW+QBjzlsABg==}
+  '@anthropic-ai/sdk@0.100.0':
+    resolution: {integrity: sha512-cAm3aXm6qAiHIvHxyIIGd6tVmsD2gDqlc2h0R20ijNUzGgVnIN822bit4mKbF6CkuV7qIrLQIPoAepHEpanrQQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -4723,8 +4723,8 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
-  llm-zoo@1.7.0:
-    resolution: {integrity: sha512-9K3j+HmVQZ4akZ3sqzl/S0XyuEoz8QcK7ArkYh/4iSFB4NtyXnYV7t0Np58SZkhnFjIlea0dpobfqESf3tXsRA==}
+  llm-zoo@1.8.0:
+    resolution: {integrity: sha512-7lDi/LmlLEK6hSYOO7A+d5q7wX6DMInuIZk6FuHvImnN1PhAuWjxYA41rMVfTUk4WEDkPL+CYL6NYTudL3mstw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -6890,9 +6890,9 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.153':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.153(@anthropic-ai/sdk@0.99.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.153(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.99.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -6905,7 +6905,7 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.153
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.153
 
-  '@anthropic-ai/sdk@0.99.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -11443,7 +11443,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llm-zoo@1.7.0(zod@4.4.3):
+  llm-zoo@1.8.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1411,6 +1411,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
         totalInput,
       ),
+      // SDK 0.100.0 reports the thinking-token breakdown of output_tokens, so
+      // Anthropic now surfaces reasoning tokens like OpenAI/Google/xAI. This is
+      // a subset of outputTokens (already billed), not an additional charge.
+      reasoningTokens: rawUsage.output_tokens_details?.thinking_tokens || undefined,
       serverToolRequests:
         (rawUsage.server_tool_use?.web_search_requests ?? 0) +
           (rawUsage.server_tool_use?.web_fetch_requests ?? 0) || undefined,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -285,7 +285,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Returns the Anthropic effort level for the current model.
    * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
    * Falls back to 'high' (the API default) when no specific effort is configured.
-   * 'max' is only valid for Opus-tier models (Opus 4.6, Opus 4.7, and Opus 4.8).
+   * The above-'high' tiers are only valid for Opus-tier models: Opus 4.8 accepts
+   * the distinct 'xhigh' ("extra") tier, while Opus 4.6/4.7 predate that split
+   * and only accept 'max'.
    */
   private getAnthropicEffort(): BetaOutputConfig['effort'] {
     const reasoningEffort = this.getEffectiveReasoningEffort();
@@ -295,12 +297,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     switch (reasoningEffort) {
       case 'xhigh':
-        // 'max' is supported on Opus 4.6, Opus 4.7, and Opus 4.8
-        return this.isClaudeOpus46() ||
-          this.isClaudeOpus47() ||
-          this.isClaudeOpus48()
-          ? 'max'
-          : 'high';
+        // Opus 4.8 exposes the distinct 'xhigh' ("extra") effort tier the SDK
+        // added in 0.100.0, which is exactly what TeXRA's "Extra High" selector
+        // means — map to it directly. Opus 4.6/4.7 predate the tier split and
+        // only accept 'max'; everything else caps at 'high'.
+        if (this.isClaudeOpus48()) return 'xhigh';
+        return this.isClaudeOpus46() || this.isClaudeOpus47() ? 'max' : 'high';
       case 'high':
         return 'high';
       case 'medium':

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -178,11 +178,12 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
 
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
 const OPUS_47_FULLNAME = 'claude-opus-4-7';
+const OPUS_48_FULLNAME = 'claude-opus-4-8';
 const SONNET_46_FULLNAME = 'claude-sonnet-4-6';
 
-// 1M context window is available natively for Opus 4.6, Opus 4.7, and Sonnet 4.6
-// at standard pricing (no beta header needed). Context window sizes come from
-// llm-zoo. Other Claude models use 200K.
+// 1M context window is available natively for Opus 4.6, Opus 4.7, Opus 4.8, and
+// Sonnet 4.6 at standard pricing (no beta header needed). Context window sizes
+// come from llm-zoo. Other Claude models use 200K.
 
 /**
  * Model patterns that require temperature removal when thinking is enabled.
@@ -252,6 +253,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return this.config.fullName.startsWith(OPUS_47_FULLNAME);
   }
 
+  private isClaudeOpus48(): boolean {
+    return this.config.fullName.startsWith(OPUS_48_FULLNAME);
+  }
+
   private isClaudeSonnet46(): boolean {
     return this.config.fullName.startsWith(SONNET_46_FULLNAME);
   }
@@ -263,12 +268,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /**
    * Whether this model supports adaptive thinking with the effort parameter.
-   * Per Anthropic docs, Opus 4.6, Opus 4.7, and Sonnet 4.6 support adaptive thinking.
-   * Opus 4.7 only accepts adaptive thinking — manual budget_tokens returns 400.
+   * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6 support
+   * adaptive thinking. Opus 4.7+ only accepts adaptive thinking — manual
+   * budget_tokens returns 400.
    */
   private supportsAdaptiveThinking(): boolean {
     return (
-      this.isClaudeOpus46() || this.isClaudeOpus47() || this.isClaudeSonnet46()
+      this.isClaudeOpus46() ||
+      this.isClaudeOpus47() ||
+      this.isClaudeOpus48() ||
+      this.isClaudeSonnet46()
     );
   }
 
@@ -276,7 +285,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Returns the Anthropic effort level for the current model.
    * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
    * Falls back to 'high' (the API default) when no specific effort is configured.
-   * 'max' is only valid for Opus-tier models (Opus 4.6 and Opus 4.7).
+   * 'max' is only valid for Opus-tier models (Opus 4.6, Opus 4.7, and Opus 4.8).
    */
   private getAnthropicEffort(): BetaOutputConfig['effort'] {
     const reasoningEffort = this.getEffectiveReasoningEffort();
@@ -286,8 +295,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     switch (reasoningEffort) {
       case 'xhigh':
-        // 'max' is supported on Opus 4.6 and Opus 4.7
-        return this.isClaudeOpus46() || this.isClaudeOpus47() ? 'max' : 'high';
+        // 'max' is supported on Opus 4.6, Opus 4.7, and Opus 4.8
+        return this.isClaudeOpus46() ||
+          this.isClaudeOpus47() ||
+          this.isClaudeOpus48()
+          ? 'max'
+          : 'high';
       case 'high':
         return 'high';
       case 'medium':
@@ -304,7 +317,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Whether this model supports Anthropic's native server-side context compaction. */
   private isCompactionEligibleModel(): boolean {
     return (
-      this.isClaudeOpus46() || this.isClaudeOpus47() || this.isClaudeSonnet46()
+      this.isClaudeOpus46() ||
+      this.isClaudeOpus47() ||
+      this.isClaudeOpus48() ||
+      this.isClaudeSonnet46()
     );
   }
 
@@ -561,18 +577,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.logger.debug('Enabling thinking for model with reasoning support');
 
       if (this.supportsAdaptiveThinking()) {
-        // Opus 4.6, Opus 4.7, and Sonnet 4.6: use adaptive thinking with effort parameter.
-        // Adaptive thinking lets the model decide when and how much to think,
-        // and automatically enables interleaved thinking between tool calls.
-        // budget_tokens is deprecated on these models.
+        // Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6: use adaptive thinking
+        // with the effort parameter. Adaptive thinking lets the model decide
+        // when and how much to think, and automatically enables interleaved
+        // thinking between tool calls. budget_tokens is deprecated on these
+        // models.
         const effort = this.getAnthropicEffort();
-        // Opus 4.7 defaults display to 'omitted', which suppresses reasoning
+        // Opus 4.7+ defaults display to 'omitted', which suppresses reasoning
         // output. Request 'summarized' so thinking tokens still stream to the
         // user — older adaptive-thinking models already emit reasoning by
         // default and are unaffected.
-        options.thinking = this.isClaudeOpus47()
-          ? { type: 'adaptive', display: 'summarized' }
-          : { type: 'adaptive' };
+        options.thinking =
+          this.isClaudeOpus47() || this.isClaudeOpus48()
+            ? { type: 'adaptive', display: 'summarized' }
+            : { type: 'adaptive' };
         options.output_config = {
           ...options.output_config,
           effort,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1414,7 +1414,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // SDK 0.100.0 reports the thinking-token breakdown of output_tokens, so
       // Anthropic now surfaces reasoning tokens like OpenAI/Google/xAI. This is
       // a subset of outputTokens (already billed), not an additional charge.
-      reasoningTokens: rawUsage.output_tokens_details?.thinking_tokens || undefined,
+      reasoningTokens:
+        rawUsage.output_tokens_details?.thinking_tokens || undefined,
       serverToolRequests:
         (rawUsage.server_tool_use?.web_search_requests ?? 0) +
           (rawUsage.server_tool_use?.web_fetch_requests ?? 0) || undefined,

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -44,16 +44,12 @@ function reconcileEnabledModels(
     }
   }
 
-  // One-time strip for users upgrading past version 15: remove models that
-  // the registry now marks as deprecated so normal dropdowns stay current.
-  if ((previousVersion ?? 0) < 15) {
-    for (const model of currentModels) {
-      if (isDeprecatedModel(model)) strippedSet.add(model);
-    }
-  }
-
-  // One-time strip for users upgrading past version 16: opus47/opus47T are now
-  // deprecated in favor of opus48/opus48T, so re-run the deprecated sweep.
+  // Generic deprecated-model sweep for users upgrading past version 16: remove
+  // models the registry now marks as deprecated so normal dropdowns stay
+  // current. Introduced at version 15 (sonnet/opus tiers) and re-bumped to 16
+  // when opus47/opus47T were deprecated in favor of opus48/opus48T. Bump the
+  // guard to the current MODEL_LIST_VERSION whenever the registry deprecates
+  // more defaults.
   if ((previousVersion ?? 0) < 16) {
     for (const model of currentModels) {
       if (isDeprecatedModel(model)) strippedSet.add(model);

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -52,6 +52,14 @@ function reconcileEnabledModels(
     }
   }
 
+  // One-time strip for users upgrading past version 16: opus47/opus47T are now
+  // deprecated in favor of opus48/opus48T, so re-run the deprecated sweep.
+  if ((previousVersion ?? 0) < 16) {
+    for (const model of currentModels) {
+      if (isDeprecatedModel(model)) strippedSet.add(model);
+    }
+  }
+
   const kept = currentModels.filter((model) => !strippedSet.has(model));
   const added = DEFAULT_MODELS.filter(
     (model) => !kept.includes(model) && !isDeprecatedModel(model),

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -16,7 +16,7 @@ import {
 export const DEFAULT_MODELS = [
   'gemini31p',
   'sonnet46T',
-  'opus47T',
+  'opus48T',
   'gpt55',
   'gpt54',
   'deepseekT',
@@ -25,7 +25,7 @@ export const DEFAULT_MODELS = [
 ];
 
 /** Increment when the persisted model list needs reconciliation. */
-export const MODEL_LIST_VERSION = 15;
+export const MODEL_LIST_VERSION = 16;
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -374,7 +374,7 @@ export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
  * string, but the dropdown is fixed to the canonical Anthropic families. */
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-4-6',
-  'claude-opus-4-7',
+  'claude-opus-4-8',
   'claude-haiku-4-5-20251001',
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -993,7 +993,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(compactionEdit.instructions, undefined);
   });
 
-  it('uses adaptive thinking with max effort for Opus 4.8 xhigh reasoning', async () => {
+  it('uses adaptive thinking with xhigh effort for Opus 4.8 xhigh reasoning', async () => {
     const handler = createAnthropicHandler({
       supportsReasoning: true,
       supportsReasoningEffort: true,
@@ -1039,8 +1039,8 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
     assert.equal(
       options.output_config?.effort,
-      'max',
-      'xhigh reasoning effort should map to max on Opus 4.8',
+      'xhigh',
+      "xhigh reasoning effort should map to the 'xhigh' (extra) tier on Opus 4.8",
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -924,12 +924,12 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('adds native compaction context edit for Claude Opus 4.7 tool-use runs', async () => {
+  it('adds native compaction context edit for Claude Opus 4.8 tool-use runs', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,
       supportsReasoning: false,
     });
-    handler.config.fullName = 'claude-opus-4-7';
+    handler.config.fullName = 'claude-opus-4-8';
     handler.setAgentCategory(AgentCategory.ToolUse);
 
     stubHandlerForTest(handler);
@@ -950,7 +950,7 @@ describe('ModelHandlerAnthropic message guards', () => {
               id: 'msg',
               type: 'message',
               role: 'assistant',
-              model: 'claude-opus-4-7',
+              model: 'claude-opus-4-8',
               content: [{ type: 'text', text: 'ok' }],
               stop_reason: 'end_turn',
               usage: { input_tokens: 1, output_tokens: 1 },
@@ -993,13 +993,13 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(compactionEdit.instructions, undefined);
   });
 
-  it('uses adaptive thinking with max effort for Opus 4.7 xhigh reasoning', async () => {
+  it('uses adaptive thinking with max effort for Opus 4.8 xhigh reasoning', async () => {
     const handler = createAnthropicHandler({
       supportsReasoning: true,
       supportsReasoningEffort: true,
       reasoningEffort: ReasoningEffort.XHIGH,
     });
-    handler.config.fullName = 'claude-opus-4-7';
+    handler.config.fullName = 'claude-opus-4-8';
 
     stubHandlerForTest(handler);
 
@@ -1019,7 +1019,7 @@ describe('ModelHandlerAnthropic message guards', () => {
               id: 'msg',
               type: 'message',
               role: 'assistant',
-              model: 'claude-opus-4-7',
+              model: 'claude-opus-4-8',
               content: [{ type: 'text', text: 'ok' }],
               stop_reason: 'end_turn',
               usage: { input_tokens: 1, output_tokens: 1 },
@@ -1035,12 +1035,12 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(
       options.thinking,
       { type: 'adaptive', display: 'summarized' },
-      'Opus 4.7 should request adaptive thinking with display: summarized so reasoning still streams',
+      'Opus 4.8 should request adaptive thinking with display: summarized so reasoning still streams',
     );
     assert.equal(
       options.output_config?.effort,
       'max',
-      'xhigh reasoning effort should map to max on Opus 4.7',
+      'xhigh reasoning effort should map to max on Opus 4.8',
     );
   });
 

--- a/src/test/tools/DelegationTools.test.ts
+++ b/src/test/tools/DelegationTools.test.ts
@@ -13,7 +13,7 @@ import { WorkspaceFS } from '@utils/files';
 
 const BASE_INPUT: WorkflowAgentInput = {
   agent: 'criticize',
-  model: 'opus47T',
+  model: 'opus48T',
   instruction: 'Review the manuscript.',
   inputFiles: ['main.tex'],
   contextFiles: [],

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -670,7 +670,7 @@ const WorkflowAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      'Model short name (e.g., opus47T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
+      'Model short name (e.g., opus48T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
     ),
   instruction: z
     .string()
@@ -855,7 +855,7 @@ const DelegateAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      'Model short name (e.g., opus47T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
+      'Model short name (e.g., opus48T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
     ),
   instruction: z
     .string()

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -117,7 +117,7 @@ const ClaudeAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      "Claude model to use (e.g. 'claude-sonnet-4-6', 'claude-opus-4-7'). Defaults to user-configured model.",
+      "Claude model to use (e.g. 'claude-sonnet-4-6', 'claude-opus-4-8'). Defaults to user-configured model.",
     ),
   effort: z
     .enum(CLAUDE_AGENT_EFFORT_LEVELS)

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -30,9 +30,10 @@ export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-4-6';
  * so a persisted selection maps forward to Opus 4.8 to keep users on the Opus
  * tier across the bump.
  */
-const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> = {
-  'claude-opus-4-7': 'claude-opus-4-8',
-};
+const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
+  {
+    'claude-opus-4-7': 'claude-opus-4-8',
+  };
 
 export function parseClaudeAgentModel(raw: string): ClaudeAgentModel {
   if ((CLAUDE_AGENT_MODELS as readonly string[]).includes(raw)) {

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -24,10 +24,21 @@ import {
 /** Default Claude model passed to the Agent SDK. */
 export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-4-6';
 
+/**
+ * Models retired from the picker that should resolve to their successor instead
+ * of silently dropping to the Sonnet default. Opus 4.7 was the prior top tier,
+ * so a persisted selection maps forward to Opus 4.8 to keep users on the Opus
+ * tier across the bump.
+ */
+const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> = {
+  'claude-opus-4-7': 'claude-opus-4-8',
+};
+
 export function parseClaudeAgentModel(raw: string): ClaudeAgentModel {
-  return (CLAUDE_AGENT_MODELS as readonly string[]).includes(raw)
-    ? (raw as ClaudeAgentModel)
-    : CLAUDE_AGENT_DEFAULT_MODEL;
+  if ((CLAUDE_AGENT_MODELS as readonly string[]).includes(raw)) {
+    return raw as ClaudeAgentModel;
+  }
+  return RETIRED_CLAUDE_AGENT_MODELS[raw] ?? CLAUDE_AGENT_DEFAULT_MODEL;
 }
 
 export function getClaudeAgentModel(): ClaudeAgentModel {

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -32,7 +32,7 @@ export type ClaudeAgentEffort = (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number];
  * suffix (its only published identifier at time of writing). */
 export const CLAUDE_AGENT_MODELS = [
   'claude-sonnet-4-6',
-  'claude-opus-4-7',
+  'claude-opus-4-8',
   'claude-haiku-4-5-20251001',
 ] as const;
 export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -83,7 +83,7 @@ function abortAfter(ms: number): { signal: AbortSignal; cancel: () => void } {
  * the legacy rewrite while leaving the rest of the path alone.
  */
 function escapeOctokitLegacyTemplate(path: string): string {
-  return path.replace(/:([a-z]\w+)/g, '%3A$1');
+  return path.replaceAll(/:([a-z]\w+)/g, '%3A$1');
 }
 
 export async function ghGet<T>(


### PR DESCRIPTION
Bump llm-zoo to ^1.8.0 (ships opus48/opus48T and marks opus47/opus47T
deprecated) and @anthropic-ai/sdk to ^0.100.0.

Wire Opus 4.8 into the Anthropic model handler with the same adaptive
thinking, 'max' effort, summarized reasoning display, and native
compaction behavior as Opus 4.7. Make opus48T the default Anthropic model
and bump MODEL_LIST_VERSION to 16 so existing users have the now-deprecated
Opus 4.7 swept and Opus 4.8 added. Update the Claude Agent picker, setup
defaults, delegation examples, docs, and tests to reference Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flagship Anthropic routing (effort tiers, defaults, and persisted model lists) and dependency versions that affect all Anthropic API calls; scope is mostly an extension of existing Opus 4.7 behavior with tests updated.
> 
> **Overview**
> Adds **Claude Opus 4.8** (`opus48` / `opus48T`) via **`llm-zoo` ^1.8.0** and **`@anthropic-ai/sdk` ^0.100.0**, replacing Opus 4.7 as the default Anthropic tier across defaults, setup, GitHub code-review docs, relay tier tables, and user-facing guides.
> 
> The **Anthropic handler** treats `claude-opus-4-8` like other adaptive-thinking Opus/Sonnet 4.6 models (1M context, compaction, summarized adaptive thinking) but maps TeXRA **Extra High** reasoning to API **`xhigh`** on 4.8 (4.6/4.7 still use **`max`**). Usage stats now surface **`reasoningTokens`** from the SDK’s thinking-token breakdown.
> 
> **`MODEL_LIST_VERSION` 16** strips registry-deprecated models (including `opus47` / `opus47T`) and adds `opus48T` to default enabled models. **Claude Code** integration switches the picker to **`claude-opus-4-8`** and forwards persisted **`claude-opus-4-7`** selections to 4.8.
> 
> Minor: import reorder in `compareCommands.ts`, delegation tool examples updated, `githubClient` uses `replaceAll` for Octokit path escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6849171f57103044d8e8aafc51b2efbbfcec09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->