### PR TITLE
fix: exclude stopped harness children from active counts

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -99,6 +99,13 @@ function stopMatchingChild(
   return child.executionId === executionId ? stoppedChild(child) : child;
 }
 
+function isDifferentExecution(
+  child: ActiveChildInfo,
+  executionId: string,
+): boolean {
+  return child.executionId !== executionId;
+}
+
 function harnessMessageEntry(id: string, text: string): ConversationEntry {
   return {
     id,
@@ -292,8 +299,8 @@ function markHarnessInterrupted(): void {
     ...slice,
     status: STREAM_STATUS.STOPPED,
     runStartedAt: undefined,
-    activeSubagents: slice.activeSubagents.map(stoppedChild),
-    activeProcesses: slice.activeProcesses.map(stoppedChild),
+    activeSubagents: [],
+    activeProcesses: [],
     childStreams: slice.childStreams.map(stoppedChild),
     entries: [
       ...slice.entries,
@@ -345,11 +352,11 @@ function markHarnessExecutionStopped(executionId: string): void {
   const messageId = `harness-killed-${executionId}-${Date.now()}`;
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
-    activeSubagents: slice.activeSubagents.map((child) =>
-      stopMatchingChild(child, executionId),
+    activeSubagents: slice.activeSubagents.filter((child) =>
+      isDifferentExecution(child, executionId),
     ),
-    activeProcesses: slice.activeProcesses.map((child) =>
-      stopMatchingChild(child, executionId),
+    activeProcesses: slice.activeProcesses.filter((child) =>
+      isDifferentExecution(child, executionId),
     ),
     childStreams: slice.childStreams.map((child) =>
       stopMatchingChild(child, executionId),


### PR DESCRIPTION
## Summary

- move stopped harness subagents/processes out of the active arrays
- keep stopped sub-workflow pages visible through retained `childStreams`
- make the harness status bar count only still-active child work after per-child kill or global interrupt

Closes #4673.

## Verification

- `npm run format`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_INTERRUPT=1 HARNESS_CAN_DELEGATE=1 HARNESS_ENTRIES=3 node packages/cli/dist/bin/tui-harness.js`, open Subagents with Option-s / `Esc s`, press `k`, verify `strategy stopped` remains visible and status drops from `3 sub` to `2 sub`
- `git diff --check`
- `npm run lint` (passes with the existing 3 import-order warnings outside this change)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only state updates in tui-harness.tsx with no production auth or runtime path changes.
> 
> **Overview**
> The TUI test harness now treats **stopped** subagents and processes as no longer “active,” matching how the real CLI status bar counts `activeSubagents` / `activeProcesses` by array length.
> 
> On **global interrupt**, `activeSubagents` and `activeProcesses` are **cleared** instead of marking every row `STOPPED` in place; `childStreams` still get `stoppedChild` so sub-workflow pages stay navigable.
> 
> On **per-execution kill**, killed rows are **removed** from `activeSubagents` and `activeProcesses` via a new `isDifferentExecution` helper, while `childStreams` continues to mark only the matching execution as stopped—so the status bar drops (e.g. `3 sub` → `2 sub`) but stopped children remain visible through `childStreams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5624bc98b73fc9b50e0b1a4e8dd61584d593ba05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->