### PR TITLE
[codex] Make CLI edit approval diffs scrollable

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -11,9 +11,11 @@ import {
   patchStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
+import { enqueueApproval } from '../src/chat/tui/state/approvalQueue';
 
 const STREAM_ID = 'harness-stream-1';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
+const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 
 function makeEntries(count: number): ConversationEntry[] {
   const entries: ConversationEntry[] = [];
@@ -33,6 +35,34 @@ function makeEntries(count: number): ConversationEntry[] {
   return entries;
 }
 
+function makeEditApprovalRequest() {
+  const originalBody = Array.from(
+    { length: 24 },
+    (_, index) => `Line ${index + 1}: placeholder.`,
+  );
+  const proposedBody = Array.from(
+    { length: 24 },
+    (_, index) => `Line ${index + 1}: finite-domain proof step ${index + 1}.`,
+  );
+  return {
+    path: 'draft.tex',
+    originalContent: [
+      '\\documentclass{article}',
+      '\\begin{document}',
+      ...originalBody,
+      '\\end{document}',
+    ].join('\n'),
+    proposedContent: [
+      '\\documentclass{article}',
+      '\\begin{document}',
+      ...proposedBody,
+      '\\end{document}',
+    ].join('\n'),
+    sourceTool: 'harness',
+    streamId: STREAM_ID,
+  };
+}
+
 cliState.sessionMeta.set({
   agent: 'chat',
   model: 'harness-model',
@@ -47,6 +77,13 @@ patchStream(STREAM_ID, (slice) => ({
   status: undefined,
   entries: makeEntries(ENTRY_COUNT),
 }));
+
+if (SHOW_EDIT_APPROVAL) {
+  void enqueueApproval({
+    kind: 'toolEdit',
+    request: makeEditApprovalRequest(),
+  });
+}
 
 const ink = render(
   <App

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -67,13 +67,11 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   }, [maxScrollOffset]);
 
   useInput(
-    (input, key) => {
-      if (key.downArrow || input === 'j') scrollTo((current) => current + 1);
-      else if (key.upArrow || input === 'k') scrollTo((current) => current - 1);
+    (_input, key) => {
+      if (key.downArrow) scrollTo((current) => current + 1);
+      else if (key.upArrow) scrollTo((current) => current - 1);
       else if (key.pageDown) scrollTo((current) => current + pageRows);
       else if (key.pageUp) scrollTo((current) => current - pageRows);
-      else if (input === 'g') scrollTo(0);
-      else if (input === 'G') scrollTo(maxScrollOffset);
     },
     { isActive: diffScrollable },
   );
@@ -104,7 +102,6 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
           hints={[
             { key: '↑/↓', action: 'scroll diff' },
             { key: 'PgUp/PgDn', action: 'page' },
-            { key: 'g/G', action: 'top/bottom' },
           ]}
         />
       ) : null}

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -1,10 +1,17 @@
-import { useMemo } from 'react';
-import { Box, Text, useWindowSize } from 'ink';
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import { ConfirmCard } from './ConfirmCard';
-import { buildHunks, DiffView, statsFromHunks } from '../render/DiffView';
+import {
+  buildHunks,
+  diffDisplayLines,
+  DiffView,
+  maxDiffScrollOffset,
+  statsFromHunks,
+} from '../render/DiffView';
+import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
@@ -19,6 +26,7 @@ export interface EditApprovalProps {
 
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
+  const [scrollOffset, setScrollOffset] = useState(0);
   const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
   const maxDiffLines =
     props.availableRows === undefined
@@ -40,6 +48,35 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
     ],
   );
   const stats = useMemo(() => statsFromHunks(hunks), [hunks]);
+  const diffRows = useMemo(() => diffDisplayLines(hunks).length, [hunks]);
+  const maxScrollOffset = maxDiffScrollOffset(diffRows, maxDiffLines);
+  const diffScrollable = maxScrollOffset > 0;
+  const pageRows = Math.max(1, maxDiffLines - 2);
+
+  function scrollTo(next: number | ((currentOffset: number) => number)): void {
+    setScrollOffset((current) => {
+      const requested = typeof next === 'function' ? next(current) : next;
+      return Math.max(0, Math.min(maxScrollOffset, requested));
+    });
+  }
+
+  useEffect(() => {
+    setScrollOffset((current) =>
+      Math.max(0, Math.min(maxScrollOffset, current)),
+    );
+  }, [maxScrollOffset]);
+
+  useInput(
+    (input, key) => {
+      if (key.downArrow || input === 'j') scrollTo((current) => current + 1);
+      else if (key.upArrow || input === 'k') scrollTo((current) => current - 1);
+      else if (key.pageDown) scrollTo((current) => current + pageRows);
+      else if (key.pageUp) scrollTo((current) => current - pageRows);
+      else if (input === 'g') scrollTo(0);
+      else if (input === 'G') scrollTo(maxScrollOffset);
+    },
+    { isActive: diffScrollable },
+  );
 
   return (
     <ConfirmCard
@@ -57,10 +94,20 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
         <DiffView
           hunks={hunks}
           maxDisplayLines={maxDiffLines}
-          maxHunkLines={30}
+          scrollOffset={scrollOffset}
           width={diffWidth}
         />
       </Box>
+      {diffScrollable ? (
+        <KeyHints
+          confirmCancel={false}
+          hints={[
+            { key: '↑/↓', action: 'scroll diff' },
+            { key: 'PgUp/PgDn', action: 'page' },
+            { key: 'g/G', action: 'top/bottom' },
+          ]}
+        />
+      ) : null}
     </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -149,15 +149,70 @@ export function boundedDiffDisplayLines(
   maxHunkLines = 0,
   maxDisplayLines = 0,
 ): DiffDisplayLine[] {
+  return scrollBoundedDiffDisplayLines(hunks, maxHunkLines, maxDisplayLines, 0);
+}
+
+export function maxDiffScrollOffset(
+  totalLines: number,
+  maxDisplayLines: number,
+): number {
+  if (maxDisplayLines <= 0 || totalLines <= maxDisplayLines) return 0;
+  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+}
+
+export function scrollBoundedDiffDisplayLines(
+  hunks: readonly Hunk[],
+  maxHunkLines = 0,
+  maxDisplayLines = 0,
+  scrollOffset = 0,
+): DiffDisplayLine[] {
   const lines = diffDisplayLines(hunks, maxHunkLines);
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
-  const visibleLines = lines.slice(0, Math.max(0, maxDisplayLines - 1));
+  if (maxDisplayLines === 1) {
+    return [
+      {
+        kind: 'overflow',
+        text: `... ${lines.length} diff rows hidden`,
+      },
+    ];
+  }
+
+  const offset = Math.max(
+    0,
+    Math.min(scrollOffset, maxDiffScrollOffset(lines.length, maxDisplayLines)),
+  );
+  const hiddenBefore = offset;
+  const reserveBefore = hiddenBefore > 0 ? 1 : 0;
+  const provisionalVisible = Math.max(0, maxDisplayLines - reserveBefore);
+  const hiddenAfterProvisional = Math.max(
+    0,
+    lines.length - (offset + provisionalVisible),
+  );
+  const reserveAfter = hiddenAfterProvisional > 0 ? 1 : 0;
+  const visibleCount = Math.max(
+    0,
+    maxDisplayLines - reserveBefore - reserveAfter,
+  );
+  const visibleLines = lines.slice(offset, offset + visibleCount);
+  const hiddenAfter = Math.max(0, lines.length - (offset + visibleCount));
   return [
+    ...(hiddenBefore > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: `... ${hiddenBefore} previous diff rows`,
+          },
+        ]
+      : []),
     ...visibleLines,
-    {
-      kind: 'overflow',
-      text: `... ${lines.length - visibleLines.length} more diff rows`,
-    },
+    ...(hiddenAfter > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: `... ${hiddenAfter} more diff rows`,
+          },
+        ]
+      : []),
   ];
 }
 
