### PR TITLE
[codex] Stop headless multi-agent runs after one cycle

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -187,7 +187,7 @@ async function runMultiAgentShow(
   return CliExitCode.Success;
 }
 
-async function runMultiAgentPreset(
+export async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
@@ -234,6 +234,7 @@ async function runMultiAgentPreset(
       enforceCategory: true,
       registerExecution: true,
       markErrorOnThrow: true,
+      stopAfterCycle: true,
       wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
     },
   );

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const mocks = vi.hoisted(() => ({
+  executeCliRequest: vi.fn(),
+  expandRunInputs: vi.fn(),
+  getToolUseAgents: vi.fn(),
+  getWorkflowAgents: vi.fn(),
+  initCliPlatform: vi.fn(),
+  installCliApprovalHandlers: vi.fn(),
+  isAuthenticated: vi.fn(),
+  loadAgents: vi.fn(),
+  writeTextStderr: vi.fn(),
+  writeTextStdout: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  getToolUseAgents: mocks.getToolUseAgents,
+  getWorkflowAgents: mocks.getWorkflowAgents,
+  loadAgents: mocks.loadAgents,
+}));
+
+vi.mock('@agent/storage', () => ({
+  writeTerminalStatus: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/approvalAdapter', () => ({
+  hasCliApprovalDenied: vi.fn(() => false),
+  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initCliPlatform: mocks.initCliPlatform,
+  initLocalCliPlatform: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeNdjsonStdout: vi.fn(),
+  writeTextStderr: mocks.writeTextStderr,
+  writeTextStdout: mocks.writeTextStdout,
+}));
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProvider: () => ({
+    isAuthenticated: mocks.isAuthenticated,
+  }),
+}));
+
+vi.mock('@cli/runtime/multiAgentPresets', () => ({
+  cliMultiAgentPlanHasGaps: vi.fn(() => false),
+  cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
+  findCliMultiAgentPreset: vi.fn(() => ({
+    id: 'mathematician',
+    name: 'Mathematician',
+    description: 'For math papers.',
+    workflowAgents: [],
+    toolUseAgents: ['orchestrator'],
+    source: 'built-in',
+  })),
+  formatCliMultiAgentPresetDetails: vi.fn(() => ''),
+  formatCliMultiAgentPresetList: vi.fn(() => ''),
+  planCliMultiAgentPresetRun: vi.fn(() => ({
+    preset: {
+      id: 'mathematician',
+      name: 'Mathematician',
+      source: 'built-in',
+    },
+    rootAgent: {
+      name: 'orchestrator',
+      category: 'toolUse',
+      source: 'builtInToolUse',
+      path: '/agents/orchestrator.yaml',
+      tools: ['delegate_agent'],
+    },
+    missingWorkflowAgents: [],
+    missingToolUseAgents: [],
+    workflowAgentKeys: [],
+    toolUseAgentKeys: ['builtInToolUse:orchestrator'],
+  })),
+  readCliMultiAgentPresets: vi.fn(() => []),
+  withCliMultiAgentPresetVisibility: vi.fn(
+    (_plan: unknown, run: () => Promise<unknown>) => run(),
+  ),
+}));
+
+vi.mock('@cli/commands/_helpers/modelArg', () => ({
+  buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
+    ...context,
+    helperModel: model,
+    quietLogs: true,
+    renderRunProgress: false,
+  })),
+  resolveCliRunModel: vi.fn(
+    (_context: CliContext, model: string | undefined) => model ?? 'deepseekT',
+  ),
+}));
+
+vi.mock('@cli/commands/_helpers/runExecution', () => ({
+  executeCliRequest: mocks.executeCliRequest,
+}));
+
+vi.mock('@cli/commands/_helpers/workflowInputs', () => ({
+  expandRunInputs: mocks.expandRunInputs,
+}));
+
+function cliContext(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/project',
+    mode: 'headless',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    quietLogs: false,
+    renderRunProgress: true,
+    stderrIsTty: false,
+    colorEnabled: false,
+    version: '0.0.0',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+describe('CLI multi-agent run command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.expandRunInputs.mockResolvedValue({
+      inputFiles: ['problem.tex'],
+      contextFiles: [],
+    });
+    mocks.getWorkflowAgents.mockReturnValue([]);
+    mocks.getToolUseAgents.mockReturnValue([
+      {
+        name: 'orchestrator',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/orchestrator.yaml',
+        tools: ['delegate_agent'],
+      },
+    ]);
+    mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.executeCliRequest.mockResolvedValue({
+      result: {
+        category: 'toolUse',
+        executionId: 'exec-1',
+        status: 'completed',
+        lastResponse: 'The proof is correct.',
+      },
+      terminalStatus: 'completed',
+    });
+  });
+
+  it('stops the headless team root after one cycle instead of waiting for a follow-up', async () => {
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: ['problem.tex'],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Inspect the proof without editing files.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.executeCliRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.executeCliRequest.mock.calls[0]?.[2]).toMatchObject({
+      enforceCategory: true,
+      registerExecution: true,
+      markErrorOnThrow: true,
+      stopAfterCycle: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Make `texra multi-agent run` use the same headless tool-use lifecycle as `texra agents run` by stopping after the root agent's first cycle.
- Add a command-boundary regression test proving the multi-agent runner passes `stopAfterCycle: true` into shared execution.

Closes #4632.

## Dogfood Notes

Reproduced in a real TTY on a telescoping-sum proof with:

```sh
texra-local --cwd /tmp/texra-cli-math-dogfood multi-agent run mathematician --input problem.tex --model deepseekT --approval-policy never --instruction "Dogfood run: inspect the short proof, explain whether it is correct, and if useful delegate to an appropriate built-in specialist. Do not edit files."
```

Before the fix, the run reached `waiting` and Node emitted `Warning: Detected unsettled top-level await ... packages/cli/dist/bin/texra.js:3002`, exiting 13. After rebuilding with this patch, the same command exits 0, shows `[r1] ... stopped`, and prints the proof verification without the bundled stack dump.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build`
- TTY dogfood command above, before and after the fix
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows headless multi-agent lifecycle to match agents run; behavior change is intentional and covered by a focused unit test.
> 
> **Overview**
> Headless **`texra multi-agent run`** now passes **`stopAfterCycle: true`** into shared **`executeCliRequest`**, matching **`texra agents run`** so the team root finishes after one model/tool cycle instead of sitting in **`waiting`** (which caused unsettled top-level await warnings and bad exits in TTY dogfood).
> 
> **`runMultiAgentPreset`** is **exported** so the CLI layer can be tested without going through the command router. A new Vitest file asserts the multi-agent runner forwards **`stopAfterCycle: true`** along with the existing enforce/register/mark-error flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833999512af83b8de4d3f28aac7c6ee7f9726c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->