### PR TITLE
fix: keep CLI edit approval footer visible

### DIFF
--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -11,11 +11,13 @@ import {
   maxDiffScrollOffset,
   statsFromHunks,
 } from '../render/DiffView';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
-const EDIT_APPROVAL_FIXED_ROWS = 8;
+const EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE = 8;
+const CONFIRM_CARD_HORIZONTAL_DECORATION = 4;
 const MIN_EDIT_DIFF_WIDTH = 20;
 
 export interface EditApprovalProps {
@@ -24,14 +26,38 @@ export interface EditApprovalProps {
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
+export function editApprovalDiffRowsBudget({
+  availableRows,
+  columns,
+  title,
+}: {
+  readonly availableRows?: number;
+  readonly columns: number;
+  readonly title: string;
+}): number {
+  if (availableRows === undefined) return 30;
+
+  const titleWidth = Math.max(
+    MIN_EDIT_DIFF_WIDTH,
+    columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
+  );
+  const titleRows = wrapAnsiToWidth(title, titleWidth).split('\n').length;
+  return Math.max(
+    1,
+    availableRows - EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE - titleRows,
+  );
+}
+
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const [scrollOffset, setScrollOffset] = useState(0);
+  const title = `Apply edit to ${props.request.path}?`;
   const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
-  const maxDiffLines =
-    props.availableRows === undefined
-      ? 30
-      : Math.max(1, props.availableRows - EDIT_APPROVAL_FIXED_ROWS);
+  const maxDiffLines = editApprovalDiffRowsBudget({
+    availableRows: props.availableRows,
+    columns,
+    title,
+  });
 
   // Single diff pass shared between the summary line and the inline view.
   const hunks = useMemo(
@@ -83,7 +109,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
     <ConfirmCard
       borderStyle="double"
       color="cyan"
-      title={`Apply edit to ${props.request.path}?`}
+      title={title}
       alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
       onDecide={props.onDecide}
     >

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { editApprovalDiffRowsBudget } from '@cli/chat/tui/modals/EditApproval';
+
+describe('CLI edit approval layout', () => {
+  it('reserves footer rows when the approval title wraps', () => {
+    const title =
+      'Apply edit to /private/tmp/texra-queued-transcript-gZNBeZ/bolzano_weierstrass.tex?';
+
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 16,
+        columns: 80,
+        title,
+      }),
+    ).toBe(6);
+  });
+
+  it('keeps a usable one-line diff on very short terminals', () => {
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 8,
+        columns: 80,
+        title: 'Apply edit to proof.tex?',
+      }),
+    ).toBe(1);
+  });
+
+  it('preserves the generous fallback when terminal rows are unknown', () => {
+    expect(
+      editApprovalDiffRowsBudget({
+        columns: 80,
+        title: 'Apply edit to proof.tex?',
+      }),
+    ).toBe(30);
+  });
+});


### PR DESCRIPTION
Closes #4648.

## Summary
- Account for wrapped edit-approval titles when budgeting visible diff rows.
- Keep the approval footer and bottom border visible for large edit approvals on short terminals.
- Add focused CLI layout regression coverage for wrapped titles and short terminal budgets.

## Validation
- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/EditApproval.vitest.mts src/test-kernel/cli/DiffView.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `npm run texra-local:build`
- Real TTY smoke in `/tmp/texra-approval-footer-smoke-2YZzt3`: `texra-local --approval-policy ask orchestrate` produced a 119-line `write_file` approval, and the footer `y approve · n reject · a approve session · e feedback · Esc cancel` plus the bottom border remained visible below the truncated diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal layout budgeting only; no auth, tools, or file-write behavior changes.
> 
> **Overview**
> The CLI edit-approval modal no longer assumes the title is a single line when sizing the inline diff. **`editApprovalDiffRowsBudget`** subtracts the wrapped title height (via **`wrapAnsiToWidth`**) and the other fixed chrome rows from **`availableRows`**, so long paths do not steal rows from the approval footer and card border on short terminals.
> 
> **`EditApproval`** uses that helper for **`maxDiffLines`** instead of a flat **`availableRows - 8`**. New Vitest cases cover wrapped titles, very short terminals, and the unchanged 30-line fallback when row count is unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d3038a3e23be832f9d20d8e30754813c5249dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->