### PR TITLE
fix: keep active CLI todos visible

### DIFF
--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -36,13 +36,30 @@ function todoColor(status: TodoStatus): string | undefined {
   }
 }
 
-function TodoRow({ todo }: { todo: TodoItem }): React.JSX.Element {
+function TodoRow({
+  compact = false,
+  todo,
+}: {
+  readonly compact?: boolean;
+  readonly todo: TodoItem;
+}): React.JSX.Element {
   const label =
     todo.status === TODO_STATUS.IN_PROGRESS ? todo.activeForm : todo.content;
   return (
-    <Box>
-      <Text color={todoColor(todo.status)}>{todoMarker(todo.status)} </Text>
-      <Text dimColor={todo.status === TODO_STATUS.COMPLETED}>{label}</Text>
+    <Box
+      height={compact ? 1 : undefined}
+      minWidth={0}
+      overflowY={compact ? 'hidden' : undefined}
+    >
+      <Box flexShrink={0}>
+        <Text color={todoColor(todo.status)}>{todoMarker(todo.status)} </Text>
+      </Box>
+      <Text
+        dimColor={todo.status === TODO_STATUS.COMPLETED}
+        wrap={compact ? 'truncate-end' : undefined}
+      >
+        {label}
+      </Text>
     </Box>
   );
 }
@@ -145,16 +162,24 @@ export function compactTodosPlanRows({
 function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
   switch (row.kind) {
     case 'todo':
-      return <TodoRow todo={row.todo} />;
+      return <TodoRow compact todo={row.todo} />;
     case 'planSummary':
-      return <Text dimColor>{row.summary}</Text>;
+      return (
+        <Box height={1} minWidth={0} overflowY="hidden">
+          <Text dimColor wrap="truncate-end">
+            {row.summary}
+          </Text>
+        </Box>
+      );
     case 'planStep':
       return (
-        <Box>
-          <Text color={todoColor(row.step.status)}>
-            {todoMarker(row.step.status)}{' '}
-          </Text>
-          <Text>{`${row.stepIndex + 1}. ${row.step.title}`}</Text>
+        <Box height={1} minWidth={0} overflowY="hidden">
+          <Box flexShrink={0}>
+            <Text color={todoColor(row.step.status)}>
+              {todoMarker(row.step.status)}{' '}
+            </Text>
+          </Box>
+          <Text wrap="truncate-end">{`${row.stepIndex + 1}. ${row.step.title}`}</Text>
         </Box>
       );
   }
@@ -192,10 +217,12 @@ export function TodosPlanPanel(
           <CompactRow key={`${row.kind}:${row.sourceIndex}`} row={row} />
         ))}
         {hiddenCount > 0 && rows.length < props.maxRows ? (
-          <Text
-            dimColor
-            wrap="truncate-end"
-          >{`+${hiddenCount} more todo/plan item${hiddenCount === 1 ? '' : 's'}`}</Text>
+          <Box height={1} minWidth={0} overflowY="hidden">
+            <Text
+              dimColor
+              wrap="truncate-end"
+            >{`+${hiddenCount} more todo/plan item${hiddenCount === 1 ? '' : 's'}`}</Text>
+          </Box>
         ) : null}
       </Box>
     );

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -3,7 +3,13 @@
 
 import { Box, Text } from 'ink';
 
-import { TODO_STATUS, type TodoItem, type TodoStatus } from '@shared/schemas';
+import {
+  TODO_STATUS,
+  type Plan,
+  type PlanStep,
+  type TodoItem,
+  type TodoStatus,
+} from '@shared/schemas';
 
 import { cliState } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
@@ -41,6 +47,119 @@ function TodoRow({ todo }: { todo: TodoItem }): React.JSX.Element {
   );
 }
 
