### PR TITLE
fix: avoid queued notice for idle CLI follow-ups

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -163,6 +163,16 @@ export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
     : undefined;
 }
 
+export function chatTuiShouldAnnounceQueuedFollowUp(
+  targetStreamId: StreamTabId | undefined,
+): boolean {
+  if (!targetStreamId) return true;
+  const status =
+    cliState.streams.get().get(targetStreamId)?.status ??
+    StreamStatusService.get(targetStreamId);
+  return status !== STREAM_STATUS.WAITING;
+}
+
 interface SlashCommandContext {
   readonly session: TuiSession;
   readonly initialAgent: string;
@@ -882,10 +892,13 @@ export async function runChat(
     // user submits before `onStreamResolved` populates `session.streamId`.
     // p-queue serializes work but doesn't have an "await predicate" primitive,
     // so the task itself waits for the stream id via a tiny poll loop.
-    appendLocalAssistantTranscript(
-      formatQueuedFollowUpNotice(line),
-      childFollowUpTarget ?? session.streamId,
-    );
+    const initialFollowUpTarget = childFollowUpTarget ?? session.streamId;
+    if (chatTuiShouldAnnounceQueuedFollowUp(initialFollowUpTarget)) {
+      appendLocalAssistantTranscript(
+        formatQueuedFollowUpNotice(line),
+        initialFollowUpTarget,
+      );
+    }
     void followUpQueue.add(async () => {
       let followUpTarget = childFollowUpTarget;
       while (

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -47,6 +47,7 @@ import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanStartRootRun,
   chatTuiActiveChildFollowUpTarget,
+  chatTuiShouldAnnounceQueuedFollowUp,
   clearTuiSessionRunState,
 } from '@cli/chat/tui/runChatTui';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -322,6 +323,20 @@ describe('CLI TUI row allocation', () => {
 
     cliState.activeStreamId.set(child1);
     expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+  });
+
+  it('announces queued follow-ups only when the target is not waiting', () => {
+    expect(chatTuiShouldAnnounceQueuedFollowUp(undefined)).toBe(true);
+
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    expect(chatTuiShouldAnnounceQueuedFollowUp(root)).toBe(false);
+
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    expect(chatTuiShouldAnnounceQueuedFollowUp(root)).toBe(true);
+
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    setParentStream(child1, root);
+    expect(chatTuiShouldAnnounceQueuedFollowUp(child1)).toBe(false);
   });
 
   it('clears stale resume ids when clearing chat session run state', () => {


### PR DESCRIPTION
## Summary

- suppress the local `Queued follow-up` transcript notice when the target stream is already in the waiting/idle state
- keep the notice for unresolved or actively running target streams, where the message is genuinely queued
- add focused CLI TUI state coverage for root and child follow-up targets

Closes #4640.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI transcript UX change with unit tests; follow-up delivery behavior is unchanged aside from when the notice is shown.
> 
> **Overview**
> The CLI chat TUI no longer shows the local **"Queued follow-up"** assistant notice when the follow-up target stream is already **waiting** (idle). Follow-ups are still enqueued and sent via `followUpQueue`; only the misleading transcript line is skipped in that case.
> 
> A new helper **`chatTuiShouldAnnounceQueuedFollowUp`** decides whether to announce: it still shows the notice when the target is unresolved or actively running, and when there is no target stream id yet. Tests cover root and child follow-up targets across `WAITING` vs `RUNNING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3997d5f061bab778555ab73a558fbbc530fc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->