### PR TITLE
refactor(trace): per-instance stage scope, orphan rendering + drop the workarounds (R1–R4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Progress board never silently hides a run's groups** — if a stage group's parent is missing from a stream (e.g. a stale cross-trace id), the group and everything under it now render at the top of the transcript instead of vanishing. Paired with giving each run its own private stage scope so a stage from one run can no longer leak as the parent of another.
+
 ## [0.38.3] - 2026-05-29
 
 ### Features

--- a/docs/proposals/progress-grouping-refactor.md
+++ b/docs/proposals/progress-grouping-refactor.md
@@ -1,0 +1,377 @@
+# PRD: Progress-board grouping — remove the cross-trace footgun
+
+> Status: **Fact-checked** — every claim below has been verified against the
+> codebase. Line numbers and verdicts are recorded in the Fact-check summary at
+> the end. Deletion targets and their safety verdicts are in Deletions enabled.
+
+## Background
+
+A subagent run's progress-board transcript rendered blank except for the user
+instruction: the round groups (`Init`, `r0`, `r1`) and every nested card
+(scratchpad, statistics, latexdiff results, loaded-files) were missing.
+
+Shipped fix (PR #4620): `beginRunStage` now opens the `"Run:"` stage with
+`{ root: true }` so it does not inherit an ambient cross-trace parent.
+
+That one-liner patches the symptom. This PRD targets the **class** of bug it
+came from, with a bias toward **removing** mechanisms rather than adding them —
+the end state should be a smaller, simpler grouping system that still works.
+
+## Root cause
+
+The bug is the product of three confirmed facts that compound.
+
+1. **Module-level stage scope, shared across all traces.** (C1, supported)
+   `src/agent/trace/TraceEmitter.ts:37` declares
+   `const stageScope = new AsyncLocalStorage<string[]>()` at **module scope**
+   (before the class at line 43; the class holds only the instance field
+   `subscribers` at line 44). A single stack instance is therefore shared across
+   _all_ `TraceEmitter` instances. `currentStageStack()` (`:39-41`) returns
+   `stageScope.getStore() ?? []`. `emit()` (`:55-61`) stamps any event lacking a
+   `stageId` with `currentStageStack().at(-1)`. `withStage()` (`:76-83`) pushes
+   onto the stack via `stageScope.run([...currentStageStack(), stageId], ...)`.
+
+2. **Parent resolution falls back to the ambient stage.** (C2, C3, supported)
+   `openStage(label, options = {})` (`TraceEmitter.ts:175`) resolves the parent
+   as `options.root ? undefined : (options.parent?.id ?? options.parentId ?? this.activeStageId())`
+   (`:177-179`). `beginRunStage` (`AgentLaunchContext.ts:163-170`) ends with
+   `return agentLogger.openStage(label, { root: true })`, so `root: true` forces
+   `parentId === undefined` (the documented "ROOT INVARIANT" at
+   `AgentLaunchContext.ts:156-161`).
+
+3. **The subagent launch runs inside the orchestrator's ambient stage.** (C4,
+   supported) `DelegationTools.ts:364` calls `executeAgent(...)` synchronously
+   from inside the delegation tool's `execute()`. `executeAgent.ts:386` awaits
+   `buildAgentLaunchContext(...)`, which calls `beginRunStage` via
+   `assembleAgentLaunchContext` (`AgentLaunchContext.ts:245-249`). At that moment
+   the orchestrator's own tool-use stage is the active ambient stage: the
+   orchestrator opens `taskStage = logger.openStage("Task: ...")`
+   (`executeAgent.ts:441`) and runs the whole tool-use flow inside
+   `taskStage.run(...)` (`:444`), which pushes the Task stage id onto the shared
+   `stageScope` (via `StageHandleImpl.run` → `within` → `withStage`,
+   `TraceEmitter.ts:238-251, 76-83`). Without `{ root: true }`, the subagent's
+   `"Run:"` stage would inherit `activeStageId()` (`:177-179, 72-74`) — the
+   orchestrator's Task stage id, which lives on the orchestrator's trace, not on
+   the subagent's own run trace (`createRunTrace` at `AgentLaunchContext.ts:223`).
+   So the `"Run:"` stage inherited a `parentGroupId` absent from its own stream.
+   Both docstrings (`AgentLaunchContext.ts:156-162`, `AgentTrace.ts:47-55`)
+   describe this exact scenario.
+
+4. **The renderer silently drops orphan subtrees.** (C5, supported)
+   `messageIndex.rebuildTree`
+   (`packages/extension/src/progressView/frontend/components/messageIndex.ts:72-137`)
+   builds the tree only down from parentless roots:
+   `this.tree = groups.filter((g) => !g.parentGroupId)...map(buildNode)`
+   (`:128-129`). `buildNode` only descends through `childrenMap.get(group.id)`
+   (`:114-124`), and `childrenMap` is keyed by `parentGroupId` (`:81-85`). A group
+   whose `parentGroupId` points to a group **not** in the set is excluded from
+   roots (its truthy `parentGroupId` fails the `:129` filter) and is filed under
+   `childrenMap[<missing-parent-id>]`, which `buildNode` never queries. The orphan
+   and its entire subtree are therefore never visited — **silently, with no
+   warning, no logging, and no fallback**. This is why the failure was invisible.
+   Worse, the orphan's messages are also lost: `:101` files a message into
+   `messagesByGroup` whenever `groupMap.has(msg.groupId)` is true; the orphan group
+   _is_ in `groupMap`, so its messages go to `messagesByGroup` (not `ungrouped`)
+   and are never read into any tree node.
+
+The original blank-transcript symptom (a `"Run: devise"` stage carrying a
+`parentGroupId` with no matching group entry in its stream) is consistent with
+this root cause. **Unconfirmed:** the specific persisted-streamLog evidence for
+the `devise@opus48T#…` run (group id `0a171d9d…`) cited in the original draft was
+not re-verified in this fact-check pass and should be treated as anecdotal.
+
+## Goals
+
+- Remove the cross-trace inheritance hazard **by construction**, not by
+  per-call-site discipline.
+- Make orphaned groups **render** (degrade gracefully) instead of vanishing.
+- Net-negative LoC: delete the options/side-channels that become unnecessary
+  (see Deletions enabled).
+- Zero behavior change for the cases that already work (top-level runs,
+  within-trace nesting, tool-use cards).
+
+## Non-goals
+
+- Rewriting the AgentTrace SDK surface or the recorder/store schema.
+- Changing how the orchestrator displays subagents (background-tasks panel).
+
+## Proposed changes
+
+### R1 — Per-trace stage scope (highest leverage)
+
+Move `stageScope` from a module-level singleton to a `private readonly stageScope`
+field on `TraceEmitter`, and convert `currentStageStack()` into a private method
+reading `this.stageScope`. Ambient parent-inheritance then works _within_ a trace
+(the legitimate case) and is **structurally impossible across traces** (always the
+wrong case).
+
+**Feasibility (F-scope-readers): safe to make per-instance, risk MEDIUM.** No code
+relies on the scope being **shared across distinct `TraceEmitter` instances**.
+Each agent run creates its own emitter via `new TraceEmitter()` in
+`createRunTrace`/`createChannelTrace` (`src/logger/runTrace.ts:29,49`), yet today
+all instances share the one module-level scope. The only cross-instance
+interactions — `src/tools/claudeAgent.ts:558` and `src/tools/codex.ts:557` — treat
+that sharing as an **unwanted leak** they defend against with `{ root: true }`.
+With a per-instance store, a fresh emitter starts empty, so its first `openStage`
+naturally resolves `parentId = undefined` even without the flag; the leak
+disappears by construction and `{ root: true }` becomes redundant-but-harmless
+there. All same-instance nesting (ResponseCycle, outputState, reflection rounds,
+`roundPersistedFlow`, `ModelHandler` streams) behaves identically because the push
+and the read happen on the same instance within the same async activation.
+
+**Why MEDIUM, not low:** (1) the existing regression test
+(`RunTraceStream.vitest.ts:151-165`) uses a single shared logger and does **not**
+exercise the true cross-_instance_ case, so it will not catch a per-instance
+regression — we must add a two-instance test (below); (2) the child-session IIFEs
+in `claudeAgent`/`codex` rely on `AsyncLocalStorage` propagation, so verify the
+per-instance field is captured by the same instance the child loop calls (it is,
+since `logger` is the child's own emitter).
+
+In-file readers/writers of the scope to convert (`TraceEmitter.ts`):
+
+- WRITERS: `withStage()` (`:82`), `openStream()` explicit-stageId branch (`:207`).
+- READERS: `emit()` fallback (`:61`), `activeStageId()` (`:73`), `withStage()`
+  pre-push read (`:81`), `openStage()` parentId default (`:179`), `openStream()`
+  comparison (`:204-205`).
+
+Downstream consumers of `activeStageId()` (unchanged, read whatever the
+per-instance scope resolves to): `toolUseHelpers.ts:37`,
+`ToolUseCycleFlow.ts:570,639`. `noopTrace.ts:43-44,61` is a separate no-op impl
+with no shared scope — unaffected.
+
+### R2 — Render orphans instead of dropping them (guardrail)
+
+In `messageIndex.rebuildTree`, treat a group whose `parentGroupId` is not present
+in `groupMap` as a **root** (attach at timeline top). This degrades gracefully
+(rounds still show, just un-nested) and makes future orphan bugs visible. Pairs
+with R1: R1 prevents the bug, R2 ensures the next one is at least seen.
+
+**Feasibility (F-orphan-render): one-line change, risk LOW.** The single
+load-bearing line is the root filter at `messageIndex.ts:129`. Change:
+
+```ts
+// before
+this.tree = groups.filter((g) => !g.parentGroupId)...
+// after
+this.tree = groups.filter((g) => !g.parentGroupId || !groupMap.has(g.parentGroupId))...
+```
+
+`groupMap` is already built (`:76,80`) and in scope, so no new state is needed.
+This pushes orphan groups — and, via `buildNode`, their children **and** their
+messages from `messagesByGroup` — into `this.tree`; `rebuildTimeline`
+(`:147-152`) then interleaves them at the top level by `group.startTime`. No
+change needed to `rebuildTimeline`, `childrenMap` construction, or message
+classification. No code or test relies on the drop: the only non-test callers
+(`TaskGroupList.ts:200,223,244`) just render `this.tree`/`this.timeline`, and the
+existing tests (`TaskGroupListIndex.vitest.ts:69,120`) use only self-consistent
+inputs. `logSlice.ts:90,119` set `parentGroupId` from `entry.groupId` at
+GROUP_START/GROUP_END with no guarantee the parent exists in the same snapshot —
+confirming transient orphans (child arrives before parent, or parent pruned) are
+real, so this is a correctness improvement, not dead defensiveness.
+
+**Render-side follow-up (not a blocker):** `TaskGroupList.renderGroupNode:474`
+selects layout via the raw `!group.parentGroupId` field, so a re-rooted orphan
+(which still has a dangling `parentGroupId`) would render in the nested/collapsible
+style rather than the root-container style — cosmetically inconsistent. If that
+matters, gate that branch on actual tree-root membership (a flag set by
+`rebuildTree`, or a `groupMap` check) rather than the raw field.
+
+A dev-mode warning when re-rooting is optional; if added, it must respect the
+"stateless renderer / no render-time side effects" rule and live in the
+data-building path, not in a component render.
+
+### R3 — Collapse the dual trace in `executeAgent` (remove a footgun)
+
+`executeAgent.ts:65-66` keeps a module-level `logger = createChannelTrace(CHANNEL)`
+alongside the recorder-attached run trace `ctx.logger`. (C6, supported)
+`createChannelTrace` (`src/logger/runTrace.ts:28-32`) attaches **only** a channel
+subscriber — no transcript recorder — whereas `createRunTrace` (`:49-54`) attaches
+**both** a channel subscriber and `attachTranscriptRecorder`. (C7, supported)
+`ctx.logger` is the run trace: `AgentLaunchContext.ts:223-225,295`.
+
+The `"Task:"` stage at `executeAgent.ts:441` is opened on the module-level channel
+`logger`, **not** on `ctx.logger`, so its `stage.start`/`stage.end` events reach
+the per-channel output sink but **never** the webview/CLI transcript. The
+actually visible top-level stage is `ctx.parentStage` = `"Run: <agent>"`, opened
+on the run trace via `beginRunStage` (`AgentLaunchContext.ts:245-249`). The rounds
+parent **explicitly** to `ctx.parentStage` (C10, supported): `runReflectionFlow`
+forwards `parentStage` into `RoundPersistedFlow`, whose `createRoundStage` opens
+each round with `{ parent }` (`runReflectionFlow.ts:245-258`,
+`roundPersistedFlow.ts:256-261`). The channel `taskStage` merely wraps the flow
+via `taskStage.run(...)` and is never passed as the round parent — so it is inert
+in the transcript today, which is precisely the trap.
+
+**Feasibility (F-task-stage): safe to delete the `"Task:"` stage and the
+module-level channel logger, risk LOW.** `taskStage` is a pure local: defined at
+`:441`, consumed only at `:444`; its `.id` is never read, stored, or returned, and
+grep for `taskStage` returns only those two lines. The `"Task:"` label is
+special-cased nowhere. The `.run` wrapping is **not** load-bearing: inner flows
+root their stages off `ctx.parentStage`/`ctx.logger`, not off the ambient
+`activeStageId`, so removing `taskStage.run` and inlining its body changes neither
+transcript output nor the round hierarchy.
+
+Concrete change:
+
+1. Drop `taskStage = logger.openStage('Task: ...')` (`:441`) and inline its body
+   (replace `return taskStage.run(async () => {...})` with the body directly).
+2. Redirect the diagnostic calls on the module-level `logger`
+   (`:198,274,422,423,424,427,445`) to `ctx.logger` — each is inside a closure
+   where `ctx` is in scope, and `ctx.logger` exposes `debug/info/warn/error`
+   (`AgentTrace.ts:146-149`). `:216` already uses `ctx.logger` (`logSdkError`).
+3. Then remove `CHANNEL` (`:65`), `logger` (`:66`), and the `createChannelTrace`
+   import (`:26`).
+
+The one judgment call: those diagnostics currently land on the dedicated
+`'executeAgent'` channel sink, whereas `ctx.logger` writes to the per-stream
+channel + transcript. If a dedicated `'executeAgent'` debug channel is wanted,
+keep the module-level `logger` for the plain log calls and delete only the
+`openStage`/`run` wrapping. Risk is LOW because no machine-readable consumer
+(id, label match) exists.
+
+### R4 — Fold the usage groupId side-channel into the stage handle
+
+Statistics/usage grouping currently uses an explicit
+`usageMonitor.setActiveGroupId(stage.id)` wired in the `onStageCreated` callback
+(`runReflectionFlow.ts:256-258`). (C8, supported) Once R1 makes within-trace
+ambient stamping reliable, this parallel channel is redundant.
+
+**Feasibility (F-setActiveGroupId): safe to delete, risk LOW.** The mechanism has
+exactly five references repo-wide: field decl `UsageMonitor.ts:88`; sole writer
+`setActiveGroupId` (`:106-108`); sole reader
+`logger.usage(payload, { stageId: this.activeGroupId ?? storageKey })` (`:180`),
+gated on `AgentCategory.Workflow` (`:178`); and the sole caller
+`runReflectionFlow.ts:257`. No subclasses, no tests, no serialization, no other
+consumers.
+
+The normal stage scope already covers this: the value passed is `stage.id` from
+`createRoundStage` = `logger.openStage('r${roundIndex}', { parent })`;
+`RoundPersistedFlow` runs every node inside that round stage's scope via
+`inStage()` → `within()` (`roundPersistedFlow.ts:124-129,181,191`); `recordUsage`
+fires through `onRoundFinalized` on both the success path
+(`ResponseCycleFlow.ts:455-457`) and error path (`ResponseCycleNode.ts:121`),
+both inside node execution (i.e. inside the round-stage scope, which
+`AsyncLocalStorage` propagates across awaits); and `TraceEmitter.emit`
+(`:55-61`) already stamps `stageId` from `currentStageStack().at(-1)` — the exact
+same round stage id `setActiveGroupId` stored. The tool-use path is unaffected:
+it uses plain `PersistedFlow`, never calls `setActiveGroupId`, and `recordUsage`
+skips `logger.usage` entirely for `AgentCategory.ToolUse` (`:178`).
+
+Concrete change:
+
+1. Delete `UsageMonitor.ts:88` (field) and `:100-108` (`setActiveGroupId`).
+2. Delete the `onStageCreated` block at `runReflectionFlow.ts:256-258` (and drop
+   `usageMonitor` from that closure if otherwise unused).
+3. At `UsageMonitor.ts:179-181`, replace
+   `logger.usage(payload, { stageId: this.activeGroupId ?? storageKey })` with
+   `logger.usage(payload, { stageId: logger.activeStageId() ?? storageKey })`.
+
+**Behavioral nuance:** the current fallback is `this.activeGroupId ?? storageKey`.
+A bare `logger.usage(payload)` would stamp `activeStageId() ?? undefined`, losing
+the `storageKey` safety net for any hypothetical future workflow caller that logs
+usage **outside** a round stage. In all current paths a round stage is always
+active when workflow usage is logged, so the result is identical — but using
+`logger.activeStageId() ?? storageKey` (step 3 above) preserves the `storageKey`
+fallback defensively. Risk is LOW and confined to workflow-agent usage-line
+grouping in the transcript.
+
+## Recorder ↔ slice contract (document, no code change)
+
+(C9, supported) `TexraTranscriptRecorder.ts:156-168` appends a `GROUP_START`
+entry on `stage.start` and `:170-178` updates the **same** `event.id` in place to
+`GROUP_END` on `stage.end`, with `status` and `endTime`. So one store entry
+transitions GROUP_START → GROUP_END in place; the persisted shape therefore
+differs between a mid-run reload (GROUP_START present) and a post-run snapshot
+(already GROUP_END). The slice tolerates a GROUP_END arriving with no prior
+GROUP_START: `logSlice.ts:102-131` (`updateTaskGroups`), after the
+`if (entry.type !== GROUP_END) return false;` guard, handles `groupIndex === -1`
+by **creating** a new task group (`:112-121`) instead of failing; otherwise it
+updates the existing group (`:122`). This implicit recorder↔slice contract should
+be documented in both files.
+
+## Sequencing
+
+1. **R1 + R2 together** (structural fix + guardrail) in one PR, separate from the
+   shipped #4620 one-liner. **Do not** revert the `{ root: true }` flag at
+   `AgentLaunchContext.ts:169` until R1 has landed and the new cross-instance test
+   is green — see Deletions enabled for why the flag is only safe to remove after
+   per-instance scoping is verified.
+2. R3, then R4 as independent follow-ups. R4's redundancy argument depends on R1,
+   so land R4 after R1.
+
+## Test plan
+
+- Existing coverage: `src/test-kernel/agent/trace/RunTraceStream.vitest.ts`
+  (`within`/`openStage`/`root` at `:119-165`, tool-use card groupId,
+  stream coalescing), `RunTraceDispose.vitest.ts:24` (openStream),
+  `EmitToolUseCard.vitest.ts:15-75` (multiple `new TraceEmitter()` instances).
+  Note: `RunTraceStream.vitest.ts:151-165` uses a single shared logger, so it does
+  **not** exercise the cross-instance leak.
+- **Add a cross-instance test (required for R1):** push a stage on emitter A,
+  then `openStage`/`activeStageId` on a separate emitter B; assert B's stage is a
+  root (`parentId === undefined`) **without** `{ root: true }`. This is the gate
+  that confirms per-instance scoping closes the leak.
+- **Add a `rebuildTree` orphan test (required for R2):** a group with a dangling
+  `parentGroupId` plus a message under it; assert it appears at timeline top with
+  its message intact. None exists today.
+- After per-instance scoping lands, verify child-agent transcripts still group
+  correctly (the `claudeAgent`/`codex` session scenario) before removing the
+  `root` option.
+- `npm run typecheck`; targeted `vitest run` on the trace + progressView suites.
+
+## Fact-check summary
+
+| Claim                   | Verdict     | One-line                                                                                                                                                    |
+| ----------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1                      | supported   | `stageScope` is module-level (`TraceEmitter.ts:37`), shared across all instances; `emit()` `:55-61`, `withStage()` `:76-83`.                                |
+| C2                      | supported   | `openStage` parent resolution `options.root ? undefined : (...?? this.activeStageId())` at `:177-179` (sig `:175`).                                         |
+| C3                      | supported   | `beginRunStage` opens with `{ root: true }` (`AgentLaunchContext.ts:163-170`), yielding `parentId === undefined`.                                           |
+| C4                      | supported   | Subagent launch runs inside the orchestrator's `taskStage.run` scope; without `root` it would inherit the cross-trace Task id.                              |
+| C5                      | supported   | `rebuildTree` root filter `:128-129` + `buildNode` `:114-124` silently drop orphan subtrees (and their messages, `:101`); no warning/fallback.              |
+| C6                      | supported   | `executeAgent.ts:65-66` module-level channel `logger`; `taskStage` opened on it at `:441`, never on `ctx.logger`.                                           |
+| C7                      | supported   | `createChannelTrace` = channel sink only (`runTrace.ts:28-32`); `createRunTrace` = channel + transcript recorder (`:49-54`).                                |
+| C8                      | supported   | Usage grouping wired via `onStageCreated → setActiveGroupId(stage.id)` (`runReflectionFlow.ts:256-258`; `UsageMonitor.ts:106`).                             |
+| C9                      | supported   | Recorder collapses GROUP_START→GROUP_END on one id in place (`TexraTranscriptRecorder.ts:156-178`); slice tolerates lone GROUP_END (`logSlice.ts:102-131`). |
+| C10                     | supported   | Rounds parent explicitly to `ctx.parentStage` (`runReflectionFlow.ts:245-258`, `roundPersistedFlow.ts:256-261`); channel `taskStage` is inert.              |
+| C11                     | supported   | `StageOptions.root` doc (`AgentTrace.ts:47-55`) describes the cross-trace child-agent-session case verbatim.                                                |
+| EVID (devise streamLog) | unconfirmed | Specific `devise@opus48T#…` / `0a171d9d…` persisted-log evidence not re-verified in this pass; treat as anecdotal.                                          |
+
+## Deletions enabled
+
+Each item lists the concrete declarations/call-sites to remove and the safety
+verdict. Net effect is negative LoC.
+
+- **`{ root: true }` at `AgentLaunchContext.ts:169`** — _conditional, risk MEDIUM_
+  (F-root-callers). Safe to revert **only after** R1 makes `stageScope`
+  per-instance and the cross-instance test passes. If reverted while the scope is
+  still a module singleton, the `"Run:"` subtree re-orphans (real regression).
+- **The `root` option entirely** — _conditional, risk MEDIUM_ (F-root-callers).
+  Sole reader is the branch at `TraceEmitter.ts:177-179`. Three production callers
+  pass `{ root: true }`, all for the same cross-trace reason:
+  `AgentLaunchContext.ts:169`, `claudeAgent.ts:558`, `codex.ts:557`. No
+  within-trace caller needs it (the only same-trace use is the synthetic vitest at
+  `RunTraceStream.vitest.ts:155`). After per-instance scoping, the option is
+  removable: delete the field + doc (`AgentTrace.ts:47-55`), collapse the
+  `:177-179` branch to `options.parent?.id ?? options.parentId ?? this.activeStageId()`,
+  change the 3 callers to pass `{}`, and delete the vitest block (`:143-166`).
+  Keeping `{ root: true }` as documented defensive intent at the two child-tool
+  sites is acceptable (belt-and-suspenders); deleting it is the net-negative-LoC
+  path.
+- **Module-level `logger` / `createChannelTrace` import in `executeAgent.ts`** —
+  _safe, risk LOW_ (F-task-stage). Delete the `"Task:"` `openStage` (`:441`) and
+  its `.run` wrapping (inline the body), redirect diagnostics
+  (`:198,274,422,423,424,427,445`) to `ctx.logger`, then remove `CHANNEL` (`:65`),
+  `logger` (`:66`), and the import (`:26`). Caveat: this moves those diagnostics
+  off the dedicated `'executeAgent'` channel sink onto the per-stream
+  channel+transcript; keep the module-level logger for plain log calls if a
+  dedicated debug channel is wanted, and delete only the stage wrapping.
+- **`setActiveGroupId` + `activeGroupId` field + `onStageCreated` plumbing** —
+  _safe, risk LOW_ (F-setActiveGroupId). Delete `UsageMonitor.ts:88` and
+  `:100-108`, delete `runReflectionFlow.ts:256-258`, and change `UsageMonitor.ts:180`
+  to `logger.usage(payload, { stageId: logger.activeStageId() ?? storageKey })`.
+  The round-stage `AsyncLocalStorage` scope already stamps the same id. Only the
+  `storageKey` fallback for hypothetical out-of-round workflow usage differs;
+  the suggested replacement preserves it.
+- **Orphan-drop behavior in `rebuildTree`** — _not a deletion; a one-line fix_
+  (F-orphan-render). `messageIndex.ts:129`: add `|| !groupMap.has(g.parentGroupId)`
+  to the root predicate. No state added (`groupMap` already in scope); no caller
+  or test relies on the drop.

--- a/docs/proposals/progress-grouping-refactor.md
+++ b/docs/proposals/progress-grouping-refactor.md
@@ -169,12 +169,13 @@ GROUP_START/GROUP_END with no guarantee the parent exists in the same snapshot �
 confirming transient orphans (child arrives before parent, or parent pruned) are
 real, so this is a correctness improvement, not dead defensiveness.
 
-**Render-side follow-up (not a blocker):** `TaskGroupList.renderGroupNode:474`
-selects layout via the raw `!group.parentGroupId` field, so a re-rooted orphan
-(which still has a dangling `parentGroupId`) would render in the nested/collapsible
-style rather than the root-container style — cosmetically inconsistent. If that
-matters, gate that branch on actual tree-root membership (a flag set by
-`rebuildTree`, or a `groupMap` check) rather than the raw field.
+**Render-side (done):** `TaskGroupList.renderGroupNode` previously selected layout
+via the raw `!group.parentGroupId` field, so a re-rooted orphan (which still has a
+dangling `parentGroupId`) would render in the nested/collapsible style rather than
+the root-container style. Fixed by passing an explicit `isRoot` flag down from the
+single top-level caller (the timeline render) and branching on that — layout now
+follows actual tree position, not the raw field. Covered by a render test in
+`TaskGroupListIndex.vitest.ts`.
 
 A dev-mode warning when re-rooting is optional; if added, it must respect the
 "stateless renderer / no render-time side effects" rule and live in the

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -465,13 +465,20 @@ export class TaskGroupList extends LitElement {
   }
 
   /** Render a group node and its children recursively */
-  private renderGroupNode(node: GroupTree): TemplateResult | typeof nothing {
+  private renderGroupNode(
+    node: GroupTree,
+    isRoot = false,
+  ): TemplateResult | typeof nothing {
     const { group, children, messages } = node;
     const detailsId = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
     const contentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
 
-    // Root groups: simple container (no collapsible), always render content
-    if (!group.parentGroupId) {
+    // Tree roots: simple container (no collapsible), always render content.
+    // Keyed on tree position (isRoot), NOT group.parentGroupId, so a re-rooted
+    // orphan — a group whose parent is absent, promoted to a root by
+    // messageIndex (R2) — gets the root layout instead of nested/collapsible
+    // even though it retains its dangling parentGroupId.
+    if (isRoot) {
       return html`
         <div id=${detailsId} class="log-group log-run" data-run-id=${group.id}>
           <div id=${contentId} class="log-group-content">
@@ -612,7 +619,7 @@ export class TaskGroupList extends LitElement {
           (item) =>
             'msg' in item
               ? guard([item.msg], () => formatLogEntry(item.msg))
-              : this.renderGroupNode(item.tree),
+              : this.renderGroupNode(item.tree, true),
         )}
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -123,10 +123,15 @@ export class MessageIndex {
       return node;
     }
 
-    // Get root groups (no parent), sorted by start time.
+    // Get root groups, sorted by start time. A group counts as a root when it
+    // has no parent OR its parent is absent from this set (a dangling parent —
+    // e.g. a cross-trace id the stream never recorded). Re-rooting orphans here
+    // makes them degrade gracefully (rendered un-nested at the timeline top)
+    // instead of vanishing silently along with their whole subtree and messages.
+    // See docs/proposals/progress-grouping-refactor.md (R2).
     // Stable sort preserves original order for equal timestamps.
     this.tree = groups
-      .filter((g) => !g.parentGroupId)
+      .filter((g) => !g.parentGroupId || !groupMap.has(g.parentGroupId))
       .sort(
         (a, b) =>
           (a.startTime ?? Number.MAX_SAFE_INTEGER) -

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -25,7 +25,6 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
-import type { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
@@ -66,7 +65,6 @@ export interface RunReflectionFlowInput<
   storageKey: StorageKey;
   parentStage: StageHandle;
   getOutputFileLocation?: (round: number) => AgentFileLocation;
-  usageMonitor?: UsageMonitor;
   onRoundCompleted?: (
     roundIndex: number,
     totalRounds: number,
@@ -96,7 +94,6 @@ export async function runReflectionFlow<C = unknown>(
     userVarChannels,
     checkInterruption,
     onRoundFinalized = async () => {},
-    usageMonitor,
   } = input;
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
@@ -253,9 +250,6 @@ export async function runReflectionFlow<C = unknown>(
           logger.openStage(`r${roundIndex}`, {
             parent: parent ?? undefined,
           }),
-        onStageCreated: (stage) => {
-          usageMonitor?.setActiveGroupId(stage.id);
-        },
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();
         },

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -66,12 +66,6 @@ export interface RoundCallbacks<S extends RoundAwareState> {
     parentStage: StageHandle | null,
   ) => StageHandle;
 
-  /**
-   * Called after a new round stage is created.
-   * Use for registering usage tracking callbacks etc.
-   */
-  onStageCreated?: (stage: StageHandle) => void;
-
   /** Check if execution should be interrupted. */
   checkInterruption?: () => boolean;
 
@@ -251,7 +245,7 @@ export class RoundPersistedFlow<
   }
 
   /**
-   * Create a round stage and notify callback.
+   * Create a round stage.
    */
   private createStage(roundIndex: number): void {
     if (this.callbacks.createRoundStage) {
@@ -259,7 +253,6 @@ export class RoundPersistedFlow<
         roundIndex,
         this.parentStage,
       );
-      this.callbacks.onStageCreated?.(this.currentRoundStage);
     }
   }
 }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -153,12 +153,12 @@ async function validateModelExists(
  * its timestamp precedes the stage's startTime. The chronological timeline
  * therefore renders the instruction before the run group.
  *
- * ROOT INVARIANT: opened with `root: true` so it never inherits an ambient
- * stage from the shared trace scope. For a subagent run, the active stage at
- * launch is the orchestrator's tool-use stage — a cross-trace id that this
- * run's own stream never records. Inheriting it would orphan "Run:" (and its
- * whole Init/r0/r1 subtree) in the subagent's transcript, since the renderer
- * can only build group trees down from parentless roots.
+ * ROOT INVARIANT: each run trace owns its stage scope (per-instance
+ * AsyncLocalStorage in TraceEmitter), so this opens as a root — it cannot
+ * inherit a cross-trace ambient stage from a parent run (e.g. an
+ * orchestrator's tool-use stage when this is a subagent). That isolation is
+ * what keeps a subagent's "Run:"/Init/r0/r1 subtree from orphaning in its own
+ * transcript. See docs/proposals/progress-grouping-refactor.md (R1).
  */
 async function beginRunStage(
   agentLogger: AgentTrace,
@@ -166,7 +166,7 @@ async function beginRunStage(
   instruction: string | undefined,
 ): Promise<StageHandle> {
   if (instruction) logUserMessage(agentLogger, instruction);
-  return agentLogger.openStage(label, { root: true });
+  return agentLogger.openStage(label);
 }
 
 async function assembleAgentLaunchContext(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -438,76 +438,71 @@ export async function executeAgent(
           taskState: agentConfigToTaskState(config),
         });
 
-        const taskStage = logger.openStage(
-          `Task: ${agentName}@${config.model}`,
-        );
-        return taskStage.run(async () => {
-          logger.info(`Executing ${agentName} with model ${config.model}`);
-          const interrupts = createInterruptCallbacks();
+        logger.info(`Executing ${agentName} with model ${config.model}`);
+        const interrupts = createInterruptCallbacks();
 
-          if (setting.agentCategory === AgentCategory.ToolUse) {
-            let toolUseTurns = 0;
-            const result = await runToolUseFlow({
-              ...ctx,
-              ...interrupts,
-              onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
-              setting,
-              isSubagent,
-              onBeforeWaiting: options.onBeforeWaiting,
-              stopAfterCycle: options.stopAfterCycle,
-              onProgress: (update) => {
-                if (update.kind === 'overview') {
-                  toolUseTurns++;
-                  ctx.runtimeHost.emit('updateConversationProgress', {
-                    streamId,
-                    progress: {
-                      conversationTurns: toolUseTurns,
-                      toolCallCount: update.toolCallCount,
-                    },
-                  });
-                }
-                options.onProgress?.(update);
-              },
-              onFollowUpConsumed: () => {
-                ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                  streamId: ctx.streamId,
-                });
-                options.onFollowUpConsumed?.();
-              },
-              onModelChanged: (modelHandler, model) => {
-                ctx.config.model = model;
-                ctx.usageMonitor.setModelInfo({
-                  capabilities: modelHandler.capabilities,
-                  config: modelHandler.config,
-                });
-              },
-            });
-            return {
-              category: 'toolUse' as const,
-              status: result.status,
-              lastResponse: result.lastResponse,
-              touchedFiles: result.touchedFiles,
-              executionId: ctx.executionId,
-              streamId,
-            };
-          }
-
-          const onRoundCompleted = createRoundProgressCallback(
-            ctx.executionId,
-            streamId,
-            ctx.runtimeHost,
-            options.onProgress,
-          );
-          const result = await runReflectionFlow({
+        if (setting.agentCategory === AgentCategory.ToolUse) {
+          let toolUseTurns = 0;
+          const result = await runToolUseFlow({
             ...ctx,
             ...interrupts,
             onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
             setting,
-            parentStage: ctx.parentStage,
-            onRoundCompleted,
+            isSubagent,
+            onBeforeWaiting: options.onBeforeWaiting,
+            stopAfterCycle: options.stopAfterCycle,
+            onProgress: (update) => {
+              if (update.kind === 'overview') {
+                toolUseTurns++;
+                ctx.runtimeHost.emit('updateConversationProgress', {
+                  streamId,
+                  progress: {
+                    conversationTurns: toolUseTurns,
+                    toolCallCount: update.toolCallCount,
+                  },
+                });
+              }
+              options.onProgress?.(update);
+            },
+            onFollowUpConsumed: () => {
+              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                streamId: ctx.streamId,
+              });
+              options.onFollowUpConsumed?.();
+            },
+            onModelChanged: (modelHandler, model) => {
+              ctx.config.model = model;
+              ctx.usageMonitor.setModelInfo({
+                capabilities: modelHandler.capabilities,
+                config: modelHandler.config,
+              });
+            },
           });
-          return buildWorkflowFlowResult(result, ctx.executionId, streamId);
+          return {
+            category: 'toolUse' as const,
+            status: result.status,
+            lastResponse: result.lastResponse,
+            touchedFiles: result.touchedFiles,
+            executionId: ctx.executionId,
+            streamId,
+          };
+        }
+
+        const onRoundCompleted = createRoundProgressCallback(
+          ctx.executionId,
+          streamId,
+          ctx.runtimeHost,
+          options.onProgress,
+        );
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...interrupts,
+          onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
+          setting,
+          parentStage: ctx.parentStage,
+          onRoundCompleted,
         });
+        return buildWorkflowFlowResult(result, ctx.executionId, streamId);
       },
       {
         isSubagent,

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -44,15 +44,6 @@ export interface StageOptions {
   readonly skip?: boolean;
   /** Parent handle for nested-stage chains. */
   readonly parent?: StageHandle;
-  /**
-   * Force a root stage with no parent, ignoring the active stage from the
-   * run scope. Use when a stage must not inherit the ambient
-   * AsyncLocalStorage parent — e.g. a child agent's session stage opened
-   * on its own trace while the parent agent's tool-use stage is active
-   * (inheriting would emit a cross-trace parentId the child's subscribers
-   * can't resolve).
-   */
-  readonly root?: boolean;
 }
 
 /** Handle returned by `openStage` — wraps a stage with run/within/end ops. */

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -186,9 +186,8 @@ export class TraceEmitter implements AgentTrace {
 
   openStage(label: string, options: StageOptions = {}): StageHandle {
     const defaultStatus = options.defaultStatus ?? END_GROUP_STATUS.STOPPED;
-    const parentId = options.root
-      ? undefined
-      : (options.parent?.id ?? options.parentId ?? this.activeStageId());
+    const parentId =
+      options.parent?.id ?? options.parentId ?? this.activeStageId();
 
     if (options.skip) {
       return new SkippedStageHandle(this, parentId);

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -34,14 +34,23 @@ import type {
   StreamOptions,
 } from './AgentTrace';
 
-const stageScope = new AsyncLocalStorage<string[]>();
-
-function currentStageStack(): string[] {
-  return stageScope.getStore() ?? [];
-}
-
 export class TraceEmitter implements AgentTrace {
   private readonly subscribers = new Set<AgentTraceSubscriber>();
+
+  /**
+   * Per-instance stage scope. Kept on the instance — NOT a module singleton —
+   * so a stage opened on one trace can never leak as the ambient parent of a
+   * DIFFERENT trace. Cross-trace inheritance is the bug class behind orphaned
+   * subagent transcripts (a child run's "Run:" stage inheriting the
+   * orchestrator's tool-use stage id, absent from the child's own stream).
+   * Within a single trace, ambient nesting works exactly as before.
+   * See docs/proposals/progress-grouping-refactor.md (R1).
+   */
+  private readonly stageScope = new AsyncLocalStorage<string[]>();
+
+  private currentStageStack(): string[] {
+    return this.stageScope.getStore() ?? [];
+  }
 
   // ─── SSoT primitives ───────────────────────────────────────────────
 
@@ -58,7 +67,10 @@ export class TraceEmitter implements AgentTrace {
     const stamped: AgentEvent =
       event.stageId !== undefined
         ? event
-        : ({ ...event, stageId: currentStageStack().at(-1) } as AgentEvent);
+        : ({
+            ...event,
+            stageId: this.currentStageStack().at(-1),
+          } as AgentEvent);
 
     for (const sub of this.subscribers) {
       try {
@@ -70,7 +82,7 @@ export class TraceEmitter implements AgentTrace {
   }
 
   activeStageId(): string | undefined {
-    return currentStageStack().at(-1);
+    return this.currentStageStack().at(-1);
   }
 
   withStage<T>(
@@ -78,8 +90,8 @@ export class TraceEmitter implements AgentTrace {
     fn: () => Promise<T> | T,
   ): Promise<T> {
     if (!stageId) return Promise.resolve(fn());
-    const nextStack = [...currentStageStack(), stageId];
-    return stageScope.run(nextStack, () => Promise.resolve(fn()));
+    const nextStack = [...this.currentStageStack(), stageId];
+    return this.stageScope.run(nextStack, () => Promise.resolve(fn()));
   }
 
   // ─── Plain logging ─────────────────────────────────────────────────
@@ -202,9 +214,9 @@ export class TraceEmitter implements AgentTrace {
     // Open inside the explicit stage scope so the start event carries the
     // right stageId without forcing the caller to await.
     if (options.stageId && options.stageId !== this.activeStageId()) {
-      const nextStack = [...currentStageStack(), options.stageId];
+      const nextStack = [...this.currentStageStack(), options.stageId];
       let handle!: StreamHandle;
-      stageScope.run(nextStack, () => {
+      this.stageScope.run(nextStack, () => {
         this.emit({ type: 'stream.start', id, kind });
         handle = new StreamHandleImpl(this, id);
       });

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -79,14 +79,6 @@ export interface UsageMonitorContext {
 type UsageMonitorRunKind = 'workflow' | 'tool-use';
 
 export class UsageMonitor {
-  /**
-   * Active group ID for statistics logging.
-   * When set, statistics are logged with this group ID instead of storageKey.
-   * This allows statistics to be associated with individual rounds (r0, r1)
-   * rather than the parent stage.
-   */
-  private activeGroupId: string | undefined;
-
   constructor(
     private modelInfo: UsageMonitorModelInfo,
     private readonly context: UsageMonitorContext,
@@ -95,16 +87,6 @@ export class UsageMonitor {
 
   setModelInfo(modelInfo: UsageMonitorModelInfo): void {
     this.modelInfo = modelInfo;
-  }
-
-  /**
-   * Set the active group ID for statistics logging.
-   * Call this when entering a new round to associate statistics with that round.
-   *
-   * @param groupId - The round stage ID (e.g., r0, r1) or undefined to use storageKey
-   */
-  setActiveGroupId(groupId: string | undefined): void {
-    this.activeGroupId = groupId;
   }
 
   async recordUsage(stateGlobal: AgentRunStateSnapshot): Promise<void> {
@@ -176,8 +158,11 @@ export class UsageMonitor {
         usage: payload,
       });
       if (agentCategory === AgentCategory.Workflow) {
+        // The round stage's AsyncLocalStorage scope already stamps the active
+        // round id (r0/r1...) onto emitted events; fall back to storageKey for
+        // any usage logged outside a round stage.
         logger.usage(payload, {
-          stageId: this.activeGroupId ?? storageKey,
+          stageId: logger.activeStageId() ?? storageKey,
         });
       }
 

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -140,31 +140,6 @@ describe('tool-use card groupId resolution', () => {
   });
 });
 
-describe('openStage root option', () => {
-  it('forces a root stage even when an active stage is in scope', async () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
-      const outer = logger.openStage('outer');
-      await outer.within(async () => {
-        // A child agent's session stage opened on its own trace must NOT
-        // inherit the parent's active stage from the shared AsyncLocalStorage.
-        logger.openStage('child session', { root: true });
-      });
-
-      const entries = store.get('stream')?.getRange(0) ?? [];
-      const child = entries.find((e) => e.text === 'child session');
-      expect(child).toBeDefined();
-      expect(child?.groupId).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
-  });
-});
-
 describe('per-trace stage scope (cross-trace isolation)', () => {
   it('a run stage opened on its own trace does not inherit an active stage from another trace', async () => {
     const previousStore = getDefaultStreamLogStore();
@@ -178,10 +153,10 @@ describe('per-trace stage scope (cross-trace isolation)', () => {
       const taskStage = orchestrator.openStage('Task: orchestrator');
 
       // Subagent run on a SEPARATE trace/stream, opened *inside* the
-      // orchestrator's stage scope but WITHOUT root: true. With a per-instance
-      // stage scope (R1) the orchestrator's active stage cannot leak across
-      // traces, so the subagent's run stage is a root on its own stream. (A
-      // module-level shared scope would orphan it under the cross-trace id.)
+      // orchestrator's stage scope. With a per-instance stage scope the
+      // orchestrator's active stage cannot leak across traces, so the
+      // subagent's run stage is a root on its own stream with no extra flag.
+      // (A module-level shared scope would orphan it under the cross-trace id.)
       await taskStage.within(async () => {
         const subagent = createRunTrace('subagent').trace;
         subagent.openStage('Run: subagent');

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -164,3 +164,35 @@ describe('openStage root option', () => {
     }
   });
 });
+
+describe('per-trace stage scope (cross-trace isolation)', () => {
+  it('a run stage opened on its own trace does not inherit an active stage from another trace', async () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      // Orchestrator trace with an active "Task:" stage — mirrors a subagent
+      // launched from inside a delegation tool's stage scope.
+      const orchestrator = createRunTrace('orchestrator').trace;
+      const taskStage = orchestrator.openStage('Task: orchestrator');
+
+      // Subagent run on a SEPARATE trace/stream, opened *inside* the
+      // orchestrator's stage scope but WITHOUT root: true. With a per-instance
+      // stage scope (R1) the orchestrator's active stage cannot leak across
+      // traces, so the subagent's run stage is a root on its own stream. (A
+      // module-level shared scope would orphan it under the cross-trace id.)
+      await taskStage.within(async () => {
+        const subagent = createRunTrace('subagent').trace;
+        subagent.openStage('Run: subagent');
+      });
+
+      const entries = store.get('subagent')?.getRange(0) ?? [];
+      const runStage = entries.find((e) => e.text === 'Run: subagent');
+      expect(runStage).toBeDefined();
+      expect(runStage?.groupId).toBeUndefined();
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+});

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -223,3 +223,39 @@ describe('task-group-list ungrouped message indexes', () => {
     );
   });
 });
+
+describe('task-group-list orphan re-rooting', () => {
+  it('renders a group whose parent is absent as a root, with its subtree and messages', () => {
+    const list = createList([]);
+    // "run" points at a parent that is NOT in the set — e.g. a cross-trace
+    // stage id this stream never recorded. It must still render.
+    const run: TaskGroup = {
+      id: 'run',
+      name: 'Run: subagent',
+      startTime: 1,
+      status: STREAM_STATUS.RUNNING,
+      parentGroupId: 'phantom-orchestrator-stage',
+    };
+    const init: TaskGroup = {
+      id: 'init',
+      name: 'Init',
+      startTime: 2,
+      status: STREAM_STATUS.STOPPED,
+      parentGroupId: 'run',
+    };
+    const scratchpad = createMessage('m1', 'scratchpad', 3, 'init');
+
+    list.index.rebuildTree([run, init], [scratchpad]);
+
+    // The dangling-parent group is re-rooted instead of silently dropped.
+    expect(list.index.tree).toHaveLength(1);
+    const root = list.index.tree[0];
+    expect(root.group.id).toBe('run');
+    // Its subtree survives...
+    expect(root.children.map((c) => c.group.id)).toEqual(['init']);
+    // ...and so do the messages nested under it.
+    expect(root.children[0].messages.map((m) => m.id)).toEqual(['m1']);
+    // The nested message is not mis-filed as ungrouped.
+    expect(list.index.ungrouped).toHaveLength(0);
+  });
+});

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -258,4 +258,24 @@ describe('task-group-list orphan re-rooting', () => {
     // The nested message is not mis-filed as ungrouped.
     expect(list.index.ungrouped).toHaveLength(0);
   });
+
+  it('renders a re-rooted orphan with the root-container layout, not nested', async () => {
+    // A group with a dangling parent is promoted to a tree root; the renderer
+    // must give it the root container (keyed on tree position), not the
+    // collapsible <details> layout it would get from its raw parentGroupId.
+    const run: TaskGroup = {
+      id: 'run',
+      name: 'Run: subagent',
+      startTime: 1,
+      status: STREAM_STATUS.RUNNING,
+      parentGroupId: 'phantom-orchestrator-stage',
+    };
+    const list = await renderList([run], []);
+
+    // Root layout emits a div.log-run with data-run-id; child groups never do
+    // (they render as <details> with summary/content ids only).
+    const rootEl = list.shadowRoot?.querySelector('[data-run-id="run"]');
+    expect(rootEl).not.toBeNull();
+    expect(rootEl?.classList.contains('log-run')).toBe(true);
+  });
 });

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -551,11 +551,9 @@ function startClaudeAgentLoop(params: {
   session.setQueue(queue);
   registerInterruptible(childStreamId, session);
 
-  // Root stage: the child session runs on its own trace, but openStage
-  // would otherwise inherit the parent agent's active stage from the shared
-  // AsyncLocalStorage and emit a cross-trace parentId the child's
-  // subscribers can't resolve.
-  const sessionStage = logger.openStage('Claude Code session', { root: true });
+  // The child session runs on its own trace, whose per-instance stage scope is
+  // empty here, so this opens as a root with no cross-trace parent.
+  const sessionStage = logger.openStage('Claude Code session');
 
   queue.enqueue(initialPrompt);
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -551,10 +551,9 @@ function startCodexLoop(params: {
 
   // Start a log group so endRunningGroups() marks it as errored on reload,
   // giving the user a visual cue that the session was interrupted.
-  // Root stage — see the claudeAgent equivalent: avoid inheriting the
-  // parent agent's active stage (shared AsyncLocalStorage) on the child
-  // session's own trace.
-  const sessionStage = logger.openStage('Codex session', { root: true });
+  // Opens as a root: the child session's own trace has a per-instance stage
+  // scope that is empty here, so there is no cross-trace parent to inherit.
+  const sessionStage = logger.openStage('Codex session');
 
   // Register resumed threads immediately — without this, a second codex call
   // with the same thread_id during the first turn would bypass the in-memory


### PR DESCRIPTION
> **Scope note:** this PR originally shipped R1+R2; the stacked deletion PR #4626 was then merged **into this branch**, so it now contains the full **R1–R4** from the fact-checked PRD (`docs/proposals/progress-grouping-refactor.md`). The deletions were the "safe-after-R1" items, gated by the cross-instance test added here.

Removes the cross-trace stage-grouping bug class **by construction** and deletes the workarounds it made redundant. Net negative LoC; no user-visible behavior change beyond orphans now rendering instead of vanishing. Follows the symptom fix in #4620.

## R1 — Per-instance stage scope (the structural fix)
`TraceEmitter`'s `AsyncLocalStorage` stage stack was a **module-level singleton** shared across every emitter, so a stage opened on one trace leaked as the ambient parent of another (an orchestrator's tool-use stage becoming the parent of a subagent's `"Run:"` stage on its own stream → orphaned subtree). Moved to a **private per-instance field**: within-trace nesting unchanged; cross-trace inheritance now impossible.

## R2 — Render orphans instead of dropping them (guardrail)
`messageIndex.rebuildTree` only built the tree from parentless roots, so a group with a dangling `parentGroupId` — and its whole subtree + messages — was silently omitted. Now a group whose parent is absent is treated as a root. `TaskGroupList.renderGroupNode` keys root-vs-nested layout on tree position (an `isRoot` flag), so a re-rooted orphan gets the root container.

## R3/R4 — Drop the now-redundant workarounds (merged from #4626)
With cross-trace inheritance impossible:
- **Removed the `root` StageOptions flag entirely** + all three `{ root: true }` call sites (`beginRunStage`, `claudeAgent`, `codex`) — each opens a plain root on its own per-instance trace.
- **Removed the usage groupId side-channel** — `UsageMonitor.activeGroupId` + `setActiveGroupId`, and the `onStageCreated` round callback. Round usage now stamps from the round stage's ALS scope (`logger.activeStageId() ?? storageKey`).
- **Removed the inert `"Task:"` stage** in `executeAgent` (it was on the recorder-less channel trace; the module channel logger stays for plain diagnostics).
- Surface cleanup: dead `usageMonitor` field + import from `RunReflectionFlowInput`.

## Tests
- **Cross-trace isolation** (`RunTraceStream.vitest.ts`): a run stage opened on its own trace inside another trace's active stage is a root **without** any flag — verified to fail on the old module-level scope. This is the gate that made the R3/R4 deletions safe.
- **Orphan re-rooting** (`TaskGroupListIndex.vitest.ts`): data-shape + root-container DOM layout.

## Verification
- `npm run typecheck` clean; `vitest` green across agent + transcript + progressView suites.
- Zero remaining references to `setActiveGroupId` / `activeGroupId` / `onStageCreated` / `root: true` / `options.root` (outside an explanatory test comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)