@@ -167,6 +222,8 @@ export interface DiffViewProps {
   readonly maxDisplayLines?: number;
   /** Maximum context lines per hunk before truncating; 0 = no truncation. */
   readonly maxHunkLines?: number;
+  /** Starting diff row when maxDisplayLines truncates the display. */
+  readonly scrollOffset?: number;
   readonly width?: number;
 }
 
@@ -174,7 +231,12 @@ export function DiffView(props: DiffViewProps): React.JSX.Element {
   const maxDisplayLines = props.maxDisplayLines ?? 0;
   const max = props.maxHunkLines ?? 0;
   const width = Math.max(MIN_DIFF_WIDTH, props.width ?? DEFAULT_DIFF_WIDTH);
-  const lines = boundedDiffDisplayLines(props.hunks, max, maxDisplayLines);
+  const lines = scrollBoundedDiffDisplayLines(
+    props.hunks,
+    max,
+    maxDisplayLines,
+    props.scrollOffset ?? 0,
+  );
 
   return (
     <Box flexDirection="column">

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -156,7 +156,7 @@ export function maxDiffScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (maxDisplayLines <= 0 || totalLines <= maxDisplayLines) return 0;
+  if (maxDisplayLines <= 2 || totalLines <= maxDisplayLines) return 0;
   return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
 }
 
@@ -183,12 +183,8 @@ export function scrollBoundedDiffDisplayLines(
   );
   const hiddenBefore = offset;
   const reserveBefore = hiddenBefore > 0 ? 1 : 0;
-  const provisionalVisible = Math.max(0, maxDisplayLines - reserveBefore);
-  const hiddenAfterProvisional = Math.max(
-    0,
-    lines.length - (offset + provisionalVisible),
-  );
-  const reserveAfter = hiddenAfterProvisional > 0 ? 1 : 0;
+  const contentSlotsWithoutAfter = Math.max(0, maxDisplayLines - reserveBefore);
+  const reserveAfter = offset + contentSlotsWithoutAfter < lines.length ? 1 : 0;
   const visibleCount = Math.max(
     0,
     maxDisplayLines - reserveBefore - reserveAfter,

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -5,6 +5,8 @@ import {
   buildHunks,
   DIFF_BAND_BG,
   fillRows,
+  maxDiffScrollOffset,
+  scrollBoundedDiffDisplayLines,
 } from '@cli/chat/tui/render/DiffView';
 
 describe('CLI diff display', () => {
@@ -22,6 +24,30 @@ describe('CLI diff display', () => {
       kind: 'overflow',
       text: expect.stringContaining('more diff rows'),
     });
+  });
+
+  it('renders scroll markers around the visible diff window', () => {
+    const hunks = buildHunks(
+      'draft.tex',
+      ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'].join('\n'),
+      ['alpha', 'BETA', 'gamma', 'DELTA', 'epsilon', 'ZETA'].join('\n'),
+    );
+
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 2);
+
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toMatchObject({
+      kind: 'overflow',
+      text: '... 2 previous diff rows',
+    });
+    expect(lines.at(-1)).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('more diff rows'),
+    });
+  });
+
+  it('clamps the bottom scroll offset so the last rows remain visible', () => {
+    expect(maxDiffScrollOffset(10, 4)).toBe(7);
   });
 });
 

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -49,6 +49,28 @@ describe('CLI diff display', () => {
   it('clamps the bottom scroll offset so the last rows remain visible', () => {
     expect(maxDiffScrollOffset(10, 4)).toBe(7);
   });
+
+  it('keeps one- and two-row diff windows static', () => {
+    expect(maxDiffScrollOffset(10, 1)).toBe(0);
+    expect(maxDiffScrollOffset(10, 2)).toBe(0);
+  });
+
+  it('shows content plus an overflow marker in a two-row diff window', () => {
+    const hunks = buildHunks(
+      'draft.tex',
+      ['alpha', 'beta', 'gamma', 'delta'].join('\n'),
+      ['alpha', 'BETA', 'gamma', 'DELTA'].join('\n'),
+    );
+
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 2, 1);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.kind).not.toBe('overflow');
+    expect(lines[1]).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('more diff rows'),
+    });
+  });
 });
 
 describe('full-width diff bands', () => {


### PR DESCRIPTION
## Summary

- Make truncated CLI edit approval diffs scrollable with `↑/↓` and `PgUp/PgDn` key hints.
- Keep extremely small diff windows static so they do not advertise inert scrolling or hide all content behind overflow markers.
- Add a harness mode for deterministic edit-approval TTY checks.

Closes #4628.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/DiffView.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings in unrelated files)
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- TTY harness smoke: `HARNESS_EDIT_APPROVAL=1 HARNESS_ENTRIES=3 node packages/cli/dist/bin/tui-harness.js`, then Down/Down and `PgDn` verified the diff window scrolls, the previous/more markers update, and the key hints only show arrow/page controls.

## Dogfood Notes

A real `texra-local --cwd /tmp/texra-cli-approval-scroll chat --approval-policy ask` run against a finite-integral-domain edit prompt read the file but stayed quiet in `running` for about a minute before I interrupted it. I used the harness for deterministic approval-surface validation rather than waiting on model latency.