### PR TITLE
fix(agent): render subagent progress transcripts (open run-root stage as root)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **Live elapsed timer in the CLI chat** — the status bar now shows the seconds elapsed next to `running`, so a long "thinking" turn that streams no text still reads as alive instead of looking frozen.
 
+### Bug Fixes
+
+- **Subagent progress boards show their rounds again** — a subagent run's transcript was blank except for the instruction: the round groups (Init, r0/r1) and everything nested under them — scratchpad, statistics, latexdiff results, loaded files — failed to render. The run's root stage was inheriting the orchestrator's active stage as a cross-trace parent, orphaning the whole group tree in the subagent's own stream.
+
 ## [0.38.2] - 2026-05-27
 
 ### Features

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -152,6 +152,13 @@ async function validateModelExists(
  * At this point no group context exists, so the message gets no groupId and
  * its timestamp precedes the stage's startTime. The chronological timeline
  * therefore renders the instruction before the run group.
+ *
+ * ROOT INVARIANT: opened with `root: true` so it never inherits an ambient
+ * stage from the shared trace scope. For a subagent run, the active stage at
+ * launch is the orchestrator's tool-use stage — a cross-trace id that this
+ * run's own stream never records. Inheriting it would orphan "Run:" (and its
+ * whole Init/r0/r1 subtree) in the subagent's transcript, since the renderer
+ * can only build group trees down from parentless roots.
  */
 async function beginRunStage(
   agentLogger: AgentTrace,
@@ -159,7 +166,7 @@ async function beginRunStage(
   instruction: string | undefined,
 ): Promise<StageHandle> {
   if (instruction) logUserMessage(agentLogger, instruction);
-  return agentLogger.openStage(label);
+  return agentLogger.openStage(label, { root: true });
 }
 
 async function assembleAgentLaunchContext(


### PR DESCRIPTION
## Problem

A **subagent** run's progress-board transcript was blank except for the user instruction (and occasionally the thinking stream). Its round groups — `Init`, `r0`, `r1` — and **everything nested under them** (scratchpad, statistics, latexdiff results, loaded-files cards) didn't render. Top-level workflow runs were unaffected.

## Root cause

`beginRunStage` opened the `"Run:"` stage with a bare `agentLogger.openStage(label)`. `openStage` falls back to `activeStageId()` for the parent, which reads the **shared module-level `AsyncLocalStorage` stage stack** in `TraceEmitter`. For a subagent, the active stage at launch is the **orchestrator's tool-use stage** — an id that lives on the orchestrator's trace and is *never recorded in the subagent's own stream*.

So `"Run:"` was persisted with a `parentGroupId` pointing at a group absent from its stream. The renderer (`messageIndex.rebuildTree`) only builds the group tree down from parentless roots, so the orphaned `"Run:"` dropped its entire `Run → {Init, r0, r1}` subtree — along with every message grouped under it.

Confirmed against the persisted `streamLog` of a real `devise@opus48T#…` run: `"Run: devise"` carried `parentGroupId = 0a171d9d…`, which had no matching group entry in that stream; the grouped messages themselves (`fileList`→Init, `statistics`/`latexdiff`→r0/r1) were all recorded correctly.

## Fix

Open the run-root stage with `{ root: true }` — the option that exists for exactly this situation (its doc comment in `AgentTrace.ts` describes "a child agent's session stage opened on its own trace while the parent agent's tool-use stage is active"). It forces `parentId = undefined`, so the run root never inherits an ambient cross-trace parent.

- Top-level runs: no ambient stage at launch, so behavior is unchanged.
- Also fixes the same orphaning for **tool-use** subagents (they share `beginRunStage`).

```diff
-  return agentLogger.openStage(label);
+  return agentLogger.openStage(label, { root: true });
```

## Verification

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/agent/trace/RunTraceStream.vitest.ts` — 5/5 pass (includes the existing `openStage root option` guard that asserts a `{ root: true }` child does not inherit an active ambient stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single behavioral change at agent launch trace grouping; existing vitest covers the root option and top-level runs are unchanged.
> 
> **Overview**
> Subagent **progress board** transcripts were nearly empty because the **`Run:`** root stage picked up the orchestrator’s active stage as its parent via shared trace scope, so the subagent stream couldn’t build a group tree and dropped **Init / r0 / r1** and nested content.
> 
> **`beginRunStage`** now opens that stage with **`{ root: true }`**, matching Claude Code / Codex child sessions, so the run root has no cross-trace parent. Top-level launches are unchanged when no ambient stage exists. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14802f3859a25790e999dcce7175a4c26122c326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->