### PR TITLE
fix(cli): show stream focus shortcuts

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -26,7 +26,7 @@ import {
 } from './input/inputKeys';
 import {
   hasChildExecutionRows,
-  numericFocusTarget,
+  numericFocusTargetForActiveStream,
   resolveChildControlStreamTarget,
   type ChildControlMode,
 } from './state/childControls';
@@ -434,7 +434,12 @@ export function App(props: AppProps): React.JSX.Element {
       }
       const digit = metaChordDigit(input, key);
       if (digit !== undefined) {
-        const target = numericFocusTarget(activeSlice, digit - 1);
+        const target = numericFocusTargetForActiveStream({
+          activeStreamId,
+          parentStream,
+          streams,
+          zeroBasedIndex: digit - 1,
+        });
         if (target) cliState.activeStreamId.set(target);
       }
       return;

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'ink';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { cliState, type StreamSlice } from '../state/cliState';
-import { orderedDescendantsFromSlice } from '../state/focusCycle';
+import { orderedDescendantsFromTree } from '../state/focusCycle';
 import {
   childStreamDisplayLabel,
   streamScopeDisplayLabel,
@@ -15,10 +15,16 @@ export interface StreamTabDisplayItem {
   readonly label: string;
   readonly active: boolean;
   readonly running: boolean;
+  readonly shortcutIndex?: number;
   readonly status?: string;
 }
 
 const MAX_LABEL_WIDTH = 18;
+
+interface OrderedStreamTab {
+  readonly id: StreamTabId;
+  readonly shortcutIndex?: number;
+}
 
 function statusLabel(status: string | undefined): string | undefined {
   switch (status) {
@@ -48,19 +54,20 @@ function orderedStreamTree(init: {
   readonly rootSlice: StreamSlice | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): StreamTabId[] {
-  const ordered = orderedDescendantsFromSlice(init.rootSlice);
-  for (const [child, parent] of init.parentStream) {
-    if (
-      parent !== init.root ||
-      !init.streams.has(child) ||
-      ordered.includes(child)
-    ) {
-      continue;
-    }
-    ordered.push(child);
+}): OrderedStreamTab[] {
+  const ordered = orderedDescendantsFromTree({
+    parent: init.root,
+    parentSlice: init.rootSlice,
+    parentStream: init.parentStream,
+    streams: init.streams,
+  });
+  const out: OrderedStreamTab[] = [];
+  if (init.streams.has(init.root)) out.push({ id: init.root });
+  for (const [index, id] of ordered.entries()) {
+    if (!init.streams.has(id)) continue;
+    out.push({ id, shortcutIndex: streamTabShortcutIndex(index + 1) });
   }
-  return [init.root, ...ordered].filter((id) => init.streams.has(id));
+  return out;
 }
 
 function activeTreeRoot(
@@ -76,7 +83,11 @@ function collapseMiddle(
   items: readonly StreamTabDisplayItem[],
   width: number,
 ): readonly StreamTabDisplayItem[] {
-  const total = items.reduce((sum, item) => sum + item.label.length + 8, 0);
+  const total = items.reduce(
+    (sum, item) =>
+      sum + item.label.length + (item.shortcutIndex !== undefined ? 2 : 0) + 8,
+    0,
+  );
   if (total <= width || items.length <= 4) return items;
   const activeIndex = items.findIndex((item) => item.active);
   const keep = new Set([0, items.length - 1]);
@@ -108,6 +119,11 @@ function collapseMiddle(
   return out;
 }
 
+function streamTabShortcutIndex(position: number): number | undefined {
+  if (position <= 0 || position > 9) return undefined;
+  return position;
+}
+
 export function streamTabsDisplayItems(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
@@ -128,7 +144,8 @@ export function streamTabsDisplayItems(init: {
     streams: init.streams,
   });
   if (ordered.length < 2) return [];
-  const items = ordered.map((id): StreamTabDisplayItem => {
+  const items = ordered.map((tab): StreamTabDisplayItem => {
+    const { id } = tab;
     const slice = init.streams.get(id);
     const status = statusLabel(slice?.status);
     return {
@@ -145,6 +162,7 @@ export function streamTabsDisplayItems(init: {
       ),
       active: id === init.activeStreamId,
       running: slice?.status === STREAM_STATUS.RUNNING,
+      shortcutIndex: tab.shortcutIndex,
       status,
     };
   });
@@ -153,7 +171,11 @@ export function streamTabsDisplayItems(init: {
 
 export function streamTabSegmentText(item: StreamTabDisplayItem): string {
   if (item.id === 'ellipsis') return '…';
-  const label = item.active ? `[${item.label}]` : item.label;
+  const labeled =
+    item.shortcutIndex === undefined
+      ? item.label
+      : `${item.shortcutIndex}:${item.label}`;
+  const label = item.active ? `[${labeled}]` : labeled;
   const running = item.running ? '*' : '';
   const status =
     item.status &&

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -12,7 +12,7 @@ import { formatDuration } from '@utils/core';
 // Local imports - CLI state
 import { isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
-import { orderedDescendantsFromSlice } from './focusCycle';
+import { orderedDescendantsFromTree } from './focusCycle';
 import type { ProcessOutputTail, StreamSlice } from './cliState';
 
 export type ChildControlMode = 'subagents' | 'tasks';
@@ -281,14 +281,21 @@ export function hasChildExecutionRows(
   );
 }
 
-export function numericFocusTarget(
-  slice:
-    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
-    | undefined,
-  zeroBasedIndex: number,
-): StreamTabId | undefined {
-  if (!slice || zeroBasedIndex < 0) return undefined;
-  return orderedDescendantsFromSlice(slice)[zeroBasedIndex];
+export function numericFocusTargetForActiveStream(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly zeroBasedIndex: number;
+}): StreamTabId | undefined {
+  if (!init.activeStreamId || init.zeroBasedIndex < 0) return undefined;
+  const root =
+    init.parentStream.get(init.activeStreamId) ?? init.activeStreamId;
+  return orderedDescendantsFromTree({
+    parent: root,
+    parentSlice: init.streams.get(root),
+    parentStream: init.parentStream,
+    streams: init.streams,
+  })[init.zeroBasedIndex];
 }
 
 export function clampPickerIndex(index: number, length: number): number {

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -31,15 +31,36 @@ export function orderedDescendantsFromSlice(
   return [...new Set(out)];
 }
 
-export function orderedDescendants(parent: StreamTabId): StreamTabId[] {
-  const streams = cliState.streams.get();
-  const out = orderedDescendantsFromSlice(streams.get(parent));
-  for (const [child, recordedParent] of cliState.parentStream.get()) {
-    if (recordedParent !== parent || !streams.has(child) || out.includes(child))
+export function orderedDescendantsFromTree(init: {
+  readonly parent: StreamTabId;
+  readonly parentSlice: StreamSlice | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): StreamTabId[] {
+  const out = orderedDescendantsFromSlice(init.parentSlice).filter((id) =>
+    init.streams.has(id),
+  );
+  for (const [child, recordedParent] of init.parentStream) {
+    if (
+      recordedParent !== init.parent ||
+      !init.streams.has(child) ||
+      out.includes(child)
+    ) {
       continue;
+    }
     out.push(child);
   }
   return out;
+}
+
+export function orderedDescendants(parent: StreamTabId): StreamTabId[] {
+  const streams = cliState.streams.get();
+  return orderedDescendantsFromTree({
+    parent,
+    parentSlice: streams.get(parent),
+    parentStream: cliState.parentStream.get(),
+    streams,
+  });
 }
 
 /** Returns the next stream id the focus cycle should land on, or `undefined`

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -16,7 +16,7 @@ import {
   hasChildExecutionRows,
   liveChildExecutionElapsedKey,
   nextPickerIndex,
-  numericFocusTarget,
+  numericFocusTargetForActiveStream,
   resolveChildControlStreamTarget,
 } from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
@@ -60,8 +60,8 @@ function slice(
 }
 
 describe('CLI child execution controls', () => {
-  it('maps Alt-number focus jumps to listed descendant streams', () => {
-    const state = slice({
+  it('maps Alt-number focus jumps to visible descendant streams', () => {
+    const root = slice({
       activeSubagents: [
         {
           executionId: 'agent-1',
@@ -84,11 +84,76 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
+    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
+      ['root', root],
+      ['child-b', slice({ streamId: 'child-b' })],
+      ['child-c', slice({ streamId: 'child-c' })],
+    ]);
 
-    expect(numericFocusTarget(state, 0)).toBe('child-a');
-    expect(numericFocusTarget(state, 1)).toBe('child-c');
-    expect(numericFocusTarget(state, 2)).toBe('child-b');
-    expect(numericFocusTarget(state, 3)).toBeUndefined();
+    expect(
+      numericFocusTargetForActiveStream({
+        activeStreamId: 'root',
+        parentStream: new Map(),
+        streams,
+        zeroBasedIndex: 0,
+      }),
+    ).toBe('child-c');
+    expect(
+      numericFocusTargetForActiveStream({
+        activeStreamId: 'root',
+        parentStream: new Map(),
+        streams,
+        zeroBasedIndex: 1,
+      }),
+    ).toBe('child-b');
+    expect(
+      numericFocusTargetForActiveStream({
+        activeStreamId: 'root',
+        parentStream: new Map(),
+        streams,
+        zeroBasedIndex: 2,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('maps Alt-number focus jumps through the focused child stream tree', () => {
+    const root = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+        },
+      ],
+      childStreams: [
+        {
+          executionId: 'agent-2',
+          agentName: 'reviewer',
+          childStreamId: 'child-b',
+        },
+      ],
+    });
+    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
+      ['root', root],
+      ['child-a', slice({ streamId: 'child-a' })],
+      ['child-b', slice({ streamId: 'child-b' })],
+    ]);
+    const parentStream = new Map<
+      StreamSlice['streamId'],
+      StreamSlice['streamId']
+    >([
+      ['child-a', 'root'],
+      ['child-b', 'root'],
+    ]);
+
+    expect(
+      numericFocusTargetForActiveStream({
+        activeStreamId: 'child-a',
+        parentStream,
+        streams,
+        zeroBasedIndex: 1,
+      }),
+    ).toBe('child-b');
   });
 
   it('builds subagent and process picker items with stable labels and tails', () => {

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -112,8 +112,33 @@ describe('CLI stream tabs strip', () => {
 
     expect(items.map(streamTabSegmentText)).toEqual([
       'main*',
-      'setup(idle)',
-      '[bash]*',
+      '1:setup(idle)',
+      '[2:bash]*',
+    ]);
+  });
+
+  it('keeps child shortcut labels aligned when the root stream is missing', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const child2 = streamId('child-2');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
+      [child2, slice('child-2', { status: STREAM_STATUS.WAITING })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: child2,
+      streams,
+      parentStream: new Map([
+        [child1, root],
+        [child2, root],
+      ]),
+      width: 80,
+    });
+
+    expect(items.map(streamTabSegmentText)).toEqual([
+      '1:child-1(idle)',
+      '[2:child-2]',
     ]);
   });
 
@@ -144,7 +169,10 @@ describe('CLI stream tabs strip', () => {
       width: 80,
     });
 
-    expect(items.map(streamTabSegmentText)).toEqual(['[main]', 'polish(idle)']);
+    expect(items.map(streamTabSegmentText)).toEqual([
+      '[main]',
+      '1:polish(idle)',
+    ]);
   });
 
   it('labels the focused stopped stream in the tab strip', () => {
@@ -176,7 +204,7 @@ describe('CLI stream tabs strip', () => {
 
     expect(items.map(streamTabSegmentText)).toEqual([
       'main(stopped)',
-      '[strategy](stopped)',
+      '[1:strategy](stopped)',
     ]);
   });
 
@@ -225,7 +253,7 @@ describe('CLI stream tabs strip', () => {
 
     expect(items.map(streamTabSegmentText)).toEqual([
       'review*',
-      '[detail-review]*',
+      '[1:detail-review]*',
     ]);
   });
 
@@ -260,9 +288,9 @@ describe('CLI stream tabs strip', () => {
     expect(items.map(streamTabSegmentText)).toEqual([
       'main',
       '…',
-      '[subagent-3]',
+      '[3:subagent-3]',
       '…',
-      'subagent-5',
+      '5:subagent-5',
     ]);
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1242,6 +1242,8 @@ describe('focusCycle', () => {
     cliState.activeStreamId.set(root);
     setParentStream(child1, root);
     setParentStream(child2, root);
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(child2, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     patchStream(root, (s) => ({
       ...s,
       activeSubagents: [


### PR DESCRIPTION
## Summary
- show `1:` through `9:` prefixes on child stream tabs that match the advertised Alt/Option focus shortcuts
- make numeric focus resolve through the active stream tree, so focused child streams can still jump to sibling tabs
- share the stream-tree descendant ordering between focus handling and the stream tab strip

Closes #4753.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `git diff --check`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes; existing unrelated import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI-only focus and tab labeling; no auth, persistence, or runtime execution changes.
> 
> **Overview**
> Aligns **Alt/Option+1–9** stream focus with what users see in the tab strip by prefixing child tabs with **`1:`–`9:`** labels and driving both display and key handling from the same stream-tree ordering.
> 
> **`orderedDescendantsFromTree`** centralizes descendant ordering (visible subagents, processes, and retained `parentStream` children). The tab strip and **`numericFocusTargetForActiveStream`** (replacing slice-only **`numericFocusTarget`**) use it so shortcuts match tab order and still work when focus is on a child stream (jumps among siblings under the same root). Narrow-width tab collapsing accounts for the extra prefix characters.
> 
> Vitest coverage updates expectations for numbered tabs and the new focus resolution paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b421de18ae4a124fd6bb6c84588b3fc36737a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->