### PR TITLE
ci: skip the heavy validate matrix on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: detect
+        run: |
+          # Heavy validation (compile/build/desktop) only runs when a PR touches
+          # something other than docs. Docs-only PRs fall through to the
+          # lightweight docs-build job below, keeping CI spend down. Pushes to
+          # main and manual dispatches always run the full matrix.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' -> full validation."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          files="$(git diff --name-only "$base...$head")"
+          echo "Changed files in this PR:"
+          printf '%s\n' "$files"
+          # A file counts as "code" unless it lives under docs/ or is a *.md file.
+          if printf '%s\n' "$files" | grep -vE '^docs/|\.md$' | grep -q .; then
+            echo "Non-docs changes detected -> full validation."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only change -> lightweight docs build only."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
     name: validate (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -124,6 +164,34 @@ jobs:
           path: packages/desktop/dist/
           if-no-files-found: error
           retention-days: 14
+
+  docs-check:
+    name: docs build
+    needs: changes
+    # Runs only for docs-only PRs (where the heavy validate matrix is skipped).
+    # The VitePress docs are a self-contained npm sub-project, so this mirrors
+    # docs-deploy.yml's install/build rather than the pnpm workspace.
+    if: needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        working-directory: docs
+        run: npm ci --legacy-peer-deps
+
+      - name: Build docs site
+        working-directory: docs
+        run: npm run docs:build
 
   desktop-macos-installer:
     name: desktop installer (macOS)
@@ -425,7 +493,9 @@ jobs:
     name: validate
     runs-on: ubuntu-latest
     needs:
+      - changes
       - validate
+      - docs-check
       - desktop-macos-installer
       - desktop-linux-installer
       - desktop-windows-artifact
@@ -435,8 +505,18 @@ jobs:
     steps:
       - name: Require validation jobs success
         run: |
-          if [ '${{ needs.validate.result }}' != 'success' ]; then
+          # On code PRs the validate matrix gates; on docs-only PRs it is skipped
+          # and the lightweight docs build gates instead — require whichever ran.
+          if [ '${{ needs.validate.result }}' != 'success' ] && [ '${{ needs.validate.result }}' != 'skipped' ]; then
             echo 'Validation matrix result: ${{ needs.validate.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.docs-check.result }}' != 'success' ] && [ '${{ needs.docs-check.result }}' != 'skipped' ]; then
+            echo 'Docs build result: ${{ needs.docs-check.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.validate.result }}' = 'skipped' ] && [ '${{ needs.docs-check.result }}' != 'success' ]; then
+            echo 'Docs-only PR but docs build did not succeed: ${{ needs.docs-check.result }}'
             exit 1
           fi
           if [ '${{ needs.desktop-macos-installer.result }}' != 'success' ] && [ '${{ needs.desktop-macos-installer.result }}' != 'skipped' ]; then


### PR DESCRIPTION
## What
Docs-only PRs no longer run the heavy `validate` matrix (compile / build:initial / desktop-package / smoke on ubuntu **and** macOS). A new `changes` job diffs the PR against its base; `validate` runs only when a non-docs file changed, and docs-only PRs run a lightweight `docs build` job (VitePress) instead.

## Why
Cuts CI spend on documentation PRs — especially the ~10x macOS runner minutes.

## Details
- `changes` job: `git diff base...head`; `code=true` unless every changed file is under `docs/**` or is a `*.md` file.
- `validate` gated on `code == 'true'`; new `docs-check` (npm + `vitepress build`, mirroring docs-deploy) gated on `code != 'true'`.
- Pushes to `main` and `workflow_dispatch` always run full validation; desktop-installer jobs are unchanged (already push-only).
- The `validate` status gate accepts the docs-only path (validate skipped → docs build gates instead).

## Verification
- `actionlint .github/workflows/ci.yml` → clean (exit 0); YAML parses; `docs/package-lock.json` present for the npm cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that gates existing jobs; no application, auth, or data-handling code is modified.
> 
> **Overview**
> **Docs-only pull requests** no longer run the full `validate` matrix on Ubuntu and macOS. A new **`changes`** job diffs the PR against its base and sets `code=true` when any changed file is outside `docs/` and not a root-level `*.md` file; pushes to `main` and `workflow_dispatch` always set `code=true`.
> 
> The **`validate`** job now depends on `changes` and runs only when `code == 'true'`. For docs-only PRs, a new **`docs-check`** job runs instead: Node 22, `npm ci` in `docs/`, and `npm run docs:build` (aligned with the standalone docs deploy flow).
> 
> The **`validate-status`** gate was updated so either a successful `validate` or a successful `docs-check` satisfies the check when the other job was skipped, without weakening desktop installer or release publish requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c40d7cce5c4feda12ec8a1df96ef3a134051c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->