### PR TITLE
refactor(cli): use Zod .catch() idiom in parseOptional

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -142,8 +142,7 @@ function collectValidationWarnings(
 }
 
 function parseOptional<T>(schema: z.ZodType<T>, value: unknown): T | undefined {
-  const result = schema.safeParse(value);
-  return result.success ? result.data : undefined;
+  return schema.optional().catch(undefined).parse(value);
 }
 
 function pickCommandConfig(record: Record<string, unknown>): CliCommandConfig {


### PR DESCRIPTION
## Summary

Simplifies the CLI workspace-config loader's `parseOptional` helper
(`packages/cli/src/runtime/cliConfig.ts`) by replacing the verbose
manual `safeParse`-then-branch pattern with the Zod v4 native `.catch()`
fallback idiom.

## What was simplified

```diff
 function parseOptional<T>(schema: z.ZodType<T>, value: unknown): T | undefined {
-  const result = schema.safeParse(value);
-  return result.success ? result.data : undefined;
+  return schema.optional().catch(undefined).parse(value);
 }
```

## Why (cites repo conventions)

`AGENTS.md` -> "Zod v4 Schema Patterns" -> "Safe parsing with fallback"
explicitly calls out the manual form as the **old verbose pattern** and
prescribes the native `.catch()`-based form:

> ```ts
> // Old verbose pattern
> const result = Schema.safeParse(data);
> const value = result.success ? result.data : defaultValue;
> // Zod v4 native
> const value = Schema.catch(defaultValue).parse(data);
> ```

`parseOptional` is the canonical "parse or fall back to undefined" helper used
by every per-field pick in the config loader, so this is the most idiomatic
place to apply the rule. `.optional()` widens the schema output to `T |
undefined` so `undefined` is a valid catch value (preserving the exact return
type and semantics).

## Host impact

CLI only. No public API, no user-facing output change. Behavior is identical:
valid values parse through; invalid values fall back to `undefined`.

## Validation

- `pnpm --filter @texra-ai/cli run typecheck` — clean (exit 0)
- `pnpm run test:kernel -- src/test-kernel/cli/cliConfig.vitest.mts` — 4/4 pass
  (existing tests cover valid-preserved + invalid-ignored, the exact
  `parseOptional` behavior)
- `node packages/cli/scripts/check-host-imports.mjs` — clean (exit 0)
- `CI=true pnpm --filter @texra-ai/cli run bundle` — succeeds (exit 0)
- Built binary sanity: `texra version` and `texra run --help` against a temp
  workspace `.texra/config.json` mixing a valid + invalid model load cleanly
  (invalid model ignored, valid kept) — refactored path exercised at runtime

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-helper refactor in CLI config loading only; behavior is unchanged and covered by existing tests.
> 
> **Overview**
> Refactors **`parseOptional`** in the CLI workspace config loader (`cliConfig.ts`) to use Zod v4’s **`.optional().catch(undefined).parse()`** instead of a manual **`safeParse`** success branch.
> 
> The helper still returns **`T | undefined`** for optional config fields (`agent`, `model`, etc.): valid values pass through; invalid or missing inputs resolve to **`undefined`**, matching prior behavior with less boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c7797d78f4d84884f45a23c4d27c8c0a070c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->