### PR TITLE
fix: align CLI status detail labels

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@shared/schemas';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
+import { formatCliStatusLabel } from '../sessionStatus';
 import { approvalQueueDepth } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
@@ -73,22 +74,7 @@ export interface StatusBarDisplay {
   readonly bindings: string;
 }
 
-export function statusLabel(status: string | undefined): string {
-  switch (status) {
-    case STREAM_STATUS.INITIALIZING:
-      return 'starting…';
-    case STREAM_STATUS.RUNNING:
-      return 'running';
-    case STREAM_STATUS.WAITING:
-      return 'idle';
-    case STREAM_STATUS.STOPPED:
-      return 'stopped';
-    case STREAM_STATUS.READY:
-      return 'ready';
-    default:
-      return status ?? '—';
-  }
-}
+export const statusLabel = formatCliStatusLabel;
 
 function compactScale(scaled: number, suffix: string): string {
   const rounded = Number.isInteger(scaled)

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,5 +1,5 @@
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { StreamTabId } from '@shared/schemas';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
@@ -17,6 +17,23 @@ export function readQueuedFollowUpMessagesForStatus(
   streamId: StreamTabId | undefined,
 ): string[] {
   return streamId === undefined ? [] : ToolUseFollowUpQueue.getAll(streamId);
+}
+
+export function formatCliStatusLabel(status: string | undefined): string {
+  switch (status) {
+    case STREAM_STATUS.INITIALIZING:
+      return 'starting…';
+    case STREAM_STATUS.RUNNING:
+      return 'running';
+    case STREAM_STATUS.WAITING:
+      return 'idle';
+    case STREAM_STATUS.STOPPED:
+      return 'stopped';
+    case STREAM_STATUS.READY:
+      return 'ready';
+    default:
+      return status ?? '—';
+  }
 }
 
 function queuedFollowUpStatusLines(messages: readonly string[]): string[] {
@@ -37,7 +54,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     `model: ${input.model}`,
     `api: ${input.api}`,
     `approval: ${input.approval}`,
-    `status: ${input.status}`,
+    `status: ${formatCliStatusLabel(input.status)}`,
     ...queuedFollowUpStatusLines(input.queuedFollowUpMessages),
   ].join('\n');
 }

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
+  formatCliStatusLabel,
   formatCliSessionStatus,
   readQueuedFollowUpMessagesForStatus,
 } from '@cli/chat/tui/sessionStatus';
+import { STREAM_STATUS } from '@shared/schemas';
 
 const STREAM_ID = 'status-queued-followups-test-stream';
 
@@ -67,6 +69,20 @@ describe('CLI session status formatter', () => {
         queuedFollowUpMessages: [],
       }),
     ).toContain('queued follow-ups: 0');
+  });
+
+  it('uses the footer label for an idle waiting stream', () => {
+    expect(formatCliStatusLabel(STREAM_STATUS.WAITING)).toBe('idle');
+    expect(
+      formatCliSessionStatus({
+        agent: 'research',
+        model: 'deepseekT',
+        api: 'included relay',
+        approval: 'ask before privileged actions',
+        status: STREAM_STATUS.WAITING,
+        queuedFollowUpMessages: [],
+      }),
+    ).toContain('status: idle');
   });
 
   it('reads queued follow-ups from the queue manager for status details', () => {


### PR DESCRIPTION
Closes #4692.

## Summary
- share the CLI footer status label formatter with `/status`
- make `STREAM_STATUS.WAITING` render as `idle` in status details
- add a regression test for the completed-chat idle state

## Evidence
Real TTY dogfood on current main before the fix showed the footer as `◆ idle relay r1 ...` while `/status` printed `status: waiting`.

After rebuilding `texra-local` from this branch, a short TTY run printed:

```text
◆ idle relay r1 4.3k/1M (1%)
status: idle
queued follow-ups: 0
```

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 existing unrelated import-order warnings)
- `git diff --check`
- `npm run texra-local:build`
- live `texra-local chat --agent research --model deepseekT --approval-policy ask --api-mode included` TTY verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only refactor in the TUI with a focused unit test; no auth, data, or runtime behavior changes.
> 
> **Overview**
> **Unifies how the CLI shows stream status** so the footer and `/status` details use the same human-readable labels.
> 
> The status-bar mapping (e.g. `STREAM_STATUS.WAITING` → `idle`) moves into `formatCliStatusLabel` in `sessionStatus.ts`. `StatusBar` re-exports that as `statusLabel`, and `formatCliSessionStatus` now formats the `status:` line through the same helper instead of printing the raw enum value. A regression test asserts waiting streams report `status: idle` in session details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e611ea08741c4dba07047475888370971a0f6197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->