### PR TITLE
feat(models): add "Max" reasoning effort tier for Opus 4.8

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -92,7 +92,7 @@ Configure how TeXRA connects to AI model providers:
 
 Claude Opus 4.8 and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
 
-Opus 4.8 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High). On Opus 4.8, Extra High maps to Anthropic's `xhigh` ("extra") effort tier, recommended for difficult tasks and long-running work; the earlier Opus 4.6/4.7 models use `max` instead, since they predate the `xhigh`/`max` split.
+Opus 4.8 uses adaptive thinking only — manual thinking budgets are not supported. TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High / Max). On Opus 4.8, **Extra High** maps to Anthropic's `xhigh` ("extra") effort tier and **Max** maps to the top `max` tier — both are recommended for difficult tasks and long-running work, with Max reserved for the hardest, longest-horizon runs. The earlier Opus 4.6/4.7 models predate the `xhigh`/`max` split and accept only `max`, so both Extra High and Max collapse onto `max` there.
 
 ### Bibliography Settings
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -21,7 +21,7 @@ TeXRA supports models from multiple providers. Select models from the dropdown i
 
 Opus 4.8 and Sonnet 4.6 include the full 1M context window at standard pricing — no opt-in or beta header required. Other Claude models use a 200K context window.
 
-Claude Opus 4.8 uses adaptive thinking only (extended thinking with a manual `budget_tokens` is no longer accepted). TeXRA's reasoning-effort selector maps to Anthropic's effort levels automatically — pick `opus48T` with Extra High effort for the strongest agentic coding and long-horizon tasks. Opus 4.8 also supports high-resolution images (up to 2576px / 3.75MP) for better figure, chart, and screenshot understanding; note that TeXRA downscales images above `texra.maxImageDimension` (default 2000px) before sending, so raise that setting if you want to take full advantage of Opus 4.8's higher limit.
+Claude Opus 4.8 uses adaptive thinking only (extended thinking with a manual `budget_tokens` is no longer accepted). TeXRA's reasoning-effort selector maps to Anthropic's effort levels automatically — pick `opus48T` with Extra High (or the top Max tier) effort for the strongest agentic coding and long-horizon tasks. Opus 4.8 also supports high-resolution images (up to 2576px / 3.75MP) for better figure, chart, and screenshot understanding; note that TeXRA downscales images above `texra.maxImageDimension` (default 2000px) before sending, so raise that setting if you want to take full advantage of Opus 4.8's higher limit.
 
 ## OpenAI Models
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.17.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.8.0",
+    "llm-zoo": "^1.8.1",
     "lru-cache": "^11.5.1",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.2.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1557,7 +1557,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.17.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.8.0",
+    "llm-zoo": "^1.8.1",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.2.0",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -49,6 +49,8 @@ const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
   low: 'Low',
   medium: 'Medium',
   high: 'High',
+  xhigh: 'Extra High',
+  max: 'Max',
 };
 
 const REASONING_LEVELS = ReasoningLevelSchema.options;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.0.4:
-    hash: d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09
-    path: patches/ink@7.0.4.patch
+  ink@7.0.4: d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09
 
 importers:
 
