### PR TITLE
fix(cli): size markdown tables to content, not full terminal width

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -13,6 +13,7 @@ import Table from 'cli-table3';
 import { highlight, supportsLanguage } from 'cli-highlight';
 import Token from 'markdown-it/lib/token.mjs';
 import pico from 'picocolors';
+import stringWidth from 'string-width';
 
 import {
   createMarkdownProcessor,
@@ -58,19 +59,42 @@ const TABLE_MIN_COL_WIDTH = 5;
 // (the live region and Markdown component both pass one, so this is rare).
 const TABLE_FALLBACK_WIDTH = 80;
 
-// Distribute the available width across columns so the rendered table is never
-// wider than `width` — otherwise the trailing `wrapAnsiToWidth` hard-wrap would
-// shred the box-drawing borders. cli-table3's total width is the sum of the
-// column widths plus one border column per column boundary (numCols + 1).
-// Returns undefined when there isn't room to cap, letting cli-table3 size to
-// content instead.
+// cli-table3 pads every cell with one space on each side, so a column's total
+// width is its content width + 2.
+const TABLE_CELL_PADDING = 2;
+
+// Size each column to its widest cell (display width, ANSI-aware) so a compact
+// table stays compact instead of being stretched to fill the terminal. Only
+// when the content-sized layout would overflow `width` do we fall back to an
+// even split — capping the total so the trailing `wrapAnsiToWidth` hard-wrap
+// can't shred the box-drawing borders. cli-table3's total width is the sum of
+// the column widths plus one border column per boundary (numCols + 1). Returns
+// undefined when there isn't room to cap, letting cli-table3 size to content.
 function tableColWidths(
+  head: readonly string[],
+  rows: readonly (readonly string[])[],
   numCols: number,
   width: number | undefined,
 ): number[] | undefined {
   const total = Math.floor(width ?? TABLE_FALLBACK_WIDTH);
   const usable = total - (numCols + 1);
   if (usable < numCols * TABLE_MIN_COL_WIDTH) return undefined;
+
+  // Natural width per column = widest cell content + padding (clamped to the
+  // minimum). `stringWidth` strips ANSI and counts wide glyphs as 2 cells.
+  const natural = Array.from({ length: numCols }, (_, col) => {
+    let widest = head[col] === undefined ? 0 : stringWidth(head[col]);
+    for (const row of rows) {
+      const cell = row[col];
+      if (cell !== undefined) widest = Math.max(widest, stringWidth(cell));
+    }
+    return Math.max(TABLE_MIN_COL_WIDTH, widest + TABLE_CELL_PADDING);
+  });
+
+  // Content fits — keep the table compact (no full-width dead gaps).
+  if (natural.reduce((sum, w) => sum + w, 0) <= usable) return natural;
+
+  // Content overflows — distribute the usable width evenly and cap at `width`.
   const base = Math.floor(usable / numCols);
   const widths = Array.from({ length: numCols }, () => base);
   // Hand the floor remainder to the leftmost columns so the table fills `width`.
@@ -91,7 +115,7 @@ function renderAnsiTable(
   const numCols = Math.max(head.length, ...rows.map((row) => row.length), 1);
   const table = new Table({
     head: head.map((cell) => pico.bold(cell)),
-    colWidths: tableColWidths(numCols, width),
+    colWidths: tableColWidths(head, rows, numCols, width),
     colAligns: Array.from({ length: numCols }, (_, i) => aligns[i] ?? 'left'),
     wordWrap: true,
     // No cli-table3 colorizing — cell content already carries its own ANSI and

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -226,6 +226,22 @@ describe('renderAnsiMarkdown', () => {
     }
   });
 
+  it('sizes a small table to its content instead of stretching to full width', () => {
+    _resetAnsiMarkdownForTests();
+    const md = '| n | digits |\n|---|---|\n| 447 | 993.3 |';
+    const out = renderAnsiMarkdown(md, { width: 80 });
+    const widest = Math.max(
+      ...stripAnsi(out)
+        .split('\n')
+        .map((line) => displayWidthForTest(line)),
+    );
+    // Content needs only a handful of columns — it must not balloon to 80.
+    expect(widest).toBeLessThan(24);
+    expect(widest).toBeGreaterThan(0);
+    expect(stripAnsi(out)).toContain('447');
+    expect(stripAnsi(out)).toContain('993.3');
+  });
+
   it('memoises identical inputs (second call hits the cache)', () => {
     _resetAnsiMarkdownForTests();
     const first = renderAnsiMarkdown('# Title\n\nParagraph.');


### PR DESCRIPTION
## What & why

Fixes #4584. `tableColWidths` divided the entire terminal width evenly across columns, so a table of short cells ballooned to the full width with large empty gaps:

```
┌───────────────────────────────────────────┬───────────────────────────────────────────┐
│ n                                          │ Stirling digit estimate                    │
│ 447                                        │ 993.3                                       │
└───────────────────────────────────────────┴───────────────────────────────────────────┘
```
(top border = full PTY width, for `| 447 | 993.3 |`).

## Fix

Make `tableColWidths` content-aware: measure each column's natural width = widest cell (via `string-width`, which strips ANSI and counts wide glyphs as 2) + cli-table3's 2-cell padding, clamped to `TABLE_MIN_COL_WIDTH`. If the content-sized layout fits within the usable width, use it — the table stays compact. Only when content would overflow do we fall back to the previous even split, so the trailing `wrapAnsiToWidth` still can't shred box borders. No behaviour change for wide tables.

## Tests

`src/test-kernel/cli/AnsiMarkdown.vitest.mts`: new case asserts a small table (`| 447 | 993.3 |`) renders well under the 80-col width (compact); the existing "keeps a table within the requested width" case still guards the overflow→cap path.

## Discovery
Found by the PTY-harness friction-detection workflow driving the real TUI on math problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in CLI markdown table layout with a fallback path unchanged for overflowing tables.
> 
> **Overview**
> **CLI markdown tables** no longer stretch every column to fill the terminal. `tableColWidths` in `ansiMarkdown.ts` now measures each column from the widest header/cell (via `string-width`, with cli-table3 padding and a minimum width). When that layout fits the usable width, those natural widths are used so small tables stay compact; when content would overflow, behavior matches the previous even split so box borders still fit inside `wrapAnsiToWidth`.
> 
> A vitest case asserts a two-column table with short values stays well under an 80-column budget while still showing the cell text; the existing width-cap test still covers wide tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11a639d52f1283461d73484586826f1e2461c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->