### PR TITLE
[codex] Trim empty child picker shortcuts

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -19,7 +19,7 @@ import {
   type ChildControlMode,
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
-import { KeyHints } from '../ui/KeyHints';
+import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
@@ -38,6 +38,24 @@ export interface ChildControlPickerProps {
 
 function pickerTitle(mode: ChildControlMode): string {
   return mode === 'subagents' ? 'Subagents' : 'Background tasks';
+}
+
+export function childControlPickerHints({
+  hasItems,
+  mode,
+}: {
+  readonly hasItems: boolean;
+  readonly mode: ChildControlMode;
+}): readonly KeyHint[] {
+  if (!hasItems) {
+    return [{ key: 'Esc', action: 'close' }];
+  }
+  return [
+    { key: '↑/↓', action: 'navigate' },
+    { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
+    { key: 'k', action: 'kill' },
+    { key: 'Esc', action: 'close' },
+  ];
 }
 
 function renderItem(
@@ -483,12 +501,7 @@ export function ChildControlPicker({
       </Box>
       <Box marginTop={1}>
         <KeyHints
-          hints={[
-            { key: '↑/↓', action: 'navigate' },
-            { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
-            { key: 'k', action: 'kill' },
-            { key: 'Esc', action: 'close' },
-          ]}
+          hints={childControlPickerHints({ hasItems: items.length > 0, mode })}
           confirmCancel={false}
         />
       </Box>

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - CLI TUI state
 import {
+  childControlPickerHints,
   computePickerListLayout,
   computeTaskDetailLayout,
 } from '@cli/chat/tui/modals/ChildControlPicker';
@@ -552,5 +553,25 @@ describe('CLI child execution controls', () => {
       start: 7,
       visibleCount: 3,
     });
+  });
+
+  it('only shows applicable picker hints for empty child execution lists', () => {
+    expect(childControlPickerHints({ hasItems: false, mode: 'tasks' })).toEqual(
+      [{ key: 'Esc', action: 'close' }],
+    );
+    expect(childControlPickerHints({ hasItems: true, mode: 'tasks' })).toEqual([
+      { key: '↑/↓', action: 'navigate' },
+      { key: 'Enter', action: 'view' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'close' },
+    ]);
+    expect(
+      childControlPickerHints({ hasItems: true, mode: 'subagents' }),
+    ).toEqual([
+      { key: '↑/↓', action: 'navigate' },
+      { key: 'Enter', action: 'focus' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'close' },
+    ]);
   });
 });


### PR DESCRIPTION
Closes #4705.

## Summary
- add a child-control picker hint helper that distinguishes empty and populated lists
- show only `Esc close` when a child-control picker has no rows
- keep navigate/view/focus/kill shortcuts for populated subagent and background-task lists

## Evidence
- Harness dogfood on current main showed `Background tasks` on a focused child stream correctly said `No active background tasks.` but still advertised `↑/↓ navigate · Enter view · k kill · Esc close`.
- After the patch, the focused child stream empty picker displays `No active background tasks.` with only `Esc close`.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `git diff --check`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, 3 unrelated pre-existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI hint copy only; no execution, auth, or data-path changes.
> 
> **Overview**
> The CLI TUI **subagent / background-task picker** no longer advertises navigate, Enter, or kill shortcuts when the list is empty.
> 
> A new **`childControlPickerHints`** helper drives the footer: **only `Esc close`** when there are no rows; the full hint set when there are items, with **Enter** labeled **focus** (subagents) or **view** (tasks). **`ChildControlPicker`** uses this helper instead of a fixed hint array. Tests lock in empty vs populated behavior for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9d7d7e7eb5139f0f3511eb00e2b1cca9cb20b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->