+export type CompactTodosPlanRow =
+  | { kind: 'todo'; sourceIndex: number; todo: TodoItem }
+  | { kind: 'planSummary'; sourceIndex: number; summary: string }
+  | {
+      kind: 'planStep';
+      sourceIndex: number;
+      step: PlanStep;
+      stepIndex: number;
+    };
+
+function compactRowPriority(row: CompactTodosPlanRow): number {
+  if (row.kind === 'todo') {
+    switch (row.todo.status) {
+      case TODO_STATUS.IN_PROGRESS:
+        return 0;
+      case TODO_STATUS.PENDING:
+        return 1;
+      case TODO_STATUS.COMPLETED:
+        return 4;
+      default:
+        return 3;
+    }
+  }
+  if (row.kind === 'planStep') {
+    switch (row.step.status) {
+      case TODO_STATUS.IN_PROGRESS:
+        return 2;
+      case TODO_STATUS.PENDING:
+        return 5;
+      case TODO_STATUS.COMPLETED:
+        return 6;
+      default:
+        return 5;
+    }
+  }
+  return 3;
+}
+
+export function compactTodosPlanRows({
+  maxRows,
+  plan,
+  todos,
+}: {
+  readonly maxRows: number;
+  readonly plan: Plan | null;
+  readonly todos: readonly TodoItem[];
+}): {
+  readonly hiddenCount: number;
+  readonly rows: readonly CompactTodosPlanRow[];
+} {
+  const rowBudget = Math.max(0, Math.floor(maxRows));
+  const allRows: CompactTodosPlanRow[] = todos.map((todo, index) => ({
+    kind: 'todo',
+    sourceIndex: index,
+    todo,
+  }));
+  if (plan) {
+    allRows.push({
+      kind: 'planSummary',
+      sourceIndex: allRows.length,
+      summary: plan.summary,
+    });
+    for (const [stepIndex, step] of plan.steps.entries()) {
+      allRows.push({
+        kind: 'planStep',
+        sourceIndex: allRows.length,
+        step,
+        stepIndex,
+      });
+    }
+  }
+
+  if (allRows.length <= rowBudget) {
+    return { hiddenCount: 0, rows: allRows };
+  }
+  if (rowBudget <= 0) {
+    return { hiddenCount: allRows.length, rows: [] };
+  }
+
+  const visibleCount = rowBudget === 1 ? 1 : rowBudget - 1;
+  const rows = [...allRows]
+    .sort(
+      (left, right) =>
+        compactRowPriority(left) - compactRowPriority(right) ||
+        left.sourceIndex - right.sourceIndex,
+    )
+    .slice(0, visibleCount)
+    .sort((left, right) => left.sourceIndex - right.sourceIndex);
+
+  return {
+    hiddenCount: allRows.length - rows.length,
+    rows,
+  };
+}
+
+function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
+  switch (row.kind) {
+    case 'todo':
+      return <TodoRow todo={row.todo} />;
+    case 'planSummary':
+      return <Text dimColor>{row.summary}</Text>;
+    case 'planStep':
+      return (
+        <Box>
+          <Text color={todoColor(row.step.status)}>
+            {todoMarker(row.step.status)}{' '}
+          </Text>
+          <Text>{`${row.stepIndex + 1}. ${row.step.title}`}</Text>
+        </Box>
+      );
+  }
+}
+
 export interface TodosPlanPanelProps {
   readonly maxRows?: number;
 }
