### PR TITLE
refactor(webview): consolidate message-handler dispatch and panel buttons

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -1,15 +1,16 @@
 // `/agent` form. It lists visible tool-use agents and workflows. Before the
 // first message, tool-use agents can be chosen as the root chat agent.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
 
 import { computeAgentOptionsData } from '@agent/index';
 import type { AgentOptionData } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
+import { FormFrame } from './_shared/FormFrame';
+import { useAsyncListForm } from './_shared/useAsyncListForm';
 
 export interface AgentListFormProps {
   readonly currentAgent: string;
@@ -22,34 +23,6 @@ export interface AgentListFormProps {
 interface AgentGroups {
   readonly toolUse: readonly AgentOptionData[];
   readonly workflow: readonly AgentOptionData[];
-}
-
-interface AgentFrameProps {
-  readonly color: string;
-  readonly title: string;
-  readonly children: React.ReactNode;
-}
-
-function AgentFrame(props: AgentFrameProps): React.JSX.Element {
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={props.color}
-      flexDirection="column"
-      paddingX={1}
-    >
-      <Text bold color={props.color}>
-        {props.title}
-      </Text>
-      {props.children}
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[{ key: 'Esc', action: 'close' }]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
-  );
 }
 
 function agentDescription(agent: AgentOptionData): string {
@@ -135,56 +108,31 @@ export function agentSelectWindow({
 }
 
 export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
-  const [agents, setAgents] = useState<AgentGroups>({
-    toolUse: [],
-    workflow: [],
+  const { data, loading, error } = useAsyncListForm<AgentGroups>({
+    load: async () => {
+      const options = await computeAgentOptionsData();
+      return { toolUse: options.toolUse, workflow: options.workflow };
+    },
+    onClose: props.onClose,
   });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useInput((_input, key) => {
-    if ((loading || error) && key.escape) {
-      props.onClose();
-    }
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-    void computeAgentOptionsData()
-      .then((options) => {
-        if (cancelled) return;
-        setAgents({
-          toolUse: options.toolUse,
-          workflow: options.workflow,
-        });
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   if (loading) {
     return (
-      <AgentFrame color="cyan" title="/agent">
+      <FormFrame color="cyan" title="/agent">
         <Spinner label="Loading agent registry..." />
-      </AgentFrame>
+      </FormFrame>
     );
   }
 
   if (error) {
     return (
-      <AgentFrame color="red" title="/agent - error">
+      <FormFrame color="red" title="/agent - error">
         <Text>{error}</Text>
-      </AgentFrame>
+      </FormFrame>
     );
   }
 
+  const agents: AgentGroups = data ?? { toolUse: [], workflow: [] };
   const selectable = props.selectable === true;
   const items = agents.toolUse.map((agent) => ({
     value: agent.label,

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -35,8 +35,7 @@ export function memorySelectWindow(args: {
 
 export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
   const { data, loading, error } = useAsyncListForm<readonly MemoryViewItem[]>({
-    load: async () =>
-      (await loadMemoryItems()).slice(0, CLI_MEMORY_LIST_LIMIT),
+    load: async () => (await loadMemoryItems()).slice(0, CLI_MEMORY_LIST_LIMIT),
     onClose: props.onClose,
     isEmpty: (entries) => entries.length === 0,
   });

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -1,9 +1,8 @@
 // `/memory` form. It lists stored memory files and opens a preview when a
 // memory is selected.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
 
 import {
   CLI_MEMORY_LIST_LIMIT,
@@ -14,6 +13,12 @@ import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
+import { FormFrame } from './_shared/FormFrame';
+import {
+  computeSelectWindowSize,
+  type SelectWindowSize,
+} from './_shared/selectWindow';
+import { useAsyncListForm } from './_shared/useAsyncListForm';
 
 export interface MemoryListFormProps {
   readonly availableRows?: number;
@@ -21,106 +26,43 @@ export interface MemoryListFormProps {
   readonly onClose: () => void;
 }
 
-export function memorySelectWindow({
-  availableRows,
-  itemCount,
-}: {
+export function memorySelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
-}): {
-  readonly maxVisibleItems: number | undefined;
-  readonly showOverflow: boolean;
-} {
-  if (availableRows == null) {
-    return { maxVisibleItems: undefined, showOverflow: false };
-  }
-
-  const selectRows = Math.max(1, availableRows - 7);
-  if (itemCount <= selectRows) {
-    return { maxVisibleItems: itemCount, showOverflow: false };
-  }
-  if (selectRows < 3) {
-    return { maxVisibleItems: selectRows, showOverflow: false };
-  }
-  return { maxVisibleItems: Math.max(1, selectRows - 2), showOverflow: true };
-}
-
-function MemoryFrame(props: {
-  readonly color: string;
-  readonly title: string;
-  readonly children: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={props.color}
-      flexDirection="column"
-      paddingX={1}
-    >
-      <Text bold color={props.color}>
-        {props.title}
-      </Text>
-      {props.children}
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[{ key: 'Esc', action: 'close' }]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
-  );
+}): SelectWindowSize {
+  return computeSelectWindowSize({ ...args, chromeRows: 7 });
 }
 
 export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
-  const [items, setItems] = useState<readonly MemoryViewItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useInput((_input, key) => {
-    if ((loading || error || items.length === 0) && key.escape) {
-      props.onClose();
-    }
+  const { data, loading, error } = useAsyncListForm<readonly MemoryViewItem[]>({
+    load: async () =>
+      (await loadMemoryItems()).slice(0, CLI_MEMORY_LIST_LIMIT),
+    onClose: props.onClose,
+    isEmpty: (entries) => entries.length === 0,
   });
-
-  useEffect(() => {
-    let cancelled = false;
-    void loadMemoryItems()
-      .then((nextItems) => {
-        if (cancelled) return;
-        setItems(nextItems.slice(0, CLI_MEMORY_LIST_LIMIT));
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   if (loading) {
     return (
-      <MemoryFrame color="cyan" title="/memory">
+      <FormFrame color="cyan" title="/memory">
         <Spinner label="Loading memories..." />
-      </MemoryFrame>
+      </FormFrame>
     );
   }
 
   if (error) {
     return (
-      <MemoryFrame color="red" title="/memory - error">
+      <FormFrame color="red" title="/memory - error">
         <Text>{error}</Text>
-      </MemoryFrame>
+      </FormFrame>
     );
   }
 
+  const items = data ?? [];
   if (items.length === 0) {
     return (
-      <MemoryFrame color="yellow" title="/memory">
+      <FormFrame color="yellow" title="/memory">
         <Text>No memory files found.</Text>
-      </MemoryFrame>
+      </FormFrame>
     );
   }
 

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -2,9 +2,8 @@
 // Before the first message it can choose the root model; after that it is
 // read-only because an active conversation owns a concrete model handler.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
 
 import {
   getCliModelAccessList,
@@ -13,6 +12,12 @@ import {
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
 import { Select } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
+import { FormFrame } from './_shared/FormFrame';
+import {
+  computeSelectWindowSize,
+  type SelectWindowSize,
+} from './_shared/selectWindow';
+import { useAsyncListForm } from './_shared/useAsyncListForm';
 
 export interface ModelListFormProps {
   readonly currentModel: string;
@@ -21,34 +26,6 @@ export interface ModelListFormProps {
   readonly selectable?: boolean;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
-}
-
-interface ModelFrameProps {
-  readonly color: string;
-  readonly title: string;
-  readonly children: React.ReactNode;
-}
-
-function ModelFrame(props: ModelFrameProps): React.JSX.Element {
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={props.color}
-      flexDirection="column"
-      paddingX={1}
-    >
-      <Text bold color={props.color}>
-        {props.title}
-      </Text>
-      {props.children}
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[{ key: 'Esc', action: 'close' }]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
-  );
 }
 
 export function formatModelStatusForCliMode(
@@ -75,82 +52,36 @@ export function formatModelStatusForCliMode(
   }
 }
 
-export function modelSelectWindow({
-  availableRows,
-  itemCount,
-}: {
+export function modelSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
-}): {
-  readonly maxVisibleItems: number | undefined;
-  readonly showOverflow: boolean;
-} {
-  if (availableRows == null) {
-    return { maxVisibleItems: undefined, showOverflow: false };
-  }
-
+}): SelectWindowSize {
   // Border, title, description, and key hints are the irreducible chrome.
-  const selectRows = Math.max(1, availableRows - 5);
-  if (itemCount <= selectRows) {
-    return { maxVisibleItems: itemCount, showOverflow: false };
-  }
-
-  // Overflow markers cost rows too. On very short terminals, keep the active
-  // choice visible instead of spending the whole budget on markers.
-  if (selectRows < 3) {
-    return { maxVisibleItems: selectRows, showOverflow: false };
-  }
-
-  return {
-    maxVisibleItems: Math.max(1, selectRows - 2),
-    showOverflow: true,
-  };
+  return computeSelectWindowSize({ ...args, chromeRows: 5 });
 }
 
 export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
-  const [models, setModels] = useState<readonly CliModelAccess[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useInput((_input, key) => {
-    if ((loading || error) && key.escape) {
-      props.onClose();
-    }
+  const { data, loading, error } = useAsyncListForm<readonly CliModelAccess[]>({
+    load: getCliModelAccessList,
+    onClose: props.onClose,
   });
-
-  useEffect(() => {
-    let cancelled = false;
-    void getCliModelAccessList()
-      .then((list) => {
-        if (cancelled) return;
-        setModels(list);
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   if (loading) {
     return (
-      <ModelFrame color="cyan" title="/model">
+      <FormFrame color="cyan" title="/model">
         <Spinner label="Loading model registry..." />
-      </ModelFrame>
+      </FormFrame>
     );
   }
   if (error) {
     return (
-      <ModelFrame color="red" title="/model - error">
+      <FormFrame color="red" title="/model - error">
         <Text>{error}</Text>
-      </ModelFrame>
+      </FormFrame>
     );
   }
 
+  const models = data ?? [];
   const items = models.map((m) => ({
     value: m.model.value,
     label: m.model.label || m.model.value,

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -1,9 +1,8 @@
 // `/resume` form. It lists recent execution configurations that can be
 // restarted in the current chat TUI.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
 
 import {
   listCliHistoryEntries,
@@ -13,6 +12,12 @@ import type { ExecutionId } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
+import { FormFrame } from './_shared/FormFrame';
+import {
+  computeSelectWindowSize,
+  type SelectWindowSize,
+} from './_shared/selectWindow';
+import { useAsyncListForm } from './_shared/useAsyncListForm';
 
 export interface ResumeListFormProps {
   readonly availableRows?: number;
@@ -20,28 +25,11 @@ export interface ResumeListFormProps {
   readonly onClose: () => void;
 }
 
-export function resumeSelectWindow({
-  availableRows,
-  itemCount,
-}: {
+export function resumeSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
-}): {
-  readonly maxVisibleItems: number | undefined;
-  readonly showOverflow: boolean;
-} {
-  if (availableRows == null) {
-    return { maxVisibleItems: undefined, showOverflow: false };
-  }
-
-  const selectRows = Math.max(1, availableRows - 7);
-  if (itemCount <= selectRows) {
-    return { maxVisibleItems: itemCount, showOverflow: false };
-  }
-  if (selectRows < 3) {
-    return { maxVisibleItems: selectRows, showOverflow: false };
-  }
-  return { maxVisibleItems: Math.max(1, selectRows - 2), showOverflow: true };
+}): SelectWindowSize {
+  return computeSelectWindowSize({ ...args, chromeRows: 7 });
 }
 
 export function resumeEntryDescription(entry: CliHistoryEntry): string {
@@ -49,82 +37,37 @@ export function resumeEntryDescription(entry: CliHistoryEntry): string {
   return `${entry.timestamp}; ${entry.agent}; ${entry.status}; ${input}`;
 }
 
-function ResumeFrame(props: {
-  readonly color: string;
-  readonly title: string;
-  readonly children: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={props.color}
-      flexDirection="column"
-      paddingX={1}
-    >
-      <Text bold color={props.color}>
-        {props.title}
-      </Text>
-      {props.children}
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[{ key: 'Esc', action: 'close' }]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
-  );
-}
-
 export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
-  const [entries, setEntries] = useState<readonly CliHistoryEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useInput((_input, key) => {
-    if ((loading || error || entries.length === 0) && key.escape) {
-      props.onClose();
-    }
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-    void listCliHistoryEntries()
-      .then((nextEntries) => {
-        if (cancelled) return;
-        setEntries(nextEntries.slice(0, 50));
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const { data, loading, error } = useAsyncListForm<readonly CliHistoryEntry[]>(
+    {
+      load: async () => (await listCliHistoryEntries()).slice(0, 50),
+      onClose: props.onClose,
+      isEmpty: (entries) => entries.length === 0,
+    },
+  );
 
   if (loading) {
     return (
-      <ResumeFrame color="cyan" title="/resume">
+      <FormFrame color="cyan" title="/resume">
         <Spinner label="Loading execution history..." />
-      </ResumeFrame>
+      </FormFrame>
     );
   }
 
   if (error) {
     return (
-      <ResumeFrame color="red" title="/resume - error">
+      <FormFrame color="red" title="/resume - error">
         <Text>{error}</Text>
-      </ResumeFrame>
+      </FormFrame>
     );
   }
 
+  const entries = data ?? [];
   if (entries.length === 0) {
     return (
-      <ResumeFrame color="yellow" title="/resume">
+      <FormFrame color="yellow" title="/resume">
         <Text>No execution history found.</Text>
-      </ResumeFrame>
+      </FormFrame>
     );
   }
 

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -1,9 +1,8 @@
 // `/tools` form. It mirrors `texra tools list` inside an active TUI session
 // and toggles integrations that are marked toggleable in EXTERNAL_TOOL_DEFS.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
 
 import {
   formatCliBoolean,
@@ -13,32 +12,16 @@ import {
 } from '@cli/runtime/tools';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
+import { FormFrame } from './_shared/FormFrame';
+import {
+  computeSelectWindowSize,
+  type SelectWindowSize,
+} from './_shared/selectWindow';
+import { useAsyncListForm } from './_shared/useAsyncListForm';
 
 export interface ToolsListFormProps {
   readonly availableRows?: number;
   readonly onClose: () => void;
-}
-
-interface ToolsFrameProps {
-  readonly color: string;
-  readonly title: string;
-  readonly children: React.ReactNode;
-}
-
-function ToolsFrame(props: ToolsFrameProps): React.JSX.Element {
-  return (
-    <Box
-      borderStyle="round"
-      borderColor={props.color}
-      flexDirection="column"
-      paddingX={1}
-    >
-      <Text bold color={props.color}>
-        {props.title}
-      </Text>
-      {props.children}
-    </Box>
-  );
 }
 
 function toolDescription(tool: CliToolStatusRecord): string {
@@ -48,72 +31,41 @@ function toolDescription(tool: CliToolStatusRecord): string {
   return `${enabled}; ${detected}; ${status}`;
 }
 
-function toolsSelectWindow({
-  availableRows,
-  itemCount,
-}: {
+function toolsSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
-}): {
-  readonly maxVisibleItems: number | undefined;
-  readonly showOverflow: boolean;
-} {
-  if (availableRows == null) {
-    return { maxVisibleItems: undefined, showOverflow: false };
-  }
-  const selectRows = Math.max(1, availableRows - 5);
-  if (itemCount <= selectRows) {
-    return { maxVisibleItems: itemCount, showOverflow: false };
-  }
-  if (selectRows < 3) {
-    return { maxVisibleItems: selectRows, showOverflow: false };
-  }
-  return { maxVisibleItems: selectRows - 2, showOverflow: true };
+}): SelectWindowSize {
+  return computeSelectWindowSize({ ...args, chromeRows: 5 });
 }
 
 export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
-  const [tools, setTools] = useState<readonly CliToolStatusRecord[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>(undefined);
-
-  useInput((_input, key) => {
-    if ((loading || error) && key.escape) props.onClose();
+  const {
+    data,
+    loading,
+    error,
+    setData: setTools,
+  } = useAsyncListForm<readonly CliToolStatusRecord[]>({
+    load: readCliToolStatuses,
+    onClose: props.onClose,
   });
-
-  useEffect(() => {
-    let cancelled = false;
-    void readCliToolStatuses()
-      .then((list) => {
-        if (cancelled) return;
-        setTools(list);
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   if (loading) {
     return (
-      <ToolsFrame color="cyan" title="/tools">
+      <FormFrame color="cyan" title="/tools" showCloseHint={false}>
         <Spinner label="Checking tool integrations..." />
-      </ToolsFrame>
+      </FormFrame>
     );
   }
 
   if (error) {
     return (
-      <ToolsFrame color="red" title="/tools - error">
+      <FormFrame color="red" title="/tools - error" showCloseHint={false}>
         <Text>{error}</Text>
-      </ToolsFrame>
+      </FormFrame>
     );
   }
 
+  const tools = data ?? [];
   const selectWindow = toolsSelectWindow({
     availableRows: props.availableRows,
     itemCount: tools.length,
@@ -126,7 +78,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
   }));
 
   return (
-    <ToolsFrame color="cyan" title="/tools">
+    <FormFrame color="cyan" title="/tools" showCloseHint={false}>
       <Text dimColor>Toggle available external integrations.</Text>
       <Select
         items={items}
@@ -151,6 +103,6 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
           confirmCancel={false}
         />
       </Box>
-    </ToolsFrame>
+    </FormFrame>
   );
 }

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -4,7 +4,7 @@
 
 import { Box, Text } from 'ink';
 
-import { KeyHints } from '../../ui/KeyHints';
+import { KeyHints } from '@cli/chat/tui/ui/KeyHints';
 
 export interface FormFrameProps {
   readonly color: string;

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -1,0 +1,42 @@
+// Shared rounded panel used by `/`-form transient states (loading, error, and
+// empty). Replaces the per-form `XFrame` wrappers that all rendered the same
+// bordered column with a colored title and an `Esc close` footer.
+
+import { Box, Text } from 'ink';
+
+import { KeyHints } from '../../ui/KeyHints';
+
+export interface FormFrameProps {
+  readonly color: string;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  /**
+   * Append the canonical `Esc close` footer. Forms whose transient states
+   * carry their own footer (or none, like `/tools`) pass `false`.
+   */
+  readonly showCloseHint?: boolean;
+}
+
+export function FormFrame(props: FormFrameProps): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={props.color}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={props.color}>
+        {props.title}
+      </Text>
+      {props.children}
+      {props.showCloseHint === false ? null : (
+        <Box marginTop={1}>
+          <KeyHints
+            hints={[{ key: 'Esc', action: 'close' }]}
+            confirmCancel={false}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
@@ -1,0 +1,43 @@
+// Shared row-budget math for `/`-form select lists. Every list form windows
+// its `Select` to the foreground rows the live region grants it, reserving a
+// fixed number of chrome rows (border, title, description, key hints). The only
+// per-form difference is that chrome-row count, so the policy lives here once.
+
+export interface SelectWindowSize {
+  readonly maxVisibleItems: number | undefined;
+  readonly showOverflow: boolean;
+}
+
+/**
+ * Decide how many list rows a form's `Select` may show and whether to spend
+ * rows on overflow markers.
+ *
+ * - When `availableRows` is unknown, the caller has no row budget: show
+ *   everything (`maxVisibleItems: undefined`) and no overflow marker.
+ * - Otherwise reserve `chromeRows` for the frame and key hints, then fit the
+ *   list into what remains. On very short terminals (fewer than 3 list rows)
+ *   keep the active choice visible instead of spending the whole budget on
+ *   overflow markers.
+ */
+export function computeSelectWindowSize({
+  availableRows,
+  itemCount,
+  chromeRows,
+}: {
+  readonly availableRows: number | undefined;
+  readonly itemCount: number;
+  readonly chromeRows: number;
+}): SelectWindowSize {
+  if (availableRows == null) {
+    return { maxVisibleItems: undefined, showOverflow: false };
+  }
+
+  const selectRows = Math.max(1, availableRows - chromeRows);
+  if (itemCount <= selectRows) {
+    return { maxVisibleItems: itemCount, showOverflow: false };
+  }
+  if (selectRows < 3) {
+    return { maxVisibleItems: selectRows, showOverflow: false };
+  }
+  return { maxVisibleItems: Math.max(1, selectRows - 2), showOverflow: true };
+}

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -1,0 +1,76 @@
+// Shared data-load lifecycle for `/`-form list forms. Each form fetched its
+// list in a cancellable `useEffect`, tracked `loading` / `error`, and let `Esc`
+// close the panel while it had nothing actionable to show. That triad was
+// copied verbatim across every list form; it lives here once.
+
+import { useInput } from 'ink';
+import { useEffect, useState } from 'react';
+
+export interface AsyncListFormState<T> {
+  readonly data: T | undefined;
+  readonly loading: boolean;
+  readonly error: string | undefined;
+  /**
+   * Replace the loaded data after mount. Used by forms whose loaded list is
+   * mutable in place (e.g. `/tools` re-reading statuses after a toggle).
+   */
+  readonly setData: (next: T) => void;
+}
+
+export interface UseAsyncListFormOptions<T> {
+  /** Loads the form's data once on mount. */
+  readonly load: () => Promise<T>;
+  /** Close handler invoked when `Esc` is pressed in a non-actionable state. */
+  readonly onClose: () => void;
+  /**
+   * Returns true when loaded `data` has nothing to act on (e.g. an empty
+   * list), so `Esc` should also close. Forms whose loaded state is always
+   * actionable can omit this.
+   */
+  readonly isEmpty?: (data: T) => boolean;
+}
+
+/**
+ * Run the form's loader on mount, expose `loading` / `error` / `data`, and wire
+ * `Esc` to close while the panel is loading, errored, or empty. Matches the
+ * hand-rolled effect each form previously carried, including the
+ * cancellation guard that drops a resolved promise after unmount.
+ */
+export function useAsyncListForm<T>(
+  options: UseAsyncListFormOptions<T>,
+): AsyncListFormState<T> {
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const empty =
+    data !== undefined && options.isEmpty ? options.isEmpty(data) : false;
+
+  useInput((_input, key) => {
+    if ((loading || error !== undefined || empty) && key.escape) {
+      options.onClose();
+    }
+  });
+
+  const { load } = options;
+  useEffect(() => {
+    let cancelled = false;
+    void load()
+      .then((result) => {
+        if (cancelled) return;
+        setData(result);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Load once on mount, matching the original per-form `useEffect(..., [])`.
+  }, []);
+
+  return { data, loading, error, setData };
+}

--- a/packages/cli/src/commands/_helpers/defineCliCommand.ts
+++ b/packages/cli/src/commands/_helpers/defineCliCommand.ts
@@ -1,0 +1,71 @@
+import { defineCommand, type ArgsDef, type CommandDef } from 'citty';
+
+import { writeErrorStderr } from '@cli/runtime/logSinks';
+import type { ParsedGlobalArgs } from '@cli/runtime/globalArgs';
+
+import type { CliContext } from '@cli/runtime/cliContext';
+
+import { contextFromArgs } from './context';
+import { setExitCode } from './exitCode';
+
+// citty hands `run` a context whose `args` is keyed by the command's `ArgsDef`.
+// We mirror that shape so handlers keep full literal-typed access to `ctx.args`
+// and `ctx.rawArgs`, exactly as a hand-written `defineCommand` would.
+type CliCommandRunContext<A extends ArgsDef> = Parameters<
+  NonNullable<CommandDef<A>['run']>
+>[0];
+
+export interface DefineCliCommandOptions<A extends ArgsDef> {
+  readonly meta: CommandDef<A>['meta'];
+  readonly args?: A;
+  /**
+   * Core handler. Receives the already-built `CliContext` (with config
+   * warnings surfaced by `contextFromArgs`) and citty's run context, and
+   * returns the process exit code. The return value is forwarded to
+   * `setExitCode`, so a handler reduces to "do the work, return a code".
+   */
+  readonly run: (
+    context: CliContext,
+    ctx: CliCommandRunContext<A>,
+  ) => Promise<number>;
+  /**
+   * When set, the handler is wrapped in a try/catch that writes the error
+   * message to stderr and assigns this exit code — replacing the per-command
+   * `catch (error) { writeTextStderr(toErrorMessage(error)); setExitCode(...) }`
+   * boilerplate. Omit it for commands that rely on `runCli`'s top-level
+   * `CliUsageError` handling instead.
+   */
+  readonly catchExitCode?: number;
+}
+
+/**
+ * Folds the `contextFromArgs` → `setExitCode(await handler(...))` boilerplate
+ * (optionally with the error→stderr+exit-code catch) that every headless
+ * command repeats into one declaration. Behavior is identical to the manual
+ * form; only the scaffolding moves here.
+ */
+export function defineCliCommand<A extends ArgsDef>(
+  options: DefineCliCommandOptions<A>,
+): CommandDef<A> {
+  return defineCommand<A>({
+    meta: options.meta,
+    args: options.args,
+    async run(ctx) {
+      // citty's `ctx.args` for a generic `ArgsDef` widens past the precise
+      // `ParsedGlobalArgs` shape; every command that uses this helper spreads
+      // `GLOBAL_ARGS` (or supplies `cwd`), so the parsed object carries the
+      // global flags `contextFromArgs` reads.
+      const context = await contextFromArgs(ctx.args as ParsedGlobalArgs);
+      if (options.catchExitCode === undefined) {
+        setExitCode(await options.run(context, ctx as CliCommandRunContext<A>));
+        return;
+      }
+      try {
+        setExitCode(await options.run(context, ctx as CliCommandRunContext<A>));
+      } catch (error) {
+        writeErrorStderr(error);
+        setExitCode(options.catchExitCode);
+      }
+    },
+  });
+}

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -8,8 +8,7 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import { agentsRunCommand } from './agentsRun';
@@ -83,18 +82,15 @@ async function showAgent(context: CliContext, name: string): Promise<number> {
   return CliExitCode.Success;
 }
 
-const agentsListCommand = defineCommand({
+const agentsListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List available agents' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await listAgents(context));
-  },
+  run: (context) => listAgents(context),
 });
 
-const agentsShowCommand = defineCommand({
+const agentsShowCommand = defineCliCommand({
   meta: { name: 'show', description: 'Show one agent' },
   args: {
     ...GLOBAL_ARGS,
@@ -105,10 +101,7 @@ const agentsShowCommand = defineCommand({
         'Agent name from `texra agents list` (use `source:name` to disambiguate when the same name exists in multiple sources)',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await showAgent(context, ctx.args.name));
-  },
+  run: (context, ctx) => showAgent(context, ctx.args.name),
 });
 
 export const agentsCommand = defineCommand({

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -1,8 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { defineCommand } from 'citty';
-
 import { getAgent, loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
@@ -11,7 +9,6 @@ import {
 } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
@@ -23,11 +20,10 @@ import {
 import { CliUsageError, type CliContext } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr } from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
@@ -137,7 +133,7 @@ async function runToolUseAgent(
     if (!(error instanceof CliUsageError)) {
       throw error;
     }
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.Usage;
   }
 
@@ -200,7 +196,7 @@ async function runToolUseAgent(
   return terminalStatusExitCode(terminalStatus, runContext);
 }
 
-export const agentsRunCommand = defineCommand({
+export const agentsRunCommand = defineCliCommand({
   meta: { name: 'run', description: 'Run a tool-use agent headlessly' },
   args: {
     ...GLOBAL_ARGS,
@@ -235,17 +231,13 @@ export const agentsRunCommand = defineCommand({
         'File whose contents are passed before --instruction when both are set',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(
-      await runToolUseAgent(context, {
-        agent: ctx.args.name,
-        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
-        model: optString(ctx.args.model),
-        instruction: optString(ctx.args.instruction) ?? '',
-        instructionFile: optString(ctx.args['instruction-file']),
-      }),
-    );
-  },
+  run: (context, ctx) =>
+    runToolUseAgent(context, {
+      agent: ctx.args.name,
+      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
+      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+      model: optString(ctx.args.model),
+      instruction: optString(ctx.args.instruction) ?? '',
+      instructionFile: optString(ctx.args['instruction-file']),
+    }),
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -2,12 +2,15 @@ import { defineCommand } from 'citty';
 
 import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { isOAuthProvider } from '@auth/sharedConfig';
-import { toErrorMessage } from '@common/errors/errorMessage';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import {
+  writeErrorStderr,
+  writeTextStderr,
+  writeTextStdout,
+} from '../runtime/logSinks';
 import {
   fetchRelayUsageSummary,
   parseUtcMonth,
@@ -20,6 +23,7 @@ import {
 } from '../runtime/supabaseAuth';
 
 import { contextFromArgs } from './_helpers/context';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { setExitCode } from './_helpers/exitCode';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
@@ -74,7 +78,7 @@ async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
       },
     });
   } catch (error) {
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.ModelOrNetworkError;
   }
 
@@ -92,7 +96,7 @@ async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
   return CliExitCode.Success;
 }
 
-export const loginCommand = defineCommand({
+export const loginCommand = defineCliCommand({
   meta: { name: 'login', description: 'Sign in to TeXRA for included access' },
   args: {
     ...GLOBAL_ARGS,
@@ -121,19 +125,16 @@ export const loginCommand = defineCommand({
         'Suggest a specific provider account, such as a GitHub username or Google email',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  run: (context, ctx) => {
     const positional = optString(ctx.args.providerArg);
     const flag = optString(ctx.args.provider);
     const provider = resolveLoginProvider(positional, flag);
-    setExitCode(
-      await runLogin(context, {
-        provider,
-        noBrowser: ctx.args['no-browser'] === true,
-        selectAccount: ctx.args['select-account'] === true,
-        loginHint: optString(ctx.args['login-hint']),
-      }),
-    );
+    return runLogin(context, {
+      provider,
+      noBrowser: ctx.args['no-browser'] === true,
+      selectAccount: ctx.args['select-account'] === true,
+      loginHint: optString(ctx.args['login-hint']),
+    });
   },
 });
 
@@ -148,7 +149,7 @@ export const logoutCommand = defineCommand({
     try {
       await signOutCliSupabase();
     } catch (error) {
-      writeTextStderr(toErrorMessage(error));
+      writeErrorStderr(error);
       setExitCode(CliExitCode.ModelOrNetworkError);
       return;
     }
@@ -174,7 +175,7 @@ const authStatusCommand = defineCommand({
       await initCliPlatform({ ...context, quietLogs: true });
       profile = await getCliAuthProfile();
     } catch (error) {
-      writeTextStderr(toErrorMessage(error));
+      writeErrorStderr(error);
       setExitCode(CliExitCode.ModelOrNetworkError);
       return;
     }
@@ -228,7 +229,7 @@ const usageCommand = defineCommand({
       try {
         parseUtcMonth(month);
       } catch (error) {
-        writeTextStderr(toErrorMessage(error));
+        writeErrorStderr(error);
         setExitCode(CliExitCode.Usage);
         return;
       }
@@ -247,7 +248,7 @@ const usageCommand = defineCommand({
         month,
       });
     } catch (error) {
-      writeTextStderr(toErrorMessage(error));
+      writeErrorStderr(error);
       setExitCode(CliExitCode.ModelOrNetworkError);
       return;
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,5 +1,3 @@
-import { defineCommand } from 'citty';
-
 import {
   buildDoctorReport,
   doctorExitCode,
@@ -7,8 +5,7 @@ import {
 } from '../runtime/doctor';
 import { initCliPlatform } from '../runtime/initPlatform';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { suppressCliFetchStackLogs } from './_helpers/fetchSilencer';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import type { CliContext } from '../runtime/cliContext';
@@ -45,13 +42,10 @@ async function runDoctor(context: CliContext): Promise<number> {
   return doctorExitCode(report);
 }
 
-export const doctorCommand = defineCommand({
+export const doctorCommand = defineCliCommand({
   meta: { name: 'doctor', description: 'Check CLI runtime dependencies' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await runDoctor(context));
-  },
+  run: (context) => runDoctor(context),
 });

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from 'citty';
 
-import { toErrorMessage } from '@common/errors/errorMessage';
 import { type ExecutionId } from '@shared/schemas';
 
 import { CliExitCode } from '../runtime/exitCodes';
@@ -15,10 +14,9 @@ import {
   readCliHistoryDetails,
 } from '../runtime/history';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr } from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
@@ -85,7 +83,7 @@ async function runHistoryDelete(
   try {
     result = await deleteCliHistory({ ...options, preCountForAll });
   } catch (error) {
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.Usage;
   }
 
@@ -119,18 +117,15 @@ async function runHistoryDelete(
   return CliExitCode.Success;
 }
 
-const historyListCommand = defineCommand({
+const historyListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List stored executions' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await runHistoryList(context));
-  },
+  run: (context) => runHistoryList(context),
 });
 
-const historyShowCommand = defineCommand({
+const historyShowCommand = defineCliCommand({
   meta: { name: 'show', description: 'Show one stored execution' },
   args: {
     ...GLOBAL_ARGS,
@@ -140,19 +135,17 @@ const historyShowCommand = defineCommand({
       description: 'Execution id from `texra history list`',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  run: (context, ctx) => {
     const id = parseCliHistoryId(ctx.args.id);
     if (!id) {
       writeTextStderr(`Invalid execution id: ${ctx.args.id}`);
-      setExitCode(CliExitCode.Usage);
-      return;
+      return Promise.resolve(CliExitCode.Usage);
     }
-    setExitCode(await runHistoryShow(context, id));
+    return runHistoryShow(context, id);
   },
 });
 
-const historyDeleteCommand = defineCommand({
+const historyDeleteCommand = defineCliCommand({
   meta: { name: 'delete', description: 'Delete stored executions' },
   args: {
     ...GLOBAL_ARGS,
@@ -172,22 +165,18 @@ const historyDeleteCommand = defineCommand({
         'Confirm destructive deletes (required with --all; ignored otherwise)',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  run: (context, ctx) => {
     const rawId = optString(ctx.args.id);
     const id = rawId ? parseCliHistoryId(rawId) : undefined;
     if (rawId && !id) {
       writeTextStderr(`Invalid execution id: ${rawId}`);
-      setExitCode(CliExitCode.Usage);
-      return;
+      return Promise.resolve(CliExitCode.Usage);
     }
-    setExitCode(
-      await runHistoryDelete(context, {
-        id,
-        all: ctx.args.all === true,
-        yes: ctx.args.yes === true,
-      }),
-    );
+    return runHistoryDelete(context, {
+      id,
+      all: ctx.args.all === true,
+      yes: ctx.args.yes === true,
+    });
   },
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -174,6 +174,8 @@ export const initCommand = defineCliCommand({
       yes: ctx.args.yes === true,
       force: ctx.args.force === true,
       gitignore:
-        typeof ctx.args.gitignore === 'boolean' ? ctx.args.gitignore : undefined,
+        typeof ctx.args.gitignore === 'boolean'
+          ? ctx.args.gitignore
+          : undefined,
     }),
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,3 @@
-import { defineCommand } from 'citty';
-
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
@@ -18,8 +16,7 @@ import {
   type InitAnswers,
 } from '../runtime/initConfig';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import type { CliContext } from '../runtime/cliContext';
 
 async function gatherOptions(): Promise<{
@@ -148,7 +145,7 @@ async function runInit(
   return CliExitCode.Success;
 }
 
-export const initCommand = defineCommand({
+export const initCommand = defineCliCommand({
   meta: {
     name: 'init',
     description: 'Bootstrap a .texra/config.json with sensible defaults',
@@ -172,17 +169,11 @@ export const initCommand = defineCommand({
       description: 'Add .texra/ to .gitignore (non-interactive default: false)',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(
-      await runInit(context, {
-        yes: ctx.args.yes === true,
-        force: ctx.args.force === true,
-        gitignore:
-          typeof ctx.args.gitignore === 'boolean'
-            ? ctx.args.gitignore
-            : undefined,
-      }),
-    );
-  },
+  run: (context, ctx) =>
+    runInit(context, {
+      yes: ctx.args.yes === true,
+      force: ctx.args.force === true,
+      gitignore:
+        typeof ctx.args.gitignore === 'boolean' ? ctx.args.gitignore : undefined,
+    }),
 });

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from 'citty';
 
-import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   loadMemoryItems,
   loadMemoryPreview,
@@ -9,15 +8,14 @@ import { toDisplayPath } from '@tools/memory/memoryUtils';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import { writeTextStdout } from '../runtime/logSinks';
 import {
   formatCliMemoryList,
   formatCliMemoryPreview,
   resolveCliMemoryStoragePath,
 } from '../runtime/memory';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
@@ -63,21 +61,14 @@ async function runMemoryShow(
   return CliExitCode.Success;
 }
 
-const memoryListCommand = defineCommand({
+const memoryListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List stored memories' },
   args: { ...GLOBAL_ARGS },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    try {
-      setExitCode(await runMemoryList(context));
-    } catch (error) {
-      writeTextStderr(toErrorMessage(error));
-      setExitCode(CliExitCode.AgentError);
-    }
-  },
+  catchExitCode: CliExitCode.AgentError,
+  run: (context) => runMemoryList(context),
 });
 
-const memoryShowCommand = defineCommand({
+const memoryShowCommand = defineCliCommand({
   meta: { name: 'show', description: 'Show one stored memory' },
   args: {
     ...GLOBAL_ARGS,
@@ -88,15 +79,8 @@ const memoryShowCommand = defineCommand({
         'Memory path from `texra memory list` (e.g. memories/<file>)',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    try {
-      setExitCode(await runMemoryShow(context, ctx.args.path));
-    } catch (error) {
-      writeTextStderr(toErrorMessage(error));
-      setExitCode(CliExitCode.Usage);
-    }
-  },
+  catchExitCode: CliExitCode.Usage,
+  run: (context, ctx) => runMemoryShow(context, ctx.args.path),
 });
 
 export const memoryCommand = defineCommand({

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -7,8 +7,7 @@ import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { getCliModelAccessList } from '../runtime/modelAccess';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   formatCliModelListError,
   suppressCliFetchStackLogs,
@@ -114,18 +113,15 @@ async function showModel(context: CliContext, id: string): Promise<number> {
   return CliExitCode.Success;
 }
 
-const modelsListCommand = defineCommand({
+const modelsListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List available models' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await listModels(context));
-  },
+  run: (context) => listModels(context),
 });
 
-const modelsShowCommand = defineCommand({
+const modelsShowCommand = defineCliCommand({
   meta: { name: 'show', description: 'Show one model' },
   args: {
     ...GLOBAL_ARGS,
@@ -135,10 +131,7 @@ const modelsShowCommand = defineCommand({
       description: 'Model id from `texra models list` (case-insensitive)',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await showModel(context, ctx.args.id));
-  },
+  run: (context, ctx) => showModel(context, ctx.args.id),
 });
 
 export const modelsCommand = defineCommand({

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -34,8 +34,7 @@ import {
 import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { assertExplicitModelKnown } from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -267,18 +266,15 @@ async function runMultiAgentPreset(
   return terminalStatusExitCode(terminalStatus, runContext);
 }
 
-const multiAgentListCommand = defineCommand({
+const multiAgentListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List multi-agent team presets' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await runMultiAgentList(context));
-  },
+  run: (context) => runMultiAgentList(context),
 });
 
-const multiAgentShowCommand = defineCommand({
+const multiAgentShowCommand = defineCliCommand({
   meta: { name: 'show', description: 'Show one multi-agent team preset' },
   args: {
     ...GLOBAL_ARGS,
@@ -288,13 +284,10 @@ const multiAgentShowCommand = defineCommand({
       description: 'Preset id or name from `texra multi-agent list`',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await runMultiAgentShow(context, ctx.args.preset));
-  },
+  run: (context, ctx) => runMultiAgentShow(context, ctx.args.preset),
 });
 
-const multiAgentRunCommand = defineCommand({
+const multiAgentRunCommand = defineCliCommand({
   meta: { name: 'run', description: 'Run a multi-agent team preset' },
   args: {
     ...GLOBAL_ARGS,
@@ -330,19 +323,15 @@ const multiAgentRunCommand = defineCommand({
       description: 'Additional instruction for the team orchestrator',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(
-      await runMultiAgentPreset(context, {
-        preset: ctx.args.preset,
-        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
-        agent: optString(ctx.args.agent),
-        model: optString(ctx.args.model),
-        instruction: optString(ctx.args.instruction) ?? '',
-      }),
-    );
-  },
+  run: (context, ctx) =>
+    runMultiAgentPreset(context, {
+      preset: ctx.args.preset,
+      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
+      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+      agent: optString(ctx.args.agent),
+      model: optString(ctx.args.model),
+      instruction: optString(ctx.args.instruction) ?? '',
+    }),
 });
 
 export const multiAgentCommand = defineCommand({

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,20 +1,16 @@
-import { defineCommand } from 'citty';
-
 import { getAgent, loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
 import { readCliHistoryConfig, parseCliHistoryId } from '../runtime/history';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr } from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
@@ -72,11 +68,11 @@ export async function runResumeExecution(
     ));
   } catch (error) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      writeTextStderr(toErrorMessage(error));
+      writeErrorStderr(error);
       return CliExitCode.Interrupted;
     }
     await writeTerminalStatus(id, EXECUTION_STATUS.ERROR);
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.AgentError;
   }
 
@@ -92,7 +88,7 @@ export async function runResumeExecution(
   return terminalStatusExitCode(terminalStatus, runContext);
 }
 
-export const resumeCommand = defineCommand({
+export const resumeCommand = defineCliCommand({
   meta: { name: 'resume', description: 'Re-run a stored execution config' },
   args: {
     ...GLOBAL_ARGS,
@@ -102,14 +98,12 @@ export const resumeCommand = defineCommand({
       description: 'Execution id from `texra history list`',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  run: (context, ctx) => {
     const id = parseCliHistoryId(ctx.args.id);
     if (!id) {
       writeTextStderr(`Invalid execution id: ${ctx.args.id}`);
-      setExitCode(CliExitCode.Usage);
-      return;
+      return Promise.resolve(CliExitCode.Usage);
     }
-    setExitCode(await runResumeExecution(context, id));
+    return runResumeExecution(context, id);
   },
 });

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -13,8 +13,7 @@ import {
   skillListRecord,
 } from '../runtime/skills';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS, collectStringFlagValues } from './_helpers/globalArgs';
 import type { CliContext } from '../runtime/cliContext';
 
@@ -64,7 +63,7 @@ async function listSkills(
   return CliExitCode.Success;
 }
 
-const skillsListCommand = defineCommand({
+const skillsListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List available skills' },
   args: {
     ...GLOBAL_ARGS,
@@ -80,15 +79,11 @@ const skillsListCommand = defineCommand({
         'Additional skill root to scan; may be repeated and is resolved relative to --cwd',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(
-      await listSkills(context, {
-        includeInterop: ctx.args['include-interop'] === true,
-        additionalPaths: collectStringFlagValues(ctx.rawArgs, 'source', 's'),
-      }),
-    );
-  },
+  run: (context, ctx) =>
+    listSkills(context, {
+      includeInterop: ctx.args['include-interop'] === true,
+      additionalPaths: collectStringFlagValues(ctx.rawArgs, 'source', 's'),
+    }),
 });
 
 export const skillsCommand = defineCommand({

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -2,11 +2,13 @@ import { spawn } from 'node:child_process';
 
 import { defineCommand } from 'citty';
 
-import { toErrorMessage } from '@common/errors';
-
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import {
+  writeErrorStderr,
+  writeTextStderr,
+  writeTextStdout,
+} from '../runtime/logSinks';
 import {
   findCliToolDef,
   formatCliToolList,
@@ -140,7 +142,7 @@ async function authTool(context: CliContext, id: string): Promise<number> {
   try {
     return await shellRun(def.authCommand);
   } catch (error) {
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.AgentError;
   }
 }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,7 +1,5 @@
 import * as path from 'node:path';
 
-import { defineCommand } from 'citty';
-
 import { getAgent, loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
@@ -9,7 +7,6 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
@@ -21,11 +18,10 @@ import {
 } from '../runtime/cliConfig';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr } from '../runtime/logSinks';
+import { writeErrorStderr } from '../runtime/logSinks';
 import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { assertExplicitModelKnown } from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -158,11 +154,11 @@ async function runWorkflowAgent(
     ));
   } catch (error) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      writeTextStderr(toErrorMessage(error));
+      writeErrorStderr(error);
       return CliExitCode.Interrupted;
     }
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-    writeTextStderr(toErrorMessage(error));
+    writeErrorStderr(error);
     return CliExitCode.AgentError;
   }
 
@@ -178,7 +174,7 @@ async function runWorkflowAgent(
   return terminalStatusExitCode(terminalStatus, runContext);
 }
 
-export const runWorkflowCommand = defineCommand({
+export const runWorkflowCommand = defineCliCommand({
   meta: { name: 'run', description: 'Run a workflow agent' },
   args: {
     ...GLOBAL_ARGS,
@@ -218,18 +214,14 @@ export const runWorkflowCommand = defineCommand({
       description: 'Instruction passed to the workflow agent',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(
-      await runWorkflowAgent(context, {
-        agent: ctx.args.agent,
-        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
-        output: optString(ctx.args.output),
-        outputDir: optString(ctx.args['output-dir']),
-        model: optString(ctx.args.model),
-        instruction: optString(ctx.args.instruction) ?? '',
-      }),
-    );
-  },
+  run: (context, ctx) =>
+    runWorkflowAgent(context, {
+      agent: ctx.args.agent,
+      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
+      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+      output: optString(ctx.args.output),
+      outputDir: optString(ctx.args['output-dir']),
+      model: optString(ctx.args.model),
+      instruction: optString(ctx.args.instruction) ?? '',
+    }),
 });

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import { createInterface } from 'node:readline/promises';
 
+import { toErrorMessage } from '@common/errors/errorMessage';
 import type { LogLevel } from '@shared/schemas';
 
 /**
@@ -117,6 +118,15 @@ export function writeRawStderr(text: string): void {
 
 export function writeTextStderr(text: string): void {
   writeRaw('stderr', `${text}\n`);
+}
+
+/**
+ * Write a caught error's human-readable message to stderr. Folds the
+ * `writeTextStderr(toErrorMessage(error))` pair every command's catch block
+ * repeated so the error-formatting choice lives in one place.
+ */
+export function writeErrorStderr(error: unknown): void {
+  writeTextStderr(toErrorMessage(error));
 }
 
 export async function askCliQuestion(question: string): Promise<string> {

--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -1,7 +1,6 @@
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
+  createCommandHandler,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
@@ -14,16 +13,11 @@ export interface DesktopExecutionIpcOptions {
 export function createDesktopExecutionIpc(
   options: DesktopExecutionIpcOptions = {},
 ): DesktopMessageHandler {
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
-
-  return {
-    handleMessage(message: DesktopCommandMessage): boolean {
-      if (message.command !== MAIN_VIEW_COMMANDS.EXECUTE) return false;
-      if (!options.executeAgent) return true;
-      void options
-        .executeAgent(message as MainViewExecuteMessage)
-        .catch(reportAsyncError);
-      return true;
+  return createCommandHandler(
+    {
+      [MAIN_VIEW_COMMANDS.EXECUTE]: (message) =>
+        options.executeAgent?.(message as MainViewExecuteMessage),
     },
-  };
+    { onAsyncError: options.onAsyncError },
+  );
 }

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -31,3 +31,61 @@ export function createDesktopErrorReporter(
 function defaultReportError(error: unknown): void {
   console.error(error);
 }
+
+type CommandRunner = (message: DesktopCommandMessage) => void | Promise<void>;
+
+export interface CommandHandlerEntry {
+  /** The work to perform when the command matches. */
+  run: CommandRunner;
+  /**
+   * Optional guard. When it returns `false` the entry is treated as not
+   * matching, so `handleMessage` returns `false` and sibling handlers still
+   * receive the message.
+   */
+  when?: (message: DesktopCommandMessage) => boolean;
+  /**
+   * Whether claiming the command stops the dispatch chain. Defaults to
+   * `true`. Set to `false` for broadcast commands (e.g. `WEBVIEW_READY`) that
+   * should still reach sibling handlers after running.
+   */
+  claim?: boolean;
+}
+
+export type CommandHandlerMap = Record<
+  string,
+  CommandRunner | CommandHandlerEntry
+>;
+
+export interface CreateCommandHandlerOptions {
+  onAsyncError?: (error: unknown) => void;
+}
+
+/**
+ * Builds a {@link DesktopMessageHandler} from a `command → handler` map,
+ * centralizing the type-dispatch, async-error wrapping, and claim semantics
+ * that every manual `switch (message.command)` handler used to repeat.
+ *
+ * A bare function entry claims the command (returns `true`). Use the object
+ * form to add a `when` guard or to broadcast (`claim: false`).
+ */
+export function createCommandHandler(
+  handlers: CommandHandlerMap,
+  options: CreateCommandHandlerOptions = {},
+): DesktopMessageHandler {
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      const entry = handlers[message.command];
+      if (entry == null) return false;
+
+      const { run, when, claim } =
+        typeof entry === 'function' ? { run: entry } : entry;
+      if (when != null && !when(message)) return false;
+
+      const result = run(message);
+      if (result instanceof Promise) result.catch(reportAsyncError);
+      return claim ?? true;
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopLogIpc.ts
+++ b/packages/desktop/src/main/desktopLogIpc.ts
@@ -1,4 +1,5 @@
 import {
+  createCommandHandler,
   createDesktopErrorReporter,
   type DesktopMessageHandler,
   type DesktopRenderer,
@@ -50,21 +51,14 @@ export function createDesktopLogIpc(
     void options.exportLog?.(log.text).catch(reportAsyncError);
   }
 
-  return {
-    handleMessage(message): boolean {
-      switch (message.command) {
-        case DESKTOP_LOG_COMMANDS.REQUEST_LOG:
-          postSnapshot();
-          return true;
-        case DESKTOP_LOG_COMMANDS.COPY_LOG:
-          copyLog();
-          return true;
-        case DESKTOP_LOG_COMMANDS.EXPORT_LOG:
-          exportLog();
-          return true;
-        default:
-          return false;
-      }
+  return createCommandHandler(
+    {
+      [DESKTOP_LOG_COMMANDS.REQUEST_LOG]: () => {
+        postSnapshot();
+      },
+      [DESKTOP_LOG_COMMANDS.COPY_LOG]: () => copyLog(),
+      [DESKTOP_LOG_COMMANDS.EXPORT_LOG]: () => exportLog(),
     },
-  };
+    { onAsyncError: options.onAsyncError },
+  );
 }

--- a/packages/desktop/src/main/desktopMainViewStartup.ts
+++ b/packages/desktop/src/main/desktopMainViewStartup.ts
@@ -8,8 +8,7 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import { getConfig } from '@utils/config/configUtils';
 
 import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
+  createCommandHandler,
   type DesktopMessageHandler,
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
@@ -34,7 +33,6 @@ export function createDesktopMainViewStartup({
   loadOptions,
   onAsyncError,
 }: DesktopMainViewStartupOptions): DesktopMessageHandler {
-  const reportAsyncError = createDesktopErrorReporter(onAsyncError);
   const startupController = new MainViewStartupController({
     getConfig,
     loadOptions: async () => {
@@ -57,17 +55,16 @@ export function createDesktopMainViewStartup({
     }
   }
 
-  return {
-    handleMessage(message: DesktopCommandMessage): boolean {
-      if (
-        message.command !== MAIN_VIEW_COMMANDS.WEBVIEW_READY ||
-        message.view !== 'main'
-      ) {
-        return false;
-      }
-
-      void postStartupMessages().catch(reportAsyncError);
-      return false;
+  return createCommandHandler(
+    {
+      // WEBVIEW_READY is a broadcast: post startup messages for the main view
+      // but return `false` so sibling handlers still receive it.
+      [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
+        when: (message) => message.view === 'main',
+        run: () => postStartupMessages(),
+        claim: false,
+      },
     },
-  };
+    { onAsyncError },
+  );
 }

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -5,8 +5,7 @@ import {
   DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
 } from '../desktopOnboardingMessages.js';
 import {
-  createDesktopErrorReporter,
-  type DesktopCommandMessage,
+  createCommandHandler,
   type DesktopMessageHandler,
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
@@ -22,7 +21,6 @@ export function createDesktopOnboardingIpc(
   options: DesktopOnboardingIpcOptions = {},
 ): DesktopMessageHandler {
   const state = options.state ?? platform().globalState;
-  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
@@ -37,18 +35,11 @@ export function createDesktopOnboardingIpc(
     renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(false));
   }
 
-  return {
-    handleMessage(message: DesktopCommandMessage): boolean {
-      switch (message.command) {
-        case DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE:
-          postCurrentState();
-          return true;
-        case DESKTOP_ONBOARDING_COMMANDS.DISMISS:
-          void dismiss().catch(reportAsyncError);
-          return true;
-        default:
-          return false;
-      }
+  return createCommandHandler(
+    {
+      [DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE]: () => postCurrentState(),
+      [DESKTOP_ONBOARDING_COMMANDS.DISMISS]: () => dismiss(),
     },
-  };
+    { onAsyncError: options.onAsyncError },
+  );
 }

--- a/packages/desktop/src/main/desktopViewStateIpc.ts
+++ b/packages/desktop/src/main/desktopViewStateIpc.ts
@@ -7,10 +7,10 @@ import {
   type DesktopThemeKind,
 } from '@shared/constants/desktopTheme';
 
-import type {
-  DesktopCommandMessage,
-  DesktopMessageHandler,
-  DesktopRenderer,
+import {
+  createCommandHandler,
+  type DesktopMessageHandler,
+  type DesktopRenderer,
 } from './desktopIpcTypes.js';
 
 export type DesktopTheme = DesktopThemeKind;
@@ -56,23 +56,17 @@ export function createDesktopViewStateIpc(
 
   nativeTheme.on('updated', postTheme);
 
-  return {
-    handleMessage(message: DesktopCommandMessage): boolean {
-      switch (message.command) {
-        case MAIN_VIEW_COMMANDS.WEBVIEW_READY:
-          postTheme();
-          postDebugMode();
-          return true;
-        case MAIN_VIEW_COMMANDS.GET_THEME:
-          postTheme();
-          return true;
-        case MAIN_VIEW_COMMANDS.GET_DEBUG_MODE:
-          postDebugMode();
-          return true;
-        default:
-          return false;
-      }
+  const handler = createCommandHandler({
+    [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: () => {
+      postTheme();
+      postDebugMode();
     },
+    [MAIN_VIEW_COMMANDS.GET_THEME]: () => postTheme(),
+    [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]: () => postDebugMode(),
+  });
+
+  return {
+    handleMessage: handler.handleMessage,
     dispose() {
       nativeTheme.off('updated', postTheme);
     },

--- a/packages/extension/src/commands/_shared/registerCommands.ts
+++ b/packages/extension/src/commands/_shared/registerCommands.ts
@@ -11,7 +11,6 @@ import * as vscode from 'vscode';
  */
 export interface CommandEntry {
   id: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler: (...args: any[]) => any;
 }
 

--- a/packages/extension/src/commands/_shared/registerCommands.ts
+++ b/packages/extension/src/commands/_shared/registerCommands.ts
@@ -1,0 +1,37 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+/**
+ * A single command-to-handler binding for {@link registerCommands}.
+ *
+ * The handler keeps VS Code's native `registerCommand` signature
+ * (`(...args: any[]) => any`) so value-returning handlers — whose results
+ * flow back to `executeCommand` callers — are registered with their
+ * semantics fully intact.
+ */
+export interface CommandEntry {
+  id: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (...args: any[]) => any;
+}
+
+/**
+ * Register a list of commands and push their disposables onto the
+ * extension's subscriptions in one call.
+ *
+ * This consolidates the repeated
+ * `context.subscriptions.push(vscode.commands.registerCommand(id, handler), ...)`
+ * boilerplate shared across the command modules. Handlers are registered
+ * verbatim — no wrapping — so return values, argument lists, and each
+ * handler's own error handling are preserved exactly.
+ */
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  entries: readonly CommandEntry[],
+): void {
+  context.subscriptions.push(
+    ...entries.map(({ id, handler }) =>
+      vscode.commands.registerCommand(id, handler),
+    ),
+  );
+}

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -10,6 +10,7 @@ import {
 } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -102,10 +103,10 @@ async function handleFollowUpResult(
 }
 
 export function registerFollowUpCommand(context: vscode.ExtensionContext) {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'texra.sendFollowUp',
-      async (payload: { stream: StreamTabId; text: string }) => {
+  registerCommands(context, [
+    {
+      id: 'texra.sendFollowUp',
+      handler: async (payload: { stream: StreamTabId; text: string }) => {
         const { stream: streamId, text } = payload;
 
         await lazyDetectWaitingStatus(streamId);
@@ -113,6 +114,6 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
         const result = await sendFollowUp(streamId, text);
         await handleFollowUpResult(result, streamId);
       },
-    ),
-  );
+    },
+  ]);
 }

--- a/packages/extension/src/commands/agent/mergeCommands.ts
+++ b/packages/extension/src/commands/agent/mergeCommands.ts
@@ -3,14 +3,13 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { getHelperModelName } from '@agent/runtime/helperModel';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 
 const CHANNEL = 'MergeCommands';
 
 export function registerMergeCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.merge', handleMerge),
-  );
+  registerCommands(context, [{ id: 'texra.merge', handler: handleMerge }]);
 }
 
 async function handleMerge(

--- a/packages/extension/src/commands/files/fileSelectionCommands.ts
+++ b/packages/extension/src/commands/files/fileSelectionCommands.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { FILE_SELECTION_COMMAND_IDS, getFilterExtensions } from '@common/files';
 import { getFileLister } from '@frontend/files';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -59,44 +60,38 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
 export function registerFileSelectionCommands(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectInputFiles,
-      selectInputFiles,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectContextFiles,
-      selectContextFiles,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectMediaFiles,
-      selectMediaFiles,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectOutputFiles,
-      selectOutputFiles,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectEditedFile,
-      selectEditedFile,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.getCurrentFile,
-      getCurrentFile,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.selectBaseFile,
-      selectBaseFile,
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.refreshInputFiles,
-      () => getFileLister().list('input'),
-    ),
-    vscode.commands.registerCommand(
-      FILE_SELECTION_COMMAND_IDS.refreshBaseFiles,
-      () => getFileLister().list('input'),
-    ),
-  );
+  registerCommands(context, [
+    {
+      id: FILE_SELECTION_COMMAND_IDS.selectInputFiles,
+      handler: selectInputFiles,
+    },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.selectContextFiles,
+      handler: selectContextFiles,
+    },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.selectMediaFiles,
+      handler: selectMediaFiles,
+    },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.selectOutputFiles,
+      handler: selectOutputFiles,
+    },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.selectEditedFile,
+      handler: selectEditedFile,
+    },
+    { id: FILE_SELECTION_COMMAND_IDS.getCurrentFile, handler: getCurrentFile },
+    { id: FILE_SELECTION_COMMAND_IDS.selectBaseFile, handler: selectBaseFile },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.refreshInputFiles,
+      handler: () => getFileLister().list('input'),
+    },
+    {
+      id: FILE_SELECTION_COMMAND_IDS.refreshBaseFiles,
+      handler: () => getFileLister().list('input'),
+    },
+  ]);
 }
 
 const selectInputFiles = createPicker({

--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { toErrorMessage } from '@common/errors';
 // Local imports - frontend
 import { getFileLister } from '@frontend/files';
@@ -86,12 +87,9 @@ export async function openLabel(
 export function registerOpenFileCommands(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      openFileCommands.openFileCompile,
-      openBuildDisplayIfTex,
-    ),
-    vscode.commands.registerCommand(openFileCommands.openFile, openFile),
-    vscode.commands.registerCommand(openFileCommands.openLabel, openLabel),
-  );
+  registerCommands(context, [
+    { id: openFileCommands.openFileCompile, handler: openBuildDisplayIfTex },
+    { id: openFileCommands.openFile, handler: openFile },
+    { id: openFileCommands.openLabel, handler: openLabel },
+  ]);
 }

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -3,6 +3,7 @@ import { execa, execaSync } from 'execa';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
@@ -31,27 +32,18 @@ export const gitCommands = {
 };
 
 export function registerGitCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    // `isGitRepository`, `getRecentCommits`, and `findCommitInHistory`
-    // return values to `executeCommand` callers (sync `boolean`,
-    // `string[] | null`, `string | null` respectively) and accept
-    // optional positional arguments — they keep their per-command
-    // registration. `texra.cloneOverleafProject` migrated through the
-    // shared command registry in #3781 batch 3 (see
-    // `extensionCommandSurface.ts`).
-    vscode.commands.registerCommand(
-      gitCommands.isGitRepository,
-      isGitRepository,
-    ),
-    vscode.commands.registerCommand(
-      gitCommands.getRecentCommits,
-      getRecentCommits,
-    ),
-    vscode.commands.registerCommand(
-      gitCommands.findCommitInHistory,
-      findCommitInHistory,
-    ),
-  );
+  // `isGitRepository`, `getRecentCommits`, and `findCommitInHistory`
+  // return values to `executeCommand` callers (sync `boolean`,
+  // `string[] | null`, `string | null` respectively) and accept
+  // optional positional arguments — they keep their per-command
+  // registration. `texra.cloneOverleafProject` migrated through the
+  // shared command registry in #3781 batch 3 (see
+  // `extensionCommandSurface.ts`).
+  registerCommands(context, [
+    { id: gitCommands.isGitRepository, handler: isGitRepository },
+    { id: gitCommands.getRecentCommits, handler: getRecentCommits },
+    { id: gitCommands.findCommitInHistory, handler: findCommitInHistory },
+  ]);
 }
 
 export { cloneOverleafProject };

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -6,6 +6,7 @@ import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreCo
 
 // Local imports
 import { TaskStateSchema, type TaskState } from '@agent/core/TaskState';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { setPendingState } from '@common/state';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -21,9 +22,9 @@ const RESTORE_MALFORMED_MESSAGE =
 export function registerStateRestoreCommand(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.restoreState', restoreState),
-  );
+  registerCommands(context, [
+    { id: 'texra.restoreState', handler: restoreState },
+  ]);
 }
 
 async function restoreState(

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
 import {
   runCleanSingle,
@@ -56,11 +57,11 @@ export function registerCleanCommands(context: vscode.ExtensionContext): void {
   // `extensionCommandSurface` so the dispatch path matches the desktop
   // registry (see #3771). The remaining clean commands take typed
   // arguments and stay on per-command registration for now.
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.clean', handleClean),
-    vscode.commands.registerCommand('texra.cleanSingle', handleCleanSingle),
-    vscode.commands.registerCommand('texra.cleanMultiple', handleCleanMultiple),
-  );
+  registerCommands(context, [
+    { id: 'texra.clean', handler: handleClean },
+    { id: 'texra.cleanSingle', handler: handleCleanSingle },
+    { id: 'texra.cleanMultiple', handler: handleCleanMultiple },
+  ]);
 }
 
 async function handleCleanSingle(

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
 import {
   runPack,
@@ -197,9 +198,9 @@ async function handlePackMultiple(
 }
 
 export function registerPackCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.pack', handlePack),
-    vscode.commands.registerCommand('texra.packSingle', handlePackSingle),
-    vscode.commands.registerCommand('texra.packMultiple', handlePackMultiple),
-  );
+  registerCommands(context, [
+    { id: 'texra.pack', handler: handlePack },
+    { id: 'texra.packSingle', handler: handlePackSingle },
+    { id: 'texra.packMultiple', handler: handlePackMultiple },
+  ]);
 }

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
@@ -66,10 +67,10 @@ async function validateFilesExist(
 export function registerCompareCommands(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.compare', handleCompare),
-    vscode.commands.registerCommand('texra.acceptEdited', handleAcceptEdited),
-  );
+  registerCommands(context, [
+    { id: 'texra.compare', handler: handleCompare },
+    { id: 'texra.acceptEdited', handler: handleAcceptEdited },
+  ]);
 }
 
 async function handleCompare(

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -14,6 +14,7 @@ import {
   parseWorkflowOutputRoundDir,
 } from '@agent/output/workflowOutputLayout';
 import { getStreamTabId } from '@agent/runtime/streamTab';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import {
   showLoggedErrorMessage,
@@ -166,27 +167,21 @@ function showLatexdiffPackNotifications(
 export function registerLatexdiffCommands(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('texra.latexdiff', handleLatexdiff),
-    vscode.commands.registerCommand('texra.latexdiffvc', handleLatexdiffvc),
-    vscode.commands.registerCommand(
-      'texra.packLatexdiffvc',
-      handlePackLatexdiffvc,
-    ),
-    vscode.commands.registerCommand(
-      'texra.packLatexdiffvcMultiple',
-      handlePackLatexdiffvcMultiple,
-    ),
-    vscode.commands.registerCommand(
-      'texra.cleanLatexdiffvc',
-      handleCleanLatexdiffvc,
-    ),
-    vscode.commands.registerCommand(
-      'texra.cleanLatexdiffvcMultiple',
-      handleCleanLatexdiffvcMultiple,
-    ),
-    vscode.commands.registerCommand('texra.runLatexdiff', handleRunLatexdiff),
-  );
+  registerCommands(context, [
+    { id: 'texra.latexdiff', handler: handleLatexdiff },
+    { id: 'texra.latexdiffvc', handler: handleLatexdiffvc },
+    { id: 'texra.packLatexdiffvc', handler: handlePackLatexdiffvc },
+    {
+      id: 'texra.packLatexdiffvcMultiple',
+      handler: handlePackLatexdiffvcMultiple,
+    },
+    { id: 'texra.cleanLatexdiffvc', handler: handleCleanLatexdiffvc },
+    {
+      id: 'texra.cleanLatexdiffvcMultiple',
+      handler: handleCleanLatexdiffvcMultiple,
+    },
+    { id: 'texra.runLatexdiff', handler: handleRunLatexdiff },
+  ]);
 }
 
 async function handleLatexdiff(

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
@@ -52,9 +53,10 @@ export function registerSettingsViewCommands(
 ): void {
   initializeSettingsViewProvider(context);
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand(settingsViewCommands.showGitSettings, () =>
-      settingsViewProvider?.showSettingsView(SETTINGS_TAB.GIT),
-    ),
-  );
+  registerCommands(context, [
+    {
+      id: settingsViewCommands.showGitSettings,
+      handler: () => settingsViewProvider?.showSettingsView(SETTINGS_TAB.GIT),
+    },
+  ]);
 }

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -3,8 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { computeAgentOptionsData, refresh } from '@agent/index';
-import { registerCommands } from '@commands/_shared/registerCommands';
 import { arXivCommands } from '@commands/latex';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { gitCommands } from '@commands/git/gitCommands';
 import { toErrorMessage } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { computeAgentOptionsData, refresh } from '@agent/index';
+import { registerCommands } from '@commands/_shared/registerCommands';
 import { arXivCommands } from '@commands/latex';
 import { gitCommands } from '@commands/git/gitCommands';
 import { toErrorMessage } from '@common/errors';
@@ -32,10 +33,10 @@ export const mainViewCommands = {
 export function registerMainViewCommands(
   context: vscode.ExtensionContext,
 ): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      mainViewCommands.refreshModelOptions,
-      async () => {
+  registerCommands(context, [
+    {
+      id: mainViewCommands.refreshModelOptions,
+      handler: async () => {
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
@@ -53,11 +54,10 @@ export function registerMainViewCommands(
           );
         }
       },
-    ),
-
-    vscode.commands.registerCommand(
-      mainViewCommands.refreshAgentOptions,
-      async () => {
+    },
+    {
+      id: mainViewCommands.refreshAgentOptions,
+      handler: async () => {
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
@@ -76,11 +76,10 @@ export function registerMainViewCommands(
           );
         }
       },
-    ),
-
-    vscode.commands.registerCommand(
-      mainViewCommands.refreshAllOptions,
-      async () => {
+    },
+    {
+      id: mainViewCommands.refreshAllOptions,
+      handler: async () => {
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
@@ -106,8 +105,8 @@ export function registerMainViewCommands(
           );
         }
       },
-    ),
-  );
+    },
+  ]);
 }
 
 /**

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -388,29 +388,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     message: unknown,
     webviewView: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    await this.withActiveView(webviewView, async () => {
-      const handled = dispatchProgressViewInbound(
-        message,
-        this.handlerRegistry,
-        (error) => {
-          this.logger.debug(this.channel, 'Message validation failed', {
-            data: error,
-          });
-        },
-      );
-
-      if (
-        !handled &&
-        message &&
-        typeof message === 'object' &&
-        'command' in message
-      ) {
-        this.logger.warn(
-          this.channel,
-          `Unhandled command: ${(message as { command: string }).command}`,
-        );
-      }
-    });
+    await this.dispatchInbound(
+      message,
+      webviewView,
+      dispatchProgressViewInbound,
+      this.handlerRegistry,
+    );
   }
 
   // ============================================================
@@ -423,10 +406,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     if (view) {
       this.provider.markWebviewReady(view);
     }
-  }
-
-  private postToActiveView(message: unknown): void {
-    this.getActiveView()?.webview.postMessage(message);
   }
 
   private createStreamLifecycleController(): ProgressStreamLifecycleController {

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -69,6 +69,16 @@ export abstract class BaseFeedbackPanel extends BaseRequestPanel {
     this.emitAction('reject', feedback);
   }
 
+  protected renderApproveButton(approveTitle: string): TemplateResult {
+    return renderLabeledActionButton({
+      icon: 'check',
+      text: 'Approve',
+      title: approveTitle,
+      action: 'approve',
+      onClick: () => this.emitAction('approve'),
+    });
+  }
+
   protected renderRejectButton(rejectTitle: string): TemplateResult {
     return renderLabeledActionButton({
       icon: this.showFeedback ? 'check' : 'close',

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -17,7 +17,6 @@ import {
 
 // Local imports - progress view styles
 import type { BashPermission } from '@shared/schemas';
-import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { codeBlockStyles } from '../styles/codeBlockStyles';
 
 // Local imports - progress view formatters
@@ -53,13 +52,7 @@ export class BashRequestPanel extends BaseFeedbackPanel {
           </div>
         </div>
         <div class="bash-approval-request__actions">
-          ${renderLabeledActionButton({
-            icon: 'check',
-            text: 'Approve',
-            title: 'Allow this command to execute (y)',
-            action: 'approve',
-            onClick: () => this.emitAction('approve'),
-          })}
+          ${this.renderApproveButton('Allow this command to execute (y)')}
           ${this.renderRejectButton('Reject this command (n)')}
         </div>
         ${this.renderFeedbackSection(

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -83,13 +83,7 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
           </ol>
         </div>
         <div class="plan-approval-request__actions">
-          ${renderLabeledActionButton({
-            icon: 'check',
-            text: 'Approve',
-            title: 'Approve this plan (y)',
-            action: 'approve',
-            onClick: () => this.emitAction('approve'),
-          })}
+          ${this.renderApproveButton('Approve this plan (y)')}
           ${odysseyEnabled
             ? renderLabeledActionButton({
                 icon: 'rocket',

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -173,13 +173,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           ${this.renderProposalFiles(data)}
         </div>
         <div class="workflow-proposal__actions">
-          ${renderLabeledActionButton({
-            icon: 'check',
-            text: 'Approve',
-            title: 'Approve (y)',
-            action: 'approve',
-            onClick: () => this.emitAction('approve'),
-          })}
+          ${this.renderApproveButton('Approve (y)')}
           ${this.renderRejectButton('Reject (n)')}
           ${renderLabeledActionButton({
             icon: 'reply',

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -65,8 +65,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
           </div>
         </div>
         <div class="approval-request__actions">
-          ${this.renderDiffActions()}
-          ${this.renderApproveButton('Approve (y)')}
+          ${this.renderDiffActions()} ${this.renderApproveButton('Approve (y)')}
           ${this.renderRejectButton('Reject (n)')}
         </div>
         ${this.renderFeedbackSection(

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -66,13 +66,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
         </div>
         <div class="approval-request__actions">
           ${this.renderDiffActions()}
-          ${renderLabeledActionButton({
-            icon: 'check',
-            text: 'Approve',
-            title: 'Approve (y)',
-            action: 'approve',
-            onClick: () => this.emitAction('approve'),
-          })}
+          ${this.renderApproveButton('Approve (y)')}
           ${this.renderRejectButton('Reject (n)')}
         </div>
         ${this.renderFeedbackSection(

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -659,42 +659,17 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     message: unknown,
     webviewView: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    await this.withActiveView(webviewView, async () => {
-      const handled = dispatchSettingsViewInbound(
-        message,
-        this.handlerRegistry,
-        (error) => {
-          this.logger.debug(this.channel, 'Message validation failed', {
-            data: error,
-          });
-        },
-      );
-
-      if (
-        !handled &&
-        message &&
-        typeof message === 'object' &&
-        'command' in message
-      ) {
-        this.logger.warn(
-          this.channel,
-          `Unhandled command: ${(message as { command: string }).command}`,
-        );
-      }
-    });
+    await this.dispatchInbound(
+      message,
+      webviewView,
+      dispatchSettingsViewInbound,
+      this.handlerRegistry,
+    );
   }
 
   // ============================================================
   // Helpers
   // ============================================================
-
-  /** Run a callback with the active view's webview, if available. */
-  private async withActiveWebview(
-    fn: (webview: vscode.Webview) => Promise<void>,
-  ): Promise<void> {
-    const view = this.getActiveView();
-    if (view) await fn(view.webview);
-  }
 
   private async primeIncludedAccessIfAuthenticated(): Promise<boolean> {
     const serverSideKeyService = getServerSideKeyService();

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -355,11 +355,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     await updateConfig(configUpdate.key, configUpdate.value);
   }
 
-  /** Post message to active view if available */
-  private postToActiveView(message: unknown): void {
-    this.getActiveView()?.webview.postMessage(message);
-  }
-
   protected async handleWebviewReady(): Promise<void> {
     const webviewView = this.getActiveView();
     if (!webviewView) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -70,7 +70,7 @@ import {
   formatToolResultAsText,
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
-import { computeCachePercentage } from './utils/usageNormalization';
+import { normalizeUsage } from './support/UsageNormalizer';
 import {
   tagAnthropicSdkError,
   withSdkErrorTag,
@@ -1383,44 +1383,39 @@ export class ModelHandlerAnthropic extends ModelHandler<
     rawUsage: AnthropicUsage,
     responseTimeMs: number,
   ): NormalizedUsage {
-    if (!rawUsage) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cost: 0,
-        responseTimeMs,
+    return normalizeUsage(
+      {
         provider: 'anthropic',
-      };
-    }
+        computePrice: (usage) => this.computePrice(usage),
+        extract: (usage) => {
+          const usageTotals = this.getUsageTokenTotals(usage);
+          // Anthropic bills cache-read and cache-creation tokens separately, so
+          // total input is base + read + creation (matches percentageCached).
+          const totalInput =
+            usageTotals.baseInputTokens +
+            usageTotals.cacheReadTokens +
+            usageTotals.cacheCreationTokens;
 
-    const usageTotals = this.getUsageTokenTotals(rawUsage);
-    const totalInput =
-      usageTotals.baseInputTokens +
-      usageTotals.cacheReadTokens +
-      usageTotals.cacheCreationTokens;
-
-    return {
-      inputTokens: totalInput,
-      outputTokens: usageTotals.outputTokens,
-      cost: this.computePrice(rawUsage),
+          return {
+            inputTokens: totalInput,
+            outputTokens: usageTotals.outputTokens,
+            cachedTokens: usageTotals.cacheReadTokens,
+            cacheCreationTokens: usageTotals.cacheCreationTokens,
+            cachePercentageBasis:
+              usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
+            // SDK 0.100.0 reports the thinking-token breakdown of output_tokens,
+            // so Anthropic surfaces reasoning tokens like OpenAI/Google/xAI. This
+            // is a subset of outputTokens (already billed), not an extra charge.
+            reasoningTokens: usage.output_tokens_details?.thinking_tokens ?? 0,
+            serverToolRequests:
+              (usage.server_tool_use?.web_search_requests ?? 0) +
+              (usage.server_tool_use?.web_fetch_requests ?? 0),
+          };
+        },
+      },
+      rawUsage,
       responseTimeMs,
-      provider: 'anthropic',
-      cachedInputTokens: usageTotals.cacheReadTokens || undefined,
-      cacheCreationTokens: usageTotals.cacheCreationTokens || undefined,
-      percentageCached: computeCachePercentage(
-        usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
-        totalInput,
-      ),
-      // SDK 0.100.0 reports the thinking-token breakdown of output_tokens, so
-      // Anthropic now surfaces reasoning tokens like OpenAI/Google/xAI. This is
-      // a subset of outputTokens (already billed), not an additional charge.
-      reasoningTokens:
-        rawUsage.output_tokens_details?.thinking_tokens || undefined,
-      serverToolRequests:
-        (rawUsage.server_tool_use?.web_search_requests ?? 0) +
-          (rawUsage.server_tool_use?.web_fetch_requests ?? 0) || undefined,
-      _native: rawUsage,
-    };
+    );
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -62,7 +62,7 @@ import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
-import { computeCachePercentage } from './utils/usageNormalization';
+import { normalizeUsage } from './support/UsageNormalizer';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagGoogleSdkError, withSdkErrorTag } from './support/sdkErrorAdapters';
 import { TOOL_USE_SAFETY_BUFFER } from './contextManagementConstants';
@@ -990,32 +990,25 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     rawUsage: GenerateContentResponseUsageMetadata | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    if (!rawUsage) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cost: 0,
-        responseTimeMs,
+    return normalizeUsage(
+      {
         provider: 'google',
-      };
-    }
-
-    const { inputTokens, outputTokens, reasoningTokens } =
-      this.computeTokenCounts(rawUsage);
-    const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
-
-    return {
-      inputTokens,
-      outputTokens,
-      cost: this.computePrice(rawUsage),
+        computePrice: (usage) => this.computePrice(usage),
+        extract: (usage) => {
+          const { inputTokens, outputTokens, reasoningTokens } =
+            this.computeTokenCounts(usage);
+          return {
+            inputTokens,
+            outputTokens,
+            cachedTokens: usage.cachedContentTokenCount ?? 0,
+            reasoningTokens,
+            toolUsePromptTokens: usage.toolUsePromptTokenCount ?? 0,
+          };
+        },
+      },
+      rawUsage,
       responseTimeMs,
-      provider: 'google',
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens: reasoningTokens || undefined,
-      toolUsePromptTokens: rawUsage.toolUsePromptTokenCount || undefined,
-      _native: rawUsage,
-    };
+    );
   }
 
   addContinueMessageWithPrefill(

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -49,7 +49,7 @@ import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
-import { computeCachePercentage } from './utils/usageNormalization';
+import { normalizeUsage } from './support/UsageNormalizer';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError, withSdkErrorTag } from './support/sdkErrorAdapters';
 
@@ -1245,45 +1245,40 @@ export class ModelHandlerOpenAI<
     rawUsage: ExtendedCompletionUsage | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    if (!rawUsage) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cost: 0,
-        responseTimeMs,
+    return normalizeUsage(
+      {
         provider: this.usageProvider,
-      };
-    }
+        computePrice: (usage) => this.computePrice(usage),
+        extract: (usage) => {
+          // OpenAI: prompt_tokens_details.cached_tokens; DeepSeek: prompt_cache_hit_tokens
+          const cachedTokens =
+            usage.prompt_tokens_details?.cached_tokens ??
+            usage.prompt_cache_hit_tokens ??
+            0;
+          const cacheMissTokens = usage.prompt_cache_miss_tokens ?? 0;
 
-    // OpenAI: prompt_tokens_details.cached_tokens; DeepSeek: prompt_cache_hit_tokens
-    const cachedTokens =
-      rawUsage.prompt_tokens_details?.cached_tokens ??
-      rawUsage.prompt_cache_hit_tokens ??
-      0;
-    const cacheMissTokens = rawUsage.prompt_cache_miss_tokens ?? 0;
+          // OpenAI's prompt_tokens is the TOTAL (includes cached tokens). DeepSeek
+          // also exposes cache hit/miss fields; use their sum as a fallback if
+          // prompt_tokens is absent from an OpenAI-compatible response.
+          const inputTokens =
+            usage.prompt_tokens ??
+            (cachedTokens > 0 || cacheMissTokens > 0
+              ? cachedTokens + cacheMissTokens
+              : 0);
 
-    // OpenAI's prompt_tokens is the TOTAL (includes cached tokens). DeepSeek also
-    // exposes cache hit/miss fields; use their sum as a fallback if prompt_tokens
-    // is absent from an OpenAI-compatible response.
-    const inputTokens =
-      rawUsage.prompt_tokens ??
-      (cachedTokens > 0 || cacheMissTokens > 0
-        ? cachedTokens + cacheMissTokens
-        : 0);
-
-    return {
-      inputTokens,
-      outputTokens: rawUsage.completion_tokens ?? 0,
-      cost: this.computePrice(rawUsage),
+          return {
+            inputTokens,
+            outputTokens: usage.completion_tokens ?? 0,
+            cachedTokens,
+            cacheMissTokens,
+            reasoningTokens:
+              usage.completion_tokens_details?.reasoning_tokens ?? 0,
+          };
+        },
+      },
+      rawUsage,
       responseTimeMs,
-      provider: this.usageProvider,
-      cachedInputTokens: cachedTokens || undefined,
-      cacheMissInputTokens: cacheMissTokens || undefined,
-      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens:
-        rawUsage.completion_tokens_details?.reasoning_tokens || undefined,
-      _native: rawUsage,
-    };
+    );
   }
 
   /** Updates message content for models with prefill support. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -48,7 +48,7 @@ import {
 import { flexibleFS } from '@utils/files/flexibleFS';
 import type { FileLocation } from '@utils/files/taskRunStorage';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
-import { computeCachePercentage } from './utils/usageNormalization';
+import { normalizeUsage } from './support/UsageNormalizer';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError, withSdkErrorTag } from './support/sdkErrorAdapters';
 import {
@@ -2240,31 +2240,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     rawUsage: ResponseUsage,
     responseTimeMs: number,
   ): NormalizedUsage {
-    if (!rawUsage) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cost: 0,
-        responseTimeMs,
+    return normalizeUsage(
+      {
         provider: 'openai-response',
-      };
-    }
-
-    const inputTokens = rawUsage.input_tokens ?? 0;
-    const cachedTokens = rawUsage.input_tokens_details?.cached_tokens ?? 0;
-
-    return {
-      inputTokens,
-      outputTokens: rawUsage.output_tokens ?? 0,
-      cost: this.computePrice(rawUsage),
+        computePrice: (usage) => this.computePrice(usage),
+        extract: (usage) => ({
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cachedTokens: usage.input_tokens_details?.cached_tokens ?? 0,
+          reasoningTokens: usage.output_tokens_details?.reasoning_tokens ?? 0,
+        }),
+      },
+      rawUsage,
       responseTimeMs,
-      provider: 'openai-response',
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens:
-        rawUsage.output_tokens_details?.reasoning_tokens || undefined,
-      _native: rawUsage,
-    };
+    );
   }
 
   /** Models with prefill support do not require additional continuation messages. */

--- a/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
@@ -19,7 +19,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
-import { computeCachePercentage } from './utils/usageNormalization';
+import { normalizeUsage } from './support/UsageNormalizer';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
 // Local file imports
@@ -793,31 +793,21 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     rawUsage: ChatUsage | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    if (!rawUsage) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cost: 0,
-        responseTimeMs,
+    return normalizeUsage(
+      {
         provider: this.usageProvider,
-      };
-    }
-
-    const inputTokens = rawUsage.promptTokens ?? 0;
-    const cachedTokens = rawUsage.promptTokensDetails?.cachedTokens ?? 0;
-
-    return {
-      inputTokens,
-      outputTokens: rawUsage.completionTokens ?? 0,
-      cost: this.computePrice(rawUsage),
+        computePrice: (usage) => this.computePrice(usage),
+        extract: (usage) => ({
+          inputTokens: usage.promptTokens ?? 0,
+          outputTokens: usage.completionTokens ?? 0,
+          cachedTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
+          reasoningTokens:
+            usage.completionTokensDetails?.reasoningTokens ?? 0,
+        }),
+      },
+      rawUsage,
       responseTimeMs,
-      provider: this.usageProvider,
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens:
-        rawUsage.completionTokensDetails?.reasoningTokens || undefined,
-      _native: rawUsage,
-    };
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
@@ -801,8 +801,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           inputTokens: usage.promptTokens ?? 0,
           outputTokens: usage.completionTokens ?? 0,
           cachedTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
-          reasoningTokens:
-            usage.completionTokensDetails?.reasoningTokens ?? 0,
+          reasoningTokens: usage.completionTokensDetails?.reasoningTokens ?? 0,
         }),
       },
       rawUsage,

--- a/src/agent/modelHandlers/support/UsageNormalizer.ts
+++ b/src/agent/modelHandlers/support/UsageNormalizer.ts
@@ -1,0 +1,101 @@
+/**
+ * Generic, config-driven token-usage normalization shared by model handlers.
+ *
+ * Every provider's `normalizeUsage()` follows the same shape: null-check the
+ * raw usage object, extract input/output/cache/reasoning token counts from
+ * provider-specific fields, compute the cache percentage, compute price, and
+ * assemble a {@link NormalizedUsage}. The only thing that differs between
+ * providers is *where* those values live in the raw usage object (and a few
+ * provider-only extras such as Anthropic's cache-creation/server-tool fields or
+ * Google's tool-use prompt tokens).
+ *
+ * {@link normalizeUsage} captures that common assembly once; each handler
+ * supplies a small {@link UsageNormalizerConfig} describing how to read the
+ * fields. Behavior is intentionally byte-identical to the previous per-handler
+ * implementations — see the field mappings in each handler for details.
+ */
+
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+
+import { computeCachePercentage } from '../utils/usageNormalization';
+
+/**
+ * Token counts extracted from a provider's raw usage object.
+ *
+ * `cachePercentageBasis` is the numerator passed to
+ * {@link computeCachePercentage}; for most providers it equals `cachedTokens`,
+ * but Anthropic counts both cache-read and cache-creation tokens.
+ *
+ * `inputTokens` is the denominator for the cache percentage and the value
+ * surfaced as `NormalizedUsage.inputTokens`.
+ */
+export interface ExtractedUsageTokens {
+  inputTokens: number;
+  outputTokens: number;
+  /** Tokens served from cache. Surfaced as `cachedInputTokens` when > 0. */
+  cachedTokens: number;
+  /** Numerator for the cache percentage (defaults to `cachedTokens`). */
+  cachePercentageBasis?: number;
+  /** Tokens that missed the prompt cache (OpenAI/DeepSeek). */
+  cacheMissTokens?: number;
+  /** Tokens written to cache (Anthropic). */
+  cacheCreationTokens?: number;
+  /** Reasoning/thinking tokens. */
+  reasoningTokens?: number;
+  /** Tool-use prompt tokens (Google). */
+  toolUsePromptTokens?: number;
+  /** Number of server-side tool executions (Anthropic web search/fetch). */
+  serverToolRequests?: number;
+}
+
+/**
+ * Per-provider configuration for {@link normalizeUsage}.
+ *
+ * `T` is the provider's raw usage type (nullable for providers whose extractor
+ * already tolerates a null payload).
+ */
+export interface UsageNormalizerConfig<T> {
+  /** Usage-tracking provider identifier. */
+  provider: NormalizedUsage['provider'];
+  /** Reads provider-specific token counts from the raw usage object. */
+  extract: (rawUsage: NonNullable<T>) => ExtractedUsageTokens;
+  /** Computes API cost for the raw usage object. */
+  computePrice: (rawUsage: NonNullable<T>) => number;
+}
+
+/** Builds a {@link NormalizedUsage} from a provider config and raw usage. */
+export function normalizeUsage<T>(
+  config: UsageNormalizerConfig<T>,
+  rawUsage: T,
+  responseTimeMs: number,
+): NormalizedUsage {
+  if (!rawUsage) {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      responseTimeMs,
+      provider: config.provider,
+    };
+  }
+
+  const raw = rawUsage as NonNullable<T>;
+  const tokens = config.extract(raw);
+  const cacheBasis = tokens.cachePercentageBasis ?? tokens.cachedTokens;
+
+  return {
+    inputTokens: tokens.inputTokens,
+    outputTokens: tokens.outputTokens,
+    cost: config.computePrice(raw),
+    responseTimeMs,
+    provider: config.provider,
+    cachedInputTokens: tokens.cachedTokens || undefined,
+    cacheMissInputTokens: tokens.cacheMissTokens || undefined,
+    cacheCreationTokens: tokens.cacheCreationTokens || undefined,
+    percentageCached: computeCachePercentage(cacheBasis, tokens.inputTokens),
+    reasoningTokens: tokens.reasoningTokens || undefined,
+    toolUsePromptTokens: tokens.toolUsePromptTokens || undefined,
+    serverToolRequests: tokens.serverToolRequests || undefined,
+    _native: raw,
+  };
+}

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -34,6 +34,7 @@ import {
   publishCompiledPdfArtifact,
   type CompiledPdfArtifact,
 } from './compiledPdfArtifacts';
+import { tryOperation } from './outputOperations';
 import type { RoundFileMapping } from './types';
 
 interface DiffOutputDirectory {
@@ -113,15 +114,12 @@ export class LatexDiffManager {
     stage?: StageHandle,
   ): Promise<CompiledPdfArtifact[]> {
     const execute = () => this.performLatexdiffOperations(currRound, mapping);
-    try {
-      return await (stage ? stage.within(execute) : execute());
-    } catch (err) {
-      this.logger.error(
-        `Error during latexdiff processing: ${toErrorMessage(err)}`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
-      );
-      return [];
-    }
+    return tryOperation(() => (stage ? stage.within(execute) : execute()), {
+      logger: this.logger,
+      level: 'error',
+      label: 'Error during latexdiff processing',
+      recover: () => [],
+    });
   }
 
   private async performLatexdiffOperations(

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,9 +1,7 @@
 import { logMissingOutputs, type AgentTrace } from '@agent/trace';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { toErrorMessage } from '@common/errors';
 import {
-  MESSAGE_TYPES,
   type FileLocation,
   type OutputFileInfo,
   type OutputXmlSummary,
@@ -16,6 +14,7 @@ import {
 } from '@utils/text/xmlUtils';
 
 import { indentLatexFile, indentLatexFiles } from './LatexOutputUtils';
+import { tryOperation } from './outputOperations';
 import type { XmlOutputManager } from './XmlOutputManager';
 
 export interface ProcessingContext {
@@ -44,39 +43,44 @@ export class OutputFileProcessor {
       `Processing multiple outputs for ${outputLocation.absolutePath}`,
     );
 
-    try {
-      const processedPairs =
-        await this.ctx.xmlManager.splitScratchpadMultipleOutputXml(
-          outputLocation,
-          this.ctx.agentSetting.documentTag,
-          currRound,
-        );
+    await tryOperation(
+      async () => {
+        const processedPairs =
+          await this.ctx.xmlManager.splitScratchpadMultipleOutputXml(
+            outputLocation,
+            this.ctx.agentSetting.documentTag,
+            currRound,
+          );
 
-      if (processedPairs.length > 0) {
-        const locations = processedPairs.map((p: OutputFileInfo) => p.location);
-        await indentLatexFiles(locations, logger);
-        logger.debug(
-          `Indented multiple output files: ${locations.map((l) => l.absolutePath).join(',')}`,
-        );
+        if (processedPairs.length > 0) {
+          const locations = processedPairs.map(
+            (p: OutputFileInfo) => p.location,
+          );
+          await indentLatexFiles(locations, logger);
+          logger.debug(
+            `Indented multiple output files: ${locations.map((l) => l.absolutePath).join(',')}`,
+          );
 
-        if (this.ctx.baseFiles.length > 0) {
-          await replaceInputCommands(this.ctx.baseFiles, locations, logger);
+          if (this.ctx.baseFiles.length > 0) {
+            await replaceInputCommands(this.ctx.baseFiles, locations, logger);
+          }
+          this.ctx.setRoundOutputs(currRound, processedPairs);
+          await this.captureXmlSummary(currRound, rawLocation, processedPairs);
+          return;
         }
-        this.ctx.setRoundOutputs(currRound, processedPairs);
-        await this.captureXmlSummary(currRound, rawLocation, processedPairs);
-        return;
-      }
 
-      logger.debug(
-        `No processed files were generated from ${outputLocation.absolutePath}`,
-      );
-      await this.handleEmptyOutput(currRound, rawLocation);
-    } catch (err) {
-      logger.debug(`Error processing output file: ${toErrorMessage(err)}`, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      await this.handleEmptyOutput(currRound, rawLocation);
-    }
+        logger.debug(
+          `No processed files were generated from ${outputLocation.absolutePath}`,
+        );
+        await this.handleEmptyOutput(currRound, rawLocation);
+      },
+      {
+        logger,
+        level: 'debug',
+        label: 'Error processing output file',
+        recover: () => this.handleEmptyOutput(currRound, rawLocation),
+      },
+    );
   }
 
   private handleEmptyOutput(
@@ -96,50 +100,55 @@ export class OutputFileProcessor {
 
     logger.debug(`Processing single output for ${outputLocation.absolutePath}`);
 
-    try {
-      const processed = await this.ctx.xmlManager.processSingleXmlOutput(
-        outputLocation,
-        currRound,
-      );
+    await tryOperation(
+      async () => {
+        const processed = await this.ctx.xmlManager.processSingleXmlOutput(
+          outputLocation,
+          currRound,
+        );
 
-      if (!processed.location.absolutePath) {
+        if (!processed.location.absolutePath) {
+          logger.debug(
+            `No processed file was generated from ${outputLocation.absolutePath}`,
+          );
+          await this.handleEmptyOutput(currRound, rawLocation);
+          return;
+        }
+
+        await indentLatexFile(processed.location, logger);
         logger.debug(
-          `No processed file was generated from ${outputLocation.absolutePath}`,
+          `Indented single output file: ${processed.location.absolutePath}`,
         );
-        await this.handleEmptyOutput(currRound, rawLocation);
-        return;
-      }
 
-      await indentLatexFile(processed.location, logger);
-      logger.debug(
-        `Indented single output file: ${processed.location.absolutePath}`,
-      );
+        if (this.ctx.baseFiles.length > 0) {
+          await replaceInputCommands(
+            this.ctx.baseFiles,
+            [processed.location],
+            logger,
+          );
+        }
 
-      if (this.ctx.baseFiles.length > 0) {
-        await replaceInputCommands(
-          this.ctx.baseFiles,
-          [processed.location],
-          logger,
-        );
-      }
-
-      this.ctx.setRoundOutputs(currRound, [processed]);
-      await this.captureXmlSummary(currRound, rawLocation, [processed]);
-    } catch (err) {
-      logger.debug(`Error processing output file: ${toErrorMessage(err)}`, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      logMissingOutputs(logger, {
-        missing: [] as string[],
-        xmlFile: outputLocation.absolutePath,
-        documentTag: agentSetting.documentTag,
-      });
-      this.ctx.runtimeHost.emit('updateMissingOutputs', {
-        streamId: this.ctx.streamId,
-        filesByRound: { [currRound]: [] },
-      });
-      await this.handleEmptyOutput(currRound, rawLocation);
-    }
+        this.ctx.setRoundOutputs(currRound, [processed]);
+        await this.captureXmlSummary(currRound, rawLocation, [processed]);
+      },
+      {
+        logger,
+        level: 'debug',
+        label: 'Error processing output file',
+        recover: async () => {
+          logMissingOutputs(logger, {
+            missing: [] as string[],
+            xmlFile: outputLocation.absolutePath,
+            documentTag: agentSetting.documentTag,
+          });
+          this.ctx.runtimeHost.emit('updateMissingOutputs', {
+            streamId: this.ctx.streamId,
+            filesByRound: { [currRound]: [] },
+          });
+          await this.handleEmptyOutput(currRound, rawLocation);
+        },
+      },
+    );
   }
 
   private async captureXmlSummary(
@@ -163,61 +172,69 @@ export class OutputFileProcessor {
       return;
     }
 
-    try {
-      const rawContent = await flexibleFS.read(rawOutput);
-      const tagContents: Record<string, string | string[]> = {};
-      const documents: string[] = [];
-      const documentTag = this.ctx.agentSetting.documentTag;
+    await tryOperation(
+      async () => {
+        const rawContent = await flexibleFS.read(rawOutput);
+        const tagContents: Record<string, string | string[]> = {};
+        const documents: string[] = [];
+        const documentTag = this.ctx.agentSetting.documentTag;
 
-      const documentEntries = extractMultipleTextFromTag(
-        rawContent,
-        documentTag,
-      );
-      if (documentEntries.length > 0) {
-        const trimmedDocuments = documentEntries.map((e) => e.content.trim());
-        if (trimmedDocuments.length === 1) {
-          tagContents[documentTag] = trimmedDocuments[0];
-        } else {
-          tagContents[documentTag] = trimmedDocuments;
-        }
-
-        for (const entry of documentEntries) {
-          const nameAttr = entry.name ? ` name="${entry.name}"` : '';
-          documents.push(
-            `<${documentTag}${nameAttr}>${entry.content.trim()}</${documentTag}>`,
-          );
-        }
-      } else {
-        const singleDocument = extractTextFromTag(
+        const documentEntries = extractMultipleTextFromTag(
           rawContent,
           documentTag,
-        ).trim();
-        if (singleDocument) {
-          tagContents[documentTag] = singleDocument;
-          documents.push(`<${documentTag}>${singleDocument}</${documentTag}>`);
+        );
+        if (documentEntries.length > 0) {
+          const trimmedDocuments = documentEntries.map((e) =>
+            e.content.trim(),
+          );
+          if (trimmedDocuments.length === 1) {
+            tagContents[documentTag] = trimmedDocuments[0];
+          } else {
+            tagContents[documentTag] = trimmedDocuments;
+          }
+
+          for (const entry of documentEntries) {
+            const nameAttr = entry.name ? ` name="${entry.name}"` : '';
+            documents.push(
+              `<${documentTag}${nameAttr}>${entry.content.trim()}</${documentTag}>`,
+            );
+          }
+        } else {
+          const singleDocument = extractTextFromTag(
+            rawContent,
+            documentTag,
+          ).trim();
+          if (singleDocument) {
+            tagContents[documentTag] = singleDocument;
+            documents.push(
+              `<${documentTag}>${singleDocument}</${documentTag}>`,
+            );
+          }
         }
-      }
 
-      const scratchpadContent = extractTextFromTag(
-        rawContent,
-        'scratchpad',
-      ).trim();
-      if (scratchpadContent) {
-        tagContents.scratchpad = scratchpadContent;
-      }
+        const scratchpadContent = extractTextFromTag(
+          rawContent,
+          'scratchpad',
+        ).trim();
+        if (scratchpadContent) {
+          tagContents.scratchpad = scratchpadContent;
+        }
 
-      data.xmlSummary = {
-        tagContents,
-        documents,
-        singleOutputFile: singleFile,
-        sourceLocation: rawOutput,
-      };
-    } catch (error) {
-      this.ctx.logger.debug(
-        `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
-      );
-      data.xmlSummary = { ...emptySummary };
-    }
+        data.xmlSummary = {
+          tagContents,
+          documents,
+          singleOutputFile: singleFile,
+          sourceLocation: rawOutput,
+        };
+      },
+      {
+        logger: this.ctx.logger,
+        level: 'debug',
+        label: `Failed to collect XML summary for round ${round}`,
+        recover: () => {
+          data.xmlSummary = { ...emptySummary };
+        },
+      },
+    );
   }
 }

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -184,9 +184,7 @@ export class OutputFileProcessor {
           documentTag,
         );
         if (documentEntries.length > 0) {
-          const trimmedDocuments = documentEntries.map((e) =>
-            e.content.trim(),
-          );
+          const trimmedDocuments = documentEntries.map((e) => e.content.trim());
           if (trimmedDocuments.length === 1) {
             tagContents[documentTag] = trimmedDocuments[0];
           } else {

--- a/src/agent/output/outputOperations.ts
+++ b/src/agent/output/outputOperations.ts
@@ -1,0 +1,43 @@
+import type { AgentTrace } from '@agent/trace';
+import { toErrorMessage } from '@common/errors';
+import { MESSAGE_TYPES } from '@shared/schemas';
+
+/** Trace levels that the output managers use for recoverable failures. */
+type OutputLogLevel = 'error' | 'warn' | 'debug';
+
+export interface TryOperationOptions<T> {
+  /** Trace used for the internal failure line. */
+  logger: AgentTrace;
+  /** Trace level for the failure line (mirrors each call site's prior level). */
+  level: OutputLogLevel;
+  /**
+   * Prefix for the failure line. The resolved error message is appended as
+   * `${label}: ${toErrorMessage(err)}`, matching the previous hand-written
+   * `catch` blocks.
+   */
+  label: string;
+  /** Produces the fallback value (and any side effects) after logging. */
+  recover: (error: unknown) => T | Promise<T>;
+}
+
+/**
+ * Shared `try → log internal → recover` wrapper for the output operation
+ * managers. Runs `operation`; on failure it logs
+ * `${label}: ${toErrorMessage(err)}` at `level` with the INTERNAL message
+ * type, then returns the caller-supplied recovery value. This centralizes the
+ * identical error-recovery boilerplate that `LatexDiffManager`,
+ * `OutputFileProcessor`, and friends each repeated.
+ */
+export async function tryOperation<T>(
+  operation: () => Promise<T>,
+  { logger, level, label, recover }: TryOperationOptions<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    logger[level](`${label}: ${toErrorMessage(error)}`, {
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
+    return recover(error);
+  }
+}

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -4,9 +4,12 @@ import * as vscode from 'vscode';
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import type { DispatcherFn, HandlerRegistry } from '@shared/utils/dispatcher';
 
 // Local file imports
 import { COMMON_COMMANDS } from './commands';
+
+type CommandMessage = { command: string };
 
 /** Type guard to check if a message has a command field */
 function isCommandMessage(
@@ -106,6 +109,51 @@ export abstract class BaseViewMessageHandler<
       this._activeView = webviewView;
     }
     await handler();
+  }
+
+  /** Post a message to the tracked active view, if one is available. */
+  protected postToActiveView(message: unknown): void {
+    this._activeView?.webview.postMessage(message);
+  }
+
+  /** Run a callback with the active view's webview, if available. */
+  protected async withActiveWebview(
+    fn: (webview: vscode.Webview) => Promise<void> | void,
+  ): Promise<void> {
+    const view = this.getActiveView();
+    if (view) await fn(view.webview);
+  }
+
+  /**
+   * Schema-driven dispatch shared by views that route through a typed
+   * {@link DispatcherFn}. Tracks the active view, runs the dispatcher, logs
+   * validation failures at debug, and warns on commands with no handler.
+   */
+  protected async dispatchInbound<TMessage extends CommandMessage>(
+    message: unknown,
+    webviewView: T,
+    dispatcher: DispatcherFn<TMessage>,
+    handlers: HandlerRegistry<TMessage>,
+  ): Promise<void> {
+    await this.withActiveView(webviewView, () => {
+      const handled = dispatcher(message, handlers, (error) => {
+        this.logger.debug(this.channel, 'Message validation failed', {
+          data: error,
+        });
+      });
+
+      if (
+        !handled &&
+        message &&
+        typeof message === 'object' &&
+        'command' in message
+      ) {
+        this.logger.warn(
+          this.channel,
+          `Unhandled command: ${(message as { command: string }).command}`,
+        );
+      }
+    });
   }
 
   /**

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -2,10 +2,13 @@
 import { platform } from '@platform/platform';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { getWorkspaceState } from '@agent/core/stateStore';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
+import {
+  createEnumParser,
+  createEnumStateGetter,
+} from './support/enumConfig';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,
@@ -35,20 +38,19 @@ const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
     'claude-opus-4-7': 'claude-opus-4-8',
   };
 
-export function parseClaudeAgentModel(raw: string): ClaudeAgentModel {
-  if ((CLAUDE_AGENT_MODELS as readonly string[]).includes(raw)) {
-    return raw as ClaudeAgentModel;
-  }
-  return RETIRED_CLAUDE_AGENT_MODELS[raw] ?? CLAUDE_AGENT_DEFAULT_MODEL;
-}
+export const parseClaudeAgentModel: (raw: string) => ClaudeAgentModel =
+  createEnumParser(
+    CLAUDE_AGENT_MODELS,
+    CLAUDE_AGENT_DEFAULT_MODEL,
+    RETIRED_CLAUDE_AGENT_MODELS,
+  );
 
-export function getClaudeAgentModel(): ClaudeAgentModel {
-  const raw = getWorkspaceState().get<string>(
+export const getClaudeAgentModel: () => ClaudeAgentModel =
+  createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_MODEL,
     CLAUDE_AGENT_DEFAULT_MODEL,
+    parseClaudeAgentModel,
   );
-  return parseClaudeAgentModel(raw);
-}
 
 // ============================================================================
 // Permission mode
@@ -56,21 +58,19 @@ export function getClaudeAgentModel(): ClaudeAgentModel {
 
 const PERMISSION_MODE_DEFAULT: ClaudeAgentPermissionMode = 'acceptEdits';
 
-export function parseClaudeAgentPermissionMode(
+export const parseClaudeAgentPermissionMode: (
   raw: string,
-): ClaudeAgentPermissionMode {
-  return (CLAUDE_AGENT_PERMISSION_MODES as readonly string[]).includes(raw)
-    ? (raw as ClaudeAgentPermissionMode)
-    : PERMISSION_MODE_DEFAULT;
-}
+) => ClaudeAgentPermissionMode = createEnumParser(
+  CLAUDE_AGENT_PERMISSION_MODES,
+  PERMISSION_MODE_DEFAULT,
+);
 
-export function getClaudeAgentPermissionMode(): ClaudeAgentPermissionMode {
-  const raw = getWorkspaceState().get<string>(
+export const getClaudeAgentPermissionMode: () => ClaudeAgentPermissionMode =
+  createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
     PERMISSION_MODE_DEFAULT,
+    parseClaudeAgentPermissionMode,
   );
-  return parseClaudeAgentPermissionMode(raw);
-}
 
 // ============================================================================
 // Effort — adaptive thinking depth hint passed via `effort` SDK option
@@ -78,19 +78,15 @@ export function getClaudeAgentPermissionMode(): ClaudeAgentPermissionMode {
 
 const EFFORT_DEFAULT: ClaudeAgentEffort = 'high';
 
-export function parseClaudeAgentEffort(raw: string): ClaudeAgentEffort {
-  return (CLAUDE_AGENT_EFFORT_LEVELS as readonly string[]).includes(raw)
-    ? (raw as ClaudeAgentEffort)
-    : EFFORT_DEFAULT;
-}
+export const parseClaudeAgentEffort: (raw: string) => ClaudeAgentEffort =
+  createEnumParser(CLAUDE_AGENT_EFFORT_LEVELS, EFFORT_DEFAULT);
 
-export function getClaudeAgentEffort(): ClaudeAgentEffort {
-  const raw = getWorkspaceState().get<string>(
+export const getClaudeAgentEffort: () => ClaudeAgentEffort =
+  createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
     EFFORT_DEFAULT,
+    parseClaudeAgentEffort,
   );
-  return parseClaudeAgentEffort(raw);
-}
 
 // ============================================================================
 // Auth env — pulls ANTHROPIC_API_KEY from secrets if set

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -5,10 +5,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
-import {
-  createEnumParser,
-  createEnumStateGetter,
-} from './support/enumConfig';
+import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_AGENT_DISPLAY_MODEL,

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -15,15 +15,10 @@
  *    `query()`. Results are cached for the session.
  */
 
-import { createRequire } from 'module';
 import * as path from 'path';
 
 import { isModuleNotFoundError } from '@common/errors';
-import { executeCommandSync } from '@utils/system/execUtils';
-import {
-  getPackagedElectronResourcesPath,
-  pathExists,
-} from './support/externalBinaryUtils';
+import { pathExists, resolveBinary } from './support/externalBinaryUtils';
 
 type QueryFn = (params: {
   prompt: string | AsyncIterable<unknown>;
@@ -123,129 +118,34 @@ let cachedBinaryPath: string | undefined;
 export async function findClaudeBinaryPath(): Promise<string | undefined> {
   if (cachedBinaryPath !== undefined) return cachedBinaryPath;
 
-  const result = await findClaudeBinaryPathUncached();
-  if (result) cachedBinaryPath = result;
-  return result;
-}
-
-async function findClaudeBinaryPathUncached(): Promise<string | undefined> {
   const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
   if (!info) return undefined;
 
-  // Strategy 1: packaged Electron app.asar.unpacked resources
-  // Highest priority when present — packaged apps cannot execute binaries
-  // from inside app.asar.
-  {
-    const resourcesPath = getPackagedElectronResourcesPath();
-    const result =
-      resourcesPath == null
-        ? undefined
-        : await findClaudeBinaryInElectronResources(resourcesPath, info);
-    if (result) return result;
-  }
-
-  // Strategy 2: resolve from local project's node_modules
-  // Preferred in VS Code extension development — matches package.json.
-  {
-    const result = await resolveClaudeBinary(path.join(__dirname, '..'), info);
-    if (result) return result;
-  }
-
-  // Strategy 3: resolve from global npm prefix
-  // Preferred over PATH because the npm-installed binary matches the SDK.
-  {
-    const prefixResult = executeCommandSync(['npm', 'prefix', '-g'], {
-      timeout: 5000,
-    });
-    const prefix = prefixResult.success ? prefixResult.stdout : undefined;
-
-    if (prefix) {
-      const roots = [
-        path.join(
-          prefix,
-          'lib',
-          'node_modules',
-          '@anthropic-ai',
-          'claude-agent-sdk',
-        ),
-        path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
-      ];
-
-      for (const sdkRoot of roots) {
-        const result = await resolveClaudeBinary(sdkRoot, info);
-        if (result) return result;
-      }
-    }
-  }
-
-  // Strategy 4: PATH lookup (native installer, Homebrew, manual install)
-  // The Claude Code CLI's recommended installer drops a `claude` binary into
-  // ~/.local/bin (or similar) that the SDK is happy to invoke directly.
-  {
-    const lookupResult = executeCommandSync(
-      [process.platform === 'win32' ? 'where' : 'which', 'claude'],
-      {
-        timeout: 5000,
-      },
-    );
-    const pathHits = lookupResult.success
-      ? (lookupResult.stdout ?? '').split(/\r?\n/)
-      : [];
-
-    for (const hit of pathHits) {
-      const p = hit.trim();
-      if (!p) continue;
-      // The SDK spawns the binary directly, so skip shell-only npm shims.
-      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
-      if (await pathExists(p)) return p;
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Locate the Claude binary inside an Electron packaged app's unpacked
- * resources directory.
- */
-async function findClaudeBinaryInElectronResources(
-  resourcesPath: string,
-  info: PlatformInfo,
-): Promise<string | undefined> {
-  for (const pkg of info.pkgs) {
-    const platformPkgDir = path.join(
-      resourcesPath,
-      'app.asar.unpacked',
-      'node_modules',
-      ...pkg.split('/'),
-    );
+  // The platform binary sits directly in the platform-package directory.
+  const binaryInPlatformPackage = async (
+    platformPkgDir: string,
+  ): Promise<string | undefined> => {
     const binary = path.join(platformPkgDir, CLAUDE_BINARY_NAME);
-    if (await pathExists(binary)) return binary;
-  }
-  return undefined;
-}
+    return (await pathExists(binary)) ? binary : undefined;
+  };
 
-/**
- * Resolve the native Claude binary from a directory that contains (or nests)
- * the platform-specific package. Returns the binary path if found, or
- * `undefined`.
- */
-async function resolveClaudeBinary(
-  baseDir: string,
-  platformInfo: PlatformInfo,
-): Promise<string | undefined> {
-  const req = createRequire(path.join(baseDir, 'package.json'));
-  for (const pkg of platformInfo.pkgs) {
-    try {
-      const platformPkgJson = req.resolve(`${pkg}/package.json`);
-      const binary = path.join(
-        path.dirname(platformPkgJson),
-        CLAUDE_BINARY_NAME,
-      );
-      if (await pathExists(binary)) return binary;
-    } catch {
-      // Platform package not resolvable
-    }
-  }
-  return undefined;
+  const result = await resolveBinary({
+    platformPackages: info.pkgs,
+    binaryInPlatformPackage,
+    // The npm global prefix hosts the `@anthropic-ai/claude-agent-sdk`
+    // package; the platform packages resolve relative to those roots.
+    globalPrefixRoots: (prefix) => [
+      path.join(
+        prefix,
+        'lib',
+        'node_modules',
+        '@anthropic-ai',
+        'claude-agent-sdk',
+      ),
+      path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+    ],
+    pathCommand: 'claude',
+  });
+  if (result) cachedBinaryPath = result;
+  return result;
 }

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -1,11 +1,14 @@
 // Local imports - agent config
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { getWorkspaceState } from '@agent/core/stateStore';
 import {
   buildAgentWorkspaceOptions,
   type AgentWorkspaceOptions,
 } from './agentWorkspaceOptions';
+import {
+  createEnumParser,
+  createEnumStateGetter,
+} from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
 // Type-only imports
@@ -33,19 +36,16 @@ export type CodexReasoningEffort = (typeof REASONING_EFFORTS)[number];
 const REASONING_EFFORT_KEY = 'texra.codexReasoningEffort';
 const REASONING_EFFORT_DEFAULT: CodexReasoningEffort = 'high';
 
-export function parseCodexReasoningEffort(raw: string): CodexReasoningEffort {
-  return (REASONING_EFFORTS as readonly string[]).includes(raw)
-    ? (raw as CodexReasoningEffort)
-    : REASONING_EFFORT_DEFAULT;
-}
+export const parseCodexReasoningEffort = createEnumParser(
+  REASONING_EFFORTS,
+  REASONING_EFFORT_DEFAULT,
+);
 
-export function getCodexReasoningEffort(): CodexReasoningEffort {
-  const raw = getWorkspaceState().get<string>(
-    REASONING_EFFORT_KEY,
-    REASONING_EFFORT_DEFAULT,
-  );
-  return parseCodexReasoningEffort(raw);
-}
+export const getCodexReasoningEffort = createEnumStateGetter(
+  REASONING_EFFORT_KEY,
+  REASONING_EFFORT_DEFAULT,
+  parseCodexReasoningEffort,
+);
 
 /**
  * Codex CLI's Rust-side config deserializer only accepts a subset of the
@@ -85,19 +85,15 @@ export type CodexApprovalPolicy = ApprovalMode;
 const APPROVAL_POLICY_KEY = 'texra.codexApprovalPolicy';
 const APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
 
-export function parseCodexApprovalPolicy(raw: string): CodexApprovalPolicy {
-  return (APPROVAL_POLICIES as readonly string[]).includes(raw)
-    ? (raw as CodexApprovalPolicy)
-    : APPROVAL_POLICY_DEFAULT;
-}
+export const parseCodexApprovalPolicy: (raw: string) => CodexApprovalPolicy =
+  createEnumParser(APPROVAL_POLICIES, APPROVAL_POLICY_DEFAULT);
 
-export function getCodexApprovalPolicy(): CodexApprovalPolicy {
-  const raw = getWorkspaceState().get<string>(
+export const getCodexApprovalPolicy: () => CodexApprovalPolicy =
+  createEnumStateGetter(
     APPROVAL_POLICY_KEY,
     APPROVAL_POLICY_DEFAULT,
+    parseCodexApprovalPolicy,
   );
-  return parseCodexApprovalPolicy(raw);
-}
 
 // ============================================================================
 // Sandbox mode
@@ -115,19 +111,15 @@ export type CodexSandboxMode = SandboxMode;
 const SANDBOX_MODE_KEY = 'texra.codexSandboxMode';
 const SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';
 
-export function parseCodexSandboxMode(raw: string): CodexSandboxMode {
-  return (SANDBOX_MODES as readonly string[]).includes(raw)
-    ? (raw as CodexSandboxMode)
-    : SANDBOX_MODE_DEFAULT;
-}
+export const parseCodexSandboxMode: (raw: string) => CodexSandboxMode =
+  createEnumParser(SANDBOX_MODES, SANDBOX_MODE_DEFAULT);
 
-export function getCodexSandboxMode(): CodexSandboxMode {
-  const raw = getWorkspaceState().get<string>(
+export const getCodexSandboxMode: () => CodexSandboxMode =
+  createEnumStateGetter(
     SANDBOX_MODE_KEY,
     SANDBOX_MODE_DEFAULT,
+    parseCodexSandboxMode,
   );
-  return parseCodexSandboxMode(raw);
-}
 
 /**
  * Build synthetic execution metadata for Codex child streams.

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -5,10 +5,7 @@ import {
   buildAgentWorkspaceOptions,
   type AgentWorkspaceOptions,
 } from './agentWorkspaceOptions';
-import {
-  createEnumParser,
-  createEnumStateGetter,
-} from './support/enumConfig';
+import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
 // Type-only imports

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -14,14 +14,12 @@
  *    are cached for the session.
  */
 
-import { createRequire } from 'module';
 import * as path from 'path';
 
 import { isModuleNotFoundError } from '@common/errors';
-import { executeCommandSync } from '@utils/system/execUtils';
 import {
-  getPackagedElectronResourcesPath,
   pathExists,
+  resolveBinary,
 } from './support/externalBinaryUtils';
 
 type CodexConstructor = new (options?: any) => any;
@@ -104,6 +102,27 @@ const PLATFORM_INFO: Record<string, PlatformInfo> = {
 /** Cached result — found paths are cached; misses are retried. */
 let cachedBinaryPath: string | undefined;
 
+/** Native CLI binary filename for the current platform. */
+const CODEX_BINARY_NAME = process.platform === 'win32' ? 'codex.exe' : 'codex';
+
+/**
+ * Locate the native Codex binary inside a resolved platform-package directory.
+ * The binary nests under `vendor/<triple>/codex/<binaryName>`.
+ */
+async function codexBinaryInPlatformPackage(
+  platformPkgDir: string,
+  platformInfo: PlatformInfo,
+): Promise<string | undefined> {
+  const binary = path.join(
+    platformPkgDir,
+    'vendor',
+    platformInfo.triple,
+    'codex',
+    CODEX_BINARY_NAME,
+  );
+  return (await pathExists(binary)) ? binary : undefined;
+}
+
 /**
  * Locate the native Codex CLI binary. Results are cached for the session
  * (misses are always retried so mid-session installs are picked up).
@@ -114,84 +133,22 @@ let cachedBinaryPath: string | undefined;
 export async function findCodexBinaryPath(): Promise<string | undefined> {
   if (cachedBinaryPath !== undefined) return cachedBinaryPath;
 
-  const result = await findCodexBinaryPathUncached();
-  if (result) cachedBinaryPath = result;
-  return result;
-}
-
-async function findCodexBinaryPathUncached(): Promise<string | undefined> {
   const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
   if (!info) return undefined;
 
-  const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
-
-  // Strategy 1: packaged Electron app.asar.unpacked resources
-  // Highest priority when present — packaged apps cannot execute binaries
-  // from inside app.asar.
-  {
-    const resourcesPath = getPackagedElectronResourcesPath();
-    const result =
-      resourcesPath == null
-        ? undefined
-        : await findCodexBinaryInElectronResources(resourcesPath);
-    if (result) return result;
-  }
-
-  // Strategy 2: resolve from local project's node_modules
-  // Preferred in VS Code extension development — matches package.json.
-  {
-    const result = await resolveCodexBinary(
-      path.join(__dirname, '..'),
-      info,
-      binaryName,
-    );
-    if (result) return result;
-  }
-
-  // Strategy 3: resolve from global npm prefix
-  // Preferred over PATH because the npm-installed binary matches the SDK.
-  {
-    const prefixResult = executeCommandSync(['npm', 'prefix', '-g'], {
-      timeout: 5000,
-    });
-    const prefix = prefixResult.success ? prefixResult.stdout : undefined;
-
-    if (prefix) {
-      const roots = [
-        path.join(prefix, 'lib', 'node_modules', '@openai', 'codex'),
-        path.join(prefix, 'node_modules', '@openai', 'codex'),
-      ];
-
-      for (const codexPkgDir of roots) {
-        const result = await resolveCodexBinary(codexPkgDir, info, binaryName);
-        if (result) return result;
-      }
-    }
-  }
-
-  // Strategy 4: PATH lookup (Homebrew, manual install, etc.)
-  // Fallback — may find an older version that doesn't match the SDK.
-  {
-    const lookupResult = executeCommandSync(
-      [process.platform === 'win32' ? 'where' : 'which', 'codex'],
-      {
-        timeout: 5000,
-      },
-    );
-    const pathHits = lookupResult.success
-      ? (lookupResult.stdout ?? '').split(/\r?\n/)
-      : [];
-
-    for (const hit of pathHits) {
-      const p = hit.trim();
-      if (!p) continue;
-      // The SDK spawns the binary directly, so skip shell-only npm shims.
-      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
-      if (await pathExists(p)) return p;
-    }
-  }
-
-  return undefined;
+  const result = await resolveBinary({
+    platformPackages: [info.pkg],
+    binaryInPlatformPackage: (dir) => codexBinaryInPlatformPackage(dir, info),
+    // The npm global prefix hosts the `@openai/codex` meta-package; the
+    // platform package is resolved relative to those roots.
+    globalPrefixRoots: (prefix) => [
+      path.join(prefix, 'lib', 'node_modules', '@openai', 'codex'),
+      path.join(prefix, 'node_modules', '@openai', 'codex'),
+    ],
+    pathCommand: 'codex',
+  });
+  if (result) cachedBinaryPath = result;
+  return result;
 }
 
 /**
@@ -208,7 +165,6 @@ export async function findCodexBinaryInElectronResources(
   const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
   if (!info) return undefined;
 
-  const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
   const platformPkgDir = path.join(
     resourcesPath,
     'app.asar.unpacked',
@@ -216,52 +172,5 @@ export async function findCodexBinaryInElectronResources(
     ...info.pkg.split('/'),
   );
 
-  return resolveCodexBinaryFromPlatformPackage(
-    platformPkgDir,
-    info,
-    binaryName,
-  );
-}
-
-/**
- * Resolve the native Codex binary from a directory that contains (or nests)
- * the platform-specific package.  Returns the binary path if found, or
- * `undefined`.
- *
- * Works for both a direct `@openai/codex` package dir and any ancestor
- * that Node module resolution can traverse from.
- */
-async function resolveCodexBinary(
-  baseDir: string,
-  platformInfo: PlatformInfo,
-  binaryName: string,
-): Promise<string | undefined> {
-  try {
-    const req = createRequire(path.join(baseDir, 'package.json'));
-    const platformPkgJson = req.resolve(`${platformInfo.pkg}/package.json`);
-    const binary = await resolveCodexBinaryFromPlatformPackage(
-      path.dirname(platformPkgJson),
-      platformInfo,
-      binaryName,
-    );
-    if (binary) return binary;
-  } catch {
-    // Platform package not resolvable
-  }
-  return undefined;
-}
-
-async function resolveCodexBinaryFromPlatformPackage(
-  platformPkgDir: string,
-  platformInfo: PlatformInfo,
-  binaryName: string,
-): Promise<string | undefined> {
-  const binary = path.join(
-    platformPkgDir,
-    'vendor',
-    platformInfo.triple,
-    'codex',
-    binaryName,
-  );
-  return (await pathExists(binary)) ? binary : undefined;
+  return codexBinaryInPlatformPackage(platformPkgDir, info);
 }

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,10 +17,7 @@
 import * as path from 'path';
 
 import { isModuleNotFoundError } from '@common/errors';
-import {
-  pathExists,
-  resolveBinary,
-} from './support/externalBinaryUtils';
+import { pathExists, resolveBinary } from './support/externalBinaryUtils';
 
 type CodexConstructor = new (options?: any) => any;
 type PlatformInfo = { pkg: string; triple: string };

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -2,17 +2,12 @@
 import { z } from 'zod';
 
 // Local imports
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import {
-  API_PROVIDERS,
-  invalidateApiKeyCache,
-  isApiProvider,
-} from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
+import { refreshApiKeyCaches, requireApiProvider } from './apiKeyHelpers';
 
 const SetApiKeyInputSchema = z.strictObject({
   provider: z
@@ -71,13 +66,7 @@ export class SetApiKeyTool extends defineTool({
 }) {
   protected async execute(input: SetApiKeyInput): Promise<ToolResult> {
     const platform = getSetupPlatform();
-    const provider = input.provider.trim();
-
-    if (!isApiProvider(provider)) {
-      throw new ToolError(
-        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
-      );
-    }
+    const provider = requireApiProvider(input.provider);
 
     if (looksLikePlaceholder(input.key)) {
       throw new ToolError(
@@ -90,16 +79,7 @@ export class SetApiKeyTool extends defineTool({
     // Drop cached model availability and key-origin lookups before the refresh
     // so every downstream status surface sees the just-added key. Matches the
     // manual `texra.setApiKey` command's ordering in `apiKeyCommands`.
-    invalidateModelOptionsCache();
-    invalidateApiKeyCache();
-    await Promise.all([
-      platform.commands
-        .invoke('texra.refreshApiKeyStatus')
-        .catch(() => undefined),
-      platform.commands
-        .invoke('texra.refreshAllOptions')
-        .catch(() => undefined),
-    ]);
+    await refreshApiKeyCaches(platform);
 
     const masked = maskKey(input.key);
     return {

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -2,17 +2,12 @@
 import { z } from 'zod';
 
 // Local imports
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import {
-  API_PROVIDERS,
-  invalidateApiKeyCache,
-  isApiProvider,
-} from '@model/apiProviders';
-import { ToolError, type ToolResult } from '@tools/result';
+import { type ToolResult } from '@tools/result';
 
 // Local file imports
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
+import { refreshApiKeyCaches, requireApiProvider } from './apiKeyHelpers';
 
 const UnsetApiKeyInputSchema = z.strictObject({
   provider: z
@@ -30,13 +25,7 @@ export class UnsetApiKeyTool extends defineTool({
 }) {
   protected async execute(input: UnsetApiKeyInput): Promise<ToolResult> {
     const platform = getSetupPlatform();
-    const provider = input.provider.trim();
-
-    if (!isApiProvider(provider)) {
-      throw new ToolError(
-        `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
-      );
-    }
+    const provider = requireApiProvider(input.provider);
 
     const storedExists = await platform.secrets.storedApiKeyExists(provider);
     if (!storedExists) {
@@ -64,16 +53,7 @@ export class UnsetApiKeyTool extends defineTool({
     // Mirror the manual removal flow: drop cached model availability and
     // key-origin lookups so models that just lost their credential stop
     // appearing selectable.
-    invalidateModelOptionsCache();
-    invalidateApiKeyCache();
-    await Promise.all([
-      platform.commands
-        .invoke('texra.refreshApiKeyStatus')
-        .catch(() => undefined),
-      platform.commands
-        .invoke('texra.refreshAllOptions')
-        .catch(() => undefined),
-    ]);
+    await refreshApiKeyCaches(platform);
 
     // A shell env var can shadow the deletion — flag that so the agent can
     // tell the user why the key still appears to exist after removal.

--- a/src/tools/setup/apiKeyHelpers.ts
+++ b/src/tools/setup/apiKeyHelpers.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared helpers for the `set_api_key` / `unset_api_key` tools.
+ *
+ * Both tools validate the provider name the same way and, after mutating
+ * SecretStorage, refresh the same caches and status surfaces. Centralising
+ * keeps the validation message and the refresh ordering identical across both.
+ */
+
+import {
+  API_PROVIDERS,
+  invalidateApiKeyCache,
+  isApiProvider,
+  type ApiProvider,
+} from '@model/apiProviders';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { ToolError } from '@tools/result';
+
+import type { SetupPlatform } from './platform';
+
+/**
+ * Trim and validate a provider name, throwing a `ToolError` with the supported
+ * list when it isn't a known provider.
+ */
+export function requireApiProvider(raw: string): ApiProvider {
+  const provider = raw.trim();
+  if (!isApiProvider(provider)) {
+    throw new ToolError(
+      `Unknown provider "${provider}". Supported: ${API_PROVIDERS.join(', ')}.`,
+    );
+  }
+  return provider;
+}
+
+/**
+ * Drop cached model availability and key-origin lookups, then refresh the
+ * status surfaces. Mirrors the manual `texra.setApiKey` command ordering so
+ * every downstream status surface sees the mutation.
+ */
+export async function refreshApiKeyCaches(
+  platform: SetupPlatform,
+): Promise<void> {
+  invalidateModelOptionsCache();
+  invalidateApiKeyCache();
+  await Promise.all([
+    platform.commands.invoke('texra.refreshApiKeyStatus').catch(() => undefined),
+    platform.commands.invoke('texra.refreshAllOptions').catch(() => undefined),
+  ]);
+}

--- a/src/tools/setup/apiKeyHelpers.ts
+++ b/src/tools/setup/apiKeyHelpers.ts
@@ -42,7 +42,9 @@ export async function refreshApiKeyCaches(
   invalidateModelOptionsCache();
   invalidateApiKeyCache();
   await Promise.all([
-    platform.commands.invoke('texra.refreshApiKeyStatus').catch(() => undefined),
+    platform.commands
+      .invoke('texra.refreshApiKeyStatus')
+      .catch(() => undefined),
     platform.commands.invoke('texra.refreshAllOptions').catch(() => undefined),
   ]);
 }

--- a/src/tools/support/enumConfig.ts
+++ b/src/tools/support/enumConfig.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared helpers for tools that persist an enum-valued setting in workspace
+ * state. Both the Codex and Claude Code tools follow the same pattern:
+ *
+ *   1. A `parse(raw)` that maps an arbitrary string onto a known enum value,
+ *      falling back to a default when the string isn't recognised.
+ *   2. A `get()` that reads the persisted string from workspace state and runs
+ *      it through `parse`.
+ *
+ * Centralising the pattern keeps the parse-with-default + read-from-state
+ * semantics identical across both tools.
+ */
+
+import { getWorkspaceState } from '@agent/core/stateStore';
+
+/**
+ * Build a parser that maps an arbitrary string onto a member of `values`,
+ * returning `fallback` for anything not in the set. An optional `aliases` map
+ * redirects retired/renamed values onto a current member before the fallback.
+ */
+export function createEnumParser<T extends string>(
+  values: readonly T[],
+  fallback: T,
+  aliases?: Readonly<Record<string, T>>,
+): (raw: string) => T {
+  const known = values as readonly string[];
+  return (raw: string): T => {
+    if (known.includes(raw)) return raw as T;
+    return aliases?.[raw] ?? fallback;
+  };
+}
+
+/**
+ * Build a workspace-state accessor for an enum setting: reads the persisted
+ * string under `key` (defaulting to `fallback`) and runs it through `parse`.
+ */
+export function createEnumStateGetter<T extends string>(
+  key: string,
+  fallback: T,
+  parse: (raw: string) => T,
+): () => T {
+  return (): T => {
+    const raw = getWorkspaceState().get<string>(key, fallback);
+    return parse(raw);
+  };
+}

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -7,7 +7,11 @@
  * path-existence helpers. Centralising them here prevents silent drift.
  */
 
+import { createRequire } from 'module';
+import * as path from 'path';
+
 import { platform } from '@platform/platform';
+import { executeCommandSync } from '@utils/system/execUtils';
 
 type ElectronProcess = NodeJS.Process & {
   defaultApp?: boolean;
@@ -36,4 +40,141 @@ export async function pathExists(target: string): Promise<boolean> {
     .fs.stat(target)
     .then(() => true)
     .catch(() => false);
+}
+
+// ---------------------------------------------------------------------------
+// 4-stage binary resolution
+//
+// The Claude Code and Codex tools both locate a native CLI binary shipped as
+// npm platform packages via the same 4-stage probe: packaged Electron
+// resources → local node_modules → global npm prefix → PATH. They differ only
+// in package names, where the binary sits inside a resolved package, and the
+// PATH command name. `resolveBinary(config)` captures the shared skeleton and
+// defers those specifics to the config.
+// ---------------------------------------------------------------------------
+
+export interface ResolveBinaryConfig {
+  /**
+   * npm platform package names to probe for the current platform/arch (e.g.
+   * `['@anthropic-ai/claude-agent-sdk-linux-x64']`). Empty/undefined means the
+   * platform is unsupported and resolution returns `undefined`.
+   */
+  readonly platformPackages: readonly string[];
+  /**
+   * Locate the binary inside a resolved platform-package directory, returning
+   * its path if present or `undefined`. Codex nests the binary under
+   * `vendor/<triple>/codex/`; Claude places it directly in the package dir.
+   */
+  binaryInPlatformPackage(platformPkgDir: string): Promise<string | undefined>;
+  /**
+   * Global npm-prefix package roots to resolve the platform package from,
+   * given the detected `npm prefix -g`. Each root is passed to Node module
+   * resolution; the first that resolves a platform package + binary wins.
+   */
+  globalPrefixRoots(prefix: string): readonly string[];
+  /** Command name for the PATH lookup (e.g. `claude`, `codex`). */
+  readonly pathCommand: string;
+}
+
+/**
+ * Resolve a native CLI binary via the shared 4-stage probe. Returns the
+ * resolved path, or `undefined` to let the caller fall back to its own
+ * resolution. Caching is the caller's responsibility.
+ */
+export async function resolveBinary(
+  config: ResolveBinaryConfig,
+): Promise<string | undefined> {
+  if (config.platformPackages.length === 0) return undefined;
+
+  // Strategy 1: packaged Electron app.asar.unpacked resources
+  // Highest priority when present — packaged apps cannot execute binaries
+  // from inside app.asar.
+  {
+    const resourcesPath = getPackagedElectronResourcesPath();
+    if (resourcesPath != null) {
+      for (const pkg of config.platformPackages) {
+        const platformPkgDir = path.join(
+          resourcesPath,
+          'app.asar.unpacked',
+          'node_modules',
+          ...pkg.split('/'),
+        );
+        const binary = await config.binaryInPlatformPackage(platformPkgDir);
+        if (binary) return binary;
+      }
+    }
+  }
+
+  // Strategy 2: resolve from local project's node_modules
+  // Preferred in VS Code extension development — matches package.json.
+  {
+    const result = await resolveBinaryFromBase(
+      path.join(__dirname, '..'),
+      config,
+    );
+    if (result) return result;
+  }
+
+  // Strategy 3: resolve from global npm prefix
+  // Preferred over PATH because the npm-installed binary matches the SDK.
+  {
+    const prefixResult = executeCommandSync(['npm', 'prefix', '-g'], {
+      timeout: 5000,
+    });
+    const prefix = prefixResult.success ? prefixResult.stdout : undefined;
+
+    if (prefix) {
+      for (const root of config.globalPrefixRoots(prefix)) {
+        const result = await resolveBinaryFromBase(root, config);
+        if (result) return result;
+      }
+    }
+  }
+
+  // Strategy 4: PATH lookup (native installer, Homebrew, manual install)
+  // Fallback — may find an older version that doesn't match the SDK.
+  {
+    const lookupResult = executeCommandSync(
+      [process.platform === 'win32' ? 'where' : 'which', config.pathCommand],
+      {
+        timeout: 5000,
+      },
+    );
+    const pathHits = lookupResult.success
+      ? (lookupResult.stdout ?? '').split(/\r?\n/)
+      : [];
+
+    for (const hit of pathHits) {
+      const p = hit.trim();
+      if (!p) continue;
+      // The SDK spawns the binary directly, so skip shell-only npm shims.
+      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
+      if (await pathExists(p)) return p;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve the platform package from `baseDir` via Node module resolution, then
+ * locate the binary inside it. Returns the binary path if found.
+ */
+async function resolveBinaryFromBase(
+  baseDir: string,
+  config: ResolveBinaryConfig,
+): Promise<string | undefined> {
+  const req = createRequire(path.join(baseDir, 'package.json'));
+  for (const pkg of config.platformPackages) {
+    try {
+      const platformPkgJson = req.resolve(`${pkg}/package.json`);
+      const binary = await config.binaryInPlatformPackage(
+        path.dirname(platformPkgJson),
+      );
+      if (binary) return binary;
+    } catch {
+      // Platform package not resolvable
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
Lift postToActiveView/withActiveWebview and the typed dispatchInbound
wrapper into BaseViewMessageHandler so Main/Progress/Settings handlers
no longer duplicate them. Add shared renderApproveButton to
BaseFeedbackPanel and use it across the request panels.

https://claude.ai/code/session_01YZJFHLsPDKJxuhGchkhtGn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large but mechanical refactor across many packages; risk is regression from copy-paste removal, not new security or data paths.
> 
> **Overview**
> This PR is mostly **deduplication**: the same UI, command, IPC, and agent patterns are pulled into shared helpers, and call sites are rewired to use them without changing intended behavior.
> 
> **Webview / extension:** `BaseViewMessageHandler` gains `postToActiveView`, `withActiveWebview`, and `dispatchInbound`, so Main, Progress, and Settings handlers drop copy-pasted schema dispatch and unhandled-command logging. Progress approval panels share `renderApproveButton` via `BaseFeedbackPanel`. VS Code command modules register through `registerCommands` instead of repeating `context.subscriptions.push(registerCommand(...))`.
> 
> **CLI chat TUI:** Slash-form list UIs (`/agent`, `/memory`, `/model`, `/resume`, `/tools`) share `FormFrame`, `useAsyncListForm`, and `computeSelectWindowSize` instead of per-form frames, async load effects, and row math.
> 
> **CLI commands:** `defineCliCommand` folds `contextFromArgs` → handler → `setExitCode` (optional catch → `writeErrorStderr`). Many subcommands migrate to it; `writeErrorStderr` centralizes error text on stderr.
> 
> **Desktop:** `createCommandHandler` replaces manual `switch (message.command)` in execution, log, onboarding, startup, and view-state IPC (including broadcast `WEBVIEW_READY` via `claim: false`).
> 
> **Agent / tools:** Model handlers normalize usage through `UsageNormalizer`; output paths use `tryOperation` for log-and-recover. Claude/Codex get enum workspace parsers, shared `resolveBinary` for native CLI discovery, and shared API-key cache refresh for setup tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41c123da845ddc7afa85026b3cbe79829d8956c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->