### PR TITLE
fix: show edit lines in cramped CLI approvals

### DIFF
--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -31,6 +31,7 @@ export interface DiffStats {
 const NO_NEWLINE_MARKER = '\\';
 const MIN_DIFF_WIDTH = 20;
 const DEFAULT_DIFF_WIDTH = 74;
+const COMPACT_DIFF_DISPLAY_LINES = 3;
 
 type OverflowMarkerKind = 'hidden' | 'more' | 'previous';
 
@@ -179,7 +180,12 @@ export function maxDiffScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (maxDisplayLines <= 2 || totalLines <= maxDisplayLines) return 0;
+  if (
+    maxDisplayLines <= COMPACT_DIFF_DISPLAY_LINES ||
+    totalLines <= maxDisplayLines
+  ) {
+    return 0;
+  }
   return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
 }
 
@@ -212,6 +218,42 @@ function overflowMarkerText(
   );
 }
 
+function representativeDiffLineIndex(
+  lines: readonly DiffDisplayLine[],
+): number {
+  const changedIndex = lines.findIndex(
+    (line) => line.kind === 'added' || line.kind === 'removed',
+  );
+  if (changedIndex >= 0) return changedIndex;
+
+  const contentIndex = lines.findIndex((line) => line.kind !== 'overflow');
+  return Math.max(0, contentIndex);
+}
+
+function compactBoundedDiffDisplayLines(
+  lines: readonly DiffDisplayLine[],
+  maxDisplayLines: number,
+  width?: number,
+): DiffDisplayLine[] {
+  const visibleBudget = Math.max(1, maxDisplayLines);
+  const visibleCount = visibleBudget === 1 ? 1 : visibleBudget - 1;
+  const anchor = representativeDiffLineIndex(lines);
+  const start = Math.max(0, Math.min(anchor, lines.length - visibleCount));
+  const visibleLines = lines.slice(start, start + visibleCount);
+  if (visibleBudget === 1) return visibleLines;
+
+  const hiddenRows = Math.max(0, lines.length - visibleLines.length);
+  if (hiddenRows === 0) return visibleLines;
+
+  return [
+    ...visibleLines,
+    {
+      kind: 'overflow',
+      text: overflowMarkerText('hidden', hiddenRows, width),
+    },
+  ];
+}
+
 export function scrollBoundedDiffDisplayLines(
   hunks: readonly Hunk[],
   maxHunkLines = 0,
@@ -224,13 +266,8 @@ export function scrollBoundedDiffDisplayLines(
       ? diffDisplayLines(hunks, maxHunkLines)
       : wrappedDiffDisplayLines(hunks, width, maxHunkLines);
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
-  if (maxDisplayLines === 1) {
-    return [
-      {
-        kind: 'overflow',
-        text: overflowMarkerText('hidden', lines.length, width),
-      },
-    ];
+  if (maxDisplayLines <= COMPACT_DIFF_DISPLAY_LINES) {
+    return compactBoundedDiffDisplayLines(lines, maxDisplayLines, width);
   }
 
   const offset = Math.max(

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -52,25 +52,40 @@ describe('CLI diff display', () => {
     expect(maxDiffScrollOffset(10, 4)).toBe(7);
   });
 
-  it('keeps one- and two-row diff windows static', () => {
+  it('keeps cramped diff windows static', () => {
     expect(maxDiffScrollOffset(10, 1)).toBe(0);
     expect(maxDiffScrollOffset(10, 2)).toBe(0);
+    expect(maxDiffScrollOffset(10, 3)).toBe(0);
   });
 
-  it('shows content plus an overflow marker in a two-row diff window', () => {
+  it('shows a changed line in a one-row diff window', () => {
     const hunks = buildHunks(
       'draft.tex',
       ['alpha', 'beta', 'gamma', 'delta'].join('\n'),
       ['alpha', 'BETA', 'gamma', 'DELTA'].join('\n'),
     );
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 2, 1);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 1, 0);
 
-    expect(lines).toHaveLength(2);
-    expect(lines[0]?.kind).not.toBe('overflow');
-    expect(lines[1]).toMatchObject({
+    expect(lines).toHaveLength(1);
+    expect(['added', 'removed']).toContain(lines[0]?.kind);
+  });
+
+  it('prioritizes changed rows in a cramped diff window', () => {
+    const hunks = buildHunks(
+      'draft.tex',
+      ['alpha', 'beta', 'gamma', 'delta'].join('\n'),
+      ['alpha', 'BETA', 'gamma', 'DELTA'].join('\n'),
+    );
+
+    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 3, 0);
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]?.kind).toBe('removed');
+    expect(lines[1]?.kind).toBe('added');
+    expect(lines[2]).toMatchObject({
       kind: 'overflow',
-      text: expect.stringContaining('more rows'),
+      text: expect.stringContaining('hidden'),
     });
   });
 


### PR DESCRIPTION
## Summary
- make one-to-three-row bounded diff windows prioritize representative added/removed rows
- keep cramped diff windows static so the approval footer does not advertise ineffective scrolling
- cover one-row and cramped diff-window behavior in CLI renderer tests

Closes #4685

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/DiffView.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/EditApproval.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- TTY harness at 80x18 with delayed edit approval: modal now shows `-Line 1: placeholder.` instead of only `... rows hidden`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with three existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only diff layout and scroll gating with unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Cramped CLI edit-approval diff panes (about **1–3 visible rows**) now show **actual added/removed lines** instead of only overflow placeholders.
> 
> `scrollBoundedDiffDisplayLines` routes those budgets through a new **compact** path that anchors on the first changed row (or first real content), reserves one row for a “rows hidden” marker when needed, and **disables scrolling** (`maxDiffScrollOffset` is zero for ≤3 rows) so the footer no longer implies scroll that cannot help.
> 
> Vitest coverage in `DiffView.vitest.mts` was updated for one-row and three-row windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412e6cf04ba6a01eb1c6e9097649fdf386b9eaa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->