### PR TITLE
feat(cli): add /btw follow-up command

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -73,14 +73,27 @@ const SCENARIOS = [
     expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
   },
   {
+    name: 'btw-palette',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/bt'],
+    expect: [
+      '/btw',
+      'Queue a follow-up without interrupting the active run',
+      'Enter complete',
+      'Tab complete',
+    ],
+  },
+  {
     name: 'slash-palette-overflow',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/', DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN],
     frame: 'tail',
     expect: [
-      '… 6 earlier',
+      '… 7 earlier',
       '/status',
       'Open the session status tabs',
+      '/btw',
+      'Queue a follow-up without interrupting the active run',
       '/exit',
       'Exit the CLI session',
     ],

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -103,6 +103,14 @@ export function slashPaletteWindow({
   };
 }
 
+export function slashPaletteEnterHintAction(
+  command: SlashCommand | undefined,
+): string {
+  if (!command) return 'run';
+  if (command.formComponent) return 'open';
+  return slashPickIntent(command, 'enter') === 'submit' ? 'run' : 'complete';
+}
+
 export function SlashPalette(
   props: SlashPaletteProps,
 ): React.JSX.Element | null {
@@ -167,6 +175,7 @@ export function SlashPalette(
   if (matchCount === 0) return null;
   const window = slashPaletteWindow({ highlight, itemCount: matchCount });
   const visible = matches.slice(window.start, window.end);
+  const highlightedCommand = matches[highlight];
 
   return (
     <Box
@@ -196,7 +205,10 @@ export function SlashPalette(
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: 'Enter', action: 'run' },
+            {
+              key: 'Enter',
+              action: slashPaletteEnterHintAction(highlightedCommand),
+            },
             { key: 'Tab', action: 'complete' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -232,6 +232,11 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'Request context compaction',
   });
   registerSlashCommand({
+    name: 'btw',
+    description: 'Queue a follow-up without interrupting the active run',
+    takesArgs: true,
+  });
+  registerSlashCommand({
     name: 'exit',
     description: 'Exit the CLI session',
     aliases: ['quit'],

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -125,6 +125,12 @@ function formatQueuedFollowUpNotice(line: string): string {
   )}`;
 }
 
+export function parseBtwFollowUpMessage(line: string): string | undefined {
+  const parsed = parseSlashInput(line);
+  if (!parsed || parsed.name.toLowerCase() !== 'btw') return undefined;
+  return parsed.remainder.trim();
+}
+
 export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
   executionId: string | undefined;
@@ -962,9 +968,23 @@ export async function runChat(
   };
 
   const handleSubmittedLine = async (line: string): Promise<void> => {
+    const btwMessage = parseBtwFollowUpMessage(line);
+    if (btwMessage !== undefined) {
+      if (!btwMessage) {
+        appendLocalUserTranscript(line.trim());
+        appendLocalAssistantTranscript('Usage: /btw <message>');
+        return;
+      }
+      await submitChatMessage(btwMessage);
+      return;
+    }
     if (await handleTuiSlashCommand(line, slashCommandContext())) {
       return;
     }
+    await submitChatMessage(line);
+  };
+
+  const submitChatMessage = async (line: string): Promise<void> => {
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
       startSession(line);

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   nextSlashPaletteHighlight,
+  slashPaletteEnterHintAction,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
 
 describe('SlashPalette navigation', () => {
   it('continues down into commands hidden behind the overflow marker', () => {
-    const itemCount = 14;
+    const itemCount = 15;
     expect(
       slashPaletteWindow({
         highlight: 7,
@@ -18,7 +19,7 @@ describe('SlashPalette navigation', () => {
       start: 0,
       end: 8,
       hiddenBefore: 0,
-      hiddenAfter: 6,
+      hiddenAfter: 7,
     });
 
     const next = nextSlashPaletteHighlight({
@@ -35,9 +36,9 @@ describe('SlashPalette navigation', () => {
         maxVisibleCommands: 8,
       }),
     ).toEqual({
-      start: 6,
-      end: 14,
-      hiddenBefore: 6,
+      start: 7,
+      end: 15,
+      hiddenBefore: 7,
       hiddenAfter: 0,
     });
   });
@@ -46,16 +47,39 @@ describe('SlashPalette navigation', () => {
     expect(
       nextSlashPaletteHighlight({
         direction: 1,
-        highlight: 13,
-        itemCount: 14,
+        highlight: 14,
+        itemCount: 15,
       }),
     ).toBe(0);
     expect(
       nextSlashPaletteHighlight({
         direction: -1,
         highlight: 0,
-        itemCount: 14,
+        itemCount: 15,
       }),
-    ).toBe(13);
+    ).toBe(14);
+  });
+
+  it('describes what Enter does for the highlighted slash command', () => {
+    expect(
+      slashPaletteEnterHintAction({
+        name: 'help',
+        description: 'show help',
+      }),
+    ).toBe('run');
+    expect(
+      slashPaletteEnterHintAction({
+        name: 'btw',
+        description: 'queue follow-up',
+        takesArgs: true,
+      }),
+    ).toBe('complete');
+    expect(
+      slashPaletteEnterHintAction({
+        name: 'model',
+        description: 'choose model',
+        formComponent: () => null,
+      }),
+    ).toBe('open');
   });
 });

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -31,6 +31,7 @@ describe('slashRegistry', () => {
         'resume',
         'memory',
         'compact',
+        'btw',
       ]),
     );
     expect(
@@ -65,6 +66,12 @@ describe('slashRegistry', () => {
     expect(listSlashCommands().find((cmd) => cmd.name === 'compact')).toEqual(
       expect.objectContaining({
         description: 'Request context compaction',
+      }),
+    );
+    expect(listSlashCommands().find((cmd) => cmd.name === 'btw')).toEqual(
+      expect.objectContaining({
+        description: 'Queue a follow-up without interrupting the active run',
+        takesArgs: true,
       }),
     );
   });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -54,6 +54,7 @@ import {
   chatTuiActiveChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
   clearTuiSessionRunState,
+  parseBtwFollowUpMessage,
 } from '@cli/chat/tui/runChatTui';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
@@ -537,6 +538,16 @@ describe('CLI TUI row allocation', () => {
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     setParentStream(child1, root);
     expect(chatTuiShouldAnnounceQueuedFollowUp(child1)).toBe(false);
+  });
+
+  it('parses /btw as an explicit follow-up message', () => {
+    expect(parseBtwFollowUpMessage('/btw keep this aside')).toBe(
+      'keep this aside',
+    );
+    expect(parseBtwFollowUpMessage('/BTW   Keep casing')).toBe('Keep casing');
+    expect(parseBtwFollowUpMessage('/btw')).toBe('');
+    expect(parseBtwFollowUpMessage('ordinary prompt')).toBeUndefined();
+    expect(parseBtwFollowUpMessage('/status')).toBeUndefined();
   });
 
   it('clears stale resume ids when clearing chat session run state', () => {


### PR DESCRIPTION
## Summary

- add `/btw <message>` as an explicit TUI shortcut into the existing chat/follow-up submit path
- show usage for empty `/btw`
- register `/btw` in the slash palette and make Enter hints reflect the highlighted command (`run`, `open`, or `complete`)
- add a TTY harness scenario for `/btw` palette discoverability

Fixes #4770.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashPalette.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-btw-full-frames`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and follow-up routing only; reuses existing `submitChatMessage` / queue behavior with unit and TUI harness coverage.
> 
> **Overview**
> Adds **`/btw <message>`** as a TUI shortcut that routes into the same **queued follow-up** path as a normal message while a run is active, without going through the generic slash-command handler.
> 
> **Submit handling** in `runChatTui` now parses `/btw` first (`parseBtwFollowUpMessage`), shows **`Usage: /btw <message>`** when the argument is missing, and refactors message submission into **`submitChatMessage`** for both plain input and `/btw` bodies.
> 
> The slash palette registers **`/btw`** (`takesArgs: true`) and uses **`slashPaletteEnterHintAction`** so the **Enter** hint is **run**, **open**, or **complete** depending on the highlighted command. TUI validation adds **`btw-palette`** and updates overflow expectations for the extra builtin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e060b2f657def6fa62e5c5786fbf22bf1d6917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->