### PR TITLE
docs: update relay-tier-config model IDs

### DIFF
--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -185,8 +185,8 @@ Available to all authenticated users (free and Max tiers have the same access).
 | `sonnet46T`    | claude-sonnet-4-6 (Thinking)         | Anthropic | $3.00/$15.00            |
 | `gemini31p`    | gemini-3.1-pro-preview               | Google    | $2.00/$12.00            |
 | `grok4`        | grok-4-0709                          | xAI       | $3.00/$15.00            |
-| `deepseekpro`  | deepseek-v4-pro                      | DeepSeek  | $0.435/$0.870           |
-| `deepseekproT` | deepseek-v4-pro (Thinking)           | DeepSeek  | $0.435/$0.870           |
+| `deepseekpro`  | deepseek-v4-pro                      | DeepSeek  | $0.44/$0.87             |
+| `deepseekproT` | deepseek-v4-pro (Thinking)           | DeepSeek  | $0.44/$0.87             |
 | `glm51`        | glm-5.1                              | GLM       | $1.05/$3.50             |
 | `glm5vturbo`   | glm-5v-turbo                         | GLM       | $1.20/$4.00             |
 | `glm5turbo`    | glm-5-turbo                          | GLM       | $1.20/$4.00             |

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -159,7 +159,7 @@ Model names must match the short names defined by the [`llm-zoo`](https://www.np
 ::: warning Auto-derived snapshot
 The model rows and prices below are a **snapshot of `llm-zoo` `MODEL_CONFIGS`**. The relay builds its model list and tier assignments automatically from that package (see [Single Source of Truth](#single-source-of-truth)), so individual IDs and prices here drift whenever `llm-zoo` is bumped. Treat the tables as illustrative and re-derive from `MODEL_CONFIGS` before relying on a specific value.
 
-**Prices last verified against `llm-zoo`: 2026-05-28.**
+**Prices last verified against `llm-zoo@1.8.0` `MODEL_CONFIGS`: 2026-05-29.**
 :::
 
 ### Free / Max Tier Models (≤$3/M Input)
@@ -185,8 +185,8 @@ Available to all authenticated users (free and Max tiers have the same access).
 | `sonnet46T`    | claude-sonnet-4-6 (Thinking)         | Anthropic | $3.00/$15.00            |
 | `gemini31p`    | gemini-3.1-pro-preview               | Google    | $2.00/$12.00            |
 | `grok4`        | grok-4-0709                          | xAI       | $3.00/$15.00            |
-| `deepseekpro`  | deepseek-v4-pro                      | DeepSeek  | $1.74/$3.48             |
-| `deepseekproT` | deepseek-v4-pro (Thinking)           | DeepSeek  | $1.74/$3.48             |
+| `deepseekpro`  | deepseek-v4-pro                      | DeepSeek  | $0.435/$0.870           |
+| `deepseekproT` | deepseek-v4-pro (Thinking)           | DeepSeek  | $0.435/$0.870           |
 | `glm51`        | glm-5.1                              | GLM       | $1.05/$3.50             |
 | `glm5vturbo`   | glm-5v-turbo                         | GLM       | $1.20/$4.00             |
 | `glm5turbo`    | glm-5-turbo                          | GLM       | $1.20/$4.00             |


### PR DESCRIPTION
Audits the model IDs and prices in `docs/relay-tier-config.md` against the documented source of truth (`llm-zoo` `MODEL_CONFIGS`). The only confirmed inaccuracy was the `deepseek-v4-pro` price; this corrects it and refreshes the verification date. No model IDs were removed because all IDs flagged in the issue are still present in the registry.

## What changed

- Corrected `deepseekpro` / `deepseekproT` pricing from `$1.74/$3.48` to `$0.435/$0.870` (the actual `inputPrice`/`outputPrice` for `deepseek-v4-pro` in `llm-zoo` `MODEL_CONFIGS`).
- Updated the "prices last verified" note from `2026-05-28` to `2026-05-29` and made it explicit that verification was against `llm-zoo@1.8.0` `MODEL_CONFIGS`.
- Deliberately did NOT remove `gpt54-` / `gpt54--` (see Verification) — they remain valid registry entries.

## Verification

Checked the doc against the locally-resolved `llm-zoo` registry (the source of truth the doc itself cites). The worktree had no `node_modules`, so I read the package from the main checkout, which resolves `llm-zoo@1.8.0` (root `package.json` declares `^1.8.0`; `pnpm-lock.yaml:4731,11451` pins `1.8.0`; `node_modules/llm-zoo` symlinks to `.pnpm/llm-zoo@1.8.0_zod@4.4.3`). The relay function imports `npm:llm-zoo@^1.6.1` (`supabase/functions/relay/models.ts:11`), so I cross-checked the affected entries across `llm-zoo` 1.6.1, 1.7.0, and 1.8.0 — all three agree on the values below.

Source-of-truth references:

- `src/model/modelOptionsBasic.ts:1` imports `MODEL_CONFIGS` from `llm-zoo`; `DEFAULT_MODELS` (`:16-25`) lists `gpt55`, `gpt54`, `deepseekproT`, `kimi26T`, etc.
- `supabase/functions/relay/models.ts:77-79` derives `RELAY_MODELS` from `MODEL_CONFIGS` (every non-`openRouterOnly` model); `:57-60` computes `minTier` (`≤$3` → `free`, `>$3` → `Ultra`).
- `llm-zoo@1.8.0` `MODEL_CONFIGS` entries (verified by requiring the package and dumping each config):
  - `gpt54-` → `gpt-5.4-mini-2026-03-17`, OpenAI, `$0.75/$4.50`, not deprecated — PRESENT (doc lines 54, 88, 171 correct).
  - `gpt54--` → `gpt-5.4-nano-2026-03-17`, OpenAI, `$0.20/$1.25`, not deprecated — PRESENT (doc lines 55, 89, 172 correct).
  - `gpt55` → `gpt-5.5-2026-04-23`, OpenAI, `$5.00/$30.00` — PRESENT (doc line 202 correct).
  - `gpt55pro` → `gpt-5.5-pro-2026-04-23`, OpenAI, `$30.00/$180.00` — PRESENT (doc line 203 correct).
  - `kimi26` / `kimi26T` → `kimi-k2.6`, Moonshot, `$0.60/$2.80` — PRESENT (doc lines 178-179 correct).
  - `deepseekpro` / `deepseekproT` → `deepseek-v4-pro`, DeepSeek, `$0.435/$0.870` — PRESENT but the doc listed `$1.74/$3.48`. Fixed.

What I could NOT fully verify:

- The upstream `llm-zoo` MODEL_CONFIGS is only accessible as the built `dist/index.cjs` in the main checkout's `node_modules`; I could not consult the original `llm-zoo` repo TypeScript source. The values were read directly from the resolved package, so they reflect what TeXRA actually ships.
- I only re-verified the prices the issue called out plus the full Free/Max model list; I spot-checked the other Free/Max rows (deepseek, glm5, minimax, qwen, haiku, sonnet, gemini, grok, glm51/turbo) and they all matched 1.8.0, but I did not exhaustively diff every row's display rounding.
- The doc's price-decimal convention is normally 2 places; `deepseek-v4-pro` is `0.435`, so I used 3-decimal precision (`$0.435/$0.870`) to stay accurate rather than round away a significant digit. Flagging in case maintainers prefer rounding (`$0.44/$0.87`).

Closes #4564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to illustrative pricing tables; no runtime relay or tier logic is modified.
> 
> **Overview**
> Updates the **relay tier config** doc snapshot so it matches **`llm-zoo@1.8.0` `MODEL_CONFIGS`**.
> 
> **`deepseekpro` / `deepseekproT`** per-million token prices are corrected from **$1.74/$3.48** to **$0.44/$0.87**. The “prices last verified” callout now names **`llm-zoo@1.8.0`** and the date **2026-05-29**. No model IDs or tier lists change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517d8f0909bc3b253b4d480794520b189f4f3925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->