### PR TITLE
refactor(agent): Agent SDK readiness Step 3 — host-agnostic instruction-action tokens

### DIFF
--- a/docs/proposals/agent-sdk-readiness.md
+++ b/docs/proposals/agent-sdk-readiness.md
@@ -1,6 +1,6 @@
 # Agent SDK Readiness — Findings & Refactoring Plan
 
-**Status:** Audit (2026-05-30). **Steps 1–2 landed**; Steps 3–7 pending.
+**Status:** Audit (2026-05-30). **Steps 1–3 landed**; Steps 4–7 pending.
 **Scope:** `src/agent/` core + runtime, `src/agent/modelHandlers/`, logger (`src/logger/` + `src/agent/trace/`), and the public/packaging surface (`packages/core`, `packages/cli` consumption, `@agent/*` aliases, `src/platform`).
 **Target:** Alignment with the **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`) patterns — one curated package surface, a single `query()`-style entry returning a typed async stream, one structured `Options` object, a thin provider layer, tools-as-data, and subagents-as-config.
 **Related:** [`agent-trace-sdk-surface.md`](./agent-trace-sdk-surface.md), [`logger-simplification-feasibility.md`](./logger-simplification-feasibility.md), [`unified-output-protocol.md`](./unified-output-protocol.md).
@@ -143,7 +143,7 @@ Each step is independently shippable; later steps are additive so nothing breaks
 
 1. ✅ **Zero-risk cleanups (LANDED):** removed the dead `getDefaultAgentRuntimeHost` singleton (migrated ~9 tests to local hosts); collapsed `InterruptCallbacks` into `Pick<BaseFlowContextInit,…>`; deleted the unreachable `domainMessageType` arms; deleted the bypassed `core/index.ts` barrel (Item 4). Typecheck + vitest + eslint clean.
 2. ✅ **Break `@logger → @transcript` (LANDED):** relocated `createRunTrace`/`flushPendingRunTraces`/`RunTrace` into `@transcript` (the verifier's "move the two symbols" option — lower risk than parameterizing, since ~10 test callers depend on the default transcript behavior); `@logger` now imports nothing from `@transcript`, leaving `createChannelTrace` as its only run-trace factory. Pure relocation + import-path swaps, no behavior change. Typecheck (×4) + vitest (63 tests) + eslint clean.
-3. **Minimal host-command de-leak (1 PR):** swap the inline `texra.*` action literals for a typed action token keyed off the existing `AgentErrorKind`. No contract change.
+3. ✅ **Minimal host-command de-leak (LANDED):** the agent core no longer bakes `texra.*` command IDs / English button titles into `requestShowInstruction`. It emits host-agnostic `INSTRUCTION_ACTION` tokens (`@eventBus`); the VS Code extension maps each token → command + label in `agentEventListeners.ts`. Desktop/CLI already ignore these events (unchanged). Typecheck (×4) + vitest + eslint clean; no test changes needed (the `texra.*` IDs stay registered in the extension).
 4. **Barrels as packaging prep:** add curated `runtime/index.ts` and `toolUse/index.ts` re-exporting the host-facing surface; delete the half-used `core/index.ts`. Do **not** mass-migrate the 125+ deep imports (churn without a lint gate). These feed Step 5.
 5. **Populate `@texra/core`:** replace the stub with re-exports of the Step-4 barrels + `@platform` + registry + storage + config/validation + trace + result. Purely additive (aliases stay); add a _warn-only_ `no-restricted-imports` rule steering new host code to `@texra/core`.
 6. **Unify the run entry:** widen `RunExecutionRequestOptions` to the full option set so `runValidatedExecutionRequest` becomes the single entry; migrate the CLI chat path (`runChatTui.tsx:819`) and `DelegationTools.ts:365` onto it. Behavior-preserving per call site.

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -10,8 +10,11 @@ import * as vscode from 'vscode';
 
 import { getRunStorageService } from '@agent/runtime/RunStorageService';
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { bus, INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
+import type {
+  InstructionAction,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
@@ -33,14 +36,42 @@ function handleRequestOpenFile(
   );
 }
 
+/**
+ * Maps the host-agnostic action tokens the agent core emits to the VS Code
+ * command (and button label) this host invokes. Keeping this table here — not
+ * in the agent core — is what lets the core stay free of `texra.*` command IDs.
+ */
+const INSTRUCTION_ACTION_VIEW: Record<
+  InstructionAction,
+  { title: string; command: string; args?: unknown[] }
+> = {
+  [INSTRUCTION_ACTION.SET_API_KEY]: {
+    title: 'Set API Key',
+    command: 'texra.setApiKey',
+  },
+  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: {
+    title: 'Open Settings Guide',
+    command: 'texra.openDoc',
+    args: ['configuration'],
+  },
+  [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: {
+    title: 'Model Documentation',
+    command: 'texra.openDoc',
+    args: ['models'],
+  },
+};
+
 function handleRequestShowInstruction(
   payload: ProgressEventPayloads['requestShowInstruction'],
 ): void {
-  const actions = (payload.actions ?? []).map((a) => ({
-    title: a.title,
-    callback: () =>
-      void vscode.commands.executeCommand(a.command, ...(a.args ?? [])),
-  }));
+  const actions = (payload.actions ?? []).map((token) => {
+    const view = INSTRUCTION_ACTION_VIEW[token];
+    return {
+      title: view.title,
+      callback: () =>
+        void vscode.commands.executeCommand(view.command, ...(view.args ?? [])),
+    };
+  });
 
   showInstructionWithSuppress(
     payload.key,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -28,6 +28,7 @@ import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage, toErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
+import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
   type ExecutionId,
@@ -133,13 +134,7 @@ async function validateModelExists(
   runtimeHost.emit('requestShowInstruction', {
     key: 'modelNotRecognized',
     message: `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
