### PR TITLE
fix: stop harness child executions from picker

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -92,6 +92,22 @@ function stoppedChild(child: ActiveChildInfo): ActiveChildInfo {
   };
 }
 
+function stopMatchingChild(
+  child: ActiveChildInfo,
+  executionId: string,
+): ActiveChildInfo {
+  return child.executionId === executionId ? stoppedChild(child) : child;
+}
+
+function harnessMessageEntry(id: string, text: string): ConversationEntry {
+  return {
+    id,
+    role: 'assistant',
+    text,
+    finalized: true,
+  };
+}
+
 function makeEditApprovalRequest() {
   const originalBody = Array.from(
     { length: 24 },
@@ -304,12 +320,60 @@ function appendHarnessAssistantTranscript(text: string): void {
     ...slice,
     entries: [
       ...slice.entries,
-      {
-        id: `harness-local-${Date.now()}-${slice.entries.length}`,
-        role: 'assistant',
+      harnessMessageEntry(
+        `harness-local-${Date.now()}-${slice.entries.length}`,
         text,
-        finalized: true,
-      },
+      ),
+    ],
+  }));
+}
+
+function markHarnessExecutionStopped(executionId: string): void {
+  const parentSlice = cliState.streams.get().get(STREAM_ID);
+  if (!parentSlice) return;
+
+  const executionRows = [
+    ...parentSlice.activeSubagents,
+    ...parentSlice.activeProcesses,
+    ...parentSlice.childStreams,
+  ];
+  const executionRow = executionRows.find(
+    (child) => child.executionId === executionId,
+  );
+  if (!executionRow) return;
+
+  const messageId = `harness-killed-${executionId}-${Date.now()}`;
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    activeSubagents: slice.activeSubagents.map((child) =>
+      stopMatchingChild(child, executionId),
+    ),
+    activeProcesses: slice.activeProcesses.map((child) =>
+      stopMatchingChild(child, executionId),
+    ),
+    childStreams: slice.childStreams.map((child) =>
+      stopMatchingChild(child, executionId),
+    ),
+    entries: [
+      ...slice.entries,
+      harnessMessageEntry(
+        messageId,
+        `Harness kill requested for ${executionId}.`,
+      ),
+    ],
+  }));
+
+  if (!executionRow.childStreamId) return;
+  patchStream(executionRow.childStreamId, (slice) => ({
+    ...slice,
+    status: STREAM_STATUS.STOPPED,
+    runStartedAt: undefined,
+    entries: [
+      ...slice.entries,
+      harnessMessageEntry(
+        `${messageId}-${executionRow.childStreamId}`,
+        'Harness kill requested for this sub-workflow.',
+      ),
     ],
   }));
 }
@@ -335,7 +399,7 @@ function handleHarnessSubmit(line: string): void {
 const ink = render(
   <App
     onSubmit={handleHarnessSubmit}
-    onKillExecution={() => undefined}
+    onKillExecution={markHarnessExecutionStopped}
     canInterruptActiveRun={() => canInterrupt}
     canStopActiveRun={() => canInterrupt}
     onInterruptActive={markHarnessInterrupted}


### PR DESCRIPTION
## Summary

- wire the CLI TUI harness `onKillExecution` callback to stop the selected child execution
- update matching subagent, process, and retained child-stream rows to `stopped`
- append harness transcript markers so the manual scenario shows which execution was killed

Closes #4671.

## Verification

- `npm run format`
- `npx prettier --write packages/cli/scripts/tui-harness.tsx`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_INTERRUPT=1 HARNESS_CAN_DELEGATE=1 HARNESS_ENTRIES=3 node packages/cli/dist/bin/tui-harness.js`, open Subagents with Option-s / `Esc s`, press `k`, reopen picker and verify `strategy` shows `stopped`
- `git diff --check`
- `npm run compile:fast`
- `npm run lint` (passes with the existing 3 import-order warnings outside this change)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the manual TUI harness script; no production CLI runtime or auth paths are modified.
> 
> **Overview**
> The TUI **test harness** now simulates killing a child execution from the Subagents/background picker instead of ignoring `onKillExecution`.
> 
> `markHarnessExecutionStopped` finds the row by `executionId`, marks the matching entry in **active subagents**, **processes**, and **child streams** as `stopped`, and appends harness transcript lines on the parent (and on the linked child stream when present). Small helpers (`stopMatchingChild`, `harnessMessageEntry`) dedupe that patching logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bf4b008a8586f42ea59e7a0d9da53f2bba4a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->