### PR TITLE
[codex] Show queued follow-up text without duplicate count

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -5,6 +5,8 @@
 import { render } from 'ink';
 import React from 'react';
 
+import { STREAM_STATUS } from '@shared/schemas';
+
 import { App } from '../src/chat/tui/App';
 import {
   cliState,
@@ -20,6 +22,15 @@ const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
+const QUEUED_FOLLOW_UPS = parseList(process.env.HARNESS_QUEUED_FOLLOWUPS);
+
+function parseList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split('||')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
 
 function makeEntries(count: number): ConversationEntry[] {
   const entries: ConversationEntry[] = [];
@@ -78,8 +89,12 @@ cliState.sessionMeta.set({
 cliState.activeStreamId.set(STREAM_ID);
 patchStream(STREAM_ID, (slice) => ({
   ...slice,
-  status: undefined,
+  status: QUEUED_FOLLOW_UPS.length > 0 ? STREAM_STATUS.RUNNING : slice.status,
+  runStartedAt:
+    QUEUED_FOLLOW_UPS.length > 0 ? Date.now() - 42_000 : slice.runStartedAt,
   entries: makeEntries(ENTRY_COUNT),
+  queuedFollowUps: QUEUED_FOLLOW_UPS.length,
+  queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));
 
 if (SHOW_EDIT_APPROVAL) {

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -162,19 +162,12 @@ export function queuedFollowUpsSummary(
   maxColumns?: number,
 ): string | undefined {
   if (messages.length === 0) return undefined;
-  const prefix =
-    messages.length === 1 ? 'queued: ' : `queued ${messages.length}: `;
-  const prefixWidth = stringWidth(prefix);
   const previewLength =
     maxColumns === undefined
       ? QUEUED_FOLLOW_UP_PREVIEW_LENGTH
-      : Math.min(
-          QUEUED_FOLLOW_UP_PREVIEW_LENGTH,
-          Math.max(0, maxColumns - prefixWidth),
-        );
+      : Math.min(QUEUED_FOLLOW_UP_PREVIEW_LENGTH, Math.max(0, maxColumns));
   if (previewLength < STATUS_BAR_MIN_RIGHT_PREVIEW) return undefined;
-  const preview = truncateSummaryToColumns(messages[0] ?? '', previewLength);
-  return `${prefix}${preview}`;
+  return truncateSummaryToColumns(messages[0] ?? '', previewLength);
 }
 
 function queuedFollowUpsCountSegment(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -10,31 +10,31 @@ import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
 describe('CLI StatusBar display model', () => {
-  it('summarizes queued follow-up messages', () => {
+  it('previews queued follow-up messages without duplicating the count', () => {
     expect(queuedFollowUpsSummary([])).toBeUndefined();
     expect(queuedFollowUpsSummary(['Keep the proof under one page.'])).toBe(
-      'queued: Keep the proof under one page.',
+      'Keep the proof under one page.',
     );
     expect(
       queuedFollowUpsSummary([
         'Keep the proof under one page.',
         'Also mention the finite monoid argument.',
       ]),
-    ).toBe('queued 2: Keep the proof under one page.');
+    ).toBe('Keep the proof under one page.');
   });
 
   it('hides queued follow-up previews when the right side has no safe width', () => {
     expect(queuedFollowUpsSummary(['Keep the proof under one page.'], 20)).toBe(
-      'queued: Keep the pr…',
+      'Keep the proof unde…',
     );
     expect(
-      queuedFollowUpsSummary(['Keep the proof under one page.'], 19),
+      queuedFollowUpsSummary(['Keep the proof under one page.'], 11),
     ).toBeUndefined();
   });
 
   it('truncates queued follow-up previews by display columns', () => {
     expect(queuedFollowUpsSummary(['請補充一個單調有界證明。'], 20)).toBe(
-      'queued: 請補充一個…',
+      '請補充一個單調有界…',
     );
   });
 
@@ -64,7 +64,7 @@ describe('CLI StatusBar display model', () => {
       'queued 1',
     ]);
     expect(display.left.at(-1)).toMatchObject({ color: 'yellow' });
-    expect(display.right).toBe('queued: Keep the proof under one page.');
+    expect(display.right).toBe('Keep the proof under one page.');
   });
 
   it('keeps idle state compact and omits static agent/model names', () => {
@@ -162,7 +162,7 @@ describe('CLI StatusBar display model', () => {
       '1 proc',
       '3 approvals',
     ]);
-    expect(display.right).toBe('queued 2: Keep the proof under one page.');
+    expect(display.right).toBe('Keep the proof under one page.');
     expect(display.bindings).toContain('[Alt-s]subagents');
     // Stream-navigation hints appear once more than one stream is live.
     expect(display.bindings).toContain('[Tab]streams');
@@ -287,7 +287,7 @@ describe('CLI StatusBar display model', () => {
       width: 60,
     });
 
-    expect(display.right).toBeUndefined();
+    expect(display.right).toBe('Keep the proof un…');
   });
 
   it('shows the resume command while exit confirmation is armed', () => {


### PR DESCRIPTION
## Summary

- Keep the queued follow-up count on the durable left status segment, and show only the queued message preview on the right.
- Add a `HARNESS_QUEUED_FOLLOWUPS` TTY harness seed so queued-message display can be dogfooded without a live model run.
- Update status-bar tests for the wider message preview budget.

Closes #4657

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- Real 60x20 TTY harness smoke: `HARNESS_ENTRIES=8 HARNESS_QUEUED_FOLLOWUPS="Keep the proof under one page.||Also mention the finite monoid argument." TERM=xterm-256color node packages/cli/dist/bin/tui-harness.js`; status shows `queued 2` once and `Keep the proof under one page.` as the preview.
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 import-order warnings)
- `npm run texra-local:build`
- `texra-local version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI status-bar display and harness/test updates only; no auth, data, or runtime execution paths.
> 
> **Overview**
> The CLI status bar no longer repeats the queued follow-up count on the right: **`queued N`** stays on the left, and the right side shows only a truncated preview of the first queued message.
> 
> Preview width logic drops the old **`queued:` / `queued N:`** prefix so more columns go to the message text; tests and the TTY harness (`HARNESS_QUEUED_FOLLOWUPS`, optional running state) were updated to exercise that layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998ff5eb6bf1489a6a4c7d8140151077bdf5aca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->