### PR TITLE
fix(cli): compact one-line tool rows in transcript viewer

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -35,19 +35,59 @@ function entryLines(entry: ConversationEntry, cols: number): readonly string[] {
   }
 }
 
-/** Render the active slice into a flat line array with a blank separator
- *  between entries. Returns an empty array when there is nothing to show. */
+function isCompactToolEntry(
+  entry: ConversationEntry,
+  lines: readonly string[],
+): boolean {
+  return entry.role === 'tool' && lines.length <= 1;
+}
+
+function shouldSeparateEntries({
+  previousEntry,
+  previousLines,
+  nextEntry,
+  nextLines,
+}: {
+  readonly previousEntry: ConversationEntry | undefined;
+  readonly previousLines: readonly string[];
+  readonly nextEntry: ConversationEntry;
+  readonly nextLines: readonly string[];
+}): boolean {
+  if (!previousEntry) return false;
+  return !(
+    isCompactToolEntry(previousEntry, previousLines) &&
+    isCompactToolEntry(nextEntry, nextLines)
+  );
+}
+
+/** Render the active slice into a flat line array with blank separators between
+ *  substantial entries. Adjacent one-line tool calls stay stacked so compact
+ *  tool-heavy traces do not waste half the viewer on empty expansion space. */
 export function transcriptToLines(
   slice: StreamSlice | undefined,
   cols: number,
 ): readonly string[] {
   if (!slice) return [];
   const out: string[] = [];
+  let previousEntry: ConversationEntry | undefined;
+  let previousLines: readonly string[] = [];
   for (const entry of slice.entries) {
     const lines = entryLines(entry, cols);
     if (lines.length === 0) continue;
-    if (out.length > 0) out.push('');
+    if (
+      out.length > 0 &&
+      shouldSeparateEntries({
+        previousEntry,
+        previousLines,
+        nextEntry: entry,
+        nextLines: lines,
+      })
+    ) {
+      out.push('');
+    }
     out.push(...lines);
+    previousEntry = entry;
+    previousLines = lines;
   }
   return out;
 }

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -14,10 +14,12 @@ import {
   type ConversationEntry,
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
+import { transcriptToLines } from '@cli/chat/tui/state/transcriptLines';
 import { finalizeAssistantTranscriptEntries } from '@cli/chat/tui/state/transcript';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import {
   STREAM_STATUS,
+  TOOL_USE_STATUS,
   type NormalizedToolUse,
   type StreamTabId,
 } from '@shared/schemas';
@@ -61,6 +63,27 @@ function toolEntry(
       isUserFeedback: false,
       headerSummary: '',
       status,
+    },
+  };
+}
+
+function compactExecutionsEntry(id: string, path: string): ConversationEntry {
+  return {
+    id,
+    role: 'tool',
+    text: '',
+    finalized: true,
+    toolUse: {
+      parsed: {},
+      toolName: 'executions',
+      errorText: '',
+      outputText: '',
+      userInstructionText: '',
+      input: { path },
+      isError: false,
+      isUserFeedback: false,
+      headerSummary: '',
+      status: TOOL_USE_STATUS.COMPLETED,
     },
   };
 }
@@ -300,6 +323,41 @@ describe('CLI conversation transcript splitting', () => {
     });
 
     expect(items.slice(1).map((item) => item.id)).toEqual(['u1']);
+  });
+
+  it('compacts adjacent one-line tool rows in the transcript viewer', () => {
+    const lines = transcriptToLines(
+      sliceWithEntries(STREAM_ID, [
+        compactExecutionsEntry('t1', '/executions/3a780a389327/report'),
+        compactExecutionsEntry('t2', '/executions/3a780a389327/conversation'),
+      ]),
+      80,
+    );
+
+    expect(lines).toEqual([
+      '● executions (/executions/3a780a389327/report)',
+      '● executions (/executions/3a780a389327/conversation)',
+    ]);
+  });
+
+  it('keeps transcript viewer separators around prose and detailed tool rows', () => {
+    const lines = transcriptToLines(
+      sliceWithEntries(STREAM_ID, [
+        compactExecutionsEntry('t1', '/executions/3a780a389327/report'),
+        entry('a1', 'assistant', 'Read the report.', true),
+        toolEntry('t2', 'completed'),
+      ]),
+      80,
+    );
+
+    expect(lines).toEqual([
+      '● executions (/executions/3a780a389327/report)',
+      '',
+      'Read the report.',
+      '',
+      '● Bash (ls)',
+      '⎿ ok',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Collapse blank separators between adjacent one-line tool rows in the full transcript viewer.
- Keep blank separators around assistant prose and detailed tool output so longer entries remain readable.
- Add regression coverage for consecutive `executions` rows and mixed prose/detail rows.

Closes #4746.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:tui`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only spacing logic in the transcript viewer with targeted tests; no auth, data, or runtime behavior changes.
> 
> **Overview**
> The **ctrl+t full transcript viewer** no longer inserts a blank line between every entry. **`transcriptToLines`** now treats adjacent **tool** rows that each render to **at most one line** as a compact stack (no separator between them), while **blank lines still separate** assistant/user prose and **multi-line** tool output (e.g. Bash header plus `⎿ ok`).
> 
> Regression tests cover back-to-back **`executions`** one-liners and mixed compact tool + assistant + detailed tool layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8707959a422d88369a5070701aa5af7c9f85ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->