### PR TITLE
fix(cli): guard chat models and slash palette overflow

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -28,6 +28,7 @@ import { spawnSync } from 'node:child_process';
 
 const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
+const DOWN = ESC + '[B';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -63,6 +64,19 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],
     expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
+  },
+  {
+    name: 'slash-palette-overflow',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/', DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN],
+    frame: 'tail',
+    expect: [
+      '… 6 earlier',
+      '/status',
+      'Open the session status tabs',
+      '/exit',
+      'Exit the CLI session',
+    ],
   },
   {
     name: 'edit-approval',

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -20,28 +20,107 @@ export interface SlashPaletteProps {
   readonly onCancel: () => void;
 }
 
-const MAX_VISIBLE = 8;
+const MAX_VISIBLE_COMMANDS = 8;
 export const SLASH_PALETTE_ROWS = 13;
+
+export interface SlashPaletteWindow {
+  readonly start: number;
+  readonly end: number;
+  readonly hiddenBefore: number;
+  readonly hiddenAfter: number;
+}
+
+function clampHighlight(index: number, itemCount: number): number {
+  if (itemCount <= 0) return 0;
+  return Math.min(Math.max(index, 0), itemCount - 1);
+}
+
+export function nextSlashPaletteHighlight({
+  direction,
+  highlight,
+  itemCount,
+}: {
+  readonly direction: -1 | 1;
+  readonly highlight: number;
+  readonly itemCount: number;
+}): number {
+  if (itemCount <= 0) return 0;
+  const clamped = clampHighlight(highlight, itemCount);
+  if (direction === 1) return (clamped + 1) % itemCount;
+  return clamped <= 0 ? itemCount - 1 : clamped - 1;
+}
+
+export function slashPaletteWindow({
+  highlight,
+  itemCount,
+  maxVisibleCommands = MAX_VISIBLE_COMMANDS,
+}: {
+  readonly highlight: number;
+  readonly itemCount: number;
+  readonly maxVisibleCommands?: number;
+}): SlashPaletteWindow {
+  if (itemCount <= 0) {
+    return { start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 };
+  }
+
+  const visibleAtEdge = Math.min(Math.max(1, maxVisibleCommands), itemCount);
+  if (itemCount <= visibleAtEdge) {
+    return { start: 0, end: itemCount, hiddenBefore: 0, hiddenAfter: 0 };
+  }
+
+  const clamped = clampHighlight(highlight, itemCount);
+  if (clamped < visibleAtEdge) {
+    return {
+      start: 0,
+      end: visibleAtEdge,
+      hiddenBefore: 0,
+      hiddenAfter: itemCount - visibleAtEdge,
+    };
+  }
+
+  const bottomStart = itemCount - visibleAtEdge;
+  if (clamped >= bottomStart) {
+    return {
+      start: bottomStart,
+      end: itemCount,
+      hiddenBefore: bottomStart,
+      hiddenAfter: 0,
+    };
+  }
+
+  const visibleInMiddle = Math.max(1, visibleAtEdge - 1);
+  const centerOffset = Math.floor(visibleInMiddle / 2);
+  const start = Math.min(
+    Math.max(1, clamped - centerOffset),
+    itemCount - visibleInMiddle - 1,
+  );
+  const end = start + visibleInMiddle;
+  return {
+    start,
+    end,
+    hiddenBefore: start,
+    hiddenAfter: itemCount - end,
+  };
+}
 
 export function SlashPalette(
   props: SlashPaletteProps,
 ): React.JSX.Element | null {
   const matches = matchSlashCommands(props.query);
   const [highlight, setHighlight] = useState(0);
-  const visible = matches.slice(0, MAX_VISIBLE);
-  const visibleCount = visible.length;
+  const matchCount = matches.length;
 
   // Whenever the match list resizes (user kept typing), clamp the cursor
   // so it doesn't point past the end.
   useEffect(() => {
-    if (visibleCount === 0) {
+    if (matchCount === 0) {
       if (highlight !== 0) setHighlight(0);
       return;
     }
-    if (highlight < 0 || highlight >= visibleCount) {
-      setHighlight(Math.min(Math.max(highlight, 0), visibleCount - 1));
+    if (highlight < 0 || highlight >= matchCount) {
+      setHighlight(clampHighlight(highlight, matchCount));
     }
-  }, [visibleCount, highlight]);
+  }, [matchCount, highlight]);
 
   useInput(
     (input, key) => {
@@ -50,15 +129,27 @@ export function SlashPalette(
         return;
       }
       if (key.upArrow) {
-        setHighlight((h) => (h <= 0 ? visibleCount - 1 : h - 1));
+        setHighlight((h) =>
+          nextSlashPaletteHighlight({
+            direction: -1,
+            highlight: h,
+            itemCount: matchCount,
+          }),
+        );
         return;
       }
       if (key.downArrow) {
-        setHighlight((h) => (h + 1) % visibleCount);
+        setHighlight((h) =>
+          nextSlashPaletteHighlight({
+            direction: 1,
+            highlight: h,
+            itemCount: matchCount,
+          }),
+        );
         return;
       }
       if (isPlainReturnInput(input, key) || key.tab || input === '\t') {
-        const chosen = visible[highlight];
+        const chosen = matches[highlight];
         if (chosen) {
           props.onPick(
             chosen,
@@ -70,11 +161,12 @@ export function SlashPalette(
         }
       }
     },
-    { isActive: visibleCount > 0 },
+    { isActive: matchCount > 0 },
   );
 
-  if (visibleCount === 0) return null;
-  const truncated = matches.length - visible.length;
+  if (matchCount === 0) return null;
+  const window = slashPaletteWindow({ highlight, itemCount: matchCount });
+  const visible = matches.slice(window.start, window.end);
 
   return (
     <Box
@@ -83,15 +175,23 @@ export function SlashPalette(
       flexDirection="column"
       paddingX={1}
     >
-      {visible.map((cmd, i) => (
-        <Box key={cmd.name}>
-          <Text color={i === highlight ? 'cyan' : undefined}>
-            {i === highlight ? '›' : ' '} /{cmd.name}
-          </Text>
-          <Text dimColor>{`  ${cmd.description}`}</Text>
-        </Box>
-      ))}
-      {truncated > 0 ? <Text dimColor>{`  … ${truncated} more`}</Text> : null}
+      {window.hiddenBefore > 0 ? (
+        <Text dimColor>{`  … ${window.hiddenBefore} earlier`}</Text>
+      ) : null}
+      {visible.map((cmd, offset) => {
+        const i = window.start + offset;
+        return (
+          <Box key={cmd.name}>
+            <Text color={i === highlight ? 'cyan' : undefined}>
+              {i === highlight ? '›' : ' '} /{cmd.name}
+            </Text>
+            <Text dimColor>{`  ${cmd.description}`}</Text>
+          </Box>
+        );
+      })}
+      {window.hiddenAfter > 0 ? (
+        <Text dimColor>{`  … ${window.hiddenAfter} more`}</Text>
+      ) : null}
       <Box marginTop={1}>
         <KeyHints
           hints={[

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -400,9 +400,14 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     visibleOutput.length === 0 &&
     !patchGroups &&
     !toolUse.isError;
+  const hasDetails =
+    visibleOutput.length > 0 ||
+    (patchGroups?.length ?? 0) > 0 ||
+    toolUse.isError ||
+    showNoOutput;
 
   return (
-    <Box flexDirection="column" marginBottom={1}>
+    <Box flexDirection="column" marginBottom={hasDetails ? 1 : 0}>
       <Box flexDirection="row" flexWrap="nowrap">
         <Text color={color} dimColor={!color}>
           {STATUS_DOT}{' '}

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -21,7 +21,8 @@ export function estimateTranscriptEntryRows(
   width = 80,
 ): number {
   if (entry.role === 'tool' && entry.toolUse) {
-    return toolUseDisplayLines(entry.toolUse).length + 1;
+    const lines = toolUseDisplayLines(entry.toolUse);
+    return lines.length + (lines.length > 1 ? 1 : 0);
   }
   if (entry.role === 'process' && entry.process) {
     return Math.max(1, completedProcessDisplayLines(entry.process).length) + 1;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -39,6 +39,7 @@ import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
+import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr } from '@cli/runtime/logSinks';
 import {
@@ -277,6 +278,25 @@ async function applyInitialCliModelSelection(
   }
 }
 
+async function reconcileRootModelAfterApiModeChange(
+  context: SlashCommandContext | undefined,
+): Promise<string | undefined> {
+  if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
+
+  const currentModel = cliState.sessionMeta.get().model;
+  const resolution = await resolveCliRunnableModel(currentModel, {
+    allowFallback: true,
+  });
+  if (resolution.model === currentModel) return undefined;
+
+  await setCliHelperModel(resolution.model);
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    model: resolution.model,
+  });
+  return resolution.notice;
+}
+
 function openCliModelListForm(context: SlashCommandContext): void {
   const selectable = chatTuiCanStartRootRun(context.session);
   cliState.activeForm.set({
@@ -298,6 +318,7 @@ function openCliModelListForm(context: SlashCommandContext): void {
 
 async function applyCliApiModeSelection(
   mode: string | CliApiMode,
+  context?: SlashCommandContext,
 ): Promise<void> {
   const normalized = mode.trim().toLowerCase();
 
@@ -312,12 +333,21 @@ async function applyCliApiModeSelection(
   const apiMode = parseCliApiMode(normalized);
   if (apiMode) {
     await setCliApiMode(apiMode);
+    let modelNotice: string | undefined;
+    try {
+      modelNotice = await reconcileRootModelAfterApiModeChange(context);
+    } catch (error: unknown) {
+      modelNotice = toErrorMessage(error);
+    }
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       apiMode,
     });
     appendLocalAssistantTranscript(
-      `API mode set to ${formatCliApiMode(apiMode)}.`,
+      [
+        `API mode set to ${formatCliApiMode(apiMode)}.`,
+        ...(modelNotice ? [modelNotice] : []),
+      ].join('\n'),
     );
     return;
   }
@@ -539,11 +569,11 @@ async function handleTuiSlashCommand(
       return true;
     case 'api':
       if (!rest) {
-        openCliApiModeForm(applyCliApiModeSelection);
+        openCliApiModeForm((mode) => applyCliApiModeSelection(mode, context));
         return true;
       }
       try {
-        await applyCliApiModeSelection(rest);
+        await applyCliApiModeSelection(rest, context);
       } catch (error: unknown) {
         appendLocalAssistantTranscript(toErrorMessage(error));
       }
@@ -669,7 +699,20 @@ export async function runChat(
     envAgent: context.envAgent,
     envModel: context.envModel,
   });
-  const { agent, model } = defaults;
+  const explicitModelRequested = Boolean(
+    init.modelOverride?.trim() || context.envModel?.trim(),
+  );
+  let modelResolution: Awaited<ReturnType<typeof resolveCliRunnableModel>>;
+  try {
+    modelResolution = await resolveCliRunnableModel(defaults.model, {
+      allowFallback: !explicitModelRequested,
+    });
+  } catch (error: unknown) {
+    writeTextStderr(toErrorMessage(error));
+    return { exitCode: CliExitCode.Usage };
+  }
+  const { agent } = defaults;
+  const model = modelResolution.model;
   await setCliHelperModel(model);
   const version = await readCliVersion();
 
@@ -710,6 +753,9 @@ export async function runChat(
     teamName: init.teamName,
     version,
   });
+  if (modelResolution.notice) {
+    appendLocalAssistantTranscript(modelResolution.notice);
+  }
 
   const inputHistory = await loadInputHistory();
 
@@ -886,7 +932,8 @@ export async function runChat(
     canSelectModel: () => chatTuiCanStartRootRun(session),
     onModelSelect: (nextModel) =>
       applyInitialCliModelSelection(nextModel, slashCommandContext()),
-    onApiModeSelect: applyCliApiModeSelection,
+    onApiModeSelect: (nextMode) =>
+      applyCliApiModeSelection(nextMode, slashCommandContext()),
     onMemorySelect: showCliMemoryPreview,
     onMemoryError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { MODEL_CONFIGS } from 'llm-zoo';
+
 // Local imports - model surfaces
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
@@ -6,6 +9,11 @@ export interface CliModelAccess {
   readonly model: ModelOptionData;
   readonly available: boolean;
   readonly status: string;
+}
+
+export interface CliRunnableModelResolution {
+  readonly model: string;
+  readonly notice?: string;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
@@ -29,4 +37,106 @@ function toCliModelAccess(model: ModelOptionData): CliModelAccess {
 export async function getCliModelAccessList(): Promise<CliModelAccess[]> {
   const models = await computeModelOptionsData();
   return models.map(toCliModelAccess);
+}
+
+function findModelAccess(
+  models: readonly CliModelAccess[],
+  model: string,
+): CliModelAccess | undefined {
+  const exact = models.find((entry) => entry.model.value === model);
+  if (exact) return exact;
+
+  const lower = model.toLowerCase();
+  return models.find((entry) => entry.model.value.toLowerCase() === lower);
+}
+
+function availableModelIds(models: readonly CliModelAccess[]): string[] {
+  return models
+    .filter((entry) => entry.available)
+    .map((entry) => entry.model.value);
+}
+
+function withModelAccess(
+  models: readonly CliModelAccess[],
+  entry: CliModelAccess | undefined,
+): readonly CliModelAccess[] {
+  if (!entry || findModelAccess(models, entry.model.value)) return models;
+  return [...models, entry];
+}
+
+function getCanonicalModelConfigId(model: string): string | undefined {
+  if (Object.hasOwn(MODEL_CONFIGS, model)) return model;
+
+  const lower = model.toLowerCase();
+  return Object.keys(MODEL_CONFIGS).find((id) => id.toLowerCase() === lower);
+}
+
+function formatAvailableModels(ids: readonly string[]): string {
+  if (ids.length > 0) return `Available models: ${ids.join(', ')}.`;
+  return 'No models are currently available. Run `texra login`, switch API mode, or configure a provider API key.';
+}
+
+function formatUnavailableModelMessage(
+  model: string,
+  entry: CliModelAccess | undefined,
+  availableIds: readonly string[],
+): string {
+  const status = entry ? ` (${entry.status})` : '';
+  return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds)}`;
+}
+
+export function resolveCliRunnableModelFromAccessList(
+  models: readonly CliModelAccess[],
+  model: string,
+  options: { readonly allowFallback: boolean },
+): CliRunnableModelResolution {
+  const trimmed = model.trim();
+  const entry = findModelAccess(models, trimmed);
+  if (entry?.available) return { model: entry.model.value };
+
+  const availableIds = availableModelIds(models);
+  const unavailableMessage = formatUnavailableModelMessage(
+    trimmed,
+    entry,
+    availableIds,
+  );
+  if (!options.allowFallback || availableIds.length === 0) {
+    throw new Error(unavailableMessage);
+  }
+
+  const fallback = availableIds[0]!;
+  return {
+    model: fallback,
+    notice: `${unavailableMessage} Using "${fallback}" instead.`,
+  };
+}
+
+export async function resolveCliRunnableModel(
+  model: string,
+  options: { readonly allowFallback: boolean },
+): Promise<CliRunnableModelResolution> {
+  const models = await getCliModelAccessList();
+  const trimmed = model.trim();
+  const hiddenModelId =
+    trimmed && !findModelAccess(models, trimmed)
+      ? getCanonicalModelConfigId(trimmed)
+      : undefined;
+  let hiddenModel: CliModelAccess | undefined;
+  if (hiddenModelId != null) {
+    const hiddenModelOption = (
+      await computeModelOptionsData([hiddenModelId])
+    )[0];
+    if (!hiddenModelOption) {
+      throw new Error(
+        `Model "${hiddenModelId}" is configured but has no option data.`,
+      );
+    }
+    hiddenModel = toCliModelAccess(hiddenModelOption);
+  }
+
+  return resolveCliRunnableModelFromAccessList(
+    withModelAccess(models, hiddenModel),
+    trimmed,
+    options,
+  );
 }

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveCliRunnableModel,
+  resolveCliRunnableModelFromAccessList,
+  type CliModelAccess,
+} from '@cli/runtime/modelAccess';
+import { computeModelOptionsData } from '@model/computeModelOptions';
+import type { ModelOptionData } from '@shared/schemas';
+
+vi.mock('@model/computeModelOptions', () => ({
+  computeModelOptionsData: vi.fn(),
+}));
+
+vi.mock('llm-zoo', () => ({
+  MODEL_CONFIGS: {
+    hiddenFixtureModel: {},
+  },
+}));
+
+const computeModelOptionsDataMock = vi.mocked(computeModelOptionsData);
+
+function model(
+  value: string,
+  overrides: Partial<CliModelAccess> = {},
+): CliModelAccess {
+  return {
+    model: { value, label: value },
+    available: true,
+    status: 'available',
+    ...overrides,
+  };
+}
+
+describe('CLI model access resolution', () => {
+  beforeEach(() => {
+    computeModelOptionsDataMock.mockReset();
+  });
+
+  it('keeps the requested model when it is currently runnable', () => {
+    expect(
+      resolveCliRunnableModelFromAccessList(
+        [model('sonnet46T'), model('opus48T')],
+        'opus48T',
+        { allowFallback: false },
+      ),
+    ).toEqual({ model: 'opus48T' });
+  });
+
+  it('rejects an explicit model that is unavailable in the active API mode', () => {
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('sonnet46T'),
+          model('opus48T', { available: false, status: 'not included' }),
+        ],
+        'opus48T',
+        { allowFallback: false },
+      ),
+    ).toThrow(
+      'Model "opus48T" is not available in the active API mode (not included). Available models: sonnet46T.',
+    );
+  });
+
+  it('falls back from stale defaults to the first currently runnable model', () => {
+    expect(
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('opus48T', { available: false, status: 'not included' }),
+          model('deepseekT'),
+          model('sonnet46T'),
+        ],
+        'opus48T',
+        { allowFallback: true },
+      ),
+    ).toEqual({
+      model: 'deepseekT',
+      notice:
+        'Model "opus48T" is not available in the active API mode (not included). Available models: deepseekT, sonnet46T. Using "deepseekT" instead.',
+    });
+  });
+
+  it('reports when no fallback model is runnable', () => {
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(
+        [model('gemini31p', { available: false, status: 'missing api key' })],
+        'gemini31p',
+        { allowFallback: true },
+      ),
+    ).toThrow(
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available.',
+    );
+  });
+
+  it('checks access for explicit models hidden from the visible model list', async () => {
+    computeModelOptionsDataMock
+      .mockResolvedValueOnce([
+        modelOption('sonnet46T', { availabilityLabel: 'Included access' }),
+      ])
+      .mockResolvedValueOnce([
+        modelOption('hiddenFixtureModel', { availabilityLabel: 'API key set' }),
+      ]);
+
+    await expect(
+      resolveCliRunnableModel('HIDDENFIXTUREMODEL', { allowFallback: false }),
+    ).resolves.toEqual({ model: 'hiddenFixtureModel' });
+    expect(computeModelOptionsDataMock).toHaveBeenNthCalledWith(2, [
+      'hiddenFixtureModel',
+    ]);
+  });
+
+  it('reports stale hidden model configuration directly', async () => {
+    computeModelOptionsDataMock
+      .mockResolvedValueOnce([
+        modelOption('sonnet46T', { availabilityLabel: 'Included access' }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await expect(
+      resolveCliRunnableModel('hiddenFixtureModel', { allowFallback: false }),
+    ).rejects.toThrow(
+      'Model "hiddenFixtureModel" is configured but has no option data.',
+    );
+  });
+});
+
+function modelOption(
+  value: string,
+  overrides: Partial<ModelOptionData> = {},
+): ModelOptionData {
+  return {
+    value,
+    label: value,
+    ...overrides,
+  };
+}

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  nextSlashPaletteHighlight,
+  slashPaletteWindow,
+} from '@cli/chat/tui/commands/SlashPalette';
+
+describe('SlashPalette navigation', () => {
+  it('continues down into commands hidden behind the overflow marker', () => {
+    const itemCount = 14;
+    expect(
+      slashPaletteWindow({
+        highlight: 7,
+        itemCount,
+        maxVisibleCommands: 8,
+      }),
+    ).toEqual({
+      start: 0,
+      end: 8,
+      hiddenBefore: 0,
+      hiddenAfter: 6,
+    });
+
+    const next = nextSlashPaletteHighlight({
+      direction: 1,
+      highlight: 7,
+      itemCount,
+    });
+
+    expect(next).toBe(8);
+    expect(
+      slashPaletteWindow({
+        highlight: next,
+        itemCount,
+        maxVisibleCommands: 8,
+      }),
+    ).toEqual({
+      start: 6,
+      end: 14,
+      hiddenBefore: 6,
+      hiddenAfter: 0,
+    });
+  });
+
+  it('wraps navigation across the full match list', () => {
+    expect(
+      nextSlashPaletteHighlight({
+        direction: 1,
+        highlight: 13,
+        itemCount: 14,
+      }),
+    ).toBe(0);
+    expect(
+      nextSlashPaletteHighlight({
+        direction: -1,
+        highlight: 0,
+        itemCount: 14,
+      }),
+    ).toBe(13);
+  });
+});

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -912,6 +912,29 @@ describe('CLI transcript state', () => {
     expect(estimateTranscriptEntryRows(entry, width)).toBe(renderedRows + 1);
   });
 
+  it('does not reserve spacer rows for compact one-line tool calls', () => {
+    const entry = {
+      id: 'empty-tool',
+      role: 'tool',
+      text: '',
+      finalized: false,
+      toolUse: {
+        parsed: {},
+        toolName: 'executions',
+        errorText: '',
+        outputText: '',
+        userInstructionText: '',
+        input: { path: '/executions/3a780a389327/report' },
+        isError: false,
+        isUserFeedback: false,
+        headerSummary: '',
+        status: 'completed',
+      },
+    } as const;
+
+    expect(estimateTranscriptEntryRows(entry, 80)).toBe(1);
+  });
+
   it('keeps pending transcript rows within their viewport budget', () => {
     const pending = [
       {


### PR DESCRIPTION
## Summary
- resolve the chat root model against current CLI model access before mounting the TUI
- fail explicit unavailable models with the active-mode available model list instead of letting the first request hit a tier error
- fall back stale defaults and pre-run /api switches to the first runnable model, with an inline notice
- let the slash-command palette navigate into overflowed commands while keeping the prompt/palette height stable
- keep empty-detail tool rows compact so repeated `executions (...)` rows do not reserve blank spacer rows

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/SlashPalette.vitest.mts src/test-kernel/tools/DelegationModelAvailability.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts
- npm run format
- npm run compile:safe
- npm run lint (passes with 3 pre-existing import-order warnings)
- npm run texra-local:build
- corepack pnpm --filter @texra-ai/cli validate:tui slash-palette-overflow
- corepack pnpm --filter @texra-ai/cli validate:tui
- TERM=xterm-256color texra-local chat --api-mode=included --model opus48T
- TERM=xterm-256color texra-local chat --api-mode=personal --model opus48T, then /api included and /status in a TTY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which model runs at chat start and after API mode switches (user-visible, tier/auth sensitive) but is covered by dedicated resolution tests and manual validation; palette and layout tweaks are lower impact.
> 
> **Overview**
> The CLI now **resolves the chat root model against current API-mode access** before the TUI mounts: explicit `--model` / env choices that are unavailable fail early with a list of runnable models; stale defaults can **fall back** to the first available model with an inline transcript notice. **`/api` switches** (form or slash) run the same reconciliation when no run is active and append any model-change notice to the assistant transcript.
> 
> The **slash-command palette** no longer caps navigation to the first eight matches—it uses a sliding window with **“… N earlier” / “… N more”** markers so ↑/↓ can reach every command while keeping a fixed visible row budget; a **validate-tui** scenario covers overflow scrolling.
> 
> Minor TUI layout fixes: **one-line tool rows** skip extra bottom margin and **transcript row estimates** omit a spacer row when a tool call has only a header line, freeing viewport space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909243c4b9d871cb3e38bb887595c62f6782f4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->