### PR TITLE
docs: resolve doc-sweep drift across guide pages

### DIFF
--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -59,7 +59,7 @@ sequenceDiagram
 1.  **Initialization:** TeXRA loads the agent definition and reads the files you selected.
 2.  **Prompt Construction:** It combines the agent's `systemPrompt`, `userPrefix` (filled with your files and instruction), and `userRequest` templates into a full prompt for the LLM.
 3.  **LLM Interaction (Round 0):** TeXRA sends the prompt to the selected LLM API. The LLM generates a response, typically including reasoning (`<scratchpad>`) and the final answer wrapped in XML tags (e.g., `<document>...</document>`).
-4.  **Processing:** TeXRA saves the raw LLM response (often as an `.xml` file internally). It then parses this file, extracts the content from the primary XML tag (defined by `settings.documentTag`), and saves _that extracted content_ to the final output file in task storage (e.g., `r0/output.tex`). You can monitor this in the [ProgressBoard](./progress-board.md). For LaTeX files, TeXRA can also automatically generate a `latexdiff` file comparing the output to the input, enhancing observability. See the [LaTeX Diff guide](./latex-diff.md) for details.
+4.  **Processing:** TeXRA saves the raw LLM response (often as an `.xml` file internally, e.g., `r{round}/output.xml`). It then parses this file, extracts the content from the primary XML tag (defined by `settings.documentTag`), and saves _that extracted content_ to the final output file in task storage (e.g., `r{round}/output.tex`, so Round 0 is `r0/output.tex`, the first reflection is `r1/output.tex`, and so on). You can monitor this in the [ProgressBoard](./progress-board.md). For LaTeX files, TeXRA can also automatically generate a `latexdiff` file comparing the output to the input, enhancing observability. See the [LaTeX Diff guide](./latex-diff.md) for details.
 
 **Continuation Handling:** If the LLM response gets cut off due to output token limits before generating the required `endTag`, TeXRA automatically sends a continuation prompt. This prompt asks the model to resume generating exactly where it left off, ensuring complete outputs even for very long tasks. This happens seamlessly within a processing round.
 
