### PR TITLE
refactor(controllers): simplify shared layer + TUI/extension sharing roadmap

### DIFF
--- a/docs/proposals/tui-extension-sharing.md
+++ b/docs/proposals/tui-extension-sharing.md
@@ -1,0 +1,100 @@
+# Sharing & consistency: CLI TUI ↔ VS Code extension
+
+Status: proposal / roadmap. Produced by an adversarial analysis pass over the
+shared cross-host layer (`src/controllers`, `src/hosts`, `src/shared`) versus
+the CLI TUI state layer (`packages/cli/src/chat/tui/state/`).
+
+## The situation today
+
+The intended host-neutral layer already exists and is VS Code-free:
+
+- `src/controllers/{progressView,settingsView,mainView}` (~2.6k lines)
+- `src/shared/settingsView/handlers/*` (~440 lines)
+- `src/hosts/*` ports (`promptHost`, `terminalHost`, `diffViewHost`,
+  `clipboardHost`, `externalOpener`)
+
+But adoption is lopsided: the **extension consumes `@controllers` (8 imports)**,
+while the **CLI consumes it 0 times**. The CLI instead re-implements the same
+orchestration in `packages/cli/src/chat/tui/state/` (18 files). `cliState.ts`
+states the intent explicitly — it _"mirrors the webview's `progressState`
+shape … so future feature parity is a port, not a rewrite."_ That parallelism
+is the inconsistency: two implementations of the same orchestration kept in
+lockstep by hand, which drifts.
+
+Two concrete drifts already exist:
+
+1. **Approval handling is implemented three times** — extension
+   (`ProgressViewMessageHandler`), CLI TUI (`subscribeApprovals.ts`), and CLI
+   headless (`approvalAdapter.ts`) — all calling the same
+   `@agent/runtime/runCoordinators` + `@tools/{approval,inquiry,userQuestion}`
+   functions with _subtly different feedback strings_.
+2. **The CLI silently cannot do proposal "setup" actions** that the extension
+   supports: the extension routes proposals through
+   `ProgressAgentProposalController.handleAction` (which knows `setup` +
+   `restoreTaskState`), but the CLI calls `resolveProposal({action})` directly
+   and has no notion of `setup`.
+
+## Recommended direction (laddered, low-risk first)
+
+Each rung is independently shippable and behavior-preserving until the last.
+
+### Rung 1 — a canonical `ApprovalDecision` schema (small, low risk)
+
+Add `src/shared/schemas/approvalDecision.ts` (Zod + `z.infer`):
+`{ accepted, feedback?, userQuestionAnswers?, bypass?, apiMode? }`. Re-derive
+the two existing CLI decision shapes from it (TUI =
+`packages/cli/src/chat/tui/state/approvalQueue.ts`; headless =
+`approvalAdapter.ts` via `.pick({ accepted, userMessage })`). No runtime change
+— this just gives later work one decision vocabulary.
+
+### Rung 2 — share the auto-decision policy ladder (small, low risk)
+
+Move `denyMessage` + the per-kind yolo/deny feedback strings (currently
+copy-pasted between `approvalAdapter.ts` and `subscribeApprovals.ts`) into a
+shared `src/controllers/approval/approvalPolicy.ts`. Both CLI paths import it;
+CLI-only wiring (`enqueueCliPrompt`) stays in the CLI.
+
+### Rung 3 — route proposals through the existing controller (medium)
+
+Wire a `ProgressAgentProposalController` in the CLI with CLI deps
+(`resolveProposal` from `runCoordinators`, `restoreTaskState` → `false`
+initially) and replace `subscribeApprovals.dispatchProposal`'s direct
+`resolveProposal` call with `controller.handleAction(...)`. This reuses an
+already-shared controller and is the first step toward closing the setup-action
+drift — no new abstraction.
+
+### Rung 4 — one host-neutral approval dispatcher (medium)
+
+With rungs 1–3 in place, add `src/controllers/approval/ApprovalDecisionDispatcher.ts`
+taking a normalized `ApprovalDecision` + event payload and performing the
+coordinator/tool dispatch. All three hosts then only _collect_ the decision
+(modal / stderr prompt / webview message) and call the one dispatcher — the
+three divergent accept→approve / reject+feedback copies collapse to one.
+
+## Adjacent shared-state wins (independent of approvals)
+
+- **Terminal-status predicate** (small): CLI's `FINAL_TRANSCRIPT_STATUSES` /
+  `isFinalTranscriptStatus` (`transcript.ts`) duplicates a concept that belongs
+  next to `LIVE_ELAPSED_STREAM_STATUSES` in the shared stream schema. Add
+  `TERMINAL_STREAM_STATUSES` + `isTerminalStreamStatus()` there and delegate.
+- **Child-stream selectors** (small): move `mergeChildStreams` +
+  `visibleSubagentRows` (`childStreamMerge.ts`) and `childElapsed` /
+  `hasLiveChildElapsed` (`childControls.ts`) into
+  `src/shared/selectors/` (they depend only on `ActiveChildInfo`), leaving thin
+  re-exports so CLI call sites/tests are untouched; the webview adopts them in a
+  follow-up. This is where the CLI could _gain_ the webview's finished-child
+  counts and stop drifting on badge logic.
+- **CLI host shims** (medium): implement `packages/cli/src/hosts/CliPromptHost.ts`
+  against the existing `PromptHost` port (only `confirm`/`warning` are needed by
+  `SettingsMemoryController`). That unlocks CLI reuse of the host-neutral
+  Settings controllers without touching controller code, validated by the
+  existing `src/test-kernel/hosts` FakeHosts invariants.
+
+## Principle
+
+Treat `src/controllers` + `src/hosts` as the single home for view-orchestration
+logic, and the CLI `state/` layer as _host wiring_ (Ink signals + keystrokes)
+that consumes it via injected ports — mirroring how the extension consumes it
+via webview messages. New view behavior should land in a controller once, with
+both hosts adopting it, rather than being added to the webview and ported to the
+TUI by hand.

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -77,24 +77,18 @@ export class ProgressAgentProposalController {
 
   private buildTaskState(proposal: AgentProposal): TaskState | null {
     const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
-    const activeFiles =
-      proposal.agentCategory === AgentCategory.Workflow
-        ? {
-            input: proposal.inputFiles.length > 0,
-            context: proposal.contextFiles.length > 0,
-            media: proposal.mediaFiles.length > 0,
-            output: proposal.outputFiles.length > 0,
-          }
-        : {
-            input: false,
-            context: false,
-            media: false,
-            output: false,
-          };
+    const activeFiles = isWorkflow
+      ? {
+          input: proposal.inputFiles.length > 0,
+          context: proposal.contextFiles.length > 0,
+          media: proposal.mediaFiles.length > 0,
+          output: proposal.outputFiles.length > 0,
+        }
+      : undefined;
 
     const result = AgentConfigSchema.safeParse({
       ...proposal,
-      ...(isWorkflow && {
+      ...(activeFiles && {
         inputFilesActive: activeFiles.input,
         contextFilesActive: activeFiles.context,
         mediaFilesActive: activeFiles.media,
@@ -108,7 +102,7 @@ export class ProgressAgentProposalController {
     }
 
     return (
-      isWorkflow
+      activeFiles
         ? { agentConfig: result.data, activeFiles }
         : { agentConfig: result.data }
     ) as TaskState & { agentConfig: AgentConfig };

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -230,10 +230,7 @@ export class ProgressFollowUpController {
     executionId: string | undefined,
   ): string {
     const executionHint = executionId ? `Execution: ${executionId}` : undefined;
-    const editableHint =
-      editableFiles.length > 0
-        ? `Editable workspace target${editableFiles.length === 1 ? '' : 's'}: ${editableFiles.join(', ')}`
-        : undefined;
+    const editableHint = `Editable workspace target${editableFiles.length === 1 ? '' : 's'}: ${editableFiles.join(', ')}`;
     const failureLines = compileFailures.map((failure) => {
       const outputPath =
         executionId && failure.output.kind === 'runStorage'

--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -95,17 +95,17 @@ export class SettingsAgentFileController {
       ? input.name
       : `${input.name}.yaml`;
     const baseName = input.name.replace(/\.yaml$/, '');
-    const description =
-      input.category === 'toolUse'
-        ? `${baseName} — interactive tool-use agent`
-        : `${baseName} — workflow agent`;
+    const isToolUse = input.category === 'toolUse';
+    const description = isToolUse
+      ? `${baseName} — interactive tool-use agent`
+      : `${baseName} — workflow agent`;
 
     return {
       fileName,
       filePath: path.join(input.customDir, fileName),
       baseName,
       description,
-      templateKind: input.category === 'toolUse' ? 'toolUse' : 'workflowSingle',
+      templateKind: isToolUse ? 'toolUse' : 'workflowSingle',
     };
   }
 

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -155,7 +155,7 @@ export class SettingsModelSelectionController {
     if (!helperModel || helperModel === DEFAULT_HELPER_MODEL) {
       return DEFAULT_HELPER_MODEL;
     }
-    if (visibleModels.length === 0 || visibleModels.includes(helperModel)) {
+    if (visibleModels.includes(helperModel)) {
       return helperModel;
     }
     return visibleModels[0] ?? DEFAULT_HELPER_MODEL;

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -40,37 +40,34 @@ export function buildApprovalSettingsMessage(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_SANDBOX_MODE,
         'workspace-write',
-      ) ?? 'workspace-write',
+      ),
     ),
     codexReasoningEffort: parseCodexReasoningEffort(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_REASONING_EFFORT,
         'high',
-      ) ?? 'high',
+      ),
     ),
     codexApprovalPolicy: parseCodexApprovalPolicy(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_APPROVAL_POLICY,
         'never',
-      ) ?? 'never',
+      ),
     ),
     claudeAgentModel: parseClaudeAgentModel(
       workspaceState.get<string>(
         WorkspaceStateKey.CLAUDE_AGENT_MODEL,
         CLAUDE_AGENT_DEFAULT_MODEL,
-      ) ?? CLAUDE_AGENT_DEFAULT_MODEL,
+      ),
     ),
     claudeAgentPermissionMode: parseClaudeAgentPermissionMode(
       workspaceState.get<string>(
         WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
         'acceptEdits',
-      ) ?? 'acceptEdits',
+      ),
     ),
     claudeAgentEffort: parseClaudeAgentEffort(
-      workspaceState.get<string>(
-        WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
-        'high',
-      ) ?? 'high',
+      workspaceState.get<string>(WorkspaceStateKey.CLAUDE_AGENT_EFFORT, 'high'),
     ),
   };
 }


### PR DESCRIPTION
Addresses two requests: **(1)** how the CLI TUI and the VS Code extension should share more / be more consistent, and **(2)** a code-simplifier pass — both aimed at the **host-neutral shared layer** (`src/controllers`, `src/hosts`, `src/shared`) that both hosts are *supposed* to share.

## Findings: the TUI/extension consistency gap

The intended shared layer already exists and is VS Code-free, but adoption is lopsided — the **extension imports `@controllers` 8×; the CLI imports it 0×**, re-implementing the same orchestration in `packages/cli/src/chat/tui/state/` (18 files). `cliState.ts` even says it *"mirrors the webview's progressState shape … so feature parity is a port, not a rewrite."* That hand-maintained parallel is the inconsistency, and it has already drifted:
- **Approval handling is implemented three times** (extension `ProgressViewMessageHandler`, CLI TUI `subscribeApprovals.ts`, CLI headless `approvalAdapter.ts`) with subtly different feedback strings.
- **The CLI silently can't do proposal "setup" actions** the extension supports (it calls `resolveProposal` directly instead of routing through `ProgressAgentProposalController`).

`docs/proposals/tui-extension-sharing.md` (added here) lays out a **laddered, low-risk roadmap**: canonical `ApprovalDecision` Zod schema → shared approval-policy helpers → route proposals through the existing controller → one host-neutral approval dispatcher; plus shared stream/child-execution selectors and CLI host-port shims (e.g. `CliPromptHost`). Each rung is independently shippable and behavior-preserving until the last.

## Code-simplifier: 5 verified shared-layer cleanups

From a 14-candidate adversarial pass over the shared layer (9 rejected as subjective/risky), **5 applied** — all behavior-preserving, test-consumer-checked, no `vscode` import, no IPC/handler contract change:
- `ProgressAgentProposalController.buildTaskState` — drop the dead all-false `activeFiles` object on the non-workflow path + duplicate `agentCategory` check.
- `ProgressFollowUpController.buildCompileFixerQuestion` — remove the unreachable empty-`editableFiles` branch.
- `SettingsAgentFileController.planTemplateAgent` — compute the `toolUse` predicate once.
- `SettingsModelSelectionController.getEffectiveHelperModel` — drop the unreachable `visibleModels.length === 0` guard (single read boundary never yields empty).
- `approvalHandlers.buildApprovalSettingsMessage` — drop the redundant `?? '<default>'` on six `workspaceState.get(key, default)` reads (both the get default and the enum-parser fallback already guarantee a value).

**Verified:** root tsc ✅, tsconfig.test-kernel ✅, controllers/settings/desktop kernel suites (322 tests) ✅, prettier ✅, vscode-free guard ✅.

Fifth pass after #4725 (TUI), #4740 (CLI runtime/commands), #4752 (core), #4759 (tools/shared). No new dependencies; no lockfile change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and dead-code removal in host-neutral controllers/handlers; no new runtime wiring or security-sensitive behavior changes in the diff.
> 
> **Overview**
> Adds **`docs/proposals/tui-extension-sharing.md`**, a roadmap for aligning the **CLI TUI** with the **VS Code extension** via the existing host-neutral layer (`src/controllers`, `src/hosts`, `src/shared`) instead of parallel `packages/cli/.../tui/state/` orchestration. It documents current drift (triple approval paths, missing CLI proposal **setup**) and a **four-rung** plan (shared `ApprovalDecision` schema, shared approval policy, route proposals through `ProgressAgentProposalController`, single approval dispatcher), plus follow-on shared selectors and CLI host shims.
> 
> The code diff is a **behavior-preserving simplification** pass on shared controllers/handlers: **`ProgressAgentProposalController`** only attaches workflow `activeFiles` when relevant; **`ProgressFollowUpController`** always includes the editable-files hint when compile-fixer runs (empty case already blocked upstream); **`SettingsAgentFileController`** deduplicates the tool-use branch; **`SettingsModelSelectionController`** drops a redundant empty-model guard given `getVisibleModels()` normalization; **`approvalHandlers`** removes duplicate `?? default` fallbacks on `workspaceState.get` reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca81b6608085ab678fdb73a424cf9d6423813f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->