### PR TITLE
docs: reconcile lean.md tools, team presets, and Mathlib version

### DIFF
--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -46,7 +46,7 @@ Open **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>) 
 
 ## Choosing an Agent
 
-The built-in `lean` agent is always available. The **Lean Project** team adds four more agents — a `leanOrchestrator` plus the specialists it delegates to — which are [remote agents](./remote-agents.md), so [sign in](./remote-agents.md) to sync them.
+The built-in `lean` agent is always available. The **Lean Project** team adds a `leanOrchestrator` plus the Lean specialists it delegates to (`leanSearch`, `leanSimplifier`, `leanBlueprint`) — all [remote agents](./remote-agents.md), so [sign in](./remote-agents.md) to sync them. The team also bundles the `latexFixer` and `progressCheck` helpers that every preset shares.
 
 | Agent              | Availability       | Best for                                                                 |
 | ------------------ | ------------------ | ------------------------------------------------------------------------ |


### PR DESCRIPTION
Audit of `docs/guide/lean.md` against the lean agent's tool inventory and the multi-agent preset registry. The page was accurate except for the Lean Project team's agent count, which is corrected here.

## What changed

- Reworded the Lean Project team sentence in `docs/guide/lean.md`. It previously claimed the team "adds four more agents." The registry actually enrolls **six** agents beyond the built-in `lean`: `leanOrchestrator`, the `leanSearch`/`leanSimplifier`/`leanBlueprint` specialists, plus the shared `latexFixer`/`progressCheck` helpers. The new wording names the specialists explicitly and acknowledges the helper agents instead of miscounting. The specialist table below it was already correct and is unchanged.

## Verification

Source-of-truth files opened and checked:

- `src/shared/schemas/agentPresets.ts:30-83` — `AGENT_MODE_PRESETS`. Confirmed both team names exist verbatim: `Lean Project` (`id: lean-project`, line 33) and `Mathematician` (`id: mathematician`, line 69). `lean-project.toolUseAgents` = `lean`, `leanSearch`, `leanSimplifier`, `leanBlueprint`, `latexFixer`, `progressCheck`, `leanOrchestrator` (lines 38-46) — i.e. six agents beyond `lean`, which is why "four more agents" was wrong. The `mathematician` preset (lines 67-83) bundles `lean` alongside `research`/`review`/`simplifier`/`latexFixer`/`progressCheck`/`orchestrator` plus the workflow agents, so lean.md:59's "bundles the `lean` agent alongside the LaTeX and research agents" is accurate and left unchanged.
- `packages/extension/resources/tool_use_agents/lean.yaml:6-28` — the `lean` agent's tool list. The Lean-specific tools the doc describes (`lean_diagnostics`, `lean_inspect`, `lean_loogle`, `lean_file`, `lean_project`) all match; the remaining yaml tools are generic (`bash`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `ls`, `memory`, `todo_write`, `github_subscription`). No drift in the tool descriptions.
- `src/tools/lean/leanConstants.ts:15,19-34` and `src/tools/lean/LspTools.ts:32-71` — `lean_file` subcommands (`restart`, `refresh_dependencies`) and `lean_project` subcommands (`restart_server`, `stop_server`, `build`, `clean`, `fetch_cache`, `fetch_file_cache`, `install_elan`, `install_deps`, `update_elan`, `select_toolchain`) match the doc's "Refresh a Stuck File" and "Manage the Project" sections exactly.
- `src/tools/lean/LoogleTool.ts:4,94` — Loogle endpoint `https://loogle.lean-lang.org/` matches lean.md:91. No change needed.
- `src/tools/externalToolDefs.ts:285-318` — the `lean4` tool group (id, tool list, elan install command `https://elan.lean-lang.org/elan-init.sh`, install guide) matches the Prerequisites section of the doc.
- `docs/guide/built-in-agents.md:38,100-104` — cross-links consistent; the preset names there (`Lean Project`, `Physicist`, `Mathematician`) and the `lean` agent description match. `docs/guide/agent-architecture.md` contains no Lean/team-specific references, so lean.md's link to it stays a generic pointer (no consistency issue).

Could NOT verify (flagged, left unchanged):

- **Mathlib version pin / LeanSearch endpoint / Lake or `lean --version` minimums.** The repo contains no Mathlib version pin, no LeanSearch endpoint, and no toolchain-version minimum. lean.md does not assert any of these either — it only uses `lake --version` as a presence check, which matches `externalToolDefs.ts`. There was nothing to reconcile, so nothing was changed here.
- **Remote agent definitions** (`leanSearch`, `leanSimplifier`, `leanBlueprint`, `leanOrchestrator`). These are remote/synced agents with no YAML in this repo, so their individual capabilities could not be re-verified beyond their names in the preset registry. The "Best for" descriptions in the lean.md table were left as-is.

Closes #4562

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Fixes **Lean Project** team documentation in `docs/guide/lean.md` so it matches the preset registry instead of saying the team adds “four more agents.”
> 
> The paragraph now names **`leanOrchestrator`** and the delegated specialists (**`leanSearch`**, **`leanSimplifier`**, **`leanBlueprint`**) as remote agents, and notes that the preset also includes the shared **`latexFixer`** and **`progressCheck`** helpers. The agent table and the rest of the guide are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e7b3876d4aff38934464df2efc8eff74e1a681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->