### PR TITLE
docs(site): template-var palette + migration split, dedup terminal chrome

### DIFF
--- a/docs/.vitepress/components/CliChatHero.vue
+++ b/docs/.vitepress/components/CliChatHero.vue
@@ -34,11 +34,11 @@ const calls = [
 <template>
   <div class="mockup cli-chat" role="group" aria-label="texra chat session">
     <!-- Faux terminal titlebar: traffic-light dots + window title -->
-    <div class="cc-bar">
-      <span class="cc-light cc-light--r"></span>
-      <span class="cc-light cc-light--y"></span>
-      <span class="cc-light cc-light--g"></span>
-      <span class="cc-title">texra chat</span>
+    <div class="mk-term-bar">
+      <span class="mk-term-light mk-term-light--r"></span>
+      <span class="mk-term-light mk-term-light--y"></span>
+      <span class="mk-term-light mk-term-light--g"></span>
+      <span class="mk-term-title">texra chat</span>
     </div>
 
     <div class="cc-body">
@@ -123,36 +123,7 @@ const calls = [
   font-family: var(--vp-font-family-base);
 }
 
-/* Titlebar */
-.cc-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--mk-space-6);
-  padding: var(--mk-space-7) var(--mk-space-12);
-  background: var(--mk-bg-soft);
-  border-bottom: 1px solid var(--mk-border);
-}
-.cc-light {
-  width: var(--mk-space-9);
-  height: var(--mk-space-9);
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.cc-light--r {
-  background: var(--color-error);
-}
-.cc-light--y {
-  background: var(--color-warning);
-}
-.cc-light--g {
-  background: var(--color-success);
-}
-.cc-title {
-  margin-left: var(--mk-space-7);
-  font-family: var(--vp-font-family-mono);
-  font-size: var(--mk-fs-72);
-  color: var(--mk-text-faint);
-}
+/* Titlebar comes from the shared `.mk-term-*` classes in theme/mockup.css. */
 
 /* Terminal body */
 .cc-body {

--- a/docs/.vitepress/components/CliToolsListHero.vue
+++ b/docs/.vitepress/components/CliToolsListHero.vue
@@ -53,11 +53,11 @@ const rows = [
 <template>
   <div class="mockup ctl" role="group" aria-label="texra tools list output">
     <!-- Faux terminal titlebar -->
-    <div class="ctl-bar">
-      <span class="ctl-light ctl-light--r"></span>
-      <span class="ctl-light ctl-light--y"></span>
-      <span class="ctl-light ctl-light--g"></span>
-      <span class="ctl-title">texra tools list</span>
+    <div class="mk-term-bar">
+      <span class="mk-term-light mk-term-light--r"></span>
+      <span class="mk-term-light mk-term-light--y"></span>
+      <span class="mk-term-light mk-term-light--g"></span>
+      <span class="mk-term-title">texra tools list</span>
     </div>
 
     <div class="ctl-body">
@@ -113,36 +113,7 @@ const rows = [
   font-family: var(--vp-font-family-base);
 }
 
-/* Titlebar (mirrors CliChatHero) */
-.ctl-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--mk-space-6);
-  padding: var(--mk-space-7) var(--mk-space-12);
-  background: var(--mk-bg-soft);
-  border-bottom: 1px solid var(--mk-border);
-}
-.ctl-light {
-  width: var(--mk-space-9);
-  height: var(--mk-space-9);
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.ctl-light--r {
-  background: var(--color-error);
-}
-.ctl-light--y {
-  background: var(--color-warning);
-}
-.ctl-light--g {
-  background: var(--color-success);
-}
-.ctl-title {
-  margin-left: var(--mk-space-7);
-  font-family: var(--vp-font-family-mono);
-  font-size: var(--mk-fs-72);
-  color: var(--mk-text-faint);
-}
+/* Titlebar comes from the shared `.mk-term-*` classes in theme/mockup.css. */
 
 /* Body */
 .ctl-body {

--- a/docs/.vitepress/components/DesktopMigrationSplit.vue
+++ b/docs/.vitepress/components/DesktopMigrationSplit.vue
@@ -1,0 +1,121 @@
+<script setup>
+// Frameless two-column split for guide/desktop-migration.md. The page draws the
+// key distinction twice in prose — "What Carries Over" vs "What To Reconfigure"
+// — as two flat bullet lists the reader has to hold side by side in their head.
+// Rendering them as a literal side-by-side comparison makes the boundary the
+// figure itself: anything that lives in the project folder or on the machine
+// follows you (green, no action); anything the extension host stored privately
+// must be set again in the desktop app (amber, reconfigure).
+//
+// Card shell + inline mono header come by COMPOSITION from <MockCard>, and the
+// header state badge from <StatusPill>, so the `--mk-*` colour + dimensional
+// tokens resolve here and the split flips cleanly between the docs light / dark
+// themes. Each row carries its own category glyph rather than a uniform check,
+// so the figure stays scannable as a map of what moves where.
+import MockCard from './MockCard.vue';
+import StatusPill from './StatusPill.vue';
+
+// Carries over because it lives outside the VS Code extension host.
+const carries = [
+  { icon: 'file-lines', text: 'Manuscript source & repository history' },
+  { icon: 'file-code', text: 'Workspace .env files, if you keep keys there' },
+  {
+    icon: 'screwdriver-wrench',
+    text: 'System tools — LaTeX, Perl, Git, Ghostscript',
+  },
+  { icon: 'robot', text: 'Project-local custom agent YAML' },
+  { icon: 'users', text: 'Committed team config (.latexindent.yaml, …)' },
+];
+
+// Stored privately by the extension host — re-enter it in the desktop app.
+const reconfigure = [
+  { icon: 'key', text: 'Provider API keys — Models tab' },
+  { icon: 'right-to-bracket', text: 'TeXRA / remote-agent sign-in' },
+  { icon: 'code-branch', text: 'GitHub token for PR & issue tools' },
+  { icon: 'gear', text: 'Agent visibility, model list, tool approvals' },
+  { icon: 'wrench', text: 'LaTeX settings stored only in VS Code' },
+  { icon: 'clock-rotate-left', text: 'Execution history & task archives' },
+];
+</script>
+
+<template>
+  <div
+    class="mockup dm-split"
+    role="group"
+    aria-label="Desktop migration: what carries over vs what to reconfigure"
+  >
+    <MockCard class="dm-keep" icon="check-double" title="Carries over">
+      <template #head>
+        <StatusPill class="dm-tag" variant="success" shape="pill"
+          >no action</StatusPill
+        >
+      </template>
+      <div class="dm-rows">
+        <div v-for="(r, i) in carries" :key="i" class="dm-row">
+          <wa-icon class="dm-ic" library="texra" :name="r.icon"></wa-icon>
+          <span class="dm-tx">{{ r.text }}</span>
+        </div>
+      </div>
+    </MockCard>
+
+    <MockCard class="dm-redo" icon="arrows-rotate" title="Reconfigure">
+      <template #head>
+        <StatusPill class="dm-tag" variant="warning" shape="pill"
+          >set again</StatusPill
+        >
+      </template>
+      <div class="dm-rows">
+        <div v-for="(r, i) in reconfigure" :key="i" class="dm-row">
+          <wa-icon class="dm-ic" library="texra" :name="r.icon"></wa-icon>
+          <span class="dm-tx">{{ r.text }}</span>
+        </div>
+      </div>
+    </MockCard>
+  </div>
+</template>
+
+<style scoped>
+.dm-split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--mk-space-12);
+  margin: var(--mk-space-16) 0;
+  font-family: var(--vp-font-family-base);
+}
+@media (max-width: 640px) {
+  .dm-split {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.dm-tag {
+  margin-left: auto;
+}
+.dm-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-3);
+  margin-top: var(--mk-space-4);
+}
+.dm-row {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-8);
+  padding: var(--mk-space-2) 0;
+}
+.dm-ic {
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: var(--mk-space-12);
+}
+/* Two-tone leading glyphs: green = follows you, amber = set it again. */
+.dm-keep .dm-ic {
+  color: var(--color-success);
+}
+.dm-redo .dm-ic {
+  color: var(--color-warning);
+}
+.dm-tx {
+  color: var(--mk-text-dim);
+  min-width: 0;
+}
+</style>

