### PR TITLE
fix(cli): use @cli alias for logSinks import in dispatch.ts (unblock lint on main)

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,6 +1,6 @@
 import { renderUsage, showUsage, type CommandDef } from 'citty';
 
-import { writeRawStderr } from '../../runtime/logSinks';
+import { writeRawStderr } from '@cli/runtime/logSinks';
 
 import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
 


### PR DESCRIPTION
## What & why

`main` is currently red on lint: PR #4589 (`refactor(cli): split commands/root.ts into per-command modules`) landed `packages/cli/src/commands/_helpers/dispatch.ts` with a deep relative import

```
import { writeRawStderr } from '../../runtime/logSinks';
```

which violates the repo's `local/prefer-alias-for-deep-relative-imports` rule. `pnpm run lint` therefore exits 1 on `main`, so the `validate` check fails on **every open PR** that gets merge-tested against `main` (e.g. #4586).

## Fix

Switch to the alias the rule mandates — behavior-identical:

```
import { writeRawStderr } from '@cli/runtime/logSinks';
```

Verified: `eslint packages/cli/src` → 0 errors, `tsc -p packages/cli/tsconfig.json` → clean.

Unblocks `validate` for the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-path change with no logic or behavior impact.
> 
> **Overview**
> **Fixes a lint failure on `main`** by updating the `writeRawStderr` import in `dispatch.ts` from a deep relative path (`../../runtime/logSinks`) to the **`@cli/runtime/logSinks`** alias required by `local/prefer-alias-for-deep-relative-imports`.
> 
> No runtime behavior change—only import style so `eslint` / `validate` pass again for PRs merged against `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d172de41732f35701c6ea8b474ff982340ecccf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->