@@ -128,8 +126,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.8.0
-        version: 1.8.0(zod@4.4.3)
+        specifier: ^1.8.1
+        version: 1.8.1(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.1
         version: 11.5.1
@@ -577,8 +575,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.8.0
-        version: 1.8.0(zod@4.4.3)
+        specifier: ^1.8.1
+        version: 1.8.1(zod@4.4.3)
       mark.js:
         specifier: ^8.11.1
         version: 8.11.1
@@ -4728,8 +4726,8 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
-  llm-zoo@1.8.0:
-    resolution: {integrity: sha512-7lDi/LmlLEK6hSYOO7A+d5q7wX6DMInuIZk6FuHvImnN1PhAuWjxYA41rMVfTUk4WEDkPL+CYL6NYTudL3mstw==}
+  llm-zoo@1.8.1:
+    resolution: {integrity: sha512-mp1pxAeMRqg7Z4mISkvhD2HY1AuR2G7QfpXQNNAaVb22Bls2Qndx+sDwK+SIR5cH4V5ENZjN97MVyi47kNDyJA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -11448,7 +11446,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llm-zoo@1.8.0(zod@4.4.3):
+  llm-zoo@1.8.1(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -477,8 +477,8 @@ export abstract class ModelHandler<
 
   /**
    * Returns the effective reasoning effort for the current user and model.
-   * On GPT-5 models accessed via included (server-side) keys, xhigh reasoning
-   * is capped: Max tier → high, free tier → medium.
+   * On GPT-5 models accessed via included (server-side) keys, the above-high
+   * tiers (xhigh and max) are capped: Max tier → high, free tier → medium.
    */
   protected getEffectiveReasoningEffort(): ReasoningEffort | null {
     const { supportsReasoningEffort, reasoningEffort } = this.capabilities;
@@ -493,7 +493,8 @@ export abstract class ModelHandler<
     const isGpt5 = this.config.name.startsWith('gpt5');
     if (
       isGpt5 &&
-      reasoningEffort === ReasoningEffort.XHIGH &&
+      (reasoningEffort === ReasoningEffort.XHIGH ||
+        reasoningEffort === ReasoningEffort.MAX) &&
       this.shouldUseServerSideKeys()
     ) {
       const userTier = getServerSideKeyService().getUserTier();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -286,8 +286,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
    * Falls back to 'high' (the API default) when no specific effort is configured.
    * The above-'high' tiers are only valid for Opus-tier models: Opus 4.8 accepts
-   * the distinct 'xhigh' ("extra") tier, while Opus 4.6/4.7 predate that split
-   * and only accept 'max'.
+   * both the distinct 'xhigh' ("extra") tier and the top 'max' tier, while Opus
+   * 4.6/4.7 predate that split and only accept 'max'.
    */
   private getAnthropicEffort(): BetaOutputConfig['effort'] {
     const reasoningEffort = this.getEffectiveReasoningEffort();
@@ -296,6 +296,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     switch (reasoningEffort) {
+      case 'max':
+        // The top tier ("Max"). Opus 4.8/4.7/4.6 all accept Anthropic's 'max'
+        // effort; everything else caps at 'high'.
+        return this.isClaudeOpus48() ||
+          this.isClaudeOpus47() ||
+          this.isClaudeOpus46()
+          ? 'max'
+          : 'high';
       case 'xhigh':
         // Opus 4.8 exposes the distinct 'xhigh' ("extra") effort tier the SDK
         // added in 0.100.0, which is exactly what TeXRA's "Extra High" selector

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -81,10 +81,13 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
 
   /**
    * DeepSeek's OpenAI-format API accepts only high/max. Its compatibility layer
-   * maps low/medium to high and xhigh to max, so do that explicitly.
+   * maps low/medium to high and the above-high tiers (xhigh, max) to max, so do
+   * that explicitly.
    */
   protected override validateReasoningEffort(effort: string): string {
-    return effort === ReasoningEffort.XHIGH ? 'max' : 'high';
+    return effort === ReasoningEffort.XHIGH || effort === ReasoningEffort.MAX
+      ? 'max'
+      : 'high';
   }
 
   /** DeepSeek requires merging consecutive roles and stringified content. */

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -223,6 +223,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
       case ReasoningEffort.HIGH:
       case ReasoningEffort.XHIGH:
+      case ReasoningEffort.MAX:
+        // Gemini tops out at HIGH thinking; xhigh/max both map to it.
         return ThinkingLevel.HIGH;
 
       default:

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1716,11 +1716,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Build shared params used by both token counting and API call
 
-    // OpenAI Responses API doesn't support 'none'; clamp to 'low'.
+    // OpenAI Responses API doesn't support 'none' (clamp to 'low') or
+    // Anthropic's top 'max' tier (clamp to OpenAI's 'xhigh' ceiling).
     const rawEffort = this.capabilities.supportsReasoning
       ? this.getEffectiveReasoningEffort()
       : undefined;
-    const reasoningEffort = rawEffort === 'none' ? ('low' as const) : rawEffort;
+    const reasoningEffort =
+      rawEffort === 'none'
+        ? ('low' as const)
+        : rawEffort === 'max'
+          ? ('xhigh' as const)
+          : rawEffort;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const baseParams = {

--- a/src/agent/runtime/reasoningEffort.ts
+++ b/src/agent/runtime/reasoningEffort.ts
@@ -9,4 +9,6 @@ export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
   low: ReasoningEffort.LOW,
   medium: ReasoningEffort.MEDIUM,
   high: ReasoningEffort.HIGH,
+  xhigh: ReasoningEffort.XHIGH,
+  max: ReasoningEffort.MAX,
 };

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -192,8 +192,15 @@ export type UpdateAgentSelectionMessage = z.infer<
 // Model selection data schema
 // ============================================================
 
-/** Reasoning effort levels that a user can select. */
-export const ReasoningLevelSchema = z.enum(['none', 'low', 'medium', 'high']);
+/** Reasoning effort levels that a user can select (low → high tiers). */
+export const ReasoningLevelSchema = z.enum([
+  'none',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
 export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
 
 export const ModelSelectionItemSchema = z.object({

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1044,6 +1044,52 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('uses adaptive thinking with max effort for Opus 4.8 max reasoning', async () => {
+    const handler = createAnthropicHandler({
+      supportsReasoning: true,
+      supportsReasoningEffort: true,
+      reasoningEffort: ReasoningEffort.MAX,
+    });
+    handler.config.fullName = 'claude-opus-4-8';
+
+    stubHandlerForTest(handler);
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-8',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    await handler.createResponse({ client, messages, temperature: 0 });
+
+    const options = messageOptions[0] ?? {};
+    assert.equal(
+      options.output_config?.effort,
+      'max',
+      "max reasoning effort should map to the top 'max' tier on Opus 4.8",
+    );
+  });
+
   it('uses the Anthropic minimum trigger for manual compaction requests', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,


### PR DESCRIPTION
Adds a user-selectable **Max** reasoning-effort tier for Opus 4.8 (Anthropic's `max`), keeping **Extra High** (`xhigh`) as the distinct lower tier. Unblocked by the llm-zoo 1.8.1 release.

Closes #4576

## What changed
- Bump `llm-zoo` `^1.8.0` → `^1.8.1` (root + extension). 1.8.1 adds `ReasoningEffort.MAX` above `XHIGH` and flips `opus48T` to `supportsReasoningEffort: true` (default `HIGH`), so the effort path is now live in production (it previously short-circuited to `'high'`).
- `ReasoningLevelSchema` gains `'xhigh'` and `'max'`; `LEVEL_TO_EFFORT` maps them to `ReasoningEffort.XHIGH`/`MAX` (the reverse `EFFORT_TO_LEVEL` map derives automatically).
- `getAnthropicEffort`: `'max'` → `'max'` on Opus 4.8/4.7/4.6 (top tier); `'xhigh'` → `'xhigh'` on 4.8 (unchanged).
- Cross-provider knock-on: OpenAI Responses clamps `'max'` → its `'xhigh'` ceiling; the settings reasoning-level label map gains "Extra High" / "Max".
- Docs (`configuration.md`, `models.md`) describe the `high → xhigh → max` tiers; added an Anthropic-handler test for the `max` tier.

## Verification
- `npm run typecheck` passes (root + `tsc` test-kernel + extension + cli) after the bump.
- Confirmed `ReasoningEffort.MAX = "max"` (above `XHIGH`) and `opus48T.supportsReasoningEffort: true` in installed llm-zoo 1.8.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how reasoning effort is sent to multiple LLM providers and included-access caps; mis-mapping could affect cost/latency or API errors on edge models.
> 
> **Overview**
> Adds a user-selectable **Max** reasoning tier (above **Extra High** / `xhigh`) wired through settings, runtime mapping, and provider handlers after bumping **`llm-zoo`** to **1.8.1** (`ReasoningEffort.MAX`, `opus48T` reasoning-effort support).
> 
> The Models UI and **`ReasoningLevelSchema`** now expose **`xhigh`** and **`max`**; **`LEVEL_TO_EFFORT`** maps them to the new enum values. **Anthropic** sends **`max`** on Opus 4.6/4.7/4.8 and **`xhigh`** only on 4.8 for Extra High. **OpenAI Responses** clamps **`max`** → **`xhigh`**; **Gemini**, **DeepSeek**, and **included-access GPT-5** relay caps treat **`max`** like the other top tiers where applicable.
> 
> Docs describe the **Low → Max** ladder for Opus 4.8; a new Anthropic test covers **`max`** on Opus 4.8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962a1130eb8140fa6d8160f67735395bc1654104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->