### PR TITLE
fix: harden compact CLI todo priorities

### DIFF
--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -75,31 +75,34 @@ export type CompactTodosPlanRow =
     };
 
 function compactRowPriority(row: CompactTodosPlanRow): number {
-  if (row.kind === 'todo') {
-    switch (row.todo.status) {
-      case TODO_STATUS.IN_PROGRESS:
-        return 0;
-      case TODO_STATUS.PENDING:
-        return 1;
-      case TODO_STATUS.COMPLETED:
-        return 4;
-      default:
-        return 3;
-    }
+  switch (row.kind) {
+    case 'todo':
+      switch (row.todo.status) {
+        case TODO_STATUS.IN_PROGRESS:
+          return 0;
+        case TODO_STATUS.PENDING:
+          return 1;
+        case TODO_STATUS.COMPLETED:
+          return 4;
+        default:
+          return 3;
+      }
+    case 'planStep':
+      switch (row.step.status) {
+        case TODO_STATUS.IN_PROGRESS:
+          return 2;
+        case TODO_STATUS.PENDING:
+          return 3;
+        case TODO_STATUS.COMPLETED:
+          return 6;
+        default:
+          return 3;
+      }
+    case 'planSummary':
+      return 5;
   }
-  if (row.kind === 'planStep') {
-    switch (row.step.status) {
-      case TODO_STATUS.IN_PROGRESS:
-        return 2;
-      case TODO_STATUS.PENDING:
-        return 5;
-      case TODO_STATUS.COMPLETED:
-        return 6;
-      default:
-        return 5;
-    }
-  }
-  return 3;
+  const exhaustive: never = row;
+  return exhaustive;
 }
 
 export function compactTodosPlanRows({
@@ -143,6 +146,8 @@ export function compactTodosPlanRows({
     return { hiddenCount: allRows.length, rows: [] };
   }
 
+  // At one row, show the highest-signal item instead of spending the only row
+  // on the hidden-count marker.
   const visibleCount = rowBudget === 1 ? 1 : rowBudget - 1;
   const rows = [...allRows]
     .sort(
@@ -198,25 +203,29 @@ export function TodosPlanPanel(
   if (!slice) return null;
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;
-  if (props.maxRows !== undefined && props.maxRows <= 0) return null;
+  const rowBudget =
+    props.maxRows === undefined
+      ? undefined
+      : Math.max(0, Math.floor(props.maxRows));
+  if (rowBudget !== undefined && rowBudget <= 0) return null;
 
-  if (props.maxRows !== undefined) {
+  if (rowBudget !== undefined) {
     const { hiddenCount, rows } = compactTodosPlanRows({
-      maxRows: props.maxRows,
+      maxRows: rowBudget,
       plan,
       todos,
     });
     return (
       <Box
         flexDirection="column"
-        height={props.maxRows}
+        height={rowBudget}
         overflowY="hidden"
         paddingX={1}
       >
         {rows.map((row) => (
           <CompactRow key={`${row.kind}:${row.sourceIndex}`} row={row} />
         ))}
-        {hiddenCount > 0 && rows.length < props.maxRows ? (
+        {hiddenCount > 0 && rows.length < rowBudget ? (
           <Box height={1} minWidth={0} overflowY="hidden">
             <Text
               dimColor

--- a/src/test-kernel/cli/TodosPlanPanel.vitest.mts
+++ b/src/test-kernel/cli/TodosPlanPanel.vitest.mts
@@ -86,4 +86,25 @@ describe('CLI TodosPlanPanel display model', () => {
     ]);
     expect(display.hiddenCount).toBe(5);
   });
+
+  it('shows pending plan steps before completed context rows', () => {
+    const display = compactTodosPlanRows({
+      maxRows: 2,
+      plan: {
+        summary: 'Finish the remaining proof obligations.',
+        steps: [
+          {
+            title: 'Check the last lemma',
+            description: 'Verify the only unfinished plan item.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+        ],
+      },
+      todos: [todos[0]],
+    });
+
+    expect(display.rows.map(rowKey)).toEqual(['plan:Check the last lemma']);
+    expect(display.hiddenCount).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- normalize the compact todo/plan panel to an integer row budget before layout
- make compact row priority exhaustive, with plan summaries explicitly ranked
- surface pending plan steps before completed/context rows when space is tight
- document the intentional one-row behavior and cover the pending-plan priority case

Closes #4688

## Verification
- `corepack pnpm exec vitest run src/test-kernel/cli/TodosPlanPanel.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with three existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only display ordering and layout for todos/plan; no auth, data, or API changes.
> 
> **Overview**
> Hardens how the compact CLI **todos/plan** panel picks and lays out rows when vertical space is tight.
> 
> **Row budget** is normalized with `Math.floor` / `Math.max(0, …)` before compacting and before setting panel height, so fractional or negative `maxRows` values behave consistently.
> 
> **Compact row ordering** is refactored to an exhaustive `switch` on row kind. **Pending plan steps** now rank above completed todos and the plan summary (and above the old default bucket), so a scarce row budget surfaces unfinished plan work instead of completed context. **Plan summaries** get an explicit priority. A short comment documents that with **one row**, the UI shows the highest-signal item rather than only a “+N more” line.
> 
> Adds a Vitest case for pending plan steps winning over completed todos when `maxRows` is 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e88ce5a211d03a4e65109c4cf6a3922492d2794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->