### PR TITLE
fix: show orchestrate team identity in chat

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -45,6 +45,7 @@ const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
+const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
 let harnessApprovalPolicy: CliApprovalPolicy = 'ask';
 const EDIT_APPROVAL_DELAY_MS = Number(
@@ -164,6 +165,7 @@ cliState.sessionMeta.set({
   cwd: process.cwd(),
   apiMode: 'personal',
   canDelegate: CAN_DELEGATE,
+  teamName: TEAM_NAME,
   version: '0.0.0-harness',
 });
 cliState.activeStreamId.set(STREAM_ID);
@@ -508,6 +510,7 @@ function appendHarnessStatus(): void {
     formatCliSessionStatus({
       agent: meta.agent,
       model: meta.model,
+      teamName: meta.teamName,
       api: meta.apiMode,
       approval: formatApprovalPolicyForCli(harnessApprovalPolicy),
       status: slice?.status ?? 'not started',

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -17,6 +17,7 @@ import { selectPendingEntriesForViewport } from './transcriptViewport';
 // even as the file is split into focused modules.
 export {
   appendStaticTranscriptItems,
+  sessionHeaderIdentityLine,
   StaticConversationTranscript,
   type StaticTranscriptItem,
 } from './StaticConversationTranscript';

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -43,6 +43,14 @@ function shortenCwd(cwd: string): string {
   return cwd;
 }
 
+export function sessionHeaderIdentityLine(meta: SessionMeta): string {
+  const model = meta.model || '—';
+  if (meta.teamName) {
+    return `team: ${meta.teamName} · root: ${meta.agent || 'chat'} · model: ${model}`;
+  }
+  return `agent: ${meta.agent || 'chat'} · model: ${model}`;
+}
+
 function SessionHeaderBlock({
   meta,
   width,
@@ -65,9 +73,7 @@ function SessionHeaderBlock({
           <Text dimColor>{shortCliApiMode(meta.apiMode)}</Text>
         </Box>
         <Box>
-          <Text wrap="truncate-end">
-            agent: {meta.agent || 'chat'} · model: {meta.model || '—'}
-          </Text>
+          <Text wrap="truncate-end">{sessionHeaderIdentityLine(meta)}</Text>
         </Box>
         <Text dimColor wrap="truncate-end">
           {shortenCwd(meta.cwd)}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -111,6 +111,8 @@ export interface RunChatInit {
   readonly agentOverride?: string;
   /** `--model` override from the CLI; falls through `resolveChatDefaults`. */
   readonly modelOverride?: string;
+  /** Visible team identity when chat was launched from a multi-agent preset. */
+  readonly teamName?: string;
 }
 
 const QUEUED_FOLLOW_UP_NOTICE_LENGTH = 96;
@@ -573,6 +575,7 @@ async function handleTuiSlashCommand(
         formatCliSessionStatus({
           agent: meta.agent || context.initialAgent,
           model: meta.model || context.initialModel,
+          teamName: meta.teamName,
           api: formatCliApiMode(getCliApiMode()),
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
           status: slice?.status ?? 'not started',
@@ -704,6 +707,7 @@ export async function runChat(
     cwd: context.cwd,
     apiMode: getCliApiMode(),
     canDelegate: agentSupportsDelegation(agent),
+    teamName: init.teamName,
     version,
   });
 

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -7,6 +7,7 @@ const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
 export interface CliSessionStatusInput {
   readonly agent: string;
   readonly model: string;
+  readonly teamName?: string;
   readonly api: string;
   readonly approval: string;
   readonly status: string;
@@ -50,6 +51,7 @@ function queuedFollowUpStatusLines(messages: readonly string[]): string[] {
 
 export function formatCliSessionStatus(input: CliSessionStatusInput): string {
   return [
+    ...(input.teamName ? [`team: ${input.teamName}`] : []),
     `agent: ${input.agent}`,
     `model: ${input.model}`,
     `api: ${input.api}`,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -54,6 +54,7 @@ export interface SessionMeta {
   readonly cwd: string;
   readonly apiMode: CliApiMode;
   readonly canDelegate: boolean;
+  readonly teamName?: string;
   readonly version: string;
 }
 

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -78,6 +78,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       const result = await withCliMultiAgentPresetVisibility(plan, () =>
         runChat(context, {
           agentOverride: plan.rootAgent?.name,
+          teamName: action.presetName,
         }),
       );
       return result.exitCode;

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -7,7 +7,11 @@ import type { CliMultiAgentPreset } from './multiAgentPresets';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string }
-  | { readonly kind: 'preset'; readonly preset: string }
+  | {
+      readonly kind: 'preset';
+      readonly preset: string;
+      readonly presetName: string;
+    }
   | { readonly kind: 'resume'; readonly id: ExecutionId }
   | { readonly kind: 'help' }
   | { readonly kind: 'exit' };
@@ -88,7 +92,7 @@ function presetItems(
   presets: readonly CliMultiAgentPreset[],
 ): CliOrchestrationItem[] {
   return presets.slice(0, MAX_PRESET_ITEMS).map((preset) => ({
-    value: { kind: 'preset', preset: preset.id },
+    value: { kind: 'preset', preset: preset.id, presetName: preset.name },
     label: `Team ${preset.name}`,
     description: `${preset.source}; workflow:${preset.workflowAgents.length}; tool-use:${preset.toolUseAgents.length}`,
   }));

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -5,6 +5,7 @@ import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
   selectPendingEntriesForViewport,
+  sessionHeaderIdentityLine,
 } from '@cli/chat/tui/panes/ConversationPane';
 import {
   cliState,
@@ -266,6 +267,19 @@ describe('CLI conversation transcript splitting', () => {
       meta: { ...SESSION_META, model: 'sonnet' },
     });
     expect(again).toHaveLength(1);
+  });
+
+  it('labels preset-launched sessions with team and root identity', () => {
+    expect(
+      sessionHeaderIdentityLine({
+        ...SESSION_META,
+        agent: 'orchestrator',
+        teamName: 'Physicist',
+      }),
+    ).toBe('team: Physicist · root: orchestrator · model: deepseekT');
+    expect(sessionHeaderIdentityLine(SESSION_META)).toBe(
+      'agent: research · model: deepseekT',
+    );
   });
 
   it('only feeds the active stream into scrollback, not background subagents', () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -111,8 +111,29 @@ describe('CLI orchestration items', () => {
 
     expect(items.find((item) => item.label === 'Team Physicist')).toEqual(
       expect.objectContaining({
-        value: { kind: 'preset', preset: 'physicist' },
+        value: expect.objectContaining({
+          kind: 'preset',
+          preset: 'physicist',
+        }),
         description: 'built-in; workflow:1; tool-use:2',
+      }),
+    );
+  });
+
+  it('carries preset display names through team launch actions', () => {
+    const items = buildCliOrchestrationItems({
+      presets: [preset({ id: 'physicist', name: 'Physicist' })],
+      history: [],
+      toolUseAgents: [],
+    });
+
+    expect(items.find((item) => item.label === 'Team Physicist')).toEqual(
+      expect.objectContaining({
+        value: {
+          kind: 'preset',
+          preset: 'physicist',
+          presetName: 'Physicist',
+        },
       }),
     );
   });

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -71,6 +71,20 @@ describe('CLI session status formatter', () => {
     ).toContain('queued follow-ups: 0');
   });
 
+  it('includes team identity when a chat was launched from a preset', () => {
+    expect(
+      formatCliSessionStatus({
+        agent: 'orchestrator',
+        model: 'harness-model',
+        teamName: 'Physicist',
+        api: 'personal',
+        approval: 'ask',
+        status: 'running',
+        queuedFollowUpMessages: [],
+      }),
+    ).toContain(['team: Physicist', 'agent: orchestrator'].join('\n'));
+  });
+
   it('uses the footer label for an idle waiting stream', () => {
     expect(formatCliStatusLabel(STREAM_STATUS.WAITING)).toBe('idle');
     expect(


### PR DESCRIPTION
## Summary
- carry the selected orchestrate team name into chat session metadata
- render preset-launched sessions as team/root/model in the static CLI header and include the team in /status
- add a HARNESS_TEAM_NAME knob so the TUI harness can exercise team-header rendering

Closes #4708.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts
- corepack pnpm --filter @texra-ai/cli run bundle:harness
- PTY harness replay with HARNESS_TEAM_NAME=Physicist: header shows "team: Physicist · root: chat · model: harness-model" and /status includes "team: Physicist"
- npm run format
- npm run compile:safe
- npm run lint (passes with the existing 3 import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only session metadata and formatting; no changes to agent execution, auth, or delegation behavior.
> 
> **Overview**
> When a chat is started from an **orchestrate** team preset, the CLI now keeps the preset’s display name in session metadata and surfaces it in the TUI.
> 
> **Orchestration** preset actions include `presetName`; launching a team passes that into `runChat` as `teamName` on `SessionMeta`. The static session header uses `sessionHeaderIdentityLine` to show `team: … · root: … · model: …` instead of only `agent · model`, and **`/status`** prepends a `team:` line when present. The TUI harness accepts **`HARNESS_TEAM_NAME`** to exercise the same rendering.
> 
> Plain **New chat** sessions are unchanged (no `teamName`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25f19922806b3ba9112b6c5718fed7f0695957b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->