### PR TITLE
fix(cli): clarify task picker sub-workflow scope

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -77,7 +77,7 @@ const SCENARIOS = [
     },
     keys: [ESC + 'p'], // Option/Alt-p
     expect: [
-      'Background tasks',
+      'Tasks and sub-workflows',
       'Stream: main',
       'Enter view',
       'k kill',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -36,8 +36,14 @@ export interface ChildControlPickerProps {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
 
-function pickerTitle(mode: ChildControlMode): string {
-  return mode === 'subagents' ? 'Subagents' : 'Background tasks';
+export function pickerTitle(mode: ChildControlMode): string {
+  return mode === 'subagents' ? 'Subagents' : 'Tasks and sub-workflows';
+}
+
+export function emptyPickerText(mode: ChildControlMode): string {
+  return mode === 'subagents'
+    ? 'No active subagents.'
+    : 'No active tasks or sub-workflows.';
 }
 
 export function pickerKeyHints(
@@ -493,7 +499,7 @@ export function ChildControlPicker({
             ) : null}
           </>
         ) : (
-          <Text dimColor>No active {pickerTitle(mode).toLowerCase()}.</Text>
+          <Text dimColor>{emptyPickerText(mode)}</Text>
         )}
       </Box>
       <Box marginTop={1}>

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest';
 import {
   computePickerListLayout,
   computeTaskDetailLayout,
+  emptyPickerText,
   pickerKeyHints,
+  pickerTitle,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
@@ -538,6 +540,13 @@ describe('CLI child execution controls', () => {
       key: 'Enter',
       action: 'focus',
     });
+  });
+
+  it('labels the task picker as a combined task and sub-workflow view', () => {
+    expect(pickerTitle('subagents')).toBe('Subagents');
+    expect(pickerTitle('tasks')).toBe('Tasks and sub-workflows');
+    expect(emptyPickerText('subagents')).toBe('No active subagents.');
+    expect(emptyPickerText('tasks')).toBe('No active tasks or sub-workflows.');
   });
 
   it('preserves output rows in compact task detail views', () => {


### PR DESCRIPTION
## Summary
- Rename the Option-p picker from `Background tasks` to `Tasks and sub-workflows`
- Give the empty state explicit copy for tasks/sub-workflows instead of deriving it from the title
- Update the committed PTY TUI validator and child-control unit coverage for the new copy

Closes #4713.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness && corepack pnpm --filter @texra-ai/cli run validate:tui task-picker`
- compact PTY frame capture at 80x18 confirmed title: `Tasks and sub-workflows`
- `corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings in unrelated files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible copy and test expectations only; no behavior or control-flow changes.
> 
> **Overview**
> The Option/Alt-p **task** child-control picker is relabeled from **Background tasks** to **Tasks and sub-workflows**, with dedicated empty-state copy instead of lowercasing the title.
> 
> `pickerTitle` and new `emptyPickerText` are **exported** from `ChildControlPicker` for reuse; the PTY `task-picker` scenario and `ChildControls` unit tests assert the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf91b2fdb9e9aee2dbfea9e4605d7985666d807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->