### PR TITLE
[codex] List queued follow-ups in CLI status

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -5,6 +5,7 @@
 import { render } from 'ink';
 import React from 'react';
 
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   STREAM_STATUS,
   TODO_STATUS,
@@ -18,6 +19,10 @@ import {
   setParentStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
+import {
+  formatCliSessionStatus,
+  readQueuedFollowUpMessagesForStatus,
+} from '../src/chat/tui/sessionStatus';
 import { enqueueApproval } from '../src/chat/tui/state/approvalQueue';
 
 const STREAM_ID = 'harness-stream-1';
@@ -31,6 +36,10 @@ const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
 const QUEUED_FOLLOW_UPS = parseList(process.env.HARNESS_QUEUED_FOLLOWUPS);
+const HARNESS_FOLLOW_UP_QUEUE = ToolUseFollowUpQueue.acquire(STREAM_ID);
+for (const followUp of QUEUED_FOLLOW_UPS) {
+  HARNESS_FOLLOW_UP_QUEUE.enqueue(followUp);
+}
 
 function parseList(value: string | undefined): string[] {
   if (!value) return [];
@@ -289,9 +298,43 @@ function markHarnessInterrupted(): void {
   }
 }
 
+function appendHarnessAssistantTranscript(text: string): void {
+  const streamId = cliState.activeStreamId.get() ?? STREAM_ID;
+  patchStream(streamId, (slice) => ({
+    ...slice,
+    entries: [
+      ...slice.entries,
+      {
+        id: `harness-local-${Date.now()}-${slice.entries.length}`,
+        role: 'assistant',
+        text,
+        finalized: true,
+      },
+    ],
+  }));
+}
+
+function handleHarnessSubmit(line: string): void {
+  if (line.trim() !== '/status') return;
+
+  const meta = cliState.sessionMeta.get();
+  const streamId = cliState.activeStreamId.get() ?? STREAM_ID;
+  const slice = cliState.streams.get().get(streamId);
+  appendHarnessAssistantTranscript(
+    formatCliSessionStatus({
+      agent: meta.agent,
+      model: meta.model,
+      api: meta.apiMode,
+      approval: 'ask',
+      status: slice?.status ?? 'not started',
+      queuedFollowUpMessages: readQueuedFollowUpMessagesForStatus(streamId),
+    }),
+  );
+}
+
 const ink = render(
   <App
-    onSubmit={() => undefined}
+    onSubmit={handleHarnessSubmit}
     onKillExecution={() => undefined}
     canInterruptActiveRun={() => canInterrupt}
     canStopActiveRun={() => canInterrupt}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -77,6 +77,10 @@ import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { listSlashCommands, parseSlashInput } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
+import {
+  formatCliSessionStatus,
+  readQueuedFollowUpMessagesForStatus,
+} from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
 import { installTuiApprovals } from './state/subscribeApprovals';
@@ -566,13 +570,15 @@ async function handleTuiSlashCommand(
         ? cliState.streams.get().get(activeStreamId)
         : undefined;
       appendLocalAssistantTranscript(
-        [
-          `agent: ${meta.agent || context.initialAgent}`,
-          `model: ${meta.model || context.initialModel}`,
-          `api: ${formatCliApiMode(getCliApiMode())}`,
-          `approval: ${formatApprovalPolicy(context.getApprovalPolicy())}`,
-          `status: ${slice?.status ?? 'not started'}`,
-        ].join('\n'),
+        formatCliSessionStatus({
+          agent: meta.agent || context.initialAgent,
+          model: meta.model || context.initialModel,
+          api: formatCliApiMode(getCliApiMode()),
+          approval: formatApprovalPolicy(context.getApprovalPolicy()),
+          status: slice?.status ?? 'not started',
+          queuedFollowUpMessages:
+            readQueuedFollowUpMessagesForStatus(activeStreamId),
+        }),
       );
       return true;
     }

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,0 +1,43 @@
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { StreamTabId } from '@shared/schemas';
+import { truncateSummary } from '@utils/text/stringUtils';
+
+const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
+
+export interface CliSessionStatusInput {
+  readonly agent: string;
+  readonly model: string;
+  readonly api: string;
+  readonly approval: string;
+  readonly status: string;
+  readonly queuedFollowUpMessages: readonly string[];
+}
+
+export function readQueuedFollowUpMessagesForStatus(
+  streamId: StreamTabId | undefined,
+): string[] {
+  return streamId === undefined ? [] : ToolUseFollowUpQueue.getAll(streamId);
+}
+
+function queuedFollowUpStatusLines(messages: readonly string[]): string[] {
+  if (messages.length === 0) return ['queued follow-ups: 0'];
+
+  return [
+    `queued follow-ups: ${messages.length}`,
+    ...messages.map(
+      (message, index) =>
+        `${index + 1}. ${truncateSummary(message, QUEUED_FOLLOW_UP_STATUS_LENGTH)}`,
+    ),
+  ];
+}
+
+export function formatCliSessionStatus(input: CliSessionStatusInput): string {
+  return [
+    `agent: ${input.agent}`,
+    `model: ${input.model}`,
+    `api: ${input.api}`,
+    `approval: ${input.approval}`,
+    `status: ${input.status}`,
+    ...queuedFollowUpStatusLines(input.queuedFollowUpMessages),
+  ].join('\n');
+}

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import {
+  formatCliSessionStatus,
+  readQueuedFollowUpMessagesForStatus,
+} from '@cli/chat/tui/sessionStatus';
+
+const STREAM_ID = 'status-queued-followups-test-stream';
+
+describe('CLI session status formatter', () => {
+  it('lists queued follow-up messages in the details output', () => {
+    expect(
+      formatCliSessionStatus({
+        agent: 'chat',
+        model: 'harness-model',
+        api: 'personal',
+        approval: 'ask',
+        status: 'running',
+        queuedFollowUpMessages: [
+          'First queued follow-up is to re-run the narrow layout proof check.',
+          'Second queued message asks for the theorem statement cleanup.',
+        ],
+      }),
+    ).toBe(
+      [
+        'agent: chat',
+        'model: harness-model',
+        'api: personal',
+        'approval: ask',
+        'status: running',
+        'queued follow-ups: 2',
+        '1. First queued follow-up is to re-run the narrow layout proof check.',
+        '2. Second queued message asks for the theorem statement cleanup.',
+      ].join('\n'),
+    );
+  });
+
+  it('keeps multiline queued follow-ups readable as one-line summaries', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'running',
+      queuedFollowUpMessages: [
+        [
+          'Please inspect the generated diff.',
+          'Then report whether the queued edits should still run.',
+        ].join('\n'),
+      ],
+    });
+
+    expect(status).toContain(
+      '1. Please inspect the generated diff. Then report whether the queued edits should still run.',
+    );
+  });
+
+  it('reports an empty follow-up queue explicitly', () => {
+    expect(
+      formatCliSessionStatus({
+        agent: 'chat',
+        model: 'harness-model',
+        api: 'personal',
+        approval: 'ask',
+        status: 'waiting',
+        queuedFollowUpMessages: [],
+      }),
+    ).toContain('queued follow-ups: 0');
+  });
+
+  it('reads queued follow-ups from the queue manager for status details', () => {
+    const queue = ToolUseFollowUpQueue.acquire(STREAM_ID);
+    ToolUseFollowUpQueue.drain(STREAM_ID);
+    try {
+      queue.enqueue('Fresh queue message');
+
+      expect(readQueuedFollowUpMessagesForStatus(STREAM_ID)).toEqual([
+        'Fresh queue message',
+      ]);
+    } finally {
+      ToolUseFollowUpQueue.drain(STREAM_ID);
+    }
+  });
+});


