### PR TITLE
fix: show CLI Ctrl-C exit after idle response

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -52,7 +52,9 @@ import {
 } from '@cli/runtime/memory';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
+  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
+  type StreamStatus,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -126,6 +128,14 @@ export interface ClearableTuiSessionState {
 }
 
 type TuiSession = ClearableTuiSessionState;
+type InterruptibleTuiSessionState = Pick<
+  ClearableTuiSessionState,
+  'streamId' | 'runPromise' | 'runCompleted'
+>;
+type PendingTuiRunSessionState = Pick<
+  ClearableTuiSessionState,
+  'runPromise' | 'runCompleted'
+>;
 
 export function clearTuiSessionRunState(
   session: ClearableTuiSessionState,
@@ -138,20 +148,26 @@ export function clearTuiSessionRunState(
   session.stopRequested = false;
 }
 
-export function chatTuiCanInterruptActiveRun(session: {
-  readonly streamId: StreamTabId | undefined;
-  readonly runPromise: Promise<unknown> | undefined;
-  readonly runCompleted: boolean;
-}): boolean {
+export function chatTuiCanInterruptActiveRun(
+  session: InterruptibleTuiSessionState,
+): boolean {
   return Boolean(
     session.streamId && session.runPromise && !session.runCompleted,
   );
 }
 
-export function chatTuiCanStartRootRun(session: {
-  readonly runPromise: Promise<unknown> | undefined;
-  readonly runCompleted: boolean;
-}): boolean {
+export function chatTuiCanStopActiveRun(
+  session: InterruptibleTuiSessionState,
+  status: StreamStatus | undefined,
+): boolean {
+  if (!session.runPromise || session.runCompleted) return false;
+  if (!session.streamId) return true;
+  return status === undefined || LIVE_ELAPSED_STREAM_STATUSES.has(status);
+}
+
+export function chatTuiCanStartRootRun(
+  session: PendingTuiRunSessionState,
+): boolean {
   return !session.runPromise || session.runCompleted;
 }
 
@@ -711,8 +727,15 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
+  const rootStreamStatus = (): StreamStatus | undefined =>
+    session.streamId
+      ? (cliState.streams.get().get(session.streamId)?.status ??
+        StreamStatusService.get(session.streamId))
+      : undefined;
+  const canInterruptActiveRun = (): boolean =>
+    chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
-    Boolean(session.runPromise && !session.runCompleted);
+    chatTuiCanStopActiveRun(session, rootStreamStatus());
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
@@ -930,7 +953,7 @@ export async function runChat(
   const ink = render(
     <App
       onSubmit={handleSubmit}
-      canInterruptActiveRun={() => chatTuiCanInterruptActiveRun(session)}
+      canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
       onInterruptActive={interruptActive}
       onCtrlC={() => handleSigint()}
@@ -996,6 +1019,10 @@ export async function runChat(
       return;
     }
     if (!canStopActiveRun()) {
+      if (canInterruptActiveRun()) {
+        session.stopRequested = true;
+        interruptActive();
+      }
       exitNow(130);
       return;
     }

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -47,6 +47,7 @@ import {
 import { renderAnsiMarkdown } from '@cli/chat/tui/render/ansiMarkdown';
 import {
   chatTuiCanInterruptActiveRun,
+  chatTuiCanStopActiveRun,
   chatTuiCanStartRootRun,
   chatTuiActiveChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
@@ -362,6 +363,101 @@ describe('CLI TUI row allocation', () => {
         runPromise,
       }),
     ).toBe(true);
+  });
+
+  it('only reports Ctrl-C stoppable while the root stream is actively responding', () => {
+    const runPromise = Promise.resolve();
+
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: undefined,
+        },
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.RUNNING,
+      ),
+    ).toBe(true);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.INITIALIZING,
+      ),
+    ).toBe(true);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.RESUMING,
+      ),
+    ).toBe(true);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.WAITING,
+      ),
+    ).toBe(false);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.ERROR,
+      ),
+    ).toBe(false);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.STOPPED,
+      ),
+    ).toBe(false);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: false,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.READY,
+      ),
+    ).toBe(false);
+    expect(
+      chatTuiCanStopActiveRun(
+        {
+          runCompleted: true,
+          runPromise,
+          streamId: root,
+        },
+        STREAM_STATUS.RUNNING,
+      ),
+    ).toBe(false);
   });
 
   it('selects the focused child stream as a follow-up target', () => {


### PR DESCRIPTION
## Summary
- make the CLI Ctrl-C stop decision follow the root stream live status instead of the long-lived chat session promise
- keep startup-without-stream stoppable, but show exit after waiting/error/stopped states
- cover waiting/error states in the TUI state tests

Closes #4661

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run format`
- `npm run texra-local:build && texra-local version`
- real TTY `texra-local chat --api-mode=personal`, submitted a short math prompt with missing DeepSeek key: after the error, status showed `idle api` and footer showed `[Ctrl-C]exit`; Ctrl-C exited with code 130
- `npm run compile:safe`
- `npm run lint` (passes with the existing 3 unrelated import-order warnings)

## Note
The local worktree had pre-existing unrelated edits in subagent-list/harness files. This PR commit only changes `runChatTui.tsx` and `TuiStateAndFocus.vitest.mts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input and session-guard logic with unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> The CLI chat TUI no longer treats **Ctrl-C “stop”** as tied only to an in-flight `runPromise`. **`chatTuiCanStopActiveRun`** now also requires the root stream to be in a **live responding** status (`INITIALIZING`, `RUNNING`, `RESUMING`, or pre-stream startup); when the stream is **idle** (`WAITING`, `ERROR`, `STOPPED`, `READY`, etc.), the footer can show **`[Ctrl-C] exit`** and the first Ctrl-C exits immediately (code 130) instead of arming a double-tap stop.
> 
> **`handleSigint`** is adjusted so that if stop is not allowed but an active run is still interruptible, it interrupts once and then exits—avoiding a stuck “stop” UX after errors or finished turns.
> 
> Tests cover stop vs interrupt across stream statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2f62787e47ffd89fd2a6cbb90722eae3e0d1e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->