@@ -55,6 +174,32 @@ export function TodosPlanPanel(
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
+
+  if (props.maxRows !== undefined) {
+    const { hiddenCount, rows } = compactTodosPlanRows({
+      maxRows: props.maxRows,
+      plan,
+      todos,
+    });
+    return (
+      <Box
+        flexDirection="column"
+        height={props.maxRows}
+        overflowY="hidden"
+        paddingX={1}
+      >
+        {rows.map((row) => (
+          <CompactRow key={`${row.kind}:${row.sourceIndex}`} row={row} />
+        ))}
+        {hiddenCount > 0 && rows.length < props.maxRows ? (
+          <Text
+            dimColor
+            wrap="truncate-end"
+          >{`+${hiddenCount} more todo/plan item${hiddenCount === 1 ? '' : 's'}`}</Text>
+        ) : null}
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/src/test-kernel/cli/TodosPlanPanel.vitest.mts
+++ b/src/test-kernel/cli/TodosPlanPanel.vitest.mts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compactTodosPlanRows,
+  type CompactTodosPlanRow,
+} from '@cli/chat/tui/panes/TodosPlanPanel';
+import { TODO_STATUS, type Plan, type TodoItem } from '@shared/schemas';
+
+function rowKey(row: CompactTodosPlanRow): string {
+  switch (row.kind) {
+    case 'todo':
+      return `todo:${row.todo.content}`;
+    case 'planSummary':
+      return 'plan:summary';
+    case 'planStep':
+      return `plan:${row.step.title}`;
+  }
+}
+
+describe('CLI TodosPlanPanel display model', () => {
+  const todos: TodoItem[] = [
+    {
+      content: 'Split theorem into algebraic and analytic checks',
+      activeForm: 'Splitting theorem into checks',
+      status: TODO_STATUS.COMPLETED,
+    },
+    {
+      content: 'Ask leanSolver to verify the finite case',
+      activeForm: 'Waiting for leanSolver',
+      status: TODO_STATUS.IN_PROGRESS,
+    },
+    {
+      content: 'Merge subagent conclusions into final answer',
+      activeForm: 'Merging subagent conclusions',
+      status: TODO_STATUS.PENDING,
+    },
+  ];
+  const plan: Plan = {
+    summary: 'Coordinate a small math proof through nested CLI work.',
+    steps: [
+      {
+        title: 'Route proof obligations',
+        description: 'Choose the right specialist for each proof branch.',
+        files: [],
+        status: TODO_STATUS.COMPLETED,
+      },
+      {
+        title: 'Check formalizable parts',
+        description: 'Have a subagent inspect the Lean-style finite case.',
+        files: [],
+        status: TODO_STATUS.IN_PROGRESS,
+      },
+    ],
+  };
+
+  it('keeps active todo rows visible in a constrained mixed panel', () => {
+    const display = compactTodosPlanRows({ maxRows: 4, plan, todos });
+
+    expect(display.rows.map(rowKey)).toEqual([
+      'todo:Ask leanSolver to verify the finite case',
+      'todo:Merge subagent conclusions into final answer',
+      'plan:Check formalizable parts',
+    ]);
+    expect(display.hiddenCount).toBe(3);
+  });
+
+  it('uses all rows when the todo and plan content fits', () => {
+    const display = compactTodosPlanRows({ maxRows: 6, plan, todos });
+
+    expect(display.rows.map(rowKey)).toEqual([
+      'todo:Split theorem into algebraic and analytic checks',
+      'todo:Ask leanSolver to verify the finite case',
+      'todo:Merge subagent conclusions into final answer',
+      'plan:summary',
+      'plan:Route proof obligations',
+      'plan:Check formalizable parts',
+    ]);
+    expect(display.hiddenCount).toBe(0);
+  });
+
+  it('uses the single available row for the highest-signal item', () => {
+    const display = compactTodosPlanRows({ maxRows: 1, plan, todos });
+
+    expect(display.rows.map(rowKey)).toEqual([
+      'todo:Ask leanSolver to verify the finite case',
+    ]);
+    expect(display.hiddenCount).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit compact row model for the CLI todo/plan bottom panel
- prioritize active todo and active plan rows when space is constrained by subagent/process rows
- show a compact overflow row instead of relying on nested Ink clipping

Closes #4684

## Verification
- `corepack pnpm install` (clean worktree dependency links)
- `corepack pnpm exec vitest run src/test-kernel/cli/TodosPlanPanel.vitest.mts`
- `npm run format`
- `git diff --check`
- `npm run lint` (passes with three existing import-order warnings outside this change)
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- TTY harness with `HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_DELEGATE=1 HARNESS_CAN_INTERRUPT=1 HARNESS_ENTRIES=10`: compact panel shows `Waiting for leanSolver`, pending merge todo, active plan step, and `+3 more todo/plan items`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI display logic only; behavior is covered by new unit tests and does not touch auth, data, or core runtime paths.
> 
> **Overview**
> When the CLI todo/plan bottom panel runs with a **row budget** (shared with subagent rows), it no longer renders the full list and lets Ink clip overflow. It now builds a **compact row model** that merges todos and plan summary/steps, **prioritizes in-progress todos** (then pending todos, then active plan steps) within the budget, and reserves one line for a **“+N more todo/plan items”** overflow hint when content does not fit.
> 
> **`TodoRow`** and new **`CompactRow`** paths use single-line height, **`truncate-end`**, and flex layout so labels stay visible instead of being cut off by nested overflow. The unconstrained layout (no `maxRows`) is unchanged. Vitest coverage was added for **`compactTodosPlanRows`** selection and hidden counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06aab02ba3eebd0e8b469073a22bde6dd6b4f165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->