### PR TITLE
refactor(core): Agent SDK readiness Step 6 — runAgent / runAgentStream surface

### DIFF
--- a/packages/cli/src/commands/_helpers/runExecution.ts
+++ b/packages/cli/src/commands/_helpers/runExecution.ts
@@ -1,5 +1,5 @@
 import { writeTerminalStatus } from '@agent/storage';
-import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
+import { runAgent } from '@agent/runtime/runAgent';
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
 
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -12,7 +12,7 @@ import {
 } from './terminalStatus';
 
 export interface CliExecuteOptions {
-  /** Forwarded to `runValidatedExecutionRequest`. */
+  /** Forwarded to `runAgent`. */
   readonly enforceCategory?: boolean;
   readonly registerExecution?: boolean;
   /**
@@ -44,7 +44,7 @@ export async function executeCliRequest(
 ): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
   const runtimeHost = createCliRuntimeHost(runContext);
   const invoke = (): Promise<ExecuteAgentResult> =>
-    runValidatedExecutionRequest(request, {
+    runAgent(request, {
       runtimeHost,
       enforceCategory: options.enforceCategory,
       registerExecution: options.registerExecution,

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -1,15 +1,13 @@
 import { getExecutionStore } from '@agent/storage';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
-import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
+import { runAgent } from '@agent/runtime/runAgent';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 
 import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
-export type ExecuteAgentResult = Awaited<
-  ReturnType<typeof runValidatedExecutionRequest>
->;
+export type ExecuteAgentResult = Awaited<ReturnType<typeof runAgent>>;
 
 type CliRunResultFor<T extends ExecuteAgentResult> = Omit<T, 'status'> & {
   status: ExecutionStatus;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsc --noEmit -p tsconfig.json"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,26 +1,28 @@
 /**
  * `@texra/core` — the curated public surface of the TeXRA agent core.
  *
- * This is the single entry point a host (the VS Code extension, the CLI, the
- * Electron desktop app, or a future embedder) should depend on, analogous to a
- * single SDK package: import the run entry, the typed config/result, the
- * injected host port, the telemetry channel, the agent registry, and the
- * platform composition root from here — not via deep `@agent/*` / `@platform`
- * path aliases into internals.
+ * Single entry point a host (the VS Code extension, the CLI, the Electron
+ * desktop app, or a future embedder) depends on — like one SDK package —
+ * instead of deep `@agent/*` / `@platform` imports into internals.
  *
- * Everything re-exported here is host-neutral (VS Code-free): this package
+ * Minimal usage:
+ *
+ *   import { initPlatform, validateExecutionRequest, runAgent } from '@texra/core';
+ *   initPlatform(services);                       // once, at startup
+ *   const v = validateExecutionRequest({ config });
+ *   if (v.valid) await runAgent(v.request, { runtimeHost });
+ *
+ * For per-chunk streaming/lifecycle callbacks or subagent lineage, use the
+ * lower-level `runAgentStream` engine instead of `runAgent`.
+ *
+ * Everything re-exported here is host-neutral (VS Code-free): the package
  * typechecks with only `@types/node`, so a `vscode` dependency leaking into the
- * surface fails the build. The set is a subset of what `@texra-ai/cli` already
- * imports, which is what guarantees it stays Node-importable.
- *
- * NOTE: deep `@agent/*` imports still work and are not being migrated in bulk
- * (that is intentionally out of scope). This module establishes the curated
- * surface; steering existing call sites onto it can follow incrementally.
+ * surface fails the build. Deep `@agent/*` imports still work and are not being
+ * migrated in bulk; this module is the curated entry, adopted incrementally.
  */
 
-// ── Platform composition root + service contract ──
-// Hosts call initPlatform() once at startup with their concrete services;
-// core code reads them via platform().
+// ── 1. Platform composition root ──
+// Hosts call initPlatform() once at startup; core reads services via platform().
 export {
   initPlatform,
   platform,
@@ -29,17 +31,19 @@ export {
   type Platform,
 } from '@platform/platform';
 
-// ── Agent configuration & category ──
+// ── 2. Agent configuration & identity ──
 export {
   AgentConfigSchema,
   type AgentConfig,
   type AgentConfigPayload,
 } from '@agent/core/AgentConfig';
 export { AgentCategory } from '@agent/core/AgentDataclass';
+export type { ExecutionId } from '@shared/schemas';
 
-// ── Execution-request validation (host → core contract) ──
+// ── 3. Building a run request (host → core contract) ──
 // `validateExecutionRequest` is the non-throwing {valid,message} variant UI
-// hosts use; headless callers may parse with AgentConfigSchema directly.
+// hosts use; headless callers may AgentConfigSchema.parse(...) and build a
+// ValidatedExecutionRequest directly.
 export {
   validateExecutionRequest,
   type ExecutionRequest,
@@ -47,24 +51,37 @@ export {
   type ExecutionValidationResult,
 } from '@agent/core/executionRequests';
 
-// ── Run entry points ──
-export { executeAgent, getAgentPath } from '@agent/runtime/executeAgent';
+// ── 4. Running an agent ──  (the section to read first)
+/**
+ * START HERE. The high-level entry every host uses: defaults the executionId,
+ * applies register-on-fresh / reuse-on-resume, runs the agent, and (for a
+ * workflow result) invokes openWorkflowOutput. Use this unless you need
+ * streaming callbacks or subagent lineage.
+ */
+export { runAgent, type RunAgentOptions } from '@agent/runtime/runAgent';
+/**
+ * Lower-level streaming/lineage dispatcher behind runAgent. Use ONLY for
+ * per-chunk streaming/lifecycle callbacks (onStreamResolved/onProgress/
+ * onCompleted/onError) or subagent lineage (isSubagent/parentStreamId/
+ * delegationDepth) — the caller owns executionId and registerExecution.
+ */
 export {
-  runValidatedExecutionRequest,
-  type RunExecutionRequestOptions,
-} from '@agent/runtime/runExecutionRequest';
+  executeAgent as runAgentStream,
+  type ExecuteAgentOptions,
+} from '@agent/runtime/executeAgent';
 export {
   type AgentFlowResult,
   AgentFlowResultSchema,
+  type WorkflowFlowResult,
 } from '@agent/runtime/AgentFlowResult';
 
-// ── Host port (injected by the consumer; receives progress events) ──
+// ── 5. Host port (consumer-injected progress-event sink) ──
 export {
   type AgentRuntimeHost,
   noopAgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
 
-// ── Telemetry: the AgentTrace discriminated-event channel ──
+// ── 6. Telemetry: the AgentTrace discriminated-event channel ──
 // SDK consumers attach their own subscriber via trace.subscribe(...).
 export {
   type AgentTrace,
@@ -74,7 +91,7 @@ export {
   noopTrace,
 } from '@agent/trace';
 
-// ── Agent registry (discover/resolve agent definitions) ──
+// ── 7. Agent registry (discover/resolve agent definitions) ──
 export {
   loadAgents,
   getAgent,
@@ -85,7 +102,9 @@ export {
   type ResolvedAgent,
 } from '@agent/index';
 
-// ── Execution storage (per-run KV + history) ──
+// ── 8. Execution storage (per-run KV + history) ──
+// registerExecution is normally handled by runAgent; call it directly only
+// when bypassing the wrapper (e.g. a custom streaming host on runAgentStream).
 export {
   getExecutionStore,
   registerExecution,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1216,9 +1216,8 @@ export class DesktopProgressBridge {
   }
 
   async runExecution(request: ValidatedExecutionRequest): Promise<void> {
-    const { runValidatedExecutionRequest } =
-      await import('@agent/runtime/runExecutionRequest');
-    await runValidatedExecutionRequest(request, {
+    const { runAgent } = await import('@agent/runtime/runAgent');
+    await runAgent(request, {
       runtimeHost: this.runtimeHost,
       openWorkflowOutput: async (result) => {
         const output = result.outputs.at(-1);

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -4,7 +4,7 @@ import { ZodError } from 'zod';
 
 // Local imports
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
-import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
+import { runAgent } from '@agent/runtime/runAgent';
 import { formatZodError } from '@common/errors';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
@@ -41,7 +41,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
         : null;
     const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
 
-    await runValidatedExecutionRequest(
+    await runAgent(
       { config, executionId: wrapped?.executionId },
       {
         runtimeHost: extensionAgentRuntimeHost,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -7,7 +7,7 @@ import { executeAgent } from './executeAgent';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 
-export interface RunExecutionRequestOptions {
+export interface RunAgentOptions {
   runtimeHost: AgentRuntimeHost;
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
   enforceCategory?: boolean;
@@ -15,9 +15,22 @@ export interface RunExecutionRequestOptions {
   stopAfterCycle?: boolean;
 }
 
-export async function runValidatedExecutionRequest(
+/**
+ * START HERE — the high-level entry every host uses to run an agent.
+ *
+ * Validates-then-runs: assigns an executionId when the request omits one (a
+ * fresh run), registers fresh runs in the execution store (resume reuses the
+ * record; override via `registerExecution`), runs the agent, and — for a
+ * workflow result — invokes `openWorkflowOutput` so the host can surface output.
+ *
+ * Use this unless you need per-chunk streaming/lifecycle callbacks or subagent
+ * lineage; for those, drop to the lower-level engine `executeAgent` (exported
+ * as `runAgentStream` from `@texra/core`), where the caller owns executionId
+ * generation and `registerExecution`.
+ */
+export async function runAgent(
   request: ValidatedExecutionRequest,
-  options: RunExecutionRequestOptions,
+  options: RunAgentOptions,
 ): Promise<AgentFlowResult> {
   const executionId =
     request.executionId ?? (generateExecutionId() as ExecutionId);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -90,8 +90,8 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
   vi.doMock('@agent/runtime/RunStorageService', () => ({
     setRunStorageService: vi.fn(),
   }));
-  vi.doMock('@agent/runtime/runExecutionRequest', () => ({
-    runValidatedExecutionRequest: vi.fn(),
+  vi.doMock('@agent/runtime/runAgent', () => ({
+    runAgent: vi.fn(),
   }));
   vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
@@ -206,15 +206,14 @@ async function createExecution(options: {
   };
   showErrorMessage?: (message: string) => Promise<void> | void;
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
-  runValidatedExecutionRequest?: RunExecutionRequest;
+  runAgent?: RunExecutionRequest;
 }): Promise<DesktopExecution> {
   vi.resetModules();
   vi.doMock('@agent/runtime/RunStorageService', () => ({
     setRunStorageService: vi.fn(),
   }));
-  vi.doMock('@agent/runtime/runExecutionRequest', () => ({
-    runValidatedExecutionRequest:
-      options.runValidatedExecutionRequest ?? vi.fn(async () => {}),
+  vi.doMock('@agent/runtime/runAgent', () => ({
+    runAgent: options.runAgent ?? vi.fn(async () => {}),
   }));
   vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
@@ -274,7 +273,7 @@ function progressMessages(
 describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/RunStorageService');
-    vi.doUnmock('@agent/runtime/runExecutionRequest');
+    vi.doUnmock('@agent/runtime/runAgent');
     vi.doUnmock('@common/storage/KVStore');
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger');
@@ -590,11 +589,11 @@ describe('DesktopProgressBridge', () => {
   it('surfaces invalid execution requests through the host error path', async () => {
     const postToRenderer = vi.fn();
     const showErrorMessage = vi.fn();
-    const runValidatedExecutionRequest = vi.fn(async () => {});
+    const runAgent = vi.fn(async () => {});
     const execution = await createExecution({
       postToRenderer,
       showErrorMessage,
-      runValidatedExecutionRequest,
+      runAgent,
       prepareMainViewExecutionRequest: vi.fn(() => ({
         valid: false,
         message: 'Select an input file first.',
@@ -607,7 +606,7 @@ describe('DesktopProgressBridge', () => {
         'Select an input file first.',
       );
       expect(postToRenderer).not.toHaveBeenCalled();
-      expect(runValidatedExecutionRequest).not.toHaveBeenCalled();
+      expect(runAgent).not.toHaveBeenCalled();
     } finally {
       execution.dispose();
     }
@@ -616,7 +615,7 @@ describe('DesktopProgressBridge', () => {
   it('lets runtime execution errors propagate to the IPC error handler', async () => {
     const failure = new Error('execution failed');
     const execution = await createExecution({
-      runValidatedExecutionRequest: vi.fn(async () => {
+      runAgent: vi.fn(async () => {
         throw failure;
       }),
       prepareMainViewExecutionRequest: vi.fn(() => ({
@@ -644,9 +643,9 @@ describe('DesktopProgressBridge', () => {
       filePath: 'main.tex',
       prompt: 'draft',
     };
-    const runValidatedExecutionRequest = vi.fn(async () => {});
+    const runAgent = vi.fn(async () => {});
     const execution = await createExecution({
-      runValidatedExecutionRequest,
+      runAgent,
       prepareMainViewExecutionRequest: vi.fn(() => ({
         valid: true,
         request,
@@ -655,7 +654,7 @@ describe('DesktopProgressBridge', () => {
 
     try {
       await execution.handleExecute({ command: 'execute' });
-      expect(runValidatedExecutionRequest).toHaveBeenCalledWith(
+      expect(runAgent).toHaveBeenCalledWith(
         request,
         expect.objectContaining({
           openWorkflowOutput: expect.any(Function),
@@ -668,14 +667,14 @@ describe('DesktopProgressBridge', () => {
 
   it('opens workflow outputs through the desktop preview host', async () => {
     const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
-    const runValidatedExecutionRequest = vi.fn(async (_request, options) => {
+    const runAgent = vi.fn(async (_request, options) => {
       await options.openWorkflowOutput({
         outputs: [{ absolutePath: '/tmp/result.pdf' }],
       });
     });
     const execution = await createExecution({
       opener,
-      runValidatedExecutionRequest,
+      runAgent,
       prepareMainViewExecutionRequest: vi.fn(() => ({
         valid: true,
         request: {


### PR DESCRIPTION
## Summary

**Step 6** of the Agent SDK readiness plan — the **behavior-neutral surface curation** that makes the run entry self-explanatory. (The reconsideration rejected the structural facade/`query()`-handle designs; this is the rename/curation that actually pays off without the type-wall or infeasible-handle problems.)

The `@texra/core` surface previously exposed **two sibling-named run entries** (`runValidatedExecutionRequest` *and* `executeAgent` + `getAgentPath`) with no signal as to which is the front door. Now the names encode altitude.

## Changes
- Rename the high-level wrapper `runValidatedExecutionRequest` → **`runAgent`** (file `runExecutionRequest.ts` → `runAgent.ts`, `RunExecutionRequestOptions` → `RunAgentOptions`). **Body byte-identical** — same register-on-fresh / reuse-on-resume rule, same workflow-gated `openWorkflowOutput`. Adds a "START HERE" doc comment. All importers updated: extension `executeCommand`, desktop dynamic `import()` + **its test mock path/key**, CLI `runExecution` + `terminalStatus` (`ReturnType`).
- `@texra/core`: `runAgent` is the front door; alias the lower-level engine `executeAgent` as **`runAgentStream`** (+ `ExecuteAgentOptions`); **drop `getAgentPath`** from the surface (its one real consumer uses a deep import); add `ExecutionId` + `WorkflowFlowResult`; **number the export sections**; add a **usage example**; add an explicit `package.json` `exports` map.

The verified two-path design is unchanged — `runAgent` owns the host register/open-output policy; `runAgentStream` is the streaming/lineage engine. No merge, no global-state change.

## Verification
Typecheck clean across **root + test-kernel + extension + CLI + desktop + `@texra/core`** (the last guards the surface VS Code-free via `types: ["node"]`); ESLint clean; the desktop agent-execution **mock test (15) passes** (confirms the renamed dynamic-import path/key work at runtime); no dangling old-name references. No behavior change.

Next in the plan: Step 7 (incremental module-global → per-run-handle relocation), long-horizon.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only run entry and SDK export curation with identical implementation and updated tests; no auth, data, or execution logic changes.
> 
> **Overview**
> **Step 6 (Agent SDK readiness)** is a **behavior-neutral** rename and curation of the public run API so embedders can tell which entry point to use.
> 
> The high-level wrapper **`runValidatedExecutionRequest`** is renamed to **`runAgent`** (`runExecutionRequest.ts` → `runAgent.ts`, `RunExecutionRequestOptions` → `RunAgentOptions`). Implementation is unchanged: same execution-id defaulting, register-on-fresh / reuse-on-resume, and workflow **`openWorkflowOutput`** hook. **CLI**, **VS Code extension**, and **desktop** (including dynamic import and Vitest mocks) now call **`runAgent`**.
> 
> **`@texra/core`** documents the two-tier model: **`runAgent`** as the default “START HERE” entry; the lower-level **`executeAgent`** is exported as **`runAgentStream`** for streaming/lineage callers who own registration. **`getAgentPath`** is dropped from the curated surface (callers keep deep imports). The barrel adds **`ExecutionId`**, **`WorkflowFlowResult`**, numbered export sections, a minimal usage example, and an explicit **`package.json` `exports`** map for `"."`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0305125efd5a55fab0d7fcabb168af6da92033d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->