### PR TITLE
[codex] Redact CLI API account email

### DIFF
--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,6 +4,7 @@ import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { isOAuthProvider } from '@auth/sharedConfig';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
+import { formatCliAccountLabelForDisplay } from '../runtime/accountDisplay';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -184,7 +185,11 @@ const authStatusCommand = defineCommand({
       json: profile,
       ndjson: { kind: 'auth-status', ...profile },
       text: profile.authenticated
-        ? `Signed in as ${profile.accountLabel ?? 'unknown'} (${profile.tier ?? 'unknown'}).`
+        ? `Signed in as ${
+            profile.accountLabel
+              ? formatCliAccountLabelForDisplay(profile.accountLabel)
+              : 'unknown'
+          } (${profile.tier ?? 'unknown'}).`
         : 'Not signed in.',
     });
     setExitCode(CliExitCode.Success);

--- a/packages/cli/src/runtime/accountDisplay.ts
+++ b/packages/cli/src/runtime/accountDisplay.ts
@@ -1,0 +1,33 @@
+const EMAIL_LIKE_ACCOUNT_PATTERN =
+  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const EMAIL_LIKE_ACCOUNT_EXACT_PATTERN =
+  /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+
+function maskIdentifierPart(part: string): string {
+  return part ? `${part.at(0)}***` : '***';
+}
+
+export function formatCliAccountLabelForDisplay(accountLabel: string): string {
+  const trimmed = accountLabel.trim();
+  if (!EMAIL_LIKE_ACCOUNT_EXACT_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  const atIndex = trimmed.indexOf('@');
+
+  const localPart = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex + 1);
+  const domainParts = domain.split('.');
+  const suffix = domainParts.length > 1 ? domainParts.at(-1) : undefined;
+  const domainName = suffix ? domainParts.slice(0, -1).join('.') : domain;
+  const maskedDomain = suffix
+    ? `${maskIdentifierPart(domainName)}.${suffix}`
+    : maskIdentifierPart(domainName);
+  return `${maskIdentifierPart(localPart)}@${maskedDomain}`;
+}
+
+export function redactEmailAccountLabelsForDisplay(text: string): string {
+  return text.replaceAll(EMAIL_LIKE_ACCOUNT_PATTERN, (accountLabel) =>
+    formatCliAccountLabelForDisplay(accountLabel),
+  );
+}

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,8 +1,9 @@
 import { toErrorMessage } from '@common/errors/errorMessage';
 
+import { formatCliAccountLabelForDisplay } from './accountDisplay';
 import { formatCliApiMode, getCliApiMode } from './apiAccessMode';
 import { fetchRelayUsageSummary, type RelayUsageSummary } from './relayUsage';
-import { getCliAuthProfile } from './supabaseAuth';
+import { getCliAuthProfile, type CliAuthProfile } from './supabaseAuth';
 
 function formatPercent(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return '0%';
@@ -16,14 +17,23 @@ export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
   return `relay usage this month: ${used} used, ${remaining} remaining`;
 }
 
+export function formatCliAuthStatusLine(
+  profile: Pick<CliAuthProfile, 'authenticated' | 'accountLabel'>,
+): string {
+  if (!profile.authenticated) return 'auth: signed out';
+  return `auth: signed in${
+    profile.accountLabel
+      ? ` as ${formatCliAccountLabelForDisplay(profile.accountLabel)}`
+      : ''
+  }`;
+}
+
 export async function loadCliApiStatusLines(): Promise<string[]> {
   const mode = getCliApiMode();
   const profile = await getCliAuthProfile();
   const lines = [
     `api: ${formatCliApiMode(mode)}`,
-    profile.authenticated
-      ? `auth: signed in${profile.accountLabel ? ` as ${profile.accountLabel}` : ''}`
-      : 'auth: signed out',
+    formatCliAuthStatusLine(profile),
   ];
 
   if (profile.tier) lines.push(`tier: ${profile.tier}`);

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -9,6 +9,7 @@ import {
 } from '@latex/latexToolchain';
 
 // Local imports - CLI runtime
+import { redactEmailAccountLabelsForDisplay } from './accountDisplay';
 import { workspaceCliConfigPath } from './cliConfig';
 import { CliExitCode } from './exitCodes';
 import {
@@ -333,8 +334,11 @@ export function formatDoctorText(
   };
   return report.checks
     .map((check) => {
-      const head = `${marker[check.status]} ${check.name}: ${check.message}`;
-      return check.hint ? `${head}\n     ${style.muted(check.hint)}` : head;
+      const message = redactEmailAccountLabelsForDisplay(check.message);
+      const head = `${marker[check.status]} ${check.name}: ${message}`;
+      return check.hint
+        ? `${head}\n     ${style.muted(redactEmailAccountLabelsForDisplay(check.hint))}`
+        : head;
     })
     .join('\n');
 }

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatRelayUsageStatus } from '@cli/runtime/apiStatus';
+import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
+import {
+  formatCliAuthStatusLine,
+  formatRelayUsageStatus,
+} from '@cli/runtime/apiStatus';
 import type { RelayUsageSummary } from '@cli/runtime/relayUsage';
 
 describe('CLI API status text', () => {
@@ -25,6 +29,37 @@ describe('CLI API status text', () => {
 
     expect(formatRelayUsageStatus(summary)).toBe(
       'relay usage this month: 14.0% used, 86.0% remaining',
+    );
+  });
+
+  it('redacts email account labels before showing auth status in the TUI', () => {
+    expect(formatCliAccountLabelForDisplay('sirui.lu.phys@gmail.com')).toBe(
+      's***@g***.com',
+    );
+    expect(
+      formatCliAuthStatusLine({
+        authenticated: true,
+        accountLabel: 'user@example.edu',
+      }),
+    ).toBe('auth: signed in as u***@e***.edu');
+  });
+
+  it('keeps non-email account labels readable', () => {
+    expect(formatCliAccountLabelForDisplay('github-user')).toBe('github-user');
+    expect(formatCliAccountLabelForDisplay('team@internal')).toBe(
+      'team@internal',
+    );
+    expect(
+      formatCliAuthStatusLine({
+        authenticated: true,
+        accountLabel: 'team@internal',
+      }),
+    ).toBe('auth: signed in as team@internal');
+    expect(formatCliAuthStatusLine({ authenticated: true })).toBe(
+      'auth: signed in',
+    );
+    expect(formatCliAuthStatusLine({ authenticated: false })).toBe(
+      'auth: signed out',
     );
   });
 });

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -117,6 +117,80 @@ describe('CLI doctor', () => {
     expect(formatDoctorText(report)).toContain('Ignoring invalid model.');
   });
 
