### PR TITLE
feat(cli): show elapsed timer in TUI status bar during running turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **Live elapsed timer in the CLI chat** — the status bar now shows the seconds elapsed next to `running`, so a long "thinking" turn that streams no text still reads as alive instead of looking frozen.
+
 ## [0.38.2] - 2026-05-27
 
 ### Features

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,5 +1,6 @@
 import process from 'node:process';
 
+import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
@@ -32,6 +33,10 @@ export interface StatusBarSegment {
 
 export interface StatusBarDisplayInput {
   readonly status: string | undefined;
+  /** Milliseconds since the running turn began. When set and `status` is
+   *  `running`, the bar shows a live `Ns` segment so a long token-less
+   *  "thinking" turn still reads as alive. Omitted in tests/headless. */
+  readonly elapsedMs?: number;
   readonly pendingExitHint: boolean;
   readonly pendingExitResumeId: string | undefined;
   readonly bypass: BypassState;
@@ -180,6 +185,15 @@ export function buildStatusBarDisplay(
     left.push({ text: 'Press Ctrl-C again to exit', color: 'yellow' });
   } else {
     left.push({ text: statusLabel(input.status), color: 'dim' });
+    if (
+      input.status === STREAM_STATUS.RUNNING &&
+      input.elapsedMs !== undefined
+    ) {
+      left.push({
+        text: `${Math.floor(input.elapsedMs / 1000)}s`,
+        color: 'dim',
+      });
+    }
   }
 
   left.push({ text: input.apiMode, color: 'dim' });
@@ -242,8 +256,24 @@ export function StatusBar(): React.JSX.Element {
   const approvals = useSignal(approvalQueueDepth);
   const caps = useSignal(terminalCapabilities);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+
+  // Re-render once a second while a turn is running so the elapsed segment
+  // ticks even when the model streams no tokens (the live region is otherwise
+  // only repainted by stream-log change events). The interval is armed only
+  // while `runStartedAt` is set, so an idle session adds no churn.
+  const runStartedAt =
+    slice?.status === STREAM_STATUS.RUNNING ? slice.runStartedAt : undefined;
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (runStartedAt === undefined) return;
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [runStartedAt]);
+
   const display = buildStatusBarDisplay({
     status: slice?.status,
+    elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     pendingExitHint,
     pendingExitResumeId,
     bypass: slice?.bypass ?? NO_BYPASS,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -70,6 +70,10 @@ export interface BypassState {
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   readonly status: StreamStatus | undefined;
+  /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
+   *  status. Drives the StatusBar's live elapsed-time segment so a long
+   *  token-less "thinking" turn still shows liveness. */
+  readonly runStartedAt: number | undefined;
   readonly description: string | undefined;
   readonly usage: TokenUsageStats | undefined;
   readonly conversation: ConversationProgress | undefined;
@@ -163,6 +167,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
     status: undefined,
+    runStartedAt: undefined,
     description: undefined,
     usage: undefined,
     conversation: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,6 +1,7 @@
 // Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
 
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS } from '@shared/schemas';
 
 import { patchStream } from './cliState';
 import { syncStreamLog } from './subscribeStreamLog';
@@ -16,11 +17,17 @@ export function subscribeStreamStatus(): () => void {
     // carrying `WAITING` from the previous turn would otherwise finalize
     // the next run's first chunks early, shoving partial text into
     // `<Static>` before it finished streaming.
-    patchStream(change.streamId, (slice) =>
-      slice.status === change.status
-        ? slice
-        : { ...slice, status: change.status },
-    );
+    patchStream(change.streamId, (slice) => {
+      if (slice.status === change.status) return slice;
+      // Stamp the turn-start clock when entering RUNNING (keeping any prior
+      // stamp if we re-enter without leaving), and clear it otherwise so the
+      // StatusBar's elapsed segment only ticks during an active turn.
+      const runStartedAt =
+        change.status === STREAM_STATUS.RUNNING
+          ? (slice.runStartedAt ?? Date.now())
+          : undefined;
+      return { ...slice, status: change.status, runStartedAt };
+    });
     syncStreamLog(change.streamId);
     if (isFinalTranscriptStatus(change.status)) {
       finalizeAssistantTranscriptEntries(change.streamId);

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -34,6 +34,7 @@ function slice(
   return {
     streamId: 'root',
     status: undefined,
+    runStartedAt: undefined,
     description: undefined,
     usage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -296,6 +296,7 @@ function sliceWithEntries(
   return {
     streamId,
     status: undefined,
+    runStartedAt: undefined,
     description: undefined,
     usage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -107,6 +107,56 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[Alt-1..9]focus');
   });
 
+  it('shows a live elapsed segment only while running', () => {
+    const running = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 110_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUps: 0,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+    });
+
+    expect(running.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'running',
+      '110s',
+      'api',
+    ]);
+
+    // The same elapsed reading is suppressed once the turn is no longer running.
+    const idle = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      elapsedMs: 110_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUps: 0,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+    });
+
+    expect(idle.left.map(statusBarSegmentText)).toEqual(['◆', 'idle', 'api']);
+  });
+
   it('preserves YOLO and BYPASS badges without agent/model text', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -38,6 +38,7 @@ function slice(
   return {
     streamId: streamId(streamIdValue),
     status: undefined,
+    runStartedAt: undefined,
     description: undefined,
     usage: undefined,
     conversation: undefined,


### PR DESCRIPTION
During a long "thinking" turn that streams no tokens, the TUI status bar was stuck on a static `◆ running` with no liveness cue, so the chat looked frozen (observed ~110s, zero streamed bytes). This adds a live elapsed-time segment that ticks while a turn is running. The root cause is that the TUI live region is only repainted on stream-log change events, so a token-less turn produced no repaints at all — the fix both stamps a turn-start clock and drives a tightly-scoped 1s re-render while running.

## What changed

- `state/cliState.ts`: add `runStartedAt: number | undefined` to `StreamSlice` — the data-model home for the turn-start clock (stored at the source, not synthesized at render time).
- `state/subscribeStreamStatus.ts`: stamp `runStartedAt = Date.now()` when a stream enters `RUNNING` (preserving an existing stamp on re-entry) and clear it on any other status, alongside the existing status patch.
- `panes/StatusBar.tsx`: add an optional `elapsedMs` input to `buildStatusBarDisplay` and push a `dim` `${Math.floor(elapsedMs / 1000)}s` segment (e.g. `110s`) right after the status label, only while `status === RUNNING`. The `StatusBar` component arms a 1s `setInterval` re-render scoped to the running window (`useEffect` keyed on `runStartedAt`), so an idle session adds no churn and the timer is torn down when the turn ends.
- `CHANGELOG.md`: user-facing `[Unreleased] > Features` entry.
- Tests: new `StatusBar.vitest` case asserting the `110s` segment appears only while running and is suppressed once idle; `runStartedAt: undefined` added to the three full `StreamSlice` literal factories so the shared kernel typechecks.

## Verification

- `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:266-284` — confirmed the live region repaints only via `store.onChange` (a 16ms-coalesced timer per change event), so a token-less RUNNING turn produces zero repaints. This is why a render-only read of the slice would never tick, and why a scoped 1s re-render is required.
- `packages/cli/src/chat/tui/state/subscribeStreamStatus.ts:12-29` — the only status mirror; all other slice updates go through `patchStream(...)` with `{ ...slice }` spreads (`state/subscribeRuntimeHost.ts:57-174`, `state/subscribeStreamLog.ts:304-364`), so `runStartedAt` is preserved across token/usage/progress patches.
- `packages/cli/src/chat/tui/panes/StatusBar.tsx:236` is imported only by `packages/cli/src/chat/tui/App.tsx:16,410`; `state/cliState.ts` and `state/subscribeStreamStatus.ts` are wired only from `packages/cli/src/chat/tui/runChatTui.tsx` (the interactive-TTY entry). The headless renderer is the separate `packages/cli/src/runtime/runProgressRenderer.ts` (already prints elapsed via its own `formatElapsed`, `runProgressRenderer.ts:197`). Nothing on the headless `texra run` / `--print` / `--output-format json|ndjson` path was touched, so that output stays byte-identical.
- Existing `src/test-kernel/cli/StatusBar.vitest.mts` RUNNING cases pass no `elapsedMs`, so the new segment is opt-in and they remain green.

### Could not verify
- Did not run `pnpm install` / typecheck / build / vitest per task instructions (worktree has no `node_modules`); CI will typecheck, lint, and run the kernel suite. The pre-commit Prettier hook passed.
- Could not run the live TUI to eyeball the ticking timer; behavior is covered by the static `buildStatusBarDisplay` test and reasoned from the repaint-cadence reading above.

### Ambiguity resolved conservatively
- The issue referenced an "existing turn-start clock that drives `turnDurationMs`" and an "existing live-region repaint cadence" and said "do not add a new timer." Neither exists in the CLI: there is no `turnDurationMs` field anywhere (`grep` repo-wide) and no periodic repaint during a token-less turn. I therefore (a) added `runStartedAt` as the turn-start clock at its data-model source, and (b) added a single `setInterval` that is armed *only* while running and torn down otherwise — the minimal mechanism that can make the segment actually tick. I kept the literal `${Math.floor(elapsedMs / 1000)}s` format from the issue rather than reusing the headless-only `formatElapsed` (`1m 50s`) to avoid exporting a private helper; happy to switch to `m s` formatting if preferred.

Closes #4585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only CLI status bar and stream slice timing; no auth, data, or headless run paths touched.
> 
> **Overview**
> The CLI chat **status bar** now shows a **live elapsed seconds** segment (e.g. `110s`) next to `running` during an active turn, so long model “thinking” periods with no streamed tokens still look alive instead of frozen.
> 
> **`StreamSlice`** gains **`runStartedAt`**, set when a stream enters **`RUNNING`** and cleared on any other status in **`subscribeStreamStatus`**. **`buildStatusBarDisplay`** accepts optional **`elapsedMs`** and renders the timer only while running; **`StatusBar`** runs a **1s interval** re-render only while that clock is set, because the live region otherwise repaints only on stream-log changes.
> 
> **CHANGELOG** documents the feature; kernel tests cover the elapsed segment and update **`StreamSlice`** test fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c9425d662684dc19a5bcfc57c2d2885013debc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->