### PR TITLE
fix(docs): render inline {{ template vars }} literally on the docs site

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -184,6 +184,29 @@ const baseConfig = {
     },
   },
   ignoreDeadLinks: true,
+  markdown: {
+    // VitePress v2 alpha does NOT wrap inline code in v-pre, so Vue
+    // interpolates any `{{ ... }}` inside backticks — template-variable
+    // references like `{{ INPUT_CONTENT }}` would render empty (or break the
+    // build on filtered expressions like `{{ X | join(", ") }}`). Re-add
+    // v-pre to every inline code token so the braces are shown literally,
+    // matching how fenced code blocks already behave.
+    config: (md) => {
+      const defaultCodeInline =
+        md.renderer.rules.code_inline ||
+        ((tokens, idx, options, _env, self) =>
+          `<code${self.renderAttrs(tokens[idx])}>${md.utils.escapeHtml(
+            tokens[idx].content
+          )}</code>`);
+      md.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
+        const token = tokens[idx];
+        if (token.content.includes('{{') || token.content.includes('}}')) {
+          token.attrSet('v-pre', '');
+        }
+        return defaultCodeInline(tokens, idx, options, env, self);
+      };
+    },
+  },
   // Public site allowlist: only index.md, launch.md, terms.md, providers.md,
   // and everything under guide/ except the desktop pages, which stay internal
   // while the desktop app is in beta. Every other markdown file in this

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -196,7 +196,7 @@ const baseConfig = {
         md.renderer.rules.code_inline ||
         ((tokens, idx, options, _env, self) =>
           `<code${self.renderAttrs(tokens[idx])}>${md.utils.escapeHtml(
-            tokens[idx].content
+            tokens[idx].content,
           )}</code>`);
       md.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
         const token = tokens[idx];

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -22,10 +22,10 @@ These `.yaml` files have two main parts (and thankfully, YAML is usually less pr
     - _(Other settings control output format, inheritance, etc. See [Configuration](./configuration.md) and [Custom Agents](./custom-agents.md) for full details)._
 2.  **`prompts`**: Contain text templates that TeXRA fills with your specific context (input files, instructions) to guide the LLM at different stages:
     - `systemPrompt`: Sets the overall role and high-level instructions for the LLM.
-    - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `&#123;&#123; INPUT_CONTENT &#125;&#125;`) and the specific instruction you typed in the UI (available via `&#123;&#123; INSTRUCTION &#125;&#125;`).
+    - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `{{ INPUT_CONTENT }}`) and the specific instruction you typed in the UI (available via `{{ INSTRUCTION }}`).
     - `userRequest`: Asks the LLM to perform the initial task (Round 0). Often instructs the LLM to think within `<scratchpad>` tags and then output the main content wrapped within the XML tags defined by `settings.documentTag` (e.g., `<document>...</document>`). You can also provide an **array** here: the first entry becomes the round 0 request, and any additional entries drive automatic reflection rounds (Round 1+). When a run consumes more rounds than entries you specify, the first reflection template is reused.
 
-\_(Prompts use Jinja2 templating. For a detailed list of available variables like `&#123;&#123; INPUT_CONTENT &#125;&#125;` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)\*
+\_(Prompts use Jinja2 templating. For a detailed list of available variables like `{{ INPUT_CONTENT }}` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)\*
 
 ::: tip Transparency & Customization
 The prompts described above (`systemPrompt`, `userPrefix`, etc.) represent TeXRA's structured approach to guiding the LLM. This structured, template-based system means the agent's behavior is transparent and highly customizable through the `.yaml` file, not a hidden black box.

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -112,9 +112,9 @@ prompts:
 
 #### <wa-icon library="texra" name="symbol-variable"></wa-icon> Using Variables in Prompts (Jinja2 Templating)
 
-Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `&#123;&#123; variable_name &#125;&#125;` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
+Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `{{ variable_name }}` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
 
-This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `&#123;&#123; INPUT_CONTENT &#125;&#125;` while the full list of selected files can be accessed through `&#123;&#123; ALL_INPUTS &#125;&#125;`. When you run the agent these placeholders are replaced with real data.
+This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `{{ INPUT_CONTENT }}` while the full list of selected files can be accessed through `{{ ALL_INPUTS }}`. When you run the agent these placeholders are replaced with real data.
 
 **Common Variables:**
 
