### PR TITLE
[codex] Explain CLI subagent fallback scope

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -325,17 +325,29 @@ export function App(props: AppProps): React.JSX.Element {
           parentStream,
           streams,
         });
+        const targetStreamLabel = target.streamId
+          ? streamScopeDisplayLabel({
+              parentStream,
+              streamId: target.streamId,
+              streams,
+            })
+          : undefined;
+        const fallbackFromStreamLabel = target.fallbackFromStreamId
+          ? streamScopeDisplayLabel({
+              parentStream,
+              streamId: target.fallbackFromStreamId,
+              streams,
+            })
+          : undefined;
+        const streamScopeDetail =
+          childControlMode === 'subagents' &&
+          targetStreamLabel &&
+          fallbackFromStreamLabel
+            ? `${fallbackFromStreamLabel} has no subagents`
+            : undefined;
         return (
           <ChildControlPicker
-            activeStreamLabel={
-              target.streamId
-                ? streamScopeDisplayLabel({
-                    parentStream,
-                    streamId: target.streamId,
-                    streams,
-                  })
-                : undefined
-            }
+            activeStreamLabel={targetStreamLabel}
             activeStreamId={target.streamId}
             availableRows={foregroundRows}
             mode={childControlMode}
@@ -343,6 +355,7 @@ export function App(props: AppProps): React.JSX.Element {
             onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
             onKillExecution={props.onKillExecution}
             slice={target.slice}
+            streamScopeDetail={streamScopeDetail}
             streams={streams}
           />
         );

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -32,6 +32,7 @@ export interface ChildControlPickerProps {
   readonly onFocusStream: (streamId: StreamTabId) => void;
   readonly onKillExecution: (executionId: string) => void;
   readonly slice: StreamSlice | undefined;
+  readonly streamScopeDetail?: string;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
 
@@ -139,20 +140,20 @@ export function computeTaskDetailLayout({
 
 export function computePickerListLayout({
   availableRows,
-  hasParentStream,
   highlight,
   itemCount,
+  scopeLineCount,
 }: {
   readonly availableRows?: number;
-  readonly hasParentStream: boolean;
   readonly highlight: number;
   readonly itemCount: number;
+  readonly scopeLineCount: number;
 }): PickerListLayout {
   const rows = Math.max(0, availableRows ?? 18);
   const fixedRows =
     2 + // border
     1 + // title
-    (hasParentStream ? 1 : 0) +
+    Math.max(0, scopeLineCount) +
     1 + // list top margin
     2; // hints margin + row
   const rowBudget = Math.max(1, rows - fixedRows);
@@ -337,6 +338,7 @@ export function ChildControlPicker({
   onFocusStream,
   onKillExecution,
   slice,
+  streamScopeDetail,
   streams,
 }: ChildControlPickerProps): React.JSX.Element {
   const liveElapsedKey = liveChildExecutionElapsedKey(slice);
@@ -355,11 +357,16 @@ export function ChildControlPicker({
     : undefined;
   const listLayout = computePickerListLayout({
     availableRows,
-    hasParentStream: streamScopeLabel !== undefined,
     highlight,
     itemCount: items.length,
+    scopeLineCount: streamScopeLabel !== undefined ? 1 : 0,
   });
   const visibleItems = items.slice(listLayout.start, listLayout.end);
+  const streamScopeText = streamScopeLabel
+    ? `Stream: ${streamScopeLabel}${
+        streamScopeDetail ? ` (${streamScopeDetail})` : ''
+      }`
+    : undefined;
 
   useEffect(() => {
     setHighlight((current) => clampPickerIndex(current, items.length));
@@ -451,8 +458,10 @@ export function ChildControlPicker({
       <Text bold color="cyan">
         {pickerTitle(mode)}
       </Text>
-      {streamScopeLabel ? (
-        <Text dimColor>{`Stream: ${streamScopeLabel}`}</Text>
+      {streamScopeText ? (
+        <Text dimColor wrap="truncate-end">
+          {streamScopeText}
+        </Text>
       ) : null}
       <Box flexDirection="column" marginTop={1}>
         {items.length > 0 ? (

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -30,6 +30,7 @@ export interface ChildControlItem {
 }
 
 export interface ChildControlStreamTarget {
+  readonly fallbackFromStreamId?: StreamTabId;
   readonly slice: StreamSlice | undefined;
   readonly streamId: StreamTabId | undefined;
 }
@@ -227,6 +228,7 @@ export function resolveChildControlStreamTarget({
   const parentSlice = parentStreamId ? streams.get(parentStreamId) : undefined;
   if (hasVisibleSubagents(parentSlice)) {
     return {
+      fallbackFromStreamId: activeStreamId,
       streamId: parentStreamId,
       slice: parentSlice,
     };

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -386,6 +386,7 @@ describe('CLI child execution controls', () => {
     });
 
     expect(target.streamId).toBe('main');
+    expect(target.fallbackFromStreamId).toBe('review-stream');
     expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
       {
         executionId: 'agent-1',
@@ -541,9 +542,9 @@ describe('CLI child execution controls', () => {
     expect(
       computePickerListLayout({
         availableRows: 12,
-        hasParentStream: true,
         highlight: 8,
         itemCount: 12,
+        scopeLineCount: 1,
       }),
     ).toMatchObject({
       hiddenAfter: 2,


### PR DESCRIPTION
Closes #4698.

## Summary
- record when the subagent picker falls back from a focused leaf stream to its parent stream
- show that fallback inline in the picker scope line, e.g. `Stream: main (strategy has no subagents)`
- keep picker targeting unchanged and preserve compact 58x18 rendering

## Evidence
- Harness dogfood on current main showed `Option-s` from focused `strategy` opened the parent list as `Stream: main` while the footer still highlighted `[strategy]`.
- A first separate-line explanation hid one subagent row at 58x18, so the final UI uses one compact scope line.
- Rebuilt the harness and verified all three subagent rows remain visible with `Stream: main (strategy has no subagents)`.

## Validation
- `corepack pnpm install`
- `npm run format`
- `git diff --check`
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- PTY harness check with `HARNESS_ENTRIES=12 HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_DELEGATE=1 HARNESS_CAN_INTERRUPT=1`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI copy and optional metadata only; subagent resolution logic is unchanged aside from recording the prior stream id for display.
> 
> **Overview**
> When the **subagents** picker falls back from a focused leaf stream to its parent (because the leaf has no visible subagents), the UI now explains that on the existing **Stream:** scope line instead of only showing the parent name.
> 
> `resolveChildControlStreamTarget` records **`fallbackFromStreamId`** on that fallback path; **`App`** turns it into inline detail (e.g. `Stream: main (strategy has no subagents)`). **`ChildControlPicker`** accepts optional **`streamScopeDetail`**, renders it in parentheses on one truncated line, and **`computePickerListLayout`** uses **`scopeLineCount`** so row budgeting stays the same. Subagent targeting behavior is unchanged; tests cover the new fallback field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7288c22ed95d05968a469838e34fea624b52dae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->