### PR TITLE
fix(cli): advertise orchestration letter hotkeys

### DIFF
--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -1,7 +1,7 @@
 import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
 
 import { Select } from '../chat/tui/ui/Select';
-import { KeyHints } from '../chat/tui/ui/KeyHints';
+import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
 import type {
   CliOrchestrationAction,
@@ -11,6 +11,14 @@ import type {
 interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
   readonly onResolve: (action: CliOrchestrationAction) => void;
+}
+
+export function orchestrationKeyHints(): readonly KeyHint[] {
+  return [
+    { key: '↑/↓', action: 'navigate' },
+    { key: '1-9/a-z/Enter', action: 'open' },
+    { key: 'Esc', action: 'exit' },
+  ];
 }
 
 function OrchestrationApp(props: OrchestrationAppProps): React.JSX.Element {
@@ -23,8 +31,8 @@ function OrchestrationApp(props: OrchestrationAppProps): React.JSX.Element {
     app.exit();
   };
 
-  useInput((input, key) => {
-    if (key.escape || input.toLowerCase() === 'q') {
+  useInput((_input, key) => {
+    if (key.escape) {
       finish({ kind: 'exit' });
     }
   });
@@ -45,14 +53,7 @@ function OrchestrationApp(props: OrchestrationAppProps): React.JSX.Element {
         />
       </Box>
       <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: '↑/↓', action: 'navigate' },
-            { key: '1-9/Enter', action: 'open' },
-            { key: 'q/Esc', action: 'exit' },
-          ]}
-          confirmCancel={false}
-        />
+        <KeyHints hints={orchestrationKeyHints()} confirmCancel={false} />
       </Box>
     </Box>
   );

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { orchestrationKeyHints } from '@cli/orchestration/runOrchestrationTui';
 import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 
 import type { CliHistoryEntry } from '@cli/runtime/history';
@@ -46,6 +47,24 @@ function preset(overrides: Partial<CliMultiAgentPreset>): CliMultiAgentPreset {
 }
 
 describe('CLI orchestration items', () => {
+  it('advertises the full direct-open hotkey range used by Select', () => {
+    expect(orchestrationKeyHints()).toContainEqual({
+      key: '1-9/a-z/Enter',
+      action: 'open',
+    });
+  });
+
+  it('keeps the exit hint out of the Select letter hotkey range', () => {
+    expect(orchestrationKeyHints()).toContainEqual({
+      key: 'Esc',
+      action: 'exit',
+    });
+    expect(orchestrationKeyHints()).not.toContainEqual({
+      key: 'q/Esc',
+      action: 'exit',
+    });
+  });
+
   it('starts with new chat and keeps help as the final active item', () => {
     const items = buildCliOrchestrationItems({
       presets: [],


### PR DESCRIPTION
## Summary
- expose the orchestration picker key-hint list so it can be tested
- advertise `1-9/a-z/Enter` for direct opening, matching the existing Select hotkeys
- keep exit on `Esc` so `q` remains available as Select's row hotkey in long orchestration lists
- cover the footer hints in the CLI orchestration test suite

Closes #4742.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/SelectHotkeys.vitest.mts`
- `git diff --check`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes; existing unrelated import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI hint text and Esc-only exit in the orchestration screen; no auth, data, or core runtime behavior changes.
> 
> **Overview**
> Aligns the orchestration startup picker footer with **Select**’s real direct-open keys and avoids advertising a conflicting exit chord.
> 
> A shared **`orchestrationKeyHints()`** helper now drives the footer and is covered by tests. The open hint is **`1-9/a-z/Enter`** (was **`1-9/Enter`**), and exit is **`Esc` only**—**`q`** is no longer listed or handled as exit so it does not clash with letter row hotkeys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d96ebffc7a584b830aba329d970703bc2d6163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->