### PR TITLE
fix(cli): keep root run progress visible

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -15,7 +15,8 @@ interface RenderState {
   agent?: string;
   inputFile?: string;
   phase?: string;
-  activeWork?: string;
+  activeProcesses?: string;
+  activeSubagents?: string;
 }
 
 export interface RunProgressRenderer {
@@ -55,6 +56,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private lastRenderAt = 0;
   private lastLine = '';
   private liveLine = false;
+  private rootStreamId: string | undefined;
 
   constructor(init: RunProgressRendererInit) {
     this.write = init.write ?? writeRawStderr;
@@ -67,14 +69,20 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   handle(event: ProgressEvent, payload: unknown): boolean {
     switch (event) {
       case 'setTaskState':
-        this.applyTaskState(payload as ProgressEventPayloads['setTaskState']);
-        this.render(true);
+        if (
+          this.applyTaskState(payload as ProgressEventPayloads['setTaskState'])
+        ) {
+          this.render(true);
+        }
         return true;
       case 'updateConversationProgress':
-        this.applyConversationProgress(
-          payload as ProgressEventPayloads['updateConversationProgress'],
-        );
-        this.render();
+        if (
+          this.applyConversationProgress(
+            payload as ProgressEventPayloads['updateConversationProgress'],
+          )
+        ) {
+          this.render();
+        }
         return true;
       case 'updateActiveProcesses':
         this.applyActiveProcesses(
@@ -89,16 +97,29 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         this.render(true);
         return true;
       case 'updateStreamStatus':
-        this.state.phase = String(
-          (payload as ProgressEventPayloads['updateStreamStatus']).status,
-        );
-        this.render(true);
+        if (
+          this.isRootStream(
+            (payload as ProgressEventPayloads['updateStreamStatus']).streamId,
+          )
+        ) {
+          this.state.phase = String(
+            (payload as ProgressEventPayloads['updateStreamStatus']).status,
+          );
+          this.render(true);
+        }
         return true;
       case 'updateStreamDescription':
-        this.state.phase = (
-          payload as ProgressEventPayloads['updateStreamDescription']
-        ).description;
-        this.render(true);
+        if (
+          this.isRootStream(
+            (payload as ProgressEventPayloads['updateStreamDescription'])
+              .streamId,
+          )
+        ) {
+          this.state.phase = (
+            payload as ProgressEventPayloads['updateStreamDescription']
+          ).description;
+          this.render(true);
+        }
         return true;
       default:
         return false;
@@ -119,35 +140,60 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
   }
 
-  private applyTaskState(payload: ProgressEventPayloads['setTaskState']): void {
+  private applyTaskState(
+    payload: ProgressEventPayloads['setTaskState'],
+  ): boolean {
+    if (!this.claimRootStream(payload.streamId)) return false;
+
     const config = payload.taskState.agentConfig;
     this.state.agent = config.agent;
     this.state.inputFile = safeBasename(config.inputFiles.at(0));
     this.state.phase ??= 'running';
+    return true;
   }
 
   private applyConversationProgress(
     payload: ProgressEventPayloads['updateConversationProgress'],
-  ): void {
+  ): boolean {
+    if (!this.claimRootStream(payload.streamId)) return false;
+
     this.state.round = payload.progress.conversationTurns || undefined;
     this.state.toolCallCount = payload.progress.toolCallCount || undefined;
     this.state.phase ??= 'running';
+    return true;
   }
 
   private applyActiveProcesses(
     payload: ProgressEventPayloads['updateActiveProcesses'],
   ): void {
-    const activeProcess = payload.processes[0];
-    this.state.activeWork = activeProcess
-      ? `tool: ${activeProcess.toolName ?? activeProcess.agentName}`
-      : undefined;
+    if (!this.claimRootStream(payload.parentStreamId)) return;
+
+    this.state.activeProcesses = formatActiveChildren(
+      'tool',
+      payload.processes.map(
+        (activeProcess) => activeProcess.toolName ?? activeProcess.agentName,
+      ),
+    );
   }
 
   private applyActiveSubagents(
     payload: ProgressEventPayloads['updateActiveSubagents'],
   ): void {
-    const child = payload.children[0];
-    this.state.activeWork = child ? `subagent: ${child.agentName}` : undefined;
+    if (!this.claimRootStream(payload.parentStreamId)) return;
+
+    this.state.activeSubagents = formatActiveChildren(
+      'subagent',
+      payload.children.map((child) => child.agentName),
+    );
+  }
+
+  private claimRootStream(streamId: string): boolean {
+    this.rootStreamId ??= streamId;
+    return this.rootStreamId === streamId;
+  }
+
+  private isRootStream(streamId: string): boolean {
+    return this.rootStreamId === streamId;
   }
 
   private render(force = false): void {
@@ -178,8 +224,13 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     parts.push(subject || phase || 'running');
     if (subject && phase && phase !== 'running') parts.push(phase);
 
-    if (this.state.activeWork) parts.push(this.state.activeWork);
-    if (this.state.toolCallCount != null && !this.state.activeWork) {
+    if (this.state.activeSubagents) parts.push(this.state.activeSubagents);
+    if (this.state.activeProcesses) parts.push(this.state.activeProcesses);
+    if (
+      this.state.toolCallCount != null &&
+      !this.state.activeSubagents &&
+      !this.state.activeProcesses
+    ) {
       parts.push(`tools: ${this.state.toolCallCount}`);
     }
     parts.push(formatElapsed(now - this.startedAt));
@@ -189,6 +240,21 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
 function safeBasename(file: string | undefined): string | undefined {
   return file ? path.basename(file) : undefined;
+}
+
+function formatActiveChildren(
+  kind: 'subagent' | 'tool',
+  names: readonly (string | undefined)[],
+): string | undefined {
+  const namedChildren = names.filter((name): name is string => Boolean(name));
+  const first = namedChildren[0];
+  if (!first) return undefined;
+
+  const label =
+    namedChildren.length === 1 ? kind : kind === 'tool' ? 'tools' : 'subagents';
+  const suffix =
+    namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
+  return `${label}: ${first}${suffix}`;
 }
 
 function formatElapsed(ms: number): string {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -25,15 +25,21 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
   };
 }
 
-function workflowTaskState() {
+function workflowTaskState(
+  overrides: {
+    streamId?: string;
+    agent?: string;
+    inputFiles?: string[];
+  } = {},
+) {
   return {
-    streamId: 'stream-1',
+    streamId: overrides.streamId ?? 'stream-1',
     taskState: {
       agentConfig: {
-        agent: 'polish',
+        agent: overrides.agent ?? 'polish',
         agentCategory: AgentCategory.Workflow,
         model: 'deepseekT',
-        inputFiles: ['paper.tex'],
+        inputFiles: overrides.inputFiles ?? ['paper.tex'],
         contextFiles: [],
         mediaFiles: [],
         outputFiles: [],
@@ -121,6 +127,135 @@ describe('CLI run progress renderer', () => {
       'polish paper.tex · 0s\n' +
         'polish paper.tex · drafting · 0s\n' +
         'polish paper.tex · drafting · tool: Bash · 0s\n',
+    );
+  });
+
+  it('keeps the root run visible when child streams update progress', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'coordinator',
+        inputFiles: ['main.tex'],
+      }),
+    );
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'child-stream',
+        agent: 'reviewer',
+        inputFiles: ['chapter.tex'],
+      }),
+    );
+    renderer?.handle('updateStreamDescription', {
+      streamId: 'child-stream',
+      description: 'reviewing chapter.tex',
+    });
+    renderer?.handle('updateActiveSubagents', {
+      parentStreamId: 'root-stream',
+      children: [
+        {
+          executionId: 'child-1',
+          childStreamId: 'child-stream',
+          agentName: 'reviewer',
+          status: 'running',
+        },
+        {
+          executionId: 'child-2',
+          childStreamId: 'child-stream-2',
+          agentName: 'compiler',
+          status: 'running',
+        },
+        {
+          executionId: 'child-3',
+          childStreamId: 'child-stream-3',
+          agentName: 'proofreader',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(output).toBe(
+      'coordinator main.tex · 0s\n' +
+        'coordinator main.tex · subagents: reviewer +2 · 0s\n',
+    );
+  });
+
+  it('can claim the root stream from conversation progress', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        minIntervalMs: 0,
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle('updateConversationProgress', {
+      streamId: 'root-stream',
+      progress: { conversationTurns: 2, toolCallCount: 4 },
+    });
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'child-stream',
+        agent: 'reviewer',
+        inputFiles: ['chapter.tex'],
+      }),
+    );
+
+    expect(output).toBe('[r2] · running · tools: 4 · 0s\n');
+  });
+
+  it('keeps named active children visible when earlier entries are unnamed', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle('setTaskState', workflowTaskState());
+    renderer?.handle('updateActiveProcesses', {
+      parentStreamId: 'stream-1',
+      processes: [
+        {
+          executionId: 'process-1',
+          agentName: '',
+          toolName: '',
+          status: 'running',
+        },
+        {
+          executionId: 'process-2',
+          agentName: 'latexmk',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(output).toBe(
+      'polish paper.tex · 0s\npolish paper.tex · tool: latexmk · 0s\n',
     );
   });
 


### PR DESCRIPTION
## Summary

- keep `texra run` text progress rooted on the coordinator stream instead of letting child stream task/description events overwrite the headline
- summarize all active subagents/processes in the run-progress suffix instead of only showing the first child
- add a regression test for root progress with multiple active child streams

Closes #4756.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `git diff --check`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI stderr display logic only; behavior is covered by new unit tests and does not touch auth, data, or execution.
> 
> **Overview**
> **`texra run` text progress** now pins the headline to the first-seen (coordinator) stream so child `setTaskState`, stream status/description, and conversation progress no longer replace the root agent and input file.
> 
> Active work is shown as separate **subagent** and **tool** suffixes, with a compact `name +N` summary when multiple named children run; unnamed entries are skipped so a later named child still appears. Tool-call counts are hidden while either suffix is present.
> 
> Regression coverage was added for root-vs-child streams, root claim via conversation progress, and unnamed-then-named active processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0499bb607a9ef336a52ccab7b5c8227c82dc7e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->