### PR TITLE
[codex] Compact CLI child execution panel

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -5,12 +5,13 @@
 import { render } from 'ink';
 import React from 'react';
 
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_STATUS, TODO_STATUS } from '@shared/schemas';
 
 import { App } from '../src/chat/tui/App';
 import {
   cliState,
   patchStream,
+  setParentStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
 import { enqueueApproval } from '../src/chat/tui/state/approvalQueue';
@@ -19,6 +20,8 @@ const STREAM_ID = 'harness-stream-1';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
+const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
+const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
@@ -49,6 +52,23 @@ function makeEntries(count: number): ConversationEntry[] {
     });
   }
   return entries;
+}
+
+function makeChildEntries(agent: string, action: string): ConversationEntry[] {
+  return [
+    {
+      id: `${agent}-user`,
+      role: 'user',
+      text: `Please handle the ${action} sub-workflow.`,
+      finalized: true,
+    },
+    {
+      id: `${agent}-assistant`,
+      role: 'assistant',
+      text: `${agent} is checking the ${action} details and preparing a concise result.`,
+      finalized: false,
+    },
+  ];
 }
 
 function makeEditApprovalRequest() {
@@ -97,6 +117,114 @@ patchStream(STREAM_ID, (slice) => ({
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));
+
+if (SHOW_CHILDREN) {
+  const startedAt = Date.now() - 74_000;
+  const childStreams = [
+    {
+      executionId: 'harness-child-strategy',
+      agentName: 'strategy',
+      childStreamId: 'harness-child-strategy-stream',
+      status: STREAM_STATUS.RUNNING,
+      startedAt,
+    },
+    {
+      executionId: 'harness-child-lean',
+      agentName: 'leanSolver',
+      childStreamId: 'harness-child-lean-stream',
+      status: STREAM_STATUS.WAITING,
+      elapsed: '2m 03s',
+    },
+    {
+      executionId: 'harness-child-review',
+      agentName: 'reviewer',
+      childStreamId: 'harness-child-review-stream',
+      status: STREAM_STATUS.RUNNING,
+      startedAt: startedAt + 12_000,
+    },
+  ];
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    status: STREAM_STATUS.RUNNING,
+    runStartedAt: startedAt,
+    activeSubagents: childStreams,
+    childStreams,
+    activeProcesses: [
+      {
+        executionId: 'harness-process-latexmk',
+        agentName: 'latex build',
+        toolName: 'bash',
+        status: STREAM_STATUS.RUNNING,
+        startedAt: Date.now() - 19_000,
+      },
+    ],
+    processOutput: new Map([
+      [
+        'harness-process-latexmk',
+        {
+          stdout: [
+            'latexmk: applying rule pdflatex',
+            'chapter1.tex:47: Overfull hbox',
+            'main.tex: Proof sketch needs one missing reference',
+          ].join('\n'),
+          stderr: '',
+        },
+      ],
+    ]),
+  }));
+  for (const child of childStreams) {
+    const streamId = child.childStreamId;
+    setParentStream(streamId, STREAM_ID);
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      status: child.status,
+      description: `${child.agentName} sub-workflow`,
+      entries: makeChildEntries(child.agentName, child.executionId),
+      runStartedAt:
+        child.status === STREAM_STATUS.RUNNING ? startedAt : undefined,
+    }));
+  }
+}
+
+if (SHOW_TODOS) {
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    todos: [
+      {
+        content: 'Split theorem into algebraic and analytic checks',
+        activeForm: 'Splitting theorem into checks',
+        status: TODO_STATUS.COMPLETED,
+      },
+      {
+        content: 'Ask leanSolver to verify the finite case',
+        activeForm: 'Waiting for leanSolver',
+        status: TODO_STATUS.IN_PROGRESS,
+      },
+      {
+        content: 'Merge subagent conclusions into final answer',
+        activeForm: 'Merging subagent conclusions',
+        status: TODO_STATUS.PENDING,
+      },
+    ],
+    plan: {
+      summary: 'Coordinate a small math proof through nested CLI work.',
+      steps: [
+        {
+          title: 'Route proof obligations',
+          description: 'Choose the right specialist for each proof branch.',
+          files: [],
+          status: TODO_STATUS.COMPLETED,
+        },
+        {
+          title: 'Check formalizable parts',
+          description: 'Have a subagent inspect the Lean-style finite case.',
+          files: [],
+          status: TODO_STATUS.IN_PROGRESS,
+        },
+      ],
+    },
+  }));
+}
 
 if (SHOW_EDIT_APPROVAL) {
   const showApproval = () =>

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -5,7 +5,11 @@
 import { render } from 'ink';
 import React from 'react';
 
-import { STREAM_STATUS, TODO_STATUS } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  TODO_STATUS,
+  type ActiveChildInfo,
+} from '@shared/schemas';
 
 import { App } from '../src/chat/tui/App';
 import {
@@ -69,6 +73,14 @@ function makeChildEntries(agent: string, action: string): ConversationEntry[] {
       finalized: false,
     },
   ];
