### PR TITLE
fix(cli): show conversation preview in history

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -22,6 +22,8 @@ import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
+const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
+const CONVERSATION_PREVIEW_CONTENT_LIMIT = 4000;
 
 const KV_FILES = new Set([
   'meta.json',
@@ -49,8 +51,21 @@ export interface CliHistoryDetails {
   readonly config: AgentConfig | null;
   readonly resultMeta: ResultMeta | null;
   readonly report: string | null;
+  readonly conversationPreview: CliHistoryConversationPreview | null;
   readonly files: readonly CliHistoryFile[];
   readonly hasFlowRecord: boolean;
+}
+
+export interface CliHistoryConversationPreview {
+  readonly messageCount: number;
+  readonly messages: readonly CliHistoryConversationPreviewMessage[];
+}
+
+export interface CliHistoryConversationPreviewMessage {
+  readonly index: number;
+  readonly role: string;
+  readonly content: string;
+  readonly truncated: boolean;
 }
 
 export interface CliHistoryFile {
@@ -82,23 +97,26 @@ export async function readCliHistoryDetails(
   id: ExecutionId,
 ): Promise<CliHistoryDetails | null> {
   const store = getExecutionStore(id);
-  const [meta, config, resultMeta, report, files, hasFlowRecord] =
+  const [meta, config, resultMeta, report, conversation, files, hasFlowRecord] =
     await Promise.all([
       store.readMeta(),
       store.readConfig(),
       store.readResultMeta(),
       store.readReport(),
+      store.readConversation(),
       listGeneratedFiles(id),
       store.exists(flowKey(id)),
     ]);
+  const conversationPreview = createConversationPreview(conversation);
 
-  if (!meta && !config && !hasFlowRecord) return null;
+  if (!meta && !config && !conversationPreview && !hasFlowRecord) return null;
   return {
     id,
     meta,
     config,
     resultMeta,
     report,
+    conversationPreview,
     files,
     hasFlowRecord,
   };
@@ -195,6 +213,8 @@ export function formatCliHistoryDetailsText(
   }
   if (details.report) {
     lines.push('', 'Report:', details.report);
+  } else if (details.conversationPreview) {
+    lines.push('', formatConversationPreview(details.conversationPreview));
   }
   lines.push('', 'Config:', JSON.stringify(config ?? {}, null, 2));
   lines.push('', `Files (${details.files.length}):`);
@@ -235,6 +255,98 @@ function isHistoryKvFile(name: string): boolean {
 function formatCliHistoryFile(file: CliHistoryFile): string {
   const kind = file.isDirectory ? '<dir>' : `${file.size}`;
   return `${kind}\t${file.path}`;
+}
+
+function createConversationPreview(
+  conversation: readonly unknown[] | null,
+): CliHistoryConversationPreview | null {
+  if (!conversation?.length) return null;
+  const messages = conversation
+    .map((message, i) => toConversationPreviewMessage(message, i + 1))
+    .filter((message) => message.content.trim().length > 0);
+  if (!messages.length) return null;
+
+  const lastAssistant = messages.findLast(
+    (message) => message.role === 'assistant',
+  );
+  const selected = lastAssistant
+    ? [lastAssistant]
+    : messages.slice(-CONVERSATION_PREVIEW_MESSAGE_LIMIT);
+
+  return {
+    messageCount: conversation.length,
+    messages: selected,
+  };
+}
+
+function toConversationPreviewMessage(
+  message: unknown,
+  index: number,
+): CliHistoryConversationPreviewMessage {
+  const raw = isRecord(message) ? message : {};
+  const role = typeof raw.role === 'string' ? raw.role : 'unknown';
+  const content = formatConversationMessageContent(raw.content);
+  const truncated = content.length > CONVERSATION_PREVIEW_CONTENT_LIMIT;
+  return {
+    index,
+    role,
+    content: truncated
+      ? `${content.slice(0, CONVERSATION_PREVIEW_CONTENT_LIMIT).trimEnd()}\n...[truncated]`
+      : content,
+    truncated,
+  };
+}
+
+function formatConversationPreview(
+  preview: CliHistoryConversationPreview,
+): string {
+  const shown =
+    preview.messages.length === 1
+      ? `${preview.messages[0]?.role ?? 'message'} message ${preview.messages[0]?.index ?? '?'}`
+      : `${preview.messages.length} recent messages`;
+  const lines = [
+    `Conversation (${preview.messageCount} messages; showing ${shown}):`,
+  ];
+  for (const message of preview.messages) {
+    lines.push('', `[${message.role} #${message.index}]`, message.content);
+  }
+  return lines.join('\n');
+}
+
+function formatConversationMessageContent(content: unknown): string {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map(formatConversationContentBlock).join('\n').trim();
+  }
+  return formatJsonish(content);
+}
+
+function formatConversationContentBlock(block: unknown): string {
+  if (typeof block === 'string') return block;
+  if (!isRecord(block)) return formatJsonish(block);
+  if (typeof block.text === 'string') return block.text;
+
+  switch (block.type) {
+    case 'tool_use':
+      return `[tool_use: ${String(block.name ?? 'unknown')}]`;
+    case 'tool_result':
+      return `[tool_result: ${formatConversationMessageContent(block.content)}]`;
+    default:
+      return formatJsonish(block);
+  }
+}
+
+function formatJsonish(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 async function listGeneratedFiles(id: ExecutionId): Promise<CliHistoryFile[]> {

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -6,6 +6,7 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
+  readConversation: vi.fn(),
   readMeta: vi.fn(),
   readResultMeta: vi.fn(),
   readReport: vi.fn(),
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', () => ({
   getExecutionStore: vi.fn(() => ({
     readConfig: mocks.readConfig,
+    readConversation: mocks.readConversation,
     readMeta: mocks.readMeta,
     readResultMeta: mocks.readResultMeta,
     readReport: mocks.readReport,
@@ -37,6 +39,7 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
+  formatCliHistoryDetailsText,
   formatCliHistoryText,
   listCliHistoryEntries,
   parseCliHistoryId,
@@ -64,6 +67,7 @@ describe('CLI history runtime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readConfig.mockResolvedValue(config);
+    mocks.readConversation.mockResolvedValue(null);
     mocks.readMeta.mockResolvedValue(null);
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
@@ -112,6 +116,53 @@ describe('CLI history runtime', () => {
     await expect(readCliHistoryConfig('a1' as ExecutionId)).resolves.toEqual(
       config,
     );
+  });
+
+  it('shows a bounded final assistant preview when no report is stored', async () => {
+    mocks.readConversation.mockResolvedValue([
+      { role: 'user', content: 'Review the proof.' },
+      { role: 'assistant', content: '' },
+      { role: 'tool', content: 'problem.tex contents' },
+      { role: 'assistant', content: 'Final proof analysis.' },
+    ]);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+    expect(details?.conversationPreview).toEqual({
+      messageCount: 4,
+      messages: [
+        {
+          index: 4,
+          role: 'assistant',
+          content: 'Final proof analysis.',
+          truncated: false,
+        },
+      ],
+    });
+    expect(formatCliHistoryDetailsText(details!)).toContain(
+      [
+        'Conversation (4 messages; showing assistant message 4):',
+        '',
+        '[assistant #4]',
+        'Final proof analysis.',
+      ].join('\n'),
+    );
+    expect(formatCliHistoryDetailsText(details!)).not.toContain(
+      'problem.tex contents',
+    );
+  });
+
+  it('uses the stored report instead of duplicating conversation preview text', async () => {
+    mocks.readReport.mockResolvedValue('Structured report.');
+    mocks.readConversation.mockResolvedValue([
+      { role: 'assistant', content: 'Final proof analysis.' },
+    ]);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId);
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(text).toContain('Report:\nStructured report.');
+    expect(text).not.toContain('Conversation (');
   });
 
   it('reports not-found deletion through the structured result', async () => {


### PR DESCRIPTION
## Summary
- add a bounded `conversationPreview` to `history show` details by reading persisted execution conversations
- render the final non-empty assistant message in text output when no report is stored
- keep stored reports authoritative and avoid dumping full transcripts into history output

Closes #4775.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `npm run lint` (passes with existing import-order warnings in unrelated files)
- `texra-local --cwd /tmp/texra-math-dogfood history show c0cd81040b96 --output-format=text`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and read-only preview logic only; no auth, persistence writes, or execution behavior changes.
> 
> **Overview**
> **`history show`** now loads persisted conversations and exposes a bounded **`conversationPreview`** on structured output (JSON/NDJSON), so runs with only a transcript can still be found and inspected.
> 
> When no stored **report** exists, text formatting prints a short **Conversation** section instead of leaving the body empty. The preview favors the **last non-empty assistant** message (or up to three recent messages), caps content length, and normalizes mixed content blocks without dumping the full thread. A stored **report** still wins and suppresses the preview in text output.
> 
> Vitest coverage was added for preview selection, formatting, and report precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e99ff565a0f62ed8356521918228eb1308809a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->