### PR TITLE
fix: label CLI child stream scopes

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -32,6 +32,7 @@ import {
 } from './state/childControls';
 import { canShowSubagentControls, cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
+import { streamScopeDisplayLabel } from './state/streamLabels';
 import { useSignal } from './state/useSignal';
 import type { InputHistory } from './history/inputHistory';
 
@@ -326,6 +327,15 @@ export function App(props: AppProps): React.JSX.Element {
         });
         return (
           <ChildControlPicker
+            activeStreamLabel={
+              target.streamId
+                ? streamScopeDisplayLabel({
+                    parentStream,
+                    streamId: target.streamId,
+                    streams,
+                  })
+                : undefined
+            }
             activeStreamId={target.streamId}
             availableRows={foregroundRows}
             mode={childControlMode}

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -24,6 +24,7 @@ import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
 export interface ChildControlPickerProps {
+  readonly activeStreamLabel: string | undefined;
   readonly activeStreamId: StreamTabId | undefined;
   readonly availableRows?: number;
   readonly mode: ChildControlMode;
@@ -328,6 +329,7 @@ function TaskDetailView({
 }
 
 export function ChildControlPicker({
+  activeStreamLabel,
   activeStreamId,
   availableRows,
   mode,
@@ -347,12 +349,13 @@ export function ChildControlPicker({
   const [tailExecutionId, setTailExecutionId] = useState<string | undefined>(
     undefined,
   );
+  const parentStreamLabel = activeStreamLabel ?? activeStreamId;
   const tailItem = tailExecutionId
     ? items.find((item) => item.executionId === tailExecutionId)
     : undefined;
   const listLayout = computePickerListLayout({
     availableRows,
-    hasParentStream: activeStreamId !== undefined,
+    hasParentStream: parentStreamLabel !== undefined,
     highlight,
     itemCount: items.length,
   });
@@ -448,8 +451,8 @@ export function ChildControlPicker({
       <Text bold color="cyan">
         {pickerTitle(mode)}
       </Text>
-      {activeStreamId ? (
-        <Text dimColor>{`Parent stream: ${activeStreamId}`}</Text>
+      {parentStreamLabel ? (
+        <Text dimColor>{`Parent stream: ${parentStreamLabel}`}</Text>
       ) : null}
       <Box flexDirection="column" marginTop={1}>
         {items.length > 0 ? (

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -4,6 +4,10 @@ import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { cliState, type StreamSlice } from '../state/cliState';
 import { orderedDescendantsFromSlice } from '../state/focusCycle';
+import {
+  childStreamDisplayLabel,
+  streamScopeDisplayLabel,
+} from '../state/streamLabels';
 import { useSignal } from '../state/useSignal';
 
 export interface StreamTabDisplayItem {
@@ -37,15 +41,6 @@ function truncate(value: string, maxWidth: number): string {
   if (value.length <= maxWidth) return value;
   if (maxWidth <= 1) return '…';
   return `${value.slice(0, maxWidth - 1)}…`;
-}
-
-function childLabel(parent: StreamSlice | undefined, id: StreamTabId): string {
-  const child = [
-    ...(parent?.activeSubagents ?? []),
-    ...(parent?.activeProcesses ?? []),
-    ...(parent?.childStreams ?? []),
-  ].find((entry) => entry.childStreamId === id);
-  return child?.agentName || child?.toolName || child?.executionId || id;
 }
 
 function orderedStreamTree(init: {
@@ -139,7 +134,13 @@ export function streamTabsDisplayItems(init: {
     return {
       id,
       label: truncate(
-        id === root ? 'main' : childLabel(rootSlice, id),
+        id === root
+          ? streamScopeDisplayLabel({
+              parentStream: init.parentStream,
+              streamId: id,
+              streams: init.streams,
+            })
+          : childStreamDisplayLabel(rootSlice, id),
         MAX_LABEL_WIDTH,
       ),
       active: id === init.activeStreamId,

--- a/packages/cli/src/chat/tui/state/streamLabels.ts
+++ b/packages/cli/src/chat/tui/state/streamLabels.ts
@@ -1,0 +1,34 @@
+// Shared display labels for stream-scoped CLI controls.
+
+// Local imports - shared schemas
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - CLI state
+import type { StreamSlice } from './cliState';
+
+export function childStreamDisplayLabel(
+  parent:
+    | Pick<StreamSlice, 'activeSubagents' | 'activeProcesses' | 'childStreams'>
+    | undefined,
+  streamId: StreamTabId,
+): string {
+  const child = [
+    ...(parent?.activeSubagents ?? []),
+    ...(parent?.activeProcesses ?? []),
+    ...(parent?.childStreams ?? []),
+  ].find((entry) => entry.childStreamId === streamId);
+  return child?.agentName || child?.toolName || child?.executionId || streamId;
+}
+
+export function streamScopeDisplayLabel(init: {
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streamId: StreamTabId;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): string {
+  const parentStreamId = init.parentStream.get(init.streamId);
+  if (!parentStreamId) return 'main';
+  return childStreamDisplayLabel(
+    init.streams.get(parentStreamId),
+    init.streamId,
+  );
+}

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -18,6 +18,7 @@ import {
 } from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
+import { streamScopeDisplayLabel } from '@cli/chat/tui/state/streamLabels';
 import type {
   ProcessOutputTail,
   StreamSlice,
@@ -393,6 +394,41 @@ describe('CLI child execution controls', () => {
         label: 'review',
       },
     ]);
+  });
+
+  it('labels child-control stream scopes with friendly stream names', () => {
+    const parent = slice({
+      streamId: 'main',
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const child = slice({ streamId: 'review-stream' });
+    const parentStream = new Map([['review-stream', 'main']] as const);
+    const streams = new Map([
+      ['main', parent],
+      ['review-stream', child],
+    ] as const);
+
+    expect(
+      streamScopeDisplayLabel({
+        parentStream,
+        streamId: 'main',
+        streams,
+      }),
+    ).toBe('main');
+    expect(
+      streamScopeDisplayLabel({
+        parentStream,
+        streamId: 'review-stream',
+        streams,
+      }),
+    ).toBe('review');
   });
 
   it('keeps subagent controls on the focused child when it has descendants', () => {

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -180,6 +180,55 @@ describe('CLI stream tabs strip', () => {
     ]);
   });
 
+  it('labels nested child stream roots with their friendly stream name', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const grandchild1 = streamId('grandchild-1');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          childStreams: [
+            child({
+              executionId: 'r1',
+              childStreamId: child1,
+              agentName: 'review',
+            }),
+          ],
+        }),
+      ],
+      [
+        child1,
+        slice('child-1', {
+          status: STREAM_STATUS.RUNNING,
+          activeSubagents: [
+            child({
+              executionId: 'r2',
+              childStreamId: grandchild1,
+              agentName: 'detail-review',
+            }),
+          ],
+        }),
+      ],
+      [grandchild1, slice('grandchild-1', { status: STREAM_STATUS.RUNNING })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: grandchild1,
+      streams,
+      parentStream: new Map([
+        [child1, root],
+        [grandchild1, child1],
+      ]),
+      width: 80,
+    });
+
+    expect(items.map(streamTabSegmentText)).toEqual([
+      'review*',
+      '[detail-review]*',
+    ]);
+  });
+
   it('collapses the middle entries under narrow widths while preserving focus', () => {
     const root = streamId('root');
     const childIds = Array.from({ length: 5 }, (_, i) =>


### PR DESCRIPTION
## Summary
- replace raw stream ids in the CLI child-control scope label with the same friendly stream labels used by the tab strip
- share stream-label resolution between the tab strip and child-control picker
- cover parent and nested child stream labels in CLI tests

Closes #4680

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `git diff --check`
- `npm run lint` (passes with three existing import-order warnings outside this change)
- `npm run compile:safe`
- TTY harness at 80x24: focus child stream, open subagents picker; observed `Parent stream: main` instead of `Parent stream: harness-stream-1`