-    actions: [
-      {
-        title: 'Model Documentation',
-        command: 'texra.openDoc',
-        args: ['models'],
-      },
-    ],
+    actions: [INSTRUCTION_ACTION.OPEN_MODELS_DOC],
     showSuppress: false,
   });
   throw new AgentError(`Model ${modelName} not found in MODEL_CONFIGS`);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -23,6 +23,7 @@ import {
   classifyAgentError,
   getSdkErrorMessage,
 } from '@common/errors';
+import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
@@ -236,12 +237,8 @@ async function runFlowWithLifecycle(
           message:
             'API key not found. Set your API key in the extension settings and run again.',
           actions: [
-            { title: 'Set API Key', command: 'texra.setApiKey' },
-            {
-              title: 'Open Settings Guide',
-              command: 'texra.openDoc',
-              args: ['configuration'],
-            },
+            INSTRUCTION_ACTION.SET_API_KEY,
+            INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE,
           ],
           showSuppress: false,
         });

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -59,6 +59,22 @@ interface SetTaskStatePayload {
 
 const MAX_BUFFER_SIZE = 1000;
 
+/**
+ * Host-agnostic action tokens for {@link ProgressEventPayloads.requestShowInstruction}.
+ * The agent core emits a token; each host maps it to its own UI affordance
+ * (the VS Code extension to a command + button title, other hosts as they see
+ * fit). This keeps host-specific command IDs and labels out of the VS Code-free
+ * agent core.
+ */
+export const INSTRUCTION_ACTION = {
+  SET_API_KEY: 'set-api-key',
+  OPEN_CONFIGURATION_GUIDE: 'open-configuration-guide',
+  OPEN_MODELS_DOC: 'open-models-doc',
+} as const;
+
+export type InstructionAction =
+  (typeof INSTRUCTION_ACTION)[keyof typeof INSTRUCTION_ACTION];
+
 export interface ProgressEventPayloads {
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: {
@@ -212,8 +228,11 @@ export interface ProgressEventPayloads {
   requestShowInstruction: {
     key: string;
     message: string;
-    /** Actions rendered as buttons. Each maps to a VS Code command. */
-    actions?: { title: string; command: string; args?: unknown[] }[];
+    /**
+     * Host-agnostic action tokens rendered as buttons. The host maps each
+     * token to its own UI affordance (see {@link INSTRUCTION_ACTION}).
+     */
+    actions?: InstructionAction[];
     showSuppress?: boolean;
   };
   /** Request the frontend to show the agent-config banner in the main webview. */


### PR DESCRIPTION
## Summary

**Step 3** of the Agent SDK readiness plan (`docs/proposals/agent-sdk-readiness.md`): stop baking VS Code command IDs and English button labels into the **VS Code-free agent core** (audit finding **AC-01**).

## What changed

- Add host-agnostic **`INSTRUCTION_ACTION`** tokens + `InstructionAction` type in `@eventBus/ProgressEventBus`. `requestShowInstruction.actions` is now `InstructionAction[]` instead of `{ title, command, args }[]`.
- The agent core emits **tokens**: `executeAgent.ts` (missing-api-key → `SET_API_KEY`, `OPEN_CONFIGURATION_GUIDE`) and `AgentLaunchContext.ts` (model-not-recognized → `OPEN_MODELS_DOC`). `OutputNode`'s instruction has no actions and is untouched.
- The **VS Code extension** (`agentEventListeners.ts`) owns the token → `{ command, title, args }` mapping. The `texra.*` command IDs and labels now live in the host, where they belong.

## Why / scope

The audit downgraded AC-01 to low (the leaked command IDs were benign dead payload for non-VS-Code hosts), so this is a clean separation-of-concerns polish, not a behavior change:

- **No behavior change for the VS Code user** — the same buttons fire the same commands.
- **No test changes** — the `texra.*` command IDs stay registered in the extension, so command-registry/invoke tests are unaffected; no test asserted the `actions` payload shape.
- **Desktop/CLI unchanged** — they already `break`/ignore `requestShowInstruction`.

## Verification

`tsc --noEmit` clean across root + test-kernel + extension + CLI; ESLint clean on changed files; `AgentLaunchContext` vitest passes. Steps 4–7 remain in the plan doc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boundary refactor on UI event payloads with no auth or execution-path changes; VS Code mapping preserves the same commands for end users.
> 
> **Overview**
> **Agent SDK readiness Step 3:** instruction buttons on `requestShowInstruction` no longer carry VS Code command IDs and labels from the vscode-free agent core.
> 
> The event bus now defines **`INSTRUCTION_ACTION`** tokens and types `requestShowInstruction.actions` as `InstructionAction[]`. **`executeAgent`** (missing API key) and **`AgentLaunchContext`** (unknown model) emit those tokens instead of inline `texra.*` commands. The **VS Code extension** maps each token to button title + `vscode.commands.executeCommand` in `agentEventListeners.ts`. **`agent-sdk-readiness.md`** marks Step 3 as landed.
> 
> VS Code behavior should be unchanged; desktop/CLI hosts that already ignore this event are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1bb8a466a22ceb8e81026178943db14ae35cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->