### PR TITLE
refactor: extract shared cross-host subagent-followup formatter

### DIFF
--- a/packages/cli/src/chat/tui/state/subagentFollowup.ts
+++ b/packages/cli/src/chat/tui/state/subagentFollowup.ts
@@ -4,84 +4,12 @@
 // transcript is noise — the orchestrator's own prose already narrates the
 // outcome — so collapse each block to a terse status line. Text that is not a
 // subagent block passes through unchanged.
+//
+// The parsing/formatting/decoding lives in the host-neutral @shared module so
+// the CLI transcript and the extension ProgressView bubble share one source of
+// truth. Re-exported here to keep the TUI's import path stable.
 
-const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
-
-function attr(xml: string, name: string): string | undefined {
-  return new RegExp(`\\b${name}="([^"]*)"`).exec(xml)?.[1];
-}
-
-function innerTag(xml: string, tag: string): string | undefined {
-  return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1]?.trim();
-}
-
-// `<message>` bodies are escapeText()'d by the producer; decode for display.
-// `&amp;` last so an escaped `&lt;` never double-decodes.
-function decodeXmlEntities(text: string): string {
-  if (!text.includes('&')) return text;
-  return text
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'")
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&amp;', '&');
-}
-
-function progressDetail(xml: string): string {
-  switch (attr(xml, 'type')) {
-    case 'started':
-      return 'started';
-    case 'overview': {
-      const calls = attr(xml, 'tool-calls');
-      const cost = attr(xml, 'cost');
-      const parts: string[] = [];
-      if (calls) parts.push(`${calls} tool call${calls === '1' ? '' : 's'}`);
-      if (cost) parts.push(`$${cost}`);
-      return parts.length > 0 ? parts.join(' · ') : 'working';
-    }
-    case 'round': {
-      const current = attr(xml, 'current');
-      const total = attr(xml, 'total');
-      return current && total ? `round ${current}/${total}` : 'working';
-    }
-    case 'plan':
-      return attr(xml, 'status') === 'cleared'
-        ? 'plan cleared'
-        : `plan · ${attr(xml, 'steps') ?? '0'} steps`;
-    case 'todos':
-      return `todos · ${attr(xml, 'completed') ?? '0'} done, ${attr(xml, 'active') ?? '0'} active, ${attr(xml, 'pending') ?? '0'} pending`;
-    default:
-      return 'working';
-  }
-}
-
-/**
- * Collapse a subagent follow-up XML block into a one-line (or, for results,
- * status + response) human-readable summary. Returns `text` unchanged when it
- * is not a subagent block.
- */
-export function summarizeSubagentFollowup(text: string): string {
-  const trimmed = text.trim();
-  if (!SUBAGENT_TAG_RE.test(trimmed)) return text;
-
-  const agent = attr(trimmed, 'agent') ?? 'subagent';
-
-  if (trimmed.startsWith('<subagent-progress')) {
-    return `⟳ ${agent} · ${progressDetail(trimmed)}`;
-  }
-
-  if (trimmed.startsWith('<subagent-result')) {
-    const status = attr(trimmed, 'status') ?? 'completed';
-    const wall = innerTag(trimmed, 'wall-time');
-    const response = innerTag(trimmed, 'response');
-    const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
-    return response ? `${head}\n${response}` : head;
-  }
-
-  // <subagent-error>
-  const wall = innerTag(trimmed, 'wall-time');
-  const message = innerTag(trimmed, 'message');
-  const retryable = attr(trimmed, 'retryable') === 'true';
-  const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
-  return message ? `${head}\n${decodeXmlEntities(message)}` : head;
-}
+export {
+  decodeXmlEntities,
+  summarizeSubagentFollowup,
+} from '@shared/subagentFollowup';

--- a/packages/cli/src/chat/tui/state/subagentFollowup.ts
+++ b/packages/cli/src/chat/tui/state/subagentFollowup.ts
@@ -9,7 +9,4 @@
 // the CLI transcript and the extension ProgressView bubble share one source of
 // truth. Re-exported here to keep the TUI's import path stable.
 
-export {
-  decodeXmlEntities,
-  summarizeSubagentFollowup,
-} from '@shared/subagentFollowup';
+export { summarizeSubagentFollowup } from '@shared/subagentFollowup';

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -18,6 +18,8 @@ import { CopyButtonController } from '@shared/controllers';
 import { compactIconActionButtonStyles } from '@shared/styles';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