+  it('redacts email account labels in text output', async () => {
+    const report = await buildDoctorReport(context, {
+      nodeVersion: '24.0.0',
+      authProfile: async () => ({
+        authenticated: true,
+        accountLabel: 'user@example.edu',
+        tier: 'Max',
+      }),
+      modelAccessList: async () =>
+        [
+          {
+            available: true,
+            status: 'available',
+            model: { value: 'deepseekT', label: 'DeepSeek T' },
+          },
+        ] as never,
+      latexToolchain: async () => ({
+        ...latexProbe,
+        tools: latexProbe.tools.map((tool) => ({ ...tool, installed: true })),
+      }),
+      pathStat: async () => directory,
+      pathAccess: async () => undefined,
+    });
+
+    const text = formatDoctorText(report);
+    const authCheck = report.checks.find((check) => check.id === 'auth');
+    const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
+
+    expect(authCheck?.message).toContain('user@example.edu');
+    expect(text).toContain('Stored sign-in found for u***@e***.edu, Max.');
+    expect(text).not.toContain('user@example.edu');
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'auth',
+        message: 'Stored sign-in found for user@example.edu, Max.',
+      }),
+    );
+  });
+
+  it('keeps non-email account labels readable in text output', async () => {
+    const report = await buildDoctorReport(context, {
+      nodeVersion: '24.0.0',
+      authProfile: async () => ({
+        authenticated: true,
+        accountLabel: 'team@internal',
+      }),
+      modelAccessList: async () =>
+        [
+          {
+            available: true,
+            status: 'available',
+            model: { value: 'deepseekT', label: 'DeepSeek T' },
+          },
+        ] as never,
+      latexToolchain: async () => ({
+        ...latexProbe,
+        tools: latexProbe.tools.map((tool) => ({ ...tool, installed: true })),
+      }),
+      pathStat: async () => directory,
+      pathAccess: async () => undefined,
+    });
+
+    const text = formatDoctorText(report);
+    const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
+
+    expect(text).toContain('Stored sign-in found for team@internal.');
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'auth',
+        message: 'Stored sign-in found for team@internal.',
+      }),
+    );
+  });
+
   it('emits stable ndjson record kinds', async () => {
     const report = await buildDoctorReport(context, {
       nodeVersion: '24.0.0',


### PR DESCRIPTION
## Summary

- Redact email-shaped account labels in CLI human-readable auth status output before they render in the interactive TUI or status diagnostics.
- Keep non-email account labels readable and preserve the underlying auth/session values for JSON and NDJSON output.
- Add focused coverage for the redacted auth status line and doctor text output, including that doctor structured records keep the raw diagnostic message.

Closes #4652

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/Doctor.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `npm run texra-local:build`
- `texra-local auth status` -> `Signed in as s***@g***.com (Max).`
- `texra-local doctor` -> `Stored sign-in found for s***@g***.com.`
- `texra-local doctor --output-format json` check: auth message is raw and the JSON omits the display mask.
- Real 24x80 TTY smoke: `TERM=xterm-256color texra-local --approval-policy ask orchestrate`, then `/api`; panel shows `auth: signed in as s***@g***.com` instead of the full email.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only privacy change with no auth or session logic changes; structured outputs remain raw by design.
> 
> **Overview**
> Adds **`accountDisplay`** helpers that mask **email-shaped** account labels (e.g. `u***@e***.edu`) while leaving other labels unchanged.
> 
> **Human-readable CLI output** now uses that masking for **`texra auth status`**, the TUI **`/api`** auth line via **`formatCliAuthStatusLine`**, and **`doctor`** text (messages and hints). **JSON / NDJSON** payloads still carry the **raw** account strings for diagnostics and automation.
> 
> Tests cover masking rules, auth status lines, and doctor text vs structured records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb19c5cd10ce75a4eaae2d0938b64ff42a49351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->