### PR TITLE
fix: show parent subagents from child streams

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -27,6 +27,7 @@ import {
 import {
   hasChildExecutionRows,
   numericFocusTarget,
+  resolveChildControlStreamTarget,
   type ChildControlMode,
 } from './state/childControls';
 import { canShowSubagentControls, cliState } from './state/cliState';
@@ -193,6 +194,7 @@ export function App(props: AppProps): React.JSX.Element {
   const pending = useSignal(currentApproval);
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
+  const parentStream = useSignal(cliState.parentStream);
   const sessionMeta = useSignal(cliState.sessionMeta);
   const activeForm = useSignal(cliState.activeForm);
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
@@ -233,9 +235,15 @@ export function App(props: AppProps): React.JSX.Element {
   const inputDisabled = props.inputDisabled === true || foregroundOpen;
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const subagentControlTarget = resolveChildControlStreamTarget({
+    activeStreamId,
+    mode: 'subagents',
+    parentStream,
+    streams,
+  });
   const subagentControlsAvailable = canShowSubagentControls(
     sessionMeta,
-    activeSlice,
+    subagentControlTarget.slice,
   );
   const hasSubagentPanel =
     !foregroundOpen && hasChildExecutionRows(activeSlice);
@@ -278,15 +286,21 @@ export function App(props: AppProps): React.JSX.Element {
       );
     }
     if (childControlMode) {
+      const target = resolveChildControlStreamTarget({
+        activeStreamId,
+        mode: childControlMode,
+        parentStream,
+        streams,
+      });
       return (
         <ChildControlPicker
-          activeStreamId={activeStreamId}
+          activeStreamId={target.streamId}
           availableRows={foregroundRows}
           mode={childControlMode}
           onClose={() => setChildControlMode(undefined)}
           onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
           onKillExecution={props.onKillExecution}
-          slice={activeSlice}
+          slice={target.slice}
           streams={streams}
         />
       );

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -29,6 +29,11 @@ export interface ChildControlItem {
   readonly tailLines: readonly string[];
 }
 
+export interface ChildControlStreamTarget {
+  readonly slice: StreamSlice | undefined;
+  readonly streamId: StreamTabId | undefined;
+}
+
 export interface PickerKeyInput {
   readonly input: string;
   readonly upArrow?: boolean;
@@ -190,6 +195,44 @@ export function buildChildControlItems(
       ),
     ),
   ];
+}
+
+function hasVisibleSubagents(
+  slice: Pick<StreamSlice, 'activeSubagents' | 'childStreams'> | undefined,
+): boolean {
+  return slice !== undefined && visibleSubagentRows(slice).length > 0;
+}
+
+export function resolveChildControlStreamTarget({
+  activeStreamId,
+  mode,
+  parentStream,
+  streams,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly mode: ChildControlMode;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): ChildControlStreamTarget {
+  const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  if (
+    mode !== 'subagents' ||
+    !activeStreamId ||
+    hasVisibleSubagents(activeSlice)
+  ) {
+    return { streamId: activeStreamId, slice: activeSlice };
+  }
+
+  const parentStreamId = parentStream.get(activeStreamId);
+  const parentSlice = parentStreamId ? streams.get(parentStreamId) : undefined;
+  if (hasVisibleSubagents(parentSlice)) {
+    return {
+      streamId: parentStreamId,
+      slice: parentSlice,
+    };
+  }
+
+  return { streamId: activeStreamId, slice: activeSlice };
 }
 
 export function liveChildExecutionElapsedKey(

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -14,6 +14,7 @@ import {
   liveChildExecutionElapsedKey,
   nextPickerIndex,
   numericFocusTarget,
+  resolveChildControlStreamTarget,
 } from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
@@ -358,6 +359,115 @@ describe('CLI child execution controls', () => {
     });
 
     expect(hasChildExecutionRows(state)).toBe(true);
+  });
+
+  it('falls back to the parent subagent list when the focused child is a leaf', () => {
+    const parent = slice({
+      streamId: 'main',
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const child = slice({ streamId: 'review-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'subagents',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([
+        ['main', parent],
+        ['review-stream', child],
+      ]),
+    });
+
+    expect(target.streamId).toBe('main');
+    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        childStreamId: 'review-stream',
+        kind: 'subagent',
+        label: 'review',
+      },
+    ]);
+  });
+
+  it('keeps subagent controls on the focused child when it has descendants', () => {
+    const child = slice({
+      streamId: 'review-stream',
+      activeSubagents: [
+        {
+          executionId: 'agent-2',
+          agentName: 'detail-review',
+          childStreamId: 'detail-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'subagents',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([['review-stream', child]]),
+    });
+
+    expect(target.streamId).toBe('review-stream');
+    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+      {
+        executionId: 'agent-2',
+        childStreamId: 'detail-stream',
+        kind: 'subagent',
+        label: 'detail-review',
+      },
+    ]);
+  });
+
+  it('keeps a leaf child selected when the parent has no visible subagents', () => {
+    const child = slice({ streamId: 'review-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'subagents',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([
+        ['main', slice({ streamId: 'main' })],
+        ['review-stream', child],
+      ]),
+    });
+
+    expect(target.streamId).toBe('review-stream');
+    expect(target.slice).toBe(child);
+  });
+
+  it('keeps task controls scoped to the focused child stream', () => {
+    const child = slice({ streamId: 'review-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'tasks',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([
+        [
+          'main',
+          slice({
+            streamId: 'main',
+            activeSubagents: [
+              {
+                executionId: 'agent-1',
+                agentName: 'review',
+                childStreamId: 'review-stream',
+                status: 'running',
+              },
+            ],
+          }),
+        ],
+        ['review-stream', child],
+      ]),
+    });
+
+    expect(target.streamId).toBe('review-stream');
+    expect(target.slice).toBe(child);
   });
 
   it('keeps picker key handling independent of Ink rendering', () => {


### PR DESCRIPTION
## Summary

- route `Option-s` to the parent subagent list when the focused stream is a leaf child
- keep nested subagent controls scoped to the focused child when it has descendants
- cover the parent fallback and nested-child behavior in CLI state tests

Closes #4642.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run texra-local:build`
- Rebuilt `texra-local --approval-policy ask orchestrate` TTY smoke: after approving a `review` subagent and focusing `[review]`, `Option-s` showed the parent stream with a selectable `review` row instead of `No active subagents`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI stream-targeting logic with unit tests; no auth, persistence, or execution-path changes.
> 
> **Overview**
> When you focus a **leaf** subagent stream (no subagents of its own), **Option-s** and the subagent control picker now resolve against the **parent** stream if that parent still has visible subagents, so you can pick siblings (e.g. `review`) instead of seeing an empty list.
> 
> If the focused stream **does** have nested subagents, controls stay on that stream. **Task** mode (`Option-p`) is unchanged and always uses the focused stream. Availability for opening subagent controls (`canShowSubagentControls`) uses the same resolved target slice.
> 
> New pure helper `resolveChildControlStreamTarget` plus CLI tests for parent fallback, nested focus, and task scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76561d0f628f73bbc4611dd41645fd9a94214bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->