### PR TITLE
refactor(rateLimiter): replace manual timing with Bottleneck scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "arxiv-client": "^0.0.9",
     "axios": "^1.16.1",
     "bibtex": "^0.9.0",
+    "bottleneck": "^2.19.5",
     "deepmerge": "^4.3.1",
     "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       bibtex:
         specifier: ^0.9.0
         version: 0.9.0
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -2852,6 +2855,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
@@ -9309,6 +9315,8 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  bottleneck@2.19.5: {}
 
   boundary@2.0.0: {}
 

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -1,30 +1,19 @@
-import { delay } from '@utils/core';
+import Bottleneck from 'bottleneck';
 
-/**
- * Simple rate limiter to respect API rate limits for academic metadata services.
- * Ensures minimum delay between consecutive requests to the same API.
- */
+const limiters = new Map<string, Bottleneck>();
 
-const lastRequestTimes = new Map<string, number>();
+function getLimiter(apiName: string, minDelayMs: number): Bottleneck {
+  const existing = limiters.get(apiName);
+  if (existing) return existing;
+  const limiter = new Bottleneck({ minTime: minDelayMs, maxConcurrent: 1 });
+  limiters.set(apiName, limiter);
+  return limiter;
+}
 
-/**
- * Enforces rate limiting by waiting if necessary before allowing the next request.
- *
- * @param apiName - Unique identifier for the API (e.g., 'arxiv', 'crossref')
- * @param minDelayMs - Minimum milliseconds between requests
- * @returns Promise that resolves when it's safe to make the next request
- */
+/** Enforces a minimum delay between consecutive requests to the same API. */
 export async function waitForRateLimit(
   apiName: string,
   minDelayMs: number,
 ): Promise<void> {
-  const lastTime = lastRequestTimes.get(apiName) ?? 0;
-  const elapsed = Date.now() - lastTime;
-  const waitTime = minDelayMs - elapsed;
-
-  if (waitTime > 0) {
-    await delay(waitTime);
-  }
-
-  lastRequestTimes.set(apiName, Date.now());
+  await getLimiter(apiName, minDelayMs).schedule(() => Promise.resolve());
 }

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -4,7 +4,10 @@ const limiters = new Map<string, Bottleneck>();
 
 function getLimiter(apiName: string, minDelayMs: number): Bottleneck {
   const existing = limiters.get(apiName);
-  if (existing) return existing;
+  if (existing) {
+    void existing.updateSettings({ minTime: minDelayMs });
+    return existing;
+  }
   const limiter = new Bottleneck({ minTime: minDelayMs, maxConcurrent: 1 });
   limiters.set(apiName, limiter);
   return limiter;


### PR DESCRIPTION
The previous implementation tracked last-call timestamps in a module-global Map and computed wait times by hand. Concurrent callers could both read the same stale timestamp and proceed without waiting, defeating the rate limit.

Bottleneck's minTime+maxConcurrent:1 queues callers serially, so concurrent requests are guaranteed to be spaced by minDelayMs regardless of timing interleave. Exported API is unchanged; no call-site or test edits needed.

https://claude.ai/code/session_01Vm8t5ySvzBYxsQB5XBU77Q

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to citation tooling; fixes a concurrency race in rate limiting without altering external APIs.
> 
> **Overview**
> Citation API throttling in `rateLimiter.ts` no longer uses hand-rolled `lastRequestTimes` + `delay`; it now depends on **Bottleneck** with one limiter per `apiName` (`minTime`, `maxConcurrent: 1`) and `schedule()` so callers are queued serially.
> 
> The public **`waitForRateLimit(apiName, minDelayMs)`** contract is unchanged, so arXiv/Crossref tool call sites and tests stay as-is. **`minDelayMs` can be updated** on an existing limiter via `updateSettings` when the same API is requested with a different delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d9a17ae21383f8aee8d641166d7abdce249f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->