### PR TITLE
fix: mark queued follow-up overflow

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -164,19 +164,23 @@ function queuedFollowUpsListSummary(
   maxColumns: number,
 ): string | undefined {
   const previewItems = messages.slice(0, QUEUED_FOLLOW_UP_PREVIEW_ITEMS);
+  const overflowCount = messages.length - previewItems.length;
+  const overflowMarker =
+    overflowCount > 0 ? `+${overflowCount} more` : undefined;
   const separatorColumns =
-    Math.max(0, previewItems.length - 1) *
+    Math.max(0, previewItems.length - 1 + (overflowMarker ? 1 : 0)) *
     stringWidth(QUEUED_FOLLOW_UP_SEPARATOR);
+  const overflowColumns = overflowMarker ? stringWidth(overflowMarker) : 0;
   const itemColumns = Math.floor(
-    (maxColumns - separatorColumns) / previewItems.length,
+    (maxColumns - separatorColumns - overflowColumns) / previewItems.length,
   );
   if (itemColumns < QUEUED_FOLLOW_UP_MIN_ITEM_PREVIEW) return undefined;
 
-  return previewItems
-    .map((message, index) =>
-      numberedQueuedFollowUpPreview(message, index, itemColumns),
-    )
-    .join(QUEUED_FOLLOW_UP_SEPARATOR);
+  const previewParts = previewItems.map((message, index) =>
+    numberedQueuedFollowUpPreview(message, index, itemColumns),
+  );
+  if (overflowMarker) previewParts.push(overflowMarker);
+  return previewParts.join(QUEUED_FOLLOW_UP_SEPARATOR);
 }
 
 export function queuedFollowUpsSummary(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -23,6 +23,12 @@ describe('CLI StatusBar display model', () => {
     ).toBe('1. Keep the proof und… · 2. Also mention the f…');
   });
 
+  it('marks hidden queued follow-up previews', () => {
+    expect(queuedFollowUpsSummary(['first', 'second', 'third'])).toBe(
+      '1. first · 2. second · +1 more',
+    );
+  });
+
   it('hides queued follow-up previews when the right side has no safe width', () => {
     expect(queuedFollowUpsSummary(['Keep the proof under one page.'], 20)).toBe(
       'Keep the proof unde…',


### PR DESCRIPTION
Closes #4694.

## Summary
- add a `+N more` marker when the status-bar queued-follow-up preview omits messages
- keep the marker inside the existing right-side width budget
- add a regression test for hidden queued follow-ups

## Evidence
Harness dogfood on `main` at 100 columns showed:

```text
◆ running 42s api queued 3                         1. Please add the mis… · 2. Then rerun the sho…
```

After this patch, the same harness scenario shows:

```text
◆ running 42s api queued 3                         1. Please add th… · 2. Then rerun th… · +1 more
```

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- live 100-column TTY harness verification with `HARNESS_QUEUED_FOLLOWUPS='...||...||...'`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 existing unrelated import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to status bar preview text with a regression test; no auth, data, or session logic.
> 
> **Overview**
> When more than two follow-ups are queued, the status bar right-side preview now appends a **`+N more`** suffix (e.g. `1. first · 2. second · +1 more`) instead of only showing the first two items with no indication that others exist.
> 
> Column budgeting in `queuedFollowUpsListSummary` reserves width for that marker and its separator so the preview still fits the existing right-side budget. A Vitest case locks in the overflow behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930e6e70e0ffcf9f5567ab342c2be5d2776e1d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->