@@ -141,7 +141,7 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 - &#123;&#123; INPUT_FILES &#125;&#125;: Array of input filenames. Editing agents
   should iterate over this list and emit one `<document name="...">` block per
   input filename, preserving the input order and names. Use
-  `&#123;&#123; INPUT_FILES | join(", ") &#125;&#125;` for a human-readable list. See
+  `{{ INPUT_FILES | join(", ") }}` for a human-readable list. See
   [Handling Multiple Files](./multiple-output.md).
 - &#123;&#123; OUTPUT_FILES &#125;&#125;: Array of declared generated output filenames.
   This is only populated for agents that set `defaultOutputFiles` or receive an
@@ -149,8 +149,8 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 
 **Custom Variables (from `settings`):**
 
-- Files specified in `requiredFiles` or `requiredFilesInternal` are available as `&#123;&#123; VARNAME_CONTENT &#125;&#125;` (e.g., `&#123;&#123; TEMPLATE_CONTENT &#125;&#125;`).
-- Files matched by `filePatternsContain` are available as `&#123;&#123; VARNAME_CONTENT &#125;&#125;` (e.g., `&#123;&#123; BIBLIOGRAPHY_CONTENT &#125;&#125;`).
+- Files specified in `requiredFiles` or `requiredFilesInternal` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ TEMPLATE_CONTENT }}`).
+- Files matched by `filePatternsContain` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ BIBLIOGRAPHY_CONTENT }}`).
 - When agents finish, TeXRA automatically captures detected XML segments so orchestrated workflows can reuse them without going through the file picker again (details below).
 
 **Example Usage in `userPrefix`:**

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -84,7 +84,7 @@ part of the current agent settings schema. Update existing YAML files to declare
 Workflow edit prompts can use `INPUT_FILES` to request and format
 multiple outputs within the `<documents>` tag. `INPUT_FILES` is an array
 of selected input filenames, so templates should iterate over it. Use
-`&#123;&#123; INPUT_FILES | join(", ") &#125;&#125;` when the prompt needs a readable list.
+`{{ INPUT_FILES | join(", ") }}` when the prompt needs a readable list.
 
 ```yaml
 # Inside a workflow agent's userRequest prompt:


### PR DESCRIPTION
VitePress v2-alpha does not wrap inline code in v-pre, so Vue interpolated
any `{{ ... }}` inside backticks: HTML-entity-escaped spros like
`&#123;&#123; INPUT_CONTENT &#125;&#125;` shipped as literal entity text,
while raw `{{ INPUT_CONTENT }}` was eaten and rendered empty (and filtered
forms like `{{ X | join(", ") }}` broke the build).

- Add a markdown-it `code_inline` override in the VitePress config that
  re-applies v-pre to any inline code containing braces, fixing every
  current and future page in one place.
- Decode the over-escaped &#123;/&#125; entities back to raw braces inside
  inline code in agent-architecture, custom-agents, and multiple-output so
  they render as {{ INPUT_CONTENT }} / {{ INSTRUCTION }} again. Prose-level
  entities (which already render correctly) are left untouched.

https://claude.ai/code/session_01AnZBVq828tqRKp6znse544

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress markdown config only; no runtime product or security impact.
> 
> **Overview**
> Fixes the docs site so **Jinja2 placeholders** like `{{ INPUT_CONTENT }}` show up correctly inside inline code instead of being swallowed or breaking the build.
> 
> **VitePress** gets a **markdown-it** hook on `code_inline` that sets **`v-pre`** when inline code contains `{{` or `}}`, so Vue stops treating those tokens as templates (including filtered forms like `{{ INPUT_FILES | join(", ") }}`).
> 
> **Guide copy** in `agent-architecture`, `custom-agents`, and `multiple-output` replaces HTML-entity–escaped braces in backticks with real `{{ ... }}` syntax now that rendering is safe site-wide. Prose bullets that still use entities are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b21797ee085026f9cd4b5e38f5d0bea65c4d7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->