### PR TITLE
fix: keep CLI approvals behind active foreground panels

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -16,6 +16,10 @@ import { enqueueApproval } from '../src/chat/tui/state/approvalQueue';
 const STREAM_ID = 'harness-stream-1';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
+const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
+const EDIT_APPROVAL_DELAY_MS = Number(
+  process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
+);
 
 function makeEntries(count: number): ConversationEntry[] {
   const entries: ConversationEntry[] = [];
@@ -68,7 +72,7 @@ cliState.sessionMeta.set({
   model: 'harness-model',
   cwd: process.cwd(),
   apiMode: 'personal',
-  canDelegate: false,
+  canDelegate: CAN_DELEGATE,
   version: '0.0.0-harness',
 });
 cliState.activeStreamId.set(STREAM_ID);
@@ -79,10 +83,17 @@ patchStream(STREAM_ID, (slice) => ({
 }));
 
 if (SHOW_EDIT_APPROVAL) {
-  void enqueueApproval({
-    kind: 'toolEdit',
-    request: makeEditApprovalRequest(),
-  });
+  const showApproval = () =>
+    void enqueueApproval({
+      kind: 'toolEdit',
+      request: makeEditApprovalRequest(),
+    });
+
+  if (EDIT_APPROVAL_DELAY_MS > 0) {
+    setTimeout(showApproval, EDIT_APPROVAL_DELAY_MS);
+  } else {
+    showApproval();
+  }
 }
 
 const ink = render(

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -179,6 +179,30 @@ export function appEscapeInterruptActive({
   );
 }
 
+export type ForegroundSurfaceKind =
+  | 'transcript'
+  | 'childControls'
+  | 'form'
+  | 'approval';
+
+export function foregroundSurfaceKind({
+  activeFormOpen,
+  childControlMode,
+  pendingApproval,
+  transcriptViewerOpen,
+}: {
+  readonly activeFormOpen: boolean;
+  readonly childControlMode?: ChildControlMode;
+  readonly pendingApproval: boolean;
+  readonly transcriptViewerOpen: boolean;
+}): ForegroundSurfaceKind | undefined {
+  if (transcriptViewerOpen) return 'transcript';
+  if (childControlMode !== undefined) return 'childControls';
+  if (activeFormOpen) return 'form';
+  if (pendingApproval) return 'approval';
+  return undefined;
+}
+
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
   readonly onKillExecution: (executionId: string) => void;
@@ -271,47 +295,56 @@ export function App(props: AppProps): React.JSX.Element {
     hasTodosPlanPanel,
     rows: bottomPanelBudget,
   });
+  const foregroundKind = foregroundSurfaceKind({
+    activeFormOpen: activeForm !== undefined,
+    childControlMode,
+    pendingApproval: pending !== undefined,
+    transcriptViewerOpen,
+  });
   function renderForegroundSurface(): React.ReactNode {
-    if (pending) {
-      return <ApprovalModal pending={pending} availableRows={foregroundRows} />;
+    switch (foregroundKind) {
+      case 'transcript':
+        return (
+          <TranscriptViewer
+            availableRows={foregroundRows}
+            onClose={() => cliState.transcriptViewerOpen.set(false)}
+            slice={activeSlice}
+            width={transcriptWidth}
+          />
+        );
+      case 'childControls': {
+        if (!childControlMode) return null;
+        const target = resolveChildControlStreamTarget({
+          activeStreamId,
+          mode: childControlMode,
+          parentStream,
+          streams,
+        });
+        return (
+          <ChildControlPicker
+            activeStreamId={target.streamId}
+            availableRows={foregroundRows}
+            mode={childControlMode}
+            onClose={() => setChildControlMode(undefined)}
+            onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
+            onKillExecution={props.onKillExecution}
+            slice={target.slice}
+            streams={streams}
+          />
+        );
+      }
+      case 'form':
+        return activeForm?.render(
+          () => cliState.activeForm.set(undefined),
+          foregroundRows,
+        );
+      case 'approval':
+        return pending ? (
+          <ApprovalModal pending={pending} availableRows={foregroundRows} />
+        ) : null;
+      case undefined:
+        return null;
     }
-    if (transcriptViewerOpen) {
-      return (
-        <TranscriptViewer
-          availableRows={foregroundRows}
-          onClose={() => cliState.transcriptViewerOpen.set(false)}
-          slice={activeSlice}
-          width={transcriptWidth}
-        />
-      );
-    }
-    if (childControlMode) {
-      const target = resolveChildControlStreamTarget({
-        activeStreamId,
-        mode: childControlMode,
-        parentStream,
-        streams,
-      });
-      return (
-        <ChildControlPicker
-          activeStreamId={target.streamId}
-          availableRows={foregroundRows}
-          mode={childControlMode}
-          onClose={() => setChildControlMode(undefined)}
-          onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
-          onKillExecution={props.onKillExecution}
-          slice={target.slice}
-          streams={streams}
-        />
-      );
-    }
-    if (activeForm) {
-      return activeForm.render(
-        () => cliState.activeForm.set(undefined),
-        foregroundRows,
-      );
-    }
-    return null;
   }
   const foregroundSurface = renderForegroundSurface();
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -21,6 +21,7 @@ import {
   allocateSidePanelRows,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
+  foregroundSurfaceKind,
 } from '@cli/chat/tui/App';
 import {
   nextFocusBack,
@@ -256,6 +257,55 @@ describe('CLI TUI row allocation', () => {
         slashPaletteOpen: true,
       }),
     ).toBe(false);
+  });
+
+  it('keeps user-opened foreground surfaces ahead of new approvals', () => {
+    expect(
+      foregroundSurfaceKind({
+        activeFormOpen: false,
+        childControlMode: 'subagents',
+        pendingApproval: true,
+        transcriptViewerOpen: false,
+      }),
+    ).toBe('childControls');
+
+    expect(
+      foregroundSurfaceKind({
+        activeFormOpen: false,
+        childControlMode: undefined,
+        pendingApproval: true,
+        transcriptViewerOpen: true,
+      }),
+    ).toBe('transcript');
+
+    expect(
+      foregroundSurfaceKind({
+        activeFormOpen: true,
+        childControlMode: undefined,
+        pendingApproval: true,
+        transcriptViewerOpen: false,
+      }),
+    ).toBe('form');
+  });
+
+  it('shows approvals when no existing foreground surface owns input', () => {
+    expect(
+      foregroundSurfaceKind({
+        activeFormOpen: false,
+        childControlMode: undefined,
+        pendingApproval: true,
+        transcriptViewerOpen: false,
+      }),
+    ).toBe('approval');
+
+    expect(
+      foregroundSurfaceKind({
+        activeFormOpen: false,
+        childControlMode: undefined,
+        pendingApproval: false,
+        transcriptViewerOpen: false,
+      }),
+    ).toBeUndefined();
   });
 
   it('only reports a chat run interruptible after stream resolution', () => {


### PR DESCRIPTION
Closes #4650.

## Summary
- Preserve user-opened foreground panels ahead of newly-arrived approval modals.
- Keep approvals queued behind transcript, subagent/task controls, and active forms until the visible panel is closed.
- Add regression coverage for foreground-surface priority and extend the TUI harness with delayed approvals plus delegation controls for replaying this race.

## Root Cause
The App foreground renderer gave pending approvals absolute priority over existing foreground panels. If an approval arrived while a user was pressing `Esc` to close Subagents or another panel, the approval modal could mount first and consume the same `Esc` as a reject/cancel action.

## Validation
- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- Harness TTY replay: `TERM=xterm-256color HARNESS_ENTRIES=2 HARNESS_CAN_DELEGATE=1 HARNESS_EDIT_APPROVAL=1 HARNESS_EDIT_APPROVAL_DELAY_MS=6000 node packages/cli/dist/bin/tui-harness.js`; opened Subagents with `Option-s`, watched `1 approval` queue behind it, pressed `Esc`, and confirmed the approval appeared still pending instead of being rejected.
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TUI input ownership and approval visibility timing; behavior is covered by new unit tests and harness replay, but affects interactive edit-approval flows.
> 
> **Overview**
> Fixes a focus race where **new tool approvals preempted** transcript, subagent/task controls, and active forms, so **Esc** while closing a panel could reject the approval instead of dismissing the panel.
> 
> **`foregroundSurfaceKind`** centralizes priority (transcript → child controls → form → approval) and **`renderForegroundSurface`** renders from that instead of checking pending approvals first. Approvals still queue in state; they only take the foreground when nothing else is open.
> 
> The TUI harness gains **`HARNESS_CAN_DELEGATE`**, **`HARNESS_EDIT_APPROVAL_DELAY_MS`**, and tests lock in the priority behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfc1de3d46ad76d2c191a4df81e71df398bf1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->