### PR TITLE
fix: TUI transcript close chord casing + housekeeping vscode coupling

### DIFF
--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -74,7 +74,7 @@ export function TranscriptViewer({
   }, [maxOffset]);
 
   useInput((input, key) => {
-    if (key.escape || (key.ctrl && input === 't')) onClose();
+    if (key.escape || (key.ctrl && input.toLowerCase() === 't')) onClose();
     else if (key.downArrow) scrollTo((current) => current + 1);
     else if (key.upArrow) scrollTo((current) => current - 1);
     else if (key.pageDown) scrollTo((current) => current + viewRows);

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 
 // Third-party imports
-import * as vscode from 'vscode';
 import { sync as globSync } from 'glob';
 import { MODELS } from 'llm-zoo';
 
@@ -152,13 +151,7 @@ export async function runCleanBuild(): Promise<void> {
 
   for (const dir of buildDirs) {
     try {
-      await vscode.workspace.fs.delete(
-        vscode.Uri.file(path.join(workspacePath, dir)),
-        {
-          recursive: true,
-          useTrash: false,
-        },
-      );
+      await WorkspaceFS.delete(dir, { recursive: true, useTrash: false });
       logger.debug(CHANNEL, `Removed build directory: ${dir}`);
     } catch (err) {
       logger.error(


### PR DESCRIPTION
- Normalize input case in TranscriptViewer close handler so ctrl+t
  toggles the viewer closed even when the terminal delivers uppercase
  'T', matching the open handler's casing normalization (#4553).
- Replace vscode.workspace.fs.delete / vscode.Uri.file in
  runCleanBuild with WorkspaceFS.delete, removing the lone vscode
  import from src/housekeeping/clean.ts (#4532).

https://claude.ai/code/session_01CsKoyrpF1VUp4LAWTNBDRb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX and filesystem abstraction tweaks with no auth, security, or broad behavioral changes.
> 
> **Overview**
> Aligns **TranscriptViewer** close handling with the open chord in `App.tsx` by comparing `input.toLowerCase() === 't'` under Ctrl, so terminals that deliver uppercase `T` can still dismiss the full transcript view.
> 
> In **housekeeping** `runCleanBuild`, recursive build-folder removal now goes through `WorkspaceFS.delete` instead of `vscode.workspace.fs.delete`, dropping the last direct `vscode` dependency from `clean.ts` while keeping the same `recursive` / `useTrash: false` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ac62d7df6c2134d4835965366bd1e07fd7ddb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->