### PR TITLE
fix(cli): advertise child picker digit jumps

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -53,12 +53,14 @@ export function pickerKeyHints(
   if (itemCount <= 0) {
     return [{ key: 'Esc', action: 'close' }];
   }
-  return [
-    { key: '↑/↓', action: 'navigate' },
+  const hints: KeyHint[] = [{ key: '↑/↓', action: 'navigate' }];
+  if (itemCount > 1) hints.push({ key: '1-9', action: 'jump' });
+  hints.push(
     { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
     { key: 'k', action: 'kill' },
     { key: 'Esc', action: 'close' },
-  ];
+  );
+  return hints;
 }
 
 function renderItem(

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -579,7 +579,7 @@ describe('CLI child execution controls', () => {
     expect(nextPickerIndex(2, 3, 'down')).toBe(0);
   });
 
-  it('advertises only applicable keys for empty child pickers', () => {
+  it('advertises only applicable keys for child pickers', () => {
     expect(pickerKeyHints('tasks', 0)).toEqual([
       { key: 'Esc', action: 'close' },
     ]);
@@ -589,6 +589,14 @@ describe('CLI child execution controls', () => {
       { key: 'k', action: 'kill' },
       { key: 'Esc', action: 'close' },
     ]);
+    expect(childPickerKeyAction({ input: '3' })).toEqual({
+      kind: 'jump',
+      index: 2,
+    });
+    expect(pickerKeyHints('tasks', 3)).toContainEqual({
+      key: '1-9',
+      action: 'jump',
+    });
     expect(pickerKeyHints('subagents', 1)).toContainEqual({
       key: 'Enter',
       action: 'focus',


### PR DESCRIPTION
## Summary
- add a `1-9 jump` footer hint for multi-item child-control pickers
- keep empty and single-item child picker hints minimal
- extend child-control tests so advertised hints match existing digit-jump handling

Closes #4745.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts`
- `git diff --check`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes; existing unrelated import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer hint and test-only changes in the CLI TUI; no change to jump or kill handling logic.
> 
> **Overview**
> The child-control picker footer now shows a **`1-9` / jump** hint only when there is more than one item, so empty pickers still show just **Esc**, and single-item lists omit the digit shortcut.
> 
> Tests were broadened to assert that multi-item task pickers include the jump hint and that digit keys still map to jump actions, matching behavior that was already handled in `childPickerKeyAction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b317065d6e7c5fbcbb3e7d8f17dad5de9ad99109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->