### PR TITLE
fix(cli): stop Ink live-region residue on terminal resize + cut idle repaint churn

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -12,7 +12,7 @@ import { processTailLines } from '../state/childControls';
 import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
-import { childStatusColor, childStatusMarker } from './SubagentListDisplay';
+import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
@@ -31,7 +31,7 @@ function Row({ child, index, tail }: RowProps): React.JSX.Element {
       <Box flexDirection="row">
         <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
         <Text color={childStatusColor(child.status)}>
-          {childStatusMarker()}
+          {CHILD_STATUS_MARKER}
         </Text>
         <Text>{child.agentName || child.toolName || child.executionId}</Text>
         {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -4,7 +4,6 @@
 //
 // The leading numeric index is currently a visual cue only.
 
-import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
@@ -13,39 +12,17 @@ import { processTailLines } from '../state/childControls';
 import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
-import {
-  childStatusColor,
-  childStatusMarker,
-  childStatusPulses,
-} from './SubagentListDisplay';
+import { childStatusColor, childStatusMarker } from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
   readonly index: number;
-  readonly pulseOn: boolean;
   readonly tail?: ProcessOutputTail;
 }
 
 const TAIL_LINES = 4;
-const PULSE_INTERVAL_MS = 700;
 
-function usePulse(enabled: boolean): boolean {
-  const [pulseOn, setPulseOn] = useState(true);
-  useEffect(() => {
-    if (!enabled) {
-      setPulseOn(true);
-      return;
-    }
-    const timer = setInterval(
-      () => setPulseOn((value) => !value),
-      PULSE_INTERVAL_MS,
-    );
-    return () => clearInterval(timer);
-  }, [enabled]);
-  return pulseOn;
-}
-
-function Row({ child, index, pulseOn, tail }: RowProps): React.JSX.Element {
+function Row({ child, index, tail }: RowProps): React.JSX.Element {
   // The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
   // pulling the last `TAIL_LINES` non-blank lines is bounded work.
   const tailLines = processTailLines(tail).slice(-TAIL_LINES);
@@ -54,7 +31,7 @@ function Row({ child, index, pulseOn, tail }: RowProps): React.JSX.Element {
       <Box flexDirection="row">
         <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
         <Text color={childStatusColor(child.status)}>
-          {childStatusMarker(child.status, pulseOn)}
+          {childStatusMarker()}
         </Text>
         <Text>{child.agentName || child.toolName || child.executionId}</Text>
         {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
@@ -86,11 +63,6 @@ export function SubagentList(
   const activeProcesses = slice?.activeProcesses ?? [];
   const processOutput = slice?.processOutput;
   const subagents = slice ? visibleSubagentRows(slice) : [];
-  const pulseOn = usePulse(
-    [...subagents, ...activeProcesses].some((child) =>
-      childStatusPulses(child.status),
-    ),
-  );
   if (!slice) return null;
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
@@ -109,12 +81,7 @@ export function SubagentList(
             Subagents
           </Text>
           {subagents.map((child, i) => (
-            <Row
-              key={child.executionId}
-              child={child}
-              index={i}
-              pulseOn={pulseOn}
-            />
+            <Row key={child.executionId} child={child} index={i} />
           ))}
         </Box>
       ) : null}
@@ -128,7 +95,6 @@ export function SubagentList(
               key={child.executionId}
               child={child}
               index={subagents.length + i}
-              pulseOn={pulseOn}
               tail={processOutput?.get(child.executionId)}
             />
           ))}

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -11,6 +11,4 @@ export function childStatusColor(status: string | undefined): string {
 // non-alt-screen repaint can leave stale glyphs behind on those reprints. Status
 // is conveyed by `childStatusColor`, and liveness by the `running · Ns` text, so
 // the animation bought churn without information.
-export function childStatusMarker(): string {
-  return '● ';
-}
+export const CHILD_STATUS_MARKER = '● ';

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -5,14 +5,12 @@ export function childStatusColor(status: string | undefined): string {
   return 'green';
 }
 
-export function childStatusPulses(status: string | undefined): boolean {
-  return !status || status === 'running' || status === 'in_progress';
-}
-
-export function childStatusMarker(
-  status: string | undefined,
-  pulseOn: boolean,
-): string {
-  if (!childStatusPulses(status)) return '● ';
-  return pulseOn ? '● ' : '○ ';
+// A steady marker — intentionally NOT animated. A blinking dot forced the whole
+// live region (including the stable Todos/Plan panel below it) to repaint twice
+// a second for the entire lifetime of a long-running async subagent, and Ink's
+// non-alt-screen repaint can leave stale glyphs behind on those reprints. Status
+// is conveyed by `childStatusColor`, and liveness by the `running · Ns` text, so
+// the animation bought churn without information.
+export function childStatusMarker(): string {
+  return '● ';
 }

--- a/patches/ink@7.0.4.patch
+++ b/patches/ink@7.0.4.patch
@@ -1,0 +1,18 @@
+diff --git a/build/ink.js b/build/ink.js
+index b8fd45cc990adbc080eff28fc37463cd91337dff..5640b6159be1e6ababac8a77fbc9dcd45d209ce7 100644
+--- a/build/ink.js
++++ b/build/ink.js
+@@ -261,8 +261,11 @@ export default class Ink {
+     }
+     resized = () => {
+         const currentWidth = getWindowSize(this.options.stdout).columns;
+-        if (currentWidth < this.lastTerminalWidth) {
+-            // We clear the screen when decreasing terminal width to prevent duplicate overlapping re-renders.
++        if (currentWidth !== this.lastTerminalWidth) {
++            // Clear on ANY width change, not just a decrease. On widening, the
++            // previously soft-wrapped output occupies more physical rows than the
++            // new render, so without clearing first Ink redraws on top and leaves
++            // the old tail behind as scrollback residue (TeXRA patch).
+             this.log.clear();
+             this.lastOutput = '';
+             this.lastOutputToRender = '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  ink@7.0.4:
+    hash: d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09
+    path: patches/ink@7.0.4.patch
+
 importers:
 
   .:
@@ -350,7 +355,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@inkjs/ui':
         specifier: ^2.0.0
-        version: 2.0.0(ink@7.0.4(@types/react@19.2.15)(react@19.2.6))
+        version: 2.0.0(ink@7.0.4(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6))
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
@@ -386,7 +391,7 @@ importers:
         version: 0.28.0
       ink:
         specifier: ^7.0.4
-        version: 7.0.4(@types/react@19.2.15)(react@19.2.6)
+        version: 7.0.4(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6)
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
@@ -7654,13 +7659,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkjs/ui@2.0.0(ink@7.0.4(@types/react@19.2.15)(react@19.2.6))':
+  '@inkjs/ui@2.0.0(ink@7.0.4(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.4.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 7.0.4(@types/react@19.2.15)(react@19.2.6)
+      ink: 7.0.4(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10957,7 +10962,7 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink@7.0.4(@types/react@19.2.15)(react@19.2.6):
+  ink@7.0.4(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,5 @@ allowBuilds:
   esbuild: true
   keytar: true
   protobufjs: true
+patchedDependencies:
+  ink@7.0.4: patches/ink@7.0.4.patch

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  CHILD_STATUS_MARKER,
   childStatusColor,
-  childStatusMarker,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 
 describe('CLI SubagentList display model', () => {
   it('renders a steady (non-animated) marker for every status', () => {
     // The marker is intentionally static: a blinking dot forced the whole live
     // region to repaint twice a second, which surfaced Ink repaint residue.
-    expect(childStatusMarker()).toBe('● ');
+    expect(CHILD_STATUS_MARKER).toBe('● ');
   });
 
   it('maps status colors consistently', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -3,21 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
   childStatusColor,
   childStatusMarker,
-  childStatusPulses,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 
 describe('CLI SubagentList display model', () => {
-  it('pulses running statuses', () => {
-    expect(childStatusPulses(undefined)).toBe(true);
-    expect(childStatusPulses('running')).toBe(true);
-    expect(childStatusPulses('in_progress')).toBe(true);
-    expect(childStatusPulses('waiting')).toBe(false);
-  });
-
-  it('alternates the marker only for active rows', () => {
-    expect(childStatusMarker('running', true)).toBe('● ');
-    expect(childStatusMarker('running', false)).toBe('○ ');
-    expect(childStatusMarker('waiting', false)).toBe('● ');
+  it('renders a steady (non-animated) marker for every status', () => {
+    // The marker is intentionally static: a blinking dot forced the whole live
+    // region to repaint twice a second, which surfaced Ink repaint residue.
+    expect(childStatusMarker()).toBe('● ');
   });
 
   it('maps status colors consistently', () => {

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -27,8 +27,12 @@ import { WorkspaceFS } from '@utils/files';
 import { defineTool } from './core/define';
 
 const WriteInputSchema = z.strictObject({
-  path: z.string(),
-  content: z.string(),
+  path: z
+    .string()
+    .describe(
+      'The file path to write, workspace-relative or absolute.',
+    ),
+  content: z.string().describe('The full file contents to write.'),
 });
 
 export type WriteInput = z.infer<typeof WriteInputSchema>;

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -29,9 +29,7 @@ import { defineTool } from './core/define';
 const WriteInputSchema = z.strictObject({
   path: z
     .string()
-    .describe(
-      'The file path to write, workspace-relative or absolute.',
-    ),
+    .describe('The file path to write, workspace-relative or absolute.'),
   content: z.string().describe('The full file contents to write.'),
 });
 


### PR DESCRIPTION
## Problem

The CLI TUI's live region was getting destroyed on terminal **resize**: widening the terminal left stale, duplicated content scattered across the screen (e.g. many `executions (/executions)` copies, overlapping todo lines rendering as `fileser` / `verifyo`). It also churned the whole live region ~1.4×/sec while idle-waiting on a long-running async subagent.

## Root cause

`ink@7.0.4`'s `resized` handler only clears the live region when the terminal width **decreases**:

\`\`\`js
if (currentWidth < this.lastTerminalWidth) { this.log.clear(); ... }
\`\`\`

On **widening**, the previously soft-wrapped output occupies more physical rows than the new (unwrapped) render, so Ink redraws on top without erasing the old tail — which then leaks into scrollback and the terminal reflows it to the new width, producing the scatter.

## Changes

1. **Patch `ink@7.0.4`** (`pnpm patch`) so `resized` clears on **any** width change, not just shrink. Checked in as `patches/ink@7.0.4.patch` + `patchedDependencies` in `pnpm-workspace.yaml` (lockfile updated, no version drift).
2. **Remove the 700ms blink** in `SubagentList`: it forced a full live-region repaint twice a second for the entire lifetime of an async subagent — the residue *amplifier*. Marker is now a steady `●` (status via color, liveness via the `running · Ns` text). Deletes `usePulse` / `childStatusPulses` / `pulseOn` plumbing.
3. **`write_file` tool schema**: add `path` / `content` field descriptions so models stop emitting the `file_path` alias. Schema stays strict — no alias accepted.

## Verification

- `npm run typecheck` — passes (EXIT 0).
- `SubagentListDisplay.vitest.mts` — updated and passing.
- `texra-local` built; confirmed the patched resize handler is in the minified bundle (`e!==this.lastTerminalWidth&&(this.log.clear(),…)`) and the old `○` blink glyph is gone.

## Note for reviewers

This patch was applied with pnpm 10.33.2 because pnpm **11.1.1** (the corepack-pinned version) silently no-ops installs in a non-TTY context (it aborts a `node_modules` purge with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`). On an interactive machine, your next `corepack pnpm install` may prompt to remove + reinstall `node_modules` — that's expected and re-applies the patch under 11.1.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI rendering and tool-schema documentation changes; the Ink patch is small and behavior is limited to terminal resize/clear and display churn.
> 
> **Overview**
> Fixes CLI TUI corruption and idle flicker by patching **Ink** and simplifying the subagent list UI, plus a small **write_file** schema tweak.
> 
> **Ink `7.0.4`** is vendored via `pnpm` (`patches/ink@7.0.4.patch`, `pnpm-workspace.yaml` + lockfile): on terminal resize, the live region now clears when width changes in **either** direction, not only on shrink. That avoids stale soft-wrapped rows lingering as duplicated/garbled scrollback when the terminal widens.
> 
> **Subagent list** drops the 700ms pulsing status dot (`usePulse`, `childStatusPulses`, alternating `●`/`○`). Rows always show a static `CHILD_STATUS_MARKER`; color and `running · Ns` text still convey state without forcing ~2 full live-region repaints per second (which amplified Ink repaint artifacts on panels below). Tests updated accordingly.
> 
> **`write_file`** Zod fields `path` and `content` gain `.describe()` text so models use the correct parameter names; the schema stays strict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f656b5dd54ec55ac72aa7a6bf55c49ca1b3650e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->