### PR TITLE
refactor(cli): simplify non-TUI runtime/commands — DRY, dead code, flatten wrappers

### DIFF
--- a/packages/cli/src/commands/_helpers/remoteAgents.ts
+++ b/packages/cli/src/commands/_helpers/remoteAgents.ts
@@ -1,3 +1,5 @@
+import { getAgent, loadAgents, type AgentEntry } from '@agent/index';
+
 import { getCliAuthProvider } from '@cli/runtime/supabaseAuth';
 
 export async function shouldHonorRemoteAgentPriority(
@@ -5,4 +7,21 @@ export async function shouldHonorRemoteAgentPriority(
 ): Promise<boolean> {
   if (agentName.includes(':')) return false;
   return getCliAuthProvider().isAuthenticated();
+}
+
+/**
+ * Resolve an agent from the local registry, falling back to a full
+ * (remote-inclusive) reload when it is missing or remote agents should take
+ * priority. Callers must populate the local registry first (typically via
+ * `loadAgents({ includeRemote: false })`).
+ */
+export async function resolveAgentWithRemoteFallback(
+  name: string,
+): Promise<AgentEntry | undefined> {
+  let agent = getAgent(name);
+  if (!agent || (await shouldHonorRemoteAgentPriority(name))) {
+    await loadAgents();
+    agent = getAgent(name);
+  }
+  return agent;
 }

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -36,6 +36,17 @@ function isExecutionStatus(
   );
 }
 
