### PR TITLE
refactor(extension): DRY, dead code, flatten wrappers in the VS Code host

### DIFF
--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -114,7 +114,7 @@ const UserPartSchema = z.discriminatedUnion('type', [
 ]);
 type UserPart = z.infer<typeof UserPartSchema>;
 
-export const ExportNodeSchema = z.discriminatedUnion('kind', [
+const ExportNodeSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('user-message'), parts: z.array(UserPartSchema) }),
   z.object({ kind: z.literal('assistant-text'), text: z.string() }),
   z.object({

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -36,12 +36,7 @@ import { getAuthStatus } from '@auth/authCommands';
 import { tryResumeFromSnapshot } from '@commands/agent/resumeFromSnapshot';
 import { toErrorMessage } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
-import {
-  globalSM,
-  initializeStateManagers,
-  workspaceSM,
-  WorkspaceStateKey,
-} from '@common/state';
+import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
 import { isTerminalStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
@@ -371,6 +366,17 @@ export async function activate(context: vscode.ExtensionContext) {
       void vscode.commands.executeCommand(command, ...args);
     }
   });
+  // Defense in depth: the only consumers today validate keys before reaching
+  // the config adapter, but the adapter is documented as `texra.*`-scoped and a
+  // future tool wiring through `platform.config` should not be able to read or
+  // write arbitrary VS Code settings by accident.
+  const assertTexraScopedKey = (key: string): void => {
+    if (!key.startsWith('texra.')) {
+      throw new Error(
+        `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
+      );
+    }
+  };
   setSetupPlatform({
     secrets: {
       providers: SecretManager.API_PROVIDERS,
@@ -420,23 +426,11 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     config: {
       get: (key) => {
-        // Defense in depth: the only consumers today validate keys before
-        // reaching here, but the adapter is documented as `texra.*`-scoped
-        // and a future tool wiring through `platform.config` should not be
-        // able to read arbitrary VS Code settings by accident.
-        if (!key.startsWith('texra.')) {
-          throw new Error(
-            `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
-          );
-        }
+        assertTexraScopedKey(key);
         return vscode.workspace.getConfiguration(undefined, null).get(key);
       },
       update: async (key, value, target) => {
-        if (!key.startsWith('texra.')) {
-          throw new Error(
-            `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
-          );
-        }
+        assertTexraScopedKey(key);
         const scope =
           target === 'workspace'
             ? vscode.ConfigurationTarget.Workspace

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -25,7 +25,7 @@ import {
   type LatexConfigField,
 } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
-import { isConfigExplicitlySet, updateConfig } from '@utils/config';
+import { updateConfig } from '@utils/config';
 import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
@@ -103,6 +103,13 @@ export async function copyDefaultAgents(
   }
 }
 
+/** External-root registration options for the custom agents directory. */
+const CUSTOM_AGENT_ROOT_OPTIONS = {
+  kind: 'custom',
+  writable: true,
+  label: 'Custom agents',
+} as const;
+
 /**
  * Register agent directories + bundled reference docs with the external-roots
  * allowlist so the creator tool-use agent can read/write them through the
@@ -130,11 +137,10 @@ export async function registerAgentDirectoryRoots(
         label: 'Built-in tool-use agents',
       }),
     async () =>
-      registerExternalRoot(await agentDirectories.custom(), {
-        kind: 'custom',
-        writable: true,
-        label: 'Custom agents',
-      }),
+      registerExternalRoot(
+        await agentDirectories.custom(),
+        CUSTOM_AGENT_ROOT_OPTIONS,
+      ),
     () =>
       registerExternalRoot(
         path.join(context.extensionPath, 'resources', 'docs', 'agent-creation'),
@@ -168,11 +174,7 @@ export async function registerAgentDirectoryRoots(
 export async function refreshCustomAgentRoot(): Promise<void> {
   try {
     const custom = await agentDirectories.custom();
-    registerExternalRoot(custom, {
-      kind: 'custom',
-      writable: true,
-      label: 'Custom agents',
-    });
+    registerExternalRoot(custom, CUSTOM_AGENT_ROOT_OPTIONS);
   } catch (err) {
     logger.error(
       'extension',
@@ -240,18 +242,7 @@ export async function configureLatexSettings(): Promise<void> {
       await resetLegacyLatexSettings();
     }
 
-    const settings: Array<[string, unknown]> = [
-      [
-        '[latex]',
-        {
-          'editor.wordWrap': 'on',
-        },
-      ],
-    ];
-
-    for (const [key, value] of settings) {
-      await updateConfig(key, value, GLOBAL_IF_UNSET);
-    }
+    await updateConfig('[latex]', { 'editor.wordWrap': 'on' }, GLOBAL_IF_UNSET);
 
     if (!vscode.env.appName?.toLowerCase().includes('windsurf')) {
       await updateConfig(
@@ -386,38 +377,6 @@ async function promptLatexWorkshopInstall(): Promise<void> {
 }
 
 /**
- * One-shot per-workspace migration for LaTeX/compile/diff settings that moved
- * from `package.json` `contributes.configuration` to TeXRA workspace state.
- *
- * Gating: a single workspace-scoped marker (`LATEX_SETTINGS_MIGRATED`) is set
- * after the first run. Subsequent activations skip the entire pass. This is
- * essential for correctness — without a marker, a per-key "skip if storage has
- * any value" gate would re-import the legacy settings.json value the moment a
- * user resets a key to default via the LaTeX tab UI (`update(key, undefined)`
- * removes the key from storage; the next activation would read it back from
- * settings.json again). Marker prevents that footgun.
- *
- * Per-workspace, not per-user: workspace state is per-workspace and a global
- * once-per-user marker would let the first opened workspace consume the
- * migration and silently skip every other workspace.
- *
- * Source detection has two paths:
- * 1. `inspect()` — for keys that were declared in `contributes.configuration`
- *    at upgrade time. Considers only `workspaceFolderValue`, `workspaceValue`,
- *    `globalValue`, never `defaultValue` (avoids persisting VS Code's
- *    compiled-in defaults into workspace state, which would block future
- *    default changes).
- * 2. `get()` fallback — for users who upgrade directly past the package.json
- *    deregistration. VS Code may treat the now-unregistered keys' settings.json
- *    entries as opaque, so `inspect()` can return undefined or all-undefined.
- *    `get()` reads the merged config; for unregistered keys this is just the
- *    user's settings.json entry (no compiled-in default to confuse the result).
- *
- * Once migrated, the LaTeX tab UI writes to workspaceSM directly. A user who
- * later edits the legacy `texra.*` keys in settings.json sees no effect —
- * that path is no longer authoritative.
- */
-/**
  * Read an explicit legacy `texra.*` value from VS Code config, considering
  * only workspaceFolder/workspace/global (never default). For keys deregistered
  * from `package.json` `contributes.configuration`, VS Code may not surface
@@ -466,6 +425,38 @@ function validateLegacyLatexConfigValue(
   return undefined;
 }
 
+/**
+ * One-shot per-workspace migration for LaTeX/compile/diff settings that moved
+ * from `package.json` `contributes.configuration` to TeXRA workspace state.
+ *
+ * Gating: a single workspace-scoped marker (`LATEX_SETTINGS_MIGRATED`) is set
+ * after the first run. Subsequent activations skip the entire pass. This is
+ * essential for correctness — without a marker, a per-key "skip if storage has
+ * any value" gate would re-import the legacy settings.json value the moment a
+ * user resets a key to default via the LaTeX tab UI (`update(key, undefined)`
+ * removes the key from storage; the next activation would read it back from
+ * settings.json again). Marker prevents that footgun.
+ *
+ * Per-workspace, not per-user: workspace state is per-workspace and a global
+ * once-per-user marker would let the first opened workspace consume the
+ * migration and silently skip every other workspace.
+ *
+ * Source detection has two paths:
+ * 1. `inspect()` — for keys that were declared in `contributes.configuration`
+ *    at upgrade time. Considers only `workspaceFolderValue`, `workspaceValue`,
+ *    `globalValue`, never `defaultValue` (avoids persisting VS Code's
+ *    compiled-in defaults into workspace state, which would block future
+ *    default changes).
+ * 2. `get()` fallback — for users who upgrade directly past the package.json
+ *    deregistration. VS Code may treat the now-unregistered keys' settings.json
+ *    entries as opaque, so `inspect()` can return undefined or all-undefined.
+ *    `get()` reads the merged config; for unregistered keys this is just the
+ *    user's settings.json entry (no compiled-in default to confuse the result).
+ *
+ * Once migrated, the LaTeX tab UI writes to workspaceSM directly. A user who
+ * later edits the legacy `texra.*` keys in settings.json sees no effect —
+ * that path is no longer authoritative.
+ */
 export async function migrateLatexConfigToStorage(): Promise<void> {
   // One-shot gate. Once this workspace has been migrated, never run again —
   // post-migration the LaTeX tab UI is the only authoritative writer. Re-

--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -443,12 +443,7 @@ export class ProgressEventHandler {
         [opts.activeField]: opts.next,
         [opts.countField]: (prev[opts.countField] ?? 0) + newlyFinished,
       };
-      nextBadges = {
-        activeSubagents: updatedState.activeSubagents,
-        finishedSubagentCount: updatedState.finishedSubagentCount,
-        activeProcesses: updatedState.activeProcesses,
-        finishedProcessCount: updatedState.finishedProcessCount,
-      };
+      nextBadges = this.toBadgeSnapshot(updatedState);
       return updatedState;
     });
 
@@ -459,6 +454,15 @@ export class ProgressEventHandler {
     ) {
       this.webviewUpdater.updateStreamBadges(parentStreamId, nextBadges);
     }
+  }
+
+  private toBadgeSnapshot(state: StreamExecutionState): StreamBadgeSnapshot {
+    return {
+      activeSubagents: state.activeSubagents,
+      finishedSubagentCount: state.finishedSubagentCount,
+      activeProcesses: state.activeProcesses,
+      finishedProcessCount: state.finishedProcessCount,
+    };
   }
 
   private markAllRunningTasksAsCancelled(): void {
@@ -494,7 +498,7 @@ export class ProgressEventHandler {
 
     this.webviewBridge.syncStream(stream);
 
-    const { extras } = this.prepareStreamSyncExtras(stream);
+    const extras = this.buildStreamSyncExtras(stream);
     const { todos, plan } = this.state.getWorkPlan(stream);
     const queuedFollowUps = ToolUseFollowUpQueue.getAll(stream);
     const agentCategory = this.getStreamCategory(stream);
@@ -509,12 +513,7 @@ export class ProgressEventHandler {
       const streamState = this.state.getStreamState(stream);
       if (streamState) {
         conversationProgress = streamState.conversationProgress;
-        badges = {
-          activeSubagents: streamState.activeSubagents,
-          finishedSubagentCount: streamState.finishedSubagentCount,
-          activeProcesses: streamState.activeProcesses,
-          finishedProcessCount: streamState.finishedProcessCount,
-        };
+        badges = this.toBadgeSnapshot(streamState);
       }
       parentStreamId = this.state.meta.getParentStreamId(stream);
     }
@@ -544,9 +543,9 @@ export class ProgressEventHandler {
     });
   }
 
-  private prepareStreamSyncExtras(stream: StreamTabId): {
-    extras: import('@progressView/managers/WebviewUpdater').LogContentExtras;
-  } {
+  private buildStreamSyncExtras(
+    stream: StreamTabId,
+  ): import('@progressView/managers/WebviewUpdater').LogContentExtras {
     // Workflow files/missing outputs are flat (one run per tab).
     const workflowFiles = mapToRecord(this.state.outputFiles.getFiles(stream));
     const workflowMissingOutputs = mapToRecord(
@@ -565,13 +564,11 @@ export class ProgressEventHandler {
     const contextState = this.state.getContextState(stream);
 
     return {
-      extras: {
-        workflowFiles,
-        workflowMissingOutputs,
-        workflowCompileFailures,
-        runUsage,
-        contextState,
-      },
+      workflowFiles,
+      workflowMissingOutputs,
+      workflowCompileFailures,
+      runUsage,
+      contextState,
     };
   }
 

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -58,11 +58,6 @@ import {
   tabStreams$,
 } from './progressState';
 
-/** Schema for persisted preferences. */
-const ProgressViewPrefsSchema = z.object({
-  streamFilter: AgentCategoryFilterSchema.catch('all'),
-});
-
 // Local imports - event handlers
 import {
   handleDeleteAll,
@@ -93,6 +88,11 @@ import './components/UserMessage';
 import './components/StatisticsPanel';
 import './components/LatexdiffResults';
 import './components/ContextManagement';
+
+/** Schema for persisted preferences. */
+const ProgressViewPrefsSchema = z.object({
+  streamFilter: AgentCategoryFilterSchema.catch('all'),
+});
 
 registerTeXRAWebAwesomeIcons();
 

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -100,35 +100,28 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.USER_QUESTION]: 'Question',
 };
 
+const APPROVE_REJECT: ActionConfig[] = [
+  { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
+  { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
+];
+
+const REJECT_ONLY: ActionConfig[] = [
+  { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
+];
+
 /** Primary actions (approve/reject) for each permission type */
 const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
-  [PERMISSION_KIND.TOOL_EDIT]: [
-    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
-  [PERMISSION_KIND.BASH]: [
-    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
+  [PERMISSION_KIND.TOOL_EDIT]: APPROVE_REJECT,
+  [PERMISSION_KIND.BASH]: APPROVE_REJECT,
   [PERMISSION_KIND.RETRY]: [
     { action: 'retry', label: 'Retry', icon: 'refresh', variant: 'approve' },
     { action: 'cancel', label: 'Cancel', icon: 'x', variant: 'reject' },
   ],
-  [PERMISSION_KIND.PROPOSAL]: [
-    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
-  [PERMISSION_KIND.PLAN_APPROVAL]: [
-    { action: 'approve', label: 'Approve', icon: 'check', variant: 'approve' },
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
+  [PERMISSION_KIND.PROPOSAL]: APPROVE_REJECT,
+  [PERMISSION_KIND.PLAN_APPROVAL]: APPROVE_REJECT,
   // External inquiry uses its own panel with answer textarea; only reject here as fallback.
-  [PERMISSION_KIND.EXTERNAL_INQUIRY]: [
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
-  [PERMISSION_KIND.USER_QUESTION]: [
-    { action: 'reject', label: 'Reject', icon: 'x', variant: 'reject' },
-  ],
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: REJECT_ONLY,
+  [PERMISSION_KIND.USER_QUESTION]: REJECT_ONLY,
 };
 
 /** Secondary actions for each permission type */

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -700,16 +700,10 @@ export class StreamTabs extends LitElement {
     const override = this.userOverride.get(parentId);
     if (override) return override === 'expanded';
 
-    let anyActive = false;
-    let anyUnknown = false;
-    for (const child of children) {
-      const activity = this.getBranchActivity(child.name, new Set([parentId]));
-      if (activity === 'active') anyActive = true;
-      else if (activity === 'unknown') anyUnknown = true;
-    }
-    if (anyActive) return true;
-    if (anyUnknown) return true;
-    return false;
+    return children.some(
+      (child) =>
+        this.getBranchActivity(child.name, new Set([parentId])) !== 'finished',
+    );
   }
 
   private getStatus(name: StreamTabId): string {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -200,15 +200,15 @@ type ToolSectionOptions = {
   extraClass?: string;
 };
 
-/**
- * Build a tool section with appropriate code highlighting based on tool type.
- */
 function toolDisplayText(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value == null) return '';
   return String(value);
 }
 
+/**
+ * Build a tool section with appropriate code highlighting based on tool type.
+ */
 function buildToolSection(
   label: string,
   text: unknown,
@@ -259,7 +259,6 @@ type ToolSectionContext = {
   filePath: string;
   parsedOutput: unknown;
   outputText: string;
-  isInProgress: boolean;
 };
 
 function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
@@ -767,7 +766,6 @@ export function formatToolUseTemplate(
     filePath,
     parsedOutput: parsed.output,
     outputText,
-    isInProgress,
   });
 
   // Show output if present

--- a/packages/extension/src/progressView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/progressView/frontend/messageDispatcher.ts
@@ -91,15 +91,10 @@ const handlers: HandlerRegistry = {
 export function dispatchMessage(
   message: ProgressViewOutboundMessage,
   ctx: MessageHandlerContext,
-): boolean {
+): void {
   const handler = handlers[message.command] as
     | TypedHandler<typeof message>
     | undefined;
 
-  if (handler) {
-    handler(message, ctx);
-    return true;
-  }
-
-  return false;
+  handler?.(message, ctx);
 }

--- a/packages/extension/src/progressView/state/ProgressViewState.ts
+++ b/packages/extension/src/progressView/state/ProgressViewState.ts
@@ -237,10 +237,6 @@ export class ProgressViewState {
     });
   }
 
-  getTodos(stream: StreamTabId): TodoItem[] {
-    return this._sessionState.get(stream)?.workPlan.todos ?? [];
-  }
-
   setPlan(stream: StreamTabId, plan: Plan | null): void {
     const state = this.getOrCreateSession(stream);
     state.workPlan = WorkPlanSnapshotSchema.parse({
@@ -248,10 +244,6 @@ export class ProgressViewState {
       plan,
       planSummary: plan?.summary ?? null,
     });
-  }
-
-  getPlan(stream: StreamTabId): Plan | null {
-    return this._sessionState.get(stream)?.workPlan.plan ?? null;
   }
 
   getWorkPlan(stream: StreamTabId): WorkPlanSnapshot {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -1470,30 +1470,30 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderKey(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_KEY>,
   ): Promise<void> {
-    const provider = data.provider;
-    try {
-      await this.profileKeyController.setProviderKey(provider);
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.channel,
-        `Failed to set ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key`,
-        error,
-      );
-      // On error, still refresh settings view to reflect current key state.
-      await this.withActiveWebview((w) => this.sendProfileData(w));
-    }
+    await this.runProviderKeyAction(data.provider, 'set', (provider) =>
+      this.profileKeyController.setProviderKey(provider),
+    );
   }
 
   private async handleRemoveProviderKey(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.REMOVE_PROVIDER_KEY>,
   ): Promise<void> {
-    const provider = data.provider;
+    await this.runProviderKeyAction(data.provider, 'remove', (provider) =>
+      this.profileKeyController.removeProviderKey(provider),
+    );
+  }
+
+  private async runProviderKeyAction(
+    provider: string,
+    verb: 'set' | 'remove',
+    actionFn: (provider: string) => Promise<void>,
+  ): Promise<void> {
     try {
-      await this.profileKeyController.removeProviderKey(provider);
+      await actionFn(provider);
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to remove ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key`,
+        `Failed to ${verb} ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key`,
         error,
       );
       // On error, still refresh settings view to reflect current key state.
@@ -1517,6 +1517,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     ]);
   }
 
