### PR TITLE
ci: skip desktop builds on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,19 @@ jobs:
       - name: Compile
         run: pnpm run compile
 
-      - name: Build initial extension and desktop artifacts
-        run: pnpm run build:initial
+      - name: Build extension package
+        run: pnpm run build:fast
+
+      - name: Check extension VSIX contents
+        run: pnpm run check:vsix-contents
+
+      - name: Build desktop artifacts
+        if: github.event_name != 'pull_request'
+        run: pnpm run desktop:build
+
+      - name: Check desktop build artifacts
+        if: github.event_name != 'pull_request'
+        run: pnpm run check:desktop-build-artifacts
 
       - name: Package desktop app
         if: github.event_name != 'pull_request' && runner.os == 'macOS'
@@ -158,6 +169,7 @@ jobs:
           retention-days: 14
 
       - name: Upload desktop build artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: texra-desktop-dist-${{ runner.os }}


### PR DESCRIPTION
## Summary
- replace PR validation `build:initial` with extension-only build and VSIX checks
- keep desktop build/package checks on push and manual CI runs
- skip desktop build artifact uploads on pull requests

## Validation
- `git diff --check`
- `corepack pnpm exec prettier --check .github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pull requests no longer exercise desktop build or dist artifact checks in the validate job, so desktop-only regressions could slip through until push or the dedicated desktop jobs run.
> 
> **Overview**
> PR CI on the **validate** matrix no longer runs the monolithic `build:initial` step (desktop build + extension build + combined artifact checks). It always runs **`build:fast`** and **`check:vsix-contents`** so pull requests still produce and verify the VSIX.
> 
> **Desktop work is deferred off pull requests:** `desktop:build`, `check:desktop-build-artifacts`, local package/smoke steps, and upload of `texra-desktop-dist-*` artifacts run only when `github.event_name != 'pull_request'` (pushes and manual runs). Extension VSIX upload on Linux is unchanged.
> 
> Push/main desktop coverage still comes from the existing **desktop installer / Windows artifact** jobs, which are unchanged by this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c714b7d651d883be29a190f6f1fc2a72ab1b4315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->