### PR TITLE
fix: show queued follow-up status promptly

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,8 +1,9 @@
 import process from 'node:process';
 
-import { Box, Text } from 'ink';
+import { Box, Text, useWindowSize } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
+import stringWidth from 'string-width';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
@@ -10,7 +11,7 @@ import {
   type ConversationProgress,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { truncateSummary } from '@utils/text/stringUtils';
+import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { approvalQueueDepth } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
@@ -58,6 +59,9 @@ export interface StatusBarDisplayInput {
   /** Advertise Shift+Enter for newline when the Kitty keyboard protocol is
    *  active; otherwise the universal Ctrl-J is the only reliable binding. */
   readonly shiftEnterNewline?: boolean;
+  /** Terminal width in columns. Used to keep right-side previews from
+   *  colliding with durable left-side status segments. */
+  readonly width?: number;
 }
 
 export interface StatusBarDisplay {
@@ -131,18 +135,46 @@ function roundSegment(
 }
 
 const QUEUED_FOLLOW_UP_PREVIEW_LENGTH = 48;
+const STATUS_BAR_HORIZONTAL_PADDING = 2;
+const STATUS_BAR_MIN_RIGHT_PREVIEW = 12;
+// Preserve a readable separator between the left status group and right preview.
+const STATUS_BAR_RIGHT_PREVIEW_GAP = 2;
+
+function truncateSummaryToColumns(text: string, maxColumns: number): string {
+  const summary = collapseWhitespace(text);
+  if (stringWidth(summary) <= maxColumns) return summary;
+
+  const ellipsis = '…';
+  const contentColumns = Math.max(0, maxColumns - stringWidth(ellipsis));
+  let width = 0;
+  let truncated = '';
+  for (const char of summary) {
+    const charWidth = stringWidth(char);
+    if (width + charWidth > contentColumns) break;
+    truncated += char;
+    width += charWidth;
+  }
+  return `${truncated}${ellipsis}`;
+}
 
 export function queuedFollowUpsSummary(
   messages: readonly string[],
+  maxColumns?: number,
 ): string | undefined {
   if (messages.length === 0) return undefined;
-  const preview = truncateSummary(
-    messages[0] ?? '',
-    QUEUED_FOLLOW_UP_PREVIEW_LENGTH,
-  );
-  return messages.length === 1
-    ? `queued: ${preview}`
-    : `queued ${messages.length}: ${preview}`;
+  const prefix =
+    messages.length === 1 ? 'queued: ' : `queued ${messages.length}: `;
+  const prefixWidth = stringWidth(prefix);
+  const previewLength =
+    maxColumns === undefined
+      ? QUEUED_FOLLOW_UP_PREVIEW_LENGTH
+      : Math.min(
+          QUEUED_FOLLOW_UP_PREVIEW_LENGTH,
+          Math.max(0, maxColumns - prefixWidth),
+        );
+  if (previewLength < STATUS_BAR_MIN_RIGHT_PREVIEW) return undefined;
+  const preview = truncateSummaryToColumns(messages[0] ?? '', previewLength);
+  return `${prefix}${preview}`;
 }
 
 function queuedFollowUpsCountSegment(
@@ -151,6 +183,32 @@ function queuedFollowUpsCountSegment(
   return messages.length > 0
     ? { text: `queued ${messages.length}`, color: 'yellow' }
     : undefined;
+}
+
+function statusBarSegmentWidth(segment: StatusBarSegment): number {
+  return stringWidth(segment.text) + (segment.badge ? 2 : 0);
+}
+
+function statusBarSegmentsWidth(segments: readonly StatusBarSegment[]): number {
+  return segments.reduce(
+    (total, segment, index) =>
+      total + statusBarSegmentWidth(segment) + (index === 0 ? 0 : 1),
+    0,
+  );
+}
+
+function rightStatusBudget(
+  segments: readonly StatusBarSegment[],
+  width: number | undefined,
+): number | undefined {
+  if (width === undefined) return undefined;
+  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
+  return Math.max(
+    0,
+    innerWidth -
+      statusBarSegmentsWidth(segments) -
+      STATUS_BAR_RIGHT_PREVIEW_GAP,
+  );
 }
 
 export function defaultShortcutModifierLabel(
@@ -254,7 +312,10 @@ export function buildStatusBarDisplay(
 
   return {
     left,
-    right: queuedFollowUpsSummary(input.queuedFollowUpMessages),
+    right: queuedFollowUpsSummary(
+      input.queuedFollowUpMessages,
+      rightStatusBudget(left, input.width),
+    ),
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
@@ -279,6 +340,7 @@ export function StatusBar(): React.JSX.Element {
   const pendingExitResumeId = useSignal(cliState.pendingExitResumeId);
   const approvals = useSignal(approvalQueueDepth);
   const caps = useSignal(terminalCapabilities);
+  const { columns } = useWindowSize();
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
 
   const runStartedAt =
@@ -302,6 +364,7 @@ export function StatusBar(): React.JSX.Element {
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
     shiftEnterNewline: caps.kittyKeyboard,
+    width: columns,
   });
 
   return (

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -35,6 +35,25 @@ function sameQueuedFollowUps(
   );
 }
 
+function refreshQueuedFollowUps(
+  streamId: ProgressEventPayloads['updateQueuedFollowUps']['streamId'],
+): void {
+  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  patchStream(streamId, (s) => {
+    if (
+      s.queuedFollowUps === messages.length &&
+      sameQueuedFollowUps(s.queuedFollowUpMessages, messages)
+    ) {
+      return s;
+    }
+    return {
+      ...s,
+      queuedFollowUps: messages.length,
+      queuedFollowUpMessages: messages,
+    };
+  });
+}
+
 /** Cap on per-process tail length held in the signal map (UTF-16 code
  *  units, not bytes — markdown-it / ink work in JS strings). Beyond this
  *  we truncate at the head via the shared `appendTail` helper so the live
@@ -177,23 +196,17 @@ function applyToState<K extends ProgressEvent>(
       return;
     }
     case 'updateQueuedFollowUps': {
-      // The event itself has no delta payload — re-read the queue directly so
-      // the StatusBar pill stays accurate after both enqueue and drain.
+      // The event itself has no delta payload, so re-read the queue directly.
       const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
-      const messages = ToolUseFollowUpQueue.getAll(p.streamId);
-      patchStream(p.streamId, (s) => {
-        if (
-          s.queuedFollowUps === messages.length &&
-          sameQueuedFollowUps(s.queuedFollowUpMessages, messages)
-        ) {
-          return s;
-        }
-        return {
-          ...s,
-          queuedFollowUps: messages.length,
-          queuedFollowUpMessages: messages,
-        };
-      });
+      refreshQueuedFollowUps(p.streamId);
+      return;
+    }
+    case 'followUpSent': {
+      // Active-session follow-ups enter the same queue before the wait node
+      // consumes them; refresh immediately so the status bar shows the pending
+      // message instead of only seeing the later drain event.
+      const p = payload as ProgressEventPayloads['followUpSent'];
+      refreshQueuedFollowUps(p.streamId);
       return;
     }
     default:

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -23,6 +23,21 @@ describe('CLI StatusBar display model', () => {
     ).toBe('queued 2: Keep the proof under one page.');
   });
 
+  it('hides queued follow-up previews when the right side has no safe width', () => {
+    expect(queuedFollowUpsSummary(['Keep the proof under one page.'], 20)).toBe(
+      'queued: Keep the pr…',
+    );
+    expect(
+      queuedFollowUpsSummary(['Keep the proof under one page.'], 19),
+    ).toBeUndefined();
+  });
+
+  it('truncates queued follow-up previews by display columns', () => {
+    expect(queuedFollowUpsSummary(['請補充一個單調有界證明。'], 20)).toBe(
+      'queued: 請補充一個…',
+    );
+  });
+
   it('keeps queued follow-up counts in the durable left status segments', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,
@@ -250,6 +265,29 @@ describe('CLI StatusBar display model', () => {
       badge: true,
       badgeColor: 'yellow',
     });
+  });
+
+  it('budgets queued follow-up previews with rendered badge padding', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: { superYolo: true, toolEdit: true },
+      queuedFollowUpMessages: ['Keep the proof under one page.'],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      width: 60,
+    });
+
+    expect(display.right).toBeUndefined();
   });
 
   it('shows the resume command while exit confirmation is armed', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -8,6 +8,7 @@ import {
   StreamLogStore,
 } from '@transcript';
 
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   cliState,
   patchStream,
@@ -913,6 +914,32 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 
     expect(cliState.activeStreamId.get()).toBe(root);
     expect(cliState.streams.get().has(child1)).toBe(true);
+  });
+
+  it('refreshes queued follow-up display when an active follow-up is sent', () => {
+    const wrapped = wrapRuntimeHost(makeHost());
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    const queue = ToolUseFollowUpQueue.acquire(root);
+
+    try {
+      queue.enqueue('Keep the proof under one page.');
+      wrapped.emit('followUpSent', { streamId: root });
+
+      let slice = cliState.streams.get().get(root);
+      expect(slice?.queuedFollowUps).toBe(1);
+      expect(slice?.queuedFollowUpMessages).toEqual([
+        'Keep the proof under one page.',
+      ]);
+
+      queue.drain();
+      wrapped.emit('updateQueuedFollowUps', { streamId: root });
+
+      slice = cliState.streams.get().get(root);
+      expect(slice?.queuedFollowUps).toBe(0);
+      expect(slice?.queuedFollowUpMessages).toEqual([]);
+    } finally {
+      ToolUseFollowUpQueue.release(root);
+    }
   });
 
   it('persists a bounded completed-process transcript before pruning processOutput', () => {


### PR DESCRIPTION
## Summary

- refresh CLI queued-follow-up state when active sessions emit `followUpSent`
- keep queued follow-up previews width-budgeted so they do not collide with left status segments
- cover the active follow-up enqueue/drain path and narrow right-preview budget in CLI tests

Closes #4644.

## Validation

- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run texra-local:build`
- Rebuilt `texra-local --approval-policy ask orchestrate` TTY smoke: while a proof response was streaming, submitting `Follow-up: also avoid naming the Euler-Mascheroni constant.` showed `queued 1` plus a separated truncated preview in the status bar until the follow-up was consumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI status-bar and progress-event wiring only; no auth, persistence, or agent execution logic changes.
> 
> **Overview**
> **Queued follow-ups** now show in the CLI status bar as soon as a message is sent during an active run, not only when the queue is later drained.
> 
> The runtime host handles **`followUpSent`** by reusing the same queue refresh path as **`updateQueuedFollowUps`**. The status bar **sizes the right-hand preview** from terminal width and left segments (including badge padding), uses **display-column** truncation via `string-width`, and **drops** the preview when there isn’t enough room—while the left **`queued N`** segment stays. Tests cover enqueue/drain, narrow terminals, and wide characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bba923a7d9b8110d3c9f7541d0b0b4e66b6c2b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->