@@ -73,14 +73,14 @@ When an agent definition includes multiple `userRequest` entries (or increases `
 
 1.  **Reflection Prompt:** It renders the appropriate reflection template from subsequent `userRequest` entries to ask the LLM to critique and improve its own Round 0 output (which is included in the conversation history).
 2.  **LLM Interaction (Round 1):** The LLM generates a revised response.
-3.  **Processing:** TeXRA saves this refined output to a separate round path (e.g., `r1/output.ext`).
+3.  **Processing:** TeXRA saves this refined output to a separate round path (`r{round}/output.ext`, e.g., `r1/output.ext` for the first reflection, `r2/output.ext` for the next).
 
 You can control how many rounds execute by editing the agent YAML—either adjust `settings.rounds` for the maximum number of passes or add more entries to `userRequest`. The run stops early whenever the model signals it is finished or when no reflection prompt content is supplied.
 
 This basic flow, potentially with the reflection rounds, allows TeXRA agents to perform targeted tasks based on their specific definitions and your instructions. For concrete examples of built-in agents, see the [Built-in Agent Reference](./built-in-agents.md).
 
 ::: warning Potential XML Issues
-Occasionally, LLMs might generate slightly malformed XML (e.g., missing closing tags), especially with very long or complex outputs. If TeXRA fails to extract content from an agent's raw XML output (`r0/output.xml` or `r1/output.xml`), you might need to manually inspect the `.xml` file and correct any structural errors (like adding a missing `</document>` tag) before TeXRA can process it correctly. See the [Troubleshooting guide](./troubleshooting.md#output-file-corruption) for more details.
+Occasionally, LLMs might generate slightly malformed XML (e.g., missing closing tags), especially with very long or complex outputs. If TeXRA fails to extract content from an agent's raw XML output (any round's `r{round}/output.xml`, e.g., `r0/output.xml`), you might need to manually inspect the `.xml` file and correct any structural errors (like adding a missing `</document>` tag) before TeXRA can process it correctly. See the [Troubleshooting guide](./troubleshooting.md#output-file-corruption) for more details.
 :::
 
 ### Reflection

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -57,6 +57,7 @@ settings:
   agentCategory: workflow # 'workflow' for structured reasoning with XML-wrapped output, or 'toolUse' for interactive agents that call tools (file editing, web search, etc.)
   temperature: 0.1 # LLM creativity (0.0 = deterministic, >0 = more random). Can be overridden by user settings.
   isRewrite: true # Does the agent primarily rewrite existing content (true) or generate new content (false)?
+  rounds: 2 # Maximum number of passes (Round 0 plus reflection rounds). The actual count is max(rounds, number of userRequest entries); a run can still stop early once the model signals it is finished.
 
   # Output Handling
   documentTag: documents # The main XML tag wrapping the agent's final output (required for CoT).
@@ -74,7 +75,7 @@ settings:
   # filePatternsContain:
   #   - pattern: 'bibliography' # Find files whose names contain this pattern.
   #     varName: BIBLIOGRAPHY # Make content available via {{ BIBLIOGRAPHY_CONTENT }} in prompts.
-  #     categories: ['contextFile', 'contextFiles'] # Search within these UI file categories.
+  #     categories: ['inputFiles', 'contextFiles'] # Search within these UI file categories (e.g. inputFiles, contextFiles, mediaFiles).
   # defaultOutputFiles: # Used when the agent is designed to produce multiple outputs.
   #   - 'introduction.tex'
   #   - 'methods.tex'

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -56,7 +56,11 @@ See [TeXRA CLI](./texra-cli.md) for usage, shell completion, and workspace defau
 
 ## Installing Required Dependencies
 
-Now for the slightly less fun part – making sure TeXRA has all the tools it needs to work its magic. TeXRA relies on several external tools to function properly. Follow the instructions for your operating system.
+Now for the slightly less fun part – making sure TeXRA has the tools it needs. Only a **LaTeX distribution** is strictly required for core document processing; the other tools below unlock specific features (Perl for `latexindent`/`latexdiff`, GraphicsMagick/ImageMagick + Ghostscript for figure and image processing). Install the ones you need and follow the instructions for your operating system.
+
+::: tip Check what's detected with `texra doctor`
+Run `texra doctor` to see what TeXRA found. It reports the LaTeX toolchain (`latexmk`, `pdflatex`, `xelatex`, `lualatex`, `bibtex`, `biber`, `latexdiff`, `latexindent`) along with Node.js, authentication, and model availability. The optional image tools (GraphicsMagick/ImageMagick, Ghostscript) and Wolfram are checked on demand the first time you use a feature that needs them, rather than up front.
+:::
 
 ### Homebrew (macOS only) {#homebrew}
 
@@ -141,8 +145,8 @@ pdflatex --version
 
 ### Perl
 
-::: info
-Perl is required for LaTeX tools and document processing.
+::: info OPTIONAL
+Perl backs the `latexindent` and `latexdiff` LaTeX tools (both are Perl scripts). Install it only if you use auto-formatting or LaTeX diffs — it's usually already bundled with MiKTeX/TeX Live and pre-installed on macOS/Linux.
 :::
 
 #### Windows
@@ -163,8 +167,8 @@ sudo apt-get install perl
 
 ### GraphicsMagick/ImageMagick
 
-::: tip RECOMMENDED
-GraphicsMagick is the recommended option for better performance.
+::: tip OPTIONAL
+Needed only for TeXRA's figure and image processing features. GraphicsMagick is the recommended option for better performance; ImageMagick is a drop-in alternative.
 :::
 
 #### GraphicsMagick
@@ -207,8 +211,8 @@ sudo apt-get install imagemagick
 
 ### Ghostscript
 
-::: warning REQUIRED
-Ghostscript is required by GraphicsMagick/ImageMagick for PDF processing.
+::: info OPTIONAL
+Ghostscript is used by GraphicsMagick/ImageMagick to rasterize PDF figures. Install it alongside GraphicsMagick/ImageMagick only if you use TeXRA's figure/image processing features.
 :::
 
 #### Windows

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -53,7 +53,7 @@ The header provides a summary and actions for the selected stream:
   - **Grey (Stopped)**: The agent finished successfully or was stopped manually before completion.
   - **Red (Error)**: The agent encountered an error during execution.
   - **Yellow (Ready/Initial)**: The view is ready, but no stream is active yet.
-- **Token & Cost Summary**: Displays the combined input and output token counts from all completed rounds (`r0` and `r1`) along with the estimated cost.
+- **Token & Cost Summary**: Displays the combined input and output token counts from all completed rounds (e.g., `r0`, `r1`, `r2`, …) along with the estimated cost.
 - **Stream Header Actions**:
   - <wa-icon library="texra" name="debug-stop"></wa-icon> **Stop**: Attempts to gracefully stop the currently running task for this stream. For providers supporting `AbortController` (like OpenAI or Anthropic) the active request is aborted immediately; otherwise the current API call will finish before stopping.
   - <wa-icon library="texra" name="debug-rerun"></wa-icon> **Run Again**: Re-runs the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction) that was used when it originally ran. Useful for retrying failed tasks or reproducing results.

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -51,7 +51,7 @@ The `web_search` tool prefers the active provider's native search (Anthropic, Op
 
 ### <wa-icon library="texra" name="book"></wa-icon> Manage References with Zotero
 
-If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Make sure Zotero is running while you use these features — check status on **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>) → **Academic Research** (<wa-icon library="texra" name="mortar-board"></wa-icon>).
+If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Make sure Zotero is running while you use these features — check status on **Dashboard → Integrations** (<wa-icon library="texra" name="robot"></wa-icon>).
 
 ```
 Search my Zotero library for papers by Vaswani on attention mechanisms.

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -32,7 +32,7 @@ read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
 documents for the selected inputs:
 
 ```bash
-texra run firstread --input appendices.tex --context Draft0.tex --context refs.bib
+texra run correct --input appendices.tex --context Draft0.tex --context refs.bib
 ```
 
 Pass multiple inputs with repeated `--input` flags, a directory, or a glob.
@@ -41,8 +41,8 @@ their generated artifacts to a directory with `--output-dir`; relative document
 paths are preserved under that directory:
 
 ```bash
-texra run firstread --input Draft0.tex --input appendices.tex --output-dir flagged
-texra run logic --input 'paper/**/*.tex' --output-dir logic-pass
+texra run polish --input Draft0.tex --input appendices.tex --output-dir polished
+texra run correct --input 'paper/**/*.tex' --output-dir corrected
 ```
 
 Workflow agents always write generated files into the execution's run-storage

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -154,7 +154,13 @@ interface TierModelConfig {
 
 ## Model Names
 
-Model names must match the short names defined in `src/model/ModelRegistry.ts`.
+Model names must match the short names defined by the [`llm-zoo`](https://www.npmjs.com/package/llm-zoo) package's `MODEL_CONFIGS` — the same source of truth `src/model/modelOptionsBasic.ts` and the relay function (`supabase/functions/relay/models.ts`) both import.
+
+::: warning Auto-derived snapshot
+The model rows and prices below are a **snapshot of `llm-zoo` `MODEL_CONFIGS`**. The relay builds its model list and tier assignments automatically from that package (see [Single Source of Truth](#single-source-of-truth)), so individual IDs and prices here drift whenever `llm-zoo` is bumped. Treat the tables as illustrative and re-derive from `MODEL_CONFIGS` before relying on a specific value.
+
+**Prices last verified against `llm-zoo`: 2026-05-28.**
+:::
 
 ### Free / Max Tier Models (≤$3/M Input)
 
@@ -200,11 +206,12 @@ Available to Ultra tier subscribers only (includes all lower tier models).
 
 ### Single Source of Truth
 
-The relay function uses a `RELAY_MODELS` array as the single source of truth. Each model entry specifies:
+The relay function builds its `RELAY_MODELS` array automatically from the `llm-zoo` package's `MODEL_CONFIGS` (every non-`openRouterOnly` model), so no model list is hand-maintained. Each derived entry specifies:
 
-- `shortName`: UI identifier
-- `apiPatterns`: API name prefixes for server-side validation
-- `minTier`: Minimum tier required ('free' or 'Ultra' — free and Max share the same ≤$3 cutoff)
+- `shortName`: UI identifier (from `config.name`)
+- `apiPatterns`: API name prefixes for server-side validation (from `config.fullName`)
+- `inputPrice`: input price per 1M tokens (from `config.inputPrice`)
+- `minTier`: minimum tier required, computed from `inputPrice` — `≤$3` → `free`, `>$3` → `Ultra`. (Free and Max share the same ≤$3 cutoff, so all non-Ultra models are assigned `free`.)
 
 Tier-specific arrays are derived automatically:
 


### PR DESCRIPTION
Address the doc-sweep issues #4557–#4564:

- agent-architecture.md / progress-board.md (#4557): replace hardcoded
  r0/r1 round assumptions with the canonical r{round}/output.ext path
  format so r2, r3, … are clearly possible.
- texra-cli.md (#4558): replace firstread/logic examples (reference-only
  agents) with built-in equivalents (correct, polish).
- custom-agents.md (#4559): document the `rounds` setting and fix the
  filePatternsContain `categories` example to use real category names
  (inputFiles/contextFiles/mediaFiles).
- research-tools.md (#4560): Zotero status lives under Dashboard →
  Integrations (ai-agents category), not Tools → Academic Research.
- installation.md (#4563): distinguish the required LaTeX distribution
  from feature-specific optional tools (Perl, GraphicsMagick/ImageMagick,
  Ghostscript) and document what `texra doctor` actually probes.
- relay-tier-config.md (#4564): point at the real source of truth
  (llm-zoo MODEL_CONFIGS, not the nonexistent ModelRegistry.ts), describe
  the auto-derived tier assignment, and stamp the verification date.

Verified #4561 (README/CHANGELOG) and #4562 (lean.md) against source with
no actionable drift: README is intentionally version-agnostic and its
commands resolve; lean team presets and the Loogle endpoint match code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates with no runtime or API changes; risk is limited to doc accuracy, which was cross-checked against relay/model sources in the PR description.
> 
> **Overview**
> This PR **aligns user-facing docs with current product behavior** after a doc-sweep (issues #4557–#4564): no application code changes.
> 
> **Workflow rounds & paths:** `agent-architecture.md` and `progress-board.md` stop implying only `r0`/`r1`; they document the generic `r{round}/output.*` layout and token totals across arbitrary reflection rounds.
> 
> **Custom agents & CLI:** `custom-agents.md` documents `settings.rounds` and fixes `filePatternsContain` categories to real picker names (`inputFiles`, `contextFiles`, `mediaFiles`). `texra-cli.md` swaps reference-only `firstread`/`logic` examples for built-in **`correct`** and **`polish`**.
> 
> **Install & integrations:** `installation.md` separates **required** LaTeX from **optional** Perl / image stack tools, adds what **`texra doctor`** checks up front vs on-demand, and retags callouts accordingly. `research-tools.md` points Zotero status to **Dashboard → Integrations** instead of Tools → Academic Research.
> 
> **Relay tiers:** `relay-tier-config.md` replaces the obsolete `ModelRegistry.ts` pointer with **`llm-zoo` `MODEL_CONFIGS`**, explains auto-derived relay models/tiers from pricing, and marks model tables as a dated snapshot (2026-05-28).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ddec3440aac0857a13f8d81b7981489227ae40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->