### PR TITLE
refactor(core): simplify host-agnostic model/latex/replacement/utils

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -54,19 +54,6 @@ export class LatexMediaManager {
     private readonly fileService?: TaskRunFileService,
   ) {}
 
-  /**
-   * Resolve a figure path (relative to the LaTeX directory) to an absolute,
-   * normalized path. Mirrors the resolution used inside
-   * `extractFigurePathsFromLatex` so figure paths returned from a symlinked
-   * run-storage `.tex` map back to their real workspace location.
-   */
-  private resolveFigureAbsolutePath(
-    baseDir: string,
-    relativePath: string,
-  ): string {
-    return path.normalize(path.join(baseDir, relativePath));
-  }
-
   private async mirrorFigureDependencies(
     latexFile: FileLocation,
     figures: string[],
@@ -85,7 +72,7 @@ export class LatexMediaManager {
       if (!trimmed) {
         continue;
       }
-      absolutePaths.add(this.resolveFigureAbsolutePath(baseDir, trimmed));
+      absolutePaths.add(path.normalize(path.join(baseDir, trimmed)));
     }
 
     if (absolutePaths.size === 0) {
@@ -419,7 +406,7 @@ export class LatexMediaManager {
       // files when the .tex is symlinked into run storage.
       const baseDir = await resolveLatexDir(file.absolutePath);
       const fileLocations = figures.map((relativePath) =>
-        pathToLocation(this.resolveFigureAbsolutePath(baseDir, relativePath)),
+        pathToLocation(path.normalize(path.join(baseDir, relativePath))),
       );
 
       const existenceChecks = await Promise.all(

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -63,13 +63,9 @@ export class TikzPictureManager {
   /**
    * Extract TikZ pictures with their labels from a LaTeX file
    * @param latexFile FileLocation of the LaTeX file
-   * @param channel Optional channel for logging
    * @returns Array of [label, tikzpictures] tuples
    */
-  async extract(
-    latexFile: FileLocation,
-    channel: string = this.channel,
-  ): Promise<[string, string[]][]> {
+  async extract(latexFile: FileLocation): Promise<[string, string[]][]> {
     const content = await flexibleFS.read(latexFile);
 
     // Regular expressions to match figure environments and tikzpictures
@@ -90,7 +86,7 @@ export class TikzPictureManager {
 
       if (tikzMatches.length > 0) {
         labeledTikzPictures.push([label, tikzMatches]);
-        logger.debug(channel, `Found TikZ picture with label: ${label}`);
+        logger.debug(this.channel, `Found TikZ picture with label: ${label}`);
       }
     }
 
@@ -103,7 +99,6 @@ export class TikzPictureManager {
    * @param label Label for the figure
    * @param buildDirLocation Build directory FileLocation
    * @param suffix Optional suffix for multiple pictures with same label
-   * @param channel Optional channel for logging
    * @returns FileLocation of created LaTeX file
    */
   async createStandalone(
@@ -111,7 +106,6 @@ export class TikzPictureManager {
     label: string,
     buildDirLocation: FileLocation,
     suffix?: string,
-    channel: string = this.channel,
   ): Promise<FileLocation> {
     const standaloneContent = await renderPrompt(this.getTikzTemplate(), {
       tikzpicture: tikzpictures,
@@ -131,7 +125,7 @@ export class TikzPictureManager {
 
     await flexibleFS.write(texLocation, standaloneContent);
     logger.debug(
-      channel,
+      this.channel,
       `Created standalone LaTeX file: ${texLocation.absolutePath}`,
     );
 
@@ -141,13 +135,9 @@ export class TikzPictureManager {
   /**
    * Extract and compile TikZ pictures from a LaTeX file
    * @param latexFile Location of the LaTeX file
-   * @param channel Optional channel for logging
    * @returns Array of FileLocations for compiled PDF files
    */
-  async compile(
-    latexFile: FileLocation,
-    channel: string = this.channel,
-  ): Promise<FileLocation[]> {
+  async compile(latexFile: FileLocation): Promise<FileLocation[]> {
     const inputName = path.parse(path.basename(latexFile.absolutePath)).name;
     const inputDir = path.dirname(
       latexFile.kind !== 'external'
@@ -164,12 +154,12 @@ export class TikzPictureManager {
     await flexibleFS.ensureDir(buildDirLocation);
 
     logger.debug(
-      channel,
+      this.channel,
       `Extracting TikZ pictures from ${latexFile.absolutePath}`,
     );
-    const labeledTikzPictures = await this.extract(latexFile, channel);
+    const labeledTikzPictures = await this.extract(latexFile);
     logger.debug(
-      channel,
+      this.channel,
       `Found ${labeledTikzPictures.length} labeled TikZ pictures`,
     );
 
@@ -190,9 +180,11 @@ export class TikzPictureManager {
           label,
           buildDirLocation,
           suffix,
-          channel,
         );
-        await compileLatex2Pdf(texLocation, { channel, compiler: 'pdflatex' });
+        await compileLatex2Pdf(texLocation, {
+          channel: this.channel,
+          compiler: 'pdflatex',
+        });
 
         // Derive PDF location from tex location
         const pdfFilename = path
@@ -213,7 +205,7 @@ export class TikzPictureManager {
         if (await flexibleFS.exists(pdfLocation)) {
           compiledFiles.push(pdfLocation);
           logger.debug(
-            channel,
+            this.channel,
             `Successfully compiled: ${pdfLocation.absolutePath}`,
           );
         }

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -36,6 +36,9 @@ export interface DownloadSourceOptions {
 const INVALID_ARXIV_INPUT_ERROR =
   'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
 
+const PDF_ONLY_SUBMISSION_ERROR =
+  'This arXiv paper only has a PDF submission — no LaTeX source is available for download';
+
 function normalizeWorkspaceRelativeDirectory(candidate: string): string {
   return candidate
     .trim()
@@ -70,9 +73,7 @@ export class ArxivSourceProcessor {
    */
   private getExtensionFromContentType(contentType: string): string {
     if (contentType.includes('pdf')) {
-      throw new Error(
-        'This arXiv paper only has a PDF submission — no LaTeX source is available for download',
-      );
+      throw new Error(PDF_ONLY_SUBMISSION_ERROR);
     }
 
     const isTar = contentType.includes('tar');
@@ -282,9 +283,7 @@ export class ArxivSourceProcessor {
             () => undefined,
           );
         }
-        throw new Error(
-          'This arXiv paper only has a PDF submission — no LaTeX source is available for download',
-        );
+        throw new Error(PDF_ONLY_SUBMISSION_ERROR);
       }
 
       const isArchive =

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -175,9 +175,7 @@ export async function loadBibliographyEntries(
   const entries = new Map<string, string>();
   const hasWildcard = citationKeys.includes('*');
   const filteredKeys = citationKeys.filter((key) => key !== '*');
-  const normalizedRequestedKeys = new Set(
-    filteredKeys.map((key) => key.toLowerCase()),
-  );
+  const includeAll = hasWildcard || filteredKeys.length === 0;
   const parsedEntries = new Map<string, { key: string; value: string }>();
 
   for (const filePath of bibliographyFiles) {
@@ -191,7 +189,7 @@ export async function loadBibliographyEntries(
     }
   }
 
-  if (hasWildcard || normalizedRequestedKeys.size === 0) {
+  if (includeAll) {
     for (const { key, value } of parsedEntries.values()) {
       if (!entries.has(key)) {
         entries.set(key, value);
@@ -207,10 +205,9 @@ export async function loadBibliographyEntries(
     }
   }
 
-  const missingKeys =
-    hasWildcard || normalizedRequestedKeys.size === 0
-      ? []
-      : filteredKeys.filter((key) => !parsedEntries.has(key.toLowerCase()));
+  const missingKeys = includeAll
+    ? []
+    : filteredKeys.filter((key) => !parsedEntries.has(key.toLowerCase()));
 
   return {
     entries,
@@ -223,9 +220,6 @@ export function summarizeBibliographyEntries(
   limit: number,
 ): string[] {
   const values = [...entries.values()].slice(0, limit);
-  if (values.length === 0) {
-    return [];
-  }
   // Join entries with empty lines between them
   return values.flatMap((entry, i) =>
     i < values.length - 1 ? [entry, ''] : [entry],

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -73,8 +73,6 @@ async function resolveFigurePath(
 export async function extractFigurePathsFromLatex(
   latexFileLocation: FileLocation,
 ): Promise<string[]> {
-  const figurePaths: string[] = [];
-
   const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
   const graphicspaths = [latexDir]; // Start with the directory of the LaTeX file
 
@@ -108,12 +106,11 @@ export async function extractFigurePathsFromLatex(
         graphicspaths,
         latexDir,
       );
-      if (resolved && !discovered.has(resolved)) {
-        figurePaths.push(resolved);
+      if (resolved) {
         discovered.add(resolved);
       }
     }
   }
 
-  return figurePaths;
+  return [...discovered];
 }

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -71,11 +71,10 @@ export async function extractLatexFileDependencies(
   const uncommented = stripLatexComments(content);
 
   const texInputPaths: string[] = [];
-  for (const match of uncommented.matchAll(INPUT_PATTERN)) {
-    texInputPaths.push(match[1]);
-  }
-  for (const match of uncommented.matchAll(INCLUDE_PATTERN)) {
-    texInputPaths.push(match[1]);
+  for (const pattern of [INPUT_PATTERN, INCLUDE_PATTERN]) {
+    for (const match of uncommented.matchAll(pattern)) {
+      texInputPaths.push(match[1]);
+    }
   }
 
   const bibCandidates = collectBibliographyPaths(latexDir, uncommented);
@@ -88,10 +87,7 @@ export async function extractLatexFileDependencies(
   ]);
 
   const results = new Set<string>();
-  for (const resolved of texResolved) {
-    if (resolved) results.add(resolved);
-  }
-  for (const resolved of bibResolved) {
+  for (const resolved of [...texResolved, ...bibResolved]) {
     if (resolved) results.add(resolved);
   }
 

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -24,17 +24,6 @@ export interface LatexToolchainProbe {
   readonly hasLatexmk: boolean;
 }
 
-export const LATEX_TOOLCHAIN_TOOLS: readonly LatexToolName[] = [
-  'latexmk',
-  'pdflatex',
-  'xelatex',
-  'lualatex',
-  'bibtex',
-  'biber',
-  'latexdiff',
-  'latexindent',
-];
-
 const TOOL_PURPOSES: Record<LatexToolName, string> = {
   latexmk: 'LaTeX build orchestration',
   pdflatex: 'PDFLaTeX compiler',
@@ -57,10 +46,11 @@ const REQUIRED_TOOLS = new Set<LatexToolName>(['latexmk']);
 
 /** Probe the LaTeX tools used by both the extension and CLI surfaces. */
 export async function probeLatexToolchain(): Promise<LatexToolchainProbe> {
+  const toolNames = Object.keys(TOOL_PURPOSES) as LatexToolName[];
   const installed = await Promise.all(
-    LATEX_TOOLCHAIN_TOOLS.map((tool) => checkToolInstalled(tool, false)),
+    toolNames.map((tool) => checkToolInstalled(tool, false)),
   );
-  const tools = LATEX_TOOLCHAIN_TOOLS.map((name, index): LatexToolStatus => {
+  const tools = toolNames.map((name, index): LatexToolStatus => {
     return {
       name,
       installed: installed[index] ?? false,

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -267,7 +267,8 @@ export class DiffCommandExecutor {
     pictureEnvs: string;
     subtype?: string;
   } {
-    const changesOnly = getWorkspaceState().get<boolean>(
+    const state = getWorkspaceState();
+    const changesOnly = state.get<boolean>(
       WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY,
       LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
     );
@@ -275,7 +276,7 @@ export class DiffCommandExecutor {
     return {
       mathMarkup:
         options?.mathMarkup ??
-        getWorkspaceState().get<MathMarkupOption>(
+        state.get<MathMarkupOption>(
           WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,
           LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup as MathMarkupOption,
         ),

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -42,8 +42,7 @@ export function generateDiffFileName(
     const sameModel = inputRoundMatch[2] === editedRoundMatch[2];
 
     // Extract base name from edited filename using round pattern
-    const name = path.parse(editedFileName).name;
-    const lastMatch = extractLastRoundMatch(name);
+    const lastMatch = extractLastRoundMatch(editedBaseName);
     if (lastMatch?.index == null) {
       throw new Error(
         `Failed to extract base name from edited file: ${editedFileName}`,
@@ -53,7 +52,7 @@ export function generateDiffFileName(
     // The -1 excludes the trailing underscore from _rN_ when includeRound is true
     const endIndex =
       lastMatch.index + (sameModel ? lastMatch[0].length - 1 : 0);
-    const baseName = name.slice(0, endIndex);
+    const baseName = editedBaseName.slice(0, endIndex);
     const modelSuffix = sameModel ? `_${editedRoundMatch[2]}` : '';
 
     return `${baseName}${modelSuffix}_diffr${secondRound}r${firstRound}.tex`;

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -80,9 +80,15 @@ export class DiffFileProcessor {
         return [];
       }
 
-      const lineState = this.updateLineState(line, documentStarted);
-      documentStarted = lineState.documentStarted;
-      skippingPreambleBlock = lineState.skipBlock ?? skippingPreambleBlock;
+      if (DOCUMENT_START_MARKERS.some((marker) => line.includes(marker))) {
+        documentStarted = true;
+        skippingPreambleBlock = false;
+      } else if (
+        !documentStarted &&
+        PREAMBLE_SKIP_MARKERS.some((marker) => line.includes(marker))
+      ) {
+        skippingPreambleBlock = true;
+      }
 
       if (skippingPreambleBlock) {
         return [];
@@ -92,22 +98,6 @@ export class DiffFileProcessor {
     });
 
     return processedLines.join('\n') + '\n';
-  }
-
-  private updateLineState(
-    line: string,
-    documentStarted: boolean,
-  ): { documentStarted: boolean; skipBlock?: boolean } {
-    if (DOCUMENT_START_MARKERS.some((marker) => line.includes(marker))) {
-      return { documentStarted: true, skipBlock: false };
-    }
-    if (
-      !documentStarted &&
-      PREAMBLE_SKIP_MARKERS.some((marker) => line.includes(marker))
-    ) {
-      return { documentStarted, skipBlock: true };
-    }
-    return { documentStarted };
   }
 
   private formatLine(line: string): string[] {

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -47,16 +47,16 @@ async function hasChinesePackages(
 // Texcount Schemas
 // ============================================================================
 
-export const TexcountModeSchema = z.enum(['separate', 'include', 'sum']);
+const TexcountModeSchema = z.enum(['separate', 'include', 'sum']);
 export type TexcountMode = z.infer<typeof TexcountModeSchema>;
 
-export const TexcountOptionsSchema = z.object({
+const TexcountOptionsSchema = z.object({
   mode: TexcountModeSchema.optional(),
   channel: z.string().optional(),
 });
 export type TexcountOptions = z.infer<typeof TexcountOptionsSchema>;
 
-export const TexcountResultSchema = z.object({
+const TexcountResultSchema = z.object({
   output: z.string().nullable(),
   errors: z.array(z.string()),
 });

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -29,7 +29,3 @@ export const ToolDefinitionSchema = z.looseObject({
 
 /** Tool definition type - derived from schema */
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
-
-// ============================================================================
-// Type Guards and Utilities
-// ============================================================================

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -7,12 +7,7 @@ import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { apiKeyExists, isApiProvider } from './apiProviders';
-import {
-  buildModelHint,
-  formatContext,
-  formatCost,
-  getVisibleModels,
-} from './modelOptionsBasic';
+import { buildBaseModelOption, getVisibleModels } from './modelOptionsBasic';
 import { shouldRouteModelThroughOpenRouter } from './openRouterRouting';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
@@ -70,12 +65,7 @@ const AVAILABILITY_STATUS: Record<
 async function getPersonalAccessKindForModel(
   config: ModelConfig,
   hasOpenRouter: boolean,
-  useOpenRouter: boolean,
 ): Promise<PersonalModelAccessKind | null> {
-  if (shouldRouteModelThroughOpenRouter(config, useOpenRouter)) {
-    return hasOpenRouter ? 'openrouter-key' : null;
-  }
-
   const { provider } = config;
   if (!isApiProvider(provider)) {
     return 'provider-key';
@@ -146,7 +136,6 @@ async function resolveModelAvailability(
   const personalAccess = await getPersonalAccessKindForModel(
     config,
     ctx.hasOpenRouter,
-    ctx.useOpenRouter,
   );
   return personalAccess
     ? AVAILABILITY_STATUS[personalAccess]
@@ -215,12 +204,7 @@ async function buildModelOptionData(
 
   const availability = await resolveModelAvailability(model, config, ctx);
   return {
-    value: model,
-    label: config.label,
-    provider: config.provider,
-    context: formatContext(config.contextWindow),
-    cost: formatCost(config.inputPrice, config.outputPrice),
-    hint: buildModelHint(config),
+    ...buildBaseModelOption(model, config),
     availability: availability.kind,
     availabilityLabel: availability.label,
     requiresKey: availability.requiresKey,

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -38,15 +38,6 @@ export function getVisibleModels(): string[] {
   );
 }
 
-/**
- * Resolve a model against the user's visible-models list.
- */
-export function resolveVisibleModel(model: string): string {
-  const visibleModels = getVisibleModels();
-  if (visibleModels.length === 0 || visibleModels.includes(model)) return model;
-  return visibleModels[0];
-}
-
 /** Return whether the registry marks a model as deprecated. */
 export function isDeprecatedModel(model: string): boolean {
   return MODEL_CONFIGS[model]?.deprecated ?? false;
@@ -85,6 +76,21 @@ export function buildModelHint(config: ModelConfig): string {
   return base;
 }
 
+/** Project a model config to the base option fields shared across views. */
+export function buildBaseModelOption(
+  model: string,
+  config: ModelConfig,
+): ModelOptionData {
+  return {
+    value: model,
+    label: config.label,
+    provider: config.provider,
+    context: formatContext(config.contextWindow),
+    cost: formatCost(config.inputPrice, config.outputPrice),
+    hint: buildModelHint(config),
+  };
+}
+
 /** Build model options from static config without provider availability checks. */
 export function buildBasicModelOptionsData(
   visibleModels: readonly string[] = getVisibleModels(),
@@ -92,13 +98,6 @@ export function buildBasicModelOptionsData(
   return visibleModels.map((model) => {
     const config = MODEL_CONFIGS[model];
     if (!config) return { value: model, label: model };
-    return {
-      value: model,
-      label: config.label,
-      provider: config.provider,
-      context: formatContext(config.contextWindow),
-      cost: formatCost(config.inputPrice, config.outputPrice),
-      hint: buildModelHint(config),
-    };
+    return buildBaseModelOption(model, config);
   });
 }

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -23,33 +23,21 @@ export const GREEK_LETTER_SHORTCUTS: { [key: string]: string } = {
   gamma: 'ga',
   delta: 'de',
   epsilon: 'eps',
-  varepsilon: 'varepsilon',
   zeta: 'ze',
-  eta: 'eta',
   theta: 'ta',
   Theta: 'Ta',
   iota: 'io',
   kappa: 'ka',
   lambda: 'la',
-  mu: 'mu',
-  nu: 'nu',
-  xi: 'xi',
   omicron: 'om',
-  pi: 'pi',
-  rho: 'rho',
   sigma: 'sg',
   Sigma: 'Sig',
-  tau: 'tau',
   upsilon: 'ups',
   phi: 'phi',
   varphi: 'vphi',
-  chi: 'chi',
-  psi: 'psi',
   omega: 'om',
   Omega: 'Om',
   Gamma: 'Ga',
-  Lambda: 'Lambda',
-  Delta: 'Delta',
 };
 
 // Automatically generated replacement patterns
@@ -588,11 +576,6 @@ export const MAX_STYLE_REPLACEMENTS: ReplacementCategory = {
   },
 };
 
-// Helper to create | separated regex part from a list of words
-function createWordRegexPart(words: string[]): string {
-  return words.join('|');
-}
-
 // prettier-ignore
 // Define the comprehensive list of all trigger words
 const _fullWordsArrayInternal = [
@@ -680,15 +663,9 @@ const _gepWordsArrayInternal = _fullWordsArrayInternal.filter(
 );
 
 // Create regex parts for use in the patterns object
-const SEP_WORDS_REGEX_PART_INTERNAL = createWordRegexPart(
-  _sepWordsArrayInternal,
-);
-const GEP_WORDS_REGEX_PART_INTERNAL = createWordRegexPart(
-  _gepWordsArrayInternal,
-);
-const FULL_WORDS_REGEX_PART_INTERNAL = createWordRegexPart(
-  _fullWordsArrayInternal,
-);
+const SEP_WORDS_REGEX_PART_INTERNAL = _sepWordsArrayInternal.join('|');
+const GEP_WORDS_REGEX_PART_INTERNAL = _gepWordsArrayInternal.join('|');
+const FULL_WORDS_REGEX_PART_INTERNAL = _fullWordsArrayInternal.join('|');
 
 // Pre-construct the regex patterns
 const SEP_WORDS_CREF_EQN_PATTERN = `(${SEP_WORDS_REGEX_PART_INTERNAL})(?:,)?\\s+\\\\cref\\{(eqn:[^,}]+)\\}`;

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -143,9 +143,6 @@ export const EQUATION_REPLACEMENTS: ReplacementCategory = {
     // Environment name fixes
     patterns['\\end{Galign}'] = '\\end{align}';
 
-    // Unusual line/paragraph separators (Gemini problem)
-    patterns['/[\u2028\u2029]/g'] = '\n';
-
     patterns[':\\colon'] = '\\colon';
     return patterns;
   })(),

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -8,7 +8,7 @@ import {
 const EQUATION_ENVIRONMENT_PATTERN =
   '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';
 
-function getSafeString(value: string | number | undefined): string {
+function getSafeString(value: string | undefined): string {
   return typeof value === 'string' ? value : '';
 }
 

--- a/src/utils/diagnostics/diagnosticFormatting.ts
+++ b/src/utils/diagnostics/diagnosticFormatting.ts
@@ -48,17 +48,16 @@ const SEVERITY_CONFIG: Record<
   [SEVERITY_HINT]: { label: 'hint', countKey: 'hints', plural: 'hints' },
 };
 
-/** Ordered formatting config for consistent output */
+/** Ordered formatting config for consistent output, derived from SEVERITY_CONFIG. */
 const COUNT_FORMAT_ORDER: Array<{
   key: keyof SeverityCounts;
   label: string;
   plural: string;
-}> = [
-  { key: 'errors', label: 'error', plural: 'errors' },
-  { key: 'warnings', label: 'warning', plural: 'warnings' },
-  { key: 'info', label: 'info', plural: 'info' },
-  { key: 'hints', label: 'hint', plural: 'hints' },
-];
+}> = Object.values(SEVERITY_CONFIG).map(({ countKey, label, plural }) => ({
+  key: countKey,
+  label,
+  plural,
+}));
 
 /** Get the string label for a severity level. */
 export function getSeverityLabel(severity: number): string {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -6,11 +6,6 @@ import { WORKFLOW_OUTPUT_BASENAME } from '@agent/output/workflowOutputLayout';
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
-  AgentFileLocationSchema,
-  ExternalFileLocationSchema,
-  FileLocationSchema,
-  RunStorageFileLocationSchema,
-  WorkspaceFileLocationSchema,
   type AgentFileLocation,
   type ExecutionId,
   type ExternalFileLocation,
@@ -146,16 +141,11 @@ export async function resolveRunDir(
 /**
  * @internal Used internally by TaskRunFileService
  */
-function getRunStoragePaths(
+function getRunStorageAbsolutePath(
   id: ExecutionId,
   workspaceRelative: string,
-): { absolute: string; storageRelative: string; runRelative: string } {
-  const storageRelative = path.join(TASK_RUNS_DIR, id, workspaceRelative);
-  return {
-    absolute: StorageFS.fullPath(storageRelative),
-    storageRelative,
-    runRelative: workspaceRelative,
-  };
+): string {
+  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id, workspaceRelative));
 }
 
 async function ensureParentDir(filePath: string): Promise<void> {
@@ -178,10 +168,9 @@ async function snapshotExists(absolutePath: string): Promise<boolean> {
 }
 
 async function createSymlink(
-  source: FileLocation,
+  sourceAbsolute: string,
   destination: string,
 ): Promise<void> {
-  const sourceAbsolute = source.absolutePath;
   await ensureParentDir(destination);
   try {
     await fs.symlink(sourceAbsolute, destination);
@@ -343,12 +332,15 @@ export class TaskRunFileService {
       if (!stats.isFile()) return;
 
       const snapshotRelative = path.join('original', target.relativePath);
-      const snapshotPaths = getRunStoragePaths(executionId, snapshotRelative);
+      const snapshotAbsolute = getRunStorageAbsolutePath(
+        executionId,
+        snapshotRelative,
+      );
 
-      if (await snapshotExists(snapshotPaths.absolute)) return;
+      if (await snapshotExists(snapshotAbsolute)) return;
 
-      await ensureParentDir(snapshotPaths.absolute);
-      await fs.copyFile(target.absolutePath, snapshotPaths.absolute);
+      await ensureParentDir(snapshotAbsolute);
+      await fs.copyFile(target.absolutePath, snapshotAbsolute);
     } catch (error) {
       if (isFileNotFoundError(error)) return;
       throw new Error(
@@ -424,10 +416,13 @@ export class TaskRunFileService {
     }
 
     await this.ensureRunDirectory();
-    const runPaths = getRunStoragePaths(executionId, location.relativePath);
+    const runAbsolute = getRunStorageAbsolutePath(
+      executionId,
+      location.relativePath,
+    );
 
     if (!this.mirroredDependencies.has(location.relativePath)) {
-      await createSymlink(location, runPaths.absolute);
+      await createSymlink(location.absolutePath, runAbsolute);
       this.mirroredDependencies.add(location.relativePath);
     }
 
@@ -436,8 +431,8 @@ export class TaskRunFileService {
     }
 
     return createRunStorageLocation(
-      runPaths.absolute,
-      runPaths.runRelative,
+      runAbsolute,
+      location.relativePath,
       executionId,
     );
   }
@@ -559,10 +554,7 @@ export class TaskRunFileService {
         }
 
         try {
-          await createSymlink(
-            createRunStorageLocation(sourceAbsolute, relativePath, executionId),
-            destinationAbsolute,
-          );
+          await createSymlink(sourceAbsolute, destinationAbsolute);
         } catch (error) {
           logger.debug(
             CHANNEL,

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -220,7 +220,7 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
 }
 
 /** Convert a single page of a PDF to a base64 encoded PNG image. */
-export async function singlePagePdf2Png(
+async function singlePagePdf2Png(
   pdfPath: string,
   pageNum: number = 1,
   quality: number = 300,
@@ -279,7 +279,7 @@ export async function singlePagePdf2Png(
 }
 
 /** Convert multiple pages of a PDF to base64 encoded PNG images. */
-export async function multiPagePdf2Png(
+async function multiPagePdf2Png(
   pdfPath: string,
   quality: number = 300,
   maxSize: [number, number] = [1024, 1024],

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -260,7 +260,8 @@ export async function checkToolInstalled(
 
     // Check if output contains version-like pattern (e.g., "3.7.1")
     const hasVersionOutput = (result: { stdout?: string; stderr?: string }) =>
-      result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
+      /\d+\.\d+/.test(result.stdout ?? '') ||
+      /\d+\.\d+/.test(result.stderr ?? '');
 
     const executeWithFallback = async (
       cmd: string,
@@ -410,12 +411,12 @@ export async function runToolWithCheck(
 
 /**
  * Check if multiple tools are installed
- * @param configs Array of tool configurations
+ * @param configs Array of tool names
  * @param showError Whether to show error messages for missing tools
  * @returns Promise<boolean[]> Array of booleans indicating which tools are installed
  */
 export async function checkMultipleToolsInstalled(
-  configs: string[] | ToolConfig[],
+  configs: string[],
   showError: boolean = true,
 ): Promise<boolean[]> {
   return Promise.all(

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -19,7 +19,7 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 // Format Detection (inlined from xmlFormatDetection.ts - only used here)
 // ─────────────────────────────────────────────────────────────────────────────
 
-export enum OutputFormat {
+enum OutputFormat {
   HTML = 'html',
   LaTeX = 'latex',
   MARKDOWN = 'markdown',
@@ -36,14 +36,6 @@ function detectInputFormat(text: string): OutputFormat {
     return OutputFormat.HTML;
   }
   return OutputFormat.MARKDOWN;
-}
-
-function containsHtml(text: string): boolean {
-  return HTML_PATTERN.test(text);
-}
-
-function containsLatex(text: string): boolean {
-  return LATEX_PATTERN.test(text);
 }
 
 const CHANNEL = 'xmlConversion';
@@ -217,7 +209,7 @@ export async function formatContent(content: string): Promise<string> {
   if (pandocResult !== null) return pandocResult;
 
   let result = trimmed;
-  if (containsHtml(result)) result = convertHtmlToMarkdown(result);
-  if (containsLatex(result)) result = convertLatexToMarkdown(result);
+  if (HTML_PATTERN.test(result)) result = convertHtmlToMarkdown(result);
+  if (LATEX_PATTERN.test(result)) result = convertLatexToMarkdown(result);
   return result;
 }

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -17,7 +17,7 @@ export {
 } from './xmlCdata';
 
 // Re-export from conversion module
-export { OutputFormat, formatContent } from './xmlConversion';
+export { formatContent } from './xmlConversion';
 
 // Re-export from extraction module
 export {


### PR DESCRIPTION
Third cleanup pass after #4725 (TUI) and #4740 (CLI runtime/commands). This one targets the **host-agnostic shared core** — `src/model`, `src/latex`, `src/replacement`, `src/utils` (VS Code-free zones, ~14.5k lines).

### How it was produced & verified
A code-simplifier fan-out over 11 file-groups surfaced **47 candidates**; each was **adversarially verified** with explicit checks for: test-consumer breakage (grep `src/test-kernel` / `src/test` / `*.vitest.*`), **byte-identical output** for replacement/latexdiff/prompt code, and the **no-`vscode`-import** architectural rule. **17 rejected** (subjective restyle or behavior-sensitive — e.g. a `flatMap→join` that would have changed a `string[]` return type, kept only its dead-guard deletion). **30 applied.**

Proven green: `tsc --noEmit` ✅, `tsc -p tsconfig.test-kernel.json` ✅, **full test-kernel vitest — 236 files / 1294 tests** ✅, `prettier --check` ✅, and a vscode-free-zone guard (no host import introduced) ✅.

### Changes (30)
- **Dead code:** unused exports (`resolveVisibleModel`, `OutputFormat` enum + re-export, `singlePagePdf2Png`/`multiPagePdf2Png` export keywords, three texcount Zod schema exports); a **never-firing replacement rule** (a regex pattern placed as a literal string in a non-regex category); **12 no-op identity Greek-letter shortcuts** (`\name → \name`); a provably-dead OpenRouter re-check; five unused Zod imports; a content-less comment banner.
- **DRY:** extract `buildBaseModelOption` (model-option projection shared by two modules) and a PDF-only-submission error const; derive the latex toolchain list and diagnostic `COUNT_FORMAT_ORDER` from their single sources; fold duplicated input/include + figure-dedup loops; hoist repeated `getWorkspaceState()` / `path.parse()` calls.
- **Flatten / clarify:** inline trivial wrappers (`resolveFigureAbsolutePath`, `createWordRegexPart`, `containsHtml`/`containsLatex`, the `updateLineState` latch); narrow over-wide param/return types; use `.test()` where only truthiness is consumed; collapse a redundant parallel Set in `extractFigure`.

Replacement-rule and latexdiff changes are byte-output-preserving by construction (deleted a dead rule + identity no-ops; CSE/hoisting only). No new dependencies; no lockfile change; no `vscode` import.

**Note:** `src/test/` Mocha suites can't run locally (they require the VS Code test env per CLAUDE.md), so CI's `validate` job is the authoritative check for any coverage living there. The full Vitest kernel suite (1294 tests) passes.

**Verified:** ran the full test-kernel suite from this branch — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical cleanup and export narrowing in non-critical shared code; replacement and model availability paths were verified to preserve prior behavior.
> 
> **Overview**
> This PR is a **host-agnostic cleanup** across `src/model`, `src/latex`, `src/replacement`, and `src/utils`: dead exports and no-op patterns are removed, small helpers are inlined or merged, and shared projection logic is centralized—without intended behavior changes.
> 
> **LaTeX / media:** Figure path resolution drops a private wrapper in favor of direct `path.join`/`normalize`. `TikzPictureManager` no longer takes per-call `channel` overrides (it always uses the instance channel). arXiv PDF-only errors share one constant. Bibliography loading uses a single `includeAll` flag; figure and `\input`/`\include` extraction dedupe via `Set` and combined loops. The toolchain probe list is derived from `TOOL_PURPOSES` instead of a duplicate array. latexdiff hoists workspace state and reuses parsed basenames in diff filename logic; preamble skipping in the diff file processor is inlined.
> 
> **Model:** `buildBaseModelOption` centralizes label/context/cost/hint fields for basic and availability-aware option builders. `resolveVisibleModel` is removed. Personal-key resolution no longer re-checks OpenRouter routing (that remains in `resolveModelAvailability`).
> 
> **Replacement:** Twelve identity Greek-letter shortcuts, a never-applied Unicode line-separator literal rule, and a small `createWordRegexPart` helper are removed.
> 
> **Utils:** Diagnostic count ordering is built from `SEVERITY_CONFIG`. Task-run storage symlinks take absolute source paths and a slimmer path helper. PDF page-to-PNG helpers are module-private; `checkMultipleToolsInstalled` is typed as `string[]` only. XML formatting drops exported `OutputFormat` and duplicate detect helpers in favor of regex tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f59be401da87d3c33a35fc8dc1326d559a8713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->