### PR TITLE
test(cli): cover TUI approval decisions

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -70,6 +70,22 @@ const SCENARIOS = [
     expect: ['Apply edit to draft.tex?', 'y approve', 'n reject', 'approval'],
   },
   {
+    name: 'edit-approval-approve',
+    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    keys: ['y'],
+    frame: 'tail',
+    expect: ['[/status]details', '[/model]models'],
+    unexpect: ['Apply edit to draft.tex?', '1 approval'],
+  },
+  {
+    name: 'edit-approval-reject',
+    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    keys: ['n'],
+    frame: 'tail',
+    expect: ['[/status]details', '[/model]models'],
+    unexpect: ['Apply edit to draft.tex?', '1 approval'],
+  },
+  {
     name: 'subagents',
     env: {
       HARNESS_ENTRIES: '4',


### PR DESCRIPTION
## Summary

- add PTY frame-capture coverage for approving an edit approval with `y`
- add PTY frame-capture coverage for rejecting an edit approval with `n`
- assert the visible tail clears both the modal and the `1 approval` badge after either decision

Closes #4722.

## Dogfood Evidence

- rebuilt and linked `texra-local`
- opened the live TTY launcher and selected `Team Mathematician`
- sent a small theorem prompt; the relay session proposed `proof_n_even.tex`, surfaced a write approval diff, accepted `n`, and continued with an inline proof
- verified `proof_n_even.tex` was not created after rejection

## Validation

- `CI=true corepack pnpm --filter @texra-ai/cli run validate:tui edit-approval edit-approval-approve edit-approval-reject`
- `CI=true corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the TUI validation script; no production runtime behavior is modified.
> 
> **Overview**
> Extends the CLI **TUI PTY validator** so edit-approval flows are covered end-to-end, not only when the modal is visible.
> 
> Two scenarios are added in `validate-tui.mjs`: **`edit-approval-approve`** sends `y` and **`edit-approval-reject`** sends `n`, each with `HARNESS_EDIT_APPROVAL=1` and **`frame: 'tail'`** so assertions target the bottom of the screen. Both expect the normal status/model chrome (`[/status]details`, `[/model]models`) and **`unexpect`** the prompt `Apply edit to draft.tex?` and the **`1 approval`** badge—guarding that approve and reject both dismiss the modal and clear pending-approval UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f87ef853bd7505f53515df1bcf1c5ae69123bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->