### PR TITLE
fix: align CLI Ctrl-C footer action

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -19,6 +19,7 @@ const STREAM_ID = 'harness-stream-1';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
+let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
@@ -111,21 +112,45 @@ if (SHOW_EDIT_APPROVAL) {
   }
 }
 
+function markHarnessInterrupted(): void {
+  canInterrupt = false;
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    status: STREAM_STATUS.STOPPED,
+    runStartedAt: undefined,
+    entries: [
+      ...slice.entries,
+      {
+        id: 'harness-interrupted',
+        role: 'assistant',
+        text: 'Harness interrupt requested.',
+        finalized: true,
+      },
+    ],
+  }));
+}
+
 const ink = render(
   <App
     onSubmit={() => undefined}
     onKillExecution={() => undefined}
-    canInterruptActiveRun={() => false}
-    onInterruptActive={() => undefined}
+    canInterruptActiveRun={() => canInterrupt}
+    canStopActiveRun={() => canInterrupt}
+    onInterruptActive={markHarnessInterrupted}
   />,
   {
     stdout: process.stdout,
     stderr: process.stderr,
     stdin: process.stdin,
+    exitOnCtrlC: false,
   },
 );
 
 process.on('SIGINT', () => {
+  if (canInterrupt) {
+    markHarnessInterrupted();
+    return;
+  }
   ink.unmount();
   process.exit(0);
 });

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -207,7 +207,9 @@ export interface AppProps {
   readonly onSubmit: (line: string) => void;
   readonly onKillExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
+  readonly canStopActiveRun?: () => boolean;
   readonly onInterruptActive: () => void;
+  readonly onCtrlC?: () => void;
   readonly inputDisabled?: boolean;
   readonly history?: InputHistory;
 }
