### PR TITLE
fix(cli): show process tail in compact child panel

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -76,7 +76,14 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    expect: ['strategy', 'leanSolver', 'reviewer', '3 sub', '[Tab]streams'],
+    expect: [
+      'strategy',
+      'leanSolver',
+      'reviewer',
+      'main.tex: Proof sketch',
+      '3 sub',
+      '[Tab]streams',
+    ],
   },
   {
     name: 'task-picker',

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -34,6 +34,27 @@ export interface ChildRow {
 
 const TAIL_LINES = 4;
 
+export function compactChildRowText({
+  child,
+  nowMs,
+  tail,
+}: {
+  readonly child: ActiveChildInfo;
+  readonly nowMs: number;
+  readonly tail?: ProcessOutputTail;
+}): string {
+  const tailSummary = processTailLines(tail).at(-1);
+  const elapsed = childElapsed(child, nowMs);
+  const label = child.agentName || child.toolName || child.executionId;
+  return [
+    `${label}${child.status ? ` ${child.status}` : ''}`,
+    elapsed,
+    tailSummary,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(' · ');
+}
+
 function Row({
   child,
   compact = false,
@@ -59,9 +80,7 @@ function Row({
         </Text>
         {compact ? (
           <Text wrap="truncate-end">
-            {label}
-            {child.status ? ` ${child.status}` : ''}
-            {elapsed ? ` · ${elapsed}` : ''}
+            {compactChildRowText({ child, nowMs, tail })}
           </Text>
         ) : (
           <>
@@ -156,6 +175,7 @@ export function SubagentList(
             compact
             index={index}
             nowMs={nowMs}
+            tail={processOutput?.get(child.executionId)}
           />
         ))}
         {hiddenCount > 0 ? (

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -4,7 +4,10 @@ import {
   CHILD_STATUS_MARKER,
   childStatusColor,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
-import { compactRows } from '@cli/chat/tui/panes/SubagentList';
+import {
+  compactChildRowText,
+  compactRows,
+} from '@cli/chat/tui/panes/SubagentList';
 import type { ActiveChildInfo } from '@shared/schemas';
 
 describe('CLI SubagentList display model', () => {
@@ -79,5 +82,26 @@ describe('CLI SubagentList display model', () => {
       'latexmk',
     ]);
     expect(display.hiddenCount).toBe(0);
+  });
+
+  it('summarizes the latest process output in compact rows', () => {
+    expect(
+      compactChildRowText({
+        child: {
+          executionId: 'latexmk',
+          agentName: 'latex build',
+          status: 'running',
+          elapsed: '19sec',
+        },
+        nowMs: Date.now(),
+        tail: {
+          stdout:
+            'latexmk: applying rule pdflatex\nmain.tex: Proof sketch needs one missing reference',
+          stderr: '',
+        },
+      }),
+    ).toBe(
+      'latex build running · 19sec · main.tex: Proof sketch needs one missing reference',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- include the latest process output line in compact CLI child/process rows
- keep the row budget unchanged by appending the tail summary to the same truncated row
- extend the PTY TUI validator so the seeded `latexmk` warning context must be visible in the subagent/process panel

Closes #4718

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SubagentListDisplay.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness && corepack pnpm --filter @texra-ai/cli run validate:tui subagents`
- viewport capture at 88x20 with `HARNESS_CHILDREN=1`
- `corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and test-only harness expectations; no auth, data, or runtime execution path changes beyond TUI rendering.
> 
> **Overview**
> Compact **subagent/process** rows in the CLI TUI now show the **latest stdout/stderr line** on the same truncated row (label, status, elapsed, then tail), without increasing row height. **`compactChildRowText`** centralizes that formatting; the compact list passes **`processOutput`** tails into each row (previously compact rows omitted tails).
> 
> The **subagents** PTY harness scenario asserts the seeded **`main.tex: Proof sketch`** warning is visible, and a **Vitest** case locks in the compact summary string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a79a75148ca8227b7594cdc2f2048e2f9bb53e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->