### PR TITLE
Extract tool resolution logic into agentToolResolution module

### DIFF
--- a/packages/extension/resources/tool_use_agents/lean.yaml
+++ b/packages/extension/resources/tool_use_agents/lean.yaml
@@ -20,7 +20,7 @@ settings:
     - memory
     # GitHub PR subscription — opt-in. Disabled by default; enable in
     # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
-    # When disabled by the user, resolveTools() strips these from the
+    # When disabled by the user, resolveAgentTools() strips these from the
     # model's tool list. When enabled but the token/git-repo check has
     # not yet populated the availability cache (i.e. before the Tools
     # dashboard has run its checks), the tools may still appear and

--- a/reference-agents/Lean4/lean.yaml
+++ b/reference-agents/Lean4/lean.yaml
@@ -20,7 +20,7 @@ settings:
     - memory
     # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
     # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
-    # Git. When disabled by the user, resolveTools() strips this from the
+    # Git. When disabled by the user, resolveAgentTools() strips this from the
     # model's tool list. When enabled but the token/git-repo check has not yet
     # populated the availability cache (i.e. before the Tools dashboard has
     # run its checks), the tool may still appear and calls will fail at

--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -31,7 +31,7 @@ settings:
     - lean_project
     # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
     # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
-    # Git. When disabled by the user, resolveTools() strips this from the
+    # Git. When disabled by the user, resolveAgentTools() strips this from the
     # model's tool list. When enabled but the token/git-repo check has not yet
     # populated the availability cache (i.e. before the Tools dashboard has
     # run its checks), the tool may still appear and calls will fail at

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -25,7 +25,7 @@ settings:
     - claude_code
     # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
     # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
-    # Git. When disabled by the user, resolveTools() strips this from the
+    # Git. When disabled by the user, resolveAgentTools() strips this from the
     # model's tool list. When enabled but the token/git-repo check has not yet
     # populated the availability cache (i.e. before the Tools dashboard has
     # run its checks), the tool may still appear and calls will fail at

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -19,31 +19,18 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { listToolInjections } from '@agent/runtime/toolInjection';
+import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { executionToEndStatus } from '@common/constants/streamStatus';
-import type { ToolDefinition } from '@model';
-import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
   END_GROUP_STATUS,
   EXECUTION_STATUS,
   type EndGroupStatus,
 } from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 
 import { getDefaultToolRegistry } from '@tools/registry';
-import {
-  getDisabledToolNames,
-  getUnavailableToolNamesCached,
-} from '@tools/toolAvailability';
-import { notifyUnavailableTools } from '@tools/toolUnavailableNotification';
-import {
-  availableModelNamesFromOptions,
-  withDelegationModelAvailability,
-} from '@tools/delegationModelAvailability';
-import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -105,102 +92,6 @@ export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
 const IMMEDIATE_COMPACTION_FOLLOW_UP =
   'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
 
