### PR TITLE
refactor: consolidate duplicate patterns into shared utilities

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -8,7 +8,11 @@ import { waitForRetry } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getConfig } from '@agent/core/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { ensureError, normalizeProviderError, toErrorMessage } from '@common/errors';
+import {
+  ensureError,
+  normalizeProviderError,
+  toErrorMessage,
+} from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -8,7 +8,7 @@ import { waitForRetry } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getConfig } from '@agent/core/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { normalizeProviderError, toErrorMessage } from '@common/errors';
+import { ensureError, normalizeProviderError, toErrorMessage } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
 
@@ -113,10 +113,7 @@ export abstract class RetryableInvocationNode<
     const refreshed = await SupabaseClient.getAccessToken(true);
     if (!refreshed) {
       services.logger.debug('Token refresh failed, skipping auto-retries');
-      this._persistent401Error =
-        originalError instanceof Error
-          ? originalError
-          : new Error(String(originalError));
+      this._persistent401Error = ensureError(originalError);
       throw originalError;
     }
 
@@ -143,8 +140,7 @@ export abstract class RetryableInvocationNode<
         services.logger.debug(
           'Still 401 after token refresh, skipping auto-retries',
         );
-        this._persistent401Error =
-          retryErr instanceof Error ? retryErr : new Error(String(retryErr));
+        this._persistent401Error = ensureError(retryErr);
       }
       throw retryErr;
     }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -10,7 +10,7 @@ import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/AgentState';
-import { formatProviderHttpError } from '@common/errors';
+import { ensureError, formatProviderHttpError } from '@common/errors';
 import type { AgentFileLocation } from '@utils/files';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -122,7 +122,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       const formatted = formatProviderHttpError(error);
       return {
         outcome: 'failed',
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: ensureError(error),
         userRetryable: formatted.userRetryable,
       };
     }

--- a/src/agent/modelHandlers/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropicTools.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer';
 
+import { extractMimeSubtype } from '@utils/text/stringUtils';
+
 // Third-party imports
 import { toFile } from '@anthropic-ai/sdk';
 
@@ -108,7 +110,7 @@ export async function uploadToolAttachments(
         attachment.path ??
           (isPdf
             ? 'document.pdf'
-            : `image.${normalized.split('/').pop() ?? 'png'}`),
+            : `image.${extractMimeSubtype(normalized, 'png')}`),
       );
 
       const base64Data = buffer.toString('base64');

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -48,7 +48,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
-import { objectToLogString } from '@utils/text/stringUtils';
+import { extractMimeSubtype, objectToLogString } from '@utils/text/stringUtils';
 import { normalizeUsage } from './support/UsageNormalizer';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { tagOpenAISdkError, withSdkErrorTag } from './support/sdkErrorAdapters';
