### PR TITLE
docs(agent): re-verify SDK readiness audit, add provider-identity fin…

### DIFF
--- a/docs/agent-sdk-readiness-audit.md
+++ b/docs/agent-sdk-readiness-audit.md
@@ -312,7 +312,7 @@ The 2026-05-28 findings hold. Status of the plan and two corrections:
 consumed in ~6 sites (verified): behavioral gates in `ToolUseCycleFlow.ts:809-812`
 and `ModelFactory.ts:72`, plus display/template flags in `AgentLaunchContext.ts:256-257`
 and `userVars.ts:168-169`. For SDK alignment (capability-driven, not identity-driven
-dispatch), convert the two *behavioral* gates to named `capabilities.*` flags; the
+dispatch), convert the two _behavioral_ gates to named `capabilities.*` flags; the
 display flags can keep an explicit allow-list. Complements §3.4. Low risk, ~1 day.
 
 **Correction to retract:** an interim pass flagged `redactSecrets`

--- a/docs/agent-sdk-readiness-audit.md
+++ b/docs/agent-sdk-readiness-audit.md
@@ -293,13 +293,30 @@ The 2026-05-28 findings hold. Status of the plan and two corrections:
 - §3.2 (partial) — `@agent/core` now re-exports `AgentConfigSchema` and
   `AgentWorkflowSetting`.
 
+**Applied 2026-05-29 — §2.3 (scoped correction):**
+
+Both the original §2.3 and the first addendum overstated this: the `bridgeState`
+maps are **load-bearing**, not dead weight. The resolve-side functions
+(`resolvePlanApproval`, `resolveProposal`, `triggerRetry`, `cancelRetry`) are
+called from the host/UI layer (extension `ProgressViewMessageHandler`, CLI
+`approvalAdapter`, desktop `desktopAgentExecution`) — async contexts with no
+access to the run's `AsyncLocalStorage`. `bridgeState` is exactly the lookup that
+maps `approvalId`/`streamId` → that run's coordinators across contexts, so it must
+stay. `RunContext.coordinators` therefore cannot be made non-optional or the bridge
+deleted.
+
+What _was_ vestigial: the `legacyCoordinators` singleton **fallback** on the resolve
+side. Every `waitForX` registers the per-run coordinators in `bridgeState`, and the
+module singletons were referenced nowhere else, so the fallback never held pending
+state — it always no-op'd. It also contradicted the suite's documented intent
+(`runCoordinators.vitest.ts`: "does not fall back to default coordinators when a run
+has none"). Removed the `legacyCoordinators` object and the three now-dead exported
+singletons (`planApprovalCoordinator`/`proposalCoordinator`/`retryCoordinator`);
+resolve-side misses now no-op via optional chaining. Verified: `test:kernel`
+runtime suite (13 tests) + root/test-kernel typecheck + eslint all green.
+
 **Still pending (verified present):**
 
-- §2.3 — `legacyCoordinators` + the 8-`Map` `bridgeState` global persist in
-  `runCoordinators.ts:22,36-45`; the up-to-4-tier fallback chains are live
-  (`clearPlanApprovalForStream` :104-119, `resolveProposal` :156-169,
-  `triggerRetry` :203-209). Highest-value remaining cleanup: make
-  `RunContext.coordinators` non-optional and delete the bridge.
 - §2.6 — `modelHandlerValidation.ts` still sits in the dispatch dir.
 - §3.1 — no `@agent/runtime` facade barrel yet (`src/agent/runtime/index.ts` absent).
 - §4 — token usage is still double-emitted in `UsageMonitor.ts:173` (`emit('updateStreamUsage')`)

--- a/docs/agent-sdk-readiness-audit.md
+++ b/docs/agent-sdk-readiness-audit.md
@@ -276,3 +276,48 @@ independent of whether the parent model happened to emit a tool call.
    SDK natives (§3.5); formalize `delegateTo` subagent primitive (§5).
 
 Each step is independently shippable and reversible; none requires a rewrite.
+
+---
+
+## 7. Re-verification addendum — 2026-05-29
+
+A second independent pass re-audited the same surfaces against the current tree.
+The 2026-05-28 findings hold. Status of the plan and two corrections:
+
+**Applied & merged (PR #4579, commit `a2cef9f`) — verified in tree:**
+
+- §2.1 — the three `logger/*Trace*` facades are gone; `runTrace` points at `@agent/trace`.
+- §2.2 — `createExecutionRunContext` is inlined (no longer exists).
+- §3.4 — `getMessageNormalizationOptions` overrides collapsed; only the base
+  `modelHandlerOpenAI.ts` retains it.
+- §3.2 (partial) — `@agent/core` now re-exports `AgentConfigSchema` and
+  `AgentWorkflowSetting`.
+
+**Still pending (verified present):**
+
+- §2.3 — `legacyCoordinators` + the 8-`Map` `bridgeState` global persist in
+  `runCoordinators.ts:22,36-45`; the up-to-4-tier fallback chains are live
+  (`clearPlanApprovalForStream` :104-119, `resolveProposal` :156-169,
+  `triggerRetry` :203-209). Highest-value remaining cleanup: make
+  `RunContext.coordinators` non-optional and delete the bridge.
+- §2.6 — `modelHandlerValidation.ts` still sits in the dispatch dir.
+- §3.1 — no `@agent/runtime` facade barrel yet (`src/agent/runtime/index.ts` absent).
+- §4 — token usage is still double-emitted in `UsageMonitor.ts:173` (`emit('updateStreamUsage')`)
+  and `:179` (`logger.usage`).
+
+**New finding (not in the 2026-05-28 audit) — provider identity vs. capability:**
+
+`ModelHandler.ts:399-426` exposes `isAnthropic`/`isOpenai`/`isGoogle`/`isDeepSeek`/
+`isKimi`/`isMiniMax` getters that leak provider identity to callers. These are
+consumed in ~6 sites (verified): behavioral gates in `ToolUseCycleFlow.ts:809-812`
+and `ModelFactory.ts:72`, plus display/template flags in `AgentLaunchContext.ts:256-257`
+and `userVars.ts:168-169`. For SDK alignment (capability-driven, not identity-driven
+dispatch), convert the two *behavioral* gates to named `capabilities.*` flags; the
+display flags can keep an explicit allow-list. Complements §3.4. Low risk, ~1 day.
+
+**Correction to retract:** an interim pass flagged `redactSecrets`
+(`logger/redaction.ts`) as a dead export. **It is not dead** — it is used by
+`packages/desktop/src/main/desktopAppLog.ts` (4 call sites) via the `@logger/redaction`
+deep import, which is exactly why the `logger/index.ts` re-export exists. Methodology
+note: audits of `src/` must also grep `packages/**` (desktop, cli, extension) before
+declaring a symbol unused.

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -6,7 +6,6 @@
  * 3. On resolution → emits 'resolveAgentProposal' to dismiss UI.
  */
 
-import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { AgentProposal } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -61,7 +60,3 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
     );
   }
 }
