### PR TITLE
refactor(tools,shared): DRY, dead code, Zod idioms, flatten wrappers

### DIFF
--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -387,14 +387,10 @@ const commandKeybindingOrder = [
 
 function keybindingForCommand(id: CommandId): CommandKeybinding {
   const entry = commandCatalogById.get(id);
-  if (!entry || !('keybinding' in entry)) {
+  if (!entry?.keybinding) {
     throw new Error(`Command has no keybinding: ${id}`);
   }
-  const keybinding = entry.keybinding;
-  if (keybinding == null) {
-    throw new Error(`Command has no keybinding: ${id}`);
-  }
-  return keybinding;
+  return entry.keybinding;
 }
 
 export const commandKeybindings = commandKeybindingOrder.map((id) => ({

--- a/src/shared/controllers/CopyButtonController.ts
+++ b/src/shared/controllers/CopyButtonController.ts
@@ -135,16 +135,4 @@ export class CopyButtonController implements ReactiveController {
 
     return true;
   };
-
-  /**
-   * Update the default title (useful when text context changes).
-   */
-  setDefaultTitle(title: string): void {
-    if (this._config.defaultTitle !== title) {
-      this._config.defaultTitle = title;
-      if (!this._copied) {
-        this.host.requestUpdate();
-      }
-    }
-  }
 }

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -67,9 +67,7 @@ function getDisplayName(
   return 'unknown';
 }
 
-export function transformDiffResultToDisplay(
-  entry: DiffResult,
-): DiffResultDisplay {
+function transformDiffResultToDisplay(entry: DiffResult): DiffResultDisplay {
   return {
     baseFile: getAbsolutePath(entry.baseLocation),
     revisedFile: getAbsolutePath(entry.revised.location),
@@ -162,7 +160,7 @@ export const LegacyDiffResultSchema = z
   });
 
 /** Parse a diff result entry from either new or legacy format */
-export function parseDiffResultEntry(
+function parseDiffResultEntry(
   data: unknown,
 ):
   | { success: true; data: DiffResultDisplay }

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -347,9 +347,6 @@ export type ActionDetail = z.infer<typeof ActionDetailSchema>;
 const FileListSchema = z.array(z.string());
 const FilesPayloadSchema = z.object({ files: FileListSchema });
 const SingleFileSelectedSchema = z.object({ filePath: z.string() });
-const BaseFileOptionsSchema = z.object({
-  preserveBaseFile: z.boolean().nullish(),
-});
 
 export const SetModelOptionsMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS),
@@ -372,7 +369,7 @@ export const SetEditedFileMessageSchema = FilesPayloadSchema.extend({
 
 export const SetBaseFileMessageSchema = FilesPayloadSchema.extend({
   command: z.literal(MAIN_VIEW_COMMANDS.SET_BASE_FILE),
-  preserveBaseFile: BaseFileOptionsSchema.shape.preserveBaseFile,
+  preserveBaseFile: z.boolean().nullish(),
 });
 
 export const EditedFileSelectedMessageSchema = SingleFileSelectedSchema.extend({

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -49,18 +49,6 @@ export const RetryPermissionSchema = z.strictObject({
 });
 export type RetryPermission = z.infer<typeof RetryPermissionSchema>;
 
-export const AgentProposalActionSchema = z.enum(['approve', 'reject', 'setup']);
-export type AgentProposalAction = z.infer<typeof AgentProposalActionSchema>;
-
-export const AgentProposalActionMessageSchema = z.object({
-  proposalId: z.string(),
-  action: AgentProposalActionSchema,
-  feedback: z.string().optional(),
-});
-export type AgentProposalActionMessage = z.infer<
-  typeof AgentProposalActionMessageSchema
->;
-
 /** Workflow agent proposal - includes file fields for document processing */
 export const WorkflowAgentProposalSchema = BaseProposalFieldsSchema.merge(
   WorkflowSpecificFieldsSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -603,12 +603,10 @@ export type UpdateInlineCriticismEnabledMessage = z.infer<
 // Provider key inbound messages (settings-only)
 // Keep the outer optional: callers may omit apiKey so the host can prompt.
 const SubmittedApiKeySchema = z
-  .preprocess(
-    (value) =>
-      typeof value === 'string' && value.trim() === '' ? undefined : value,
-    z.string().trim().min(1).optional(),
-  )
-  .optional();
+  .string()
+  .trim()
+  .optional()
+  .transform((v) => (v ? v : undefined));
 
 const SetProviderKeyMessageSchema = z.object({
   command: z.literal(CMD.SET_PROVIDER_KEY),
@@ -914,15 +912,10 @@ const GetLatexConfigValuesMessageSchema = commandOnly(
  * using `LatexConfigValuesSchema.shape[field]`.
  */
 // Use the canonical field list from latex.ts as the schema source so it can
-// never drift from `LATEX_FIELD_TO_KEY`. The runtime tuple cast preserves the
-// literal types so `LatexConfigField` (re-exported above) stays as the same
-// union of string literals consumers already rely on.
-const LatexConfigFieldSchema = z.enum(
-  LATEX_CONFIG_FIELDS as readonly [
-    (typeof LATEX_CONFIG_FIELDS)[number],
-    ...(typeof LATEX_CONFIG_FIELDS)[number][],
-  ],
-);
+// never drift from `LATEX_FIELD_TO_KEY`. z.enum accepts the readonly array
+// directly and preserves the literal types so `LatexConfigField` (re-exported
+// above) stays as the same union of string literals consumers already rely on.
+const LatexConfigFieldSchema = z.enum(LATEX_CONFIG_FIELDS);
 
 const SetLatexConfigValueMessageSchema = z.object({
   command: z.literal(CMD.SET_LATEX_CONFIG_VALUE),

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -166,11 +166,6 @@ export class PersistedState<T extends Record<string, unknown>> {
     }
     this.storage.set(this.key, this.state);
   }
-
-  /** Reload from storage */
-  reload(): void {
-    this.state = this.load();
-  }
 }
 
 /**

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -620,14 +620,13 @@ async function proposeAndExecute(
   );
   if (nonApproveResult) return nonApproveResult;
 
-  // At this point result.action === 'approve' (all other cases returned above)
-  const modelOverride = result.action === 'approve' ? result.model : undefined;
+  // At this point result.action === 'approve' (all other cases returned above).
+  if (result.action !== 'approve') {
+    throw new Error(`Unexpected non-approve proposal result: ${result.action}`);
+  }
+  const modelOverride = result.model;
   const agentOverride =
-    result.action === 'approve' &&
-    result.agent &&
-    result.agent !== proposal.agent
-      ? result.agent
-      : undefined;
+    result.agent && result.agent !== proposal.agent ? result.agent : undefined;
 
   // Re-validate against the current registry — between proposal display and
   // approval the agent may have been removed/renamed, or the approval could
@@ -732,15 +731,13 @@ function isBibFile(filePath: string): boolean {
   return getBasename(filePath).toLowerCase().endsWith('.bib');
 }
 
-function getContextFiles(input: WorkflowAgentInput): string[] {
-  return input.contextFiles.filter(isNonEmptyString);
-}
-
 /** Reject workflow proposals that attach oversized bibliography files. */
 export async function rejectOversizedBibAttachments(
   input: WorkflowAgentInput,
 ): Promise<ToolResult | null> {
-  const bibFiles = getContextFiles(input).filter(isBibFile);
+  const bibFiles = input.contextFiles
+    .filter(isNonEmptyString)
+    .filter(isBibFile);
 
   for (const bibFile of bibFiles) {
     const stats = await WorkspaceFS.stat(bibFile);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -17,6 +17,7 @@ import { platform } from '@platform/platform';
 import {
   getExecutionStore,
   type ChildRecord,
+  type TodoEntry,
   listExecutions,
 } from '@agent/storage';
 import { flowKey } from '@agent/node/persistedFlow';
@@ -467,23 +468,13 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         lines.push(`Parent: ${meta.parentExecutionId}`);
       }
 
-      await this.appendChildren(lines, children);
-
-      if (todos.length > 0) {
-        lines.push('', ...formatTodoSection(todos));
-      }
-
-      if (report) {
-        lines.push('', 'Result:', report);
-      }
-
-      const runningPaths = getAvailablePaths(
+      await this.appendSummaryTail(
+        lines,
+        executionId,
         handle.category,
-        children.length > 0,
-      );
-      lines.push(
-        '',
-        `Available paths: ${runningPaths.map((p) => `/executions/${executionId}/${p}`).join(', ')}`,
+        children,
+        todos,
+        report,
       );
 
       return { output: lines.join('\n') };
@@ -533,6 +524,30 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       lines.push(`Parent: ${meta.parentExecutionId}`);
     }
 
+    await this.appendSummaryTail(
+      lines,
+      executionId,
+      category,
+      children,
+      todos,
+      report,
+    );
+
+    return { output: lines.join('\n') };
+  }
+
+  /**
+   * Append the shared summary tail (children, todos, report, available paths)
+   * common to both the running-handle and completed-execution branches.
+   */
+  private async appendSummaryTail(
+    lines: string[],
+    executionId: ExecutionId,
+    category: string | undefined,
+    children: ChildRecord[],
+    todos: TodoEntry[],
+    report: string | null,
+  ): Promise<void> {
     await this.appendChildren(lines, children);
 
     if (todos.length > 0) {
@@ -543,13 +558,11 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       lines.push('', 'Result:', report);
     }
 
-    const completedPaths = getAvailablePaths(category, children.length > 0);
+    const paths = getAvailablePaths(category, children.length > 0);
     lines.push(
       '',
-      `Available paths: ${completedPaths.map((p) => `/executions/${executionId}/${p}`).join(', ')}`,
+      `Available paths: ${paths.map((p) => `/executions/${executionId}/${p}`).join(', ')}`,
     );
-
-    return { output: lines.join('\n') };
   }
 
   /** Fetch metas and format each child as a summary line. */

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -248,7 +248,6 @@ export class TextEditorTool extends defineTool({
 
       if (viewRange) {
         if (
-          viewRange.length !== 2 ||
           !Number.isInteger(viewRange[0]) ||
           !Number.isInteger(viewRange[1])
         ) {
@@ -356,6 +355,28 @@ export class TextEditorTool extends defineTool({
     }
   }
 
+  /**
+   * Shared edit prelude for strReplace/insert: gate on read-before-edit, then
+   * read and tab-expand the file. Returns the read-gate ToolResult when the
+   * edit must be blocked, otherwise the file content and its tab-expanded form.
+   */
+  private async prepareEditContent(
+    filePath: string,
+  ): Promise<
+    | { readGate: ToolResult }
+    | { fileContent: string; expandedFileContent: string }
+  > {
+    const exists = await WorkspaceFS.exists(filePath);
+    const readGate = requireFileReadForEdit(filePath, exists);
+    if (readGate) {
+      return { readGate };
+    }
+    const fileContent = await WorkspaceFS.read(filePath);
+    // Expand tabs to 4 spaces for consistent display
+    const expandedFileContent = fileContent.replaceAll('\t', '    ');
+    return { fileContent, expandedFileContent };
+  }
+
   private async strReplace(
     filePath: string,
     displayPath: string,
@@ -363,15 +384,12 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      const exists = await WorkspaceFS.exists(filePath);
-      const readGate = requireFileReadForEdit(filePath, exists);
-      if (readGate) {
-        return readGate;
+      const prepared = await this.prepareEditContent(filePath);
+      if ('readGate' in prepared) {
+        return prepared.readGate;
       }
-      const fileContent = await WorkspaceFS.read(filePath);
+      const { fileContent, expandedFileContent } = prepared;
 
-      // Expand tabs to 4 spaces for consistent display
-      const expandedFileContent = fileContent.replaceAll('\t', '    ');
       const expandedOldStr = oldStr.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
@@ -462,15 +480,12 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      const exists = await WorkspaceFS.exists(filePath);
-      const readGate = requireFileReadForEdit(filePath, exists);
-      if (readGate) {
-        return readGate;
+      const prepared = await this.prepareEditContent(filePath);
+      if ('readGate' in prepared) {
+        return prepared.readGate;
       }
-      const fileContent = await WorkspaceFS.read(filePath);
+      const { fileContent, expandedFileContent } = prepared;
 
-      // Expand tabs to 4 spaces for consistent display
-      const expandedFileContent = fileContent.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
       const fileLines = expandedFileContent.split('\n');

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -1,0 +1,42 @@
+// Shared helpers for the agent-CLI tool modules (codex.ts, claudeAgent.ts).
+// Host-agnostic, VS Code-free: pure predicates and a turn-summary logger.
+
+import { type AgentTrace } from '@agent/trace';
+import { StreamStatus, STREAM_STATUS } from '@shared/schemas';
+import { formatDuration } from '@utils/core';
+
+/** True for an AbortController-style cancellation error. */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+/**
+ * True when an error/abort represents a clean, caller-initiated interruption
+ * rather than a genuine failure.
+ */
+export function isCleanInterruption(
+  err: unknown,
+  signal: AbortSignal,
+  session: { isInterrupted(): boolean },
+): boolean {
+  return signal.aborted || session.isInterrupted() || isAbortError(err);
+}
+
+/** Transient statuses owned by a running agent loop. */
+export function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
+  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
+}
+
+/** Log a turn summary (duration + token usage) to the child stream. */
+export function logTurnSummary(
+  logger: AgentTrace,
+  wallTimeMs: number,
+  usage: { input_tokens?: number; output_tokens?: number } | null | undefined,
+): void {
+  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
+  if (usage) {
+    logger.info(
+      `Tokens: ${usage.input_tokens ?? 0} in / ${usage.output_tokens ?? 0} out`,
+    );
+  }
+}

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -20,11 +20,10 @@ import {
   type FileLocation,
 } from '@utils/files';
 
-type BuildDisplayFn = (
+export type BuildDisplayFn = (
   location: FileLocation,
   options?: { preserveFocus?: boolean },
 ) => Promise<void>;
-export type { BuildDisplayFn };
 
 interface LatexPreviewDisplayOptions {
   openBuildDisplay?: BuildDisplayFn;

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -54,7 +54,6 @@ import type {
   StreamTabId,
   ExecutionId,
   StorageKey,
-  StreamStatus,
   TokenUsageStats,
   ToolUseLog,
 } from '@shared/schemas';
@@ -66,7 +65,6 @@ import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
-import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -78,6 +76,11 @@ import {
   findClaudeBinaryPath,
 } from './claudeAgentImport';
 import { createChildStream } from './childStream';
+import {
+  isCleanInterruption,
+  isLoopOwnedStatus,
+  logTurnSummary,
+} from './agentCliShared';
 import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
@@ -198,22 +201,6 @@ class ClaudeAgentSession implements IInterruptible {
   }
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === 'AbortError';
-}
-
-function isCleanInterruption(
-  err: unknown,
-  signal: AbortSignal,
-  session: ClaudeAgentSession,
-): boolean {
-  return signal.aborted || session.isInterrupted() || isAbortError(err);
-}
-
-function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
-  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
-}
-
 function finalizeClaudeAgentLoopStatus(
   childStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
@@ -302,19 +289,6 @@ function publishClaudeAgentStreamUsage(
     executionId,
     usage,
   });
-}
-
-function logTurnSummary(
-  logger: AgentTrace,
-  wallTimeMs: number,
-  usage: TurnResult['usage'],
-): void {
-  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
-  if (usage) {
-    logger.info(
-      `Tokens: ${usage.input_tokens ?? 0} in / ${usage.output_tokens ?? 0} out`,
-    );
-  }
 }
 
 // ============================================================================

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -51,7 +51,6 @@ import type {
   StreamTabId,
   ExecutionId,
   StorageKey,
-  StreamStatus,
   TodoItem,
   TokenUsageStats,
   ToolUseLog,
@@ -64,7 +63,6 @@ import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
-import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -73,6 +71,11 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream } from './childStream';
+import {
+  isCleanInterruption,
+  isLoopOwnedStatus,
+  logTurnSummary,
+} from './agentCliShared';
 import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
@@ -215,22 +218,6 @@ class CodexFollowUpSession implements IInterruptible {
   }
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === 'AbortError';
-}
-
-function isCleanCodexInterruption(
-  err: unknown,
-  signal: AbortSignal,
-  session: CodexFollowUpSession,
-): boolean {
-  return signal.aborted || session.isInterrupted() || isAbortError(err);
-}
-
-function isCodexLoopOwnedStatus(status: StreamStatus | undefined): boolean {
-  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
-}
-
 /**
  * Clear the transient status owned by a Codex loop after the loop exits.
  * Explicit terminal statuses set by other runtime paths, such as STOPPED or
@@ -240,7 +227,7 @@ export function finalizeCodexLoopStatus(
   childStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  if (isCodexLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
+  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
     StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
       runtimeHost,
     });
@@ -432,20 +419,6 @@ function publishCodexItemProgress(params: {
   return true;
 }
 
-/** Log a turn summary to the child stream. */
-function logTurnSummary(
-  logger: AgentTrace,
-  wallTimeMs: number,
-  usage: RunResult['usage'],
-): void {
-  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
-  if (usage) {
-    logger.info(
-      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
-    );
-  }
-}
-
 // ============================================================================
 // Streaming helpers
 // ============================================================================
@@ -602,7 +575,7 @@ function startCodexLoop(params: {
           );
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (caught) {
-          if (isCleanCodexInterruption(caught, signal, session)) break;
+          if (isCleanInterruption(caught, signal, session)) break;
           err = caught;
           logger.error(toErrorMessage(caught));
         } finally {
@@ -820,11 +793,11 @@ async function launchCodexSession(
   };
 }
 
-async function resumeCodexThread(
+function resumeCodexThread(
   threadId: string,
   prompt: string,
   callerStreamId: StreamTabId | undefined,
-): Promise<ToolResult> {
+): ToolResult {
   const stored = threadRegistry.get(threadId);
   if (!stored) {
     throw new ToolError(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -297,18 +297,13 @@ export class PRPollingSource extends PollingSourceBase<
     runtimeHost: AgentRuntimeHost,
   ): Disposable {
     const key = prKeyToString(input);
-    const minAnnotationLevel =
-      input.minAnnotationLevel ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
     const disposable = this.register(
       key,
       () => createInitialState(input),
       onEvent,
       runtimeHost,
     );
-    this.getSubscriptionState(key)?.annotationLevelByListener.set(
-      onEvent,
-      minAnnotationLevel,
-    );
+    this.setListenerAnnotationLevel(key, onEvent, input);
     return {
       dispose: () => {
         this.getSubscriptionState(key)?.annotationLevelByListener.delete(
@@ -325,13 +320,46 @@ export class PRPollingSource extends PollingSourceBase<
     runtimeHost: AgentRuntimeHost,
   ): void {
     const key = prKeyToString(input);
+    this.updateListenerRuntimeHost(key, onEvent, runtimeHost);
+    this.setListenerAnnotationLevel(key, onEvent, input);
+  }
+
+  /** Resolve the effective annotation level and record it per listener. */
+  private setListenerAnnotationLevel(
+    key: string,
+    onEvent: (text: string) => void,
+    input: PRSubscribeInput,
+  ): void {
     const minAnnotationLevel =
       input.minAnnotationLevel ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
-    this.updateListenerRuntimeHost(key, onEvent, runtimeHost);
     this.getSubscriptionState(key)?.annotationLevelByListener.set(
       onEvent,
       minAnnotationLevel,
     );
+  }
+
+  /**
+   * Compute the CI-terminal status for a tick.
+   *
+   * `complete` is true only when we have the head SHA, a non-empty run set,
+   * the full set (length >= total_count — `fetchAllCheckRuns` dedupes by id and
+   * returns the latest total_count, so this is safe against mid-walk page
+   * shifts), and every run has completed. `passed` requires `complete` plus
+   * every run passing.
+   */
+  private static ciTerminalStatus(
+    headSha: string | undefined,
+    runs: GhCheckRun[],
+    totalCount: number,
+  ): { complete: boolean; passed: boolean } {
+    const complete =
+      !!headSha &&
+      runs.length > 0 &&
+      runs.length >= totalCount &&
+      runs.every((r) => r.status === 'completed');
+    const passed =
+      complete && runs.every((r) => isPassingConclusion(r.conclusion));
+    return { complete, passed };
   }
 
   protected emitKeysChangedEvent(
@@ -535,23 +563,17 @@ export class PRPollingSource extends PollingSourceBase<
           state.ciStartedSha = state.headSha;
         }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
-        // we only surface transitions that happen after subscribe. Gate on
-        // runs.length > 0: an empty array is ambiguous (no CI configured vs.
-        // runs not yet registered), so "done" isn't meaningful and seeding
-        // would suppress the real terminal event once runs appear. Also
-        // require we have the full set (length >= total_count). The runs
-        // array from fetchAllCheckRuns is deduped by id and total_count is
-        // the latest server-reported value, so this comparison is safe
-        // against mid-walk page shifts that would otherwise let a duplicate-
-        // padded array trip the gate before a newly-registered run was seen.
-        if (
-          state.headSha &&
-          runs.length > 0 &&
-          runs.length >= checksRes.data.total_count &&
-          runs.every((r) => r.status === 'completed')
-        ) {
+        // we only surface transitions that happen after subscribe. See
+        // `ciTerminalStatus` for the gating rationale (empty/partial run sets,
+        // page-shift safety).
+        const { complete, passed } = PRPollingSource.ciTerminalStatus(
+          state.headSha,
+          runs,
+          checksRes.data.total_count,
+        );
+        if (complete) {
           state.ciCompleteSha = state.headSha;
-          if (runs.every((r) => isPassingConclusion(r.conclusion))) {
+          if (passed) {
             state.ciPassedSha = state.headSha;
           }
         }
@@ -661,21 +683,14 @@ export class PRPollingSource extends PollingSourceBase<
       // deduped against its own marker so a rerun turning red→green still
       // emits "CI passed" even after "CI complete" already fired.
       //
-      // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
-      // configured vs. runs not yet registered), so "done" isn't meaningful.
-      // Also require we have the full set (length >= total_count). The API
-      // caps at per_page=100; `fetchAllCheckRuns` walks pagination, dedupes
-      // runs by id (so page-shift duplicates can't pad the count), AND
-      // returns the latest `total_count` from this tick's 200 responses
-      // (not a stale page-1 snapshot or a stuck monotonic max from a prior
-      // mid-walk inflation). A duplicate-filled buffer can therefore never
-      // trick this gate into firing "CI complete" before every run is seen.
-      if (
-        state.headSha &&
-        runs.length > 0 &&
-        runs.length >= checksRes.data.total_count &&
-        runs.every((r) => r.status === 'completed')
-      ) {
+      // See `ciTerminalStatus` for the gating rationale (empty/partial run
+      // sets, page-shift safety).
+      const { complete, passed } = PRPollingSource.ciTerminalStatus(
+        state.headSha,
+        runs,
+        checksRes.data.total_count,
+      );
+      if (complete && state.headSha) {
         const headSha = state.headSha;
         if (state.ciCompleteSha !== headSha) {
           state.ciCompleteSha = headSha;
@@ -684,10 +699,7 @@ export class PRPollingSource extends PollingSourceBase<
             formatCIComplete(state.slug, pr.pullNumber, headSha, runs),
           );
         }
-        if (
-          state.ciPassedSha !== headSha &&
-          runs.every((r) => isPassingConclusion(r.conclusion))
-        ) {
+        if (state.ciPassedSha !== headSha && passed) {
           state.ciPassedSha = headSha;
           this.emit(
             state,

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -489,18 +489,21 @@ function classifyTransition(
  * and canonical: `https://api.github.com/repos/o/r/issues/{number}`.
  */
 const ISSUE_URL_NUMBER_RE = /\/issues\/(\d+)(?:[?#]|$)/;
+
+/** Run a capture-group-1 regex against a URL and parse the match as a finite number. */
+function matchPositiveInt(re: RegExp, url: string): number | undefined {
+  const m = re.exec(url);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 function parseTargetNumberFromIssueUrl(c: GhIssueComment): number | undefined {
   const url = c.issue_url ?? c.html_url;
-  const m = ISSUE_URL_NUMBER_RE.exec(url);
-  if (m) {
-    const n = Number(m[1]);
-    if (Number.isFinite(n)) return n;
-  }
+  const issueNumber = matchPositiveInt(ISSUE_URL_NUMBER_RE, url);
+  if (issueNumber !== undefined) return issueNumber;
   // Fallback: review comments and certain PR-only flows expose `/pull/{n}`.
-  const p = /\/pull\/(\d+)(?:[?#/]|$)/.exec(url);
-  if (!p) return undefined;
-  const n = Number(p[1]);
-  return Number.isFinite(n) ? n : undefined;
+  return matchPositiveInt(PR_NUMBER_RE, url);
 }
 
 /**
@@ -509,10 +512,7 @@ function parseTargetNumberFromIssueUrl(c: GhIssueComment): number | undefined {
  */
 const PR_NUMBER_RE = /\/pull\/(\d+)(?:[?#/]|$)/;
 function parsePRNumberFromReviewCommentUrl(url: string): number | undefined {
-  const m = PR_NUMBER_RE.exec(url);
-  if (!m) return undefined;
-  const n = Number(m[1]);
-  return Number.isFinite(n) ? n : undefined;
+  return matchPositiveInt(PR_NUMBER_RE, url);
 }
 
 /** Process-wide singleton. */

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -164,6 +164,13 @@ function describeAnnotationLevel(level: GitHubCheckAnnotationLevel): string {
   }
 }
 
+/** Shared body sentence describing what a PR subscription delivers. */
+function prSubscriptionActivitySentence(
+  annotationLevelDescription: string,
+): string {
+  return `New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups.`;
+}
+
 async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
@@ -200,7 +207,7 @@ async function execSubscribe(
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
+        ? `Subscribed to ${slug}. ${prSubscriptionActivitySentence(annotationLevelDescription)} Auto-unsubscribes on PR close/merge.`
         : `Already subscribed to ${slug}. Inline check annotation filter is now ${annotationLevelDescription}. Activity continues until command="unsubscribe" or the PR closes.`,
     };
   }
@@ -244,7 +251,7 @@ async function execSubscribe(
           : `Subscribed to ${prSlug}`
         : `Already subscribed to ${prSlug}`,
       output: created
-        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
+        ? `${prSlug} is a PR. ${prSubscriptionActivitySentence(annotationLevelDescription)} Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${prSlug}. Inline check annotation filter is now ${annotationLevelDescription}.`,
     };
   }

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -22,7 +22,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
   ExternalInquiryThreadIdSchema,
-  type ExternalInquiryThreadId,
+  type ExternalInquiryThreadSummary,
   type InquiryActionMessage,
   type StreamTabId,
 } from '@shared/schemas';
@@ -225,14 +225,7 @@ function buildReadOutput(manifest: ExternalInquiryThreadManifest): ToolResult {
 }
 
 function buildListOutput(
-  summaries: {
-    threadId: ExternalInquiryThreadId;
-    status: string;
-    lastQuestionPreview: string;
-    turnCount: number;
-    lastActivityIso: string;
-    parentStreamId: string | null;
-  }[],
+  summaries: ExternalInquiryThreadSummary[],
   filterStatus: string,
   scope: string,
 ): ToolResult {

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -80,7 +80,7 @@ const LegacyManifestSchema = z
     turns: z.array(ExternalInquiryTurnRecordSchema),
   })
   .transform(
-    (raw): z.infer<typeof CanonicalManifestSchema> => ({
+    (raw): ExternalInquiryThreadManifest => ({
       threadId: raw.threadId,
       parentStreamId: null,
       status: 'answered' as const,
@@ -449,8 +449,7 @@ export async function recordAnswerForOpenTurn(params: {
     if (existing.status !== 'open') return null;
     if (existing.turns.length === 0) return null;
 
-    const lastTurn = existing.turns.at(-1);
-    if (!lastTurn) return null;
+    const lastTurn = existing.turns.at(-1)!;
     if (lastTurn.answer) return null;
 
     const timestamp = new Date().toISOString();
@@ -544,8 +543,7 @@ export async function persistOpenTurnDraft(params: {
     if (!existing || existing.status !== 'open' || existing.turns.length === 0)
       return;
 
-    const lastTurn = existing.turns.at(-1);
-    if (!lastTurn) return;
+    const lastTurn = existing.turns.at(-1)!;
     if (lastTurn.answer) return;
 
     const nextTurn: ExternalInquiryTurnRecord = {

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -111,21 +111,19 @@ Directory listings are paginated — use offset/limit to page through results (d
 Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies, pitfalls, best practices). Pinned memories are always loaded at session start. Use \`unpin\` to remove the pinned status. Maximum ${MAX_PINNED_MEMORIES} pinned memories allowed.`,
   schema: MemoryToolInputSchema,
 }) {
-  /**
-   * Normalize a raw display path into a `{ display, storage }` pair at the
-   * dispatch boundary so ops never need to call `resolveMemoryPath` themselves.
-   * Throws ToolError if the path is outside `/memories`.
-   */
-  private locate(rawPath: string): MemoryLocation {
-    const storage = this.resolveMemoryPath(rawPath);
-    return { display: toDisplayPath(storage), storage };
-  }
-
   protected async execute(input: MemoryToolInput): Promise<ToolResult> {
+    // Normalize a raw display path into a `{ display, storage }` pair at the
+    // dispatch boundary so ops never need to call `resolveMemoryPath`
+    // themselves. Throws ToolError if the path is outside `/memories`.
     const locate = (
       raw: string | undefined | null,
       field: string,
-    ): MemoryLocation => this.locate(requireField(raw, field, input.command));
+    ): MemoryLocation => {
+      const storage = this.resolveMemoryPath(
+        requireField(raw, field, input.command),
+      );
+      return { display: toDisplayPath(storage), storage };
+    };
 
     switch (input.command) {
       case 'view':

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -118,13 +118,9 @@ interface ConnectorResult {
  */
 async function checkZoteroRunning(port: number): Promise<void> {
   try {
-    const response = await axios.get(
-      `http://127.0.0.1:${port}/connector/ping`,
-      { timeout: ZOTERO_PING_TIMEOUT_MS },
-    );
-    if (response.status !== 200) {
-      throw new Error('Unexpected response');
-    }
+    await axios.get(`http://127.0.0.1:${port}/connector/ping`, {
+      timeout: ZOTERO_PING_TIMEOUT_MS,
+    });
   } catch {
     throw new ToolError(
       `Zotero is not reachable on port ${port}. ` +


### PR DESCRIPTION
Fourth cleanup pass after #4725 (TUI), #4740 (CLI runtime/commands), and #4752 (shared core). This one targets the host-agnostic **`src/tools` + `src/shared`** zones (~42k lines, 106 test-kernel files exercising them).

### How it was produced & verified
A code-simplifier fan-out over 10 file-groups surfaced **47 candidates**; each was **adversarially verified** with explicit checks for: test-consumer breakage, the no-`vscode`-import rule, **Zod-idiom correctness**, and **contract-shape stability** (tool I/O + IPC message + schema parsed/serialized shapes must be identical). **22 rejected** (subjective, contract-risky, or e.g. the full agent session-loop which is *not* safely mergeable — only its small leaf helpers are). **25 applied.**

Proven green: `tsc --noEmit` ✅, `tsc -p tsconfig.test-kernel.json` ✅, **full test-kernel vitest — 236 files / 1298 tests** ✅, `prettier --check` ✅, and a vscode-free-zone guard on every changed + new file ✅.

### Changes (25)
- **Shared agent-CLI helpers:** new `src/tools/agentCliShared.ts` exporting `isAbortError` / `isCleanInterruption` (generic over `{ isInterrupted() }`) / `isLoopOwnedStatus` / `logTurnSummary`, de-duplicating verbatim copies in `codex.ts` and `claudeAgent.ts` (turn-summary log output kept byte-identical).
- **Dead code:** unused exports (`AgentProposalAction*` in `prompts`, transform/parse helpers in `diffResult`, `CopyButtonController.setDefaultTitle`, `PersistedState.reload`) and unreachable branches (`TextEditorTool` `view_range` length re-check that the Zod `.length(2)` already guarantees, `ZoteroAddTool` non-2xx throw under axios default `validateStatus`, redundant `lastTurn` guards).
- **DRY:** extract `showSummary` tail, the PR CI-terminal gate, the listener-annotation setter, the PR activity sentence, a URL int parser, the edit-content prelude.
- **Zod idioms:** `SubmittedApiKeySchema` `z.preprocess` → `trim().optional().transform(...)`; `LatexConfigFieldSchema` drops the readonly-tuple cast; inline single-use option schemas; reuse existing inferred types instead of inline structural duplicates.
- **Flatten / clarify:** inline trivial wrappers (`getContextFiles`, `MemoryTool` locate); make `resumeCodexThread` synchronous (no `await`); collapse redundant approve-action and keybinding guards; single `export type` lines.

No tool returns host UI; no `vscode` import; no contract change. No new dependencies; no lockfile change.

**Verified:** ran the full test-kernel suite (1298 tests) from this branch — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactors and private symbol moves only; PR description states contracts and full test-kernel suite were verified unchanged.
> 
> **Overview**
> This PR is a **behavior-preserving cleanup** across `src/shared` and `src/tools`: deduplication, dead-code removal, and clearer Zod/types—no intended changes to tool I/O, IPC message shapes, or user-visible strings.
> 
> **Shared:** Command keybinding lookup is simplified; unused APIs are dropped (`CopyButtonController.setDefaultTitle`, `PersistedState.reload`, duplicate `AgentProposalAction*` in `prompts.ts`—progress view keeps its own schema). Diff parsing helpers are **module-private** but still drive `parseDiffResultEntries`. Settings/main-view schemas use idiomatic Zod (`SubmittedApiKeySchema` trim/transform, `LatexConfigFieldSchema` without a tuple cast, inlined `preserveBaseFile`).
> 
> **Tools:** New **`agentCliShared.ts`** centralizes abort/interruption/loop-status/turn-summary logging for **Codex** and **Claude** agents. **`ExecutionsTool`** factors a shared summary tail; **`TextEditorTool`** shares edit prelude for str-replace/insert; **`DelegationTools`** tightens post-approve typing and inlines bib filtering; **`resumeCodexThread`** is sync; GitHub PR polling extracts **`ciTerminalStatus`** and subscription copy helpers; inquiry/memory/Zotero paths drop redundant checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b38cb8cf835e93c5a35ee49409bd8f6ee8fc57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->