### PR TITLE
fix(cli): show compact approval diff context

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -80,6 +80,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval-approve',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    bootExpect: 'Use foreground panel shortcuts',
     keys: ['y'],
     frame: 'tail',
     expect: ['[/status]details', '[/model]models'],
@@ -88,6 +89,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval-reject',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    bootExpect: 'Use foreground panel shortcuts',
     keys: ['n'],
     frame: 'tail',
     expect: ['[/status]details', '[/model]models'],

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -6,6 +6,7 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import {
   buildHunks,
+  COMPACT_DIFF_DISPLAY_LINES,
   diffVisualRowCount,
   DiffView,
   maxDiffScrollOffset,
@@ -16,7 +17,8 @@ import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
-const EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE = 8;
+const EDIT_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 8;
+const EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 const EDIT_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;
 const EDIT_APPROVAL_FEEDBACK_PREFIX_COLUMNS = 2;
 const MIN_EDIT_DIFF_WIDTH = 20;
@@ -58,13 +60,21 @@ export function editApprovalDiffRowsBudget({
           value: feedbackValue,
         })
       : 0;
-  return Math.max(
-    1,
+  const spaciousDiffRows =
     availableRows -
-      EDIT_APPROVAL_FIXED_ROWS_EXCLUDING_TITLE -
-      titleRows -
-      feedbackRows,
-  );
+    EDIT_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE -
+    titleRows -
+    feedbackRows;
+  if (spaciousDiffRows > COMPACT_DIFF_DISPLAY_LINES) {
+    return spaciousDiffRows;
+  }
+
+  const compactDiffRows =
+    availableRows -
+    EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE -
+    titleRows -
+    feedbackRows;
+  return Math.max(1, Math.min(COMPACT_DIFF_DISPLAY_LINES, compactDiffRows));
 }
 
 export function editApprovalFeedbackRows({
@@ -127,6 +137,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const maxScrollOffset = maxDiffScrollOffset(diffRows, maxDiffLines);
   const diffScrollable = maxScrollOffset > 0;
   const pageRows = Math.max(1, maxDiffLines - 2);
+  const compactDiffLayout = maxDiffLines <= COMPACT_DIFF_DISPLAY_LINES;
 
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {
@@ -166,7 +177,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
         +{stats.added} / −{stats.removed} · {stats.hunks} hunks · source:{' '}
         {props.request.sourceTool}
       </Text>
-      <Box marginY={1} flexDirection="column">
+      <Box marginY={compactDiffLayout ? 0 : 1} flexDirection="column">
         <DiffView
           hunks={hunks}
           maxDisplayLines={maxDiffLines}

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -31,7 +31,7 @@ export interface DiffStats {
 const NO_NEWLINE_MARKER = '\\';
 const MIN_DIFF_WIDTH = 20;
 const DEFAULT_DIFF_WIDTH = 74;
-const COMPACT_DIFF_DISPLAY_LINES = 3;
+export const COMPACT_DIFF_DISPLAY_LINES = 3;
 
 type OverflowMarkerKind = 'hidden' | 'more' | 'previous';
 

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -50,10 +50,20 @@ describe('CLI edit approval layout', () => {
     ).toBe(3);
   });
 
-  it('keeps a usable one-line diff on very short terminals', () => {
+  it('uses compact diff rows on short terminals', () => {
     expect(
       editApprovalDiffRowsBudget({
-        availableRows: 8,
+        availableRows: 10,
+        columns: 80,
+        title: 'Apply edit to draft.tex?',
+      }),
+    ).toBe(3);
+  });
+
+  it('keeps a usable diff line on very short terminals', () => {
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 7,
         columns: 80,
         title: 'Apply edit to proof.tex?',
       }),


### PR DESCRIPTION
## Summary
- use a compact no-margin approval diff layout before short terminals collapse to a one-line diff
- keep compact diff rows tied to the renderer threshold so changed rows and the hidden-row marker fit together
- make approval decision TUI validator scenarios wait for the approval foreground surface before sending y/n

Closes #4727

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/EditApproval.vitest.mts src/test-kernel/cli/DiffView.vitest.mts
- TERM=xterm-256color HARNESS_CHILDREN=1 HARNESS_TODOS=1 HARNESS_CAN_DELEGATE=1 HARNESS_CAN_INTERRUPT=1 HARNESS_EDIT_APPROVAL=1 HARNESS_EDIT_APPROVAL_DELAY_MS=1500 node packages/cli/dist/bin/tui-harness.js at 80x18 after rebuilding bundle:harness
- corepack pnpm --filter @texra-ai/cli validate:tui
- npm run format
- npm run compile:safe
- npm run lint (passes with existing import-order warnings in unrelated files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and harness timing only; no auth, data, or API surface changes.
> 
> **Overview**
> Short terminals no longer collapse edit-approval diffs to a single line as aggressively. **`editApprovalDiffRowsBudget`** switches to a **compact** chrome budget (fewer fixed rows, diff capped at **`COMPACT_DIFF_DISPLAY_LINES` (3)**) when the spacious layout would not leave more than three diff rows; the approval modal drops vertical margin around **`DiffView`** in that mode so changed lines and overflow markers still fit.
> 
> **`COMPACT_DIFF_DISPLAY_LINES`** is now exported from **`DiffView`** so approval layout and the renderer share the same threshold.
> 
> TUI harness **`edit-approval-approve`** / **`edit-approval-reject`** wait for **`Use foreground panel shortcuts`** before sending **y**/**n**, matching the approval foreground surface. Vitest expectations were updated for compact (e.g. 10 rows → 3 diff lines) vs very short (7 rows → 1 line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0c0aba885e6906fa05f97a6c818494e7da2ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->