### PR TITLE
fix(cli): disable kill for retained child rows

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -255,6 +255,28 @@ const SCENARIOS = [
     maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
+    name: 'stopped-subagent-picker',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', 'k', ESC + 's', DOWN, DOWN, 'k'],
+    expect: [
+      'Subagents',
+      'Stream: main',
+      '› 3. strategy — stopped',
+      'Enter focus',
+      'Esc close',
+    ],
+    unexpect: [
+      'k kill',
+      'Harness kill requested for harness-child-strategy.\n\nHarness kill requested for harness-child-strategy.',
+    ],
+    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+  },
+  {
     name: 'empty-task-picker',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -50,17 +50,16 @@ export function emptyPickerText(mode: ChildControlMode): string {
 export function pickerKeyHints(
   mode: ChildControlMode,
   itemCount: number,
+  canKill = itemCount > 0,
 ): readonly KeyHint[] {
   if (itemCount <= 0) {
     return [{ key: 'Esc', action: 'close' }];
   }
   const hints: KeyHint[] = [{ key: '↑/↓', action: 'navigate' }];
   if (itemCount > 1) hints.push({ key: '1-9', action: 'jump' });
-  hints.push(
-    { key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' },
-    { key: 'k', action: 'kill' },
-    { key: 'Esc', action: 'close' },
-  );
+  hints.push({ key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' });
+  if (canKill) hints.push({ key: 'k', action: 'kill' });
+  hints.push({ key: 'Esc', action: 'close' });
   return hints;
 }
 
@@ -285,7 +284,7 @@ function TaskDetailView({
       return: key.return,
     });
     if (action.kind === 'close') onBack();
-    if (action.kind === 'kill') onKill();
+    if (action.kind === 'kill' && item.killable) onKill();
     if (action.kind === 'up') {
       setScrollOffset((current) => Math.max(0, current - 1));
     }
@@ -345,7 +344,7 @@ function TaskDetailView({
               ...(item.childStreamId
                 ? [{ key: 'f', action: 'focus stream' }]
                 : []),
-              { key: 'k', action: 'kill' },
+              ...(item.killable ? [{ key: 'k', action: 'kill' }] : []),
               { key: 'Esc', action: 'back' },
             ]}
             confirmCancel={false}
@@ -445,7 +444,7 @@ export function ChildControlPicker({
         }
         case 'kill': {
           const item = items[highlight];
-          if (!item) return;
+          if (!item?.killable) return;
           onKillExecution(item.executionId);
           onClose();
           return;
@@ -513,7 +512,11 @@ export function ChildControlPicker({
       </Box>
       <Box marginTop={1}>
         <KeyHints
-          hints={pickerKeyHints(mode, items.length)}
+          hints={pickerKeyHints(
+            mode,
+            items.length,
+            items[highlight]?.killable ?? false,
+          )}
           confirmCancel={false}
         />
       </Box>

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -26,6 +26,7 @@ export interface ChildControlItem {
   readonly description: string;
   readonly status?: string;
   readonly elapsed?: string | null;
+  readonly killable: boolean;
   readonly tailLines: readonly string[];
 }
 
@@ -86,6 +87,12 @@ function childLabel(child: {
   return child.agentName || child.toolName || child.executionId;
 }
 
+function childKey(
+  child: Pick<ActiveChildInfo, 'childStreamId' | 'executionId'>,
+): string {
+  return child.childStreamId ?? child.executionId;
+}
+
 function streamDescription(
   child: Pick<ActiveChildInfo, 'childStreamId'>,
   streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'description'>>,
@@ -117,6 +124,7 @@ function buildSubagentItem(
     Pick<StreamSlice, 'description' | 'entries'>
   >,
   nowMs?: number,
+  killable = true,
 ): ChildControlItem {
   const label = childLabel(child);
   const command = streamDescription(child, streamsById) ?? label;
@@ -130,6 +138,7 @@ function buildSubagentItem(
     description: compactParts([child.status, elapsed ?? undefined]),
     status: child.status,
     elapsed,
+    killable,
     tailLines: streamTranscriptLines(child, streamsById),
   };
 }
@@ -152,6 +161,7 @@ function buildProcessItem(
     description: compactParts([child.status, elapsed ?? undefined, lastLine]),
     status: child.status,
     elapsed,
+    killable: true,
     tailLines,
   };
 }
@@ -179,8 +189,14 @@ export function buildChildControlItems(
   nowMs?: number,
 ): readonly ChildControlItem[] {
   if (mode === 'subagents') {
+    const activeKeys = new Set(slice.activeSubagents.map(childKey));
     return visibleSubagentRows(slice).map((child) =>
-      buildSubagentItem(child, streamsById, nowMs),
+      buildSubagentItem(
+        child,
+        streamsById,
+        nowMs,
+        activeKeys.has(childKey(child)),
+      ),
     );
   }
 

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -186,6 +186,7 @@ describe('CLI child execution controls', () => {
         label: 'critic',
         command: 'critic',
         description: 'running · 12s',
+        killable: true,
         tailLines: [],
       },
     ]);
@@ -196,6 +197,7 @@ describe('CLI child execution controls', () => {
         kind: 'subagent',
         label: 'critic',
         command: 'critic',
+        killable: true,
       },
       {
         executionId: 'proc-1',
@@ -203,6 +205,7 @@ describe('CLI child execution controls', () => {
         label: 'latexmk',
         command: 'latexmk',
         description: 'running · 3s · warning',
+        killable: true,
         tailLines: ['first', 'second', 'warning'],
       },
     ]);
@@ -363,6 +366,7 @@ describe('CLI child execution controls', () => {
         kind: 'subagent',
         label: 'polisher',
         description: 'running',
+        killable: true,
       },
       {
         executionId: 'agent-1',
@@ -370,6 +374,7 @@ describe('CLI child execution controls', () => {
         kind: 'subagent',
         label: 'critic',
         description: 'completed',
+        killable: false,
       },
     ]);
   });
@@ -665,6 +670,10 @@ describe('CLI child execution controls', () => {
     expect(pickerKeyHints('subagents', 1)).toContainEqual({
       key: 'Enter',
       action: 'focus',
+    });
+    expect(pickerKeyHints('subagents', 1, false)).not.toContainEqual({
+      key: 'k',
+      action: 'kill',
     });
   });
 


### PR DESCRIPTION
## Summary

- mark child-control picker rows as killable only while they come from active subagent/process lists
- hide and ignore `k kill` for retained stopped/completed subagent history rows while keeping them focusable
- add a deterministic TUI scenario that stops a subagent, highlights the retained stopped row, and verifies no duplicate kill request is emitted

Closes #4783.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-stopped-picker-fixed stopped-subagent-picker`
- inspected `/private/tmp/texra-stopped-picker-fixed/01-stopped-subagent-picker.txt` for `Enter focus · Esc close` with no `k kill`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-frames-stopped-row`
- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with the same three unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only behavior for child picker kill affordances; no auth, persistence, or runtime execution path changes beyond skipping invalid kill actions.
> 
> **Overview**
> The CLI child-control pickers now treat **kill** as valid only for rows backed by **active** subagents or processes. Retained stopped/completed subagent history stays in the list and can still be focused or viewed, but **`k kill` is hidden and ignored** so kill is not sent for executions that are no longer active.
> 
> `ChildControlItem` gains a **`killable`** flag set in `buildChildControlItems` by matching visible subagent rows against `activeSubagents`. Picker and task-detail key hints and handlers respect that flag. Unit tests cover `killable: false` for completed retained rows; **`stopped-subagent-picker`** in `validate-tui` checks a stopped row shows **Enter focus** without **k kill** or duplicate harness kill messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea78d77d4b41dc8b87f6aaf82c9f8df78830f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->