### PR TITLE
refactor(tools): extract shared edit-approval handshake

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -15,10 +15,8 @@ import {
 } from '@tools/pathResolution';
 import { countOccurrences } from '@tools/utils';
 import {
-  buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
+  requestApprovedEditContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
@@ -98,22 +96,18 @@ export class EditFileTool extends defineTool({
         currentContent.slice(idx + old_str.length);
     }
 
-    const approval = await requestToolEditApproval({
+    const outcome = await requestApprovedEditContent({
       path: targetPath,
+      displayPath,
       originalContent: currentContent,
       proposedContent: updatedContent,
       sourceTool: 'edit_file',
     });
-
-    if (!approval.accepted) {
-      return buildApprovalRejectedResult(
-        displayPath,
-        'edit_file',
-        approval.userMessage,
-      );
+    if ('rejected' in outcome) {
+      return outcome.rejected;
     }
+    const { approval, finalContent } = outcome;
 
-    const finalContent = getApprovedContent(approval, updatedContent);
     const { appliedContent } = await writeApprovedContent(
       targetPath,
       currentContent,

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -15,10 +15,8 @@ import {
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
 import {
-  buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
+  requestApprovedEditContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
@@ -310,20 +308,17 @@ export class TextEditorTool extends defineTool({
       const proposedContent = isTexFile(filePath)
         ? replacementEngine.applyAll(content)
         : content;
-      const approval = await requestToolEditApproval({
+      const outcome = await requestApprovedEditContent({
         path: filePath,
+        displayPath,
         originalContent: '',
-        proposedContent: proposedContent,
+        proposedContent,
         sourceTool: 'text_editor:create',
       });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          displayPath,
-          'text_editor:create',
-          approval.userMessage,
-        );
+      if ('rejected' in outcome) {
+        return outcome.rejected;
       }
+      const { approval, finalContent } = outcome;
 
       // Create parent directories if they don't exist
       const dirPath = path.dirname(filePath);
@@ -331,7 +326,6 @@ export class TextEditorTool extends defineTool({
         await WorkspaceFS.ensureDir(dirPath);
       }
 
-      const finalContent = getApprovedContent(approval, proposedContent);
       const { appliedContent } = await writeApprovedContent(
         filePath,
         '',
@@ -407,26 +401,22 @@ export class TextEditorTool extends defineTool({
         expandedNewStr,
       );
 
-      const approval = await requestToolEditApproval({
+      const outcome = await requestApprovedEditContent({
         path: filePath,
+        displayPath,
         originalContent: fileContent,
         proposedContent: newFileContent,
         sourceTool: 'text_editor:str_replace',
       });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          displayPath,
-          'text_editor:str_replace',
-          approval.userMessage,
-        );
+      if ('rejected' in outcome) {
+        return outcome.rejected;
       }
+      const { approval, finalContent } = outcome;
 
-      const approvedContent = getApprovedContent(approval, newFileContent);
       const { appliedContent, baseContent } = await writeApprovedContent(
         filePath,
         fileContent,
-        approvedContent,
+        finalContent,
       );
       if (appliedContent !== baseContent) {
         this.addToHistory(filePath, baseContent);
@@ -500,26 +490,22 @@ export class TextEditorTool extends defineTool({
       ];
       const newFileContent = newFileLines.join('\n');
 
-      const approval = await requestToolEditApproval({
+      const outcome = await requestApprovedEditContent({
         path: filePath,
+        displayPath,
         originalContent: fileContent,
         proposedContent: newFileContent,
         sourceTool: 'text_editor:insert',
       });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          displayPath,
-          'text_editor:insert',
-          approval.userMessage,
-        );
+      if ('rejected' in outcome) {
+        return outcome.rejected;
       }
+      const { approval, finalContent } = outcome;
 
-      const approvedContent = getApprovedContent(approval, newFileContent);
       const { appliedContent, baseContent } = await writeApprovedContent(
         filePath,
         fileContent,
-        approvedContent,
+        finalContent,
       );
       if (appliedContent !== baseContent) {
         this.addToHistory(filePath, baseContent);
@@ -578,26 +564,22 @@ export class TextEditorTool extends defineTool({
       const previousContent = history.at(-1)!;
       const currentContent = await WorkspaceFS.read(filePath);
 
-      const approval = await requestToolEditApproval({
+      const outcome = await requestApprovedEditContent({
         path: filePath,
+        displayPath,
         originalContent: currentContent,
         proposedContent: previousContent,
         sourceTool: 'text_editor:undo_edit',
       });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          displayPath,
-          'text_editor:undo_edit',
-          approval.userMessage,
-        );
+      if ('rejected' in outcome) {
+        return outcome.rejected;
       }
+      const { approval, finalContent } = outcome;
 
-      const approvedContent = getApprovedContent(approval, previousContent);
       const { appliedContent } = await writeApprovedContent(
         filePath,
         currentContent,
-        approvedContent,
+        finalContent,
       );
       history.pop();
 

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -15,10 +15,8 @@ import {
   currentToolRoot,
 } from '@tools/pathResolution';
 import {
-  buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
+  requestApprovedEditContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
@@ -60,22 +58,18 @@ export class WriteFileTool extends defineTool({
       ? replacementEngine.applyAll(input.content)
       : input.content;
 
-    const approval = await requestToolEditApproval({
+    const outcome = await requestApprovedEditContent({
       path: filePath,
+      displayPath,
       originalContent,
       proposedContent,
       sourceTool: 'write_file',
     });
-
-    if (!approval.accepted) {
-      return buildApprovalRejectedResult(
-        displayPath,
-        'write_file',
-        approval.userMessage,
-      );
+    if ('rejected' in outcome) {
+      return outcome.rejected;
     }
+    const { approval, finalContent } = outcome;
 
-    const finalContent = getApprovedContent(approval, proposedContent);
     const { appliedContent } = await writeApprovedContent(
       filePath,
       originalContent,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -364,6 +364,54 @@ export function buildApprovalRejectedResult(
   return result;
 }
 
+export interface ApprovedEditContent {
+  approval: ToolEditApprovalResult;
+  /** Content to write: the user's adjustments if any, else the proposal. */
+  finalContent: string;
+}
+
+/**
+ * Run the tool-edit approval handshake for a proposed edit.
+ *
+ * Returns `{ rejected }` (a {@link ToolResult} to return directly) when the
+ * user declines, otherwise the approval plus the resolved `finalContent`.
+ * Centralizes the request → reject → resolve sequence shared by every edit
+ * tool so `sourceTool` is named once and the rejection message stays uniform.
+ * Callers own the write/record/post-processing steps, which vary per tool.
+ */
+export async function requestApprovedEditContent(request: {
+  path: string;
+  displayPath: string;
+  originalContent: string;
+  proposedContent: string;
+  sourceTool: string;
+}): Promise<{ rejected: ToolResult } | ApprovedEditContent> {
+  const { path, displayPath, originalContent, proposedContent, sourceTool } =
+    request;
+
+  const approval = await requestToolEditApproval({
+    path,
+    originalContent,
+    proposedContent,
+    sourceTool,
+  });
+
+  if (!approval.accepted) {
+    return {
+      rejected: buildApprovalRejectedResult(
+        displayPath,
+        sourceTool,
+        approval.userMessage,
+      ),
+    };
+  }
+
+  return {
+    approval,
+    finalContent: getApprovedContent(approval, proposedContent),
+  };
+}
+
 /**
  * Enable tool-edit YOLO on a freshly resolved child subagent stream.
  *


### PR DESCRIPTION
The single-edit tools (edit_file, write_file, and the four text_editor operations) each repeated the same request -> reject -> resolve sequence, passing sourceTool twice (once to requestToolEditApproval, once to buildApprovalRejectedResult) -- a DRY hazard where the two could drift.

Introduce requestApprovedEditContent() in toolEditApproval.ts, which runs the handshake and returns either a ready-to-return rejection ToolResult or the approval plus resolved finalContent. Callers keep their own write/record/post-processing steps, which legitimately differ per tool (ensureDir for create, addToHistory for str_replace/insert, history.pop for undo_edit). The batch AcceptRunFilesTool keeps using the lower-level primitives since its accumulate-and-continue loop has different semantics.

No behavior change; typecheck, lint, and the approval test suite pass.

https://claude.ai/code/session_01BXyY61ZXD9Dv7Edet7k6Ej

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with approval tests passing; batch accept_run_files path unchanged.
> 
> **Overview**
> Consolidates the repeated **request → reject → resolve** flow for single-file edit tools into **`requestApprovedEditContent`** in `toolEditApproval.ts`. **`edit_file`**, **`write_file`**, and the four **`text_editor`** mutating commands now call that helper with **`displayPath`** and handle a discriminated **`{ rejected }`** vs **`{ approval, finalContent }`** outcome instead of inlining **`requestToolEditApproval`**, **`buildApprovalRejectedResult`**, and **`getApprovedContent`**.
> 
> **`sourceTool`** is only passed once per call, so approval requests and rejection messages stay aligned. Per-tool behavior after approval (writes, history, **`ensureDir`**, etc.) is unchanged. **`accept_run_files`** still uses the lower-level approval APIs for its batch loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96dda47c6c63417ea744d71bea6ec471c3bb13db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->