--- a/docs/.vitepress/components/StatusDotLegend.vue
+++ b/docs/.vitepress/components/StatusDotLegend.vue
@@ -79,7 +79,7 @@ const states = [
 }
 /* Only the Running dot animates — same intent as the live .sh-dot. */
 .sdl-dot.sdl-pulse {
-  box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.6);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
   animation: mk-shpulse 1.8s infinite;
 }
 .sdl-label {

--- a/docs/.vitepress/components/TemplateVarsPalette.vue
+++ b/docs/.vitepress/components/TemplateVarsPalette.vue
@@ -1,0 +1,172 @@
+<script setup>
+// Frameless template-variable palette for guide/custom-agents.md's "Using
+// Variables in Prompts" section. The source prose enumerates the built-in Jinja2
+// variables as two flat bullet lists, which buries the naming convention that
+// actually makes them memorable: `*_FILE` is a path, `*_CONTENT` is that file's
+// text, `ALL_*` is every selected file as one XML bundle, and `LIST_OF_*` is the
+// same set as a comma-separated path list. Rendering them as grouped mono token
+// chips — each tagged with its kind — turns the namespace into a map the reader
+// scans once instead of parsing twelve bullets.
+//
+// Card shell + inline mono header come by COMPOSITION from <MockCard>, and the
+// per-row kind chip from <StatusPill>, so the `--mk-*` colour + dimensional
+// tokens resolve here and the palette flips cleanly between the docs light / dark
+// themes. Tokens are stored as plain strings (`{{ … }}` in the DATA, not the
+// template markup) so Vue renders the braces literally instead of interpolating.
+import MockCard from './MockCard.vue';
+import StatusPill from './StatusPill.vue';
+
+// kind → StatusPill variant: path=blue, text=neutral, xml=purple, csv=green.
+// The kind label is the lesson — it teaches the *_FILE / *_CONTENT / ALL_ /
+// LIST_OF_ convention at a glance.
+const groups = [
+  {
+    label: 'One selected file',
+    vars: [
+      {
+        token: '{{ INSTRUCTION }}',
+        kind: 'text',
+        gloss: 'What you typed in the Instruction box',
+      },
+      { token: '{{ INPUT_FILE }}', kind: 'path', gloss: 'Primary input file' },
+      {
+        token: '{{ INPUT_CONTENT }}',
+        kind: 'text',
+        gloss: 'Text of the primary input file',
+      },
+      {
+        token: '{{ CONTEXT_FILE }}',
+        kind: 'path',
+        gloss: 'Primary context file',
+      },
+      {
+        token: '{{ CONTEXT_CONTENT }}',
+        kind: 'text',
+        gloss: 'Text of the primary context file',
+      },
+      {
+        token: '{{ EDITED_FILE }}',
+        kind: 'path',
+        gloss: 'Edited file (used in merge)',
+      },
+      {
+        token: '{{ EDITED_CONTENT }}',
+        kind: 'text',
+        gloss: 'Text of the edited file',
+      },
+      {
+        token: '{{ MEDIA_FILE }}',
+        kind: 'path',
+        gloss: 'Primary media file — content sent separately',
+      },
+    ],
+  },
+  {
+    label: 'Every selected file',
+    vars: [
+      {
+        token: '{{ ALL_INPUTS }}',
+        kind: 'xml',
+        gloss: 'All inputs wrapped in <document> tags',
+      },
+      {
+        token: '{{ ALL_CONTEXTS }}',
+        kind: 'xml',
+        gloss: 'All context files as the same XML',
+      },
+      {
+        token: '{{ LIST_OF_ALL_INPUTS }}',
+        kind: 'csv',
+        gloss: 'Comma-separated input paths',
+      },
+      {
+        token: '{{ LIST_OF_ALL_CONTEXTS }}',
+        kind: 'csv',
+        gloss: 'Comma-separated context paths',
+      },
+    ],
+  },
+];
+
+const KIND_VARIANT = {
+  path: 'info',
+  text: 'neutral',
+  xml: 'accent',
+  csv: 'success',
+};
+</script>
+
+<template>
+  <MockCard class="tv" icon="symbol-variable" title="Built-in prompt variables">
+    <div v-for="(g, gi) in groups" :key="gi" class="tv-group">
+      <div class="tv-glabel">{{ g.label }}</div>
+      <div class="tv-rows">
+        <div v-for="(v, i) in g.vars" :key="i" class="tv-row">
+          <code class="tv-token">{{ v.token }}</code>
+          <StatusPill
+            class="tv-kind"
+            :variant="KIND_VARIANT[v.kind]"
+            shape="chip"
+            >{{ v.kind }}</StatusPill
+          >
+          <span class="tv-gloss">{{ v.gloss }}</span>
+        </div>
+      </div>
+    </div>
+  </MockCard>
+</template>
+
+<style scoped>
+.tv-group + .tv-group {
+  margin-top: var(--mk-space-12);
+}
+.tv-glabel {
+  font-family: var(--vp-font-family-base);
+  font-size: var(--mk-fs-66);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--mk-space-6);
+}
+.tv-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-3);
+}
+.tv-row {
+  display: grid;
+  grid-template-columns: minmax(0, max-content) auto 1fr;
+  align-items: center;
+  gap: var(--mk-space-8);
+  padding: var(--mk-space-2) 0;
+}
+.tv-token {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-76);
+  color: var(--mk-accent);
+  background: color-mix(in srgb, var(--mk-accent) 10%, transparent);
+  border: 1px solid var(--mk-border-soft);
+  border-radius: var(--mk-radius-sm);
+  padding: 0 var(--mk-space-6);
+  white-space: nowrap;
+}
+.tv-kind {
+  justify-self: start;
+}
+.tv-gloss {
+  font-family: var(--vp-font-family-base);
+  font-size: var(--mk-fs-76);
+  color: var(--color-text-secondary);
+  min-width: 0;
+}
+/* Stack token + gloss on narrow screens; the kind chip rides with the token. */
+@media (max-width: 560px) {
+  .tv-row {
+    grid-template-columns: 1fr auto;
+  }
+  .tv-gloss {
+    grid-column: 1 / -1;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -32,6 +32,8 @@ import ToolCallPanel from '../components/ToolCallPanel.vue';
 import FeatureCards from '../components/FeatureCards.vue';
 import DropdownMenu from '../components/DropdownMenu.vue';
 import FlowSteps from '../components/FlowSteps.vue';
+import DesktopMigrationSplit from '../components/DesktopMigrationSplit.vue';
+import TemplateVarsPalette from '../components/TemplateVarsPalette.vue';
 
 let waRegistered = false;
 
@@ -107,6 +109,8 @@ export default {
     app.component('FeatureCards', FeatureCards);
     app.component('DropdownMenu', DropdownMenu);
     app.component('FlowSteps', FlowSteps);
+    app.component('DesktopMigrationSplit', DesktopMigrationSplit);
+    app.component('TemplateVarsPalette', TemplateVarsPalette);
 
     // Side-effects (client only): load WA components + register the texra icon
     // library, and keep the WA color scheme in sync with the docs theme.

--- a/docs/.vitepress/theme/mockup.css
+++ b/docs/.vitepress/theme/mockup.css
@@ -519,6 +519,42 @@
   flex-shrink: 0;
 }
 
+/* ============================================
+   TERMINAL TITLEBAR (faux macOS window chrome)
+   Traffic-light dots + a mono window title, shared by the standalone terminal
+   cards (CliChatHero, CliToolsListHero) so the chrome is defined once. Consumers
+   keep only their own card shell (border / radius / body padding).
+   ============================================ */
+.mockup .mk-term-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-6);
+  padding: var(--mk-space-7) var(--mk-space-12);
+  background: var(--mk-bg-soft);
+  border-bottom: 1px solid var(--mk-border);
+}
+.mockup .mk-term-light {
+  width: var(--mk-space-9);
+  height: var(--mk-space-9);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.mockup .mk-term-light--r {
+  background: var(--color-error);
+}
+.mockup .mk-term-light--y {
+  background: var(--color-warning);
+}
+.mockup .mk-term-light--g {
+  background: var(--color-success);
+}
+.mockup .mk-term-title {
+  margin-left: var(--mk-space-7);
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-72);
+  color: var(--mk-text-faint);
+}
+
 /* Code / terminal output surface (editor body) */
 .mockup .surface {
   flex: 1;
@@ -833,7 +869,7 @@
   border-radius: 50%;
   background: var(--color-success);
   flex-shrink: 0;
-  box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.6);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
   animation: mk-shpulse 1.8s infinite;
 }
 .mockup .sh-badge {
@@ -1086,13 +1122,15 @@
 }
 @keyframes mk-shpulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.5);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--color-success) 50%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 5px rgba(63, 185, 80, 0);
