### PR TITLE
[codex] Wrap long CLI approval diff lines

### DIFF
--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -6,7 +6,7 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 import { ConfirmCard } from './ConfirmCard';
 import {
   buildHunks,
-  diffDisplayLines,
+  diffVisualRowCount,
   DiffView,
   maxDiffScrollOffset,
   statsFromHunks,
@@ -48,7 +48,10 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
     ],
   );
   const stats = useMemo(() => statsFromHunks(hunks), [hunks]);
-  const diffRows = useMemo(() => diffDisplayLines(hunks).length, [hunks]);
+  const diffRows = useMemo(
+    () => diffVisualRowCount(hunks, diffWidth),
+    [diffWidth, hunks],
+  );
   const maxScrollOffset = maxDiffScrollOffset(diffRows, maxDiffLines);
   const diffScrollable = maxScrollOffset > 0;
   const pageRows = Math.max(1, maxDiffLines - 2);

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -32,6 +32,8 @@ const NO_NEWLINE_MARKER = '\\';
 const MIN_DIFF_WIDTH = 20;
 const DEFAULT_DIFF_WIDTH = 74;
 
+type OverflowMarkerKind = 'hidden' | 'more' | 'previous';
+
 /** Compute hunks once; callers reuse for both stats and the renderer. */
 export function buildHunks(
   fileLabel: string,
@@ -144,6 +146,27 @@ export function diffDisplayLines(
   });
 }
 
+export function wrappedDiffDisplayLines(
+  hunks: readonly Hunk[],
+  width: number,
+  maxHunkLines = 0,
+): DiffDisplayLine[] {
+  const diffWidth = Math.max(MIN_DIFF_WIDTH, width);
+  return diffDisplayLines(hunks, maxHunkLines).flatMap((line) =>
+    wrapAnsiToWidth(line.text, diffWidth)
+      .split('\n')
+      .map((text): DiffDisplayLine => ({ ...line, text })),
+  );
+}
+
+export function diffVisualRowCount(
+  hunks: readonly Hunk[],
+  width: number,
+  maxHunkLines = 0,
+): number {
+  return wrappedDiffDisplayLines(hunks, width, maxHunkLines).length;
+}
+
 export function boundedDiffDisplayLines(
   hunks: readonly Hunk[],
   maxHunkLines = 0,
@@ -160,19 +183,64 @@ export function maxDiffScrollOffset(
   return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
 }
 
+function clipToWidth(text: string, width: number): string {
+  let clipped = '';
+  for (const char of text) {
+    if (stringWidth(clipped + char) > width) break;
+    clipped += char;
+  }
+  return clipped;
+}
+
+function overflowMarkerText(
+  kind: OverflowMarkerKind,
+  count: number,
+  width?: number,
+): string {
+  const candidates =
+    kind === 'hidden'
+      ? [
+          `... ${count} diff rows hidden`,
+          `... ${count} rows hidden`,
+          `... ${count} hidden`,
+        ]
+      : kind === 'previous'
+        ? [
+            `... ${count} previous diff rows`,
+            `... ${count} previous rows`,
+            `... ${count} prev rows`,
+          ]
+        : [
+            `... ${count} more diff rows`,
+            `... ${count} more rows`,
+            `... +${count} rows`,
+          ];
+  if (width === undefined) return candidates[0] ?? '';
+
+  const markerWidth = Math.max(MIN_DIFF_WIDTH, width);
+  return (
+    candidates.find((candidate) => stringWidth(candidate) <= markerWidth) ??
+    clipToWidth(candidates.at(-1) ?? '', markerWidth)
+  );
+}
+
 export function scrollBoundedDiffDisplayLines(
   hunks: readonly Hunk[],
   maxHunkLines = 0,
   maxDisplayLines = 0,
   scrollOffset = 0,
+  width?: number,
 ): DiffDisplayLine[] {
-  const lines = diffDisplayLines(hunks, maxHunkLines);
+  const lines =
+    width === undefined
+      ? diffDisplayLines(hunks, maxHunkLines)
+      : wrappedDiffDisplayLines(hunks, width, maxHunkLines);
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
   if (maxDisplayLines === 1) {
     return [
       {
         kind: 'overflow',
-        text: `... ${lines.length} diff rows hidden`,
+        text: overflowMarkerText('hidden', lines.length, width),
       },
     ];
   }
@@ -196,7 +264,7 @@ export function scrollBoundedDiffDisplayLines(
       ? [
           {
             kind: 'overflow' as const,
-            text: `... ${hiddenBefore} previous diff rows`,
+            text: overflowMarkerText('previous', hiddenBefore, width),
           },
         ]
       : []),
@@ -205,7 +273,7 @@ export function scrollBoundedDiffDisplayLines(
       ? [
           {
             kind: 'overflow' as const,
-            text: `... ${hiddenAfter} more diff rows`,
+            text: overflowMarkerText('more', hiddenAfter, width),
           },
         ]
       : []),
@@ -232,17 +300,13 @@ export function DiffView(props: DiffViewProps): React.JSX.Element {
     max,
     maxDisplayLines,
     props.scrollOffset ?? 0,
+    width,
   );
 
   return (
     <Box flexDirection="column">
       {lines.map((line, li) => (
-        <DiffLine
-          key={li}
-          line={line}
-          truncate={maxDisplayLines > 0}
-          width={width}
-        />
+        <DiffLine key={li} line={line} width={width} />
       ))}
     </Box>
   );
@@ -273,27 +337,15 @@ export function fillRows(text: string, width: number): string {
 
 function DiffLine({
   line,
-  truncate = false,
   width,
 }: {
   readonly line: DiffDisplayLine;
-  readonly truncate?: boolean;
   readonly width: number;
 }): React.JSX.Element {
-  // Truncate mode keeps each entry on one row (clip the overflow); otherwise
-  // pre-wrap to the diff width so a banded line wraps as multiple full rows.
-  const content = truncate ? line.text : wrapAnsiToWidth(line.text, width);
+  const content = wrapAnsiToWidth(line.text, width);
   const bg = DIFF_BAND_BG[line.kind];
   if (bg) {
-    return (
-      <Text backgroundColor={bg} wrap={truncate ? 'truncate-end' : undefined}>
-        {fillRows(content, width)}
-      </Text>
-    );
+    return <Text backgroundColor={bg}>{fillRows(content, width)}</Text>;
   }
-  return (
-    <Text dimColor wrap={truncate ? 'truncate-end' : undefined}>
-      {content}
-    </Text>
-  );
+  return <Text dimColor>{content}</Text>;
 }

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -4,9 +4,11 @@ import {
   boundedDiffDisplayLines,
   buildHunks,
   DIFF_BAND_BG,
+  diffVisualRowCount,
   fillRows,
   maxDiffScrollOffset,
   scrollBoundedDiffDisplayLines,
+  wrappedDiffDisplayLines,
 } from '@cli/chat/tui/render/DiffView';
 
 describe('CLI diff display', () => {
@@ -70,6 +72,53 @@ describe('CLI diff display', () => {
       kind: 'overflow',
       text: expect.stringContaining('more diff rows'),
     });
+  });
+
+  it('wraps long changed lines instead of replacing the tail with an ellipsis', () => {
+    const proposed =
+      'Here $2n+1$ is the $(n+1)$-st odd number, i.e., the next odd number after $2n-1$.';
+    const hunks = buildHunks('draft.tex', 'old sentence', proposed);
+
+    const lines = wrappedDiffDisplayLines(hunks, 36);
+    const rendered = lines.map((line) => line.text).join('\n');
+
+    expect(rendered).toContain('after $2n-1$.');
+    expect(rendered).not.toContain('…');
+    expect(diffVisualRowCount(hunks, 36)).toBeGreaterThan(
+      boundedDiffDisplayLines(hunks).length,
+    );
+  });
+
+  it('applies the display budget to wrapped visual diff rows', () => {
+    const hunks = buildHunks(
+      'draft.tex',
+      'old sentence',
+      'This is a deliberately long replacement sentence that needs multiple visual rows.',
+    );
+
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 0, 24);
+
+    expect(lines).toHaveLength(4);
+    expect(lines.at(-1)).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('more diff rows'),
+    });
+  });
+
+  it('keeps wrapped overflow markers to one visual row at narrow widths', () => {
+    const hunks = buildHunks('draft.tex', 'old sentence', 'x'.repeat(220));
+
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 0, 20);
+    const marker = lines.at(-1);
+
+    expect(lines).toHaveLength(4);
+    expect(marker).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('more rows'),
+    });
+    expect(marker?.text).not.toContain('diff rows');
+    expect(marker?.text).not.toContain('\n');
+    expect(marker?.text.length).toBeLessThanOrEqual(20);
   });
 });
 