-async function availableDelegationModelNamesForTools(
-  tools: readonly ToolDefinition[],
-): Promise<readonly string[] | null | undefined> {
-  if (!tools.some((tool) => DELEGATION_TOOLS.has(tool.name))) {
-    return undefined;
-  }
-
-  try {
-    return availableModelNamesFromOptions(await computeModelOptionsData());
-  } catch {
-    return null;
-  }
-}
-
-export async function resolveToolUseTools(
-  tools: AgentToolUseSetting['tools'],
-  registry: IToolRegistry,
-  logger: { warn: (msg: string) => void },
-  options: {
-    readonly approvalPromptsUnavailable?: boolean;
-    readonly delegationBlocked: boolean;
-  },
-): Promise<{ tools: ToolDefinition[]; delegationTrimmed: boolean }> {
-  const disabled = getDisabledToolNames();
-  const unavailable = getUnavailableToolNamesCached();
-  const missingDependency: string[] = [];
-
-  // Don't warn on routine filtering outcomes (user-disabled, unavailable,
-  // not in registry): they fire on every tool-use cycle and drown out real
-  // issues. Agent YAML typos are surfaced once at load time by
-  // `resolveToolDefinitions`; missing external deps are surfaced via
-  // `notifyUnavailableTools` below.
-  const toolConfigs = Array.isArray(tools) ? tools : [];
-  let delegationTrimmed = false;
-  const resolved = toolConfigs
-    .map((config) => (typeof config === 'string' ? { name: config } : config))
-    .filter((def) => {
-      if (DELEGATION_TOOLS.has(def.name) && options.delegationBlocked) {
-        delegationTrimmed = true;
-        return false;
-      }
-      if (
-        options.approvalPromptsUnavailable === true &&
-        isApprovalGatedToolName(def.name)
-      ) {
-        return false;
-      }
-      if (disabled.has(def.name)) return false;
-      if (unavailable.has(def.name)) {
-        missingDependency.push(def.name);
-        return false;
-      }
-      if (!registry.has(def.name)) return false;
-      return true;
-    });
-
-  const resolvedNames = new Set(resolved.map((d) => d.name));
-  for (const injection of listToolInjections()) {
-    if (!injection.shouldInject()) continue;
-    if (resolvedNames.has(injection.toolName)) continue;
-    if (DELEGATION_TOOLS.has(injection.toolName) && options.delegationBlocked) {
-      delegationTrimmed = true;
-      continue;
-    }
-    if (
-      options.approvalPromptsUnavailable === true &&
-      isApprovalGatedToolName(injection.toolName)
-    ) {
-      continue;
-    }
-    const tool = registry.get(injection.toolName);
-    if (tool) {
-      resolved.push(tool.definition);
-      resolvedNames.add(injection.toolName);
-    } else {
-      logger.warn(`Injected tool not found in registry: ${injection.toolName}`);
-    }
-  }
-
-  if (missingDependency.length) {
-    notifyUnavailableTools(missingDependency);
-  }
-
-  const availableModelNames =
-    await availableDelegationModelNamesForTools(resolved);
-  return {
-    tools:
-      availableModelNames === undefined
-        ? resolved
-        : resolved.map((tool) =>
-            withDelegationModelAvailability(tool, availableModelNames),
-          ),
-    delegationTrimmed,
-  };
-}
-
 export async function runToolUseFlow<C = unknown>(
   input: RunToolUseFlowInput<C>,
   toolRegistry?: IToolRegistry,
@@ -216,15 +107,13 @@ export async function runToolUseFlow<C = unknown>(
     delegationDepth,
     delegationConfig,
   );
-  const { tools: resolvedTools, delegationTrimmed } = await resolveToolUseTools(
-    setting.tools,
+  const { tools: resolvedTools, delegationTrimmed } = await resolveAgentTools({
+    tools: setting.tools,
     registry,
     logger,
-    {
-      approvalPromptsUnavailable: input.approvalPromptsUnavailable,
-      delegationBlocked: !delegationGate.allowed,
-    },
-  );
+    delegationBlocked: !delegationGate.allowed,
+    approvalPromptsUnavailable: input.approvalPromptsUnavailable,
+  });
 
   const kv = getExecutionStore(executionId);
 

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -105,7 +105,10 @@ export async function resolveAgentTools({
       delegationTrimmed = true;
       continue;
     }
-    if (approvalPromptsUnavailable === true && isApprovalGatedToolName(def.name)) {
+    if (
+      approvalPromptsUnavailable === true &&
+      isApprovalGatedToolName(def.name)
+    ) {
       continue;
     }
     if (disabled.has(def.name)) continue;

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -97,29 +97,26 @@ export async function resolveAgentTools({
   const toolConfigs = Array.isArray(tools) ? tools : [];
   let delegationTrimmed = false;
 
-  const resolved = toolConfigs
-    .map((config) => (typeof config === 'string' ? { name: config } : config))
-    .filter((def) => {
-      if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
-        delegationTrimmed = true;
-        return false;
-      }
-      if (
-        approvalPromptsUnavailable === true &&
-        isApprovalGatedToolName(def.name)
-      ) {
-        return false;
-      }
-      if (disabled.has(def.name)) return false;
-      if (unavailable.has(def.name)) {
-        missingDependency.push(def.name);
-        return false;
-      }
-      if (!effectiveRegistry.has(def.name)) return false;
-      return true;
-    });
-
-  const resolvedNames = new Set(resolved.map((d) => d.name));
+  const resolved: ToolDefinition[] = [];
+  const resolvedNames = new Set<string>();
+  for (const config of toolConfigs) {
+    const def = typeof config === 'string' ? { name: config } : config;
+    if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
+      delegationTrimmed = true;
+      continue;
+    }
+    if (approvalPromptsUnavailable === true && isApprovalGatedToolName(def.name)) {
+      continue;
+    }
+    if (disabled.has(def.name)) continue;
+    if (unavailable.has(def.name)) {
+      missingDependency.push(def.name);
+      continue;
+    }
+    if (!effectiveRegistry.has(def.name)) continue;
+    resolved.push(def);
+    resolvedNames.add(def.name);
+  }
   for (const injection of listToolInjections()) {
     if (!injection.shouldInject()) continue;
     if (resolvedNames.has(injection.toolName)) continue;

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -3,12 +3,15 @@
  *
  * The pipeline, in order:
  *   1. Start with the tool names declared in the agent YAML.
- *   2. Strip user-disabled tools (settings dashboard toggle).
- *   3. Strip tools whose external dependency is unavailable (probed at startup).
- *   4. Strip delegation tools when the nesting depth limit is reached.
- *   5. Strip approval-gated tools when approval prompts are unavailable
+ *   2. Strip delegation tools when the nesting depth limit is reached.
+ *   3. Strip approval-gated tools when approval prompts are unavailable
  *      (e.g. a subagent running without an interactive approval channel).
- *   6. Auto-inject conditional tools (memory, odyssey, etc.) registered at startup.
+ *   4. Strip user-disabled tools (settings dashboard toggle).
+ *   5. Strip tools whose external dependency is unavailable (probed at startup).
+ *   6. Auto-inject conditional tools (memory, odyssey, etc.) registered at startup;
+ *      injected tools are subject to delegation and approval gates but bypass
+ *      the disabled/unavailable filters (they are runtime infrastructure, not
+ *      user-selectable tools).
  *   7. Annotate delegation tools with the models currently available for
  *      delegation, so the model sees an accurate "Available models:" line.
  *

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -1,0 +1,160 @@
+/**
+ * Agent tool resolution — single source of truth for the effective tool list.
+ *
+ * The pipeline, in order:
+ *   1. Start with the tool names declared in the agent YAML.
+ *   2. Strip user-disabled tools (settings dashboard toggle).
+ *   3. Strip tools whose external dependency is unavailable (probed at startup).
+ *   4. Strip delegation tools when the nesting depth limit is reached.
+ *   5. Strip approval-gated tools when approval prompts are unavailable
+ *      (e.g. a subagent running without an interactive approval channel).
+ *   6. Auto-inject conditional tools (memory, odyssey, etc.) registered at startup.
+ *   7. Annotate delegation tools with the models currently available for
+ *      delegation, so the model sees an accurate "Available models:" line.
+ *
+ * Routine filtering outcomes (disabled, unavailable, not in registry) are
+ * intentionally silent — YAML typos are surfaced once at load time by
+ * `resolveToolDefinitions`; missing external dependencies are surfaced via
+ * `notifyUnavailableTools` below, not repeated on every cycle.
+ */
+
+import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
+import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
+import type { ToolDefinition } from '@model';
+import { computeModelOptionsData } from '@model/computeModelOptions';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { getDefaultToolRegistry } from '@tools/registry';
+import {
+  getDisabledToolNames,
+  getUnavailableToolNamesCached,
+} from '@tools/toolAvailability';
+import { notifyUnavailableTools } from '@tools/toolUnavailableNotification';
+import {
+  availableModelNamesFromOptions,
+  withDelegationModelAvailability,
+} from '@tools/delegationModelAvailability';
+import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
+import { listToolInjections } from './toolInjection';
+
+export interface ResolveAgentToolsInput {
+  tools: AgentToolUseSetting['tools'];
+  /** Registry to resolve tool definitions from. Defaults to the global registry. */
+  registry?: IToolRegistry;
+  logger: { warn: (msg: string) => void };
+  /** When true, delegation tools (delegate_workflow, delegate_agent) are excluded. */
+  delegationBlocked: boolean;
+  /** When true, approval-gated tools are filtered out before model invocation. */
+  approvalPromptsUnavailable?: boolean;
+}
+
+export interface ResolvedAgentTools {
+  tools: ToolDefinition[];
+  /** True if at least one delegation tool was removed due to depth limits. */
+  delegationTrimmed: boolean;
+}
+
+/**
+ * Probe the models currently available for delegation, but only when the
+ * resolved tool list actually contains a delegation tool.
+ *
+ * Returns `undefined` when no delegation tool is present (nothing to annotate),
+ * `null` when the model options could not be loaded, and the list of available
+ * model names otherwise.
+ */
+async function availableDelegationModelNamesForTools(
+  tools: readonly ToolDefinition[],
+): Promise<readonly string[] | null | undefined> {
+  if (!tools.some((tool) => DELEGATION_TOOLS.has(tool.name))) {
+    return undefined;
+  }
+
+  try {
+    return availableModelNamesFromOptions(await computeModelOptionsData());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the effective tool list for a single agent run.
+ *
+ * Called once per tool-use flow invocation. The registry is passed explicitly
+ * so callers can substitute a test registry; it defaults to the singleton
+ * returned by `getDefaultToolRegistry()`.
+ */
+export async function resolveAgentTools({
+  tools,
+  registry,
+  logger,
+  delegationBlocked,
+  approvalPromptsUnavailable,
+}: ResolveAgentToolsInput): Promise<ResolvedAgentTools> {
+  const effectiveRegistry = registry ?? getDefaultToolRegistry();
+  const disabled = getDisabledToolNames();
+  const unavailable = getUnavailableToolNamesCached();
+  const missingDependency: string[] = [];
+
+  const toolConfigs = Array.isArray(tools) ? tools : [];
+  let delegationTrimmed = false;
+
+  const resolved = toolConfigs
+    .map((config) => (typeof config === 'string' ? { name: config } : config))
+    .filter((def) => {
+      if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
+        delegationTrimmed = true;
+        return false;
+      }
+      if (
+        approvalPromptsUnavailable === true &&
+        isApprovalGatedToolName(def.name)
+      ) {
+        return false;
+      }
+      if (disabled.has(def.name)) return false;
+      if (unavailable.has(def.name)) {
+        missingDependency.push(def.name);
+        return false;
+      }
+      if (!effectiveRegistry.has(def.name)) return false;
+      return true;
+    });
+
+  const resolvedNames = new Set(resolved.map((d) => d.name));
+  for (const injection of listToolInjections()) {
+    if (!injection.shouldInject()) continue;
+    if (resolvedNames.has(injection.toolName)) continue;
+    if (DELEGATION_TOOLS.has(injection.toolName) && delegationBlocked) {
+      delegationTrimmed = true;
+      continue;
+    }
+    if (
+      approvalPromptsUnavailable === true &&
+      isApprovalGatedToolName(injection.toolName)
+    ) {
+      continue;
+    }
+    const tool = effectiveRegistry.get(injection.toolName);
+    if (tool) {
+      resolved.push(tool.definition);
+      resolvedNames.add(injection.toolName);
+    } else {
+      logger.warn(`Injected tool not found in registry: ${injection.toolName}`);
+    }
+  }
+
+  if (missingDependency.length) {
+    notifyUnavailableTools(missingDependency);
+  }
+
+  const availableModelNames =
+    await availableDelegationModelNamesForTools(resolved);
+  return {
+    tools:
+      availableModelNames === undefined
+        ? resolved
+        : resolved.map((tool) =>
+            withDelegationModelAvailability(tool, availableModelNames),
+          ),
+    delegationTrimmed,
+  };
+}

--- a/src/agent/runtime/toolInjection.ts
+++ b/src/agent/runtime/toolInjection.ts
@@ -28,7 +28,7 @@ export function registerToolInjection(
 }
 
 export function listToolInjections(): readonly ConditionalToolInjection[] {
-  return injections;
+  return [...injections];
 }
 
 /** Test-only — clears the registry so suites don't leak across runs. */

--- a/src/agent/runtime/toolInjection.ts
+++ b/src/agent/runtime/toolInjection.ts
@@ -28,7 +28,7 @@ export function registerToolInjection(
 }
 
 export function listToolInjections(): readonly ConditionalToolInjection[] {
-  return [...injections];
+  return injections;
 }
 
 /** Test-only — clears the registry so suites don't leak across runs. */

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
-import { resolveToolUseTools } from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import {
   __resetToolInjectionRegistry,
   registerToolInjection,
@@ -50,8 +50,8 @@ describe('tool-use tool resolution', () => {
       'write_file',
     ]);
 
-    const { tools, delegationTrimmed } = await resolveToolUseTools(
-      toolDefs([
+    const { tools, delegationTrimmed } = await resolveAgentTools({
+      tools: toolDefs([
         'apply_path',
         'ask_user_question',
         'bash',
@@ -65,11 +65,9 @@ describe('tool-use tool resolution', () => {
       ]),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: true,
-        delegationBlocked: false,
-      },
-    );
+      approvalPromptsUnavailable: true,
+      delegationBlocked: false,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep', 'wolfram']);
     expect(delegationTrimmed).toBe(false);
@@ -86,8 +84,8 @@ describe('tool-use tool resolution', () => {
       'update_config',
     ]);
 
-    const { tools } = await resolveToolUseTools(
-      toolDefs([
+    const { tools } = await resolveAgentTools({
+      tools: toolDefs([
         'apply_path',
         'ask_user_question',
         'bash',
@@ -98,11 +96,9 @@ describe('tool-use tool resolution', () => {
       ]),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: false,
-        delegationBlocked: false,
-      },
-    );
+      approvalPromptsUnavailable: false,
+      delegationBlocked: false,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual([
       'apply_path',
@@ -118,15 +114,13 @@ describe('tool-use tool resolution', () => {
   it('still reports delegation tools trimmed by delegation depth separately', async () => {
     const registry = registryFor(['delegate_agent', 'grep']);
 
-    const { tools, delegationTrimmed } = await resolveToolUseTools(
-      toolDefs(['delegate_agent', 'grep']),
+    const { tools, delegationTrimmed } = await resolveAgentTools({
+      tools: toolDefs(['delegate_agent', 'grep']),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: false,
-        delegationBlocked: true,
-      },
-    );
+      approvalPromptsUnavailable: false,
+      delegationBlocked: true,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(true);
@@ -135,15 +129,13 @@ describe('tool-use tool resolution', () => {
   it('keeps delegation trimming when approval filtering is also active', async () => {
     const registry = registryFor(['bash', 'delegate_agent', 'grep']);
 
-    const { tools, delegationTrimmed } = await resolveToolUseTools(
-      toolDefs(['bash', 'delegate_agent', 'grep']),
+    const { tools, delegationTrimmed } = await resolveAgentTools({
+      tools: toolDefs(['bash', 'delegate_agent', 'grep']),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: true,
-        delegationBlocked: true,
-      },
-    );
+      approvalPromptsUnavailable: true,
+      delegationBlocked: true,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(true);
@@ -156,15 +148,13 @@ describe('tool-use tool resolution', () => {
       shouldInject: () => true,
     });
 
-    const { tools, delegationTrimmed } = await resolveToolUseTools(
-      toolDefs(['grep']),
+    const { tools, delegationTrimmed } = await resolveAgentTools({
+      tools: toolDefs(['grep']),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: false,
-        delegationBlocked: true,
-      },
-    );
+      approvalPromptsUnavailable: false,
+      delegationBlocked: true,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(true);
@@ -177,15 +167,13 @@ describe('tool-use tool resolution', () => {
       shouldInject: () => true,
     });
 
-    const { tools, delegationTrimmed } = await resolveToolUseTools(
-      toolDefs(['grep']),
+    const { tools, delegationTrimmed } = await resolveAgentTools({
+      tools: toolDefs(['grep']),
       registry,
       logger,
-      {
-        approvalPromptsUnavailable: true,
-        delegationBlocked: false,
-      },
-    );
+      approvalPromptsUnavailable: true,
+      delegationBlocked: false,
+    });
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(false);


### PR DESCRIPTION
## Summary

Extracted the `resolveTools` function from `runToolUseFlow.ts` into a new dedicated module `agentToolResolution.ts`. This centralizes tool resolution logic—the pipeline that filters and injects tools based on user settings, external dependencies, nesting depth, and conditional registrations—into a single source of truth.

The new module is well-documented with a clear pipeline description and explicit comments about silent filtering outcomes, making the tool resolution strategy more discoverable and maintainable.

## Issue acceptance gates

N/A — this is a refactoring to improve code organization and maintainability.

## Single source of truth

`src/agent/runtime/agentToolResolution.ts` now owns the complete tool resolution pipeline:
1. Start with tool names from agent YAML
2. Strip user-disabled tools
3. Strip tools with unavailable external dependencies
4. Strip delegation tools when nesting depth limit is reached
5. Auto-inject conditional tools (memory, odyssey, etc.)

## Duplication and abstraction budget

**Duplication removed:** The `resolveTools` function was inlined in `runToolUseFlow.ts` and is now extracted into a reusable module. This eliminates the need to duplicate this logic if other flows or contexts need to resolve agent tools.

**Abstraction added:** `resolveAgentTools()` exports a clean interface (`ResolveAgentToolsInput` and `ResolvedAgentTools`) that encapsulates the tool resolution strategy. The function accepts an optional registry parameter, enabling test substitution without coupling to the global registry.

## Host impact

Extension: No user-facing changes; internal refactoring only.

Desktop: No user-facing changes; internal refactoring only.

CLI: No user-facing changes; internal refactoring only.

## Scheduled refactoring

None.

## Validation

- Existing tests for `runToolUseFlow` continue to pass (no behavior change).
- The extracted function maintains identical filtering and injection logic.
- Type signatures are preserved via `ResolveAgentToolsInput` and `ResolvedAgentTools` interfaces.

https://claude.ai/code/session_015ayBjwo7ULck1uN8qJ11XZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with tests retargeted; no user-facing behavior change beyond comment renames in agent YAML.
> 
> **Overview**
> Moves agent tool-list resolution out of `runToolUseFlow.ts` into **`src/agent/runtime/agentToolResolution.ts`**, exposing **`resolveAgentTools()`** as the shared pipeline (YAML tools → delegation/approval gates → disabled/unavailable filtering → conditional injections → delegation model annotations).
> 
> **`runToolUseFlow`** now imports that helper instead of inlining **`resolveToolUseTools`**, and **`ToolUseToolResolution.vitest.ts`** targets the new module with the same object-shaped options. Agent YAML comments are updated to refer to **`resolveAgentTools()`** instead of **`resolveTools()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539e76aab9649a695c4678a2c504ce4e84ae4df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->