### PR TITLE
[codex] Show queued CLI follow-up count

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -145,6 +145,14 @@ export function queuedFollowUpsSummary(
     : `queued ${messages.length}: ${preview}`;
 }
 
+function queuedFollowUpsCountSegment(
+  messages: readonly string[],
+): StatusBarSegment | undefined {
+  return messages.length > 0
+    ? { text: `queued ${messages.length}`, color: 'yellow' }
+    : undefined;
+}
+
 export function defaultShortcutModifierLabel(
   platform: NodeJS.Platform = process.platform,
 ): string {
@@ -219,6 +227,9 @@ export function buildStatusBarDisplay(
 
   const usage = formatUsage(input.usage, input.model);
   if (usage) left.push(usage);
+
+  const queued = queuedFollowUpsCountSegment(input.queuedFollowUpMessages);
+  if (queued) left.push(queued);
 
   if (input.activeSubagents > 0) {
     left.push({ text: `${input.activeSubagents} sub`, color: 'dim' });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -23,6 +23,35 @@ describe('CLI StatusBar display model', () => {
     ).toBe('queued 2: Keep the proof under one page.');
   });
 
+  it('keeps queued follow-up counts in the durable left status segments', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: ['Keep the proof under one page.'],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'running',
+      'api',
+      'queued 1',
+    ]);
+    expect(display.left.at(-1)).toMatchObject({ color: 'yellow' });
+    expect(display.right).toBe('queued: Keep the proof under one page.');
+  });
+
   it('keeps idle state compact and omits static agent/model names', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,
@@ -113,6 +142,7 @@ describe('CLI StatusBar display model', () => {
       'relay',
       'r2',
       '105k/1M (10%)',
+      'queued 2',
       '2 sub',
       '1 proc',
       '3 approvals',


### PR DESCRIPTION
## Summary
- add a durable left-side `queued N` status segment when follow-up messages are pending
- keep the existing right-side queued-message preview for wider terminals
- cover the status-bar model with queued-count regression tests

Closes #4636

## Dogfood
- Reproduced in a real 80-column TTY with `TERM=xterm-256color texra-local --cwd /tmp/texra-cli-queued-dogfood chat --agent chat --model deepseekT --approval-policy ask`: queued follow-up transcript entries appeared, but the live status line only showed running state/usage and no persistent queued indicator.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this patch)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI status bar change with no auth, data, or runtime behavior impact beyond visual feedback.
> 
> **Overview**
> The CLI chat status bar now shows a **yellow `queued N` segment on the left** whenever follow-up messages are waiting, so narrow terminals still surface queue depth even when the right side is cramped.
> 
> The existing **right-side queued preview** (`queued:` / `queued N:` with truncated text) is unchanged for wider layouts. Tests assert the new left segment, its color, and placement alongside other running-state indicators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f42596c2d88359c16db57e495eb8b58557c713f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->