+  /** Re-send settings-view profile data to the active webview. */
+  private async refreshProfile(): Promise<void> {
+    await this.withActiveWebview((w) => this.sendProfileData(w));
+  }
+
   /** Refresh settings-view agent list and main-view dropdown after agent mutations. */
   private async refreshAfterAgentMutation(): Promise<void> {
     await Promise.all([
@@ -1537,21 +1542,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_STREAMING>,
   ): Promise<void> {
     await setProviderStreaming(data.provider, data.enabled);
-    await this.withActiveWebview((w) => this.sendProfileData(w));
+    await this.refreshProfile();
   }
 
   private async handleSetProviderEndpoint(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_ENDPOINT>,
   ): Promise<void> {
     await setProviderEndpoint(data.provider, data.endpoint);
-    await this.withActiveWebview((w) => this.sendProfileData(w));
+    await this.refreshProfile();
   }
 
   private async handleSetGlobalStreaming(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GLOBAL_STREAMING>,
   ): Promise<void> {
     await setGlobalStreaming(data.enabled);
-    await this.withActiveWebview((w) => this.sendProfileData(w));
+    await this.refreshProfile();
   }
 
   private async handleSetProviderVscodeSetting(

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -563,9 +563,10 @@ export class AgentSelectionPanel extends LitElement {
         ${orderedSources.map((source) => {
           const agents = groups.get(source)!;
           const enabledInGroup = agents.filter((a) => a.enabled).length;
+          const sourceName = SOURCE_DISPLAY_NAMES[source] ?? source;
           return html`
             <div class="agent-list-section-header">
-              <span>${SOURCE_DISPLAY_NAMES[source] ?? source}</span>
+              <span>${sourceName}</span>
               <span class="agent-list-section-actions">
                 ${enabledInGroup < agents.length
                   ? html`<wa-button
@@ -573,8 +574,7 @@ export class AgentSelectionPanel extends LitElement {
                       appearance="plain"
                       size="small"
                       @click=${() => this.handleSetAllEnabled(source, true)}
-                      title="Show all ${SOURCE_DISPLAY_NAMES[source] ??
-                      source} agents"
+                      title="Show all ${sourceName} agents"
                     >
                       All
                     </wa-button>`
@@ -585,8 +585,7 @@ export class AgentSelectionPanel extends LitElement {
                       appearance="plain"
                       size="small"
                       @click=${() => this.handleSetAllEnabled(source, false)}
-                      title="Hide all ${SOURCE_DISPLAY_NAMES[source] ??
-                      source} agents"
+                      title="Hide all ${sourceName} agents"
                     >
                       None
                     </wa-button>`

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -441,7 +441,7 @@ export class LaTeXTab extends LitElement {
    * manager is either detected on the system or is `null` (always available).
    */
   private getInstallCommand(dep: DependencyInfo): InstallCommand | null {
-    const platform = this.settings.platform as OSPlatform;
+    const platform = this.settings.platform;
     const commands = DEPENDENCY_INSTALL_COMMANDS[dep.key];
     if (!commands) return null;
     const options = commands[platform];
@@ -481,7 +481,7 @@ export class LaTeXTab extends LitElement {
   private renderDependencyCard(dep: DependencyInfo): TemplateResult {
     const installed = this.settings[dep.key];
     const expanded = this.expandedGuides.has(dep.key);
-    const platform = this.settings.platform as OSPlatform;
+    const platform = this.settings.platform;
     const guideText = dep.installGuide?.[platform] ?? dep.installGuide?.linux;
     const detectedPaths = installed ? this.getDetectedPaths(dep) : [];
     const installCmd = !installed ? this.getInstallCommand(dep) : null;
@@ -582,7 +582,7 @@ export class LaTeXTab extends LitElement {
    * that isn't installed yet (e.g. Homebrew on macOS, Scoop on Windows).
    */
   private renderPrerequisiteHint(): TemplateResult | typeof nothing {
-    const platform = this.settings.platform as OSPlatform;
+    const platform = this.settings.platform;
     const pm = this.settings.packageManager;
 
     // macOS without Homebrew — installing it unlocks every brew command

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -632,9 +632,9 @@ export class MainApp extends MainAppBase {
 
   private handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
     const files = message.files ?? [];
-    const listId = this.extractFileKeyFromCommand(
-      message.command,
-    ) as keyof MultiFiles;
+    const listId = MULTI_FILE_COMMAND_TO_KEY[
+      message.command
+    ] as keyof MultiFiles;
     if (!listId) return;
 
     this.multiFiles.set({ ...this.multiFiles.get(), [listId]: files });
@@ -892,14 +892,6 @@ export class MainApp extends MainAppBase {
     this.saveState();
   }
 
-  /**
-   * Extracts the multi-list key from a SET_*_FILES command name.
-   * Compile-time verifiable via the `MULTI_FILE_COMMAND_TO_KEY` map.
-   */
-  private extractFileKeyFromCommand(command: string): string | undefined {
-    return MULTI_FILE_COMMAND_TO_KEY[command];
-  }
-
   private handleRemoveFile(listId: keyof MultiFiles, file: string): void {
     const files = (this.multiFiles.get()[listId] ?? []).filter(
       (f: string) => f !== file,
@@ -1096,14 +1088,12 @@ export class MainApp extends MainAppBase {
     return opt?.isOrchestrator ?? false;
   }
 
-  private getPlaceholderKey(): keyof typeof ONBOARDING_PLACEHOLDERS {
-    return this.isSelectedAgentOrchestrator()
-      ? 'orchestrator'
-      : this.sessionType.get();
-  }
-
   private refreshInstructionPlaceholder(advance: boolean): void {
-    const placeholders = ONBOARDING_PLACEHOLDERS[this.getPlaceholderKey()];
+    const placeholderKey: keyof typeof ONBOARDING_PLACEHOLDERS =
+      this.isSelectedAgentOrchestrator()
+        ? 'orchestrator'
+        : this.sessionType.get();
+    const placeholders = ONBOARDING_PLACEHOLDERS[placeholderKey];
     if (!placeholders.length) return;
     const current = this.instructionPlaceholder.get();
     const currentIndex = placeholders.indexOf(current);

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -776,51 +776,41 @@ export class InstructionPanel extends LitElement {
                 className: 'settings-button',
                 onClick: this.handleAgentSettings,
               })}
-              ${session.sessionType === SESSION_TYPES.WORKFLOW
-                ? html`
-                    <wa-select
-                      id="workflowAgent"
-                      class="agent-select"
-                      data-session-type="workflow"
-                      aria-label="Workflow agent"
-                      title=${this.getAgentTooltip(
-                        session.workflowAgentOptions,
-                        session.workflowAgent,
-                      ) || nothing}
-                      placement="top"
-                      placeholder="Agent…"
-                      .value=${session.workflowAgent}
-                      @focus=${this.handleAgentFocus}
-                      @change=${this.handleAgentChange}
-                    >
-                      ${renderAgentOptions(
-                        session.workflowAgentOptions,
-                        session.workflowAgent,
-                      )}
-                    </wa-select>
-                  `
-                : html`
-                    <wa-select
-                      id="toolUseAgent"
-                      class="agent-select"
-                      data-session-type="toolUse"
-                      aria-label="Tool-use agent"
-                      title=${this.getAgentTooltip(
-                        session.toolUseAgentOptions,
-                        session.toolUseAgent,
-                      ) || nothing}
-                      placement="top"
-                      placeholder="Agent…"
-                      .value=${session.toolUseAgent}
-                      @focus=${this.handleAgentFocus}
-                      @change=${this.handleAgentChange}
-                    >
-                      ${renderAgentOptions(
-                        session.toolUseAgentOptions,
-                        session.toolUseAgent,
-                      )}
-                    </wa-select>
-                  `}
+              ${(() => {
+                const agent =
+                  session.sessionType === SESSION_TYPES.WORKFLOW
+                    ? {
+                        id: 'workflowAgent',
+                        sessionType: 'workflow',
+                        ariaLabel: 'Workflow agent',
+                        options: session.workflowAgentOptions,
+                        value: session.workflowAgent,
+                      }
+                    : {
+                        id: 'toolUseAgent',
+                        sessionType: 'toolUse',
+                        ariaLabel: 'Tool-use agent',
+                        options: session.toolUseAgentOptions,
+                        value: session.toolUseAgent,
+                      };
+                return html`
+                  <wa-select
+                    id=${agent.id}
+                    class="agent-select"
+                    data-session-type=${agent.sessionType}
+                    aria-label=${agent.ariaLabel}
+                    title=${this.getAgentTooltip(agent.options, agent.value) ||
+                    nothing}
+                    placement="top"
+                    placeholder="Agent…"
+                    .value=${agent.value}
+                    @focus=${this.handleAgentFocus}
+                    @change=${this.handleAgentChange}
+                  >
+                    ${renderAgentOptions(agent.options, agent.value)}
+                  </wa-select>
+                `;
+              })()}
             </div>
             <div
               class="select-group model-select-group agent-model-select-group"


### PR DESCRIPTION
Sixth simplification pass — the first in the **VS Code extension host layer** (`packages/extension/src`, ~59k lines). Prior passes covered the TUI (#4725), CLI runtime/commands (#4740), core (#4752), tools/shared (#4759), and the shared controllers (#4764).

### How it was produced & verified
A code-simplifier fan-out over 8 file-groups surfaced **43 candidates**; each was **adversarially verified** with checks for test-consumer breakage and **IPC/webview-contract stability** (message shapes, command ids, dispatch tables, error-log strings must be unchanged). `vscode` imports are expected here, so they were not flagged. **20 rejected**, **23 confirmed → 22 applied** (1 was already in the desired state).

Proven green: root tsc ✅, extension tsc ✅, `tsconfig.test-kernel.json` ✅, **full test-kernel vitest — 236 files / 1306 tests** ✅, prettier ✅.

### Changes (22)
- **Dead code:** unused `ProgressViewState.getTodos`/`getPlan`, `ToolSectionContext.isInProgress` (never read off the context), the unconsumed boolean return of `messageDispatcher.dispatchMessage`, the `ExportNodeSchema` export, and unused imports.
- **DRY:** `toBadgeSnapshot()` shared by two `ProgressEventHandler` sites; `PermissionCard` approve/reject `ActionConfig` consts; shared provider-key-action + profile-refresh helpers in `SettingsViewMessageHandler`; a `texra.*` scope-guard + custom-agents-root literal in `extension.ts`/`setup.ts`; collapse the duplicated workflow/toolUse `<wa-select>` branches in `InstructionPanel`; hoist repeated platform/source-name lookups.
- **Flatten/clarify:** inline single-use wrappers (`prepareStreamSyncExtras`, `extractFileKeyFromCommand`, `getPlaceholderKey`); collapse a two-flag loop in `StreamTabs` to one predicate; replace a single-element array+loop with a direct `updateConfig`; re-attach two orphaned doc comments.

No IPC/contract change; no new dependencies; no lockfile change.

**Verified:** ran the full test-kernel suite (1306 tests) + extension typecheck from this branch — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors and unused-code removal across UI and setup paths; PR asserts no IPC/contract changes and full test-kernel pass.
> 
> **Overview**
> This pass **tightens the VS Code extension host** (`packages/extension/src`) with behavior-preserving refactors: less duplication, dead code removed, and a few small clarity wins—no new IPC or webview message shapes.
> 
> **Dead code and API surface:** Stops exporting `ExportNodeSchema`; drops unused `ProgressViewState.getTodos` / `getPlan`, `ToolSectionContext.isInProgress`, and the unused boolean from `dispatchMessage` (now `void` with optional handler invoke). Trims an unused import in `extension.ts` / `setup.ts`.
> 
> **DRY / helpers:** Shared `toBadgeSnapshot()` and flattened `buildStreamSyncExtras()` in `ProgressEventHandler`; `assertTexraScopedKey` for setup `platform.config`; `CUSTOM_AGENT_ROOT_OPTIONS` for custom agent roots; shared approve/reject action configs in `PermissionCard`; `runProviderKeyAction` / `refreshProfile` in settings profile key handling; one agent `<wa-select>` path in `InstructionPanel` via a small config object.
> 
> **Simplify:** `StreamTabs.computeExpanded` uses a single `some()` over branch activity; `MainApp` maps multi-file commands via `MULTI_FILE_COMMAND_TO_KEY` directly; LaTeX tab drops redundant platform casts; doc comments reattached after moves in `setup.ts` / tool formatters; prefs schema relocated in `ProgressApp` for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7c4dbe315aa1827f9260566124e491135ddab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->