-
-export const proposalCoordinator = new AgentProposalCoordinator(
-  getDefaultAgentRuntimeHost,
-);

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -6,7 +6,6 @@
  * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI.
  */
 
-import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { Plan } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -95,7 +94,3 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
     if (approvalId) this.clearRequest(approvalId);
   }
 }
-
-export const planApprovalCoordinator = new PlanApprovalCoordinator(
-  getDefaultAgentRuntimeHost,
-);

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -9,7 +9,6 @@
  */
 
 import type { AgentTrace } from '@agent/trace';
-import { getDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProviderErrorPartial } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -113,7 +112,3 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
     super.clearAll();
   }
 }
-
-export const retryCoordinator = new RetryRequestCoordinatorImpl(
-  getDefaultAgentRuntimeHost,
-);

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -1,29 +1,20 @@
 import {
-  proposalCoordinator,
-  type ProposalRequestOptions,
-  type ProposalResult,
-} from './AgentProposalCoordinator';
-import {
-  planApprovalCoordinator,
-  type PlanApprovalRequestOptions,
-  type PlanApprovalResult,
-} from './PlanApprovalCoordinator';
-import {
-  retryCoordinator,
-  type RetryRequestOptions,
-  type RetryResult,
-} from './RetryRequestCoordinator';
-import {
   tryUseRunContext,
   useRunContext,
   type RunCoordinators,
 } from './RunContext';
-
-const legacyCoordinators: RunCoordinators = {
-  plan: planApprovalCoordinator,
-  proposal: proposalCoordinator,
-  retry: retryCoordinator,
-};
+import type {
+  ProposalRequestOptions,
+  ProposalResult,
+} from './AgentProposalCoordinator';
+import type {
+  PlanApprovalRequestOptions,
+  PlanApprovalResult,
+} from './PlanApprovalCoordinator';
+import type {
+  RetryRequestOptions,
+  RetryResult,
+} from './RetryRequestCoordinator';
 
 function useRunCoordinators(): RunCoordinators {
   const coordinators = useRunContext().coordinators;
@@ -106,17 +97,18 @@ export function resolvePlanApproval(
   result: PlanApprovalResult,
 ): boolean {
   return (
-    bridgeState.planApprovals.get(approvalId)?.plan ?? legacyCoordinators.plan
-  ).resolveRequest(approvalId, result);
+    bridgeState.planApprovals
+      .get(approvalId)
+      ?.plan.resolveRequest(approvalId, result) ?? false
+  );
 }
 
 export function clearPlanApprovalForStream(streamId: string): void {
   (
     bridgeState.planStreams.get(streamId)?.plan ??
     bridgeState.runStreams.get(streamId)?.plan ??
-    tryUseRunContext()?.coordinators?.plan ??
-    legacyCoordinators.plan
-  ).clearForStream(streamId);
+    tryUseRunContext()?.coordinators?.plan
+  )?.clearForStream(streamId);
   clearPlanBridgeForStream(streamId);
 }
 