+}
+
+function stoppedChild(child: ActiveChildInfo): ActiveChildInfo {
+  return {
+    ...child,
+    status: STREAM_STATUS.STOPPED,
+    startedAt: undefined,
+  };
 }
 
 function makeEditApprovalRequest() {
@@ -181,7 +193,7 @@ if (SHOW_CHILDREN) {
       description: `${child.agentName} sub-workflow`,
       entries: makeChildEntries(child.agentName, child.executionId),
       runStartedAt:
-        child.status === STREAM_STATUS.RUNNING ? startedAt : undefined,
+        child.status === STREAM_STATUS.RUNNING ? child.startedAt : undefined,
     }));
   }
 }
@@ -242,10 +254,22 @@ if (SHOW_EDIT_APPROVAL) {
 
 function markHarnessInterrupted(): void {
   canInterrupt = false;
+  const parentSlice = cliState.streams.get().get(STREAM_ID);
+  const childStreamIds = new Set(
+    [
+      ...(parentSlice?.activeSubagents ?? []),
+      ...(parentSlice?.childStreams ?? []),
+    ]
+      .map((child) => child.childStreamId)
+      .filter((streamId): streamId is string => streamId !== undefined),
+  );
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
     status: STREAM_STATUS.STOPPED,
     runStartedAt: undefined,
+    activeSubagents: slice.activeSubagents.map(stoppedChild),
+    activeProcesses: slice.activeProcesses.map(stoppedChild),
+    childStreams: slice.childStreams.map(stoppedChild),
     entries: [
       ...slice.entries,
       {
@@ -256,6 +280,13 @@ function markHarnessInterrupted(): void {
       },
     ],
   }));
