### PR TITLE
fix(cli): hide unavailable models in picker

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -1,8 +1,9 @@
-// `/model` form. It shows the same registry used by `texra models list`.
-// Before the first message it can choose the root model; after that it is
-// read-only because an active conversation owns a concrete model handler.
+// `/model` form. It loads the same registry used by `texra models list`, then
+// shows only the entries that can run in the active API mode. Before the first
+// message it can choose the root model; after that it is read-only because an
+// active conversation owns a concrete model handler.
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import {
@@ -10,7 +11,7 @@ import {
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
-import { Select } from '../ui/Select';
+import { Select, type SelectItem } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
 import { FormFrame } from './_shared/FormFrame';
 import {
@@ -18,6 +19,7 @@ import {
   type SelectWindowSize,
 } from './_shared/selectWindow';
 import { useAsyncListForm } from './_shared/useAsyncListForm';
+import { isPlainReturnInput } from '../input/inputKeys';
 
 export interface ModelListFormProps {
   readonly currentModel: string;
@@ -60,10 +62,38 @@ export function modelSelectWindow(args: {
   return computeSelectWindowSize({ ...args, chromeRows: 5 });
 }
 
+export function modelSelectItemsForCliMode(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): ReadonlyArray<SelectItem<string>> {
+  return models
+    .filter((m) => m.available)
+    .map((m) => ({
+      value: m.model.value,
+      label: m.model.label || m.model.value,
+      description: formatModelStatusForCliMode(m, apiMode),
+    }));
+}
+
+export function hasRunnableModelSelectItems(
+  models: readonly CliModelAccess[],
+): boolean {
+  return models.some((m) => m.available);
+}
+
+function EmptyModelListState(props: { readonly onClose: () => void }) {
+  useInput((input, key) => {
+    if (isPlainReturnInput(input, key)) props.onClose();
+  });
+
+  return <Text>No models are available in this API mode.</Text>;
+}
+
 export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   const { data, loading, error } = useAsyncListForm<readonly CliModelAccess[]>({
     load: getCliModelAccessList,
     onClose: props.onClose,
+    isEmpty: (models) => !hasRunnableModelSelectItems(models),
   });
 
   if (loading) {
@@ -82,12 +112,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   }
 
   const models = data ?? [];
-  const items = models.map((m) => ({
-    value: m.model.value,
-    label: m.model.label || m.model.value,
-    description: formatModelStatusForCliMode(m, props.apiMode),
-    disabled: props.selectable ? !m.available : false,
-  }));
+  const items = modelSelectItemsForCliMode(models, props.apiMode);
   const selectable = props.selectable === true;
   const selectWindow = modelSelectWindow({
     availableRows: props.availableRows,
@@ -109,34 +134,46 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           ? 'Choose the root model for the first message.'
           : 'Available models. Start a new chat with texra --model=<name> to choose the root model.'}
       </Text>
-      <Box flexDirection="column">
-        <Select
-          items={items}
-          activeValue={props.currentModel}
-          maxVisibleItems={selectWindow.maxVisibleItems}
-          showOverflow={selectWindow.showOverflow}
-          onSelect={(value) => {
-            if (selectable) {
-              props.onSelect?.(value);
-              return;
-            }
-            props.onClose();
-          }}
-          onCancel={props.onClose}
-        />
-      </Box>
+      {items.length === 0 ? (
+        <EmptyModelListState onClose={props.onClose} />
+      ) : (
+        <Box flexDirection="column">
+          <Select
+            items={items}
+            activeValue={props.currentModel}
+            maxVisibleItems={selectWindow.maxVisibleItems}
+            showOverflow={selectWindow.showOverflow}
+            onSelect={(value) => {
+              if (selectable) {
+                props.onSelect?.(value);
+                return;
+              }
+              props.onClose();
+            }}
+            onCancel={props.onClose}
+          />
+        </Box>
+      )}
       <Box>
-        {selectable ? (
+        {selectable && items.length > 0 ? (
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
               { key: '1-9/a-z', action: 'select' },
             ]}
           />
-        ) : (
+        ) : items.length > 0 ? (
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },
+              { key: 'Enter', action: 'close' },
+              { key: 'Esc', action: 'close' },
+            ]}
+            confirmCancel={false}
+          />
+        ) : (
+          <KeyHints
+            hints={[
               { key: 'Enter', action: 'close' },
               { key: 'Esc', action: 'close' },
             ]}

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   formatModelStatusForCliMode,
+  hasRunnableModelSelectItems,
+  modelSelectItemsForCliMode,
   modelSelectWindow,
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
@@ -70,6 +72,62 @@ describe('CLI ModelListForm status text', () => {
         'included',
       ),
     ).toBe('relay: quota exhausted');
+  });
+});
+
+describe('CLI ModelListForm model visibility', () => {
+  it('shows only models runnable in the active API mode', () => {
+    const items = modelSelectItemsForCliMode(
+      [
+        access({
+          value: 'sonnet46T',
+          label: 'Sonnet',
+          availability: 'included-access',
+        }),
+        access(
+          {
+            value: 'opus48T',
+            label: 'Opus',
+            availability: 'not-included',
+            disabled: true,
+          },
+          'not included',
+        ),
+        access({
+          value: 'gpt54',
+          label: 'GPT-5.4',
+          availability: 'included-access',
+        }),
+      ],
+      'included',
+    );
+
+    expect(items.map((item) => item.value)).toEqual(['sonnet46T', 'gpt54']);
+    expect(items.map((item) => item.description)).toEqual([
+      'relay: included',
+      'relay: included',
+    ]);
+  });
+
+  it('treats filtered-empty lists as non-actionable', () => {
+    expect(
+      hasRunnableModelSelectItems([
+        access(
+          {
+            availability: 'missing-key',
+            requiresKey: true,
+          },
+          'missing api key',
+        ),
+        access(
+          {
+            availability: 'not-included',
+            disabled: true,
+          },
+          'not included',
+        ),
+      ]),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- filter `/model` picker rows to models that are runnable in the active API mode
- keep diagnostic model status formatting intact for unavailable model cases outside the picker
- add a focused model-form test for unavailable rows being omitted

Closes #4761.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ModelListForm.vitest.mts`
- `npm run texra-local:build`
- real TTY check: `TERM=xterm-256color texra-local --cwd /tmp/texra-cli-live-dogfood --api-mode=included chat --model=gpt54`, then `/model` shows only included relay models and omits `Opus 4.8` / `GPT-5.5`
- real TTY check: `TERM=xterm-256color texra-local --cwd /tmp/texra-cli-live-dogfood --api-mode=personal chat --model=gpt55`, then `/model` shows only API-key-set models
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `npm run compile:safe`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX-only filtering in the model list form; no auth, API, or runtime model selection changes beyond what users see in the picker.
> 
> **Overview**
> The **`/model`** TUI picker now lists only models that are **runnable** in the current API mode (`m.available`), instead of showing every registry row with some entries disabled.
> 
> Selectable items are built via **`modelSelectItemsForCliMode`** / **`hasRunnableModelSelectItems`**. When nothing is runnable, the form shows a short empty message and close-only key hints instead of an empty **`Select`**. **`formatModelStatusForCliMode`** is unchanged for the rows that remain visible. Tests cover filtered item lists and “all unavailable” detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf9b3a65689c9d5abe99e181c0ba56738dee3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->