### PR TITLE
fix(cli): keep stop visible in narrow status bars

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -124,6 +124,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
+    bootExpect: '[Tab]streams',
     expect: [
       'strategy',
       'leanSolver',
@@ -140,6 +141,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
+    bootExpect: '[Tab]streams',
     keys: [ESC + 'p'], // Option/Alt-p
     expect: [
       'Tasks and sub-workflows',
@@ -171,6 +173,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
+    bootExpect: '[Tab]streams',
     keys: [ESC + 's', '\r', ESC + 'p'],
     expect: [
       'Tasks and sub-workflows',
@@ -345,10 +348,11 @@ async function runScenario(scenario) {
   });
 
   // boot: wait for the interactive input/status area to settle. Static
-  // transcript user rows also contain "›", so use the status binding instead
-  // of the prompt glyph as the readiness sentinel.
+  // transcript user rows also contain "›", so use the status-bar marker
+  // instead of the prompt glyph as the readiness sentinel. Binding text is
+  // width-adaptive and may omit labels such as /status in narrow terminals.
   const bootDeadline = Date.now() + 15000;
-  const bootExpect = scenario.bootExpect ?? '[/status]details';
+  const bootExpect = scenario.bootExpect ?? '◆';
   let booted = false;
   while (Date.now() < bootDeadline) {
     await sleep(150);

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -251,6 +251,7 @@ export function statusBarBindingsText(
   modifierLabel = defaultShortcutModifierLabel(),
   shiftEnterNewline = false,
   ctrlCAction: CtrlCAction = 'exit',
+  maxColumns?: number,
 ): string {
   const bindings: string[] = [
     // Stream cycling / numeric focus only do something when there is more
@@ -274,7 +275,34 @@ export function statusBarBindingsText(
       `[${modifierLabel}-s]subagents`,
     );
   }
+  const fullBindings = joinStatusBindings(bindings);
+  if (fitsStatusBindings(fullBindings, maxColumns)) return fullBindings;
+
+  const compactBindings = joinStatusBindings([
+    ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+    `[${modifierLabel}-p]tasks`,
+    ...(subagentControlsAvailable ? [`[${modifierLabel}-s]subagents`] : []),
+    '[/status]details',
+    `[Ctrl-C]${ctrlCAction}`,
+  ]);
+  if (fitsStatusBindings(compactBindings, maxColumns)) return compactBindings;
+
+  const minimalBindings = joinStatusBindings([
+    ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+    `[${modifierLabel}-p]tasks`,
+    `[Ctrl-C]${ctrlCAction}`,
+  ]);
+  if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
+
+  return `[Ctrl-C]${ctrlCAction}`;
+}
+
+function joinStatusBindings(bindings: readonly string[]): string {
   return bindings.join('  ');
+}
+
+function fitsStatusBindings(text: string, maxColumns: number | undefined) {
+  return maxColumns === undefined || stringWidth(text) <= maxColumns;
 }
 
 function foregroundBindingsText(ctrlCAction: CtrlCAction): string {
@@ -350,6 +378,9 @@ export function buildStatusBarDisplay(
               input.shortcutModifierLabel,
               input.shiftEnterNewline,
               input.ctrlCAction,
+              input.width === undefined
+                ? undefined
+                : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
             ),
   };
 }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -181,6 +181,57 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[Alt-1..9]focus');
   });
 
+  it('keeps critical controls visible in narrow subagent sessions', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 88_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 3,
+      activeProcesses: 1,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      width: 60,
+    });
+
+    expect(display.bindings).toBe('[Tab]streams  [Alt-p]tasks  [Ctrl-C]stop');
+    expect(display.bindings).toContain('[Ctrl-C]stop');
+  });
+
+  it('keeps status discoverable in narrow single-stream sessions', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      width: 50,
+    });
+
+    expect(display.bindings).toBe(
+      '[Alt-p]tasks  [/status]details  [Ctrl-C]exit',
+    );
+  });
+
   it('hides inactive global bindings while a foreground panel owns input', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary
- make CLI status-bar shortcut text width-aware
- fall back to compact bindings that keep task navigation and `[Ctrl-C]stop` visible in narrow subagent sessions
- make subagent TUI validator boot sentinels independent of `/status` when compact bindings omit it

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `TUI_VALIDATE_COLS=60 TUI_VALIDATE_ROWS=20 corepack pnpm --filter @texra-ai/cli run validate:tui subagents task-picker task-picker-parent-fallback`
- `corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format -- --log-level warn`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

Closes #4730

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only binding display and test/harness adjustments; no auth, data, or runtime behavior changes beyond what users see in the status bar.
> 
> **Overview**
> The CLI status bar now **shrinks shortcut hint text** based on available terminal width, stepping through full, compact, and minimal binding sets so **`[Ctrl-C]stop`/`exit`**, stream/task navigation, and (when space allows) **`[/status]details`** stay visible instead of being truncated away in narrow layouts.
> 
> The TUI harness **no longer boots on `[/status]details` by default**—it uses the **`◆`** marker—and subagent/task-picker scenarios explicitly wait for **`[Tab]streams`**, matching compact bindings that drop `/status` in tight columns. **Vitest** adds narrow-width cases for subagent and single-stream sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee126243046b914887a10a41fd7acb94db3d287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->