### PR TITLE
docs: fix grip-handle description to match actual drag behavior

### DIFF
--- a/docs/.vitepress/components/FileSelectHero.vue
+++ b/docs/.vitepress/components/FileSelectHero.vue
@@ -49,6 +49,8 @@ import MockupFrame from './MockupFrame.vue';
           </div>
           <div class="flist">
             <div class="fitem">
+              <!-- Decorative only: the real UI has no grip handle; the whole
+                   row is draggable to reorder. -->
               <wa-icon
                 class="fi-grip"
                 library="texra"
@@ -201,6 +203,8 @@ import MockupFrame from './MockupFrame.vue';
   border-radius: 4px;
   background: #2c2c2c;
 }
+/* Decorative only — the real file rows have no grip handle (the whole row is
+   draggable). Kept here purely as a visual cue in this marketing mockup. */
 .fi-grip {
   font-size: 11px;
   color: var(--color-text-tertiary);

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -66,7 +66,7 @@ You can also **drag-and-drop files** from the OS file manager (or from VS Code's
 Inside the list:
 
 - Each file row has a small trash icon to remove just that file.
-- Drag a row by its grip handle to reorder files. Input files are sent to the agent in this order.
+- Drag a row to reorder files. Input files are sent to the agent in this order.
 
 The list is the only mode — there is no separate "single file" view. To work with one file, just keep the list at length one.
 

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -27,7 +27,7 @@ The main TeXRA panel includes a **Media** section for figure files:
 - **Add media files** (<wa-icon library="texra" name="add"></wa-icon>): open a file picker to append figures.
 - **Drag-and-drop** image, PDF, or audio files from anywhere onto the section.
 
-Each file appears as a row with a drag handle (for reordering) and a small trash icon (to remove just that file).
+Each file appears as a row you can drag to reorder, with a small trash icon (to remove just that file).
 
 ## <wa-icon library="texra" name="file-symlink-file"></wa-icon> Supported File Types
 


### PR DESCRIPTION
The file-reorder UI is initialized with SortableJS with no `handle` option, so the whole row is draggable, and the file rows render no grip/handle element — only a name span and a trash button. This corrects the docs prose that described a non-existent "grip handle" / "drag handle".

## What changed

- `docs/guide/file-management.md`: "Drag a row by its grip handle to reorder files." → "Drag a row to reorder files." (rest of sentence unchanged).
- `docs/guide/working-with-figures.md`: "Each file appears as a row with a drag handle (for reordering) and a small trash icon..." → "Each file appears as a row you can drag to reorder, with a small trash icon..."
- `docs/.vitepress/components/FileSelectHero.vue`: kept the `fi-grip` ellipsis icons (they are part of the marketing hero mockup) but added comments — one in the template and one on the `.fi-grip` CSS rule — noting they are decorative-only and that the real UI has no grip handle.

## Verification

Checked against the actual implementation:

- `src/shared/controllers/SortableController.ts:87` — `new Sortable(element, { animation, onEnd })` is constructed with NO `handle` option, so the entire row is the drag target.
- `packages/extension/src/webview/frontend/components/FileSelectGroup.ts:286-308` — each `.file-item` row renders only a `.file-name` span (name + optional folder) and a `wa-button` remove/trash button; there is no grip/handle element.

Prose-reword option only — no change to SortableJS or the webview component, per the issue's chosen approach.

Could not verify: nothing outstanding. This is a docs-only change; the docs site was not built locally (no node_modules in this worktree), but the edits are plain prose/comment changes with no markup-structure or template changes that would affect the build.

Closes #4566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and comment-only changes; no runtime, auth, or data-handling code.
> 
> **Overview**
> Documentation now matches how file lists actually reorder: **SortableJS** binds to the whole row (no `handle` option), and **FileSelectGroup** rows only show the name and remove control—there is no grip in the product UI.
> 
> **`file-management.md`** and **`working-with-figures.md`** drop references to a “grip” or “drag handle” and say to drag the row itself. **`FileSelectHero.vue`** keeps the decorative ellipsis icons in the docs marketing mockup but adds template/CSS comments that they are not part of the real UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd0952e93b42df2400a6ef53ad50b4d7dd71854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->