### PR TITLE
refactor(logger): Agent SDK readiness Step 2 — decouple @logger from @transcript

### DIFF
--- a/docs/proposals/agent-sdk-readiness.md
+++ b/docs/proposals/agent-sdk-readiness.md
@@ -1,6 +1,6 @@
 # Agent SDK Readiness — Findings & Refactoring Plan
 
-**Status:** Audit (2026-05-30). **Step 1 (zero-risk cleanups) landed**; Steps 2–7 pending.
+**Status:** Audit (2026-05-30). **Steps 1–2 landed**; Steps 3–7 pending.
 **Scope:** `src/agent/` core + runtime, `src/agent/modelHandlers/`, logger (`src/logger/` + `src/agent/trace/`), and the public/packaging surface (`packages/core`, `packages/cli` consumption, `@agent/*` aliases, `src/platform`).
 **Target:** Alignment with the **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`) patterns — one curated package surface, a single `query()`-style entry returning a typed async stream, one structured `Options` object, a thin provider layer, tools-as-data, and subagents-as-config.
 **Related:** [`agent-trace-sdk-surface.md`](./agent-trace-sdk-surface.md), [`logger-simplification-feasibility.md`](./logger-simplification-feasibility.md), [`unified-output-protocol.md`](./unified-output-protocol.md).
@@ -142,7 +142,7 @@ TeXRA is unusually well-positioned: YAML agent profiles are near-isomorphic to t
 Each step is independently shippable; later steps are additive so nothing breaks.
 
 1. ✅ **Zero-risk cleanups (LANDED):** removed the dead `getDefaultAgentRuntimeHost` singleton (migrated ~9 tests to local hosts); collapsed `InterruptCallbacks` into `Pick<BaseFlowContextInit,…>`; deleted the unreachable `domainMessageType` arms; deleted the bypassed `core/index.ts` barrel (Item 4). Typecheck + vitest + eslint clean.
-2. **Break `@logger → @transcript` (1 PR):** re-scope `createRunTrace`/`flushPendingRunTraces` to accept their subscriber list; leave `createChannelTrace` untouched.
+2. ✅ **Break `@logger → @transcript` (LANDED):** relocated `createRunTrace`/`flushPendingRunTraces`/`RunTrace` into `@transcript` (the verifier's "move the two symbols" option — lower risk than parameterizing, since ~10 test callers depend on the default transcript behavior); `@logger` now imports nothing from `@transcript`, leaving `createChannelTrace` as its only run-trace factory. Pure relocation + import-path swaps, no behavior change. Typecheck (×4) + vitest (63 tests) + eslint clean.
 3. **Minimal host-command de-leak (1 PR):** swap the inline `texra.*` action literals for a typed action token keyed off the existing `AgentErrorKind`. No contract change.
 4. **Barrels as packaging prep:** add curated `runtime/index.ts` and `toolUse/index.ts` re-exporting the host-facing surface; delete the half-used `core/index.ts`. Do **not** mass-migrate the 125+ deep imports (churn without a lint gate). These feed Step 5.
 5. **Populate `@texra/core`:** replace the stub with re-exports of the Step-4 barrels + `@platform` + registry + storage + config/validation + trace + result. Purely additive (aliases stay); add a _warn-only_ `no-restricted-imports` rule steering new host code to `@texra/core`.

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -2,9 +2,8 @@
 // `cliState.streams[].entries`. Approval/permission entries land in side
 // panels and modals; tool rows render inline alongside assistant prose.
 
-import { getDefaultStreamLogStore } from '@transcript';
+import { flushPendingRunTraces, getDefaultStreamLogStore } from '@transcript';
 import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
-import { flushPendingRunTraces } from '@logger';
 import {
   MESSAGE_TYPES,
   TOOL_USE_STATUS,

--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-import { setDefaultStreamLogStore, StreamLogStore } from '@transcript';
+import {
+  flushPendingRunTraces,
+  setDefaultStreamLogStore,
+  StreamLogStore,
+} from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -8,7 +12,7 @@ import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { isInFlightStatus } from '@common/constants/streamStatus';
-import { createChannelTrace, flushPendingRunTraces } from '@logger';
+import { createChannelTrace } from '@logger';
 import { OutputFilesManager } from '@progressView/managers/OutputFilesManager';
 import { UsageStatsManager } from '@progressView/managers/UsageStatsManager';
 import { StreamMetaManager } from '@progressView/managers/StreamMetaManager';

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { ZodError } from 'zod';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { createRunTrace, type RunTrace } from '@transcript';
 import { isRemoteAgent, resolveAgent, type ResolvedAgent } from '@agent/index';
 import {
   logSdkError,
@@ -27,7 +28,6 @@ import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage, toErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
-import { createRunTrace, type RunTrace } from '@logger';
 import {
   STREAM_STATUS,
   type ExecutionId,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,8 +1,3 @@
 export * as logUtils from './logUtils';
 export { redactSecrets, type LogRedactionOptions } from './redaction';
-export {
-  createChannelTrace,
-  createRunTrace,
-  flushPendingRunTraces,
-  type RunTrace,
-} from './runTrace';
+export { createChannelTrace } from './runTrace';

--- a/src/logger/runTrace.ts
+++ b/src/logger/runTrace.ts
@@ -1,22 +1,13 @@
 /**
- * Factories that produce ready-to-use {@link AgentTrace} instances with
- * the standard TeXRA subscribers attached.
+ * Factory for module-level singleton traces that need per-channel debug
+ * output and nothing else (no transcript).
  *
- * - `createChannelTrace(name)` — for module-level singletons that just need
- *   per-channel debug output (no transcript).
- *
- * - `createRunTrace(streamId, store)` — for agent runs. Attaches BOTH the
- *   channel-output subscriber AND the {@link attachTranscriptRecorder} that
- *   drives the webview transcript. Returns `{ trace, dispose }` so callers
- *   can release the subscribers when the run ends.
+ * The transcript-wired agent-run trace (`createRunTrace`) lives in
+ * `@transcript` so this package stays free of any product/transcript
+ * dependency and can be reused by SDK consumers that only want channel
+ * logging.
  */
-import {
-  attachTranscriptRecorder,
-  getDefaultStreamLogStore,
-  type StreamLogStore,
-} from '@transcript';
 import { TraceEmitter, type AgentTrace } from '@agent/trace';
-import type { StreamTabId } from '@shared/schemas';
 
 import { attachChannelSubscriber } from './logUtils';
 
@@ -29,51 +20,4 @@ export function createChannelTrace(name: string): AgentTrace {
   const trace = new TraceEmitter();
   attachChannelSubscriber(trace, { channel: name, isAgent: false });
   return trace;
-}
-
-export interface RunTrace {
-  readonly trace: AgentTrace;
-  readonly dispose: () => void;
-}
-
-/**
- * Produce a trace wired with the standard agent-run subscribers: per-channel
- * channel output AND the transcript recorder.
- *
- * `store` defaults to the global stream-log store — tests can override.
- */
-export function createRunTrace(
-  streamId: StreamTabId,
-  store: StreamLogStore = getDefaultStreamLogStore(),
-): RunTrace {
-  const trace = new TraceEmitter();
-  const unsubscribeChannel = attachChannelSubscriber(trace, {
-    channel: streamId,
-    isAgent: true,
-  });
-  const transcript = attachTranscriptRecorder(trace, streamId, store);
-
-  // Centralized registry so the static shutdown hook
-  // (`flushPendingRunTraces()`) can drain every in-flight stream buffer.
-  activeFlushers.add(transcript.flushPending);
-
-  return {
-    trace,
-    dispose: () => {
-      activeFlushers.delete(transcript.flushPending);
-      transcript.unsubscribe();
-      unsubscribeChannel();
-    },
-  };
-}
-
-const activeFlushers = new Set<() => void>();
-
-/**
- * Drain pending stream-chunk updates across every active run trace. Called
- * by shutdown paths (progress view dispose, CLI exit) so throttled stream
- * writes hit the store before the process tears down.
- */
-export function flushPendingRunTraces(): void {
-  for (const flush of [...activeFlushers]) flush();
 }

--- a/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts
@@ -2,12 +2,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
-import { createRunTrace } from '@logger';
 
 // Local imports - shared
 import { MESSAGE_TYPES } from '@shared/schemas';

--- a/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - agent
 import {
+  createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-
-import { createRunTrace } from '@logger';
 
 // Local imports - shared
 import { MESSAGE_TYPES } from '@shared/schemas';

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -1,12 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createRunTrace,
+  flushPendingRunTraces,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import { endToolUseCard, startToolUseCard } from '@agent/trace';
-import { createRunTrace, flushPendingRunTraces } from '@logger';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 describe('AgentLogger stream output', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3,11 +3,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   cliState,
@@ -62,7 +62,6 @@ import {
   moveLocalTranscriptToStream,
 } from '@cli/chat/tui/state/transcript';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { createRunTrace } from '@logger';
 import {
   MESSAGE_TYPES,
   STREAM_STATUS,

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createRunTrace,
+  flushPendingRunTraces,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-import { createRunTrace, flushPendingRunTraces } from '@logger';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 describe('createRunTrace dispose', () => {

--- a/src/test/agent/trace/logFileCategory.test.ts
+++ b/src/test/agent/trace/logFileCategory.test.ts
@@ -3,12 +3,12 @@ import { strict as assert } from 'assert';
 
 // Local imports
 import {
+  createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import { logFileCategory, type AgentTrace } from '@agent/trace';
-import { createRunTrace } from '@logger';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 describe('logFileCategory', () => {

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -3,11 +3,11 @@ import { strict as assert } from 'assert';
 
 // Local imports - test
 import {
+  createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-import { createRunTrace } from '@logger';
 
 describe('AgentLogger error data', () => {
   beforeEach(async () => {

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -7,6 +7,7 @@ import {
   type ModelConfig,
   ModelProvider,
 } from 'llm-zoo';
+import { createRunTrace } from '@transcript';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
@@ -27,7 +28,6 @@ import type { ExecResult } from '@agent/types/ResultTypes';
 
 // Internal imports
 import { MapToolRegistry } from '@agent/core/ToolTypes';
-import { createRunTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import { BashTool } from '@tools/bash';
 import * as execUtils from '@utils/system/execUtils';

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -1,4 +1,5 @@
 // Local imports - agent
+import { createRunTrace } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentCategory } from '@agent/core/AgentDataclass';
@@ -13,7 +14,6 @@ import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - errors
 import { toErrorMessage } from '@common/errors';
-import { createRunTrace } from '@logger';
 
 // Local imports - shared
 import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -24,3 +24,8 @@ export {
   attachTranscriptRecorder,
   type TranscriptRecorderHandle,
 } from './TexraTranscriptRecorder';
+export {
+  createRunTrace,
+  flushPendingRunTraces,
+  type RunTrace,
+} from './runTrace';

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -1,0 +1,66 @@
+/**
+ * The TeXRA "run trace": an {@link AgentTrace} wired with the product
+ * subscribers an agent run needs — per-channel output (from `@logger`) AND
+ * the webview/CLI transcript recorder (this package).
+ *
+ * This lives in `@transcript` rather than `@logger` so the logger package
+ * stays free of any transcript/product dependency: SDK consumers use the
+ * pure `@agent/trace` channel plus `createChannelTrace`, and attach their own
+ * subscribers — they never pull in `StreamLogStore`.
+ */
+import { TraceEmitter, type AgentTrace } from '@agent/trace';
+import { attachChannelSubscriber } from '@logger/logUtils';
+import type { StreamTabId } from '@shared/schemas';
+
+import { attachTranscriptRecorder } from './TexraTranscriptRecorder';
+import {
+  getDefaultStreamLogStore,
+  type StreamLogStore,
+} from './StreamLogStore';
+
+export interface RunTrace {
+  readonly trace: AgentTrace;
+  readonly dispose: () => void;
+}
+
+/**
+ * Produce a trace wired with the standard agent-run subscribers: per-channel
+ * channel output AND the transcript recorder.
+ *
+ * `store` defaults to the global stream-log store — tests can override.
+ */
+export function createRunTrace(
+  streamId: StreamTabId,
+  store: StreamLogStore = getDefaultStreamLogStore(),
+): RunTrace {
+  const trace = new TraceEmitter();
+  const unsubscribeChannel = attachChannelSubscriber(trace, {
+    channel: streamId,
+    isAgent: true,
+  });
+  const transcript = attachTranscriptRecorder(trace, streamId, store);
+
+  // Centralized registry so the static shutdown hook
+  // (`flushPendingRunTraces()`) can drain every in-flight stream buffer.
+  activeFlushers.add(transcript.flushPending);
+
+  return {
+    trace,
+    dispose: () => {
+      activeFlushers.delete(transcript.flushPending);
+      transcript.unsubscribe();
+      unsubscribeChannel();
+    },
+  };
+}
+
+const activeFlushers = new Set<() => void>();
+
+/**
+ * Drain pending stream-chunk updates across every active run trace. Called
+ * by shutdown paths (progress view dispose, CLI exit) so throttled stream
+ * writes hit the store before the process tears down.
+ */
+export function flushPendingRunTraces(): void {
+  for (const flush of [...activeFlushers]) flush();
+}


### PR DESCRIPTION
## Summary

**Step 2** of the Agent SDK readiness plan (`docs/proposals/agent-sdk-readiness.md`): break the `@logger → @transcript` layering inversion (audit finding **TRACE-03**) so `@logger` is a pure logging package an SDK consumer can use without pulling in TeXRA's `StreamLogStore` transcript.

## What changed

- **Relocate** `createRunTrace` / `flushPendingRunTraces` / `RunTrace` (and the `activeFlushers` shutdown registry) from `src/logger/runTrace.ts` → **`src/transcript/runTrace.ts`**. `@transcript` already owns `StreamLogStore` + `attachTranscriptRecorder`, so the composed run trace (channel output **+** transcript) belongs there.
- `src/logger/runTrace.ts` now exports **only** `createChannelTrace` and imports nothing from `@transcript` — `@logger` is transcript-free.
- Repoint the 2 production callers (`childStream.ts`, `AgentLaunchContext.ts`) and the flush callers (`ProgressViewState.ts`, `subscribeStreamLog.ts`), plus the test callers, to import the run-trace symbols from `@transcript`.

## Why relocate instead of parameterize

The plan floated two options. The verifier flagged that **parameterizing `createRunTrace`'s subscriber list** changes behavior, and discovery confirmed **~10 test callers depend on the default transcript wiring** (several assert `StreamLogStore` contents). So I took the verifier's other endorsed option — **move the symbols** — which is a pure import-path relocation with **zero behavior change**. `createChannelTrace` (23 host-neutral consumers) deliberately stays in `@logger`.

## Verification

- `tsc --noEmit` clean across root + test-kernel + extension + CLI.
- **63 vitest tests** pass across the run-trace/transcript suites (`RunTraceDispose`, `RunTraceStream`, `CodexProgressEvents`, `ClaudeAgentProgressEvents`, `TuiStateAndFocus`).
- ESLint clean on all changed files; no duplicate `@transcript` imports.

No behavior change — this is a packaging/dependency-direction move. Steps 3–7 remain in the plan doc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure relocation and import updates with preserved run-trace behavior; low risk aside from missed import sites at build time.
> 
> **Overview**
> **Agent SDK readiness Step 2** fixes the `@logger → @transcript` layering inversion by moving the transcript-wired run trace API out of `@logger` and into `@transcript`.
> 
> `createRunTrace`, `flushPendingRunTraces`, `RunTrace`, and the `activeFlushers` shutdown registry now live in `src/transcript/runTrace.ts` and are re-exported from `@transcript`. That module still composes the same behavior: channel logging via `@logger/logUtils` plus `attachTranscriptRecorder` and the default `StreamLogStore`. **`@logger`** keeps only **`createChannelTrace`** and no longer imports `@transcript`.
> 
> Call sites that need the full run trace (agent launch, child streams, progress view flush, CLI stream-log sync) and related tests import those symbols from **`@transcript`** instead of **`@logger`**. The readiness proposal doc marks Step 2 as landed.
> 
> No intentional runtime change—import paths and package boundaries only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297605eb339d2d64c74bb856cc48542c3feb9dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->