### PR TITLE
test(cli): rebuild TUI harness before validation

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -201,7 +201,14 @@ try {
 }
 
 // --- harness bundle ------------------------------------------------------
-if (!existsSync(HARNESS)) {
+if (process.env.TEXRA_TUI_HARNESS) {
+  if (!existsSync(HARNESS)) {
+    console.error('[validate-tui] custom harness does not exist:', HARNESS);
+    process.exit(1);
+  }
+} else {
+  // Rebuild the committed harness on every run so local TUI source edits are
+  // tested against the current tree instead of a stale dist/bin artifact.
   console.error('[validate-tui] building tui-harness bundle…');
   const r = spawnSync(
     process.execPath,


### PR DESCRIPTION
## Summary

- rebuild the default CLI TUI harness every time `validate:tui` runs
- preserve `TEXRA_TUI_HARNESS` as an explicit custom-bundle override, with a clear missing-file error
- close the stale-bundle blind spot found while validating #4716

Closes #4717.

## Validation

- `CI=true corepack pnpm --filter @texra-ai/cli run validate:tui task-picker-parent-fallback`
- `CI=true corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness bootstrap in `validate-tui.mjs`; no production CLI or auth paths change.
> 
> **Overview**
> **`validate:tui` now rebuilds the default TUI harness on every run** via `build-harness.mjs`, so PTY scenarios exercise the current CLI tree instead of a possibly stale `dist/bin/tui-harness.js`.
> 
> When **`TEXRA_TUI_HARNESS`** is set, the script **skips the rebuild** and only checks that the custom bundle path exists, failing fast with a clear error if it does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce35ef249f2392a63ca4182a916f9386c5b9941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->