### PR TITLE
docs: replace fabricated tool names with real registered tools

### DIFF
--- a/docs/.vitepress/components/CliChatHero.vue
+++ b/docs/.vitepress/components/CliChatHero.vue
@@ -23,7 +23,7 @@ const calls = [
   },
   {
     state: 'active',
-    tool: 'str_replace',
+    tool: 'edit_file',
     verb: 'edit',
     path: 'sections/intro.tex',
     effect: 'Tightens the motivating sentence',
@@ -87,7 +87,7 @@ const calls = [
         </li>
       </ul>
 
-      <!-- Inline diff hunk (the change str_replace is making) -->
+      <!-- Inline diff hunk (the change edit_file is making) -->
       <div class="cc-diff">
         <div class="cc-dl cc-dl--del">
           <span class="cc-gut">−</span>

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -140,7 +140,7 @@ Three research agents, each tuned for a different stage of the work — pick one
       { text: 'bash', variant: 'neutral' },
       { text: 'file-edit', variant: 'neutral' },
       { text: 'texcount', variant: 'neutral' },
-      { text: 'arxiv_metadata', variant: 'neutral' },
+      { text: 'extract_figures', variant: 'neutral' },
     ] },
     { icon: 'comment-discussion', title: 'discuss', desc: 'Brainstorming research directions with literature context.', chips: [
       { text: 'web_search', variant: 'neutral' },

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -84,15 +84,14 @@ Add this arXiv paper to my Zotero library.
 <ToolCallPanel
   title="zotero"
   icon="book"
-  tool="zotero"
   :calls="[
-    { state: 'done', verb: 'search', target: 'graph neural networks', effect: 'Finds matching items in your library' },
-    { state: 'done', verb: 'add', target: 'arxiv:2401.12345', effect: 'Adds the paper to your Zotero library' },
-    { state: 'active', verb: 'export', target: 'references.bib', effect: 'Writes the selected items as BibTeX' },
+    { state: 'done', verb: 'zotero_search', target: 'graph neural networks', effect: 'Finds matching items in your library' },
+    { state: 'done', verb: 'zotero_add', target: 'arxiv:2401.12345', effect: 'Adds the paper to your Zotero library' },
+    { state: 'active', verb: 'zotero_export', target: 'references.bib', effect: 'Writes the selected items as BibTeX' },
   ]"
 />
 
-<p class="hero-caption">How the <code>search</code> agent drives the <code>zotero</code> tool across one conversation — search → add → export — as the calls surface in the Progress view.</p>
+<p class="hero-caption">How the <code>search</code> agent drives the <code>zotero_*</code> tools across one conversation — search → add → export — as the calls surface in the Progress view.</p>
 
 ::: tip Default Bibliography Path
 Set `texra.bib.defaultPath` in your VS Code settings (<wa-icon library="texra" name="gear"></wa-icon>) to specify where Zotero exports land by default, so agents always know where to save bibliography entries.

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -52,14 +52,14 @@ Because these are tool-use agents, they can compile the figure and inspect the r
   icon="sparkle"
   caption="drawing a TikZ figure · iterating · this run"
   :calls="[
-    { state: 'done', verb: 'write_tikz', target: 'figures/ml-pipeline.tex', effect: 'Writes a first draft of the flowchart' },
-    { state: 'done', verb: 'compile_tikz', target: 'ml-pipeline.tex', effect: 'pdflatex OK → renders a PNG preview' },
-    { state: 'done', verb: 'read', target: 'ml-pipeline.png', effect: 'Sees nodes overlap, one arrow misaligned' },
-    { state: 'active', verb: 'write_tikz', target: 'ml-pipeline.tex', effect: 'Adjusts node spacing and arrow anchors, then recompiles' },
+    { state: 'done', verb: 'write_file', target: 'figures/ml-pipeline.tex', effect: 'Writes a first draft of the flowchart' },
+    { state: 'done', verb: 'bash', target: 'latexmk ml-pipeline.tex', effect: 'pdflatex OK → renders the standalone PDF' },
+    { state: 'done', verb: 'read_file', target: 'ml-pipeline.pdf', effect: 'Sees nodes overlap, one arrow misaligned' },
+    { state: 'active', verb: 'edit_file', target: 'figures/ml-pipeline.tex', effect: 'Adjusts node spacing and arrow anchors, then recompiles' },
   ]"
 />
 
-<p class="hero-caption">The agent writes, compiles, looks at the rendered PNG, and loops back to fix what it sees — a self-correcting draw cycle, not a one-shot generation.</p>
+<p class="hero-caption">The agent writes, compiles, looks at the rendered PDF, and loops back to fix what it sees — a self-correcting draw cycle, not a one-shot generation.</p>
 
 ![TikZ Figure Example](/images/tikz-figure-example.png)
 


### PR DESCRIPTION
The TikZ guide's tool-call mockup invented write_tikz/compile_tikz and a
bare read verb — none of which are registered tools. Replace them with the
research agent's actual tools (write_file, bash, read_file, edit_file) and
correct the rendered artifact from PNG to PDF, matching the working-with-
figures pattern and read_file's real PDF/image support.

Also align the zotero panel (zotero_search/zotero_add/zotero_export instead
of a non-existent single zotero tool) and the CLI chat hero (edit_file
instead of str_replace, which is a memory/text-editor command, not a tool).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress demo strings only; no runtime, auth, or product behavior changes.
> 
> **Overview**
> Documentation mockups and agent tool chips are updated so examples match **registered** tool names instead of invented or internal ones.
> 
> The **TikZ** guide’s `ToolCallPanel` now shows `write_file`, `bash`, `read_file`, and `edit_file` (replacing fictional `write_tikz` / `compile_tikz` and a bare `read` verb), and the caption refers to inspecting a **PDF** rather than PNG. The **Zotero** panel uses `zotero_search`, `zotero_add`, and `zotero_export` instead of a single `zotero` tool, with caption text updated to `zotero_*`. The **CLI chat** hero shows `edit_file` instead of `str_replace`. On **research tools**, the `research` agent chip list swaps `arxiv_metadata` for `extract_figures` to reflect the documented tool set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629c08d47c42420ab88892e7121bd44e5851c3f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->