### PR DESCRIPTION
## Summary

- Wrap long diff rows before applying the edit-approval modal's vertical display budget, so changed-line tails remain visible instead of ending in an ellipsis.
- Count wrapped visual rows when deciding whether the approval diff should be scrollable.
- Add CLI diff renderer regressions for long mathematical edit lines and budgeted wrapped rows.

Closes #4634.

## Dogfood Notes

Reproduced in a real TTY with:

```sh
TERM=xterm-256color texra-local --cwd /tmp/texra-cli-chat-dogfood chat --agent chat --model deepseekT --approval-policy ask
```

Prompted the chat agent to insert an explanatory sentence into `problem.tex`. Before the fix, the approval modal truncated the added line as:

```text
+Here $2n+1$ is the $(n+1)$-st odd number, i.e., the next odd number after …
```

After rebuilding with this patch, the same approval surface wraps the line and shows the tail:

```text
+Here $2n+1$ is the $(n+1)$-st odd number, i.e., the next odd number after
 $2n-1$, which is the precise next odd term needed for the induction step.
```

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/DiffView.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build`
- TTY dogfood command above, before and after the fix
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only diff rendering and tests; no auth, persistence, or tool-execution behavior changes.
> 
> **Overview**
> The CLI edit-approval diff now **wraps long lines to the modal width** and treats each wrapped segment as its own visual row, so reviewers see the full changed text instead of a truncated tail with an ellipsis.
> 
> **`DiffView`** gains `wrappedDiffDisplayLines` and `diffVisualRowCount`; scroll windows and overflow markers (`hidden` / `previous` / `more`) are computed on those wrapped rows and **shorten at narrow widths** so markers stay on one line. **`EditApproval`** uses `diffVisualRowCount(hunks, diffWidth)` for scroll limits. **`DiffLine`** always pre-wraps via `wrapAnsiToWidth` and drops Ink’s `truncate-end` path.
> 
> New **`DiffView.vitest.mts`** cases cover long math lines, budgeted wrapped rows, and narrow overflow labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0a2a05e9d23ea60f984db18b6a04e2152eccf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->