### PR TITLE
refactor(trace): drop root option + usage side-channel + inert Task stage (R3/R4)

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -25,7 +25,6 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
-import type { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
@@ -66,7 +65,6 @@ export interface RunReflectionFlowInput<
   storageKey: StorageKey;
   parentStage: StageHandle;
   getOutputFileLocation?: (round: number) => AgentFileLocation;
-  usageMonitor?: UsageMonitor;
   onRoundCompleted?: (
     roundIndex: number,
     totalRounds: number,
@@ -96,7 +94,6 @@ export async function runReflectionFlow<C = unknown>(
     userVarChannels,
     checkInterruption,
     onRoundFinalized = async () => {},
-    usageMonitor,
   } = input;
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
@@ -253,9 +250,6 @@ export async function runReflectionFlow<C = unknown>(
           logger.openStage(`r${roundIndex}`, {
             parent: parent ?? undefined,
           }),
-        onStageCreated: (stage) => {
-          usageMonitor?.setActiveGroupId(stage.id);
-        },
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();
         },

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -66,12 +66,6 @@ export interface RoundCallbacks<S extends RoundAwareState> {
     parentStage: StageHandle | null,
   ) => StageHandle;
 
-  /**
-   * Called after a new round stage is created.
-   * Use for registering usage tracking callbacks etc.
-   */
-  onStageCreated?: (stage: StageHandle) => void;
-
   /** Check if execution should be interrupted. */
   checkInterruption?: () => boolean;
 
@@ -251,7 +245,7 @@ export class RoundPersistedFlow<
   }
 
   /**
-   * Create a round stage and notify callback.
+   * Create a round stage.
    */
   private createStage(roundIndex: number): void {
     if (this.callbacks.createRoundStage) {
@@ -259,7 +253,6 @@ export class RoundPersistedFlow<
         roundIndex,
         this.parentStage,
       );
-      this.callbacks.onStageCreated?.(this.currentRoundStage);
     }
   }
 }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -153,12 +153,12 @@ async function validateModelExists(
  * its timestamp precedes the stage's startTime. The chronological timeline
  * therefore renders the instruction before the run group.
  *
- * ROOT INVARIANT: opened with `root: true` so it never inherits an ambient
- * stage from the shared trace scope. For a subagent run, the active stage at
- * launch is the orchestrator's tool-use stage — a cross-trace id that this
- * run's own stream never records. Inheriting it would orphan "Run:" (and its
- * whole Init/r0/r1 subtree) in the subagent's transcript, since the renderer
- * can only build group trees down from parentless roots.
+ * ROOT INVARIANT: each run trace owns its stage scope (per-instance
+ * AsyncLocalStorage in TraceEmitter), so this opens as a root — it cannot
+ * inherit a cross-trace ambient stage from a parent run (e.g. an
+ * orchestrator's tool-use stage when this is a subagent). That isolation is
+ * what keeps a subagent's "Run:"/Init/r0/r1 subtree from orphaning in its own
+ * transcript. See docs/proposals/progress-grouping-refactor.md (R1).
  */
 async function beginRunStage(
   agentLogger: AgentTrace,
@@ -166,7 +166,7 @@ async function beginRunStage(
   instruction: string | undefined,
 ): Promise<StageHandle> {
   if (instruction) logUserMessage(agentLogger, instruction);
-  return agentLogger.openStage(label, { root: true });
+  return agentLogger.openStage(label);
 }
 
 async function assembleAgentLaunchContext(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -438,76 +438,71 @@ export async function executeAgent(
           taskState: agentConfigToTaskState(config),
         });
 
-        const taskStage = logger.openStage(
-          `Task: ${agentName}@${config.model}`,
-        );
-        return taskStage.run(async () => {
-          logger.info(`Executing ${agentName} with model ${config.model}`);
-          const interrupts = createInterruptCallbacks();
+        logger.info(`Executing ${agentName} with model ${config.model}`);
+        const interrupts = createInterruptCallbacks();
 
-          if (setting.agentCategory === AgentCategory.ToolUse) {
-            let toolUseTurns = 0;
-            const result = await runToolUseFlow({
-              ...ctx,
-              ...interrupts,
-              onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
-              setting,
-              isSubagent,
-              onBeforeWaiting: options.onBeforeWaiting,
-              stopAfterCycle: options.stopAfterCycle,
-              onProgress: (update) => {
-                if (update.kind === 'overview') {
-                  toolUseTurns++;
-                  ctx.runtimeHost.emit('updateConversationProgress', {
-                    streamId,
-                    progress: {
-                      conversationTurns: toolUseTurns,
-                      toolCallCount: update.toolCallCount,
-                    },
-                  });
-                }
-                options.onProgress?.(update);
-              },
-              onFollowUpConsumed: () => {
-                ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                  streamId: ctx.streamId,
-                });
-                options.onFollowUpConsumed?.();
-              },
-              onModelChanged: (modelHandler, model) => {
-                ctx.config.model = model;
-                ctx.usageMonitor.setModelInfo({
-                  capabilities: modelHandler.capabilities,
-                  config: modelHandler.config,
-                });
-              },
-            });
-            return {
-              category: 'toolUse' as const,
-              status: result.status,
-              lastResponse: result.lastResponse,
-              touchedFiles: result.touchedFiles,
-              executionId: ctx.executionId,
-              streamId,
-            };
-          }
-
-          const onRoundCompleted = createRoundProgressCallback(
-            ctx.executionId,
-            streamId,
-            ctx.runtimeHost,
-            options.onProgress,
-          );
-          const result = await runReflectionFlow({
+        if (setting.agentCategory === AgentCategory.ToolUse) {
+          let toolUseTurns = 0;
+          const result = await runToolUseFlow({
             ...ctx,
             ...interrupts,
             onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
             setting,
-            parentStage: ctx.parentStage,
-            onRoundCompleted,
+            isSubagent,
+            onBeforeWaiting: options.onBeforeWaiting,
+            stopAfterCycle: options.stopAfterCycle,
+            onProgress: (update) => {
+              if (update.kind === 'overview') {
+                toolUseTurns++;
+                ctx.runtimeHost.emit('updateConversationProgress', {
+                  streamId,
+                  progress: {
+                    conversationTurns: toolUseTurns,
+                    toolCallCount: update.toolCallCount,
+                  },
+                });
+              }
+              options.onProgress?.(update);
+            },
+            onFollowUpConsumed: () => {
+              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                streamId: ctx.streamId,
+              });
+              options.onFollowUpConsumed?.();
+            },
+            onModelChanged: (modelHandler, model) => {
+              ctx.config.model = model;
+              ctx.usageMonitor.setModelInfo({
+                capabilities: modelHandler.capabilities,
+                config: modelHandler.config,
+              });
+            },
           });
-          return buildWorkflowFlowResult(result, ctx.executionId, streamId);
+          return {
+            category: 'toolUse' as const,
+            status: result.status,
+            lastResponse: result.lastResponse,
+            touchedFiles: result.touchedFiles,
+            executionId: ctx.executionId,
+            streamId,
+          };
+        }
+
+        const onRoundCompleted = createRoundProgressCallback(
+          ctx.executionId,
+          streamId,
+          ctx.runtimeHost,
+          options.onProgress,
+        );
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...interrupts,
+          onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
+          setting,
+          parentStage: ctx.parentStage,
+          onRoundCompleted,
         });