+  for (const streamId of childStreamIds) {
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      status: STREAM_STATUS.STOPPED,
+      runStartedAt: undefined,
+    }));
+  }
 }
 
 const ink = render(

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -155,7 +155,9 @@ export function streamTabSegmentText(item: StreamTabDisplayItem): string {
   const label = item.active ? `[${item.label}]` : item.label;
   const running = item.running ? '*' : '';
   const status =
-    !item.active && item.status && item.status !== 'running'
+    item.status &&
+    item.status !== 'running' &&
+    (!item.active || item.status === 'stopped')
       ? `(${item.status})`
       : '';
   return `${label}${running}${status}`;

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -17,21 +17,38 @@ import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
-import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
+import {
+  CHILD_STATUS_MARKER,
+  childStatusColor,
+  shouldShowChildSectionHeader,
+} from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
   readonly index: number;
   readonly nowMs: number;
+  readonly compact?: boolean;
+  readonly tail?: ProcessOutputTail;
+}
+
+export interface ChildRow {
+  readonly child: ActiveChildInfo;
+  readonly index: number;
   readonly tail?: ProcessOutputTail;
 }
 
 const TAIL_LINES = 4;
 
-function Row({ child, index, nowMs, tail }: RowProps): React.JSX.Element {
+function Row({
+  child,
+  compact = false,
+  index,
+  nowMs,
+  tail,
+}: RowProps): React.JSX.Element {
   // The state layer already caps each stream at PROCESS_TAIL_CHARS_MAX, so
   // pulling the last `TAIL_LINES` non-blank lines is bounded work.
-  const tailLines = processTailLines(tail).slice(-TAIL_LINES);
+  const tailLines = compact ? [] : processTailLines(tail).slice(-TAIL_LINES);
   const elapsed = childElapsed(child, nowMs);
   return (
     <Box flexDirection="column">
@@ -57,6 +74,40 @@ function Row({ child, index, nowMs, tail }: RowProps): React.JSX.Element {
   );
 }
 
+export function compactRows(params: {
+  readonly activeProcesses: readonly ActiveChildInfo[];
+  readonly maxRows: number;
+  readonly processOutput: ReadonlyMap<string, ProcessOutputTail> | undefined;
+  readonly subagents: readonly ActiveChildInfo[];
+}): {
+  readonly hiddenCount: number;
+  readonly rows: readonly ChildRow[];
+} {
+  const rowBudget = Math.max(0, Math.floor(params.maxRows));
+  const allRows: ChildRow[] = [
+    ...params.subagents.map((child, index) => ({ child, index })),
+    ...params.activeProcesses.map((child, processIndex) => ({
+      child,
+      index: params.subagents.length + processIndex,
+      tail: params.processOutput?.get(child.executionId),
+    })),
+  ];
+  if (allRows.length <= rowBudget) {
+    return { hiddenCount: 0, rows: allRows };
+  }
+  if (rowBudget <= 1) {
+    return {
+      hiddenCount: Math.max(0, allRows.length - rowBudget),
+      rows: allRows.slice(0, rowBudget),
+    };
+  }
+  const visibleRows = allRows.slice(0, rowBudget - 1);
+  return {
+    hiddenCount: allRows.length - visibleRows.length,
+    rows: visibleRows,
+  };
+}
+
 export interface SubagentListProps {
   readonly maxRows?: number;
 }
@@ -72,10 +123,44 @@ export function SubagentList(
   const subagents = slice ? visibleSubagentRows(slice) : [];
   const liveElapsedKey = liveChildExecutionElapsedKey(slice);
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
+  const showSectionHeader = shouldShowChildSectionHeader(props.maxRows);
 
   if (!slice) return null;
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
+
+  if (props.maxRows !== undefined) {
+    const { hiddenCount, rows } = compactRows({
+      activeProcesses,
+      maxRows: props.maxRows,
+      processOutput,
+      subagents,
+    });
+    return (
+      <Box
+        flexDirection="column"
+        height={props.maxRows}
+        overflowY="hidden"
+        paddingX={1}
+      >
+        {rows.map(({ child, index, tail }) => (
+          <Row
+            key={child.executionId}
+            child={child}
+            compact
+            index={index}
+            nowMs={nowMs}
+            tail={tail}
+          />
+        ))}
+        {hiddenCount > 0 ? (
+          <Text
+            dimColor
+          >{`   +${hiddenCount} more child execution${hiddenCount === 1 ? '' : 's'}`}</Text>
+        ) : null}
+      </Box>
+    );
+  }
 
   return (
     <Box
@@ -87,9 +172,11 @@ export function SubagentList(
     >
       {subagents.length > 0 ? (
         <Box flexDirection="column">
-          <Text bold dimColor>
-            Subagents
-          </Text>
+          {showSectionHeader ? (
+            <Text bold dimColor>
+              Subagents
+            </Text>
+          ) : null}
           {subagents.map((child, i) => (
             <Row
               key={child.executionId}
@@ -102,9 +189,11 @@ export function SubagentList(
       ) : null}
       {activeProcesses.length > 0 ? (
         <Box flexDirection="column" marginTop={subagents.length > 0 ? 1 : 0}>
-          <Text bold dimColor>
-            Processes
-          </Text>
+          {showSectionHeader ? (
+            <Text bold dimColor>
+              Processes
+            </Text>
+          ) : null}
           {activeProcesses.map((child, i) => (
             <Row
               key={child.executionId}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -97,8 +97,8 @@ export function compactRows(params: {
   }
   if (rowBudget <= 1) {
     return {
-      hiddenCount: Math.max(0, allRows.length - rowBudget),
-      rows: allRows.slice(0, rowBudget),
+      hiddenCount: allRows.length,
+      rows: [],
     };
   }
   const visibleRows = allRows.slice(0, rowBudget - 1);

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -30,7 +30,6 @@ interface RowProps {
 export interface ChildRow {
   readonly child: ActiveChildInfo;
   readonly index: number;
-  readonly tail?: ProcessOutputTail;
 }
 
 const TAIL_LINES = 4;
@@ -88,7 +87,6 @@ function Row({
 export function compactRows(params: {
   readonly activeProcesses: readonly ActiveChildInfo[];
   readonly maxRows: number;
-  readonly processOutput: ReadonlyMap<string, ProcessOutputTail> | undefined;
   readonly subagents: readonly ActiveChildInfo[];
 }): {
   readonly hiddenCount: number;
@@ -100,7 +98,6 @@ export function compactRows(params: {
     ...params.activeProcesses.map((child, processIndex) => ({
       child,
       index: params.subagents.length + processIndex,
-      tail: params.processOutput?.get(child.executionId),
     })),
   ];
   if (allRows.length <= rowBudget) {
@@ -143,7 +140,6 @@ export function SubagentList(
     const { hiddenCount, rows } = compactRows({
       activeProcesses,
       maxRows: props.maxRows,
-      processOutput,
       subagents,
     });
     return (
@@ -153,14 +149,13 @@ export function SubagentList(
         overflowY="hidden"
         paddingX={1}
       >
-        {rows.map(({ child, index, tail }) => (
+        {rows.map(({ child, index }) => (
           <Row
             key={child.executionId}
             child={child}
             compact
             index={index}
             nowMs={nowMs}
-            tail={tail}
           />
         ))}
         {hiddenCount > 0 ? (

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -17,11 +17,7 @@ import { visibleSubagentRows } from '../state/childStreamMerge';
 import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
-import {
-  CHILD_STATUS_MARKER,
-  childStatusColor,
-  shouldShowChildSectionHeader,
-} from './SubagentListDisplay';
+import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
@@ -123,7 +119,6 @@ export function SubagentList(
   const subagents = slice ? visibleSubagentRows(slice) : [];
   const liveElapsedKey = liveChildExecutionElapsedKey(slice);
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
-  const showSectionHeader = shouldShowChildSectionHeader(props.maxRows);
 
   if (!slice) return null;
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
@@ -172,11 +167,9 @@ export function SubagentList(
     >
       {subagents.length > 0 ? (
         <Box flexDirection="column">
-          {showSectionHeader ? (
-            <Text bold dimColor>
-              Subagents
-            </Text>
-          ) : null}
+          <Text bold dimColor>
+            Subagents
+          </Text>
           {subagents.map((child, i) => (
             <Row
               key={child.executionId}
@@ -189,11 +182,9 @@ export function SubagentList(
       ) : null}
       {activeProcesses.length > 0 ? (
         <Box flexDirection="column" marginTop={subagents.length > 0 ? 1 : 0}>
-          {showSectionHeader ? (
-            <Text bold dimColor>
-              Processes
-            </Text>
-          ) : null}
+          <Text bold dimColor>
+            Processes
+          </Text>
           {activeProcesses.map((child, i) => (
             <Row
               key={child.executionId}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -46,16 +46,31 @@ function Row({
   // pulling the last `TAIL_LINES` non-blank lines is bounded work.
   const tailLines = compact ? [] : processTailLines(tail).slice(-TAIL_LINES);
   const elapsed = childElapsed(child, nowMs);
+  const label = child.agentName || child.toolName || child.executionId;
   return (
-    <Box flexDirection="column">
-      <Box flexDirection="row">
+    <Box
+      flexDirection="column"
+      height={compact ? 1 : undefined}
+      overflowY={compact ? 'hidden' : undefined}
+    >
+      <Box flexDirection="row" minWidth={0}>
         <Text dimColor>{index < 9 ? ` ${index + 1} ` : '   '}</Text>
         <Text color={childStatusColor(child.status)}>
           {CHILD_STATUS_MARKER}
         </Text>
-        <Text>{child.agentName || child.toolName || child.executionId}</Text>
-        {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
-        {elapsed ? <Text dimColor>{` · ${elapsed}`}</Text> : null}
+        {compact ? (
+          <Text wrap="truncate-end">
+            {label}
+            {child.status ? ` ${child.status}` : ''}
+            {elapsed ? ` · ${elapsed}` : ''}
+          </Text>
+        ) : (
+          <>
+            <Text>{label}</Text>
+            {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
+            {elapsed ? <Text dimColor>{` · ${elapsed}`}</Text> : null}
+          </>
+        )}
       </Box>
       {tailLines.length > 0 ? (
         <Box flexDirection="column" marginLeft={4}>

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -161,6 +161,7 @@ export function SubagentList(
         {hiddenCount > 0 ? (
           <Text
             dimColor
+            wrap="truncate-end"
           >{`   +${hiddenCount} more child execution${hiddenCount === 1 ? '' : 's'}`}</Text>
         ) : null}
       </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -5,12 +5,6 @@ export function childStatusColor(status: string | undefined): string {
   return 'green';
 }
 
-export function shouldShowChildSectionHeader(
-  maxRows: number | undefined,
-): boolean {
-  return maxRows === undefined;
-}
-
 // A steady marker — intentionally NOT animated. A blinking dot forced the whole
 // live region (including the stable Todos/Plan panel below it) to repaint twice
 // a second for the entire lifetime of a long-running async subagent, and Ink's

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -5,6 +5,12 @@ export function childStatusColor(status: string | undefined): string {
   return 'green';
 }
 
+export function shouldShowChildSectionHeader(
+  maxRows: number | undefined,
+): boolean {
+  return maxRows === undefined;
+}
+
 // A steady marker — intentionally NOT animated. A blinking dot forced the whole
 // live region (including the stable Todos/Plan panel below it) to repaint twice
 // a second for the entire lifetime of a long-running async subagent, and Ink's

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -147,6 +147,39 @@ describe('CLI stream tabs strip', () => {
     expect(items.map(streamTabSegmentText)).toEqual(['[main]', 'polish(idle)']);
   });
 
+  it('labels the focused stopped stream in the tab strip', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          status: STREAM_STATUS.STOPPED,
+          childStreams: [
+            child({
+              executionId: 'r1',
+              childStreamId: child1,
+              agentName: 'strategy',
+            }),
+          ],
+        }),
+      ],
+      [child1, slice('child-1', { status: STREAM_STATUS.STOPPED })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: child1,
+      streams,
+      parentStream: new Map([[child1, root]]),
+      width: 80,
+    });
+
+    expect(items.map(streamTabSegmentText)).toEqual([
+      'main(stopped)',
+      '[strategy](stopped)',
+    ]);
+  });
+
   it('collapses the middle entries under narrow widths while preserving focus', () => {
     const root = streamId('root');
     const childIds = Array.from({ length: 5 }, (_, i) =>

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   CHILD_STATUS_MARKER,
   childStatusColor,
-  shouldShowChildSectionHeader,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import { compactRows } from '@cli/chat/tui/panes/SubagentList';
 import type { ActiveChildInfo } from '@shared/schemas';
@@ -20,12 +19,6 @@ describe('CLI SubagentList display model', () => {
     expect(childStatusColor('running')).toBe('green');
     expect(childStatusColor('waiting')).toBe('yellow');
     expect(childStatusColor('stopped')).toBe('red');
-  });
-
-  it('uses section headers only in the unbounded child list', () => {
-    expect(shouldShowChildSectionHeader(undefined)).toBe(true);
-    expect(shouldShowChildSectionHeader(2)).toBe(false);
-    expect(shouldShowChildSectionHeader(1)).toBe(false);
   });
 
   it('uses a compact child row budget instead of clipping nested sections', () => {
@@ -65,5 +58,29 @@ describe('CLI SubagentList display model', () => {
 
     expect(display.rows).toEqual([]);
     expect(display.hiddenCount).toBe(3);
+  });
+
+  it('keeps exact-fit compact rows without adding an overflow summary', () => {
+    const subagents: ActiveChildInfo[] = [
+      { executionId: 'strategy', agentName: 'strategy' },
+      { executionId: 'lean', agentName: 'leanSolver' },
+    ];
+    const activeProcesses: ActiveChildInfo[] = [
+      { executionId: 'latexmk', agentName: 'latex build' },
+    ];
+
+    const display = compactRows({
+      activeProcesses,
+      maxRows: 3,
+      processOutput: new Map(),
+      subagents,
+    });
+
+    expect(display.rows.map((row) => row.child.executionId)).toEqual([
+      'strategy',
+      'lean',
+      'latexmk',
+    ]);
+    expect(display.hiddenCount).toBe(0);
   });
 });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -34,7 +34,6 @@ describe('CLI SubagentList display model', () => {
     const display = compactRows({
       activeProcesses,
       maxRows: 3,
-      processOutput: new Map(),
       subagents,
     });
 
@@ -49,7 +48,6 @@ describe('CLI SubagentList display model', () => {
     const display = compactRows({
       activeProcesses: [{ executionId: 'latexmk', agentName: 'latex build' }],
       maxRows: 1,
-      processOutput: new Map(),
       subagents: [
         { executionId: 'strategy', agentName: 'strategy' },
         { executionId: 'lean', agentName: 'leanSolver' },
@@ -72,7 +70,6 @@ describe('CLI SubagentList display model', () => {
     const display = compactRows({
       activeProcesses,
       maxRows: 3,
-      processOutput: new Map(),
       subagents,
     });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -51,4 +51,19 @@ describe('CLI SubagentList display model', () => {
     ]);
     expect(display.hiddenCount).toBe(2);
   });
+
+  it('reserves a single overflowing row for the overflow summary', () => {
+    const display = compactRows({
+      activeProcesses: [{ executionId: 'latexmk', agentName: 'latex build' }],
+      maxRows: 1,
+      processOutput: new Map(),
+      subagents: [
+        { executionId: 'strategy', agentName: 'strategy' },
+        { executionId: 'lean', agentName: 'leanSolver' },
+      ],
+    });
+
+    expect(display.rows).toEqual([]);
+    expect(display.hiddenCount).toBe(3);
+  });
 });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   CHILD_STATUS_MARKER,
   childStatusColor,
+  shouldShowChildSectionHeader,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
+import { compactRows } from '@cli/chat/tui/panes/SubagentList';
+import type { ActiveChildInfo } from '@shared/schemas';
 
 describe('CLI SubagentList display model', () => {
   it('renders a steady (non-animated) marker for every status', () => {
@@ -17,5 +20,35 @@ describe('CLI SubagentList display model', () => {
     expect(childStatusColor('running')).toBe('green');
     expect(childStatusColor('waiting')).toBe('yellow');
     expect(childStatusColor('stopped')).toBe('red');
+  });
+
+  it('uses section headers only in the unbounded child list', () => {
+    expect(shouldShowChildSectionHeader(undefined)).toBe(true);
+    expect(shouldShowChildSectionHeader(2)).toBe(false);
+    expect(shouldShowChildSectionHeader(1)).toBe(false);
+  });
+
+  it('uses a compact child row budget instead of clipping nested sections', () => {
+    const subagents: ActiveChildInfo[] = [
+      { executionId: 'strategy', agentName: 'strategy' },
+      { executionId: 'lean', agentName: 'leanSolver' },
+      { executionId: 'review', agentName: 'reviewer' },
+    ];
+    const activeProcesses: ActiveChildInfo[] = [
+      { executionId: 'latexmk', agentName: 'latex build', toolName: 'bash' },
+    ];
+
+    const display = compactRows({
+      activeProcesses,
+      maxRows: 3,
+      processOutput: new Map(),
+      subagents,
+    });
+
+    expect(display.rows.map((row) => row.child.executionId)).toEqual([
+      'strategy',
+      'lean',
+    ]);
+    expect(display.hiddenCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- render height-bounded CLI child execution panels as compact deterministic rows instead of clipped nested subagent/process sections
- add an overflow summary row when the child list exceeds the bounded panel height
- extend the TUI harness with synthetic subagents, child streams, a process, todos, and plan data so nested CLI displays can be exercised without provider credentials

Closes #4663.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts --reporter=dot`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_ENTRIES=2 node packages/cli/dist/bin/tui-harness.js`
- `npm run compile:fast`
- `npm run lint` (passes with 3 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and test-harness only; no auth, API, or persistence changes.
> 
> **Overview**
> Height-bounded **child execution** panels now render as **single-line compact rows** (subagents and processes in one list) with a **`+N more child executions`** overflow line when the row budget is exceeded, instead of clipping nested **Subagents** / **Processes** sections with process tails.
> 
> **Stream tabs** show **`(stopped)`** on the **focused** tab when that stream is stopped (inactive tabs already showed non-running statuses).
> 
> The **TUI harness** gains **`HARNESS_CHILDREN`** and **`HARNESS_TODOS`** to seed nested child streams, a bash process tail, todos/plan, and **interrupt** now stops linked child streams as well as the parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0cc725392b8f56f3d9fc04ab5f72bef2a49c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->