### PR DESCRIPTION
Closes #4668.

## Summary
- add a shared CLI session status formatter that includes queued follow-up count and numbered message summaries
- use that formatter from /status so the compact footer has a details path for the full pending queue
- wire the TUI harness /status path through the same formatter for reproducible queued-message dogfooding

## Verification
- corepack pnpm install
- npm run texra-local:build
- corepack pnpm --filter @texra-ai/cli run bundle:harness
- TTY harness at 60x18 with HARNESS_QUEUED_FOLLOWUPS=3, then /status showed all three queued messages as a numbered wrapped list
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts --reporter=dot
- npm run compile:safe
- npm run lint (passes with existing import-order warnings in UserMessage.ts, toolFormatters.ts, AgentWorkspaceState.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only status formatting and queue reads for the CLI; no changes to execution, auth, or follow-up delivery behavior.
> 
> **Overview**
> Introduces a shared **`sessionStatus`** helper so **`/status`** output is consistent everywhere. The formatter still prints agent, model, API, approval, and stream status, and now adds **queued follow-up** details: a count plus numbered one-line summaries (multiline messages collapsed via **`truncateSummary`**).
> 
> **`runChatTui`** and the **TUI harness** both call this helper; the harness can seed **`ToolUseFollowUpQueue`** from **`HARNESS_QUEUED_FOLLOWUPS`** and responds to **`/status`** with the same transcript block as production. Vitests cover formatting, empty queues, and reading from the queue manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb5360e0ca796901d2c48adc1c88310c7b8535d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->