+        return buildWorkflowFlowResult(result, ctx.executionId, streamId);
       },
       {
         isSubagent,

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -44,15 +44,6 @@ export interface StageOptions {
   readonly skip?: boolean;
   /** Parent handle for nested-stage chains. */
   readonly parent?: StageHandle;
-  /**
-   * Force a root stage with no parent, ignoring the active stage from the
-   * run scope. Use when a stage must not inherit the ambient
-   * AsyncLocalStorage parent — e.g. a child agent's session stage opened
-   * on its own trace while the parent agent's tool-use stage is active
-   * (inheriting would emit a cross-trace parentId the child's subscribers
-   * can't resolve).
-   */
-  readonly root?: boolean;
 }
 
 /** Handle returned by `openStage` — wraps a stage with run/within/end ops. */

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -186,9 +186,8 @@ export class TraceEmitter implements AgentTrace {
 
   openStage(label: string, options: StageOptions = {}): StageHandle {
     const defaultStatus = options.defaultStatus ?? END_GROUP_STATUS.STOPPED;
-    const parentId = options.root
-      ? undefined
-      : (options.parent?.id ?? options.parentId ?? this.activeStageId());
+    const parentId =
+      options.parent?.id ?? options.parentId ?? this.activeStageId();
 
     if (options.skip) {
       return new SkippedStageHandle(this, parentId);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -79,14 +79,6 @@ export interface UsageMonitorContext {
 type UsageMonitorRunKind = 'workflow' | 'tool-use';
 
 export class UsageMonitor {
-  /**
-   * Active group ID for statistics logging.
-   * When set, statistics are logged with this group ID instead of storageKey.
-   * This allows statistics to be associated with individual rounds (r0, r1)
-   * rather than the parent stage.
-   */
-  private activeGroupId: string | undefined;
-
   constructor(
     private modelInfo: UsageMonitorModelInfo,
     private readonly context: UsageMonitorContext,
@@ -95,16 +87,6 @@ export class UsageMonitor {
 
   setModelInfo(modelInfo: UsageMonitorModelInfo): void {
     this.modelInfo = modelInfo;
-  }
-
-  /**
-   * Set the active group ID for statistics logging.
-   * Call this when entering a new round to associate statistics with that round.
-   *
-   * @param groupId - The round stage ID (e.g., r0, r1) or undefined to use storageKey
-   */
-  setActiveGroupId(groupId: string | undefined): void {
-    this.activeGroupId = groupId;
   }
 
   async recordUsage(stateGlobal: AgentRunStateSnapshot): Promise<void> {
@@ -176,8 +158,11 @@ export class UsageMonitor {
         usage: payload,
       });
       if (agentCategory === AgentCategory.Workflow) {
+        // The round stage's AsyncLocalStorage scope already stamps the active
+        // round id (r0/r1...) onto emitted events; fall back to storageKey for
+        // any usage logged outside a round stage.
         logger.usage(payload, {
-          stageId: this.activeGroupId ?? storageKey,
+          stageId: logger.activeStageId() ?? storageKey,
         });
       }
 

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -140,31 +140,6 @@ describe('tool-use card groupId resolution', () => {
   });
 });
 
-describe('openStage root option', () => {
-  it('forces a root stage even when an active stage is in scope', async () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
-      const outer = logger.openStage('outer');
-      await outer.within(async () => {
-        // A child agent's session stage opened on its own trace must NOT
-        // inherit the parent's active stage from the shared AsyncLocalStorage.
-        logger.openStage('child session', { root: true });
-      });
-
-      const entries = store.get('stream')?.getRange(0) ?? [];
-      const child = entries.find((e) => e.text === 'child session');
-      expect(child).toBeDefined();
-      expect(child?.groupId).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
-  });
-});
-
 describe('per-trace stage scope (cross-trace isolation)', () => {
   it('a run stage opened on its own trace does not inherit an active stage from another trace', async () => {
     const previousStore = getDefaultStreamLogStore();
@@ -178,10 +153,10 @@ describe('per-trace stage scope (cross-trace isolation)', () => {
       const taskStage = orchestrator.openStage('Task: orchestrator');
 
       // Subagent run on a SEPARATE trace/stream, opened *inside* the
-      // orchestrator's stage scope but WITHOUT root: true. With a per-instance
-      // stage scope (R1) the orchestrator's active stage cannot leak across
-      // traces, so the subagent's run stage is a root on its own stream. (A
-      // module-level shared scope would orphan it under the cross-trace id.)
+      // orchestrator's stage scope. With a per-instance stage scope the
+      // orchestrator's active stage cannot leak across traces, so the
+      // subagent's run stage is a root on its own stream with no extra flag.
+      // (A module-level shared scope would orphan it under the cross-trace id.)
       await taskStage.within(async () => {
         const subagent = createRunTrace('subagent').trace;
         subagent.openStage('Run: subagent');

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -551,11 +551,9 @@ function startClaudeAgentLoop(params: {
   session.setQueue(queue);
   registerInterruptible(childStreamId, session);
 
-  // Root stage: the child session runs on its own trace, but openStage
-  // would otherwise inherit the parent agent's active stage from the shared
-  // AsyncLocalStorage and emit a cross-trace parentId the child's
-  // subscribers can't resolve.
-  const sessionStage = logger.openStage('Claude Code session', { root: true });
+  // The child session runs on its own trace, whose per-instance stage scope is
+  // empty here, so this opens as a root with no cross-trace parent.
+  const sessionStage = logger.openStage('Claude Code session');
 
   queue.enqueue(initialPrompt);
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -551,10 +551,9 @@ function startCodexLoop(params: {
 
   // Start a log group so endRunningGroups() marks it as errored on reload,
   // giving the user a visual cue that the session was interrupted.
-  // Root stage — see the claudeAgent equivalent: avoid inheriting the
-  // parent agent's active stage (shared AsyncLocalStorage) on the child
-  // session's own trace.
-  const sessionStage = logger.openStage('Codex session', { root: true });
+  // Opens as a root: the child session's own trace has a per-instance stage
+  // scope that is empty here, so there is no cross-trace parent to inherit.
+  const sessionStage = logger.openStage('Codex session');
 
   // Register resumed threads immediately — without this, a second codex call
   // with the same thread_id during the first turn would bypass the in-memory


### PR DESCRIPTION
**Stacked on #4625** (R1 per-instance stage scope + R2 orphan re-root). Review/merge that first; this PR's base is its branch.

Once R1 makes cross-trace inheritance impossible by construction, the mechanisms that existed *only* to work around the shared-scope leak are dead weight. This removes them. **Net −71 LoC, no behavior change** (typecheck clean, vitest 193/193 across agent + transcript + progressView).

## Deleted

### The `root` StageOptions flag (entirely)
Its sole purpose was to stop a stage inheriting a cross-trace ambient parent — now impossible per-instance. Removed the field + doc (`AgentTrace.ts`), the branch in `openStage` (`TraceEmitter.ts`), and all three `{ root: true }` call sites:
- `beginRunStage` (`AgentLaunchContext.ts`) — the shipped #4620 workaround, now redundant.
- `claudeAgent.ts` / `codex.ts` child-session stages — each opens a plain root on its own per-instance trace.

Also deleted the obsolete `openStage root option` test — superseded by the cross-trace isolation test added in #4625.

### The usage groupId side-channel (R4)
`UsageMonitor.activeGroupId` + `setActiveGroupId`, and the `onStageCreated` round callback that fed it. Round usage now stamps from the round stage's `AsyncLocalStorage` scope — `logger.activeStageId() ?? storageKey` — which is the *same* id the side-channel stored, with the `storageKey` fallback preserved.

### The inert `"Task:"` stage (R3)
It was opened on the module-level **channel** trace (no recorder), so it never reached the transcript; and after per-instance scoping it couldn't influence the round hierarchy either. Inlined its body. The module channel logger stays for plain diagnostics (keeps them on the dedicated `executeAgent` channel, off the transcript — no behavior change).

## Surface cleanup (per request)
- Removed the now-unused `onStageCreated` from `RoundCallbacks` + its invocation in `roundPersistedFlow`.
- Removed the dead `usageMonitor` field + `UsageMonitor` import from `RunReflectionFlowInput`.

## Verification
- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/agent src/test-kernel/transcript src/test-kernel/progressView` — **193/193** across 65 files.
- Grep confirms zero remaining references to `setActiveGroupId` / `activeGroupId` / `onStageCreated` / `root: true` / `options.root` (outside an explanatory test comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deletion of dead code after per-trace stage isolation; usage and grouping behavior are intended to be unchanged with tests passing.
> 
> **Overview**
> Removes legacy workarounds that existed only to fix **shared** trace stage scope leaking across runs. After per-instance `TraceEmitter` stage isolation (stacked PR), those paths are redundant.
> 
> **Trace stages:** Deletes the `root` option on `openStage` and all `{ root: true }` call sites (`beginRunStage`, Claude/Codex child sessions). Parent resolution is always `parent` / `parentId` / active stage on **that** trace only.
> 
> **Usage grouping:** Drops `UsageMonitor.setActiveGroupId` and the reflection-flow `onStageCreated` hook that pushed round stage ids into usage. Workflow transcript usage now uses `logger.activeStageId() ?? storageKey` so round `r0`/`r1` scopes from AsyncLocalStorage match the old side-channel.
> 
> **Execution shell:** Removes the non-transcript `"Task: …"` wrapper stage in `executeAgent` and runs tool-use / reflection flows directly under the existing run lifecycle.
> 
> Tests drop the `root` option case; cross-trace isolation coverage stays on the per-instance scope test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712cef0498cdfc023965a22317463297a37bac10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->