+/** Display text for a finished tool-use run: the last response if present,
+ *  otherwise a terse status/execution-id summary. */
+export function toolUseResultText(
+  result: Extract<CliRunResult, { category: 'toolUse' }>,
+): string {
+  return (
+    result.lastResponse?.trim() ||
+    `${result.status}\nExecution: ${result.executionId}`
+  );
+}
+
 export function cliTerminalStatus(
   result: ExecuteAgentResult,
   storedTerminalStatus?: string,

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -97,10 +97,6 @@ function outputCopyRelativePath(output: OutputFileSummary): string {
   return getSafeDocumentRelativePath(withoutRoundDir.join('/'));
 }
 
-function expectedOutputCopyRelativePath(outputFile: string): string {
-  return getSafeDocumentRelativePath(outputFile);
-}
-
 export function expectedOutputFilesForOutputDir(
   agent: AgentEntry | undefined,
   inputFiles: readonly string[],
@@ -188,7 +184,7 @@ export async function resolveWorkflowOutput(
 
     const expectedOutputFiles = options.expectedOutputFiles ?? [];
     const missing = expectedOutputFiles
-      .map(expectedOutputCopyRelativePath)
+      .map((f) => getSafeDocumentRelativePath(f))
       .filter((expected) => !outputsByRelativePath.has(expected));
     if (missing.length > 0) {
       throw new Error(

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { getAgent, loadAgents } from '@agent/index';
+import { loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -29,11 +29,12 @@ import {
   resolveCliRunModel,
 } from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
-import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
+import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,
+  toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
 import { expandWorkflowInputSpecs } from './_helpers/workflowInputs';
@@ -90,9 +91,7 @@ function writeToolUseRunResult(
   emitCliResult(context, {
     json: result,
     ndjson: { kind: 'agent-result', result },
-    text:
-      result.lastResponse?.trim() ||
-      `${result.status}\nExecution: ${result.executionId}`,
+    text: toolUseResultText(result),
   });
 }
 
@@ -127,11 +126,7 @@ async function runToolUseAgent(
   await initCliPlatform(runContext);
   installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
-  let agent = getAgent(init.agent);
-  if (!agent || (await shouldHonorRemoteAgentPriority(init.agent))) {
-    await loadAgents();
-    agent = getAgent(init.agent);
-  }
+  const agent = await resolveAgentWithRemoteFallback(init.agent);
 
   if (!agent) {
     writeTextStderr(

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -23,9 +23,7 @@ import {
   signOutCliSupabase,
 } from '../runtime/supabaseAuth';
 
-import { contextFromArgs } from './_helpers/context';
 import { defineCliCommand } from './_helpers/defineCliCommand';
-import { setExitCode } from './_helpers/exitCode';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
@@ -139,20 +137,18 @@ export const loginCommand = defineCliCommand({
   },
 });
 
-export const logoutCommand = defineCommand({
+export const logoutCommand = defineCliCommand({
   meta: { name: 'logout', description: 'Sign out of TeXRA' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  async run(context) {
     await initCliPlatform({ ...context, quietLogs: true });
     try {
       await signOutCliSupabase();
     } catch (error) {
       writeErrorStderr(error);
-      setExitCode(CliExitCode.ModelOrNetworkError);
-      return;
+      return CliExitCode.ModelOrNetworkError;
     }
 
     emitCliResult(context, {
@@ -160,25 +156,23 @@ export const logoutCommand = defineCommand({
       ndjson: { kind: 'auth', authenticated: false },
       text: 'Signed out.',
     });
-    setExitCode(CliExitCode.Success);
+    return CliExitCode.Success;
   },
 });
 
-const authStatusCommand = defineCommand({
+const authStatusCommand = defineCliCommand({
   meta: { name: 'status', description: 'Show TeXRA sign-in status' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  async run(context) {
     let profile: Awaited<ReturnType<typeof getCliAuthProfile>>;
     try {
       await initCliPlatform({ ...context, quietLogs: true });
       profile = await getCliAuthProfile();
     } catch (error) {
       writeErrorStderr(error);
-      setExitCode(CliExitCode.ModelOrNetworkError);
-      return;
+      return CliExitCode.ModelOrNetworkError;
     }
 
     emitCliResult(context, {
@@ -192,7 +186,7 @@ const authStatusCommand = defineCommand({
           } (${profile.tier ?? 'unknown'}).`
         : 'Not signed in.',
     });
-    setExitCode(CliExitCode.Success);
+    return CliExitCode.Success;
   },
 });
 
@@ -215,7 +209,7 @@ function writeRelayUsageSummary(
   });
 }
 
-const usageCommand = defineCommand({
+const usageCommand = defineCliCommand({
   meta: { name: 'usage', description: 'Show relay usage for this account' },
   args: {
     ...GLOBAL_ARGS,
@@ -224,8 +218,7 @@ const usageCommand = defineCommand({
       description: 'UTC month to show, formatted as YYYY-MM',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
+  async run(context, ctx) {
     const month = optString(ctx.args.month);
     // Pre-validate `--month` before any network I/O so a malformed value
     // yields a Usage error (exit 2), not the catch-all ModelOrNetworkError
@@ -235,8 +228,7 @@ const usageCommand = defineCommand({
         parseUtcMonth(month);
       } catch (error) {
         writeErrorStderr(error);
-        setExitCode(CliExitCode.Usage);
-        return;
+        return CliExitCode.Usage;
       }
     }
     let summary: RelayUsageSummary;
@@ -245,8 +237,7 @@ const usageCommand = defineCommand({
       const profile = await getCliAuthProfile();
       if (!profile.authenticated) {
         writeTextStderr('Not signed in. Run `texra login` first.');
-        setExitCode(CliExitCode.ModelOrNetworkError);
-        return;
+        return CliExitCode.ModelOrNetworkError;
       }
       summary = await fetchRelayUsageSummary({
         tier: profile.tier ?? 'free',
@@ -254,12 +245,11 @@ const usageCommand = defineCommand({
       });
     } catch (error) {
       writeErrorStderr(error);
-      setExitCode(CliExitCode.ModelOrNetworkError);
-      return;
+      return CliExitCode.ModelOrNetworkError;
     }
 
     writeRelayUsageSummary(context, summary);
-    setExitCode(CliExitCode.Success);
+    return CliExitCode.Success;
   },
 });
 

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -44,6 +44,7 @@ import { executeCliRequest } from './_helpers/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,
+  toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
 import { expandRunInputs } from './_helpers/workflowInputs';
@@ -149,9 +150,7 @@ function writeMultiAgentRunResult(
   emitCliResult(context, {
     json: payload,
     ndjson: { kind: 'multi-agent-result', ...payload },
-    text:
-      result.lastResponse?.trim() ||
-      `${result.status}\nExecution: ${result.executionId}`,
+    text: toolUseResultText(result),
   });
 }
 

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,4 +1,4 @@
-import { getAgent, loadAgents } from '@agent/index';
+import { loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
@@ -13,7 +13,7 @@ import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
-import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
+import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   terminalStatusExitCode,
@@ -46,12 +46,7 @@ export async function runResumeExecution(
   await initCliPlatform(runContext);
   installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
-  if (
-    !getAgent(config.agent) ||
-    (await shouldHonorRemoteAgentPriority(config.agent))
-  ) {
-    await loadAgents();
-  }
+  await resolveAgentWithRemoteFallback(config.agent);
 
   const { result, terminalStatus } = await executeCliRequest(
     { config, executionId: id },

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -18,22 +18,14 @@ import {
   setCliToolEnabled,
 } from '../runtime/tools';
 
-import { contextFromArgs } from './_helpers/context';
-import { setExitCode } from './_helpers/exitCode';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
-async function withCliPlatform<T>(
-  context: CliContext,
-  work: () => Promise<T>,
-): Promise<T> {
-  await initCliPlatform({ ...context, quietLogs: true });
-  return work();
-}
-
 async function listTools(context: CliContext): Promise<number> {
-  const records = await withCliPlatform(context, readCliToolStatuses);
+  await initCliPlatform({ ...context, quietLogs: true });
+  const records = await readCliToolStatuses();
 
   emitCliResult(context, {
     json: records,
@@ -44,7 +36,8 @@ async function listTools(context: CliContext): Promise<number> {
 }
 
 async function showTool(context: CliContext, id: string): Promise<number> {
-  const record = await withCliPlatform(context, () => readCliToolStatus(id));
+  await initCliPlatform({ ...context, quietLogs: true });
+  const record = await readCliToolStatus(id);
   if (!record) {
     writeTextStderr(`Tool integration not found: ${id}`);
     return CliExitCode.Usage;
@@ -63,9 +56,8 @@ async function toggleTool(
   id: string,
   enabled: boolean,
 ): Promise<number> {
-  const ok = await withCliPlatform(context, () =>
-    setCliToolEnabled(id, enabled),
-  );
+  await initCliPlatform({ ...context, quietLogs: true });
+  const ok = await setCliToolEnabled(id, enabled);
   if (!ok) {
     writeTextStderr(`Tool integration is not toggleable: ${id}`);
     return CliExitCode.Usage;
@@ -147,19 +139,16 @@ async function authTool(context: CliContext, id: string): Promise<number> {
   }
 }
 
-const toolsListCommand = defineCommand({
+const toolsListCommand = defineCliCommand({
   meta: { name: 'list', description: 'List external tool integrations' },
   args: { ...GLOBAL_ARGS },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await listTools(context));
-  },
+  run: (context) => listTools(context),
 });
 
 // Built per key so the usage banner (citty reads `meta.name`) matches the
 // invoked alias: `texra tools status --help` prints `tools status`, not `show`.
 function toolsShowCommandNamed(name: 'show' | 'status') {
-  return defineCommand({
+  return defineCliCommand({
     meta: { name, description: 'Show one tool integration' },
     args: {
       ...GLOBAL_ARGS,
@@ -169,15 +158,12 @@ function toolsShowCommandNamed(name: 'show' | 'status') {
         description: 'Tool integration id from `texra tools list`',
       },
     },
-    async run(ctx) {
-      const context = await contextFromArgs(ctx.args);
-      setExitCode(await showTool(context, ctx.args.id));
-    },
+    run: (context, ctx) => showTool(context, ctx.args.id),
   });
 }
 
 function toggleCommand(name: 'enable' | 'disable', enabled: boolean) {
-  return defineCommand({
+  return defineCliCommand({
     meta: {
       name,
       description: `${enabled ? 'Enable' : 'Disable'} a tool integration`,
@@ -190,14 +176,11 @@ function toggleCommand(name: 'enable' | 'disable', enabled: boolean) {
         description: 'Tool integration id from `texra tools list`',
       },
     },
-    async run(ctx) {
-      const context = await contextFromArgs(ctx.args);
-      setExitCode(await toggleTool(context, ctx.args.id, enabled));
-    },
+    run: (context, ctx) => toggleTool(context, ctx.args.id, enabled),
   });
 }
 
-const toolsInstallCommand = defineCommand({
+const toolsInstallCommand = defineCliCommand({
   meta: { name: 'install', description: 'Show install help for a tool' },
   args: {
     ...GLOBAL_ARGS,
@@ -211,13 +194,11 @@ const toolsInstallCommand = defineCommand({
       description: 'Tool integration id from `texra tools list`',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await installTool(context, ctx.args.id, ctx.args.run === true));
-  },
+  run: (context, ctx) =>
+    installTool(context, ctx.args.id, ctx.args.run === true),
 });
 
-const toolsAuthCommand = defineCommand({
+const toolsAuthCommand = defineCliCommand({
   meta: { name: 'auth', description: 'Run or show auth help for a tool' },
   args: {
     ...GLOBAL_ARGS,
@@ -227,10 +208,7 @@ const toolsAuthCommand = defineCommand({
       description: 'Tool integration id from `texra tools list`',
     },
   },
-  async run(ctx) {
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await authTool(context, ctx.args.id));
-  },
+  run: (context, ctx) => authTool(context, ctx.args.id),
 });
 
 export const toolsCommand = defineCommand({

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import { getAgent, loadAgents } from '@agent/index';
+import { loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -27,7 +27,7 @@ import {
   collectStringFlagValues,
   optString,
 } from './_helpers/globalArgs';
-import { shouldHonorRemoteAgentPriority } from './_helpers/remoteAgents';
+import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   terminalStatusExitCode,
@@ -83,11 +83,7 @@ async function runWorkflowAgent(
   await initCliPlatform(runContext);
   installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
-  let agent = getAgent(init.agent);
-  if (!agent || (await shouldHonorRemoteAgentPriority(init.agent))) {
-    await loadAgents();
-    agent = getAgent(init.agent);
-  }
+  const agent = await resolveAgentWithRemoteFallback(init.agent);
   // Pre-validate the resolved agent so usage errors land before the runtime
   // host starts: an unknown name or wrong category should be exit 2 (Usage),
   // not exit 1 (AgentError) raised mid-run.

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,5 +1,3 @@
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 import { getAgent, loadAgents } from '@agent/index';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
@@ -7,6 +5,7 @@ import { isNonEmptyString } from '@utils/core/stringCore';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
+  isKnownCliModel,
   loadWorkspaceCliConfig,
   resolveConfiguredAgent,
   resolveConfiguredModel,
@@ -43,7 +42,7 @@ function pickDefaults(parsed: unknown): PartialDefaults {
   if (isNonEmptyString(record.agent)) out.agent = record.agent.trim();
   if (isNonEmptyString(record.model)) {
     const model = record.model.trim();
-    if (MODEL_CONFIGS[model]) out.model = model;
+    if (isKnownCliModel(model)) out.model = model;
   }
   return out;
 }

--- a/packages/cli/src/runtime/completionBash.ts
+++ b/packages/cli/src/runtime/completionBash.ts
@@ -39,15 +39,12 @@ function commandCaseBlock(command: CompletionCommand): string {
   return `${shellQuote(key)}) subcommands=${shellQuote(commands)}; flags=${shellQuote(flags)} ;;`;
 }
 
-function allCommandPaths(commands: readonly CompletionCommand[]): string[] {
-  return commands
+export function bashCompletion(commands: readonly CompletionCommand[]): string {
+  const root = commands.find((command) => command.path.length === 0);
+  const valueCases = flagValueCases(commands);
+  const allCommandPaths = commands
     .map((command) => commandKey(command.path))
     .filter((path) => path.length > 0);
-}
-
-export function bashCompletion(commands: readonly CompletionCommand[]): string {
-  const rootCommands = commands.find((command) => command.path.length === 0);
-  const valueCases = flagValueCases(commands);
   return `# bash completion for texra
 _texra_completion_dynamic() {
   [[ "\${TEXRA_COMPLETION_DYNAMIC:-1}" != "0" ]]
@@ -74,7 +71,7 @@ _texra_completion_path() {
     esac
     next="$token"
     [[ -n "$path" ]] && next="$path $token"
-    case " ${allCommandPaths(commands).join(' ')} " in
+    case " ${allCommandPaths.join(' ')} " in
       *" $next "*) path="$next"; ((i++)); continue ;;
     esac
     break
@@ -97,7 +94,7 @@ _texra() {
   path="$(_texra_completion_path)"
   case "$path" in
     ${commands.map(commandCaseBlock).join('\n    ')}
-    *) subcommands='${rootCommands?.subcommands.join(' ') ?? ''}'; flags='' ;;
+    *) subcommands='${root?.subcommands.join(' ') ?? ''}'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then

--- a/packages/cli/src/runtime/completionCommandTree.ts
+++ b/packages/cli/src/runtime/completionCommandTree.ts
@@ -94,12 +94,16 @@ export async function collectCommands(
     commandArgs(command),
     commandSubcommands(command),
   ]);
-  const flags = Object.entries(args)
-    .map(([name, arg]) => flagFromArg(name, arg))
-    .filter((flag): flag is CompletionFlag => flag !== undefined);
-  const positionals = Object.entries(args)
-    .filter(([, arg]) => arg.type === 'positional')
-    .map(([name]) => name);
+  const flags: CompletionFlag[] = [];
+  const positionals: string[] = [];
+  for (const [name, arg] of Object.entries(args)) {
+    if (arg.type === 'positional') {
+      positionals.push(name);
+    } else {
+      const flag = flagFromArg(name, arg);
+      if (flag !== undefined) flags.push(flag);
+    }
+  }
   const current: CompletionCommand = {
     path,
     description: meta.description ?? '',

--- a/packages/cli/src/runtime/completionZsh.ts
+++ b/packages/cli/src/runtime/completionZsh.ts
@@ -26,14 +26,16 @@ export function zshCompletion(commands: readonly CompletionCommand[]): string {
       const subs = command.subcommands.length
         ? `_values 'subcommands' ${command.subcommands.map(shellQuote).join(' ')}`
         : 'true';
+      const positionalSpecs: Record<string, string> = {
+        completion: `1:shell:(${CLI_COMPLETION_SHELLS.join(' ')})`,
+        run: `1:agent:($(_texra_agents))`,
+        'agents show': `1:agent:($(_texra_agents))`,
+        'models show': `1:model:($(_texra_models))`,
+      };
+      const positionalSpec = positionalSpecs[key];
       const specs = [
         ...command.flags.flatMap(zshFlagSpec),
-        ...(key === 'completion'
-          ? [`1:shell:(${CLI_COMPLETION_SHELLS.join(' ')})`]
-          : []),
-        ...(key === 'run' ? [`1:agent:($(_texra_agents))`] : []),
-        ...(key === 'agents show' ? [`1:agent:($(_texra_agents))`] : []),
-        ...(key === 'models show' ? [`1:model:($(_texra_models))`] : []),
+        ...(positionalSpec ? [positionalSpec] : []),
       ];
       const args = specs.length
         ? `_arguments ${specs.map(shellQuote).join(' ')}`

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -4,7 +4,7 @@
 // (init/runInitWizard) and the command (commands/init) build on these; keeping
 // the logic here makes it unit-testable without a TTY.
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { CLI_CONFIG_DIR, workspaceCliConfigPath } from './cliConfig';
@@ -53,7 +53,7 @@ export function serializeInitConfig(config: InitConfigShape): string {
 
 export async function configFileExists(filePath: string): Promise<boolean> {
   try {
-    await readFile(filePath, 'utf8');
+    await access(filePath);
     return true;
   } catch {
     return false;

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -32,10 +32,7 @@ export interface RunProgressRendererInit {
 }
 
 export function shouldRenderRunProgress(
-  context: Pick<
-    CliContext,
-    'mode' | 'outputFormat' | 'quietLogs' | 'stderrIsTty'
-  >,
+  context: Pick<CliContext, 'outputFormat' | 'quietLogs'>,
 ): boolean {
   return context.quietLogs !== true && context.outputFormat === 'text';
 }

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -55,15 +55,12 @@ export async function startLoopbackCallbackServer(
         if (session) resolveSession(session);
       })
       .catch((error: unknown) => {
+        const recoverable = isRecoverableCallbackRequestError(error);
         const message = toErrorMessage(error);
-        if (!isRecoverableCallbackRequestError(error)) {
+        if (!recoverable) {
           rejectSession(error instanceof Error ? error : new Error(message));
         }
-        writeHtml(
-          response,
-          isRecoverableCallbackRequestError(error) ? 400 : 500,
-          failureHtml(message),
-        );
+        writeHtml(response, recoverable ? 400 : 500, failureHtml(message));
       });
   });
 

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -25,6 +25,9 @@ export interface CliToolStatusRecord {
   readonly note?: string;
 }
 
+const dashboardToolDefs = (): ExternalToolDef[] =>
+  EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard);
+
 function detectedFromStatus(status: string): boolean | null {
   if (status === 'available') return true;
   if (status === 'not-found') return false;
@@ -41,29 +44,27 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
   const checks = new Map((await runExternalToolChecks()).map((r) => [r.id, r]));
   const disabledIds = getDisabledToolIds();
 
-  return EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard).map(
-    (def) => {
-      const check = checks.get(def.id);
-      const comingSoon = def.comingSoon === true;
-      const toggleable = def.toggleable === true;
-      const status = check?.status ?? (comingSoon ? 'coming-soon' : 'unknown');
-      return {
-        id: def.id,
-        name: def.name,
-        category: def.category,
-        enabled: toggleable ? !disabledIds.has(def.id) : null,
-        detected: detectedFromStatus(status),
-        status,
-        statusLabel: check?.statusLabel,
-        statusDetail: check?.statusDetail,
-        toggleable,
-        comingSoon,
-        installCommand: def.installCommand,
-        authCommand: def.authCommand,
-        note: noteForTool(def, check?.statusLabel),
-      };
-    },
-  );
+  return dashboardToolDefs().map((def) => {
+    const check = checks.get(def.id);
+    const comingSoon = def.comingSoon === true;
+    const toggleable = def.toggleable === true;
+    const status = check?.status ?? (comingSoon ? 'coming-soon' : 'unknown');
+    return {
+      id: def.id,
+      name: def.name,
+      category: def.category,
+      enabled: toggleable ? !disabledIds.has(def.id) : null,
+      detected: detectedFromStatus(status),
+      status,
+      statusLabel: check?.statusLabel,
+      statusDetail: check?.statusDetail,
+      toggleable,
+      comingSoon,
+      installCommand: def.installCommand,
+      authCommand: def.authCommand,
+      note: noteForTool(def, check?.statusLabel),
+    };
+  });
 }
 
 export async function readCliToolStatus(
@@ -77,9 +78,7 @@ export function findCliToolDef(id: string): ExternalToolDef | undefined {
 }
 
 export function cliToolIds(): string[] {
-  return EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard).map(
-    (def) => def.id,
-  );
+  return dashboardToolDefs().map((def) => def.id);
 }
 
 export async function setCliToolEnabled(


### PR DESCRIPTION
Sibling cleanup to #4725 (which covered the TUI). This pass targets the CLI's **non-TUI** layers — `runtime/` and `commands/` (~9.5k lines).

### How it was produced & verified
A code-simplifier fan-out over 9 file-groups surfaced **42 candidates**; each was **adversarially verified** with an explicit **test-consumer check** (grep `src/test-kernel` / `*.vitest.*` for any removed/renamed symbol). **27 rejected** (subjective restyle, or would break a test/behavior — including one finding that wrongly proposed dropping a `monthIndex < 0` guard that `parseUtcMonth('2026-00')` relies on). **15 applied.**

Proven green up front (the full CI-equivalent suite): `tsc --noEmit` ✅, `tsc -p tsconfig.test-kernel.json` ✅, CLI typecheck ✅, **full CLI kernel vitest — 53 files / 433 tests** ✅, bundle ✅, `prettier --check` ✅. No headless output bytes change.

### Changes (15)
- **DRY extractions:** `resolveAgentWithRemoteFallback` (`_helpers/remoteAgents`) shared by `run` / `agents run` / `resume`; `toolUseResultText` (`_helpers/terminalStatus`) shared by the agents-run + multi-agent result writers; `dashboardToolDefs()` in `runtime/tools`; `chatDefaults` reuses `isKnownCliModel` instead of a duplicate `MODEL_CONFIGS` lookup (drops a redundant `llm-zoo` import).
- **Command consistency:** convert `tools.ts` (5 leaf subcommands) and `auth.ts` (logout/status/usage) to `defineCliCommand` (matching `agents`/`models`); inline the `withCliPlatform` wrapper that two handlers already bypassed.
- **Dead code / clarity:** narrow `shouldRenderRunProgress`'s `Pick` to the two fields it reads; `configFileExists` uses `access()` instead of read-and-discard; hoist a doubled `isRecoverableCallbackRequestError()` call; single-pass the completion-tree `Object.entries`; `Record`-driven zsh positional specs; inline single-use completion helpers; rename misleading `rootCommands` → `root`; inline a trivial passthrough in `workflowOutput`.

No new dependencies; no lockfile change.

**Verified:** built from this branch and ran the full CLI kernel suite (433 tests) — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors and shared helpers with no new dependencies; behavior is intended to stay the same and the PR reports full CLI kernel tests passing.
> 
> **Overview**
> This PR refactors the **non-TUI** CLI (`commands/` and `runtime/`) for consistency and less duplication, without changing intended headless behavior.
> 
> **Shared helpers:** `resolveAgentWithRemoteFallback` centralizes local-then-remote agent loading for workflow run, tool-use `agents run`, and `resume`. `toolUseResultText` unifies plain-text output for finished tool-use runs (`agents run`, `multi-agent run`).
> 
> **Command wiring:** `auth` (logout/status/usage) and `tools` leaf subcommands move to `defineCliCommand`, returning exit codes directly instead of `contextFromArgs` + `setExitCode`. `tools` drops the `withCliPlatform` wrapper in favor of inline `initCliPlatform`.
> 
> **Small runtime cleanups:** chat defaults validate models via `isKnownCliModel` (drops direct `llm-zoo` use); external tool listing uses `dashboardToolDefs()`; `configFileExists` uses `access()`; OAuth callback error handling calls recoverability once; completion tree/zsh/bash generators are simplified; `shouldRenderRunProgress` only types the fields it reads; workflow missing-output checks inline `getSafeDocumentRelativePath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfbe62316274a6c8cb86d4b2575471d8acec22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->