### PR TITLE
fix(cli): keep task picker useful from child streams

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -97,20 +97,32 @@ const SCENARIOS = [
   {
     name: 'empty-task-picker',
     env: {
-      HARNESS_ENTRIES: '12',
-      HARNESS_CHILDREN: '1',
-      HARNESS_TODOS: '1',
-      HARNESS_CAN_DELEGATE: '1',
+      HARNESS_ENTRIES: '4',
     },
-    keys: [ESC + 'p', '\r', 'f', ESC + 'p'],
+    keys: [ESC + 'p'],
     frame: 'tail',
     expect: [
-      'Background tasks',
-      'Stream: strategy',
-      'No active background tasks.',
+      'Tasks and sub-workflows',
+      'Stream: main',
+      'No active tasks or sub-workflows.',
       'Esc close',
     ],
     unexpect: ['Enter view', 'k kill', 'navigate'],
+  },
+  {
+    name: 'task-picker-parent-fallback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    keys: [ESC + 's', '\r', ESC + 'p'],
+    expect: [
+      'Tasks and sub-workflows',
+      'Stream: main (strategy has no tasks or sub-workflows)',
+      'strategy',
+      'latex build',
+    ],
   },
   {
     name: 'todos',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -340,10 +340,10 @@ export function App(props: AppProps): React.JSX.Element {
             })
           : undefined;
         const streamScopeDetail =
-          childControlMode === 'subagents' &&
-          targetStreamLabel &&
-          fallbackFromStreamLabel
-            ? `${fallbackFromStreamLabel} has no subagents`
+          targetStreamLabel && fallbackFromStreamLabel
+            ? childControlMode === 'subagents'
+              ? `${fallbackFromStreamLabel} has no subagents`
+              : `${fallbackFromStreamLabel} has no tasks or sub-workflows`
             : undefined;
         return (
           <ChildControlPicker

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -204,6 +204,15 @@ function hasVisibleSubagents(
   return slice !== undefined && visibleSubagentRows(slice).length > 0;
 }
 
+function hasVisibleTasks(
+  slice: Pick<StreamSlice, 'activeProcesses' | 'activeSubagents'> | undefined,
+): boolean {
+  return (
+    slice !== undefined &&
+    (slice.activeSubagents.length > 0 || slice.activeProcesses.length > 0)
+  );
+}
+
 export function resolveChildControlStreamTarget({
   activeStreamId,
   mode,
@@ -216,17 +225,21 @@ export function resolveChildControlStreamTarget({
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): ChildControlStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  if (
-    mode !== 'subagents' ||
-    !activeStreamId ||
-    hasVisibleSubagents(activeSlice)
-  ) {
+  const activeHasRows =
+    mode === 'subagents'
+      ? hasVisibleSubagents(activeSlice)
+      : hasVisibleTasks(activeSlice);
+  if (!activeStreamId || activeHasRows) {
     return { streamId: activeStreamId, slice: activeSlice };
   }
 
   const parentStreamId = parentStream.get(activeStreamId);
   const parentSlice = parentStreamId ? streams.get(parentStreamId) : undefined;
-  if (hasVisibleSubagents(parentSlice)) {
+  const parentHasRows =
+    mode === 'subagents'
+      ? hasVisibleSubagents(parentSlice)
+      : hasVisibleTasks(parentSlice);
+  if (parentHasRows) {
     return {
       fallbackFromStreamId: activeStreamId,
       streamId: parentStreamId,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -481,8 +481,54 @@ describe('CLI child execution controls', () => {
     expect(target.slice).toBe(child);
   });
 
-  it('keeps task controls scoped to the focused child stream', () => {
+  it('falls back to the parent task list when the focused child is a leaf', () => {
     const child = slice({ streamId: 'review-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'tasks',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([
+        [
+          'main',
+          slice({
+            streamId: 'main',
+            activeSubagents: [
+              {
+                executionId: 'agent-1',
+                agentName: 'review',
+                childStreamId: 'review-stream',
+                status: 'running',
+              },
+            ],
+          }),
+        ],
+        ['review-stream', child],
+      ]),
+    });
+
+    expect(target.streamId).toBe('main');
+    expect(target.fallbackFromStreamId).toBe('review-stream');
+    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        childStreamId: 'review-stream',
+        kind: 'subagent',
+        label: 'review',
+      },
+    ]);
+  });
+
+  it('keeps task controls scoped to the focused child stream when it has work', () => {
+    const child = slice({
+      streamId: 'review-stream',
+      activeProcesses: [
+        {
+          executionId: 'proc-1',
+          agentName: 'latexmk',
+          status: 'running',
+        },
+      ],
+    });
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
       mode: 'tasks',
@@ -508,6 +554,13 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('review-stream');
     expect(target.slice).toBe(child);
+    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+      {
+        executionId: 'proc-1',
+        kind: 'process',
+        label: 'latexmk',
+      },
+    ]);
   });
 
   it('keeps picker key handling independent of Ink rendering', () => {


### PR DESCRIPTION
## Summary
- make the CLI task/sub-workflow picker fall back to the parent stream when the focused child has no local task rows
- annotate fallback scope as `Stream: main (strategy has no tasks or sub-workflows)`
- keep the empty-picker key-hint coverage on a genuinely empty root stream
- add a PTY validator scenario that reproduces the Alt-s -> Enter -> Alt-p path

Closes #4715

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts`
- `CI=true corepack pnpm --filter @texra-ai/cli run bundle:harness && CI=true corepack pnpm --filter @texra-ai/cli run validate:tui task-picker-parent-fallback empty-task-picker task-picker`
- `CI=true corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI stream-scoping only; no auth, persistence, or network changes.
> 
> **Overview**
> The **tasks / sub-workflows** picker (Alt-p) now mirrors subagent picker behavior: when the focused child stream has no local tasks or processes, it **falls back to the parent stream’s list** instead of showing an empty picker.
> 
> The picker header explains fallback scope (e.g. `Stream: main (strategy has no tasks or sub-workflows)`). Empty-state and PTY validation scenarios were aligned with the unified **Tasks and sub-workflows** copy, and a harness case covers **Alt-s → Enter → Alt-p** on a leaf child stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ccf66cf9118d5acd3cf524258d58e2a3ac5f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->