### PR TITLE
fix: show live CLI subagent elapsed time

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -13,10 +13,12 @@ import {
   buildChildControlItems,
   childPickerKeyAction,
   clampPickerIndex,
+  liveChildExecutionElapsedKey,
   nextPickerIndex,
   type ChildControlItem,
   type ChildControlMode,
 } from '../state/childControls';
+import { useLiveNowMs } from '../state/useLiveNowMs';
 import { KeyHints } from '../ui/KeyHints';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
@@ -335,9 +337,11 @@ export function ChildControlPicker({
   slice,
   streams,
 }: ChildControlPickerProps): React.JSX.Element {
+  const liveElapsedKey = liveChildExecutionElapsedKey(slice);
+  const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
   const items = useMemo(
-    () => (slice ? buildChildControlItems(slice, mode, streams) : []),
-    [mode, slice, streams],
+    () => (slice ? buildChildControlItems(slice, mode, streams, nowMs) : []),
+    [mode, nowMs, slice, streams],
   );
   const [highlight, setHighlight] = useState(0);
   const [tailExecutionId, setTailExecutionId] = useState<string | undefined>(

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,6 +1,5 @@
 import process from 'node:process';
 
-import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
@@ -21,6 +20,7 @@ import {
   NO_BYPASS,
   type BypassState,
 } from '../state/cliState';
+import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
 type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
@@ -281,19 +281,9 @@ export function StatusBar(): React.JSX.Element {
   const caps = useSignal(terminalCapabilities);
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
 
-  // Re-render once a second while a turn is running so the elapsed segment
-  // ticks even when the model streams no tokens (the live region is otherwise
-  // only repainted by stream-log change events). The interval is armed only
-  // while `runStartedAt` is set, so an idle session adds no churn.
   const runStartedAt =
     slice?.status === STREAM_STATUS.RUNNING ? slice.runStartedAt : undefined;
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (runStartedAt === undefined) return;
-    setNow(Date.now());
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, [runStartedAt]);
+  const now = useLiveNowMs(runStartedAt !== undefined, runStartedAt);
 
   const display = buildStatusBarDisplay({
     status: slice?.status,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -8,24 +8,31 @@ import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
 
-import { processTailLines } from '../state/childControls';
+import {
+  childElapsed,
+  liveChildExecutionElapsedKey,
+  processTailLines,
+} from '../state/childControls';
 import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
+import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
   readonly index: number;
+  readonly nowMs: number;
   readonly tail?: ProcessOutputTail;
 }
 
 const TAIL_LINES = 4;
 
-function Row({ child, index, tail }: RowProps): React.JSX.Element {
+function Row({ child, index, nowMs, tail }: RowProps): React.JSX.Element {
   // The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
   // pulling the last `TAIL_LINES` non-blank lines is bounded work.
   const tailLines = processTailLines(tail).slice(-TAIL_LINES);
+  const elapsed = childElapsed(child, nowMs);
   return (
     <Box flexDirection="column">
       <Box flexDirection="row">
@@ -35,7 +42,7 @@ function Row({ child, index, tail }: RowProps): React.JSX.Element {
         </Text>
         <Text>{child.agentName || child.toolName || child.executionId}</Text>
         {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
-        {child.elapsed ? <Text dimColor>{` · ${child.elapsed}`}</Text> : null}
+        {elapsed ? <Text dimColor>{` · ${elapsed}`}</Text> : null}
       </Box>
       {tailLines.length > 0 ? (
         <Box flexDirection="column" marginLeft={4}>
@@ -63,6 +70,9 @@ export function SubagentList(
   const activeProcesses = slice?.activeProcesses ?? [];
   const processOutput = slice?.processOutput;
   const subagents = slice ? visibleSubagentRows(slice) : [];
+  const liveElapsedKey = liveChildExecutionElapsedKey(slice);
+  const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
+
   if (!slice) return null;
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
@@ -81,7 +91,12 @@ export function SubagentList(
             Subagents
           </Text>
           {subagents.map((child, i) => (
-            <Row key={child.executionId} child={child} index={i} />
+            <Row
+              key={child.executionId}
+              child={child}
+              index={i}
+              nowMs={nowMs}
+            />
           ))}
         </Box>
       ) : null}
@@ -95,6 +110,7 @@ export function SubagentList(
               key={child.executionId}
               child={child}
               index={subagents.length + i}
+              nowMs={nowMs}
               tail={processOutput?.get(child.executionId)}
             />
           ))}

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -1,7 +1,13 @@
 // Pure state helpers for App-level child execution shortcuts and pickers.
 
 // Local imports - shared schemas
-import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
+import {
+  LIVE_ELAPSED_STREAM_STATUSES,
+  STREAM_STATUS,
+  type ActiveChildInfo,
+  type StreamTabId,
+} from '@shared/schemas';
+import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isPlainReturnInput } from '../input/inputKeys';
@@ -46,6 +52,26 @@ function compactParts(parts: readonly (string | null | undefined)[]): string {
   return parts.filter((part): part is string => Boolean(part)).join(' · ');
 }
 
+function hasLiveChildElapsed(
+  child: Pick<ActiveChildInfo, 'startedAt' | 'status'>,
+): boolean {
+  return (
+    child.startedAt !== undefined &&
+    LIVE_ELAPSED_STREAM_STATUSES.has(child.status ?? STREAM_STATUS.RUNNING)
+  );
+}
+
+export function childElapsed(
+  child: Pick<ActiveChildInfo, 'elapsed' | 'startedAt' | 'status'>,
+  nowMs = Date.now(),
+): string | null | undefined {
+  const startedAt = child.startedAt;
+  if (startedAt === undefined || !hasLiveChildElapsed(child)) {
+    return child.elapsed;
+  }
+  return formatDuration(Math.max(0, nowMs - startedAt));
+}
+
 function childLabel(child: {
   readonly agentName?: string;
   readonly toolName?: string;
@@ -84,18 +110,20 @@ function buildSubagentItem(
     StreamTabId,
     Pick<StreamSlice, 'description' | 'entries'>
   >,
+  nowMs?: number,
 ): ChildControlItem {
   const label = childLabel(child);
   const command = streamDescription(child, streamsById) ?? label;
+  const elapsed = childElapsed(child, nowMs);
   return {
     executionId: child.executionId,
     childStreamId: child.childStreamId,
     kind: 'subagent',
     label,
     command,
-    description: compactParts([child.status, child.elapsed ?? undefined]),
+    description: compactParts([child.status, elapsed ?? undefined]),
     status: child.status,
-    elapsed: child.elapsed,
+    elapsed,
     tailLines: streamTranscriptLines(child, streamsById),
   };
 }
@@ -103,23 +131,21 @@ function buildSubagentItem(
 function buildProcessItem(
   child: ActiveChildInfo,
   tail: ProcessOutputTail | undefined,
+  nowMs?: number,
 ): ChildControlItem {
   const tailLines = processTailLines(tail);
   const lastLine = tailLines.at(-1);
   const label = childLabel(child);
+  const elapsed = childElapsed(child, nowMs);
   return {
     executionId: child.executionId,
     childStreamId: child.childStreamId,
     kind: 'process',
     label,
     command: label,
-    description: compactParts([
-      child.status,
-      child.elapsed ?? undefined,
-      lastLine,
-    ]),
+    description: compactParts([child.status, elapsed ?? undefined, lastLine]),
     status: child.status,
-    elapsed: child.elapsed,
+    elapsed,
     tailLines,
   };
 }
@@ -144,21 +170,46 @@ export function buildChildControlItems(
     StreamTabId,
     Pick<StreamSlice, 'description' | 'entries'>
   > = new Map(),
+  nowMs?: number,
 ): readonly ChildControlItem[] {
   if (mode === 'subagents') {
     return visibleSubagentRows(slice).map((child) =>
-      buildSubagentItem(child, streamsById),
+      buildSubagentItem(child, streamsById, nowMs),
     );
   }
 
   return [
     ...slice.activeSubagents.map((child) =>
-      buildSubagentItem(child, streamsById),
+      buildSubagentItem(child, streamsById, nowMs),
     ),
     ...slice.activeProcesses.map((child) =>
-      buildProcessItem(child, slice.processOutput.get(child.executionId)),
+      buildProcessItem(
+        child,
+        slice.processOutput.get(child.executionId),
+        nowMs,
+      ),
     ),
   ];
+}
+
+export function liveChildExecutionElapsedKey(
+  slice: Pick<StreamSlice, 'activeProcesses' | 'activeSubagents'> | undefined,
+): string | undefined {
+  if (slice === undefined) return undefined;
+
+  const liveKeys: string[] = [];
+  for (const child of slice.activeSubagents) {
+    if (hasLiveChildElapsed(child)) {
+      liveKeys.push(`${child.executionId}:${child.startedAt}`);
+    }
+  }
+  for (const child of slice.activeProcesses) {
+    if (hasLiveChildElapsed(child)) {
+      liveKeys.push(`${child.executionId}:${child.startedAt}`);
+    }
+  }
+  liveKeys.sort();
+  return liveKeys.length > 0 ? liveKeys.join(',') : undefined;
 }
 
 export function hasChildExecutionRows(

--- a/packages/cli/src/chat/tui/state/useLiveNowMs.ts
+++ b/packages/cli/src/chat/tui/state/useLiveNowMs.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useLiveNowMs(shouldTick: boolean, resetKey?: unknown): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!shouldTick) return;
+    setNowMs(Date.now());
+    const timer = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [resetKey, shouldTick]);
+
+  return nowMs;
+}

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -9,6 +9,7 @@ import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
+  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
@@ -26,13 +27,6 @@ export const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
   STREAM_STATUS.INITIALIZING,
   STREAM_STATUS.RESUMING,
   STREAM_STATUS.WAITING,
-]);
-
-/** Statuses where the execution is actively processing (show elapsed time). */
-const PROCESSING_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.RESUMING,
 ]);
 
 export interface ExecutionHandle {
@@ -89,7 +83,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   getStatus(): ExecutionStatusInfo {
     const status =
       StreamStatusService.get(this.childStreamId) ?? STREAM_STATUS.RUNNING;
-    if (!PROCESSING_STATUSES.has(status)) {
+    if (!LIVE_ELAPSED_STREAM_STATUSES.has(status)) {
       return { status, elapsed: null };
     }
     return {
@@ -208,6 +202,7 @@ export function collectChildSummary(
       executionId: handle.executionId,
       agentName: handle.agentName,
       status,
+      startedAt: handle.startedAt,
       elapsed: elapsed ?? null,
     };
     if (handle instanceof AgentExecutionHandle) {

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -24,6 +24,13 @@ export const StreamStatusSchema = z.enum([
 ]);
 export type StreamStatus = z.infer<typeof StreamStatusSchema>;
 
+/** Statuses whose elapsed display should keep advancing while active. */
+export const LIVE_ELAPSED_STREAM_STATUSES: ReadonlySet<string> = new Set([
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.RESUMING,
+]);
+
 /** Subset of StreamStatus used for task groups */
 export const TaskGroupStatusSchema = z.enum([
   STREAM_STATUS.RUNNING,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -23,6 +23,8 @@ export const ActiveChildInfoSchema = z.object({
   childStreamId: z.string().optional(),
   /** Current execution status (e.g. "running", "waiting"). Defaults to "running". */
   status: z.string().optional(),
+  /** Epoch milliseconds when the child execution began. */
+  startedAt: z.int().positive().optional(),
   /** Formatted elapsed time (e.g. "1m 23s"). */
   elapsed: z.string().nullable().optional(),
   /** Tool name that spawned this process (e.g. "bash", "codex"). Absent for subagents. */

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -8,8 +8,10 @@ import {
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
+  childElapsed,
   childPickerKeyAction,
   hasChildExecutionRows,
+  liveChildExecutionElapsedKey,
   nextPickerIndex,
   numericFocusTarget,
 } from '@cli/chat/tui/state/childControls';
@@ -134,6 +136,90 @@ describe('CLI child execution controls', () => {
         tailLines: ['first', 'second', 'warning'],
       },
     ]);
+  });
+
+  it('derives live elapsed text for running child executions', () => {
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'running',
+          startedAt: 1_000,
+          elapsed: '1s',
+        },
+      ],
+      activeProcesses: [
+        {
+          executionId: 'proc-1',
+          agentName: 'latexmk',
+          status: 'waiting',
+          startedAt: 1_000,
+          elapsed: '1s',
+        },
+      ],
+    });
+
+    expect(
+      buildChildControlItems(state, 'subagents', new Map(), 62_000),
+    ).toMatchObject([
+      {
+        executionId: 'agent-1',
+        description: 'running · 1min, 1sec',
+        elapsed: '1min, 1sec',
+      },
+    ]);
+    expect(childElapsed(state.activeProcesses[0], 62_000)).toBe('1s');
+  });
+
+  it('keys live child elapsed timers by active execution identity', () => {
+    expect(liveChildExecutionElapsedKey(undefined)).toBeUndefined();
+
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-2',
+          agentName: 'critic',
+          status: 'running',
+          startedAt: 2_000,
+        },
+        {
+          executionId: 'agent-1',
+          agentName: 'reviewer',
+          status: 'initializing',
+          startedAt: 1_000,
+        },
+      ],
+      activeProcesses: [
+        {
+          executionId: 'proc-1',
+          agentName: 'latexmk',
+          status: 'waiting',
+          startedAt: 500,
+          elapsed: '1s',
+        },
+      ],
+    });
+
+    expect(liveChildExecutionElapsedKey(state)).toBe(
+      'agent-1:1000,agent-2:2000',
+    );
+    expect(
+      liveChildExecutionElapsedKey(
+        slice({
+          activeSubagents: [
+            {
+              executionId: 'agent-1',
+              agentName: 'critic',
+              status: 'completed',
+              startedAt: 1_000,
+              elapsed: '1s',
+            },
+          ],
+        }),
+      ),
+    ).toBeUndefined();
   });
 
   it('uses stream descriptions as visible task commands', () => {


### PR DESCRIPTION
## Summary
- pass child execution start timestamps into CLI stream state
- derive live elapsed text for running subagents/processes in the side panel and picker
- keep stopped/waiting rows on their persisted elapsed text

Closes #4638

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes; existing import-order warnings remain in unrelated files)
- `npm run texra-local:build`
- TTY dogfood: `texra-local --cwd /tmp/texra-subelapsed-final.sHMVwe --approval-policy ask orchestrate`, Team Mathematician, spawned `review`, opened parent subagent panel with `Tab` then `Option-s`; observed row advance `review — running · 4sec` -> `5sec` -> `6sec` -> `7sec` -> `8sec` -> `9sec` while the child was active.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI and optional schema fields; no auth, persistence, or execution-control behavior changes beyond elapsed labeling.
> 
> **Overview**
> Child subagent and process rows in the CLI now show **live elapsed time** that ticks every second while executions are in `running`, `initializing`, or `resuming`, instead of freezing on whatever string the backend last sent.
> 
> The runtime adds optional `startedAt` on `ActiveChildInfo` and centralizes which statuses count as “live” via `LIVE_ELAPSED_STREAM_STATUSES`. The TUI derives display duration with `childElapsed` and a shared `useLiveNowMs` hook (also replacing the status bar’s ad-hoc interval). **Waiting**, **stopped**, and other non-live statuses still use the persisted `elapsed` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ac7c43fc074baa594d1b0451366a6a3388ab07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->