### PR TITLE
fix(cli): clarify Ctrl-C stop scope on child streams

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -277,6 +277,18 @@ const SCENARIOS = [
     maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
+    name: 'focused-stopped-subagent',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', 'k', ESC + 's', DOWN, DOWN, '\r'],
+    frame: 'tail',
+    expect: ['[3:strategy](stopped)', '◆ stopped api', '[Ctrl-C]stop root'],
+  },
+  {
     name: 'empty-task-picker',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -9,6 +9,7 @@ import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   STREAM_STATUS,
   type ConversationProgress,
+  type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
 import { collapseWhitespace } from '@utils/text/stringUtils';
@@ -27,7 +28,7 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
 type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
-export type CtrlCAction = 'exit' | 'stop';
+export type CtrlCAction = 'exit' | 'stop' | 'stop root';
 
 export interface StatusBarSegment {
   readonly text: string;
@@ -309,6 +310,21 @@ function foregroundBindingsText(ctrlCAction: CtrlCAction): string {
   return `Use foreground panel shortcuts  [Ctrl-C]${ctrlCAction}`;
 }
 
+export function ctrlCActionForFocus({
+  activeStreamId,
+  canStopActiveRun,
+  parentStream,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly canStopActiveRun: boolean;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): CtrlCAction {
+  if (!canStopActiveRun) return 'exit';
+  return activeStreamId && parentStream.has(activeStreamId)
+    ? 'stop root'
+    : 'stop';
+}
+
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
@@ -436,7 +452,11 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     apiMode: shortCliApiMode(sessionMeta.apiMode),
     shiftEnterNewline: caps.kittyKeyboard,
     width: columns,
-    ctrlCAction: props.canStopActiveRun?.() ? 'stop' : 'exit',
+    ctrlCAction: ctrlCActionForFocus({
+      activeStreamId,
+      canStopActiveRun: props.canStopActiveRun?.() === true,
+      parentStream,
+    }),
     shortcutsActive: props.shortcutsActive,
   });
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildStatusBarDisplay,
+  ctrlCActionForFocus,
   defaultShortcutModifierLabel,
   queuedFollowUpsSummary,
   statusBarSegmentText,
@@ -205,6 +206,58 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.bindings).toBe('[Tab]streams  [Alt-p]tasks  [Ctrl-C]stop');
     expect(display.bindings).toContain('[Ctrl-C]stop');
+  });
+
+  it('scopes Ctrl-C stop to the root when focus is on a child stream', () => {
+    const parentStream = new Map([['child', 'root']]);
+
+    expect(
+      ctrlCActionForFocus({
+        activeStreamId: 'root',
+        canStopActiveRun: true,
+        parentStream,
+      }),
+    ).toBe('stop');
+    expect(
+      ctrlCActionForFocus({
+        activeStreamId: 'child',
+        canStopActiveRun: true,
+        parentStream,
+      }),
+    ).toBe('stop root');
+    expect(
+      ctrlCActionForFocus({
+        activeStreamId: 'child',
+        canStopActiveRun: false,
+        parentStream,
+      }),
+    ).toBe('exit');
+
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.STOPPED,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop root',
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'stopped',
+      'api',
+    ]);
+    expect(display.bindings).toContain('[Ctrl-C]stop root');
   });
 
   it('keeps status discoverable in narrow single-stream sessions', () => {


### PR DESCRIPTION
## Summary

- keep the status bar focused on the selected child stream, but label Ctrl-C as `stop root` when the focused stream is a child and the root run is the stop target
- add a focused stopped-subagent TUI scenario that reproduces the ambiguous footer from #4788
- cover the new Ctrl-C scope helper in the status-bar display tests

Fixes #4788.

## Validation

- `npm run format -- --log-level warn`
- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-frames-focus-rebased`
- `npm run compile:safe`
- `npm run lint` (passes with 12 pre-existing import-order warnings outside this diff)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and a small display helper only; no auth, data, or interrupt-handler logic changes in this diff.
> 
> **Overview**
> When the CLI TUI focus is on a **child stream** and Ctrl-C can stop a run, the status bar now advertises **`[Ctrl-C]stop root`** instead of a generic **`stop`**, so users see that interruption targets the root run while the footer still reflects the focused (e.g. stopped) subagent.
> 
> A new **`ctrlCActionForFocus`** helper drives that label from `activeStreamId`, `parentStream`, and whether stopping is allowed; **`CtrlCAction`** gains the **`stop root`** variant. Coverage includes StatusBar unit tests and a **`focused-stopped-subagent`** PTY scenario in `validate-tui.mjs` (issue #4788).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d3b1bfb09425d57f6b4e6123b6c8ec91ed3c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->