### PR TITLE
fix: filter delegation models by availability

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -23,6 +23,7 @@ import { listToolInjections } from '@agent/runtime/toolInjection';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
+import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
   END_GROUP_STATUS,
   EXECUTION_STATUS,
@@ -38,6 +39,10 @@ import {
   getUnavailableToolNamesCached,
 } from '@tools/toolAvailability';
 import { notifyUnavailableTools } from '@tools/toolUnavailableNotification';
+import {
+  availableModelNamesFromOptions,
+  withDelegationModelAvailability,
+} from '@tools/delegationModelAvailability';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -97,12 +102,26 @@ export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
 const IMMEDIATE_COMPACTION_FOLLOW_UP =
   'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
 
-function resolveTools(
+async function availableDelegationModelNamesForTools(
+  tools: readonly ToolDefinition[],
+): Promise<readonly string[] | null | undefined> {
+  if (!tools.some((tool) => DELEGATION_TOOLS.has(tool.name))) {
+    return undefined;
+  }
+
+  try {
+    return availableModelNamesFromOptions(await computeModelOptionsData());
+  } catch {
+    return null;
+  }
+}
+
+async function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
   delegationBlocked: boolean,
-): { tools: ToolDefinition[]; delegationTrimmed: boolean } {
+): Promise<{ tools: ToolDefinition[]; delegationTrimmed: boolean }> {
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
   const missingDependency: string[] = [];
@@ -147,7 +166,17 @@ function resolveTools(
     notifyUnavailableTools(missingDependency);
   }
 
-  return { tools: resolved, delegationTrimmed };
+  const availableModelNames =
+    await availableDelegationModelNamesForTools(resolved);
+  return {
+    tools:
+      availableModelNames === undefined
+        ? resolved
+        : resolved.map((tool) =>
+            withDelegationModelAvailability(tool, availableModelNames),
+          ),
+    delegationTrimmed,
+  };
 }
 
 export async function runToolUseFlow<C = unknown>(
@@ -165,7 +194,7 @@ export async function runToolUseFlow<C = unknown>(
     delegationDepth,
     delegationConfig,
   );
-  const { tools: resolvedTools, delegationTrimmed } = resolveTools(
+  const { tools: resolvedTools, delegationTrimmed } = await resolveTools(
     setting.tools,
     registry,
     logger,

--- a/src/test-kernel/tools/DelegationModelAvailability.vitest.mts
+++ b/src/test-kernel/tools/DelegationModelAvailability.vitest.mts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ToolDefinition } from '@model';
+import type { ModelOptionData } from '@shared/schemas';
+import {
+  availableModelNamesFromOptions,
+  resolveDelegationModelFromAvailableNames,
+  withDelegationModelAvailability,
+} from '@tools/delegationModelAvailability';
+
+function model(
+  value: string,
+  overrides: Partial<ModelOptionData> = {},
+): ModelOptionData {
+  return {
+    value,
+    label: value,
+    ...overrides,
+  };
+}
+
+describe('delegation model availability', () => {
+  it('filters model options to only currently runnable models', () => {
+    expect(
+      availableModelNamesFromOptions([
+        model('sonnet46T'),
+        model('opus48T', { disabled: true, availability: 'not-included' }),
+        model('gemini31p', { requiresKey: true, availability: 'missing-key' }),
+        model('deepseekT', { disabled: false, requiresKey: false }),
+      ]),
+    ).toEqual(['sonnet46T', 'deepseekT']);
+  });
+
+  it('replaces the delegation tool description with current available models', () => {
+    const tool: ToolDefinition = {
+      name: 'delegate_agent',
+      description: [
+        'Delegate to a specialist.',
+        'Available models: opus48T, sonnet46T, gemini31p',
+        'Model selection: use the largest available model when needed.',
+      ].join('\n'),
+    };
+
+    const rewritten = withDelegationModelAvailability(tool, [
+      'sonnet46T',
+      'deepseekT',
+    ]);
+
+    expect(rewritten.description).toContain(
+      'Available models: sonnet46T, deepseekT',
+    );
+    expect(rewritten.description).not.toContain('opus48T');
+    expect(rewritten.description).toContain(
+      'Model selection: use the largest available model when needed.',
+    );
+  });
+
+  it('keeps non-delegation tool descriptions unchanged', () => {
+    const tool: ToolDefinition = {
+      name: 'read_file',
+      description: 'Available models: opus48T, sonnet46T',
+    };
+
+    expect(withDelegationModelAvailability(tool, ['sonnet46T'])).toBe(tool);
+  });
+
+  it('tells the agent not to guess models when availability cannot be loaded', () => {
+    const rewritten = withDelegationModelAvailability(
+      {
+        name: 'delegate_workflow',
+        description: 'Available models: loaded at runtime.',
+      },
+      null,
+    );
+
+    expect(rewritten.description).toBe(
+      'Available models: unavailable to load; omit model unless the user explicitly requested one.',
+    );
+  });
+
+  it('rejects an explicitly requested model that is not currently available', () => {
+    expect(() =>
+      resolveDelegationModelFromAvailableNames({
+        requestedModel: 'opus48T',
+        parentModel: 'sonnet46T',
+        availableModels: ['sonnet46T', 'deepseekT'],
+      }),
+    ).toThrow(
+      'Model "opus48T" is not currently available for delegation in the active API mode. Available models: sonnet46T, deepseekT.',
+    );
+  });
+
+  it('uses the parent model only when it is available', () => {
+    expect(
+      resolveDelegationModelFromAvailableNames({
+        parentModel: 'sonnet46T',
+        availableModels: ['deepseekT', 'sonnet46T'],
+      }),
+    ).toBe('sonnet46T');
+
+    expect(
+      resolveDelegationModelFromAvailableNames({
+        parentModel: 'opus48T',
+        availableModels: ['deepseekT', 'sonnet46T'],
+      }),
+    ).toBe('deepseekT');
+  });
+
+  it('rejects delegation when no models are currently available', () => {
+    expect(() =>
+      resolveDelegationModelFromAvailableNames({
+        parentModel: 'opus48T',
+        availableModels: [],
+      }),
+    ).toThrow(
+      'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',
+    );
+  });
+});

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -37,10 +37,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - common
 
 // Local imports - model
-import {
-  getVisibleModels,
-  resolveVisibleModel,
-} from '@model/modelOptionsBasic';
+import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
   AGENT_CATEGORY,
   DEFAULT_TOOL_CONFIG,
@@ -77,8 +74,12 @@ import {
   SUBAGENT_DELIVERY_DECISION,
   type SubagentDeliveryState,
 } from '@tools/subagentDeliveryState';
-import { isWorktreeSupportEnabled } from '@tools/worktreeConfig';
+import {
+  availableModelNamesFromOptions,
+  resolveDelegationModelFromAvailableNames,
+} from '@tools/delegationModelAvailability';
 import { parseWorkingDirectory } from '@tools/pathResolution';
+import { isWorktreeSupportEnabled } from '@tools/worktreeConfig';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - memory
@@ -508,6 +509,17 @@ function formatAgentList(
     .join('\n');
 }
 
+async function resolveAvailableDelegationModel(input: {
+  readonly requestedModel?: string | null;
+  readonly parentModel?: string | null;
+}): Promise<string> {
+  const modelOptions = await computeModelOptionsData();
+  return resolveDelegationModelFromAvailableNames({
+    ...input,
+    availableModels: availableModelNamesFromOptions(modelOptions),
+  });
+}
+
 /** Throw if no visible agent of the given category matches the name. */
 function assertVisibleAgent(
   category: 'workflow' | 'toolUse',
@@ -670,7 +682,7 @@ const WorkflowAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      'Model short name (e.g., opus48T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
+      'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
     ),
   instruction: z
     .string()
@@ -763,7 +775,7 @@ ${formatAgentList(getVisibleAgents('workflow'))}
 
 Pick the agent whose description matches the task — don't default to correct. correct is for proofreading only. For applying review suggestions use apply; for new derivations use devise; for instruction-driven rewriting use polish; for critical review use criticize.
 
-Available models: ${getVisibleModels().join(', ')}
+Available models: loaded from the active API mode at runtime.
 Largest models for deep reasoning; long-context for lengthy tedious work; cost-effective for parallel routine work.
 
 Optional auto-attach from the input LaTeX:
@@ -777,8 +789,10 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
     assertVisibleAgent('workflow', input.agent);
     const ctx = getRequiredContext();
 
-    // Resolve model: explicit input → parent model → first visible model
-    const model = resolveVisibleModel(input.model ?? ctx.model ?? '');
+    const model = await resolveAvailableDelegationModel({
+      requestedModel: input.model,
+      parentModel: ctx.model,
+    });
 
     // Validate at least one input file is provided
     if (input.inputFiles.length === 0) {
@@ -855,7 +869,7 @@ const DelegateAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      'Model short name (e.g., opus48T, sonnet46T, gpt55, gemini31p). Defaults to the current model if omitted.',
+      'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
     ),
   instruction: z
     .string()
@@ -889,7 +903,7 @@ ${formatAgentList(getVisibleAgents('toolUse'))}
 
 Agent selection: choose the most specific agent whose description matches the task. Specialized agents have domain-specific tools and focused prompts that produce better results for matching tasks. Do not choose chat just because the task is a targeted edit, file operation, or mixed research/editing request; choose chat only when no listed specialized agent covers the work, and state that reason in the instruction.
 
-Available models: ${getVisibleModels().join(', ')}
+Available models: loaded from the active API mode at runtime.
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
 
 Example (new, specialized): agent=research, instruction="Derive the asymptotic expansion of the partition function in appendix_A.tex using saddle-point methods. Verify with Wolfram."
@@ -920,8 +934,10 @@ Git worktree support: ${
 
     const ctx = getRequiredContext();
 
-    // Resolve model: explicit input → parent model → first visible model
-    const model = resolveVisibleModel(input.model ?? ctx.model ?? '');
+    const model = await resolveAvailableDelegationModel({
+      requestedModel: input.model,
+      parentModel: ctx.model,
+    });
 
     // Construct tool-use proposal (no file fields)
     const proposal = ToolUseAgentProposalSchema.parse({

--- a/src/tools/delegationModelAvailability.ts
+++ b/src/tools/delegationModelAvailability.ts
@@ -1,0 +1,74 @@
+import type { ToolDefinition } from '@model';
+import type { ModelOptionData } from '@shared/schemas';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+
+const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
+
+export function availableModelNamesFromOptions(
+  models: readonly ModelOptionData[],
+): string[] {
+  return models
+    .filter((model) => model.disabled !== true && model.requiresKey !== true)
+    .map((model) => model.value);
+}
+
+function formatAvailableModelsLine(
+  modelNames: readonly string[] | null,
+): string {
+  if (modelNames === null) {
+    return 'Available models: unavailable to load; omit model unless the user explicitly requested one.';
+  }
+  if (modelNames.length === 0) {
+    return 'Available models: none currently available. Ask the user to switch API mode or configure an API key before delegating.';
+  }
+  return `Available models: ${modelNames.join(', ')}`;
+}
+
+function normalizeModelName(model: string | null | undefined): string | null {
+  const trimmed = model?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function resolveDelegationModelFromAvailableNames(input: {
+  readonly requestedModel?: string | null;
+  readonly parentModel?: string | null;
+  readonly availableModels: readonly string[];
+}): string {
+  const availableModels = [
+    ...new Set(
+      input.availableModels.map((model) => model.trim()).filter(Boolean),
+    ),
+  ];
+  if (availableModels.length === 0) {
+    throw new Error(
+      'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',
+    );
+  }
+
+  const requestedModel = normalizeModelName(input.requestedModel);
+  if (requestedModel) {
+    if (availableModels.includes(requestedModel)) return requestedModel;
+    throw new Error(
+      `Model "${requestedModel}" is not currently available for delegation in the active API mode. Available models: ${availableModels.join(', ')}.`,
+    );
+  }
+
+  const parentModel = normalizeModelName(input.parentModel);
+  return parentModel && availableModels.includes(parentModel)
+    ? parentModel
+    : availableModels[0]!;
+}
+
+export function withDelegationModelAvailability(
+  tool: ToolDefinition,
+  modelNames: readonly string[] | null,
+): ToolDefinition {
+  if (!DELEGATION_TOOLS.has(tool.name) || !tool.description) return tool;
+
+  const availableModelsLine = formatAvailableModelsLine(modelNames);
+  const description = AVAILABLE_MODELS_LINE.test(tool.description)
+    ? tool.description.replace(AVAILABLE_MODELS_LINE, availableModelsLine)
+    : `${tool.description}\n\n${availableModelsLine}`;
+
+  return { ...tool, description };
+}


### PR DESCRIPTION
## Summary
- replace static visible-model delegation prompts with runtime availability-aware model lists
- resolve delegated model choices from currently runnable models only
- reject explicit unavailable delegation models at the tool boundary with available alternatives

Closes #4699

## Verification
- corepack pnpm exec vitest run src/test-kernel/tools/DelegationModelAvailability.vitest.mts src/test-kernel/model/ComputeModelOptions.vitest.ts
- npm run format
- npm run compile:safe
- npm run lint (passes with 3 existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation model selection and tool prompts on every tool-use cycle that includes delegation tools; failures are user-visible errors rather than silent fallbacks to unavailable models.
> 
> **Overview**
> Delegation now uses **runtime model availability** from the active API mode instead of static “visible model” lists.
> 
> **Tool-use flow:** `resolveTools` is async and, when delegation tools are present, loads model options via `computeModelOptionsData` and rewrites `delegate_*` tool descriptions with the current **Available models** line (or a clear message if options fail to load).
> 
> **Delegation tools:** `delegate_workflow` and `delegate_agent` resolve the subagent model through `resolveAvailableDelegationModel`, which only accepts explicitly requested models that are runnable, defaults to the parent model when it is available, otherwise picks the first available model, and **throws** with alternatives when the choice is invalid or none are available.
> 
> **New module** `delegationModelAvailability.ts` centralizes filtering (`disabled` / `requiresKey`), description patching, and resolution logic; covered by `DelegationModelAvailability.vitest.mts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5695f8f413683f1a95fe1df8d8d85241404d9a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->