### PR TITLE
fix(cli): give wolfram tool runs a content-bearing summary

### DIFF
--- a/src/test-kernel/tools/WolframRunSummary.vitest.ts
+++ b/src/test-kernel/tools/WolframRunSummary.vitest.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { wolframRunSummary } from '@tools/wolfram/WolframTool';
+
+describe('wolframRunSummary', () => {
+  it('embeds the first code line so concurrent calls render as distinct rows', () => {
+    const a = wolframRunSummary('Print[Prime[10]]');
+    const b = wolframRunSummary('Integrate[x^2, x]');
+    expect(a).toBe('Executed: Print[Prime[10]]');
+    expect(b).toBe('Executed: Integrate[x^2, x]');
+    expect(a).not.toBe(b);
+  });
+
+  it('skips leading blank lines and uses the first meaningful line', () => {
+    expect(wolframRunSummary('\n\n  Solve[x + 1 == 0, x]  \nPrint[x]')).toBe(
+      'Executed: Solve[x + 1 == 0, x]',
+    );
+  });
+
+  it('truncates a long first line with an ellipsis', () => {
+    const long =
+      'Table[Prime[k], {k, 1, 100}] (* a deliberately very long inline comment *)';
+    const out = wolframRunSummary(long);
+    expect(out.startsWith('Executed: ')).toBe(true);
+    expect(out).toContain('…');
+    // 'Executed: ' (10) + truncateWithEllipsis budget (60)
+    expect(out.length).toBe('Executed: '.length + 60);
+  });
+
+  it('falls back to plain "Executed" when the code is empty or blank', () => {
+    expect(wolframRunSummary('')).toBe('Executed');
+    expect(wolframRunSummary('   \n  \t ')).toBe('Executed');
+  });
+});

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -5,11 +5,29 @@ import { z } from 'zod';
 import { ToolResult, ToolError } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
+// Local imports - utils
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
+
 // Local file imports
 import {
   WOLFRAM_CODE_TIMEOUT_MS,
   executeWolframCode,
 } from './wolframScriptUtils';
+
+/**
+ * Build a content-bearing summary for a wolfram run so concurrent calls render
+ * as distinct rows instead of an indistinguishable wall of "wolfram (Executed)".
+ * Mirrors bash's `Executed: <preview>` convention; uses the first non-blank
+ * line of the code so multi-line scripts still get a meaningful header.
+ */
+export function wolframRunSummary(code: string): string {
+  const firstLine = code
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  const preview = firstLine ? truncateWithEllipsis(firstLine, 60) : '';
+  return preview ? `Executed: ${preview}` : 'Executed';
+}
 
 const WolframInputSchema = z.strictObject({
   code: z.string(),
@@ -37,7 +55,7 @@ export class WolframTool extends defineTool({
     });
     if (result.success) {
       return {
-        summary: 'Executed',
+        summary: wolframRunSummary(input.code),
         output: result.output ?? '',
       };
     }


### PR DESCRIPTION
## What & why

Fixes #4583. `WolframTool` returned a constant `summary: 'Executed'`, so several `wolfram` calls in one turn all rendered as identical, indistinguishable rows:

```
● wolfram (Executed)
● wolfram (Executed)
● wolfram (Executed)
```

## Fix

Return a content-bearing summary `Executed: <first non-blank code line>` (truncated to 60), mirroring the existing bash convention (`Executed: <command> …`). Extracted as a small pure `wolframRunSummary()` helper so it's unit-testable without the `wolframscript` binary.

Because the summary flows through the shared `headerSummary` path (`normalizeToolUseData`), this fixes **both** the CLI tool rows and the webview/progress-view titles — single source of truth, no host-specific renderer needed.

```
● wolfram (Executed: Table[Prime[k], {k, 1, 5}])
● wolfram (Executed: Integrate[x^2, x])
```

## Tests

`src/test-kernel/tools/WolframRunSummary.vitest.ts`: distinct code → distinct summaries; skips leading blank lines; truncates long lines with an ellipsis; falls back to plain `Executed` for empty/blank code.

## Discovery
Found by the PTY-harness friction-detection workflow driving the real TUI on math problems (the factorial-digits run made 4 wolfram calls, all rendering identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to tool result summaries with no execution, auth, or data-path impact; covered by focused unit tests.
> 
> **Overview**
> Successful **wolfram** tool runs no longer use a fixed `Executed` summary. They now return **`Executed: <preview>`**, where the preview is the first non-blank line of the submitted code (trimmed, truncated to 60 characters with an ellipsis), matching the bash tool’s pattern. Empty or whitespace-only code still yields plain **`Executed`**.
> 
> A pure **`wolframRunSummary()`** helper was added and wired into the success path of **`WolframTool`**, so CLI tool rows and shared header/progress titles can distinguish multiple concurrent calls. Unit tests cover distinct lines, leading blanks, truncation, and the empty fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b3007d8c81772b1a54c6b668e5526636497e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->