### PR TITLE
docs(site): keep agent-sdk-readiness-audit internal

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -214,6 +214,7 @@ const baseConfig = {
   // under public/ are served as-is and are fine to expose.
   srcExclude: [
     'README.md',
+    'agent-sdk-readiness-audit.md',
     'analysis-subagent-updates.md',
     'desktop-signing-ci.md',
     'electron-migration-plan.md',


### PR DESCRIPTION
The agent-sdk-readiness-audit.md is an internal review/refactoring plan,
not a public page. VitePress was building it into the dist root, tripping
the docs-deploy public-allowlist backstop. Add it to srcExclude alongside
the other internal docs so it is never published to texra.ai.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config allowlist entry; no runtime, auth, or product behavior changes.
> 
> **Overview**
> Adds **`agent-sdk-readiness-audit.md`** to the VitePress **`srcExclude`** list in `docs/.vitepress/config.js`, alongside other internal-only docs.
> 
> That page was still being built into the site output, which could fail the **docs-deploy public allowlist** backstop. Excluding it keeps the internal audit/refactoring doc out of the **texra.ai** publish set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6b7532b7e6950e13a31e626a8a49e6d91a03bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->