### PR TITLE
[codex] Show queued CLI follow-up previews

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -11,6 +11,7 @@ import {
   type ConversationProgress,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { truncateSummary } from '@utils/text/stringUtils';
 
 import { approvalQueueDepth } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
@@ -40,7 +41,7 @@ export interface StatusBarDisplayInput {
   readonly pendingExitHint: boolean;
   readonly pendingExitResumeId: string | undefined;
   readonly bypass: BypassState;
-  readonly queuedFollowUps: number;
+  readonly queuedFollowUpMessages: readonly string[];
   readonly usage: TokenUsageStats | undefined;
   readonly conversation: ConversationProgress | undefined;
   readonly activeSubagents: number;
@@ -129,6 +130,21 @@ function roundSegment(
   return turns > 0 ? { text: `r${turns}`, color: 'dim' } : undefined;
 }
 
+const QUEUED_FOLLOW_UP_PREVIEW_LENGTH = 48;
+
+export function queuedFollowUpsSummary(
+  messages: readonly string[],
+): string | undefined {
+  if (messages.length === 0) return undefined;
+  const preview = truncateSummary(
+    messages[0] ?? '',
+    QUEUED_FOLLOW_UP_PREVIEW_LENGTH,
+  );
+  return messages.length === 1
+    ? `queued: ${preview}`
+    : `queued ${messages.length}: ${preview}`;
+}
+
 export function defaultShortcutModifierLabel(
   platform: NodeJS.Platform = process.platform,
 ): string {
@@ -190,7 +206,7 @@ export function buildStatusBarDisplay(
       input.elapsedMs !== undefined
     ) {
       left.push({
-        text: `${Math.floor(input.elapsedMs / 1000)}s`,
+        text: `${Math.floor(Math.max(0, input.elapsedMs) / 1000)}s`,
         color: 'dim',
       });
     }
@@ -227,10 +243,7 @@ export function buildStatusBarDisplay(
 
   return {
     left,
-    right:
-      input.queuedFollowUps > 0
-        ? `queued: ${input.queuedFollowUps}`
-        : undefined,
+    right: queuedFollowUpsSummary(input.queuedFollowUpMessages),
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
@@ -277,7 +290,7 @@ export function StatusBar(): React.JSX.Element {
     pendingExitHint,
     pendingExitResumeId,
     bypass: slice?.bypass ?? NO_BYPASS,
-    queuedFollowUps: slice?.queuedFollowUps ?? 0,
+    queuedFollowUpMessages: slice?.queuedFollowUpMessages ?? [],
     usage: slice?.usage,
     conversation: slice?.conversation,
     activeSubagents: slice?.activeSubagents.length ?? 0,
@@ -313,7 +326,11 @@ export function StatusBar(): React.JSX.Element {
             ),
           )}
         </Box>
-        {display.right ? <Text dimColor>{display.right}</Text> : null}
+        {display.right ? (
+          <Text dimColor wrap="truncate-end">
+            {display.right}
+          </Text>
+        ) : null}
       </Box>
       <Box paddingX={1}>
         <Text dimColor wrap="truncate-end">

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -59,6 +59,7 @@ import {
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
+import { truncateSummary } from '@utils/text/stringUtils';
 
 import { App } from './App';
 import { AgentListForm } from './forms/AgentListForm';
@@ -104,6 +105,15 @@ export interface RunChatInit {
   readonly agentOverride?: string;
   /** `--model` override from the CLI; falls through `resolveChatDefaults`. */
   readonly modelOverride?: string;
+}
+
+const QUEUED_FOLLOW_UP_NOTICE_LENGTH = 96;
+
+function formatQueuedFollowUpNotice(line: string): string {
+  return `Queued follow-up: ${truncateSummary(
+    line,
+    QUEUED_FOLLOW_UP_NOTICE_LENGTH,
+  )}`;
 }
 
 export interface ClearableTuiSessionState {
@@ -872,6 +882,10 @@ export async function runChat(
     // user submits before `onStreamResolved` populates `session.streamId`.
     // p-queue serializes work but doesn't have an "await predicate" primitive,
     // so the task itself waits for the stream id via a tiny poll loop.
+    appendLocalAssistantTranscript(
+      formatQueuedFollowUpNotice(line),
+      childFollowUpTarget ?? session.streamId,
+    );
     void followUpQueue.add(async () => {
       let followUpTarget = childFollowUpTarget;
       while (

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -79,6 +79,7 @@ export interface StreamSlice {
   readonly conversation: ConversationProgress | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUps: number;
+  readonly queuedFollowUpMessages: readonly string[];
   readonly activeSubagents: readonly ActiveChildInfo[];
   readonly activeProcesses: readonly ActiveChildInfo[];
   /** Child streams seen for this parent. This keeps completed/waiting
@@ -173,6 +174,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
     activeSubagents: [],
     activeProcesses: [],
     childStreams: [],

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -25,6 +25,16 @@ type Emit = <K extends ProgressEvent>(
   payload: ProgressEventPayloads[K],
 ) => void;
 
+function sameQueuedFollowUps(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item === right[index])
+  );
+}
+
 /** Cap on per-process tail length held in the signal map (UTF-16 code
  *  units, not bytes — markdown-it / ink work in JS strings). Beyond this
  *  we truncate at the head via the shared `appendTail` helper so the live
@@ -170,10 +180,20 @@ function applyToState<K extends ProgressEvent>(
       // The event itself has no delta payload — re-read the queue directly so
       // the StatusBar pill stays accurate after both enqueue and drain.
       const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
-      const count = ToolUseFollowUpQueue.getAll(p.streamId).length;
-      patchStream(p.streamId, (s) =>
-        s.queuedFollowUps === count ? s : { ...s, queuedFollowUps: count },
-      );
+      const messages = ToolUseFollowUpQueue.getAll(p.streamId);
+      patchStream(p.streamId, (s) => {
+        if (
+          s.queuedFollowUps === messages.length &&
+          sameQueuedFollowUps(s.queuedFollowUpMessages, messages)
+        ) {
+          return s;
+        }
+        return {
+          ...s,
+          queuedFollowUps: messages.length,
+          queuedFollowUpMessages: messages,
+        };
+      });
       return;
     }
     default:

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -40,6 +40,7 @@ function slice(
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
     activeSubagents: [],
     activeProcesses: [],
     childStreams: [],

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -302,6 +302,7 @@ function sliceWithEntries(
     conversation: undefined,
     entries,
     queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
     activeSubagents: [],
     activeProcesses: [],
     childStreams: [],

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -3,19 +3,33 @@ import { describe, expect, it } from 'vitest';
 import {
   buildStatusBarDisplay,
   defaultShortcutModifierLabel,
+  queuedFollowUpsSummary,
   statusBarSegmentText,
 } from '@cli/chat/tui/panes/StatusBar';
 import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
 describe('CLI StatusBar display model', () => {
+  it('summarizes queued follow-up messages', () => {
+    expect(queuedFollowUpsSummary([])).toBeUndefined();
+    expect(queuedFollowUpsSummary(['Keep the proof under one page.'])).toBe(
+      'queued: Keep the proof under one page.',
+    );
+    expect(
+      queuedFollowUpsSummary([
+        'Keep the proof under one page.',
+        'Also mention the finite monoid argument.',
+      ]),
+    ).toBe('queued 2: Keep the proof under one page.');
+  });
+
   it('keeps idle state compact and omits static agent/model names', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -53,7 +67,7 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -77,7 +91,10 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 2,
+      queuedFollowUpMessages: [
+        'Keep the proof under one page.',
+        'Also mention the finite monoid argument.',
+      ],
       usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
       conversation: { conversationTurns: 2, toolCallCount: 7 },
       activeSubagents: 2,
@@ -100,7 +117,7 @@ describe('CLI StatusBar display model', () => {
       '1 proc',
       '3 approvals',
     ]);
-    expect(display.right).toBe('queued: 2');
+    expect(display.right).toBe('queued 2: Keep the proof under one page.');
     expect(display.bindings).toContain('[Alt-s]subagents');
     // Stream-navigation hints appear once more than one stream is live.
     expect(display.bindings).toContain('[Tab]streams');
@@ -108,13 +125,13 @@ describe('CLI StatusBar display model', () => {
   });
 
   it('shows a live elapsed segment only while running', () => {
-    const running = buildStatusBarDisplay({
+    const runningInput = {
       status: STREAM_STATUS.RUNNING,
       elapsedMs: 110_000,
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -125,12 +142,24 @@ describe('CLI StatusBar display model', () => {
       model: 'deepseekT',
       apiMode: 'api',
       shortcutModifierLabel: 'Alt',
-    });
+    };
+    const running = buildStatusBarDisplay(runningInput);
 
     expect(running.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
       '110s',
+      'api',
+    ]);
+
+    const justStarted = buildStatusBarDisplay({
+      ...runningInput,
+      elapsedMs: -20_000,
+    });
+    expect(justStarted.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'running',
+      '0s',
       'api',
     ]);
 
@@ -141,7 +170,7 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -163,7 +192,7 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: { superYolo: true, toolEdit: true },
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -199,7 +228,7 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: true,
       pendingExitResumeId: 'abc123',
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,
@@ -228,7 +257,7 @@ describe('CLI StatusBar display model', () => {
       pendingExitHint: false,
       pendingExitResumeId: undefined,
       bypass: NO_BYPASS,
-      queuedFollowUps: 0,
+      queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
       activeSubagents: 0,

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -44,6 +44,7 @@ function slice(
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
     activeSubagents: [],
     activeProcesses: [],
     childStreams: [],


### PR DESCRIPTION
## Summary

- Show a preview of the first queued CLI follow-up in the status bar instead of only `queued: N`.
- Add an immediate local transcript acknowledgement when a follow-up is submitted while another turn is active or still resolving its stream id.
- Clamp running elapsed time at zero so a just-started turn cannot flash a negative duration.

Closes #4614.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings in unrelated files)
- `npm run texra-local:build`
- TTY smoke with `texra-local --cwd /tmp/texra-cli-dogfood chat --approval-policy ask`: submitting a prompt now starts at `running 0s` rather than flashing a negative elapsed time.

## Dogfood Notes

Filed #4628 for a separate approval UX issue found in the same TTY session: the edit approval modal can hide diff rows without a visible scroll or expand affordance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and local transcript acknowledgements only; no changes to auth, persistence, or follow-up delivery semantics beyond richer UI state.
> 
> **Overview**
> The CLI chat TUI now surfaces **queued follow-ups** with readable previews instead of only a count. Stream state carries `queuedFollowUpMessages` (synced from `ToolUseFollowUpQueue` on `updateQueuedFollowUps`), and the status bar shows a truncated first message (`queued: …` or `queued N: …`). Submitting a follow-up while a turn is still running or the stream id is not ready adds an immediate local transcript line, **Queued follow-up: …**, so users get acknowledgement before the queue drains.
> 
> Running elapsed time is **clamped at zero** so a just-started turn does not briefly show a negative `Ns` segment. Queued text on the status bar uses end truncation for narrow terminals. Vitest coverage was extended for the new summary helper and elapsed clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c374b2b45cfc87de4ca8384ba7ad30bdb14fed17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->