### PR TITLE
feat(tools): add install instructions to the TeXRA CLI integration card

### DIFF
--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -434,9 +434,14 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     description:
       'Local TeXRA command-line app integration. Detection is shown now; activation is coming soon.',
     installGuide:
-      'The TeXRA CLI is installed with the TeXRA package. Make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
+      'Run the same agents on your .tex projects without an editor — ideal for scripts, CI, and remote machines.\n\n' +
+      'Install globally from npm (requires Node.js >= 22):\n' +
+      '  npm install -g @texra-ai/cli\n\n' +
+      'The CLI also ships with the TeXRA package — make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
       'Check from a terminal:\n' +
       '  texra --version',
+    installUrl: 'https://www.npmjs.com/package/@texra-ai/cli',
+    installCommand: 'npm install -g @texra-ai/cli',
     configNotes:
       'Coming soon. This entry only checks whether the local CLI is visible.',
     comingSoon: true,


### PR DESCRIPTION
The **TeXRA CLI** entry on the Integrations (Dashboard → Integrations) card only said the CLI "ships with the TeXRA package", with no install path for users who don't have it. This adds the standalone npm install instructions so the card surfaces an **Install in Terminal** button and an **Open Install Page** link.

## What changed
`src/tools/externalToolDefs.ts` — the `texra-cli` entry:
- `installGuide` now leads with the pitch ("Run the same agents on your .tex projects without an editor — ideal for scripts, CI, and remote machines"), the command `npm install -g @texra-ai/cli` (Node.js >= 22), and keeps the existing bundled-with-TeXRA note + `texra --version` check.
- Adds `installCommand: 'npm install -g @texra-ai/cli'` and `installUrl: 'https://www.npmjs.com/package/@texra-ai/cli'`.

`ToolCard.renderGuide` already renders `installGuide` + an Install-in-Terminal button (`installCommand`) + the install-page link (`installUrl`) for external tools (`requiresSetup` is always true), so these surface without UI changes.

## Verification
- `installUrl` / `installCommand` are existing optional `ExternalToolDef` fields (type-checked by CI).
- npm package confirmed at https://www.npmjs.com/package/@texra-ai/cli.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to an external tool definition; no runtime agent or auth behavior changes.
> 
> **Overview**
> The **TeXRA CLI** integration card now documents standalone installation instead of only mentioning that the CLI ships with the TeXRA package.
> 
> The `texra-cli` definition in `externalToolDefs.ts` expands **`installGuide`** with a short value prop, **`npm install -g @texra-ai/cli`** (Node.js ≥ 22), and keeps the bundled-PATH and `texra --version` checks. It also sets **`installUrl`** and **`installCommand`** so the existing Integrations UI can show **Install in Terminal** and **Open Install Page** without any component changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d992a668817e90afbc82db5bd18790efaad295b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->