### PR TITLE
refactor(cli): extract shared headless run-model resolution into modelArg helpers

### DIFF
--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -1,5 +1,10 @@
-import { CliUsageError } from '@cli/runtime/cliContext';
-import { isKnownCliModel } from '@cli/runtime/cliConfig';
+import {
+  CLI_BUILTIN_DEFAULT_MODEL,
+  isKnownCliModel,
+  resolveConfiguredModel,
+} from '@cli/runtime/cliConfig';
+import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
+import { shouldRenderRunProgress } from '@cli/runtime/runProgressRenderer';
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
 export function assertExplicitModelKnown(
@@ -13,4 +18,35 @@ export function assertExplicitModelKnown(
     );
   }
   return trimmed;
+}
+
+/**
+ * Resolve the model for a headless runner with the shared precedence:
+ * explicit `-m` > `TEXRA_MODEL` env > configured `chat`/`run` model > builtin.
+ */
+export function resolveCliRunModel(
+  context: CliContext,
+  modelOverride: string | undefined,
+  role: 'chat' | 'run',
+): string {
+  const explicit = assertExplicitModelKnown(modelOverride);
+  return (
+    explicit ||
+    context.envModel ||
+    resolveConfiguredModel(context.cliConfig, role) ||
+    CLI_BUILTIN_DEFAULT_MODEL
+  );
+}
+
+/** Derive the headless run context shared by every CLI runner. */
+export function buildHeadlessRunContext(
+  context: CliContext,
+  model: string,
+): CliContext {
+  return {
+    ...context,
+    helperModel: model,
+    quietLogs: true,
+    renderRunProgress: shouldRenderRunProgress(context),
+  };
 }

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -13,15 +13,10 @@ import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
-import {
-  CLI_BUILTIN_DEFAULT_MODEL,
-  resolveConfiguredModel,
-} from '../runtime/cliConfig';
 import { CliUsageError, type CliContext } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
-import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -29,7 +24,10 @@ import {
   collectStringFlagValues,
   optString,
 } from './_helpers/globalArgs';
-import { assertExplicitModelKnown } from './_helpers/modelArg';
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
 import { executeCliRequest } from './_helpers/runExecution';
