### PR TITLE
refactor: consolidate isPlainObject into isObject from @utils/core

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -5,7 +5,7 @@ import { Box, Text, useWindowSize } from 'ink';
 
 // Local imports - shared schemas and utilities
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 import {
   collapseWhitespace,
   truncateWithEllipsis,
@@ -106,7 +106,7 @@ function displayToolName(toolName: string): string {
 function previewInput(input: unknown): string {
   if (typeof input === 'string') return input;
   if (input === undefined || input === null) return '';
-  if (isPlainObject(input)) {
+  if (isObject(input)) {
     for (const key of PRIMARY_INPUT_KEYS) {
       const value = input[key];
       if (typeof value === 'string' && value) return value;
@@ -175,11 +175,11 @@ function visibleOutputLines(toolUse: NormalizedToolUse): readonly string[] {
 function extractExitCode(toolUse: NormalizedToolUse): number | undefined {
   const candidates = [toolUse.parsed, toolUse.input];
   for (const candidate of candidates) {
-    if (!isPlainObject(candidate)) continue;
+    if (!isObject(candidate)) continue;
     const raw =
       candidate.exitCode ??
       candidate.exit_code ??
-      (isPlainObject(candidate.output) ? candidate.output.exitCode : undefined);
+      (isObject(candidate.output) ? candidate.output.exitCode : undefined);
     if (typeof raw === 'number' && Number.isInteger(raw)) return raw;
     if (typeof raw === 'string' && /^\d+$/.test(raw)) return Number(raw);
   }

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -5,7 +5,7 @@
 
 // Local imports - formatter helpers
 import type { LogMessageData, MessageType } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 import { safeFormat, type FormatOptions } from './baseLogFormatter';
 import {
   formatBannerContentTemplate,
@@ -72,7 +72,7 @@ function wrapWithErrorHandling(
 /** Name the tool in formatter errors so a bad card is actionable. */
 function getToolUseRenderLabel(message: LogMessageData): string {
   const data = message.data;
-  if (!isPlainObject(data)) return 'tool use';
+  if (!isObject(data)) return 'tool use';
   const toolName =
     typeof data.toolName === 'string'
       ? data.toolName

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -14,7 +14,7 @@ import type {
   LogMessageData,
 } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
@@ -112,7 +112,7 @@ function getToolTimeoutMs(
 ): number | undefined {
   const defaultTimeout = TOOL_DEFAULT_TIMEOUTS[toolName];
   if (defaultTimeout === undefined) return undefined;
-  if (!isPlainObject(input)) return defaultTimeout;
+  if (!isObject(input)) return defaultTimeout;
 
   // Some tools only have a meaningful timeout for a specific action
   const requiredAction = TIMEOUT_GATED_BY_ACTION[toolName];
@@ -191,7 +191,7 @@ function buildBannerContent(
 
 /** Extract typed edits array from parsed tool output, if present. */
 function getOutputEdits<T>(output: unknown): T[] | undefined {
-  return isPlainObject(output) ? (output.edits as T[] | undefined) : undefined;
+  return isObject(output) ? (output.edits as T[] | undefined) : undefined;
 }
 
 type ToolSectionOptions = {
@@ -249,7 +249,7 @@ function isMcpTextBlock(
   block: unknown,
 ): block is { type: 'text'; text: string } {
   return (
-    isPlainObject(block) &&
+    isObject(block) &&
     block.type === 'text' &&
     typeof block.text === 'string'
   );
@@ -266,7 +266,7 @@ type ToolSectionContext = {
 
 function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input, filePath, parsedOutput } = ctx;
-  if (!isPlainObject(input)) return [];
+  if (!isObject(input)) return [];
   const editInput = input as EditInput | TextEditorInput;
   if (
     typeof editInput.old_str !== 'string' ||
@@ -331,7 +331,7 @@ function buildFileContentSections(ctx: ToolSectionContext): TemplateResult[] {
 
 function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
-  if (!isPlainObject(input)) return [];
+  if (!isObject(input)) return [];
   const memInput = input as MemoryToolInput;
   const command = memInput.command;
   const memPath = memInput.path ?? '';
@@ -393,7 +393,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
 
 function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
-  if (!isPlainObject(input)) return [];
+  if (!isObject(input)) return [];
   const execInput = input as ExecutionsToolInput;
   const execPath = execInput.path ?? '';
   const action = execInput.action ?? EXECUTIONS_DEFAULT_ACTION;
@@ -427,7 +427,7 @@ function buildAcceptRunFilesSections(
   ctx: ToolSectionContext,
 ): TemplateResult[] {
   const { input, parsedOutput } = ctx;
-  if (!isPlainObject(input)) return [];
+  if (!isObject(input)) return [];
   const acceptInput = input as AcceptRunFilesInput;
   const sections: TemplateResult[] = [];
 
@@ -466,7 +466,7 @@ function buildAcceptRunFilesSections(
 
 function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
-  if (!isPlainObject(input)) return [];
+  if (!isObject(input)) return [];
   const delegateInput = input as DelegateAgentInput | WorkflowAgentInput;
   const sections: TemplateResult[] = [];
 
@@ -655,7 +655,7 @@ const TOOL_SECTION_BUILDERS: Array<{
 }> = [
   {
     match: (ctx) =>
-      TOOLS_WITH_DIFF_INPUT.has(ctx.toolName) && isPlainObject(ctx.input),
+      TOOLS_WITH_DIFF_INPUT.has(ctx.toolName) && isObject(ctx.input),
     build: buildEditDiffInputSections,
   },
   {
@@ -669,21 +669,21 @@ const TOOL_SECTION_BUILDERS: Array<{
     build: buildFileContentSections,
   },
   {
-    match: (ctx) => ctx.toolName === 'memory' && isPlainObject(ctx.input),
+    match: (ctx) => ctx.toolName === 'memory' && isObject(ctx.input),
     build: buildMemorySections,
   },
   {
-    match: (ctx) => ctx.toolName === 'executions' && isPlainObject(ctx.input),
+    match: (ctx) => ctx.toolName === 'executions' && isObject(ctx.input),
     build: buildExecutionsSections,
   },
   {
     match: (ctx) =>
-      ctx.toolName === 'accept_run_files' && isPlainObject(ctx.input),
+      ctx.toolName === 'accept_run_files' && isObject(ctx.input),
     build: buildAcceptRunFilesSections,
   },
   {
     match: (ctx) =>
-      DELEGATION_TOOLS.has(ctx.toolName) && isPlainObject(ctx.input),
+      DELEGATION_TOOLS.has(ctx.toolName) && isObject(ctx.input),
     build: buildDelegationSections,
   },
   {
@@ -740,18 +740,18 @@ export function formatToolUseTemplate(
   // Surface action + path for executions tool so it's visible without expanding
   let headerSummary = normalizedToolLog.headerSummary || '';
   if (!headerSummary) {
-    if (toolName === 'executions' && isPlainObject(input)) {
+    if (toolName === 'executions' && isObject(input)) {
       headerSummary =
         `${input.action ?? EXECUTIONS_DEFAULT_ACTION} ${input.path ?? ''}`.trim();
     } else if (
       toolName === 'codex' &&
-      isPlainObject(input) &&
+      isObject(input) &&
       typeof input.prompt === 'string'
     ) {
       headerSummary = truncatePrompt(input.prompt, 60);
     } else if (
       toolName === 'bash' &&
-      isPlainObject(input) &&
+      isObject(input) &&
       typeof input.command === 'string'
     ) {
       headerSummary = truncatePrompt(input.command, 60);
@@ -763,7 +763,7 @@ export function formatToolUseTemplate(
     : titleBase;
 
   const filePath =
-    isPlainObject(input) && typeof input.path === 'string' ? input.path : '';
+    isObject(input) && typeof input.path === 'string' ? input.path : '';
 
   const sections: TemplateResult[] = dispatchToolSections({
     toolName,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -249,9 +249,7 @@ function isMcpTextBlock(
   block: unknown,
 ): block is { type: 'text'; text: string } {
   return (
-    isObject(block) &&
-    block.type === 'text' &&
-    typeof block.text === 'string'
+    isObject(block) && block.type === 'text' && typeof block.text === 'string'
   );
 }
 
@@ -677,13 +675,11 @@ const TOOL_SECTION_BUILDERS: Array<{
     build: buildExecutionsSections,
   },
   {
-    match: (ctx) =>
-      ctx.toolName === 'accept_run_files' && isObject(ctx.input),
+    match: (ctx) => ctx.toolName === 'accept_run_files' && isObject(ctx.input),
     build: buildAcceptRunFilesSections,
   },
   {
-    match: (ctx) =>
-      DELEGATION_TOOLS.has(ctx.toolName) && isObject(ctx.input),
+    match: (ctx) => DELEGATION_TOOLS.has(ctx.toolName) && isObject(ctx.input),
     build: buildDelegationSections,
   },
   {

--- a/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
@@ -11,7 +11,7 @@
 import yaml from 'yaml';
 
 // Local imports - shared utilities
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 
 /**
  * Result of stringifying a value with language metadata.
@@ -53,7 +53,7 @@ export function extractCodeOnlyInput(value: unknown): {
   isCodeOnly: boolean;
   code: string;
 } {
-  if (!isPlainObject(value)) {
+  if (!isObject(value)) {
     return { isCodeOnly: false, code: '' };
   }
   // Support both 'code' (wolfram) and 'command' (bash) field names

--- a/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -18,7 +18,7 @@ import {
   migrateLegacyContextFileFields,
   type AgentProposal,
 } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 
 import { hashString } from './hashUtils';
 
@@ -46,7 +46,7 @@ function parseProposalInput(
   input: unknown,
   toolName: string,
 ): AgentProposal | null {
-  const spread = isPlainObject(input) ? input : {};
+  const spread = isObject(input) ? input : {};
 
   if (toolName === 'delegate_agent' || toolName === 'propose_agent') {
     const result = LenientToolUseProposalSchema.safeParse({
@@ -72,7 +72,7 @@ function parseProposalInput(
         : undefined;
     const extractTikz =
       migrated.extractTikz != null ? Boolean(migrated.extractTikz) : undefined;
-    const existingToolConfig = isPlainObject(migrated.toolConfig)
+    const existingToolConfig = isObject(migrated.toolConfig)
       ? migrated.toolConfig
       : {};
     const toolConfig = {

--- a/packages/extension/src/progressView/persistence/mementoMigration.ts
+++ b/packages/extension/src/progressView/persistence/mementoMigration.ts
@@ -12,7 +12,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 import { getStreamTabStore, mapStreamTabStorage } from './StreamTabStore';
 import type {
   StreamTabMeta,
@@ -181,14 +181,14 @@ function isNonNullObject(value: unknown): value is Record<string, unknown> {
 function extractTaskStateEntries(
   raw: Record<string, unknown>,
 ): [string, unknown][] {
-  const legacyBuckets = [raw.workflow, raw.toolUse].filter(isPlainObject);
+  const legacyBuckets = [raw.workflow, raw.toolUse].filter(isObject);
   if (legacyBuckets.length > 0) {
     return legacyBuckets.flatMap((bucket) =>
-      Object.entries(bucket).filter(([, v]) => isPlainObject(v)),
+      Object.entries(bucket).filter(([, v]) => isObject(v)),
     );
   }
 
-  return Object.entries(raw).filter(([, v]) => isPlainObject(v));
+  return Object.entries(raw).filter(([, v]) => isObject(v));
 }
 
 async function migrateStreamToStore(

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -9,7 +9,7 @@ import {
   type FileLocation,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 import { FlattenedEditRecordSchema } from '@tools/result';
 import { pathToLocation } from '@utils/files';
 
@@ -352,12 +352,12 @@ export class WorkPlanState {
 
 function unwrapLegacyStateValue(value: unknown, key: string): unknown {
   if (Array.isArray(value)) return value;
-  if (!isPlainObject(value)) return undefined;
+  if (!isObject(value)) return undefined;
   return value[key] ?? value;
 }
 
 function normalizeAgentWorkspaceSnapshot(input: unknown): unknown {
-  const record = isPlainObject(input) ? input : {};
+  const record = isObject(input) ? input : {};
   const workPlan = record.workPlan ?? {
     todos: unwrapLegacyStateValue(record.todos, 'todos'),
     plan: unwrapLegacyStateValue(record.plan, 'plan'),

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 
 import { PlanSchema, type Plan } from './plan';
 import { TodoItemSchema } from './todo';
@@ -15,11 +15,11 @@ function parsePlan(value: unknown): Plan | null {
 }
 
 function extractPlanSummary(value: unknown): string | null {
-  return isPlainObject(value) ? nonEmptyString(value.summary) : null;
+  return isObject(value) ? nonEmptyString(value.summary) : null;
 }
 
 function normalizeWorkPlanSnapshot(input: unknown): unknown {
-  const record = isPlainObject(input) ? input : {};
+  const record = isObject(input) ? input : {};
   const plan = parsePlan(record.plan);
   const planSummary =
     plan?.summary ??

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -9,7 +9,7 @@
 import yaml from 'yaml';
 
 import { ToolUseLogSchema, type NormalizedToolUse } from '@shared/schemas';
-import { isPlainObject } from '@shared/utils/string';
+import { isObject } from '@utils/core';
 
 function trimmedOrNull(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -22,7 +22,7 @@ function firstTrimmed(primary: unknown, fallback: unknown): string {
 }
 
 function extractOutputContent(candidate: unknown): unknown {
-  if (!isPlainObject(candidate)) return candidate;
+  if (!isObject(candidate)) return candidate;
   const {
     output,
     summary: _summary,
@@ -41,7 +41,7 @@ function formatOutputText(content: unknown): string {
   // renders the literal string "null", which would surface a spurious
   // output section for tools that return `output: null`.
   if (content === undefined || content === null) return '';
-  if (isPlainObject(content) && Object.keys(content).length === 0) return '';
+  if (isObject(content) && Object.keys(content).length === 0) return '';
   try {
     const yamlString = yaml.stringify(content);
     return typeof yamlString === 'string' ? yamlString.trimEnd() : '';
@@ -55,7 +55,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   if (!parseResult.success) return null;
 
   const validated = parseResult.data;
-  const nested = isPlainObject(validated.output) ? validated.output : {};
+  const nested = isObject(validated.output) ? validated.output : {};
 
   const summaryText = firstTrimmed(validated.summary, nested.summary);
   const errorText = firstTrimmed(validated.error, nested.error);
@@ -71,7 +71,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   const isUserFeedback = userInstructionText.length > 0;
 
   // Preserve unknown fields stripped by the schema for fallback rendering.
-  const parsed: Record<string, unknown> = isPlainObject(data)
+  const parsed: Record<string, unknown> = isObject(data)
     ? { ...data }
     : { ...validated };
 

--- a/src/shared/utils/string.ts
+++ b/src/shared/utils/string.ts
@@ -1,11 +1,5 @@
 export { capitalize } from '@utils/text/stringUtils';
 
-export function isPlainObject(
-  value: unknown,
-): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
 const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
   month: 'short',


### PR DESCRIPTION
## Summary

- `isPlainObject` in `src/shared/utils/string.ts` was byte-for-byte identical to `isObject` in `src/utils/core/typeGuards.ts`
- Remove the duplicate function and update all 9 call sites (agent core, shared schemas, CLI TUI, and 5 webview-frontend formatters) to import `isObject` from `@utils/core`
- `@utils/core` is already the designated barrel for type guards and is safe for webview/browser contexts — confirmed by existing `formatDuration` imports in the same frontend files

## Test plan

- [ ] `npm run compile:fast` passes (verified locally — clean build)
- [ ] `grep -r isPlainObject src/ packages/` returns no results (verified)
- [ ] No behaviour change: `isObject` and the removed `isPlainObject` had identical implementations

https://claude.ai/code/session_01JsTQ3YneyvwQTi7WFrREjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsTQ3YneyvwQTi7WFrREjL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename of an identical type guard with no logic changes; low risk aside from verifying no stray `isPlainObject` imports remain.
> 
> **Overview**
> Removes the duplicate **`isPlainObject`** helper from `@shared/utils/string` and switches every former caller to **`isObject`** from **`@utils/core`**, which already exposed the same non-null, non-array object check.
> 
> Call sites span shared tool-use normalization, work-plan snapshot shaping, agent workspace state, CLI TUI tool rendering, and several progress-view formatters plus memento migration—imports only, with no intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d4291354efedcbd4b085d27a680b14c68530cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->