+    box-shadow: 0 0 0 5px
+      color-mix(in srgb, var(--color-success) 0%, transparent);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(63, 185, 80, 0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 0%, transparent);
   }
 }
 @keyframes mk-blink {

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -128,25 +128,16 @@ Prompts are processed using the Jinja2 templating engine, allowing you to insert
 
 This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `{{ INPUT_CONTENT }}` while the full list of selected files can be accessed through `{{ ALL_INPUTS }}`. When you run the agent these placeholders are replaced with real data.
 
-**Common Variables:**
+<TemplateVarsPalette />
 
-- &#123;&#123; INSTRUCTION &#125;&#125;: The text entered into the "Instruction" box in the UI.
-- &#123;&#123; INPUT_FILE &#125;&#125;: The path of the primary input file.
-- &#123;&#123; INPUT_CONTENT &#125;&#125;: The full text content of the primary input file.
-- &#123;&#123; CONTEXT_FILE &#125;&#125;: Path of the primary context file.
-- &#123;&#123; CONTEXT_CONTENT &#125;&#125;: Content of the primary context file.
-- &#123;&#123; EDITED_FILE &#125;&#125;: Path of the edited file (used in `merge`).
-- &#123;&#123; EDITED_CONTENT &#125;&#125;: Content of the edited file.
-- &#123;&#123; MEDIA_FILE &#125;&#125;: Path of the primary media file.
-  \_Note: Media content itself isn't directly inserted as text; it's handled separately for multimodal models. See [Working with Figures](./working-with-figures.md).\*
-
-**Multiple File Variables:**
-
-- &#123;&#123; ALL_INPUTS &#125;&#125;: XML string containing all selected input files (primary + multiple) wrapped in `<document name="...">...</document>` tags.
-- &#123;&#123; ALL_CONTEXTS &#125;&#125;: Similar XML string for all context files (the read-only context category that combines what used to be split into "reference" and "auxiliary").
-- &#123;&#123; LIST_OF_ALL_INPUTS &#125;&#125;: Simple comma-separated string listing all input file paths.
-- &#123;&#123; LIST_OF_ALL_CONTEXTS &#125;&#125;: Similar comma-separated list for context files.
-- Legacy custom agents can still read `REFERENCE_*` and `AUXILIARY_*` aliases, but new agents should use `CONTEXT_*`.
+The naming follows one rule: `*_FILE` gives you a path, `*_CONTENT` gives you
+that file's text, `ALL_*` bundles every selected file into one
+`<document name="...">…</document>` XML string, and `LIST_OF_*` gives the same
+set as a comma-separated path list. Media is the exception — `MEDIA_FILE` is a
+path, but the media itself is sent to multimodal models separately rather than
+inlined as text (see [Working with Figures](./working-with-figures.md)). Legacy
+custom agents can still read the `REFERENCE_*` and `AUXILIARY_*` aliases, but new
+agents should use `CONTEXT_*`.
 
 **Multiple Document Output:**
 

--- a/docs/guide/desktop-migration.md
+++ b/docs/guide/desktop-migration.md
@@ -16,32 +16,20 @@ paper folder, or Overleaf Git checkout in the desktop app, TeXRA can work with
 the same `.tex`, `.bib`, figure, and configuration files already in that
 workspace.
 
-These items usually carry over because they live outside the VS Code extension:
+The split below maps the boundary. Anything that lives in the project folder or
+on your machine follows you with no action; anything the VS Code extension host
+stored privately is re-entered, once, in the desktop app.
 
-- Manuscript source files and repository history.
-- Workspace-local `.env` files, if you already use them for provider API keys.
-- LaTeX, Perl, GraphicsMagick, ImageMagick, Ghostscript, Git, and other system
-  tools installed on your machine.
-- Custom agent YAML files that live inside the project folder.
-- Team-owned files such as `.latexindent.yaml`, `tex-fmt.toml`, or shared
-  `.vscode/settings.json` files committed to the repository.
+<DesktopMigrationSplit />
 
 After opening the project in the desktop app, verify the LaTeX tool paths and
 run a small agent task before relying on the migrated setup for production work.
 
 ## What To Reconfigure
 
-Re-enter credentials and preferences that were stored by the extension host:
-
-- Model provider API keys from the Models tab.
-- TeXRA account or remote-agent sign-in.
-- GitHub token for PR and issue subscription tools.
-- Agent visibility, custom agent directory, model list, and tool approval
-  preferences.
-- LaTeX formatting, diff, TikZ, file-extension, and ignored-path settings if
-  they were only stored in VS Code user settings.
-- Execution history and task-storage archives that lived in the extension's
-  global storage.
+The amber column above is the reconfiguration checklist — provider keys, account
+and GitHub sign-in, agent and tool preferences, any LaTeX settings that lived
+only in VS Code user settings, and your execution-history archives.
 
 If a setting was committed to the workspace, keep using the committed copy. If
 it was only a personal VS Code user setting, set it again in the desktop app.


### PR DESCRIPTION
Follow-up to #4627 (which merged while this round was in flight). Continues the frameless mock-UI pass — two more prose enumerations replaced with focused figures, plus the consolidation round that didn't make the original merge.

## New figures
Mockup-native, theme-adaptive `--mk-*` tokens, no hardcoded color/px, composed from `MockCard` + `StatusPill`:

- **`TemplateVarsPalette`** (custom-agents) — the built-in Jinja2 prompt variables as grouped mono token chips tagged by kind (`path` / `text` / `xml` / `csv`), so the `*_FILE` / `*_CONTENT` / `ALL_` / `LIST_OF_` naming convention *is* the figure. Replaces two flat bullet lists; the `MEDIA_FILE` multimodal note and the legacy `REFERENCE_*`/`AUXILIARY_*` alias nuance stay in prose.
- **`DesktopMigrationSplit`** (desktop-migration) — "Carries over" vs "Reconfigure" as a literal side-by-side comparison instead of two parallel bullet lists. (Page is `srcExclude`'d while desktop is in beta, so it renders for repo/beta readers and goes live when desktop ships.)

## Consolidation
- Lift the faux terminal titlebar (traffic-light dots + window title) into shared `.mk-term-*` classes in `mockup.css`; `CliChatHero` and `CliToolsListHero` drop their byte-identical local copies (net −37 LOC across the two).
- Pulse-glow `rgba(63,185,80,…)` → `color-mix(in srgb, var(--color-success) …, transparent)` so it flips with the theme (`StatusDotLegend` + `mockup.css`).

## Verified
- `npx vitepress build` clean off current `main`; `TemplateVarsPalette` SSRs with literal `{{ … }}` braces (12 token + 12 kind chips, both groups).
- Token gate: all 17 new `--mk-*`/`--color-*` references resolve; every `wa-icon` name resolves in the texra registry; only the registered `wa-icon` element is used.
- Cherry-pick auto-merged `CliChatHero` cleanly, preserving main's `edit_file` rename alongside the titlebar dedup.
- Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress UI-only changes; no runtime product, auth, or data-path impact.
> 
> **Overview**
> Adds two frameless VitePress figures and consolidates docs mockup styling. **`TemplateVarsPalette`** replaces long Jinja2 variable bullet lists in `custom-agents.md` with grouped token chips and kind labels; **`DesktopMigrationSplit`** replaces parallel migration bullet lists in `desktop-migration.md` with a side-by-side “carries over” vs “reconfigure” comparison built from `MockCard` and `StatusPill`.
> 
> Faux terminal titlebars move into shared **`.mk-term-*`** rules in `mockup.css`, so **`CliChatHero`** and **`CliToolsListHero`** drop duplicate scoped CSS. Running-status pulse glows switch from hardcoded green `rgba` to **`color-mix`** with `var(--color-success)` in `mockup.css` and **`StatusDotLegend`**. Both components register in **`theme/index.js`** for use in markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1716882474000e4f3476364c9ca1c9a857af0b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->