### PR TITLE
fix(cli): route usage text to stderr on errors so --output-format stays clean

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,4 +1,6 @@
-import { showUsage, type CommandDef } from 'citty';
+import { renderUsage, showUsage, type CommandDef } from 'citty';
+
+import { writeRawStderr } from '../../runtime/logSinks';
 
 import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
 
@@ -208,6 +210,23 @@ export async function detectUnknownCliCommand(
 
 export function formatUnknownCliCommand(command: UnknownCliCommand): string {
   return `Unknown command: ${command.typedCommand}. Run \`${command.helpCommand} --help\` for usage.`;
+}
+
+/**
+ * Render usage text to STDERR (the diagnostic stream) instead of citty's
+ * `showUsage`, which prints to STDOUT via `consola.log`. Usage shown because of
+ * a usage error must not pollute STDOUT — otherwise `--output-format json|ndjson`
+ * stops being machine-parseable (`texra run ... --output-format json | jq`).
+ *
+ * `renderUsage` is citty's string-returning primitive (it does not write
+ * anywhere), so we own the destination. Explicit `--help` keeps using
+ * `showUsage` (STDOUT) per Unix convention.
+ */
+export async function showUsageStderr(
+  cmd: AnyCommand,
+  parent?: AnyCommand,
+): Promise<void> {
+  writeRawStderr(`${await renderUsage(cmd, parent)}\n`);
 }
 
 export { showUsage };

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -17,6 +17,7 @@ import {
   reorderGlobalFlags,
   resolveDeepestSubCommand,
   showUsage,
+  showUsageStderr,
   type UnknownCliCommand,
 } from './_helpers/dispatch';
 import { getExitCode, resetExitCode } from './_helpers/exitCode';
@@ -146,7 +147,11 @@ export async function runCli(
         rootCommand,
         rawArgs,
       );
-      await showUsage(target, parent);
+      // Usage shown on an ERROR goes to STDERR so STDOUT stays clean and
+      // machine-parseable under `--output-format json|ndjson`. The explicit
+      // `--help` path above keeps using STDOUT (`showUsage`) per Unix
+      // convention.
+      await showUsageStderr(target, parent);
       writeTextStderr(error.message);
       return { exitCode: CliExitCode.Usage };
     }

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -587,12 +587,7 @@ describe('runCli usage output stream routing', () => {
     // of an ERROR must not land on STDOUT, or it pollutes
     // `--output-format json|ndjson` (e.g. `texra run ... | jq`).
     // Mirrors the documented repro: a usage error under --output-format json.
-    const result = await runCli([
-      'run',
-      'badagent',
-      '--output-format',
-      'json',
-    ]);
+    const result = await runCli(['run', 'badagent', '--output-format', 'json']);
     expect(result.exitCode).toBe(2);
     // Usage banner + the short error line both go to the diagnostic stream.
     expect(stderr).toContain('USAGE');

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -2,10 +2,10 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { detectUnknownCliCommand } from '@cli/commands/root';
+import { detectUnknownCliCommand, runCli } from '@cli/commands/root';
 import { resolveLoginProvider } from '@cli/commands/auth';
 import { doctorPlatformInitContext } from '@cli/commands/doctor';
 import {
@@ -524,5 +524,90 @@ describe('CLI model flag validation contract', () => {
 describe('CLI login arguments', () => {
   it('prefers explicit provider flags over positional providers', () => {
     expect(resolveLoginProvider('google', 'github')).toBe('github');
+  });
+});
+
+describe('runCli usage output stream routing', () => {
+  // Capture every byte the CLI writes. Usage on an ERROR flows through
+  // writeRawStderr -> process.stderr.write; citty's showUsage (the explicit
+  // --help path) flows through console.log -> process.stdout.write. We stub
+  // both stream writers AND console.* so nothing leaks to the real terminal.
+  let stdout = '';
+  let stderr = '';
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdout = '';
+    stderr = '';
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stdout += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stderr += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+    // citty's showUsage writes via console.log; its errors via console.error.
+    consoleLogSpy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((...args: unknown[]) => {
+        stdout += `${args.join(' ')}\n`;
+      });
+    consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation((...args: unknown[]) => {
+        stderr += `${args.join(' ')}\n`;
+      });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('routes usage text to stderr (not stdout) on a usage error', async () => {
+    // Regression guard for the headless-parity contract: usage shown because
+    // of an ERROR must not land on STDOUT, or it pollutes
+    // `--output-format json|ndjson` (e.g. `texra run ... | jq`).
+    // Mirrors the documented repro: a usage error under --output-format json.
+    const result = await runCli([
+      'run',
+      'badagent',
+      '--output-format',
+      'json',
+    ]);
+    expect(result.exitCode).toBe(2);
+    // Usage banner + the short error line both go to the diagnostic stream.
+    expect(stderr).toContain('USAGE');
+    expect(stderr).toContain('Missing required argument: --input');
+    // STDOUT stays clean so structured output remains machine-parseable.
+    expect(stdout).toBe('');
+  });
+
+  it('prints explicit --help usage to stdout, not stderr', async () => {
+    // Unix convention: an explicit `--help` request is normal output (STDOUT).
+    // Only usage shown on an error is diagnostic (STDERR). This must not
+    // regress when fixing the error path.
+    const result = await runCli(['run', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('USAGE');
+    expect(stderr).toBe('');
   });
 });


### PR DESCRIPTION
Fixes #4590

## Summary

On a usage/argument error, the CLI was printing the full command usage/help text to **STDOUT** instead of STDERR. Under `--output-format json|ndjson` this pollutes the structured-output stream with ANSI-colored help text, breaking `texra run ... --output-format json | jq` and violating the repo's "Headless parity is sacred — `--output-format json|ndjson` must stay byte-identical / machine-parseable" contract.

Unix convention is preserved: an explicit `--help` request still uses STDOUT (normal output); usage shown **because of an error** now goes to STDERR (diagnostic).

## Root cause

citty's `showUsage` writes via `console.log` (STDOUT). `packages/cli/src/commands/root.ts` called it for **both** the explicit-`--help` path and the `CLIError` usage-error path.

## Fix

- Added `showUsageStderr()` in `packages/cli/src/commands/_helpers/dispatch.ts`. It uses citty's string-returning `renderUsage` primitive and writes the result via the existing `writeRawStderr` sink, so the error path owns its destination.
- `root.ts` now calls `showUsageStderr()` at the usage-error call site; the explicit-`--help` path keeps using `showUsage()` (STDOUT).
- Diff is intentionally small (3 files: 2 source + 1 test).

## Validation

Repro: `texra run badagent --output-format json --cwd /tmp 1>out 2>err`

| Stream | Before | After |
| --- | --- | --- |
| STDOUT (`out`) | 2016 bytes of ANSI usage help | **0 bytes (clean)** |
| STDERR (`err`) | 35 bytes (error line only) | usage banner + error line |
| Exit code | 2 | 2 |

Verified against the rebuilt bundle via `spawnSync` (isolated from concurrent terminal output): error path → exit 2, STDOUT 0 bytes, STDERR contains the usage banner and `Missing required argument: --input`.

Checks (run in an isolated worktree off `origin/main`):

- `vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts` → **40 passed** (added 2 tests: usage-error → STDERR / STDOUT empty; explicit `--help` → STDOUT / STDERR empty).
- `pnpm --filter @texra-ai/cli run typecheck` → clean.
- `pnpm --filter @texra-ai/cli run bundle` → succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to error-path I/O routing with regression tests; no auth, data, or workflow logic touched.
> 
> **Overview**
> Usage/help text shown **because of a usage error** no longer goes to STDOUT via citty's `showUsage` (`console.log`). The CLI adds **`showUsageStderr`**, which builds usage with citty's `renderUsage` and writes it through **`writeRawStderr`**, so **`--output-format json|ndjson`** keeps STDOUT machine-parseable (e.g. piping to `jq`).
> 
> **`runCli`** switches the `CLIError` path from `showUsage` to **`showUsageStderr`**; explicit **`--help` / `-h`** still uses **`showUsage`** on STDOUT per Unix convention.
> 
> **Tests** in `CliRootArgs.vitest.mts` stub stdout/stderr and assert: usage on a failed `texra run ... --output-format json` lands on stderr with empty stdout; `texra run --help` stays on stdout only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f97a0aa140ec439b2a5239c3dcb87d1355a4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
