### PR TITLE
refactor(shared): canonical ApprovalDecision schema (sharing roadmap Rung 1)

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -13,11 +13,11 @@ import PQueue from 'p-queue';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type {
   AgentProposalPermission,
+  ApprovalDecision as SharedApprovalDecision,
   BashPermission,
   ExternalInquiryPermission,
   PlanApprovalPermission,
   RetryPermission,
-  UserQuestionAnswers,
   UserQuestionPermission,
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
@@ -33,16 +33,13 @@ export type ApprovalPayload =
   | { kind: 'externalInquiry'; payload: ExternalInquiryPermission }
   | { kind: 'userQuestion'; payload: UserQuestionPermission };
 
-export interface ApprovalDecision {
-  readonly accepted: boolean;
-  /**
-   * Free-text payload carried with the decision. For rejections this is the
-   * user's `e`-reject-with-feedback note; for the ExternalInquiry kind on
-   * accept, it's the answer the agent gets back.
-   */
-  readonly userMessage?: string;
-  /** Structured answers for an AskUserQuestion request. */
-  readonly userQuestionAnswers?: UserQuestionAnswers;
+/**
+ * The TUI decision = the host-neutral {@link SharedApprovalDecision}
+ * (accepted / userMessage / userQuestionAnswers) plus the CLI-only session
+ * bypass + credential mode applied before accepting. See
+ * docs/proposals/tui-extension-sharing.md (Rung 1).
+ */
+export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   /** Session bypass to activate before accepting this approval. */
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -6,6 +6,7 @@ import {
   triggerRetry,
 } from '@agent/runtime/runCoordinators';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ApprovalDecision as SharedApprovalDecision } from '@shared/schemas';
 
 // Local imports - tools
 import { handleUserQuestionAction } from '@tools/userQuestion';
@@ -22,10 +23,11 @@ import { type CliContext, type CliPromptRequest } from './cliContext';
 import { askCliQuestion, writeTextStderr } from './logSinks';
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
 
-export interface ApprovalDecision {
-  readonly accepted: boolean;
-  readonly userMessage?: string;
-}
+// The headless adapter only ever sets accepted + userMessage, but reusing the
+// host-neutral shape (which also carries optional userQuestionAnswers) keeps a
+// single source of truth for the decision vocabulary across hosts. See
+// docs/proposals/tui-extension-sharing.md (Rung 1).
+export type ApprovalDecision = SharedApprovalDecision;
 
 const APPROVAL_EVENTS = [
   'showBashPermission',

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -147,6 +147,27 @@ export const UserQuestionAnswersSchema = z.record(
 );
 export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
 
+/**
+ * Host-neutral core of a resolved approval decision, shared by every host
+ * (CLI TUI, CLI headless, extension). Hosts that need extra host-specific
+ * fields (e.g. the CLI's session bypass / credential mode) extend this rather
+ * than redefining the common shape, so the accepted/feedback/answers vocabulary
+ * has a single source of truth. See docs/proposals/tui-extension-sharing.md
+ * (Rung 1).
+ */
+export const ApprovalDecisionSchema = z.object({
+  accepted: z.boolean(),
+  /**
+   * Free-text payload carried with the decision. For rejections this is the
+   * user's reject-with-feedback note; for an ExternalInquiry accept it is the
+   * answer the agent gets back.
+   */
+  userMessage: z.string().optional(),
+  /** Structured answers for an AskUserQuestion request. */
+  userQuestionAnswers: UserQuestionAnswersSchema.optional(),
+});
+export type ApprovalDecision = z.infer<typeof ApprovalDecisionSchema>;
+
 export const UserQuestionPermissionSchema = PermissionBaseSchema.extend({
   questions: z.array(UserQuestionPromptSchema).min(1).max(3),
   context: z.string().nullish(),


### PR DESCRIPTION
**Rung 1** of the TUI/extension sharing roadmap (`docs/proposals/tui-extension-sharing.md`, added in #4764) — the smallest, lowest-risk step toward de-duplicating the approval flow that is currently implemented three times (extension, CLI TUI, CLI headless) with subtly diverging shapes.

### What
Adds a host-neutral `ApprovalDecisionSchema` (Zod + `z.infer`) to `src/shared/schemas/prompts.ts` holding the common decision vocabulary — `accepted` / `userMessage` / `userQuestionAnswers` — and re-derives the two existing CLI decision shapes from it:
- **CLI TUI** (`chat/tui/state/approvalQueue.ts`): `interface ApprovalDecision extends Readonly<ApprovalDecision>` + its CLI-only `bypass` / `apiMode` fields.
- **CLI headless** (`runtime/approvalAdapter.ts`): `type ApprovalDecision = SharedApprovalDecision`.

### Why this shape
The roadmap sketched `bypass`/`apiMode` as schema fields, but those reference CLI-only types (`ApprovalBypassKind`, `CliApiMode`) — putting them in `src/shared` would pull host types the wrong way. So the **shared schema stays strictly host-neutral** and the TUI **extends** it with its CLI-only fields. One source of truth for the common shape, no host coupling.

Pure type consolidation: **no runtime behavior change, no IPC/contract change, no `vscode` import** in the shared zone. Unblocks later rungs (shared approval-policy helpers → one host-neutral dispatcher).

**Verified:** root tsc + `tsconfig.test-kernel.json` + cli typecheck + cli kernel vitest (55 files / 454 tests) + cli bundle + prettier — all green. (3 files, +35/−15.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of TypeScript/Zod types with no behavioral or contract changes; lowest-risk step on the sharing roadmap.
> 
> **Overview**
> **Rung 1** of the TUI/extension sharing roadmap: introduces a host-neutral **`ApprovalDecision`** in `src/shared/schemas/prompts.ts` (`accepted`, optional `userMessage`, optional `userQuestionAnswers`) as the single vocabulary for resolved approvals.
> 
> The **CLI TUI** now **extends** that shared type with CLI-only `bypass` and `apiMode` instead of duplicating the core fields locally. The **headless CLI** aliases the shared type directly. Duplicate local `ApprovalDecision` definitions are removed in favor of imports from `@shared/schemas`.
> 
> This is **type/schema consolidation only**—no intended runtime, IPC, or approval-flow behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbf4ba87c5f50233a4175c25610aacc7dff6106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->