### PR TITLE
[codex] Label CLI child-control scope

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -349,13 +349,13 @@ export function ChildControlPicker({
   const [tailExecutionId, setTailExecutionId] = useState<string | undefined>(
     undefined,
   );
-  const parentStreamLabel = activeStreamLabel ?? activeStreamId;
+  const streamScopeLabel = activeStreamLabel ?? activeStreamId;
   const tailItem = tailExecutionId
     ? items.find((item) => item.executionId === tailExecutionId)
     : undefined;
   const listLayout = computePickerListLayout({
     availableRows,
-    hasParentStream: parentStreamLabel !== undefined,
+    hasParentStream: streamScopeLabel !== undefined,
     highlight,
     itemCount: items.length,
   });
@@ -451,8 +451,8 @@ export function ChildControlPicker({
       <Text bold color="cyan">
         {pickerTitle(mode)}
       </Text>
-      {parentStreamLabel ? (
-        <Text dimColor>{`Parent stream: ${parentStreamLabel}`}</Text>
+      {streamScopeLabel ? (
+        <Text dimColor>{`Stream: ${streamScopeLabel}`}</Text>
       ) : null}
       <Box flexDirection="column" marginTop={1}>
         {items.length > 0 ? (


### PR DESCRIPTION
Closes #4695.

## Summary
- rename the child-control picker scope line from `Parent stream:` to `Stream:`
- keep picker targeting unchanged for parent-scoped subagent lists and child-scoped background tasks

## Evidence
- Harness dogfood on current main showed `Background tasks` with `Parent stream: strategy` after focusing the `strategy` child and opening `Option-p`.
- Rebuilt the harness and verified the picker now renders `Stream: strategy` in the focused child stream.

## Validation
- `npm run format`
- `git diff --check`
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- PTY harness check with `HARNESS_ENTRIES=8 HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_DELEGATE=1 HARNESS_CAN_INTERRUPT=1`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and variable rename only in the TUI picker; no logic or targeting changes.
> 
> **Overview**
> Updates the CLI TUI **child-control picker** (subagents / background tasks) so the scope line reads **`Stream: <label>`** instead of **`Parent stream:`**, matching that the list is scoped to the **currently focused stream** (including child streams), not only a parent.
> 
> The internal variable is renamed from `parentStreamLabel` to `streamScopeLabel`; list layout and picker behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfed2050988e65a263e3e83eefd9434e12abb6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->