### PR TITLE
fix(cli): compact foreground panels near prompt

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -119,6 +119,7 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
   },
   {
     name: 'bash-approval-approve-session',
@@ -171,6 +172,7 @@ const SCENARIOS = [
       'k kill',
       'Esc close',
     ],
+    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
     name: 'empty-task-picker',
@@ -186,6 +188,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Enter view', 'k kill', 'navigate'],
+    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
     name: 'task-picker-parent-fallback',
@@ -378,6 +381,19 @@ function frameTail(frame) {
   return lines.slice(-Math.min(lines.length, ROWS)).join('\n');
 }
 
+function blankLinesBetween(frame, from, to) {
+  const lines = frame.split('\n');
+  const toIndex = lines.findLastIndex((line) => line.includes(to));
+  if (toIndex < 0) return undefined;
+  const fromIndex = lines
+    .slice(0, toIndex)
+    .findLastIndex((line) => line.includes(from));
+  if (fromIndex < 0) return undefined;
+  return lines
+    .slice(fromIndex + 1, toIndex)
+    .filter((line) => line.trim().length === 0).length;
+}
+
 function snapshotFileName(index, name) {
   const prefix = String(index + 1).padStart(2, '0');
   return `${prefix}-${name.replace(/[^a-z0-9._-]+/gi, '-')}.txt`;
@@ -482,6 +498,18 @@ async function runScenario(scenario) {
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  for (const check of scenario.maxBlankLinesBetween ?? []) {
+    const actual = blankLinesBetween(frame, check.from, check.to);
+    if (actual === undefined) {
+      failures.push(
+        `could not find compactness markers: ${JSON.stringify(check.from)} → ${JSON.stringify(check.to)}`,
+      );
+    } else if (actual > check.max) {
+      failures.push(
+        `too many blank lines between ${JSON.stringify(check.from)} and ${JSON.stringify(check.to)}: ${actual} > ${check.max}`,
+      );
+    }
+  }
   if (scenario.expectExit && !exitedCleanly) {
     const exitDetails = exited
       ? ` (exitCode ${exited.exitCode}, signal ${exited.signal || 'none'})`

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -467,8 +467,10 @@ export function App(props: AppProps): React.JSX.Element {
           ) : null}
           {foregroundSurface ? (
             <Box
+              flexDirection="column"
               height={foregroundRows}
               alignItems="flex-start"
+              justifyContent="flex-end"
               overflowY="hidden"
             >
               {foregroundSurface}


### PR DESCRIPTION
## Summary

- bottom-align compact foreground panels inside their reserved TUI region so the active control sits directly above the prompt/status area
- add TTY harness compactness checks for bash approval, task picker, and empty task picker

Fixes #4765.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-compact-full-frames`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only CLI TUI change with added snapshot-style harness assertions; no auth, data, or API impact.
> 
> **Overview**
> **Bottom-aligns** compact foreground panels (approvals, task picker, etc.) in their reserved TUI region so they sit directly above the tip/input/status chrome instead of leaving extra vertical gap.
> 
> The foreground container in `App.tsx` now uses a column flex layout with **`justifyContent="flex-end"`**. The TUI harness gains **`maxBlankLinesBetween`** checks (panel border markers → `Tip:`) for bash approval and task-picker scenarios so regressions in vertical spacing are caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43abe282e86a7da0ea9c1460302e11057c4aaba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->