### PR TITLE
fix(cli): hide inactive shortcuts during approvals

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -67,7 +67,15 @@ const SCENARIOS = [
   {
     name: 'edit-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    expect: ['Apply edit to draft.tex?', 'y approve', 'n reject', 'approval'],
+    bootExpect: 'Use foreground panel shortcuts',
+    expect: [
+      'Apply edit to draft.tex?',
+      'y approve',
+      'n reject',
+      'approval',
+      'Use foreground panel shortcuts',
+    ],
+    unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
   },
   {
     name: 'subagents',
@@ -300,12 +308,13 @@ async function runScenario(scenario) {
   // transcript user rows also contain "›", so use the status binding instead
   // of the prompt glyph as the readiness sentinel.
   const bootDeadline = Date.now() + 15000;
+  const bootExpect = scenario.bootExpect ?? '[/status]details';
   let booted = false;
   while (Date.now() < bootDeadline) {
     await sleep(150);
     if (exited) break;
     if (
-      (await frameSnapshot()).includes('[/status]details') &&
+      (await frameSnapshot()).includes(bootExpect) &&
       Date.now() - lastData > 600
     ) {
       booted = true;

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -488,7 +488,10 @@ export function App(props: AppProps): React.JSX.Element {
           history={props.history}
         />
         <StreamTabsStrip width={columns} />
-        <StatusBar canStopActiveRun={canStopActiveRun} />
+        <StatusBar
+          canStopActiveRun={canStopActiveRun}
+          shortcutsActive={focusShortcutsActive}
+        />
       </Box>
     </>
   );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -66,6 +66,10 @@ export interface StatusBarDisplayInput {
    *  colliding with durable left-side status segments. */
   readonly width?: number;
   readonly ctrlCAction?: CtrlCAction;
+  /** False while a foreground surface (approval, picker, form, transcript,
+   *  slash palette, or reverse search) owns input and global chat shortcuts are
+   *  intentionally inactive. */
+  readonly shortcutsActive?: boolean;
 }
 
 export interface StatusBarDisplay {
@@ -287,6 +291,10 @@ export function statusBarBindingsText(
   return bindings.join('  ');
 }
 
+function foregroundBindingsText(ctrlCAction: CtrlCAction): string {
+  return `Use foreground panel shortcuts  [Ctrl-C]${ctrlCAction}`;
+}
+
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
@@ -348,13 +356,15 @@ export function buildStatusBarDisplay(
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
-        : statusBarBindingsText(
-            input.subagentControlsAvailable,
-            input.hasMultipleStreams,
-            input.shortcutModifierLabel,
-            input.shiftEnterNewline,
-            input.ctrlCAction,
-          ),
+        : input.shortcutsActive === false
+          ? foregroundBindingsText(input.ctrlCAction ?? 'exit')
+          : statusBarBindingsText(
+              input.subagentControlsAvailable,
+              input.hasMultipleStreams,
+              input.shortcutModifierLabel,
+              input.shiftEnterNewline,
+              input.ctrlCAction,
+            ),
   };
 }
 
@@ -364,6 +374,7 @@ export function statusBarSegmentText(segment: StatusBarSegment): string {
 
 export interface StatusBarProps {
   readonly canStopActiveRun?: () => boolean;
+  readonly shortcutsActive?: boolean;
 }
 
 export function StatusBar(props: StatusBarProps): React.JSX.Element {
@@ -410,6 +421,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     shiftEnterNewline: caps.kittyKeyboard,
     width: columns,
     ctrlCAction: props.canStopActiveRun?.() ? 'stop' : 'exit',
+    shortcutsActive: props.shortcutsActive,
   });
 
   return (

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -181,6 +181,36 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[Alt-1..9]focus');
   });
 
+  it('hides inactive global bindings while a foreground panel owns input', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 2,
+      activeProcesses: 1,
+      approvalDepth: 1,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      shortcutsActive: false,
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toContain('1 approval');
+    expect(display.bindings).toBe(
+      'Use foreground panel shortcuts  [Ctrl-C]stop',
+    );
+    expect(display.bindings).not.toContain('[Tab]streams');
+    expect(display.bindings).not.toContain('[Alt-p]tasks');
+    expect(display.bindings).not.toContain('[/model]models');
+  });
+
   it('shows a live elapsed segment only while running', () => {
     const runningInput = {
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary
- replace inactive global status-bar shortcuts with a foreground-panel hint while approvals/forms/pickers own input
- keep the active Ctrl-C action visible in that foreground hint
- extend the edit-approval PTY scenario to assert the new status binding and reject stale global shortcut hints

Closes #4721

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui edit-approval`
- approval+children viewport capture at 92x24 with `HARNESS_CHILDREN=1 HARNESS_EDIT_APPROVAL=1`
- `corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI status-bar copy and PTY harness assertions only; no security, auth, or data-path changes.
> 
> **Overview**
> When a **foreground panel** (e.g. edit approval) has focus, the status bar no longer lists global chat shortcuts (`[/model]`, `[Alt-p]tasks`, stream tabs, etc.) that `App` already disables. It shows **"Use foreground panel shortcuts"** and still surfaces **`[Ctrl-C]stop`/`exit`**.
> 
> `App` passes the same `focusShortcutsActive` flag used for global key handling into `StatusBar` as `shortcutsActive`. `buildStatusBarDisplay` switches the bindings line via `foregroundBindingsText` when `shortcutsActive === false`.
> 
> Coverage: a **StatusBar** unit test for the shortened bindings line, and the **edit-approval** PTY scenario now boots on the foreground hint and asserts global shortcut strings are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c226ccb9f1308a4143863f933dd8299cd7f5e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->