### PR TITLE
test(cli): add committed PTY frame-capture TUI validator

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,8 @@
     "build": "npm run typecheck && npm run check:architecture && npm run smoke:react-compiler && npm run bundle && npm run copy:resources && npm run copy:docs",
     "prepack": "npm run build",
     "validate:run": "node scripts/validate-run.mjs",
-    "validate:pack": "node scripts/validate-pack.mjs"
+    "validate:pack": "node scripts/validate-pack.mjs",
+    "validate:tui": "node scripts/validate-tui.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
@@ -61,6 +62,7 @@
     "@types/markdown-it": "^14.1.2",
     "@types/react": "^19.2.15",
     "@types/semver": "^7.7.1",
+    "@xterm/headless": "^5.5.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
@@ -69,6 +71,7 @@
     "esbuild": "^0.28.0",
     "ink": "^7.0.5",
     "markdown-it": "^14.2.0",
+    "node-pty": "^1.0.0",
     "p-queue": "^9.3.0",
     "picocolors": "^1.1.1",
     "react": "^19.2.0",

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -20,7 +20,8 @@
 // node-pty is unavailable (e.g. CI without build tools), the validator prints a
 // notice and exits 0 so it never breaks installs that opt out of the native dep.
 
-import { existsSync } from 'node:fs';
+import { chmodSync, existsSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -117,10 +118,32 @@ const scenarios = only.length
   ? SCENARIOS.filter((s) => only.includes(s.name))
   : SCENARIOS;
 
+function ensureNodePtySpawnHelperExecutable() {
+  if (process.platform === 'win32') return;
+
+  try {
+    const require = createRequire(import.meta.url);
+    const packageRoot = path.dirname(require.resolve('node-pty/package.json'));
+    const helperPath = path.join(
+      packageRoot,
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      'spawn-helper',
+    );
+    if (!existsSync(helperPath)) return;
+
+    const mode = statSync(helperPath).mode;
+    if ((mode & 0o111) === 0) chmodSync(helperPath, mode | 0o755);
+  } catch {
+    // node-pty will report the underlying PTY load/spawn failure below.
+  }
+}
+
 // --- optional deps (guarded) ---------------------------------------------
 let ptySpawn;
 let Terminal;
 try {
+  ensureNodePtySpawnHelperExecutable();
   const ptyMod = await import('node-pty');
   ptySpawn = ptyMod.spawn ?? ptyMod.default?.spawn;
   const xtermMod = await import('@xterm/headless');

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+// Deterministic PTY frame-capture validator for the CLI TUI (issue #4709).
+//
+// Launches the bundled `dist/bin/tui-harness.js` under a pseudo-terminal,
+// renders the byte stream through a headless terminal emulator, drives a few
+// product-focused scenarios with raw keystrokes, and asserts that the text a
+// human would see is actually on screen. It fails with a readable frame
+// snippet when expected UI text disappears — the regression we keep hitting as
+// the live-region / scrollback layout evolves.
+//
+// This is intentionally small: a handful of scenarios that exercise the
+// transcript, a slash command, an approval modal, the subagent panel + task
+// picker, and the Ctrl-C exit path. It is NOT a general terminal-automation
+// framework.
+//
+// Run:  node scripts/validate-tui.mjs        (from packages/cli)
+//   or: pnpm --filter @texra-ai/cli validate:tui
+//
+// Deps: node-pty (PTY; optional — native) and @xterm/headless (pure JS). If
+// node-pty is unavailable (e.g. CI without build tools), the validator prints a
+// notice and exits 0 so it never breaks installs that opt out of the native dep.
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ESC = String.fromCharCode(27);
+const ETX = String.fromCharCode(3); // Ctrl-C
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_ROOT = path.resolve(dirname, '..');
+const HARNESS =
+  process.env.TEXRA_TUI_HARNESS || path.join(CLI_ROOT, 'dist', 'bin', 'tui-harness.js');
+
+// --- optional deps (guarded) ---------------------------------------------
+let ptySpawn;
+let Terminal;
+try {
+  const ptyMod = await import('node-pty');
+  ptySpawn = ptyMod.spawn ?? ptyMod.default?.spawn;
+  const xtermMod = await import('@xterm/headless');
+  Terminal = xtermMod.Terminal ?? xtermMod.default?.Terminal;
+  if (typeof ptySpawn !== 'function' || typeof Terminal !== 'function') {
+    throw new Error('node-pty/@xterm/headless did not expose the expected API');
+  }
+} catch (err) {
+  console.error(
+    '[validate-tui] skipped — install the TUI dev deps to run this validator:\n' +
+      '  pnpm --filter @texra-ai/cli add -D node-pty @xterm/headless\n' +
+      `  (${err instanceof Error ? err.message : String(err)})`,
+  );
+  process.exit(0);
+}
+
+// --- harness bundle ------------------------------------------------------
+if (!existsSync(HARNESS)) {
+  console.error('[validate-tui] building tui-harness bundle…');
+  const r = spawnSync(
+    process.execPath,
+    [path.join(CLI_ROOT, 'scripts', 'build-harness.mjs')],
+    { cwd: CLI_ROOT, stdio: 'inherit' },
+  );
+  if (r.status !== 0 || !existsSync(HARNESS)) {
+    console.error('[validate-tui] failed to build', HARNESS);
+    process.exit(1);
+  }
+}
+
+const COLS = Number(process.env.TUI_VALIDATE_COLS ?? '100');
+const ROWS = Number(process.env.TUI_VALIDATE_ROWS ?? '40');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeTerm() {
+  return new Terminal({ cols: COLS, rows: ROWS, scrollback: 8000, allowProposedApi: true });
+}
+
+// Render the whole buffer (scrollback included) so finalized <Static> rows that
+// scrolled above the viewport still count as "on screen for the session".
+function renderFrame(term) {
+  const buf = term.buffer.active;
+  const lines = [];
+  for (let i = 0; i < buf.length; i += 1) {
+    const ln = buf.getLine(i);
+    lines.push(ln ? ln.translateToString(true) : '');
+  }
+  while (lines.length && lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}
+
+function frameTail(frame) {
+  const lines = frame.split('\n');
+  return lines.slice(-Math.min(lines.length, ROWS)).join('\n');
+}
+
+async function runScenario(scenario) {
+  const term = makeTerm();
+  let lastData = Date.now();
+  let exited = null;
+  const child = ptySpawn(process.execPath, [HARNESS], {
+    name: 'xterm-256color',
+    cols: COLS,
+    rows: ROWS,
+    cwd: CLI_ROOT,
+    env: {
+      ...process.env,
+      ...scenario.env,
+      TERM: 'xterm-256color',
+      FORCE_COLOR: '3',
+      COLUMNS: String(COLS),
+      LINES: String(ROWS),
+    },
+  });
+  child.onExit((e) => (exited = e));
+  child.onData((d) => {
+    lastData = Date.now();
+    term.write(d);
+  });
+
+  // boot: wait for the input prompt to settle
+  const bootDeadline = Date.now() + 15000;
+  let booted = false;
+  while (Date.now() < bootDeadline) {
+    await sleep(150);
+    if (exited) break;
+    if (renderFrame(term).includes('›') && Date.now() - lastData > 600) {
+      booted = true;
+      break;
+    }
+  }
+
+  for (const key of scenario.keys ?? []) {
+    child.write(key);
+    await sleep(500);
+  }
+
+  // settle after keystrokes
+  const settleDeadline = Date.now() + 4000;
+  while (Date.now() < settleDeadline && Date.now() - lastData < 500) await sleep(120);
+  await sleep(250);
+
+  const frame = renderFrame(term);
+
+  // exit cleanly: Ctrl-C (a second one if the first only interrupts a run)
+  for (let attempt = 0; attempt < 2 && !exited; attempt += 1) {
+    child.write(ETX);
+    const ctrlcDeadline = Date.now() + 2500;
+    while (!exited && Date.now() < ctrlcDeadline) await sleep(100);
+  }
+  const exitedCleanly = !!exited;
+  if (!exited) {
+    try {
+      child.kill();
+    } catch {}
+  }
+
+  const missing = (scenario.expect ?? []).filter((t) => !frame.includes(t));
+  const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
+  const failures = [];
+  if (!booted) failures.push('input prompt never rendered (boot timeout)');
+  for (const t of missing) failures.push(`expected text missing: ${JSON.stringify(t)}`);
+  for (const t of present) failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  if (scenario.expectExit && !exitedCleanly) failures.push('Ctrl-C did not exit the TUI');
+
+  return { name: scenario.name, ok: failures.length === 0, failures, frame };
+}
+
+// --- scenarios (verified against the committed harness) ------------------
+const SCENARIOS = [
+  {
+    name: 'transcript',
+    env: { HARNESS_ENTRIES: '8' },
+    expect: [
+      'TeXRA',
+      'agent: chat · model: harness-model',
+      'chat history line to grow the transcript pane',
+      '◆',
+      '[Ctrl-C]exit',
+    ],
+  },
+  {
+    name: 'slash-palette',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/mo'],
+    expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
+  },
+  {
+    name: 'edit-approval',
+    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    expect: ['Apply edit to draft.tex?', 'y approve', 'n reject', 'approval'],
+  },
+  {
+    name: 'subagents',
+    env: { HARNESS_ENTRIES: '4', HARNESS_CHILDREN: '1', HARNESS_CAN_INTERRUPT: '1' },
+    expect: ['strategy', 'leanSolver', 'reviewer', '3 sub', '[Tab]streams'],
+  },
+  {
+    name: 'task-picker',
+    env: { HARNESS_ENTRIES: '4', HARNESS_CHILDREN: '1', HARNESS_CAN_INTERRUPT: '1' },
+    keys: [ESC + 'p'], // Option/Alt-p
+    expect: ['Background tasks', 'Stream: main', 'Enter view', 'k kill', 'Esc close'],
+  },
+  {
+    name: 'todos',
+    env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
+    expect: ['Split theorem into algebraic and analytic checks', 'Route proof obligations'],
+  },
+  {
+    name: 'ctrl-c-exit',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: [ETX],
+    expectExit: true,
+  },
+];
+
+const only = process.argv.slice(2);
+const scenarios = only.length
+  ? SCENARIOS.filter((s) => only.includes(s.name))
+  : SCENARIOS;
+
+let failed = 0;
+for (const scenario of scenarios) {
+  // eslint-disable-next-line no-await-in-loop
+  const result = await runScenario(scenario);
+  if (result.ok) {
+    console.log(`✓ ${result.name}`);
+  } else {
+    failed += 1;
+    console.log(`✗ ${result.name}`);
+    for (const f of result.failures) console.log(`    - ${f}`);
+    console.log('    --- captured frame (tail) ---');
+    console.log(
+      frameTail(result.frame)
+        .split('\n')
+        .map((l) => `    | ${l}`)
+        .join('\n'),
+    );
+  }
+}
+
+console.log('');
+console.log(
+  failed === 0
+    ? `validate-tui: all ${scenarios.length} scenarios passed`
+    : `validate-tui: ${failed}/${scenarios.length} scenario(s) FAILED`,
+);
+process.exit(failed === 0 ? 0 : 1);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -260,7 +260,7 @@ async function runScenario(scenario) {
     const ctrlcDeadline = Date.now() + 2500;
     while (!exited && Date.now() < ctrlcDeadline) await sleep(100);
   }
-  const exitedCleanly = !!exited;
+  const exitedCleanly = exited?.exitCode === 0 && !exited.signal;
   if (!exited) {
     try {
       child.kill();
@@ -275,8 +275,12 @@ async function runScenario(scenario) {
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
-  if (scenario.expectExit && !exitedCleanly)
-    failures.push('Ctrl-C did not exit the TUI');
+  if (scenario.expectExit && !exitedCleanly) {
+    const exitDetails = exited
+      ? ` (exitCode ${exited.exitCode}, signal ${exited.signal || 'none'})`
+      : '';
+    failures.push(`Ctrl-C did not exit the TUI cleanly${exitDetails}`);
+  }
 
   return { name: scenario.name, ok: failures.length === 0, failures, frame };
 }

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -31,7 +31,91 @@ const ETX = String.fromCharCode(3); // Ctrl-C
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
 const HARNESS =
-  process.env.TEXRA_TUI_HARNESS || path.join(CLI_ROOT, 'dist', 'bin', 'tui-harness.js');
+  process.env.TEXRA_TUI_HARNESS ||
+  path.join(CLI_ROOT, 'dist', 'bin', 'tui-harness.js');
+
+// --- scenarios (verified against the committed harness) ------------------
+const SCENARIOS = [
+  {
+    name: 'transcript',
+    env: { HARNESS_ENTRIES: '8' },
+    expect: [
+      'TeXRA',
+      'agent: chat · model: harness-model',
+      'chat history line to grow the transcript pane',
+      '◆',
+      '[Ctrl-C]exit',
+    ],
+  },
+  {
+    name: 'slash-palette',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/mo'],
+    expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
+  },
+  {
+    name: 'edit-approval',
+    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    expect: ['Apply edit to draft.tex?', 'y approve', 'n reject', 'approval'],
+  },
+  {
+    name: 'subagents',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    expect: ['strategy', 'leanSolver', 'reviewer', '3 sub', '[Tab]streams'],
+  },
+  {
+    name: 'task-picker',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    keys: [ESC + 'p'], // Option/Alt-p
+    expect: [
+      'Background tasks',
+      'Stream: main',
+      'Enter view',
+      'k kill',
+      'Esc close',
+    ],
+  },
+  {
+    name: 'todos',
+    env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
+    expect: [
+      'Split theorem into algebraic and analytic checks',
+      'Route proof obligations',
+    ],
+  },
+  {
+    name: 'ctrl-c-exit',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: [ETX],
+    expectExit: true,
+  },
+];
+
+const only = process.argv.slice(2);
+const scenarioNames = new Set(SCENARIOS.map((s) => s.name));
+const unknownScenarios = [
+  ...new Set(only.filter((name) => !scenarioNames.has(name))),
+];
+if (unknownScenarios.length > 0) {
+  console.error(
+    `[validate-tui] unknown scenario${unknownScenarios.length === 1 ? '' : 's'}: ${unknownScenarios.join(', ')}`,
+  );
+  console.error(
+    `[validate-tui] available scenarios: ${SCENARIOS.map((s) => s.name).join(', ')}`,
+  );
+  process.exit(1);
+}
+const scenarios = only.length
+  ? SCENARIOS.filter((s) => only.includes(s.name))
+  : SCENARIOS;
 
 // --- optional deps (guarded) ---------------------------------------------
 let ptySpawn;
@@ -72,7 +156,12 @@ const ROWS = Number(process.env.TUI_VALIDATE_ROWS ?? '40');
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 function makeTerm() {
-  return new Terminal({ cols: COLS, rows: ROWS, scrollback: 8000, allowProposedApi: true });
+  return new Terminal({
+    cols: COLS,
+    rows: ROWS,
+    scrollback: 8000,
+    allowProposedApi: true,
+  });
 }
 
 // Render the whole buffer (scrollback included) so finalized <Static> rows that
@@ -136,7 +225,8 @@ async function runScenario(scenario) {
 
   // settle after keystrokes
   const settleDeadline = Date.now() + 4000;
-  while (Date.now() < settleDeadline && Date.now() - lastData < 500) await sleep(120);
+  while (Date.now() < settleDeadline && Date.now() - lastData < 500)
+    await sleep(120);
   await sleep(250);
 
   const frame = renderFrame(term);
@@ -158,65 +248,15 @@ async function runScenario(scenario) {
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
   const failures = [];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
-  for (const t of missing) failures.push(`expected text missing: ${JSON.stringify(t)}`);
-  for (const t of present) failures.push(`unexpected text present: ${JSON.stringify(t)}`);
-  if (scenario.expectExit && !exitedCleanly) failures.push('Ctrl-C did not exit the TUI');
+  for (const t of missing)
+    failures.push(`expected text missing: ${JSON.stringify(t)}`);
+  for (const t of present)
+    failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  if (scenario.expectExit && !exitedCleanly)
+    failures.push('Ctrl-C did not exit the TUI');
 
   return { name: scenario.name, ok: failures.length === 0, failures, frame };
 }
-
-// --- scenarios (verified against the committed harness) ------------------
-const SCENARIOS = [
-  {
-    name: 'transcript',
-    env: { HARNESS_ENTRIES: '8' },
-    expect: [
-      'TeXRA',
-      'agent: chat · model: harness-model',
-      'chat history line to grow the transcript pane',
-      '◆',
-      '[Ctrl-C]exit',
-    ],
-  },
-  {
-    name: 'slash-palette',
-    env: { HARNESS_ENTRIES: '4' },
-    keys: ['/mo'],
-    expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
-  },
-  {
-    name: 'edit-approval',
-    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    expect: ['Apply edit to draft.tex?', 'y approve', 'n reject', 'approval'],
-  },
-  {
-    name: 'subagents',
-    env: { HARNESS_ENTRIES: '4', HARNESS_CHILDREN: '1', HARNESS_CAN_INTERRUPT: '1' },
-    expect: ['strategy', 'leanSolver', 'reviewer', '3 sub', '[Tab]streams'],
-  },
-  {
-    name: 'task-picker',
-    env: { HARNESS_ENTRIES: '4', HARNESS_CHILDREN: '1', HARNESS_CAN_INTERRUPT: '1' },
-    keys: [ESC + 'p'], // Option/Alt-p
-    expect: ['Background tasks', 'Stream: main', 'Enter view', 'k kill', 'Esc close'],
-  },
-  {
-    name: 'todos',
-    env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
-    expect: ['Split theorem into algebraic and analytic checks', 'Route proof obligations'],
-  },
-  {
-    name: 'ctrl-c-exit',
-    env: { HARNESS_ENTRIES: '4' },
-    keys: [ETX],
-    expectExit: true,
-  },
-];
-
-const only = process.argv.slice(2);
-const scenarios = only.length
-  ? SCENARIOS.filter((s) => only.includes(s.name))
-  : SCENARIOS;
 
 let failed = 0;
 for (const scenario of scenarios) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@xterm/headless':
+        specifier: ^5.5.0
+        version: 5.5.0
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -396,6 +399,9 @@ importers:
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
+      node-pty:
+        specifier: ^1.0.0
+        version: 1.1.0
       p-queue:
         specifier: ^9.3.0
         version: 9.3.0
@@ -2596,6 +2602,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/headless@5.5.0':
+    resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -5041,6 +5050,9 @@ packages:
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -5076,6 +5088,9 @@ packages:
 
   node-pandoc@0.3.0:
     resolution: {integrity: sha512-e+kANHQQFBlN7J8wEFf7sNc1sSCLltyPtPqNA/IEapiNsA1LjZ9mtV/B0lU6b2cAdvn7rrAVNBONw+Fo1YsY+A==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
@@ -9007,6 +9022,8 @@ snapshots:
 
   '@xterm/addon-fit@0.11.0': {}
 
+  '@xterm/headless@5.5.0': {}
+
   '@xterm/xterm@6.0.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
@@ -11734,6 +11751,8 @@ snapshots:
   node-addon-api@4.3.0:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.8.1
@@ -11780,6 +11799,10 @@ snapshots:
       webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.13)(webpack-cli@7.0.3)
 
   node-pandoc@0.3.0: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.46: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ allowBuilds:
   electron-winstaller: true
   esbuild: true
   keytar: true
+  node-pty: true
   protobufjs: true
 patchedDependencies:
   ink@7.0.5: patches/ink@7.0.5.patch


### PR DESCRIPTION
Closes #4709.

Adds `packages/cli/scripts/validate-tui.mjs` (+ a `validate:tui` script): a small, **deterministic** PTY frame-capture validator for the chat TUI.

### What it does
Drives the committed `dist/bin/tui-harness.js` under a pseudo-terminal (`node-pty`), renders the byte stream through a headless terminal (`@xterm/headless`), sends raw keystrokes, and asserts that the text a human would see is actually on screen — failing with a readable frame snippet when expected UI text disappears.

### Scenarios (all via the existing `HARNESS_*` env knobs + raw keys)
| scenario | drives | asserts (sample) |
|---|---|---|
| `transcript` | `HARNESS_ENTRIES` | header, `agent: chat · model: …`, transcript rows, `◆` status, `[Ctrl-C]exit` |
| `slash-palette` | type `/mo` | `/model  List available models`, `↑/↓ navigate · Enter run · Tab complete` |
| `edit-approval` | `HARNESS_EDIT_APPROVAL` | `Apply edit to draft.tex?`, `y approve · n reject …`, `1 approval` |
| `subagents` | `HARNESS_CHILDREN` | `strategy` / `leanSolver` / `reviewer`, `3 sub`, `[Tab]streams` |
| `task-picker` | `Alt-p` | `Background tasks`, `Stream: main`, `Enter view · k kill · Esc close` |
| `todos` | `HARNESS_TODOS` | todo list + plan rows |
| `ctrl-c-exit` | `Ctrl-C` | the TUI exits cleanly |

### Run
```sh
pnpm --filter @texra-ai/cli validate:tui
# or a subset:
node packages/cli/scripts/validate-tui.mjs slash-palette task-picker
```

### Notes
- **Deterministic** — no live model / network; it drives the synthetic harness state (so it's CI-friendly).
- Deps added as CLI devDependencies: `node-pty` (PTY) + `@xterm/headless` (frame render). The validator **skips with a clear message and exits 0** if they're unavailable, so it never breaks an install/CI that opts out of the native dep. It is opt-in (not wired into the default `build`).
- Scope per the issue: a handful of product-focused regression checks, **not** a general terminal-automation framework.
- Motivation/guard: the live-region/scrollback layout is actively evolving (cf. #4163 and the in-flight progressive-scrollback work). This catches *human-visible* regressions — e.g. an approval modal, subagent panel, or footer hint silently disappearing.

**Verified:** built a fresh harness from this branch and ran all 7 scenarios — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only tooling and devDependencies; optional skip path avoids breaking installs without native PTY support.
> 
> **Overview**
> Adds an **opt-in** PTY frame-capture regression check for the CLI chat TUI (`validate:tui` / `scripts/validate-tui.mjs`), aimed at catching human-visible layout regressions as scrollback/live-region behavior evolves (#4709).
> 
> The script spawns the existing **`tui-harness`** under **`node-pty`**, renders output with **`@xterm/headless`** (full scrollback buffer), drives seven harness scenarios via **`HARNESS_*` env** and raw keys, and asserts expected on-screen strings—or prints a frame tail on failure. It can build the harness if missing, filter scenarios by CLI args, and **exits 0 with a skip message** when native PTY deps are unavailable (not wired into default **`build`**).
> 
> **`package.json`** gains devDeps **`node-pty`** and **`@xterm/headless`**; **`pnpm-workspace.yaml`** allows **`node-pty`** native builds; lockfile updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27049da82b2ffc0165d45daff514fa6de5dcd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->