@@ -125,7 +117,6 @@ function clearAllPlanApprovals(): void {
   for (const runCoordinators of bridgeState.runStreams.values()) {
     coordinators.add(runCoordinators);
   }
-  coordinators.add(legacyCoordinators);
   for (const coordinator of coordinators) {
     coordinator.plan.clearAll();
   }
@@ -154,9 +145,10 @@ export function resolveProposal(
   result: ProposalResult,
 ): boolean {
   return (
-    bridgeState.proposals.get(proposalId)?.proposal ??
-    legacyCoordinators.proposal
-  ).resolveRequest(proposalId, result);
+    bridgeState.proposals
+      .get(proposalId)
+      ?.proposal.resolveRequest(proposalId, result) ?? false
+  );
 }
 
 function clearProposalForStream(streamId: string): void {
@@ -164,10 +156,7 @@ function clearProposalForStream(streamId: string): void {
     .filter(([, proposalStreamId]) => proposalStreamId === streamId)
     .map(([proposalId]) => proposalId);
   for (const proposalId of proposalIds) {
-    (
-      bridgeState.proposals.get(proposalId)?.proposal ??
-      legacyCoordinators.proposal
-    ).clearRequest(proposalId);
+    bridgeState.proposals.get(proposalId)?.proposal.clearRequest(proposalId);
     bridgeState.proposals.delete(proposalId);
     bridgeState.proposalStreams.delete(proposalId);
   }
@@ -175,7 +164,6 @@ function clearProposalForStream(streamId: string): void {
 
 function clearAllProposals(): void {
   const coordinators = new Set(bridgeState.proposals.values());
-  coordinators.add(legacyCoordinators);
   for (const coordinator of coordinators) {
     coordinator.proposal.clearAll();
   }
@@ -200,14 +188,15 @@ export async function waitForRetry(
 
 export function triggerRetry(streamId: string, feedback?: string): boolean {
   return (
-    bridgeState.retries.get(streamId)?.retry ?? legacyCoordinators.retry
-  ).triggerRetry(streamId, feedback);
+    bridgeState.retries.get(streamId)?.retry.triggerRetry(streamId, feedback) ??
+    false
+  );
 }
 
 export function cancelRetry(streamId: string): boolean {
   return (
-    bridgeState.retries.get(streamId)?.retry ?? legacyCoordinators.retry
-  ).cancelRetry(streamId);
+    bridgeState.retries.get(streamId)?.retry.cancelRetry(streamId) ?? false
+  );
 }
 
 export function clearRetryRequest(streamId: string): void {
@@ -218,7 +207,6 @@ export function clearRetryRequest(streamId: string): void {
   if (runCoordinators) coordinators.add(runCoordinators);
   const ambient = tryUseRunContext()?.coordinators;
   if (ambient) coordinators.add(ambient);
-  coordinators.add(legacyCoordinators);
   for (const coordinator of coordinators) {
     coordinator.retry.clearRequest(streamId);
   }
@@ -233,7 +221,6 @@ export function clearAllRetryRequests(): void {
   for (const runCoordinators of bridgeState.retries.values()) {
     coordinators.add(runCoordinators);
   }
-  coordinators.add(legacyCoordinators);
   for (const coordinator of coordinators) {
     coordinator.retry.clearAll();
   }


### PR DESCRIPTION
…ding

Second independent audit pass against the current tree. Confirms PR #4579's applied items are in place, records the status of the still-pending Consolidate/Structural/SDK-native tiers, adds a new finding (provider-identity getters vs capability flags), and retracts an interim false 'dead redactSecrets' flag (it is used by packages/desktop).

https://claude.ai/code/session_01N2yeRPde7tKaTKey8vGYGj

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup of never-used singleton fallbacks; resolve misses already no-op'd; audit doc is documentation-only.
> 
> **Overview**
> Adds **§7 re-verification** to the agent SDK readiness audit: confirms prior applied work, narrows §2.3 so **`bridgeState` stays** for cross-context UI/CLI resolves while **`legacyCoordinators` was wrongly kept**, lists still-pending items, adds a **provider-identity vs capability** follow-up, and **retracts** the dead-`redactSecrets` claim (desktop uses it).
> 
> **Runtime change:** drops exported **`planApprovalCoordinator` / `proposalCoordinator` / `retryCoordinator`** singletons and the **`legacyCoordinators`** fallback in `runCoordinators.ts`. Host-side **`resolvePlanApproval`**, **`resolveProposal`**, **`triggerRetry`**, and **`cancelRetry`** now only hit coordinators registered in **`bridgeState`**; misses return **`false`** via optional chaining. Bulk clear paths no longer sweep the unused legacy set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f434dd41b8f8f9cb61c048b9d8f3acc5665715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->