### PR TITLE
[codex] Keep CLI approval feedback hints visible

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -6,6 +6,7 @@ import { Box, Text, useWindowSize, type BoxProps } from 'ink';
 import { useInput } from 'ink';
 
 import {
+  confirmCardFeedbackHints,
   confirmCardKeyAction,
   confirmCardKeyHintsForWidth,
 } from './ConfirmCardState';
@@ -31,6 +32,9 @@ export interface ConfirmCardProps {
     readonly label: string;
     readonly decision: ApprovalDecision;
   }[];
+  readonly feedbackPlaceholder?: string;
+  readonly onFeedbackModeChange?: (active: boolean) => void;
+  readonly onFeedbackValueChange?: (value: string) => void;
   readonly children: React.ReactNode;
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
@@ -45,6 +49,9 @@ export function ConfirmCard({
   rejectLabel = 'reject',
   alwaysAllow,
   extraActions = [],
+  feedbackPlaceholder = 'Feedback to send with rejection',
+  onFeedbackModeChange,
+  onFeedbackValueChange,
   children,
   onDecide,
 }: ConfirmCardProps): React.JSX.Element {
@@ -52,12 +59,22 @@ export function ConfirmCard({
   const [feedback, setFeedback] = useState('');
   const { columns } = useWindowSize();
 
+  function setFeedbackActive(active: boolean): void {
+    setFeedbackMode(active);
+    onFeedbackModeChange?.(active);
+  }
+
+  function updateFeedback(value: string): void {
+    setFeedback(value);
+    onFeedbackValueChange?.(value);
+  }
+
   useInput(
     (input, key) => {
       if (feedbackMode) {
         if (key.escape) {
-          setFeedbackMode(false);
-          setFeedback('');
+          setFeedbackActive(false);
+          updateFeedback('');
         }
         return;
       }
@@ -74,7 +91,7 @@ export function ConfirmCard({
           }
           return;
         case 'feedback':
-          setFeedbackMode(true);
+          setFeedbackActive(true);
           return;
         case 'ignore':
           for (const action of extraActions) {
@@ -89,16 +106,18 @@ export function ConfirmCard({
     { isActive: true },
   );
 
-  const hints = confirmCardKeyHintsForWidth({
-    approveLabel,
-    rejectLabel,
-    alwaysAllowLabel: alwaysAllow?.label,
-    extraActions: extraActions.map((action) => ({
-      key: action.key,
-      action: action.label,
-    })),
-    maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
-  });
+  const hints = feedbackMode
+    ? confirmCardFeedbackHints()
+    : confirmCardKeyHintsForWidth({
+        approveLabel,
+        rejectLabel,
+        alwaysAllowLabel: alwaysAllow?.label,
+        extraActions: extraActions.map((action) => ({
+          key: action.key,
+          action: action.label,
+        })),
+        maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
+      });
 
   return (
     <Box
@@ -116,7 +135,8 @@ export function ConfirmCard({
           <Text>{'> '}</Text>
           <BaseTextInput
             value={feedback}
-            onChange={setFeedback}
+            placeholder={feedbackPlaceholder}
+            onChange={updateFeedback}
             onSubmit={(value) =>
               onDecide({ accepted: false, userMessage: value.trim() })
             }

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -65,6 +65,13 @@ export function confirmCardKeyHints({
   ];
 }
 
+export function confirmCardFeedbackHints(): ConfirmCardHintAction[] {
+  return [
+    { key: 'Enter', action: 'send note' },
+    { key: 'Esc', action: 'back' },
+  ];
+}
+
 function hintColumns(hints: readonly ConfirmCardHintAction[]): number {
   return hints.reduce(
     (width, hint, index) =>

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -17,7 +17,10 @@ import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
 const EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE = 8;
+const EDIT_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;
+const EDIT_APPROVAL_FEEDBACK_PREFIX_COLUMNS = 2;
 const MIN_EDIT_DIFF_WIDTH = 20;
+const EDIT_APPROVAL_FEEDBACK_PLACEHOLDER = 'Why reject?';
 
 export interface EditApprovalProps {
   readonly availableRows?: number;
@@ -28,10 +31,16 @@ export interface EditApprovalProps {
 export function editApprovalDiffRowsBudget({
   availableRows,
   columns,
+  feedbackPlaceholder = EDIT_APPROVAL_FEEDBACK_PLACEHOLDER,
+  feedbackMode,
+  feedbackValue = '',
   title,
 }: {
   readonly availableRows?: number;
   readonly columns: number;
+  readonly feedbackPlaceholder?: string;
+  readonly feedbackMode?: boolean;
+  readonly feedbackValue?: string;
   readonly title: string;
 }): number {
   if (availableRows === undefined) return 30;
@@ -41,20 +50,58 @@ export function editApprovalDiffRowsBudget({
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const titleRows = wrapAnsiToWidth(title, titleWidth).split('\n').length;
+  const feedbackRows =
+    feedbackMode === true
+      ? editApprovalFeedbackRows({
+          columns,
+          placeholder: feedbackPlaceholder,
+          value: feedbackValue,
+        })
+      : 0;
   return Math.max(
     1,
-    availableRows - EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE - titleRows,
+    availableRows -
+      EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE -
+      titleRows -
+      feedbackRows,
+  );
+}
+
+export function editApprovalFeedbackRows({
+  columns,
+  placeholder,
+  value,
+}: {
+  readonly columns: number;
+  readonly placeholder: string;
+  readonly value: string;
+}): number {
+  const text = value.length > 0 ? value : placeholder;
+  const width = Math.max(
+    1,
+    columns -
+      CONFIRM_CARD_HORIZONTAL_DECORATION -
+      EDIT_APPROVAL_FEEDBACK_PREFIX_COLUMNS,
+  );
+  return (
+    EDIT_APPROVAL_FEEDBACK_MARGIN_ROWS +
+    Math.max(1, wrapAnsiToWidth(text, width).split('\n').length)
   );
 }
 
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
+  const [feedbackMode, setFeedbackMode] = useState(false);
+  const [feedbackValue, setFeedbackValue] = useState('');
   const [scrollOffset, setScrollOffset] = useState(0);
   const title = `Apply edit to ${props.request.path}?`;
   const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
   const maxDiffLines = editApprovalDiffRowsBudget({
     availableRows: props.availableRows,
     columns,
+    feedbackPlaceholder: EDIT_APPROVAL_FEEDBACK_PLACEHOLDER,
+    feedbackMode,
+    feedbackValue,
     title,
   });
 
@@ -110,6 +157,9 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       color="cyan"
       title={title}
       alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
+      feedbackPlaceholder={EDIT_APPROVAL_FEEDBACK_PLACEHOLDER}
+      onFeedbackModeChange={setFeedbackMode}
+      onFeedbackValueChange={setFeedbackValue}
       onDecide={props.onDecide}
     >
       <Text dimColor>

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  confirmCardFeedbackHints,
   confirmCardKeyAction,
   confirmCardKeyHints,
   confirmCardKeyHintsForWidth,
@@ -42,6 +43,13 @@ describe('CLI confirm-card key handling', () => {
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
     expect(rendered.length).toBeLessThanOrEqual(72);
+  });
+
+  it('shows submit/back hints while collecting rejection feedback', () => {
+    expect(confirmCardFeedbackHints()).toEqual([
+      { key: 'Enter', action: 'send note' },
+      { key: 'Esc', action: 'back' },
+    ]);
   });
 
   it('compacts long optional approval hints before hiding cancel', () => {

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { editApprovalDiffRowsBudget } from '@cli/chat/tui/modals/EditApproval';
+import {
+  editApprovalDiffRowsBudget,
+  editApprovalFeedbackRows,
+} from '@cli/chat/tui/modals/EditApproval';
 
 describe('CLI edit approval layout', () => {
   it('reserves footer rows when the approval title wraps', () => {
@@ -14,6 +17,37 @@ describe('CLI edit approval layout', () => {
         title,
       }),
     ).toBe(6);
+  });
+
+  it('reserves feedback input rows while collecting a rejection note', () => {
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 16,
+        columns: 80,
+        feedbackMode: true,
+        title: 'Apply edit to proof.tex?',
+      }),
+    ).toBe(5);
+  });
+
+  it('accounts for wrapped feedback placeholders on narrow terminals', () => {
+    expect(
+      editApprovalFeedbackRows({
+        columns: 16,
+        placeholder: 'Needs a smaller proof step',
+        value: '',
+      }),
+    ).toBe(4);
+
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 16,
+        columns: 16,
+        feedbackMode: true,
+        feedbackPlaceholder: 'Needs a smaller proof step',
+        title: 'Edit?',
+      }),
+    ).toBe(3);
   });
 
   it('keeps a usable one-line diff on very short terminals', () => {


### PR DESCRIPTION
## Summary

- show dedicated `Enter`/`Esc` hints while an approval feedback note is being collected
- shrink the edit-approval diff when feedback mode is open so the input, footer, and border remain visible
- add focused coverage for feedback hints and edit-approval row budgeting

Closes #4667.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- manual harness: `HARNESS_EDIT_APPROVAL=1 HARNESS_ENTRIES=8 node packages/cli/dist/bin/tui-harness.js`, press `e`, verify `Enter send note · Esc back` and bottom border remain visible, submit note
- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/modals/ConfirmCard.tsx packages/cli/src/chat/tui/modals/ConfirmCardState.ts packages/cli/src/chat/tui/modals/EditApproval.tsx src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (passes with 3 existing import-order warnings outside this PR)
- `git diff --check -- packages/cli/src/chat/tui/modals/ConfirmCard.tsx packages/cli/src/chat/tui/modals/ConfirmCardState.ts packages/cli/src/chat/tui/modals/EditApproval.tsx src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only layout and hint changes for approval modals; no auth, data, or approval decision logic changes beyond existing rejection-with-note flow.
> 
> **Overview**
> When collecting a rejection note on CLI approval modals (`e`), the footer now shows **Enter send note** and **Esc back** instead of the normal y/n hints, and the feedback field uses a configurable placeholder.
> 
> **Edit approval** tracks feedback mode and text via new `ConfirmCard` callbacks, subtracts wrapped feedback input height from the diff row budget (including narrow terminals), and uses a **Why reject?** placeholder. Tests cover feedback hints and layout budgeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9766d5b180a41074117515891e4f00cb2a4f7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->