### PR TITLE
docs(changelog): finalize 0.38.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - **Wolfram results always show a summary** — runs that returned only structured data no longer render as an empty line.
 - **Clean `--output-format` output** — usage text is routed to stderr on errors so the JSON / NDJSON stream on stdout stays parseable for scripts and CI.
 - **Drag-and-drop file selection works** — files dragged from the workspace explorer now land in the workflow Input / Context / Media buckets.
+- **Subagent progress shows in the transcript** — fixed subagent progress, result, and error updates not rendering on the progress board and chat transcript during multi-agent runs.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.38.3] - 2026-05-29
+
 ### Features
 
+- **"Max" reasoning effort for Opus 4.8** — pick the new top **Max** tier (above Extra High) in the Models tab for the hardest, longest-horizon tasks; it maps to Anthropic's `max` effort, with Extra High remaining as the `xhigh` tier.
 - **Live elapsed timer in the CLI chat** — the status bar now shows the seconds elapsed next to `running`, so a long "thinking" turn that streams no text still reads as alive instead of looking frozen.
+
+### Bug Fixes
+
+- **CLI chat redraws cleanly on resize** — fixed leftover Ink live-region residue when the terminal is resized, and cut idle repaint churn.
+- **LaTeX math survives in the transcript** — inline `$…$` / `\(…\)` spans are now preserved verbatim in the CLI's Markdown rendering instead of being mangled.
+- **Markdown tables size to their content** in the CLI chat, instead of stretching to the full terminal width.
+- **Wolfram results always show a summary** — runs that returned only structured data no longer render as an empty line.
+- **Clean `--output-format` output** — usage text is routed to stderr on errors so the JSON / NDJSON stream on stdout stays parseable for scripts and CI.
+- **Drag-and-drop file selection works** — files dragged from the workspace explorer now land in the workflow Input / Context / Media buckets.
+
+### Improvements
+
+- **Install the CLI straight from the Dashboard** — the TeXRA CLI integration card now shows the `npm install -g @texra-ai/cli` command and an npm link, for running the same agents on your `.tex` projects without an editor.
 
 ## [0.38.2] - 2026-05-27
 


### PR DESCRIPTION
Finalizes the CHANGELOG `[0.38.3]` section ahead of the **CLI 0.38.3** release. All workspace manifests are already at `0.38.3` (chore bump #4577); `@texra-ai/cli` is at `0.38.2` on npm.

Curated the user-facing changes merged since 0.38.2 — excluded internal refactors, docs-site, CI, and backend/auth infra per the "user-visible only" rule.

### Included
- **Features:** "Max" reasoning tier for Opus 4.8 (#4576); CLI elapsed timer (#4585).
- **Bug Fixes (CLI TUI):** resize residue (#4581), LaTeX math spans (#4586), table sizing (#4587), wolfram summary (#4588), `--output-format` stderr routing (#4589); plus workflow drag-and-drop (#4489).
- **Improvements:** CLI install hint on the Integrations card (#4617).

### Release checklist (CLI 0.38.3) — after this merges
1. `git checkout main && git pull`
2. Verify build: `corepack pnpm --filter @texra-ai/cli build` (typecheck + check:architecture + react-compiler smoke + bundle + copy)
3. Publish: `cd packages/cli && npm publish` (public; `prepack` rebuilds)
4. Tag + release: `gh release create cli-v0.38.3 --title "TeXRA CLI 0.38.3"` — the published-release event triggers `version-bump.yml` to open the next-dev-version bump PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no runtime or build behavior is modified.
> 
> **Overview**
> Adds a dated **`[0.38.3]`** section to `CHANGELOG.md` (2026-05-29), documenting user-facing work since 0.38.2: **Max** reasoning for Opus 4.8, CLI status-bar elapsed timer, several CLI TUI fixes (resize, LaTeX math, tables, Wolfram summaries, `--output-format` stderr routing), workflow drag-and-drop into Input/Context/Media buckets, dashboard **npm install** hint for `@texra-ai/cli`, and the existing subagent progress-board fix entry grouped under Bug Fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e0f04a63c1e409f3acde8c839876e180dba2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->