### PR TITLE
fix(cli): scope bash session approval

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -173,6 +173,12 @@ function makeBashApprovalPayload() {
 }
 
 function applyHarnessApprovalDecision(decision: ApprovalDecision): void {
+  if (decision.accepted && decision.bypass === 'bash') {
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      bypass: { ...slice.bypass, bash: true },
+    }));
+  }
   if (decision.accepted && decision.bypass === 'toolEdit') {
     patchStream(STREAM_ID, (slice) => ({
       ...slice,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -105,8 +105,8 @@ const SCENARIOS = [
     bootExpect: 'Use foreground panel shortcuts',
     keys: ['a'],
     frame: 'tail',
-    expect: ['AUTO-APPROVE', '[/status]details', '[/model]models'],
-    unexpect: ['Run bash command?', '1 approval'],
+    expect: ['AUTO-BASH', '[/status]details', '[/model]models'],
+    unexpect: ['AUTO-APPROVE', 'Run bash command?', '1 approval'],
   },
   {
     name: 'edit-approval-reject',

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -16,7 +16,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
       borderStyle="double"
       color="yellow"
       title="Run bash command?"
-      alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
+      alwaysAllow={{ kind: 'bash', label: 'approve session' }}
       onDecide={props.onDecide}
     >
       <Box marginY={1}>

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -357,6 +357,9 @@ export function buildStatusBarDisplay(
   if (input.bypass.superYolo) {
     left.push({ text: 'YOLO', badge: true, badgeColor: 'red' });
   }
+  if (input.bypass.bash) {
+    left.push({ text: 'AUTO-BASH', badge: true, badgeColor: 'yellow' });
+  }
   if (input.bypass.toolEdit) {
     left.push({ text: 'AUTO-APPROVE', badge: true, badgeColor: 'yellow' });
   }

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -22,7 +22,7 @@ import type {
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
-export type ApprovalBypassKind = 'toolEdit' | 'superYolo';
+export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
 
 export type ApprovalPayload =
   | { kind: 'bash'; payload: BashPermission }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -64,6 +64,7 @@ export interface ProcessOutputTail {
 }
 
 export interface BypassState {
+  readonly bash: boolean;
   readonly toolEdit: boolean;
   readonly superYolo: boolean;
 }
@@ -163,7 +164,11 @@ export const cliState = {
   >,
 };
 
-export const NO_BYPASS: BypassState = { toolEdit: false, superYolo: false };
+export const NO_BYPASS: BypassState = {
+  bash: false,
+  toolEdit: false,
+  superYolo: false,
+};
 
 function emptySlice(streamId: StreamTabId): StreamSlice {
   return {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -34,6 +34,7 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import {
   handleProgressViewBashApprovalAction,
+  setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
   setToolEditApprovalHandler,
 } from '@tools/approval';
@@ -139,10 +140,10 @@ function routeApproval(
         (bashPayload, decision) => {
           if (
             decision.accepted &&
-            decision.bypass === 'toolEdit' &&
+            decision.bypass === 'bash' &&
             bashPayload.streamId
           ) {
-            setToolEditApprovalSessionBypass(bashPayload.streamId, true, host);
+            setBashApprovalSessionBypass(bashPayload.streamId, true, host);
           }
           dispatchBash(bashPayload, decision);
         },

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -187,6 +187,15 @@ function applyToState<K extends ProgressEvent>(
       }));
       return;
     }
+    case 'updateBashApprovalBypassState': {
+      const p =
+        payload as ProgressEventPayloads['updateBashApprovalBypassState'];
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        bypass: { ...s.bypass, bash: p.bypassActive },
+      }));
+      return;
+    }
     case 'updateSuperYoloBypassState': {
       const p = payload as ProgressEventPayloads['updateSuperYoloBypassState'];
       patchStream(p.streamId, (s) => ({

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -931,6 +931,7 @@ export class DesktopProgressBridge {
       // TypeScript exhaustiveness.
       case 'odysseyStateChanged':
       case 'clearMissingOutputs':
+      case 'updateBashApprovalBypassState':
       case 'showRetryRequest':
       case 'resolveRetryRequest':
       case 'showExternalInquiry':

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -105,6 +105,10 @@ export interface ProgressEventPayloads {
     streamId: StreamTabId;
     bypassActive: boolean;
   };
+  updateBashApprovalBypassState: {
+    streamId: StreamTabId;
+    bypassActive: boolean;
+  };
   updateSuperYoloBypassState: {
     streamId: StreamTabId;
     bypassActive: boolean;

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -11,13 +11,20 @@ import {
 } from '@tools/userQuestion';
 import {
   cleanupAllApprovals,
+  setBashApprovalSessionBypass,
+  setToolEditApprovalSessionBypass,
   toggleProposalBypass,
+  toggleBashApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import {
   handleProgressViewBashApprovalAction,
   requestBashApproval,
 } from '@tools/approval/bashApproval';
+import {
+  requestToolEditApproval,
+  setToolEditApprovalHandler,
+} from '@tools/approval/toolEditApproval';
 import { createRecordingHost } from '../progressTestUtils';
 
 async function waitForRecordedEvent<TEvent extends string>(
@@ -162,6 +169,100 @@ describe('human prompt progress events', () => {
         payload: { streamId, bypassActive: true },
       },
     ]);
+  });
+
+  it('publishes bash bypass changes through the explicit runtime host', () => {
+    const explicit = createRecordingHost();
+    const streamId = 'stream:bash-bypass' as StreamTabId;
+
+    const enabled = toggleBashApprovalSessionBypass(streamId, explicit.host);
+
+    expect(enabled).toBe(true);
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateBashApprovalBypassState',
+        payload: { streamId, bypassActive: true },
+      },
+    ]);
+  });
+
+  it('keeps bash and edit session bypasses independent', async () => {
+    const explicit = createRecordingHost();
+    const streamId = 'stream:bypass-independence' as StreamTabId;
+
+    try {
+      setToolEditApprovalSessionBypass(streamId, true, explicit.host, {
+        silent: true,
+      });
+
+      const approval = withRunContext(
+        createRunContext({ runtimeHost: explicit.host, streamId }),
+        () =>
+          withToolFileInteractionContext({ tracker: {} as never }, () =>
+            requestBashApproval({ command: 'echo still asks' }),
+          ),
+      );
+
+      const show = await waitForRecordedEvent(
+        explicit.events,
+        'showBashPermission',
+      );
+      await handleProgressViewBashApprovalAction({
+        requestId: show.payload.requestId,
+        action: 'approve',
+      });
+      await expect(approval).resolves.toMatchObject({ accepted: true });
+
+      expect(show.payload.command).toBe('echo still asks');
+
+      explicit.events.length = 0;
+      setBashApprovalSessionBypass(streamId, true, explicit.host, {
+        silent: true,
+      });
+
+      const bypassed = await withRunContext(
+        createRunContext({ runtimeHost: explicit.host, streamId }),
+        () =>
+          withToolFileInteractionContext({ tracker: {} as never }, () =>
+            requestBashApproval({ command: 'echo bypassed' }),
+          ),
+      );
+
+      expect(bypassed).toEqual({ accepted: true });
+      expect(explicit.events).toEqual([]);
+
+      setToolEditApprovalSessionBypass(streamId, false, explicit.host, {
+        silent: true,
+      });
+
+      let editApprovalRequests = 0;
+      setToolEditApprovalHandler(async (request) => {
+        editApprovalRequests += 1;
+        return {
+          accepted: true,
+          appliedContent: request.proposedContent,
+        };
+      });
+
+      const editApproval = await withRunContext(
+        createRunContext({ runtimeHost: explicit.host, streamId }),
+        () =>
+          requestToolEditApproval({
+            path: 'draft.tex',
+            originalContent: 'old',
+            proposedContent: 'new',
+            sourceTool: 'test',
+          }),
+      );
+
+      expect(editApprovalRequests).toBe(1);
+      expect(editApproval).toMatchObject({
+        accepted: true,
+        appliedContent: 'new',
+      });
+    } finally {
+      setToolEditApprovalHandler();
+    }
   });
 
   it('publishes proposal bypass changes through the explicit runtime host', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -323,7 +323,7 @@ function sliceWithEntries(
     todos: [],
     plan: null,
     processOutput: new Map(),
-    bypass: { toolEdit: false, superYolo: false },
+    bypass: { bash: false, toolEdit: false, superYolo: false },
   };
 }
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -324,12 +324,12 @@ describe('CLI StatusBar display model', () => {
     expect(idle.left.map(statusBarSegmentText)).toEqual(['◆', 'idle', 'api']);
   });
 
-  it('preserves YOLO and auto-approval badges without agent/model text', () => {
+  it('preserves distinct YOLO and auto-approval badges', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,
       pendingExitHint: false,
       pendingExitResumeId: undefined,
-      bypass: { superYolo: true, toolEdit: true },
+      bypass: { bash: true, superYolo: true, toolEdit: true },
       queuedFollowUpMessages: [],
       usage: undefined,
       conversation: undefined,
@@ -348,11 +348,16 @@ describe('CLI StatusBar display model', () => {
       'running',
       'api',
       'YOLO',
+      'AUTO-BASH',
       'AUTO-APPROVE',
     ]);
-    expect(display.left.at(-2)).toMatchObject({
+    expect(display.left.at(-3)).toMatchObject({
       badge: true,
       badgeColor: 'red',
+    });
+    expect(display.left.at(-2)).toMatchObject({
+      badge: true,
+      badgeColor: 'yellow',
     });
     expect(display.left.at(-1)).toMatchObject({
       badge: true,
@@ -365,7 +370,7 @@ describe('CLI StatusBar display model', () => {
       status: STREAM_STATUS.RUNNING,
       pendingExitHint: false,
       pendingExitResumeId: undefined,
-      bypass: { superYolo: true, toolEdit: true },
+      bypass: { bash: false, superYolo: true, toolEdit: true },
       queuedFollowUpMessages: ['Keep the proof under one page.'],
       usage: undefined,
       conversation: undefined,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -87,7 +87,11 @@ describe('cliState Phase 4 fields', () => {
     expect(slice?.todos).toEqual([]);
     expect(slice?.plan).toBeNull();
     expect(slice?.processOutput.size).toBe(0);
-    expect(slice?.bypass).toEqual({ toolEdit: false, superYolo: false });
+    expect(slice?.bypass).toEqual({
+      bash: false,
+      toolEdit: false,
+      superYolo: false,
+    });
   });
 
   it('prunes parent edges when a stream is removed', () => {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -9,7 +9,6 @@ import { type ToolResult } from '@tools/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createStreamApprovalController } from './streamApprovalQueue';
-import { isApprovalBypassedForStream } from './toolEditApproval';
 
 export const BashApprovalRequestSchema = z.object({
   command: z.string(),
@@ -36,6 +35,36 @@ export const bashApprovalController =
 
 let approvalCounter = 0;
 
+export function setBashApprovalSessionBypass(
+  streamId: StreamTabId,
+  enabled: boolean,
+  runtimeHost: AgentRuntimeHost,
+  options?: { silent?: boolean },
+): void {
+  bashApprovalController.setBypass(streamId, enabled);
+  if (!options?.silent) {
+    runtimeHost.emit('updateBashApprovalBypassState', {
+      streamId,
+      bypassActive: enabled,
+    });
+  }
+}
+
+export function toggleBashApprovalSessionBypass(
+  streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): boolean {
+  const next = !bashApprovalController.isBypassed(streamId);
+  setBashApprovalSessionBypass(streamId, next, runtimeHost);
+  return next;
+}
+
+export function isBashApprovalBypassedForStream(
+  streamId: StreamTabId,
+): boolean {
+  return bashApprovalController.isBypassed(streamId);
+}
+
 export async function requestBashApproval(
   request: BashApprovalRequest,
 ): Promise<BashApprovalResult> {
@@ -46,7 +75,7 @@ export async function requestBashApproval(
 
   if (
     !approvalsEnabled ||
-    (streamId && isApprovalBypassedForStream(streamId))
+    (streamId && isBashApprovalBypassedForStream(streamId))
   ) {
     return { accepted: true };
   }
@@ -63,7 +92,7 @@ async function showApprovalPrompt(
   streamId: StreamTabId | undefined,
   runtimeHost: AgentRuntimeHost,
 ): Promise<BashApprovalResult> {
-  if (streamId && isApprovalBypassedForStream(streamId)) {
+  if (streamId && isBashApprovalBypassedForStream(streamId)) {
     return { accepted: true };
   }
 

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -36,6 +36,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   bashApprovalController.rejectPendingForStream(streamId);
   _rejectPendingUserQuestionsForStream(streamId);
   toolEditApprovalController.clearBypassForStream(streamId);
+  bashApprovalController.clearBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
   cleanupCoordinatorRequestsForStream(streamId);
 }
@@ -49,6 +50,7 @@ export function cleanupAllApprovals(): void {
   bashApprovalController.rejectAllPending();
   _rejectAllPendingUserQuestions();
   toolEditApprovalController.clearAllBypass();
+  bashApprovalController.clearAllBypass();
   _clearAllProposalBypass();
   cleanupAllCoordinatorRequests();
 }
@@ -61,6 +63,9 @@ export {
   requestBashApproval,
   buildBashApprovalRejectedResult,
   handleProgressViewBashApprovalAction,
+  setBashApprovalSessionBypass,
+  toggleBashApprovalSessionBypass,
+  isBashApprovalBypassedForStream,
   BASH_APPROVAL_CONFIG_KEY,
   BASH_APPROVAL_ACTIONS,
   type BashApprovalAction,


### PR DESCRIPTION
## Summary
- split CLI bash session approval from tool-edit session approval
- show a distinct `AUTO-BASH` status badge when bash approvals are bypassed
- add unit and TTY harness coverage so bash approve-session no longer implies edit auto-approval

Closes #4735.

## Validation
- `npm run format`
- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --dir packages/cli run validate:tui`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings in UserMessage.ts, toolFormatters.ts, AgentWorkspaceState.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval and session-bypass behavior for shell commands (security-sensitive), though scope is limited to per-stream bash vs edit flags with added regression coverage.
> 
> **Overview**
> **Bash “approve session” is no longer tied to tool-edit auto-approval.** The bash confirmation modal now records a **`bash`** session bypass (not `toolEdit`), and the runtime uses a dedicated bash approval controller with **`setBashApprovalSessionBypass`** / **`updateBashApprovalBypassState`** instead of reusing tool-edit bypass helpers.
> 
> The CLI status bar shows a separate **`AUTO-BASH`** badge when bash approvals are bypassed, while **`AUTO-APPROVE`** remains for edit bypass only. Stream **`BypassState`** and cleanup paths track **`bash`** independently.
> 
> Tests and the TUI harness/validator were updated so approving a bash command for the session does **not** enable edit auto-approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1057c2d852941b3b788d6a520260e3857ae412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->