### PR TITLE
fix: clarify CLI diff overflow row labels

### DIFF
--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -199,22 +199,10 @@ function overflowMarkerText(
 ): string {
   const candidates =
     kind === 'hidden'
-      ? [
-          `... ${count} diff rows hidden`,
-          `... ${count} rows hidden`,
-          `... ${count} hidden`,
-        ]
+      ? [`... ${count} rows hidden`, `... ${count} hidden`]
       : kind === 'previous'
-        ? [
-            `... ${count} previous diff rows`,
-            `... ${count} previous rows`,
-            `... ${count} prev rows`,
-          ]
-        : [
-            `... ${count} more diff rows`,
-            `... ${count} more rows`,
-            `... +${count} rows`,
-          ];
+        ? [`... ${count} previous rows`, `... ${count} prev rows`]
+        : [`... ${count} more rows`, `... +${count} rows`];
   if (width === undefined) return candidates[0] ?? '';
 
   const markerWidth = Math.max(MIN_DIFF_WIDTH, width);

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -24,7 +24,7 @@ describe('CLI diff display', () => {
     expect(lines).toHaveLength(4);
     expect(lines.at(-1)).toMatchObject({
       kind: 'overflow',
-      text: expect.stringContaining('more diff rows'),
+      text: expect.stringContaining('more rows'),
     });
   });
 
@@ -40,11 +40,11 @@ describe('CLI diff display', () => {
     expect(lines).toHaveLength(4);
     expect(lines[0]).toMatchObject({
       kind: 'overflow',
-      text: '... 2 previous diff rows',
+      text: '... 2 previous rows',
     });
     expect(lines.at(-1)).toMatchObject({
       kind: 'overflow',
-      text: expect.stringContaining('more diff rows'),
+      text: expect.stringContaining('more rows'),
     });
   });
 
@@ -70,7 +70,7 @@ describe('CLI diff display', () => {
     expect(lines[0]?.kind).not.toBe('overflow');
     expect(lines[1]).toMatchObject({
       kind: 'overflow',
-      text: expect.stringContaining('more diff rows'),
+      text: expect.stringContaining('more rows'),
     });
   });
 
@@ -101,8 +101,9 @@ describe('CLI diff display', () => {
     expect(lines).toHaveLength(4);
     expect(lines.at(-1)).toMatchObject({
       kind: 'overflow',
-      text: expect.stringContaining('more diff rows'),
+      text: expect.stringContaining('more rows'),
     });
+    expect(lines.at(-1)?.text).not.toContain('diff rows');
   });
 
   it('keeps wrapped overflow markers to one visual row at narrow widths', () => {


### PR DESCRIPTION
## Summary
- Rename approval diff overflow markers from "diff rows" to "rows" so wrapped display-row counts do not read like logical diff-line counts.
- Update CLI diff view tests to assert the human-facing marker copy.

Closes #4646.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/DiffView.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `git diff --check`
- `npm run texra-local:build`
- Real TTY smoke: `texra-local --approval-policy ask orchestrate` in `/tmp/texra-diff-row-labels-kOymkR`; approval modal showed `... 36 more rows`, then after scrolling `... 4 previous rows` and `... 33 more rows`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to TUI overflow strings and matching tests; no logic or security impact.
> 
> **Overview**
> Updates CLI approval diff **overflow markers** so counts refer to **display rows** instead of **"diff rows"**, avoiding confusion when long lines wrap into multiple visual rows.
> 
> In `overflowMarkerText` (`DiffView.tsx`), candidate strings for hidden, previous, and "more" scroll markers drop the **"diff"** wording (e.g. `... N more rows` instead of `... N more diff rows`). **Vitest** expectations in `DiffView.vitest.mts` match the new copy, including an assertion that wrapped overflow text does not contain `diff rows`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431042849815ee012688023481e3ed7b5515d757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->