### PR TITLE
docs: fix research-agent literature-search claims

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -20,7 +20,7 @@ work — with every change returned as a diff you approve.
 | ------------------------------------------ | ------------------------------------------------------------- |
 | Tighten prose in a draft                   | [Polish a draft](./workflows/polish-a-draft.md)               |
 | Fix LaTeX errors and notation              | `correct` agent — see [Built-in Agents](./built-in-agents.md) |
-| Search literature, no fabricated citations | `research` — see [Research Tools](./research-tools.md)        |
+| Search literature, no fabricated citations | `search` — see [Research Tools](./research-tools.md)          |
 | Verify proofs and derivations              | `review` — see [Built-in Agents](./built-in-agents.md)        |
 | Formalize in Lean 4                        | [Lean 4 Proofs](./lean.md)                                    |
 | Build slides from a paper                  | `paper2slide` — see [Built-in Agents](./built-in-agents.md)   |

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -6,7 +6,7 @@ You're deep in a manuscript and realise you need to cite "that attention paper f
 
 ### <wa-icon library="texra" name="mortar-board"></wa-icon> Find Papers
 
-Ask any research agent to search for papers. TeXRA queries **arXiv** (preprints) and **Crossref** (published works) automatically:
+Ask a literature-search agent — `search`, `chat`, `review`, or `presenter` — to find papers. TeXRA queries **arXiv** (preprints) and **Crossref** (published works) automatically:
 
 ```
 Find recent papers on transformer architectures for document understanding.
@@ -81,11 +81,11 @@ The `inquiry` tool lets a TeXRA agent ask one question in an external chat (Chat
 
 ## Which Agent to Use
 
-| Agent      | Best for                                                                                              |
-| ---------- | ----------------------------------------------------------------------------------------------------- |
-| `search`   | Finding papers, literature reviews, fact-checking                                                     |
-| `research` | Computational verification with Wolfram, literature lookups, and quick questions about your documents |
-| `discuss`  | Brainstorming research directions with literature context                                             |
+| Agent      | Best for                                                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `search`   | Finding papers, literature reviews, fact-checking                                                                          |
+| `research` | Computational verification with Wolfram, plus bash, file edits, and local LaTeX analysis (`.bib`, figures, TikZ, texcount) |
+| `discuss`  | Brainstorming research directions with literature context                                                                  |
 
 Pick any of them from the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>). Check `Dashboard → Agents` (<wa-icon library="texra" name="sparkle"></wa-icon>) to see exactly which tools each one has enabled.
 


### PR DESCRIPTION
The `research` tool-use agent has no literature-search tools wired, yet three docs claim it does. This corrects those claims to match the agent's actual capabilities and points the "search literature" guidance at agents that really query arXiv/Crossref.

## What changed

- `docs/guide/research-tools.md` — "Which Agent to Use" table: the `research` row no longer claims "literature lookups." It now lists what the agent actually does — Wolfram verification, bash, file edits, and local LaTeX analysis (`.bib`, figures, TikZ, texcount).
- `docs/guide/research-tools.md` — "Find Papers" section: replaced the page-level "Ask any research agent to search for papers" with the agents that actually have arXiv/Crossref tools (`search`, `chat`, `review`, `presenter`).
- `docs/guide/index.md` — "What you can do" table: the "Search literature, no fabricated citations" row now points to `search` instead of `research`.

(The table-border whitespace re-alignment in `research-tools.md` is from the repo's `prettier` pre-commit hook, not a manual edit.)

## Verification

Checked against the actual agent YAML tool declarations:

- `packages/extension/resources/tool_use_agents/research.yaml:6-19` — `tools:` block is `wolfram, todo_write, bash, read_file, write_file, edit_file, glob, grep, ls, extract_figures, extract_bib_entries, extract_tikz_figures, texcount`. No `arxiv_search`, `crossref_search`, `crossref_doi`, `download_arxiv_source`, or `web_search`. Confirms `research` cannot do literature lookups.
- `packages/extension/resources/tool_use_agents/chat.yaml:17-21` — declares `arxiv_search`, `arxiv_metadata`, `download_arxiv_source`, `crossref_search`, `crossref_doi`.
- `packages/extension/resources/tool_use_agents/review.yaml:20-23` — declares `arxiv_search`, `arxiv_metadata`, `crossref_search`, `crossref_doi`.
- `packages/extension/resources/tool_use_agents/presenter.yaml:21-24` — declares `arxiv_search`, `arxiv_metadata`, `crossref_search`, `crossref_doi`.
- `reference-agents/search.yaml:6-23` — the `search` agent (the doc's primary literature agent) declares the full set including `web_search`/`web_fetch`/Zotero tools.

Could NOT fully verify: there is no `discuss.yaml` in `packages/extension/resources/tool_use_agents/` in this tree (only `reference-agents/search.yaml` exists locally; `discuss` is described in the issue as a remote agent). The "Which Agent to Use" table's `discuss` row and the surrounding `search`/`discuss` references were left untouched — they predate this change and are out of scope for #4544, which scoped only the three `research` literature-search claims.

Closes #4544

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only corrections to user-facing docs; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documentation now matches which agents actually call arXiv/Crossref. The guide index **“Search literature”** row points readers at **`search`** instead of **`research`**.
> 
> In **Research Tools**, the **Find Papers** intro names agents with literature tools (`search`, `chat`, `review`, `presenter`), and the **`research`** row in **Which Agent to Use** drops “literature lookups” in favor of Wolfram verification, shell/file edits, and local LaTeX/bibliography analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee5504b887c6fa6f6ac1107bb3b418f81767776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->