### PR TITLE
fix: hide inactive empty picker shortcuts

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -19,7 +19,7 @@ import {
   type ChildControlMode,
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
-import { KeyHints } from '../ui/KeyHints';
+import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
@@ -38,6 +38,21 @@ export interface ChildControlPickerProps {
 
 function pickerTitle(mode: ChildControlMode): string {
   return mode === 'subagents' ? 'Subagents' : 'Background tasks';
+}
+
+export function pickerKeyHints(
+  mode: ChildControlMode,
+  itemCount: number,
+): readonly KeyHint[] {
+  if (itemCount <= 0) {
+    return [{ key: 'Esc', action: 'close' }];
+  }
+  return [
+    { key: '↑/↓', action: 'navigate' },
+    { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
+    { key: 'k', action: 'kill' },
+    { key: 'Esc', action: 'close' },
+  ];
 }
 
 function renderItem(
@@ -483,12 +498,7 @@ export function ChildControlPicker({
       </Box>
       <Box marginTop={1}>
         <KeyHints
-          hints={[
-            { key: '↑/↓', action: 'navigate' },
-            { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
-            { key: 'k', action: 'kill' },
-            { key: 'Esc', action: 'close' },
-          ]}
+          hints={pickerKeyHints(mode, items.length)}
           confirmCancel={false}
         />
       </Box>

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computePickerListLayout,
   computeTaskDetailLayout,
+  pickerKeyHints,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
@@ -521,6 +522,22 @@ describe('CLI child execution controls', () => {
     });
     expect(nextPickerIndex(0, 3, 'up')).toBe(2);
     expect(nextPickerIndex(2, 3, 'down')).toBe(0);
+  });
+
+  it('advertises only applicable keys for empty child pickers', () => {
+    expect(pickerKeyHints('tasks', 0)).toEqual([
+      { key: 'Esc', action: 'close' },
+    ]);
+    expect(pickerKeyHints('tasks', 1)).toEqual([
+      { key: '↑/↓', action: 'navigate' },
+      { key: 'Enter', action: 'view' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'close' },
+    ]);
+    expect(pickerKeyHints('subagents', 1)).toContainEqual({
+      key: 'Enter',
+      action: 'focus',
+    });
   });
 
   it('preserves output rows in compact task detail views', () => {


### PR DESCRIPTION
## Summary
- show only applicable key hints when the child-control picker has no rows
- keep normal navigate/view/kill hints when rows are available
- add focused CLI child-control coverage for the empty-state hint model

Closes #4705.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli run bundle:harness
- PTY replay of the #4705 harness flow: Option-p, Enter, f, Option-p now shows only `Esc close` in the empty picker
- npm run format
- npm run compile:safe
- npm run lint (passes with the existing 3 import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI hint text only; no auth, data, or execution-path changes.
> 
> **Overview**
> The child-control picker (subagents / background tasks) now drives footer shortcuts from a shared **`pickerKeyHints`** helper instead of a fixed hint list.
> 
> When there are **no rows**, the UI shows only **Esc · close**. When items exist, behavior is unchanged: navigate, kill, close, and **Enter** maps to **focus** (subagents) or **view** (tasks).
> 
> Unit tests in **`ChildControls.vitest.mts`** lock in the empty vs populated hint sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7233325a5332a276236afbcf86283236f602bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->