### PR TITLE
fix: skip disabled CLI select focus

### DIFF
--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -39,6 +39,72 @@ function clampIndex(index: number, length: number): number {
   return Math.min(Math.max(index, 0), length - 1);
 }
 
+function firstEnabledSelectIndex<T>(
+  items: ReadonlyArray<SelectItem<T>>,
+): number {
+  const index = items.findIndex((item) => !item.disabled);
+  return index >= 0 ? index : 0;
+}
+
+export function selectInitialHighlightIndex<T>({
+  activeValue,
+  initialIndex,
+  items,
+}: {
+  readonly activeValue?: T;
+  readonly initialIndex?: number;
+  readonly items: ReadonlyArray<SelectItem<T>>;
+}): number {
+  if (items.length === 0) return 0;
+  if (initialIndex != null) {
+    const clampedInitialIndex = clampIndex(initialIndex, items.length);
+    if (
+      !items[clampedInitialIndex]?.disabled ||
+      items.every((item) => item.disabled)
+    ) {
+      return clampedInitialIndex;
+    }
+    return firstEnabledSelectIndex(items);
+  }
+
+  const activeIndex = items.findIndex((it) => it.value === activeValue);
+  if (activeIndex >= 0 && !items[activeIndex]?.disabled) return activeIndex;
+  return firstEnabledSelectIndex(items);
+}
+
+export function nextSelectHighlightIndex<T>({
+  direction,
+  highlight,
+  items,
+}: {
+  readonly direction: -1 | 1;
+  readonly highlight: number;
+  readonly items: ReadonlyArray<SelectItem<T>>;
+}): number {
+  if (items.length === 0) return 0;
+
+  const clampedHighlight = clampIndex(highlight, items.length);
+  if (
+    items.every((item) => item.disabled) ||
+    items.every((item) => !item.disabled)
+  ) {
+    return direction === 1
+      ? (clampedHighlight + 1) % items.length
+      : clampedHighlight <= 0
+        ? items.length - 1
+        : clampedHighlight - 1;
+  }
+
+  for (
+    let next = clampedHighlight + direction;
+    next >= 0 && next < items.length;
+    next += direction
+  ) {
+    if (!items[next]?.disabled) return next;
+  }
+  return clampedHighlight;
+}
+
 export function visibleSelectRange({
   itemCount,
   highlight,
@@ -95,13 +161,11 @@ export function selectIndexForHotkey(input: string): number | undefined {
 }
 
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
-  const activeIndex = props.items.findIndex(
-    (it) => it.value === props.activeValue,
-  );
-  const initial = clampIndex(
-    props.initialIndex ?? (activeIndex >= 0 ? activeIndex : 0),
-    props.items.length,
-  );
+  const initial = selectInitialHighlightIndex({
+    activeValue: props.activeValue,
+    initialIndex: props.initialIndex,
+    items: props.items,
+  });
   const [highlight, setHighlight] = useState(initial);
 
   useEffect(() => {
@@ -124,13 +188,21 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     }
     if (key.upArrow) {
       setHighlight((h) =>
-        clampIndex(h <= 0 ? props.items.length - 1 : h - 1, props.items.length),
+        nextSelectHighlightIndex({
+          direction: -1,
+          highlight: h,
+          items: props.items,
+        }),
       );
       return;
     }
     if (key.downArrow) {
       setHighlight((h) =>
-        props.items.length === 0 ? 0 : (h + 1) % props.items.length,
+        nextSelectHighlightIndex({
+          direction: 1,
+          highlight: h,
+          items: props.items,
+        }),
       );
       return;
     }

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -5,6 +5,8 @@ import {
   modelSelectWindow,
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
+  nextSelectHighlightIndex,
+  selectInitialHighlightIndex,
   selectItemRenderKey,
   visibleSelectRange,
 } from '@cli/chat/tui/ui/Select';
@@ -114,6 +116,96 @@ describe('CLI Select visible range', () => {
         maxVisibleItems: 5,
       }),
     ).toEqual({ start: 3, end: 8 });
+  });
+});
+
+describe('CLI Select disabled-row focus', () => {
+  const items = [
+    { value: 'gemini', label: 'Gemini', disabled: true },
+    { value: 'sonnet', label: 'Sonnet' },
+    { value: 'opus', label: 'Opus' },
+    { value: 'deepseek', label: 'DeepSeek', disabled: true },
+  ];
+
+  it('starts on the active row when it is enabled', () => {
+    expect(
+      selectInitialHighlightIndex({
+        activeValue: 'sonnet',
+        items,
+      }),
+    ).toBe(1);
+  });
+
+  it('starts on the first enabled row when the active row is disabled', () => {
+    expect(
+      selectInitialHighlightIndex({
+        activeValue: 'deepseek',
+        items,
+      }),
+    ).toBe(1);
+  });
+
+  it('starts on the first enabled row when the requested initial row is disabled', () => {
+    expect(
+      selectInitialHighlightIndex({
+        initialIndex: 3,
+        items,
+      }),
+    ).toBe(1);
+  });
+
+  it('keeps arrow navigation directional around disabled rows', () => {
+    expect(
+      nextSelectHighlightIndex({
+        direction: 1,
+        highlight: 1,
+        items,
+      }),
+    ).toBe(2);
+    expect(
+      nextSelectHighlightIndex({
+        direction: 1,
+        highlight: 2,
+        items,
+      }),
+    ).toBe(2);
+    expect(
+      nextSelectHighlightIndex({
+        direction: -1,
+        highlight: 1,
+        items,
+      }),
+    ).toBe(1);
+    expect(
+      nextSelectHighlightIndex({
+        direction: -1,
+        highlight: 2,
+        items,
+      }),
+    ).toBe(1);
+  });
+
+  it('keeps wraparound navigation for all-enabled lists', () => {
+    const enabledItems = [
+      { value: 'gemini', label: 'Gemini' },
+      { value: 'sonnet', label: 'Sonnet' },
+      { value: 'opus', label: 'Opus' },
+    ];
+
+    expect(
+      nextSelectHighlightIndex({
+        direction: -1,
+        highlight: 0,
+        items: enabledItems,
+      }),
+    ).toBe(2);
+    expect(
+      nextSelectHighlightIndex({
+        direction: 1,
+        highlight: 2,
+        items: enabledItems,
+      }),
+    ).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #4665.\n\n## Summary\n- start CLI select focus on the first enabled item when the active value is disabled\n- skip disabled rows during arrow navigation while enabled rows exist\n- cover disabled-row focus and navigation with focused CLI select tests\n\n## Verification\n- corepack pnpm exec vitest run src/test-kernel/cli/ModelListForm.vitest.mts\n- npm run texra-local:build && texra-local version\n- TTY: stty cols 100 rows 30; TERM=xterm-256color texra-local chat --api-mode=personal --model deepseekT, then /model: focus starts on Sonnet while unavailable DeepSeek remains checked; Enter selects Sonnet\n- npm run format\n- npm run compile:safe\n- npm run lint (same 3 pre-existing import-order warnings, 0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only focus/navigation behavior in the shared Select primitive; no security, persistence, or API surface changes.
> 
> **Overview**
> The CLI **`Select`** component no longer lands keyboard focus on **`disabled`** rows. Initial highlight is chosen via **`selectInitialHighlightIndex`**: if **`activeValue`** or **`initialIndex`** points at a disabled item, focus moves to the **first enabled** row (still honoring an enabled active/initial index when possible).
> 
> **↑/↓** navigation now uses **`nextSelectHighlightIndex`**, which **steps over** disabled items when the list is mixed; **wraparound** behavior is unchanged when every row is enabled (or when every row is disabled).
> 
> Unit tests in **`ModelListForm.vitest.mts`** cover initial focus and arrow movement around disabled rows (e.g. **`/model`** when the current model is unavailable but still shown as checked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a2dee6b3ceaa8aee3513d63a69d7dd2ea96df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->