### PR TITLE
fix(cli): drop removed child stream rows

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -225,10 +225,15 @@ export function setParentStream(
 
 export function removeStream(streamId: StreamTabId): void {
   const current = cliState.streams.get();
-  if (!current.has(streamId)) return;
   const out = new Map(current);
-  out.delete(streamId);
-  cliState.streams.set(out);
+  let changed = out.delete(streamId);
+  for (const [id, slice] of out) {
+    const next = scrubChildStreamReferences(slice, streamId);
+    if (next === slice) continue;
+    out.set(id, next);
+    changed = true;
+  }
+  if (changed) cliState.streams.set(out);
   if (cliState.activeStreamId.get() === streamId) {
     cliState.activeStreamId.set(undefined);
   }
@@ -242,6 +247,37 @@ export function removeStream(streamId: StreamTabId): void {
     nextParents.delete(child);
   }
   if (nextParents) cliState.parentStream.set(nextParents);
+}
+
+function scrubChildStreamReferences(
+  slice: StreamSlice,
+  streamId: StreamTabId,
+): StreamSlice {
+  const activeSubagents = removeChildStreamReference(
+    slice.activeSubagents,
+    streamId,
+  );
+  const activeProcesses = removeChildStreamReference(
+    slice.activeProcesses,
+    streamId,
+  );
+  const childStreams = removeChildStreamReference(slice.childStreams, streamId);
+  if (
+    activeSubagents === slice.activeSubagents &&
+    activeProcesses === slice.activeProcesses &&
+    childStreams === slice.childStreams
+  ) {
+    return slice;
+  }
+  return { ...slice, activeSubagents, activeProcesses, childStreams };
+}
+
+function removeChildStreamReference(
+  children: readonly ActiveChildInfo[],
+  streamId: StreamTabId,
+): readonly ActiveChildInfo[] {
+  const next = children.filter((child) => child.childStreamId !== streamId);
+  return next.length === children.length ? children : next;
 }
 
 function defaultSessionMeta(): SessionMeta {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -27,6 +27,8 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '@cli/chat/tui/state/focusCycle';
+import { hasChildExecutionRows } from '@cli/chat/tui/state/childControls';
+import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import {
   finalizeSettledPrefix,
   stripOrchestratorFollowup,
@@ -109,6 +111,54 @@ describe('cliState Phase 4 fields', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     removeStream(root);
     expect(cliState.parentStream.get().has(child2)).toBe(false);
+  });
+
+  it('removes stale child rows when a stream is removed', () => {
+    cliState.activeStreamId.set(root);
+    setParentStream(child1, root);
+    patchStream(root, (s) => ({
+      ...s,
+      childStreams: [
+        {
+          executionId: 'history-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: 'completed',
+        },
+      ],
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+      activeProcesses: [
+        {
+          executionId: 'process-1',
+          agentName: 'bash',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+
+    expect(hasChildExecutionRows(cliState.streams.get().get(root))).toBe(true);
+    expect(nextFocusForward()).toBe(child1);
+
+    removeStream(child1);
+
+    const parent = cliState.streams.get().get(root);
+    expect(parent).toBeDefined();
+    if (!parent) throw new Error('missing parent stream');
+    expect(parent.childStreams).toEqual([]);
+    expect(parent.activeSubagents).toEqual([]);
+    expect(parent.activeProcesses).toEqual([]);
+    expect(visibleSubagentRows(parent)).toEqual([]);
+    expect(hasChildExecutionRows(parent)).toBe(false);
+    expect(nextFocusForward()).toBeUndefined();
   });
 
   it('treats a null-parent update as child promotion to top-level', () => {


### PR DESCRIPTION
## Summary

- scrub removed stream IDs from surviving CLI parent slices' retained subagent rows and active child lists
- keep removed auto-closed child streams out of picker rows and focus traversal
- add a regression test covering visible rows, child-control presence, and focus after removal

Closes #4758.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `git diff --check`
- `npm run format -- --log-level warn`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI state cleanup on stream removal with a focused regression test; no auth, persistence, or runtime protocol changes.
> 
> **Overview**
> When a child stream is removed, **`removeStream`** now walks every remaining parent **`StreamSlice`** and strips that id from **`childStreams`**, **`activeSubagents`**, and **`activeProcesses`**, so picker rows, child-control UI, and forward focus no longer reference a deleted stream. Parent-map pruning and active-stream clearing are unchanged.
> 
> A regression test in **`TuiStateAndFocus.vitest.mts`** asserts empty child lists, no visible subagent rows, no child execution rows, and no forward focus target after removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa83c72b957d71b191def399aa66b78b8412d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->