@@ -102,19 +100,8 @@ async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
 ): Promise<number> {
-  const explicitModel = assertExplicitModelKnown(init.model);
-  const model =
-    explicitModel ||
-    context.envModel ||
-    resolveConfiguredModel(context.cliConfig, 'chat') ||
-    CLI_BUILTIN_DEFAULT_MODEL;
-  const renderRunProgress = shouldRenderRunProgress(context);
-  const runContext: CliContext = {
-    ...context,
-    helperModel: model,
-    quietLogs: true,
-    renderRunProgress,
-  };
+  const model = resolveCliRunModel(context, init.model, 'chat');
+  const runContext = buildHeadlessRunContext(context, model);
 
   let inputFiles: string[];
   let contextFiles: string[];

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -11,10 +11,6 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError } from '../runtime/cliContext';
-import {
-  CLI_BUILTIN_DEFAULT_MODEL,
-  resolveConfiguredModel,
-} from '../runtime/cliConfig';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
@@ -31,11 +27,13 @@ import {
   type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
-import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
-import { assertExplicitModelKnown } from './_helpers/modelArg';
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import {
   GLOBAL_ARGS,
@@ -193,21 +191,10 @@ async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
-  const explicitModel = assertExplicitModelKnown(init.model);
   // A team run drives a tool-use orchestrator, so it follows the `chat`
   // (tool-use) model config rather than `run` (workflow agents).
-  const model =
-    explicitModel ||
-    context.envModel ||
-    resolveConfiguredModel(context.cliConfig, 'chat') ||
-    CLI_BUILTIN_DEFAULT_MODEL;
-  const renderRunProgress = shouldRenderRunProgress(context);
-  const runContext: CliContext = {
-    ...context,
-    helperModel: model,
-    quietLogs: true,
-    renderRunProgress,
-  };
+  const model = resolveCliRunModel(context, init.model, 'chat');
+  const runContext = buildHeadlessRunContext(context, model);
   const { inputFiles, contextFiles } = await expandRunInputs(
     init.inputFiles,
     init.contextFiles,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -12,17 +12,15 @@ import { generateExecutionId } from '@utils/core/executionId';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliUsageError } from '../runtime/cliContext';
-import {
-  CLI_BUILTIN_DEFAULT_MODEL,
-  resolveConfiguredModel,
-} from '../runtime/cliConfig';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr } from '../runtime/logSinks';
-import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
-import { assertExplicitModelKnown } from './_helpers/modelArg';
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import {
   GLOBAL_ARGS,
@@ -59,19 +57,8 @@ async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
 ): Promise<number> {
-  const explicitModel = assertExplicitModelKnown(init.model);
-  const model =
-    explicitModel ||
-    context.envModel ||
-    resolveConfiguredModel(context.cliConfig, 'run') ||
-    CLI_BUILTIN_DEFAULT_MODEL;
-  const renderRunProgress = shouldRenderRunProgress(context);
-  const runContext: CliContext = {
-    ...context,
-    helperModel: model,
-    quietLogs: true,
-    renderRunProgress,
-  };
+  const model = resolveCliRunModel(context, init.model, 'run');
+  const runContext = buildHeadlessRunContext(context, model);
   if (init.output && init.outputDir) {
     throw new CliUsageError('Use either --output or --output-dir, not both.');
   }

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -17,7 +17,7 @@ function makeContext(partial: Partial<CliContext> = {}): CliContext {
   return {
     cwd: '/tmp',
     colorEnabled: false,
-    mode: 'oneshot',
+    mode: 'headless',
     outputFormat: 'text',
     stderrIsTty: false,
     quietLogs: false,

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from '@cli/commands/_helpers/modelArg';
+import {
+  CLI_BUILTIN_DEFAULT_MODEL,
+  type CliConfigValues,
+} from '@cli/runtime/cliConfig';
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const KNOWN_MODEL = 'gpt5';
+const OTHER_MODEL = 'claudeSonnet';
+
+function makeContext(partial: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp',
+    colorEnabled: false,
+    mode: 'oneshot',
+    outputFormat: 'text',
+    stderrIsTty: false,
+    quietLogs: false,
+    ...partial,
+  } as CliContext;
+}
+
+const runConfig = (model: string): CliConfigValues => ({ run: { model } });
+
+describe('resolveCliRunModel precedence', () => {
+  it('prefers the explicit model over env and config', () => {
+    const context = makeContext({
+      envModel: OTHER_MODEL,
+      cliConfig: runConfig('deepseekR'),
+    });
+    expect(resolveCliRunModel(context, KNOWN_MODEL, 'run')).toBe(KNOWN_MODEL);
+  });
+
+  it('falls back to env when no explicit model is given', () => {
+    const context = makeContext({
+      envModel: OTHER_MODEL,
+      cliConfig: runConfig('deepseekR'),
+    });
+    expect(resolveCliRunModel(context, undefined, 'run')).toBe(OTHER_MODEL);
+  });
+
+  it('uses the configured model when no explicit or env model', () => {
+    const context = makeContext({ cliConfig: runConfig('deepseekR') });
+    expect(resolveCliRunModel(context, undefined, 'run')).toBe('deepseekR');
+  });
+
+  it('reads the role-specific config section', () => {
+    const context = makeContext({
+      cliConfig: { chat: { model: OTHER_MODEL }, run: { model: 'deepseekR' } },
+    });
+    expect(resolveCliRunModel(context, undefined, 'chat')).toBe(OTHER_MODEL);
+    expect(resolveCliRunModel(context, undefined, 'run')).toBe('deepseekR');
+  });
+
+  it('falls back to the builtin default when nothing else is set', () => {
+    expect(resolveCliRunModel(makeContext(), undefined, 'run')).toBe(
+      CLI_BUILTIN_DEFAULT_MODEL,
+    );
+  });
+});
+
+describe('buildHeadlessRunContext', () => {
+  it('sets the helper model, quiet logs, and enables progress for text output', () => {
+    const context = makeContext({ outputFormat: 'text', quietLogs: false });
+    const runContext = buildHeadlessRunContext(context, KNOWN_MODEL);
+    expect(runContext.helperModel).toBe(KNOWN_MODEL);
+    expect(runContext.quietLogs).toBe(true);
+    expect(runContext.renderRunProgress).toBe(true);
+  });
+
+  it('disables run progress for non-text output formats', () => {
+    const context = makeContext({ outputFormat: 'json' });
+    const runContext = buildHeadlessRunContext(context, KNOWN_MODEL);
+    expect(runContext.renderRunProgress).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4601

## Summary

Three CLI headless runners hand-rolled the same model-resolution fall-through and headless `runContext` literal, differing only by one config-role token. This extracts that logic into two helpers in the existing `packages/cli/src/commands/_helpers/modelArg.ts` and collapses each call site to two lines.

## What was deduplicated

**3 call sites -> 2 helpers.** Added to `modelArg.ts` (already the home of `assertExplicitModelKnown`):

- `resolveCliRunModel(context, modelOverride, role: 'chat' | 'run')` -- encapsulates the precedence `explicit -m > envModel (TEXRA_MODEL) > resolveConfiguredModel(cliConfig, role) > CLI_BUILTIN_DEFAULT_MODEL`.
- `buildHeadlessRunContext(context, model)` -- returns `{ ...context, helperModel: model, quietLogs: true, renderRunProgress: shouldRenderRunProgress(context) }`.

Each call site shrank from ~13 lines to:

```ts
const model = resolveCliRunModel(context, init.model, '<role>');
const runContext = buildHeadlessRunContext(context, model);
```

Call sites updated:
- `agentsRun.ts` (`runToolUseAgent`, role `'chat'`)
- `multiAgent.ts` (`runMultiAgentPreset`, role `'chat'` -- the rationale comment for why a team run uses `chat` is preserved at the call site)
- `workflow.ts` (`runWorkflowAgent`, role `'run'`)

The now-dead `resolveConfiguredModel`, `CLI_BUILTIN_DEFAULT_MODEL`, `shouldRenderRunProgress`, and `assertExplicitModelKnown` imports were removed from all three command files (each verified unused after the change). New imports in `modelArg.ts` use the `@cli/*` alias, matching its existing imports. The `role` param is typed exactly `'chat' | 'run'` (same as `resolveConfiguredModel`'s param).

## Why

Straight triplication with a single-token delta -- the duplication / indirection the repo's CLAUDE.md "Flattening Abstraction Layers" and duplication guidance call out. The role string stays explicit at each call site so the `chat`-vs-`run` distinction (and multiAgent's comment) is not lost.

## Host impact

CLI only. No user-facing or behavioral change -- same precedence and identical `runContext` fields.

## Validation

- **typecheck** (`pnpm --filter @texra-ai/cli run typecheck` -> `tsc --noEmit`): clean, exit 0.
- **host-imports arch check** (`node packages/cli/scripts/check-host-imports.mjs`): exit 0.
- **bundle** (`CI=true corepack pnpm --filter @texra-ai/cli run bundle`): exit 0, `dist/bin/texra.js` produced.
- **--help smoke** (no network): `texra run --help`, `texra multi-agent --help`, `texra agents run --help` all exit 0 with usage shown.
- **tests** (`vitest run`): new `cliModelResolution.vitest.mts` (7) + existing `ModelArg.vitest.mts` (3) pass; the new test drives the real `resolveCliRunModel` / `buildHeadlessRunContext`, and a temporary sentinel assertion confirmed it fails when the helper output is wrong (i.e. it genuinely exercises production code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with tests locking precedence and run context; CLI-only with no intended behavior change.
> 
> **Overview**
> Centralizes duplicated headless CLI model resolution and run context setup in `modelArg.ts`, then wires three runners to the shared helpers.
> 
> Adds **`resolveCliRunModel`** (precedence: `-m` → `TEXRA_MODEL` → role-specific `chat`/`run` config → builtin) and **`buildHeadlessRunContext`** (`helperModel`, `quietLogs: true`, `renderRunProgress` from output format). **`agentsRun`**, **`multiAgent`**, and **`workflow`** each drop ~13 lines of inline logic for two calls; **`chat`** vs **`run`** stays explicit at each site (including the multi-agent team comment).
> 
> New **`cliModelResolution.vitest.mts`** covers precedence, role-specific config, and headless context/progress behavior. No intended user-facing behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba08f080ad7f83702cfa3e4becd4547167eed4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->