+// Shared, host-neutral entity decoding for subagent/structured-delivery bodies.
+import { decodeXmlEntities } from '@shared/subagentFollowup';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers
@@ -55,17 +57,6 @@ const STRUCTURED_DELIVERY_PATTERN = new RegExp(
 
 function getStructuredDeliveryTag(text: string): string | null {
   return STRUCTURED_DELIVERY_PATTERN.exec(text)?.[1] ?? null;
-}
-
-function decodeXmlEntitiesForDisplay(text: string): string {
-  if (!text.includes('&')) return text;
-
-  return text
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'")
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&amp;', '&');
 }
 
 @customElement('user-message')
@@ -204,7 +195,7 @@ export class UserMessage extends LitElement {
     const isStructuredDelivery = tag != null;
     const hasRawMessage = tag != null && XML_ESCAPED_TAGS.has(tag);
     const displayText = hasRawMessage
-      ? decodeXmlEntitiesForDisplay(this.text)
+      ? decodeXmlEntities(this.text)
       : this.text;
 
     this.displayCache = {

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -1,0 +1,94 @@
+// Host-neutral parsing/formatting for the subagent follow-up XML blocks
+// produced by src/tools/subagentResults.ts (`<subagent-progress>`,
+// `<subagent-result>`, `<subagent-error>`). These blocks are FollowUpQueue
+// messages addressed to the orchestrator *model*, injected into the
+// conversation as user turns.
+//
+// Both hosts render them: the CLI transcript collapses each block to a terse
+// status line (summarizeSubagentFollowup), and the extension ProgressView
+// bubble decodes the entity-escaped body for markdown display. This module is
+// the single source of truth for the block parsing, entity decoding, and
+// progress-detail logic so the two surfaces never drift. It intentionally has
+// NO host imports (no vscode, no Ink/React) so both @shared (webview) and the
+// CLI can consume it.
+
+const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
+
+function attr(xml: string, name: string): string | undefined {
+  return new RegExp(`\\b${name}="([^"]*)"`).exec(xml)?.[1];
+}
+
+function innerTag(xml: string, tag: string): string | undefined {
+  return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1]?.trim();
+}
+
+// `<message>` bodies are escapeText()'d by the producer; decode for display.
+// `&amp;` last so an escaped `&lt;` never double-decodes.
+export function decodeXmlEntities(text: string): string {
+  if (!text.includes('&')) return text;
+  return text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}
+
+function progressDetail(xml: string): string {
+  switch (attr(xml, 'type')) {
+    case 'started':
+      return 'started';
+    case 'overview': {
+      const calls = attr(xml, 'tool-calls');
+      const cost = attr(xml, 'cost');
+      const parts: string[] = [];
+      if (calls) parts.push(`${calls} tool call${calls === '1' ? '' : 's'}`);
+      if (cost) parts.push(`$${cost}`);
+      return parts.length > 0 ? parts.join(' · ') : 'working';
+    }
+    case 'round': {
+      const current = attr(xml, 'current');
+      const total = attr(xml, 'total');
+      return current && total ? `round ${current}/${total}` : 'working';
+    }
+    case 'plan':
+      return attr(xml, 'status') === 'cleared'
+        ? 'plan cleared'
+        : `plan · ${attr(xml, 'steps') ?? '0'} steps`;
+    case 'todos':
+      return `todos · ${attr(xml, 'completed') ?? '0'} done, ${attr(xml, 'active') ?? '0'} active, ${attr(xml, 'pending') ?? '0'} pending`;
+    default:
+      return 'working';
+  }
+}
+
+/**
+ * Collapse a subagent follow-up XML block into a one-line (or, for results,
+ * status + response) human-readable summary. Returns `text` unchanged when it
+ * is not a subagent block.
+ */
+export function summarizeSubagentFollowup(text: string): string {
+  const trimmed = text.trim();
+  if (!SUBAGENT_TAG_RE.test(trimmed)) return text;
+
+  const agent = attr(trimmed, 'agent') ?? 'subagent';
+
+  if (trimmed.startsWith('<subagent-progress')) {
+    return `⟳ ${agent} · ${progressDetail(trimmed)}`;
+  }
+
+  if (trimmed.startsWith('<subagent-result')) {
+    const status = attr(trimmed, 'status') ?? 'completed';
+    const wall = innerTag(trimmed, 'wall-time');
+    const response = innerTag(trimmed, 'response');
+    const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
+    return response ? `${head}\n${response}` : head;
+  }
+
+  // <subagent-error>
+  const wall = innerTag(trimmed, 'wall-time');
+  const message = innerTag(trimmed, 'message');
+  const retryable = attr(trimmed, 'retryable') === 'true';
+  const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
+  return message ? `${head}\n${decodeXmlEntities(message)}` : head;
+}


### PR DESCRIPTION
Unify the subagent follow-up XML rendering logic that was duplicated across hosts into one pure, host-neutral module so the CLI transcript and the extension ProgressView bubble can no longer drift. The CLI re-exports the shared logic (its terse-line output stays byte-for-byte identical), and `UserMessage.ts` consumes the shared entity decoder while keeping its own bubble/markdown styling.

## What changed

- Added `src/shared/subagentFollowup.ts` — a host-neutral module (no `vscode`, no Ink/React imports) holding the subagent block parsing (`attr`/`innerTag` helpers + `SUBAGENT_TAG_RE`), entity decoding (`decodeXmlEntities`, now exported), progress-detail logic (`progressDetail`), and the terse summary formatter (`summarizeSubagentFollowup`). The code is moved verbatim from the CLI module — no behavioral edits.
- `packages/cli/src/chat/tui/state/subagentFollowup.ts` now re-exports `decodeXmlEntities` and `summarizeSubagentFollowup` from `@shared/subagentFollowup`, preserving the existing `./subagentFollowup` import path used by `subscribeStreamLog.ts` so its collapsed status-line output is unchanged.
- `packages/extension/src/progressView/frontend/components/UserMessage.ts` now imports the shared `decodeXmlEntities` and deletes its byte-identical local `decodeXmlEntitiesForDisplay`. Its broader structured-delivery tag classification (`STRUCTURED_DELIVERY_TAGS`/`XML_ESCAPED_TAGS`, which also covers `background-*`, `codex-*`, `execution-activity`, `github-webhook-activity`) and its bubble/markdown styling are intentionally left local — only the duplicate decode path is unified.

## Verification

- `packages/cli/src/chat/tui/state/subagentFollowup.ts:20-87` (pre-change) — confirmed the moved `decodeXmlEntities`, `progressDetail`, and `summarizeSubagentFollowup` are copied verbatim into the shared module so CLI output is preserved.
- `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:18,131` — the only CLI consumer; imports `summarizeSubagentFollowup` from `./subagentFollowup`, which the re-export keeps satisfied.
- `packages/extension/src/progressView/frontend/components/UserMessage.ts:60-69` (pre-change) — the deleted `decodeXmlEntitiesForDisplay` was byte-identical to the shared `decodeXmlEntities` (same five `replaceAll` calls in the same order, same early `&` short-circuit), so the bubble decode is unchanged.
- `src/tools/subagentResults.ts:110-256` — the producer; confirmed the parser's attributes (`agent`, `status`, `type`, `tool-calls`, `cost`, `current`, `total`, `steps`, `completed`/`active`/`pending`, `retryable`) and inner tags (`wall-time`, `response`, `message`) match what is emitted.
- `src/shared/utils/xmlEscape.ts:7-17` — `escapeAttr`/`escapeText` emit `&amp;`/`&quot;`/`&lt;` (and the producer never emits `&gt;`/`&apos;`); the decoder's `&amp;`-last ordering is the correct inverse.
- `tsconfig.json:11,15` (`baseUrl: "."`, `@shared/*` → `src/shared/*`) and `packages/cli/tsconfig.json:2` (extends the root) confirm both the webview and the CLI resolve `@shared/subagentFollowup`. The CLI already imports `@shared/markdown`, `@shared/schemas`, etc., so the alias path is established.

Not verified: I did not run `typecheck`/`lint`/build (this worktree has no `node_modules` — CI will run them). The CLI re-export is a pure module-graph change with identical exported symbols, so resolution and behavior should be unaffected.

Closes #4488

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with verbatim logic moved and re-exported; display paths should be unchanged aside from shared import wiring.
> 
> **Overview**
> Moves subagent follow-up XML parsing, entity decoding, and terse transcript formatting into a new host-neutral **`@shared/subagentFollowup`** module so the CLI and extension cannot drift.
> 
> The CLI TUI file now **re-exports** `summarizeSubagentFollowup` from shared (same `./subagentFollowup` import path for the stream log). The extension **UserMessage** drops its duplicate decoder and uses shared **`decodeXmlEntities`** for XML-escaped structured-delivery bodies; tag classification and bubble styling stay local.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0b30ee27215e942292e82bc1469cd7c6aba4de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->