@@ -229,6 +231,8 @@ export function App(props: AppProps): React.JSX.Element {
   const [childControlMode, setChildControlMode] = useState<
     ChildControlMode | undefined
   >(undefined);
+  const canStopActiveRun =
+    props.canStopActiveRun ?? props.canInterruptActiveRun;
 
   // Under the Kitty disambiguate flag (enabled in runChatTui for Shift+Enter),
   // keypad Enter becomes its own key (codepoint 57414) that Ink parses but
@@ -359,13 +363,20 @@ export function App(props: AppProps): React.JSX.Element {
   // handler (gating internally) is clearer than several hooks racing on the same
   // chord. Stays mounted so Ctrl+C works even while a modal/form owns the input.
   useInput((input, key) => {
-    // Ctrl+C exits, even over a foreground surface. We render with
+    // Ctrl+C is owned here even over foreground surfaces. We render with
     // exitOnCtrlC: false (see runChatTui), so Ink neither auto-exits nor filters
-    // Ctrl+C out of useInput — this handler is the single exit path. Ink decodes
-    // both the raw \x03 and the Kitty CSI-u form (ESC[99;5u, emitted under the
-    // disambiguate flag) to a ctrl+c key, so this one branch covers every
-    // terminal; exit() is Ink's app-level shutdown (≡ useApp().exit).
+    // Ctrl+C out of useInput. The full CLI wires onCtrlC to the same SIGINT
+    // path used by terminals that deliver a signal; harnesses can fall back to
+    // interrupt-then-exit behavior without duplicating that process lifecycle.
     if (key.ctrl && input === 'c') {
+      if (props.onCtrlC) {
+        props.onCtrlC();
+        return;
+      }
+      if (canStopActiveRun()) {
+        props.onInterruptActive();
+        return;
+      }
       exit();
       return;
     }
@@ -454,7 +465,7 @@ export function App(props: AppProps): React.JSX.Element {
           history={props.history}
         />
         <StreamTabsStrip width={columns} />
-        <StatusBar />
+        <StatusBar canStopActiveRun={canStopActiveRun} />
       </Box>
     </>
   );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -25,6 +25,7 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
 type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
+export type CtrlCAction = 'exit' | 'stop';
 
 export interface StatusBarSegment {
   readonly text: string;
@@ -62,6 +63,7 @@ export interface StatusBarDisplayInput {
   /** Terminal width in columns. Used to keep right-side previews from
    *  colliding with durable left-side status segments. */
   readonly width?: number;
+  readonly ctrlCAction?: CtrlCAction;
 }
 
 export interface StatusBarDisplay {
@@ -214,6 +216,7 @@ function statusBarBindings(
   modifierLabel: string,
   hasMultipleStreams: boolean,
   shiftEnterNewline: boolean,
+  ctrlCAction: CtrlCAction,
 ): readonly string[] {
   return [
     // Stream cycling / numeric focus only do something when there is more
@@ -226,7 +229,7 @@ function statusBarBindings(
     '[/model]models',
     '[/api]api',
     shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
-    '[Ctrl-C]stop',
+    `[Ctrl-C]${ctrlCAction}`,
   ];
 }
 
@@ -235,9 +238,15 @@ export function statusBarBindingsText(
   hasMultipleStreams: boolean,
   modifierLabel = defaultShortcutModifierLabel(),
   shiftEnterNewline = false,
+  ctrlCAction: CtrlCAction = 'exit',
 ): string {
   const bindings: string[] = [
-    ...statusBarBindings(modifierLabel, hasMultipleStreams, shiftEnterNewline),
+    ...statusBarBindings(
+      modifierLabel,
+      hasMultipleStreams,
+      shiftEnterNewline,
+      ctrlCAction,
+    ),
   ];
   if (subagentControlsAvailable) {
     const tasksBinding = `[${modifierLabel}-p]tasks`;
@@ -317,6 +326,7 @@ export function buildStatusBarDisplay(
             input.hasMultipleStreams,
             input.shortcutModifierLabel,
             input.shiftEnterNewline,
+            input.ctrlCAction,
           ),
   };
 }
@@ -325,7 +335,11 @@ export function statusBarSegmentText(segment: StatusBarSegment): string {
   return segment.text;
 }
 
-export function StatusBar(): React.JSX.Element {
+export interface StatusBarProps {
+  readonly canStopActiveRun?: () => boolean;
+}
+
+export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const sessionMeta = useSignal(cliState.sessionMeta);
@@ -358,6 +372,7 @@ export function StatusBar(): React.JSX.Element {
     apiMode: shortCliApiMode(sessionMeta.apiMode),
     shiftEnterNewline: caps.kittyKeyboard,
     width: columns,
+    ctrlCAction: props.canStopActiveRun?.() ? 'stop' : 'exit',
   });
 
   return (

--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -4,7 +4,7 @@ const TIPS = [
   'Use /help to see available commands',
   'Press /model to switch models',
   'Press /agent to switch agents',
-  'Press Ctrl-C to interrupt',
+  'Ctrl-C exits idle chats; stops active responses',
   'Use /clear to start fresh',
   'Press /status to see session details',
   'Press /api to view or change API mode',

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -711,6 +711,8 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
+  const canStopActiveRun = (): boolean =>
+    Boolean(session.runPromise && !session.runCompleted);
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
@@ -929,7 +931,9 @@ export async function runChat(
     <App
       onSubmit={handleSubmit}
       canInterruptActiveRun={() => chatTuiCanInterruptActiveRun(session)}
+      canStopActiveRun={canStopActiveRun}
       onInterruptActive={interruptActive}
+      onCtrlC={() => handleSigint()}
       onKillExecution={(executionId) => {
         clearApprovals();
         killExecution(executionId);
@@ -988,6 +992,10 @@ export async function runChat(
   };
   const handleSigint = (): void => {
     if (exitArmed) {
+      exitNow(130);
+      return;
+    }
+    if (!canStopActiveRun()) {
       exitNow(130);
       return;
     }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -98,6 +98,8 @@ describe('CLI StatusBar display model', () => {
     // (see #4399) but used to be discoverable only via source diving.
     expect(display.bindings).toContain('[Ctrl-J]newline');
     expect(display.bindings).not.toContain('[Shift-Enter]newline');
+    expect(display.bindings).toContain('[Ctrl-C]exit');
+    expect(display.bindings).not.toContain('[Ctrl-C]stop');
     expect(display.bindings).not.toContain('[Alt-s]subagents');
     // Stream-navigation hints stay hidden in a single-stream chat.
     expect(display.bindings).not.toContain('[Tab]streams');
@@ -149,6 +151,7 @@ describe('CLI StatusBar display model', () => {
       model: 'deepseekT',
       apiMode: 'relay',
       shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
@@ -164,6 +167,7 @@ describe('CLI StatusBar display model', () => {
     ]);
     expect(display.right).toBe('Keep the proof under one page.');
     expect(display.bindings).toContain('[Alt-s]subagents');
+    expect(display.bindings).toContain('[Ctrl-C]stop');
     // Stream-navigation hints appear once more than one stream is live.
     expect(display.bindings).toContain('[Tab]streams');
     expect(display.bindings).toContain('[Alt-1..9]focus');
@@ -288,6 +292,7 @@ describe('CLI StatusBar display model', () => {
     });
 
     expect(display.right).toBe('Keep the proof un…');
+    expect(display.bindings).toContain('[Ctrl-C]exit');
   });
 
   it('shows the resume command while exit confirmation is armed', () => {


### PR DESCRIPTION
## Summary
- label Ctrl-C as `exit` unless the current TUI session has an active run to stop
- route App-level Ctrl-C through the same stop/second-press-exit flow used by SIGINT
- extend the TUI harness with an interruptible mode for real terminal verification

Closes #4659

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --dir packages/cli run bundle:harness`
- TTY harness: idle at 160 cols shows `[Ctrl-C]exit`; interruptible running harness shows `[Ctrl-C]stop`, Ctrl-C marks `Harness interrupt requested.` and flips to `[Ctrl-C]exit`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 3 existing import-order warnings in unrelated files)
- `npm run texra-local:build && texra-local version`
- TTY `texra-local chat --api-mode=personal` at 160 cols shows `[Ctrl-C]exit`; Ctrl-C exits with code 130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only UX and input routing; no auth, data, or API behavior changes.
> 
> **Overview**
> The chat TUI now shows **`[Ctrl-C]exit`** when idle and **`[Ctrl-C]stop`** while a root agent run is in progress, driven by a new `canStopActiveRun` hook passed from `runChatTui` into `App` and `StatusBar`.
> 
> **Ctrl+C** at the Ink layer is routed through optional `onCtrlC` so the real CLI reuses the same **SIGINT** flow (stop run, arm second-press exit); idle sessions exit on the first press. The TUI harness gains an interruptible mode (`HARNESS_CAN_INTERRUPT`) for manual verification, and status-bar tests cover both binding labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfadb0190f0916d2d12f674cf1a9f188f427453a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->