@@ -981,9 +981,7 @@ export class ModelHandlerOpenAI<
       ) {
         // Currently OpenRouter's OpenAI-compatible audio branch is the only consumer
         // Extract format from mime type (e.g., 'wav' from 'audio/wav')
-        const audioFormat = (
-          media.media_type.split('/').pop() ?? media.media_type
-        ).toLowerCase();
+        const audioFormat = extractMimeSubtype(media.media_type).toLowerCase();
         const supportedFormats = ['wav', 'mp3'] as const;
 
         if (

--- a/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
@@ -17,6 +17,7 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 // Local imports - tools and utils
 import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
+import { extractMimeSubtype } from '@utils/text/stringUtils';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 import { normalizeUsage } from './support/UsageNormalizer';
@@ -656,9 +657,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         media.media_category === 'audio' &&
         this.capabilities.supportsNativeAudio
       ) {
-        const audioFormat = (
-          media.media_type.split('/').pop() ?? media.media_type
-        ).toLowerCase();
+        const audioFormat = extractMimeSubtype(media.media_type).toLowerCase();
         return [
           { type: 'text', text: `Audio: ${media.file_name}` },
           {

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -12,6 +12,7 @@ import { toErrorMessage } from '@common/errors';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports
+import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   AbsoluteFS,
   getMimeType,
@@ -242,7 +243,7 @@ export class MediaAttachmentProcessor {
       return { result: { path: displayPath, ok: false } };
     }
 
-    const fileExtension = path.extname(absolutePath).toLowerCase();
+    const fileExtension = getExtensionLowercase(absolutePath);
 
     try {
       // Process as audio or image based on mime type

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -11,6 +11,7 @@ import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_RANGES,
 } from '@shared/constants/latex';
+import { hasExtension } from '@utils/core/pathCore';
 import {
   createRunStorageLocation,
   flexibleFS,
@@ -84,7 +85,7 @@ export async function runCompileCheck(
 
   const texOutputs = (
     getOutputFilesByRound(ctx.outputState)[currentRound] ?? []
-  ).filter((f) => f.location.absolutePath.toLowerCase().endsWith('.tex'));
+  ).filter((f) => hasExtension(f.location.absolutePath, '.tex'));
   if (texOutputs.length === 0) return { failures: [], artifacts: [] };
 
   // Skip gracefully when no LaTeX toolchain is installed so the run doesn't

--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -7,6 +7,7 @@ import { isFile } from '@common/files/fsEntryType';
 import type { ExecutionId, FileLocation } from '@shared/schemas';
 
 // Local imports - file utilities
+import { hasExtension } from '@utils/core/pathCore';
 import {
   createRunStorageLocation,
   getComparablePath,
@@ -38,9 +39,7 @@ function normalizePdfRelativePath(pdfPath: string): string {
     .split('/')
     .filter((part) => part && part !== '.' && part !== '..');
   const normalized = parts.length > 0 ? parts.join('/') : 'output.pdf';
-  return normalized.toLowerCase().endsWith('.pdf')
-    ? normalized
-    : `${normalized}.pdf`;
+  return hasExtension(normalized, '.pdf') ? normalized : `${normalized}.pdf`;
 }
 
 function stripRoundPrefix(relativePath: string, round: number): string {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -16,7 +16,7 @@ import {
 } from '@agent/index/agentRegistry';
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { toErrorMessage } from '@common/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
 
@@ -155,8 +155,7 @@ export class RemoteAgentLoader {
         prompts: config.prompts,
       };
     } catch (error) {
-      const lastError =
-        error instanceof Error ? error : new Error(toErrorMessage(error));
+      const lastError = ensureError(error);
       logger.error(
         CHANNEL,
         `Failed to load remote agent "${agentName}": ${lastError.message}`,

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -3,7 +3,7 @@ import {
   SupabaseClient as Client,
   User,
 } from '@supabase/supabase-js';
-import { toErrorMessage } from '@common/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import {
   type UserAuthContext,
@@ -105,8 +105,7 @@ export class SupabaseClient {
       this.readinessError = null;
       return true;
     } catch (error) {
-      this.readinessError =
-        error instanceof Error ? error : new Error(toErrorMessage(error));
+      this.readinessError = ensureError(error);
       logger.error(
         'SupabaseClient',
         `Auth provider not ready: ${toErrorMessage(error)}`,

--- a/src/common/errors/errorMessage.ts
+++ b/src/common/errors/errorMessage.ts
@@ -5,3 +5,8 @@ export function toErrorMessage(err: unknown): string {
   }
   return String(err);
 }
+
+/** Coerce any thrown value to an Error instance. */
+export function ensureError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(toErrorMessage(err));
+}

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -7,7 +7,7 @@
  * @common/errors/sdkErrorUtils - they are not part of the public barrel.
  */
 export { formatError, formatZodError } from './errorFormatUtils';
-export { toErrorMessage } from './errorMessage';
+export { toErrorMessage, ensureError } from './errorMessage';
 export {
   isDiskFullError,
   isFileNotFoundError,

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -15,7 +15,7 @@ import {
   pathToLocation,
   type FileLocation,
 } from '@utils/files';
-import { hasExtension } from '@utils/core/pathCore';
+import { getExtensionLowercase, hasExtension } from '@utils/core/pathCore';
 
 // Local file imports
 import { extractLatexFileDependencies } from './extractFileDependencies';
@@ -322,7 +322,7 @@ export class LatexMediaManager {
 
     const candidates: string[] = [];
     for (const name of entries) {
-      const ext = path.extname(name).toLowerCase();
+      const ext = getExtensionLowercase(name);
       if (
         PROJECT_SIBLING_EXTENSIONS.has(ext) ||
         PROJECT_SIBLING_NAMES.has(name)

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -71,7 +71,7 @@ export function getAcceptedFileTarget(
     editedNameWithoutExt,
   );
   const targetFileName = agentSuffix
-    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
+    ? `${baseNameWithoutExt}_${agentSuffix}${path.extname(editedPath)}`
     : path.basename(editedPath);
 
   return {

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 
 // Local imports - utilities
+import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -53,10 +54,9 @@ export function getAcceptedFileTarget(
   editedPath: string,
 ): AcceptedFileTarget {
   const basePath = baseLocation.absolutePath;
-  const baseExt = path.extname(basePath).toLowerCase();
-  const editedExt = path.extname(editedPath);
+  const baseExt = getExtensionLowercase(basePath);
 
-  if (baseExt === editedExt.toLowerCase()) {
+  if (baseExt === getExtensionLowercase(editedPath)) {
     return {
       targetLocation: baseLocation,
       targetFileName: path.basename(basePath),

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -55,6 +55,7 @@ import {
   evaluateDelegationGate,
   type NestedDelegationConfig,
 } from '@shared/constants/delegationPolicy';
+import { hasExtension } from '@utils/core/pathCore';
 import { getBasename } from '@shared/utils/path';
 import { formatBytes } from '@shared/utils/string';
 
@@ -717,7 +718,7 @@ const WorkflowAgentInputSchema = z.strictObject({
 export type WorkflowAgentInput = z.infer<typeof WorkflowAgentInputSchema>;
 
 function isBibFile(filePath: string): boolean {
-  return getBasename(filePath).toLowerCase().endsWith('.bib');
+  return hasExtension(filePath, '.bib');
 }
 
 function getContextFiles(input: WorkflowAgentInput): string[] {

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -18,6 +18,7 @@ import {
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local imports - utilities
+import { hasExtension } from '@utils/core/pathCore';
 import {
   AbsoluteFS,
   createRunStorageLocation,
@@ -70,7 +71,7 @@ export class OpenPdfTool extends defineTool({
     const location = resolvePdfLocation(input.path);
     const displayPath = displayPdfLocation(location);
 
-    if (path.extname(location.absolutePath).toLowerCase() !== '.pdf') {
+    if (!hasExtension(location.absolutePath, '.pdf')) {
       throw new ToolError(`open_pdf only opens PDF files: ${displayPath}`);
     }
     if (!(await AbsoluteFS.isFile(location.absolutePath))) {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -22,6 +22,7 @@ import {
   OFFICE_EXTENSIONS,
   OFFICE_MIME_TYPES,
 } from '@utils/files/mimeUtils';
+import { hasExtension, getExtensionLowercase } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
@@ -89,7 +90,7 @@ export class ReadFileTool extends defineTool({
     let emlImages: Awaited<ReturnType<typeof parseEml>>['images'] = [];
     let lines: string[];
 
-    if (path.extname(input.path).toLowerCase() === '.eml') {
+    if (hasExtension(input.path, '.eml')) {
       const stats = await WorkspaceFS.stat(filePath);
       if (stats.size > MAX_EML_BYTES) {
         throw new ToolError(
@@ -173,7 +174,7 @@ export class ReadFileTool extends defineTool({
   ): { kind: 'pdf' | 'image' | 'document'; label: string } | null {
     const mimeType = getMimeType(filePath)?.toLowerCase();
     // Keep extension detection case-insensitive so users can reference files regardless of casing.
-    const extension = path.extname(filePath.toLowerCase());
+    const extension = getExtensionLowercase(filePath);
 
     const isPdf = mimeType === 'application/pdf' || extension === '.pdf';
     if (isPdf) {

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -7,6 +7,7 @@ import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
 } from '@tools/approval/bashApproval';
+import { tailWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -16,17 +17,6 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 const OUTPUT_PREVIEW_MAX = 4_000;
 const TERMINAL_NAME_PREFIX = 'TeXRA: ';
 
-/**
- * Keep the last `maxLen` characters; prepend an ellipsis when
- * truncated. Mirrors the runner's sliding-window `tail` — for setup
- * installers the success / error line is at the *end* of the output,
- * so head-truncation (the codebase's default `truncateWithEllipsis`)
- * would discard exactly the lines the agent needs.
- */
-function tailWithEllipsis(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return '…' + text.slice(-(maxLen - 1));
-}
 
 const SendToTerminalInputSchema = z.strictObject({
   // The single non-cosmetic guard: VS Code normalizes \n / \r when typed

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -17,7 +17,6 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 const OUTPUT_PREVIEW_MAX = 4_000;
 const TERMINAL_NAME_PREFIX = 'TeXRA: ';
 
-
 const SendToTerminalInputSchema = z.strictObject({
   // The single non-cosmetic guard: VS Code normalizes \n / \r when typed
   // into a terminal, so a multi-line input would smuggle a second

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -38,11 +38,8 @@ export function normalizeLatexPath(value: string): string {
   return posix.startsWith('./') ? posix.slice(2) : posix;
 }
 
-/**
- * Get the file extension in lowercase.
- * Internal helper for hasExtension - not exported.
- */
-function getExtensionLowercase(filePath: string): string {
+/** Get the file extension in lowercase (e.g. `'.tex'` for `'Paper.TEX'`). */
+export function getExtensionLowercase(filePath: string): string {
   if (!filePath) return '';
   return path.extname(filePath).toLowerCase();
 }

--- a/src/utils/system/binaryResolver.ts
+++ b/src/utils/system/binaryResolver.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 
 // Local imports
+import { hasExtension } from '@utils/core/pathCore';
 import { IS_WINDOWS, findToolInCommonPaths } from './platformPaths';
 
 const WINDOWS_EXTENSIONLESS_PERL_TOOLS = new Set([
@@ -74,7 +75,7 @@ export class BinaryResolverService {
 
   private needsPerlLauncher(toolName: string, resolvedPath: string): boolean {
     return (
-      resolvedPath.toLowerCase().endsWith('.pl') ||
+      hasExtension(resolvedPath, '.pl') ||
       (this.options.isWindows &&
         path.extname(resolvedPath) === '' &&
         this.isKnownPerlScript(toolName))

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -8,6 +8,7 @@ import { execaSync } from 'execa';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import { hasExtension } from '@utils/core/pathCore';
 import { AbsoluteFS } from '@utils/files';
 
 /** Whether the current platform is Windows (cached at module load). */
@@ -269,7 +270,7 @@ function findToolInCommonPathsUncached(tool: string): string | null {
     return null;
   }
   const candidates = [tool];
-  if (!tool.toLowerCase().endsWith('.pl')) {
+  if (!hasExtension(tool, '.pl')) {
     candidates.push(`${tool}.pl`);
   }
   if (IS_WINDOWS) {
@@ -277,7 +278,7 @@ function findToolInCommonPathsUncached(tool: string): string | null {
     if (tool === 'gs') {
       candidates.push('gswin64c', 'gswin32c');
       candidates.push('gswin64c.exe', 'gswin32c.exe');
-    } else if (!tool.toLowerCase().endsWith('.exe')) {
+    } else if (!hasExtension(tool, '.exe')) {
       candidates.unshift(`${tool}.exe`);
     }
   }

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -85,3 +85,21 @@ export function collapseWhitespace(text: string): string {
 export function truncateSummary(text: string, maxLength: number): string {
   return truncateWithEllipsis(collapseWhitespace(text), maxLength);
 }
+
+/**
+ * Keep the last `maxLen` characters; prepend an ellipsis when truncated.
+ * Complement to `truncateWithEllipsis` for cases where the relevant content
+ * is at the end (e.g. terminal installer output where success/error appears last).
+ */
+export function tailWithEllipsis(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return `…${text.slice(-(maxLen - 1))}`;
+}
+
+/**
+ * Extract the subtype from a MIME type string (e.g. `'wav'` from `'audio/wav'`).
+ * Returns `fallback` (defaults to the original string) when no `/` is found.
+ */
+export function extractMimeSubtype(mimeType: string, fallback?: string): string {
+  return mimeType.split('/').pop() ?? fallback ?? mimeType;
+}

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -100,6 +100,9 @@ export function tailWithEllipsis(text: string, maxLen: number): string {
  * Extract the subtype from a MIME type string (e.g. `'wav'` from `'audio/wav'`).
  * Returns `fallback` (defaults to the original string) when no `/` is found.
  */
-export function extractMimeSubtype(mimeType: string, fallback?: string): string {
+export function extractMimeSubtype(
+  mimeType: string,
+  fallback?: string,
+): string {
   return mimeType.split('/').pop() ?? fallback ?? mimeType;
 }


### PR DESCRIPTION
## Summary

Eliminates four recurring copy-paste patterns by introducing/promoting shared helpers, then routes all callsites through them. No behaviour change.

### New / promoted helpers

| Helper | Location | Replaces |
|---|---|---|
| `ensureError(err)` | `@common/errors` (new) | `err instanceof Error ? err : new Error(toErrorMessage(err))` — 5 sites |
| `getExtensionLowercase(path)` | `@utils/core/pathCore` (was private) | `path.extname(x).toLowerCase()` — 4 sites |
| `extractMimeSubtype(mime, fallback?)` | `@utils/text/stringUtils` (new) | `mime.split('/').pop() ?? fallback` — 3 sites |
| `tailWithEllipsis(text, maxLen)` | `@utils/text/stringUtils` (moved from `SendToTerminalTool`) | local private function |

### `hasExtension()` adoption (already existed, underused)

8 scattered `.toLowerCase().endsWith('.ext')` / `path.extname(...).toLowerCase() ===` calls replaced with the existing `hasExtension()` helper in:
`compileCheck`, `compiledPdfArtifacts`, `OpenPdfTool`, `DelegationTools`, `ReadTool`, `binaryResolver`, `platformPaths` (×2)

### Files changed (22)

- **New helpers:** `src/common/errors/errorMessage.ts`, `src/common/errors/index.ts`, `src/utils/core/pathCore.ts`, `src/utils/text/stringUtils.ts`
- **`ensureError` callsites:** `RetryState.ts`, `ResponseCycleNode.ts`, `RemoteAgentLoader.ts`, `SupabaseClient.ts`
- **`getExtensionLowercase` callsites:** `LatexMediaManager.ts`, `acceptedFileTarget.ts`, `MediaAttachmentProcessor.ts`, `ReadTool.ts`
- **`extractMimeSubtype` callsites:** `modelHandlerOpenAI.ts`, `modelHandlerOpenRouterNative.ts`, `anthropicTools.ts`
- **`hasExtension` callsites:** `compileCheck.ts`, `compiledPdfArtifacts.ts`, `OpenPdfTool.ts`, `DelegationTools.ts`, `ReadTool.ts`, `binaryResolver.ts`, `platformPaths.ts`
- **`tailWithEllipsis` moved:** `SendToTerminalTool.ts`

## Test plan

- [x] `npm run compile:fast` — clean build, no errors
- [ ] Verify extension-check behaviour unchanged: `.tex`, `.pdf`, `.bib`, `.eml`, `.pl`, `.exe` paths
- [ ] Verify error coercion: non-Error throws still produce an `Error` with the right `.message`
- [ ] Verify MIME subtype extraction: `audio/wav` → `wav`, `image/png` → `png`, `application/pdf` → `pdf`

https://claude.ai/code/session_01MbMFwzm4V9PvwLfaJMUZ3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbMFwzm4V9PvwLfaJMUZ3q)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication across many files with equivalent semantics; no new features or security-sensitive logic changes.
> 
> **Overview**
> This PR **centralizes repeated error, path, MIME, and string-truncation logic** into shared helpers and rewires ~22 call sites to use them, with **no intended behavior change**.
> 
> **New or promoted utilities:** `ensureError` in `@common/errors` replaces inline `instanceof Error` coercion in relay retry, reflection cycle failures, remote agent loading, and Supabase readiness. `getExtensionLowercase` is now exported from `pathCore` and replaces ad hoc `path.extname(...).toLowerCase()` in LaTeX/media/read paths. `extractMimeSubtype` and `tailWithEllipsis` live in `stringUtils` (the latter moved out of `SendToTerminalTool`). Existing **`hasExtension`** is adopted where code used `.endsWith('.ext')` or manual extension checks (compile check, PDF tools, delegation `.bib`, binary/platform path resolution, etc.).
> 
> Model handlers and Anthropic attachment upload now derive audio/image subtypes and default filenames via **`extractMimeSubtype`** instead of splitting MIME strings inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a017f91463907d565b13e52a8157413dbb182b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->