### PR TITLE
fix: notify when CLI approvals need attention

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -23,6 +23,7 @@ import {
   formatCliSessionStatus,
   readQueuedFollowUpMessagesForStatus,
 } from '../src/chat/tui/sessionStatus';
+import { notify } from '../src/chat/tui/notifications/terminalNotifier';
 import { enqueueApproval } from '../src/chat/tui/state/approvalQueue';
 
 const STREAM_ID = 'harness-stream-1';
@@ -272,10 +273,13 @@ if (SHOW_TODOS) {
 
 if (SHOW_EDIT_APPROVAL) {
   const showApproval = () =>
-    void enqueueApproval({
-      kind: 'toolEdit',
-      request: makeEditApprovalRequest(),
-    });
+    void enqueueApproval(
+      {
+        kind: 'toolEdit',
+        request: makeEditApprovalRequest(),
+      },
+      { onPresent: () => notify({ kind: 'approvalNeeded' }) },
+    );
 
   if (EDIT_APPROVAL_DELAY_MS > 0) {
     setTimeout(showApproval, EDIT_APPROVAL_DELAY_MS);

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -41,6 +41,7 @@ import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { assertNever } from '../assertNever';
+import { notify } from '../notifications/terminalNotifier';
 import { cliState } from './cliState';
 import {
   enqueueApproval,
@@ -245,7 +246,7 @@ export function approvalPayloadStreamId(
   }
 }
 
-function enqueueTuiApproval(
+export function enqueueTuiApproval(
   payload: ApprovalPayload,
   host: CliRuntimeHost,
 ): Promise<ApprovalDecision> {
@@ -253,6 +254,7 @@ function enqueueTuiApproval(
     onPresent: () => {
       const streamId = approvalPayloadStreamId(payload);
       if (streamId) host.emit('setActiveStream', { streamId });
+      notify({ kind: 'approvalNeeded' });
     },
   });
 }

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -1,12 +1,22 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const notifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
+  notify: notifyMock,
+}));
+
 import {
   clearApprovals,
   currentApproval,
   enqueueApproval,
   type ApprovalPayload,
 } from '@cli/chat/tui/state/approvalQueue';
-import { approvalPayloadStreamId } from '@cli/chat/tui/state/subscribeApprovals';
+import {
+  approvalPayloadStreamId,
+  enqueueTuiApproval,
+} from '@cli/chat/tui/state/subscribeApprovals';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 
 function bashPayload(streamId: string): ApprovalPayload {
   return {
@@ -22,6 +32,7 @@ function bashPayload(streamId: string): ApprovalPayload {
 
 afterEach(() => {
   clearApprovals();
+  notifyMock.mockClear();
 });
 
 describe('CLI approval queue', () => {
@@ -55,6 +66,43 @@ describe('CLI approval queue', () => {
     currentApproval.get()?.decide({ accepted: false });
     await expect(secondResult).resolves.toEqual({ accepted: false });
     expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('notifies only when a TUI approval becomes the foreground modal', async () => {
+    const host = { emit: vi.fn() } as unknown as CliRuntimeHost;
+    const first = bashPayload('child-1');
+    const second = bashPayload('child-2');
+
+    const firstResult = enqueueTuiApproval(first, host);
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(first);
+    });
+    expect(host.emit).toHaveBeenNthCalledWith(1, 'setActiveStream', {
+      streamId: 'child-1',
+    });
+    expect(notifyMock).toHaveBeenNthCalledWith(1, {
+      kind: 'approvalNeeded',
+    });
+
+    const secondResult = enqueueTuiApproval(second, host);
+    await Promise.resolve();
+    expect(currentApproval.get()?.payload).toBe(first);
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(firstResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(second);
+    });
+    expect(host.emit).toHaveBeenNthCalledWith(2, 'setActiveStream', {
+      streamId: 'child-2',
+    });
+    expect(notifyMock).toHaveBeenNthCalledWith(2, {
+      kind: 'approvalNeeded',
+    });
+
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(secondResult).resolves.toEqual({ accepted: false });
   });
 
   it('extracts stream ids from every approval payload used by the TUI', () => {


### PR DESCRIPTION
## Summary
- emit the terminal `approvalNeeded` notification when a TUI approval becomes the foreground modal
- keep queued approvals quiet until they actually need attention
- make the TUI harness delayed edit approval use the same notification path

Closes #4682

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/ApprovalQueue.vitest.mts`
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- TTY harness with delayed edit approval: observed fallback BEL (`\u0007`) immediately before the approval modal rendered
- `git diff --check`
- `npm run lint` (passes with three existing import-order warnings outside this change)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UX change: adds terminal notifications on existing approval presentation timing without altering approval policy or resolution logic.
> 
> **Overview**
> The CLI TUI now fires the terminal **`approvalNeeded`** notification (bell/OSC via `terminalNotifier`) only when an approval actually becomes the **foreground** modal, not when it is merely queued behind another approval.
> 
> **`enqueueTuiApproval`** is exported and wires `onPresent` to activate the related stream (`setActiveStream`) and call **`notify({ kind: 'approvalNeeded' })`**. The TUI harness’s delayed edit-approval path uses the same **`onPresent`** hook so manual testing matches production.
> 
> Tests mock **`notify`** and assert it runs once per modal promotion, alongside existing queue **`onPresent`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fcebb974f664dc85e000888df8508e444649c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->