### PR TITLE
fix: keep subagent shortcut visible on child streams

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -21,6 +21,7 @@ import {
   NO_BYPASS,
   type BypassState,
 } from '../state/cliState';
+import { resolveChildControlStreamTarget } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -342,6 +343,7 @@ export interface StatusBarProps {
 export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
+  const parentStream = useSignal(cliState.parentStream);
   const sessionMeta = useSignal(cliState.sessionMeta);
   const pendingExitHint = useSignal(cliState.pendingExitHint);
   const pendingExitResumeId = useSignal(cliState.pendingExitResumeId);
@@ -349,6 +351,12 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const subagentControlTarget = resolveChildControlStreamTarget({
+    activeStreamId,
+    mode: 'subagents',
+    parentStream,
+    streams,
+  });
 
   const runStartedAt =
     slice?.status === STREAM_STATUS.RUNNING ? slice.runStartedAt : undefined;
@@ -366,7 +374,10 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     activeSubagents: slice?.activeSubagents.length ?? 0,
     activeProcesses: slice?.activeProcesses.length ?? 0,
     approvalDepth: approvals,
-    subagentControlsAvailable: canShowSubagentControls(sessionMeta, slice),
+    subagentControlsAvailable: canShowSubagentControls(
+      sessionMeta,
+      subagentControlTarget.slice,
+    ),
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),


### PR DESCRIPTION
## Summary

- make the CLI status bar use the same parent-aware subagent target resolution as the App shortcut handler
- keep `[Option-s]subagents` advertised while focused on a child stream when the parent has subagent rows

Closes #4678.

## Verification

- `npm run format`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_INTERRUPT=1 HARNESS_CAN_DELEGATE=0 HARNESS_ENTRIES=3 node packages/cli/dist/bin/tui-harness.js`, press `Tab` to focus `strategy`, verify `[Option-s]subagents` remains visible
- `git diff --check`
- `npm run lint` (passes with the existing 3 import-order warnings outside this change)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI display fix aligning StatusBar with existing App shortcut logic; no auth, data, or API changes.
> 
> **Overview**
> The CLI status bar now resolves **subagent shortcut visibility** the same way as `App` keyboard handling: it uses `resolveChildControlStreamTarget` with `parentStream` and `mode: 'subagents'`, then passes that target slice into `canShowSubagentControls` instead of the focused stream’s slice.
> 
> **Effect:** `[Option-s]subagents` (or Alt-s) stays in the bindings line when you **Tab** into a child stream, as long as the parent stream still has subagent rows—matching what the shortcut actually opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ed301feb54594a3b76fe52f861c36f2852ca27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->