### PR TITLE
[codex] Keep CLI approval cancel hint visible

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -2,10 +2,13 @@
 // title, padded body slot, key handling, and KeyHints footer.
 
 import { useState } from 'react';
-import { Box, Text, type BoxProps } from 'ink';
+import { Box, Text, useWindowSize, type BoxProps } from 'ink';
 import { useInput } from 'ink';
 
-import { confirmCardKeyAction, confirmCardKeyHints } from './ConfirmCardState';
+import {
+  confirmCardKeyAction,
+  confirmCardKeyHintsForWidth,
+} from './ConfirmCardState';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { KeyHints } from '../ui/KeyHints';
 import type {
@@ -32,6 +35,8 @@ export interface ConfirmCardProps {
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
+export const CONFIRM_CARD_HORIZONTAL_DECORATION = 4;
+
 export function ConfirmCard({
   borderStyle,
   color,
@@ -45,6 +50,7 @@ export function ConfirmCard({
 }: ConfirmCardProps): React.JSX.Element {
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedback, setFeedback] = useState('');
+  const { columns } = useWindowSize();
 
   useInput(
     (input, key) => {
@@ -83,7 +89,7 @@ export function ConfirmCard({
     { isActive: true },
   );
 
-  const hints = confirmCardKeyHints({
+  const hints = confirmCardKeyHintsForWidth({
     approveLabel,
     rejectLabel,
     alwaysAllowLabel: alwaysAllow?.label,
@@ -91,6 +97,7 @@ export function ConfirmCard({
       key: action.key,
       action: action.label,
     })),
+    maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
   });
 
   return (

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -1,3 +1,5 @@
+import { KEY_HINT_SEPARATOR } from '../ui/KeyHints';
+
 export type ConfirmCardKeyAction =
   | 'approve'
   | 'reject'
@@ -19,6 +21,10 @@ export interface ConfirmCardHintOptions {
   readonly rejectLabel?: string;
   readonly alwaysAllowLabel?: string;
   readonly extraActions?: readonly ConfirmCardHintAction[];
+}
+
+export interface ConfirmCardHintWidthOptions extends ConfirmCardHintOptions {
+  readonly maxColumns?: number;
 }
 
 export function confirmCardKeyAction(
@@ -57,4 +63,44 @@ export function confirmCardKeyHints({
     { key: 'e', action: 'feedback' },
     { key: 'Esc', action: 'cancel' },
   ];
+}
+
+function hintColumns(hints: readonly ConfirmCardHintAction[]): number {
+  return hints.reduce(
+    (width, hint, index) =>
+      width +
+      (index === 0 ? 0 : KEY_HINT_SEPARATOR.length) +
+      hint.key.length +
+      1 +
+      hint.action.length,
+    0,
+  );
+}
+
+function compactHintAction(action: string): string {
+  switch (action) {
+    case 'approve session':
+      return 'session';
+    case 'feedback':
+      return 'note';
+    default:
+      return action;
+  }
+}
+
+export function confirmCardKeyHintsForWidth(
+  options: ConfirmCardHintWidthOptions,
+): ConfirmCardHintAction[] {
+  const fullHints = confirmCardKeyHints(options);
+  if (
+    options.maxColumns === undefined ||
+    hintColumns(fullHints) <= options.maxColumns
+  ) {
+    return fullHints;
+  }
+
+  return fullHints.map((hint) => ({
+    ...hint,
+    action: compactHintAction(hint.action),
+  }));
 }

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
-import { ConfirmCard } from './ConfirmCard';
+import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import {
   buildHunks,
   diffVisualRowCount,
@@ -17,7 +17,6 @@ import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
 const EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE = 8;
-const CONFIRM_CARD_HORIZONTAL_DECORATION = 4;
 const MIN_EDIT_DIFF_WIDTH = 20;
 
 export interface EditApprovalProps {

--- a/packages/cli/src/chat/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/chat/tui/ui/KeyHints.tsx
@@ -22,7 +22,7 @@ export interface KeyHintsProps {
   readonly confirmCancel?: boolean;
 }
 
-const SEP = ' · ';
+export const KEY_HINT_SEPARATOR = ' · ';
 
 const DEFAULT_TAIL: readonly KeyHint[] = [
   { key: 'Enter', action: 'confirm' },
@@ -39,7 +39,7 @@ export function KeyHints(props: KeyHintsProps): React.JSX.Element {
       <Text dimColor wrap="truncate-end">
         {all.map((hint, index) => (
           <Text key={`${hint.key}-${hint.action}-${index}`}>
-            {index > 0 ? SEP : ''}
+            {index > 0 ? KEY_HINT_SEPARATOR : ''}
             <Text bold>{hint.key}</Text> {hint.action}
           </Text>
         ))}

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   confirmCardKeyAction,
   confirmCardKeyHints,
+  confirmCardKeyHintsForWidth,
 } from '@cli/chat/tui/modals/ConfirmCardState';
 
 describe('CLI confirm-card key handling', () => {
@@ -41,5 +42,30 @@ describe('CLI confirm-card key handling', () => {
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
     expect(rendered.length).toBeLessThanOrEqual(72);
+  });
+
+  it('compacts long optional approval hints before hiding cancel', () => {
+    expect(
+      confirmCardKeyHintsForWidth({
+        alwaysAllowLabel: 'approve session',
+        maxColumns: 80,
+      }),
+    ).toEqual(confirmCardKeyHints({ alwaysAllowLabel: 'approve session' }));
+
+    const compact = confirmCardKeyHintsForWidth({
+      alwaysAllowLabel: 'approve session',
+      maxColumns: 56,
+    });
+
+    expect(compact).toEqual([
+      { key: 'y', action: 'approve' },
+      { key: 'n', action: 'reject' },
+      { key: 'a', action: 'session' },
+      { key: 'e', action: 'note' },
+      { key: 'Esc', action: 'cancel' },
+    ]);
+    expect(
+      compact.map((hint) => `${hint.key} ${hint.action}`).join(' · ').length,
+    ).toBeLessThanOrEqual(56);
   });
 });


### PR DESCRIPTION
## Summary

- Compact long optional approval-footer labels when the terminal is too narrow for the full hint line.
- Preserve the `Esc cancel` affordance on 60-column approval cards without changing approval key behavior.
- Add focused tests for width-aware confirm-card hints.

Closes #4654

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- Real 60x20 TTY harness smoke: `HARNESS_EDIT_APPROVAL=1 HARNESS_ENTRIES=8 TERM=xterm-256color node packages/cli/dist/bin/tui-harness.js`; footer shows `y approve · n reject · a session · e note · Esc cancel`.
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `npm run texra-local:build`
- `texra-local version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI footer label display only; approval decisions and key bindings are unchanged.
> 
> **Overview**
> Narrow terminals were truncating approval modal footers (including **Esc cancel**) because long hint lines exceeded the card width.
> 
> **ConfirmCard** now measures terminal width and builds hints via **`confirmCardKeyHintsForWidth`**, which keeps full labels when they fit and otherwise shortens known long actions (e.g. `approve session` → `session`, `feedback` → `note`) using the same separator width math as **`KeyHints`**. Horizontal padding for width budgeting is centralized as **`CONFIRM_CARD_HORIZONTAL_DECORATION`** (reused by edit approval layout). Approval key handling is unchanged; tests cover width-aware hint output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f2fabe7e6a550cb8c40d608aeff228b83aebb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->