### PR TITLE
fix(cli): bound bash approval command preview

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -43,6 +43,8 @@ const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
+const BASH_APPROVAL_COMMAND =
+  process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
@@ -163,7 +165,7 @@ function makeEditApprovalRequest() {
 function makeBashApprovalPayload() {
   return {
     requestId: 'harness-bash-approval',
-    command: 'npm run compile:safe',
+    command: BASH_APPROVAL_COMMAND,
     allowBypass: true,
     streamId: STREAM_ID,
   };

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -173,13 +173,14 @@ const SCENARIOS = [
   },
   {
     name: 'compact-long-bash-approval',
-    rows: 18,
+    rows: 14,
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
     bootExpect: 'Use foreground panel shortcuts',
+    frame: 'tail',
     expect: [
       'Run bash command?',
       "$ python3 << 'EOF'",

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -38,6 +38,21 @@ import { spawnSync } from 'node:child_process';
 const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
 const DOWN = ESC + '[B';
+const LONG_BASH_APPROVAL_COMMAND = [
+  "python3 << 'EOF'",
+  'solutions = []',
+  'for y in range(1, 100):',
+  '    x2 = 1 + 2 * y * y',
+  '    x = int(x2 ** 0.5)',
+  '    if x * x == x2:',
+  '        solutions.append((x, y))',
+  '        if x != 0:',
+  '            solutions.append((-x, y))',
+  'solutions.sort()',
+  'print("All integer pairs (x,y) with 0<y<100:")',
+  'print(solutions)',
+  'EOF',
+].join('\n');
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -134,6 +149,45 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+  },
+  {
+    name: 'long-bash-approval',
+    rows: 24,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    expect: [
+      'Run bash command?',
+      "$ python3 << 'EOF'",
+      'more rows',
+      'scroll command',
+      'y approve',
+      'Use foreground panel shortcuts',
+    ],
+    unexpect: ['╚═    print', '[Option-p]tasks'],
+    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+  },
+  {
+    name: 'compact-long-bash-approval',
+    rows: 18,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    expect: [
+      'Run bash command?',
+      "$ python3 << 'EOF'",
+      'rows hidden',
+      'y approve',
+      'Use foreground panel shortcuts',
+    ],
+    unexpect: ['╚═    print', 'scroll command', '[Option-p]tasks'],
     maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
   },
   {

--- a/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
+++ b/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
@@ -26,7 +26,13 @@ export function ApprovalModal(
   const { payload, decide } = props.pending;
   switch (payload.kind) {
     case 'bash':
-      return <BashApproval payload={payload.payload} onDecide={decide} />;
+      return (
+        <BashApproval
+          availableRows={props.availableRows}
+          payload={payload.payload}
+          onDecide={decide}
+        />
+      );
     case 'toolEdit':
       return (
         <EditApproval

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -1,27 +1,253 @@
-import { Box, Text } from 'ink';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { BashPermission } from '@shared/schemas';
 
-import { ConfirmCard } from './ConfirmCard';
+import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
+import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface BashApprovalProps {
+  readonly availableRows?: number;
   readonly payload: BashPermission;
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
+export interface BashCommandDisplayLine {
+  readonly kind: 'command' | 'overflow';
+  readonly text: string;
+}
+
+const BASH_APPROVAL_TITLE = 'Run bash command?';
+const MIN_BASH_COMMAND_WIDTH = 20;
+const DEFAULT_BASH_COMMAND_ROWS = 12;
+const COMPACT_BASH_COMMAND_ROWS = 3;
+const BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 7;
+const BASH_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
+
+export function bashApprovalCommandRowsBudget({
+  availableRows,
+  columns,
+  title = BASH_APPROVAL_TITLE,
+}: {
+  readonly availableRows?: number;
+  readonly columns: number;
+  readonly title?: string;
+}): number {
+  if (availableRows === undefined) return DEFAULT_BASH_COMMAND_ROWS;
+
+  const titleWidth = Math.max(
+    MIN_BASH_COMMAND_WIDTH,
+    columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
+  );
+  const titleRows = wrapAnsiToWidth(title, titleWidth).split('\n').length;
+  const spaciousRows =
+    availableRows -
+    BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE -
+    titleRows;
+  if (spaciousRows > COMPACT_BASH_COMMAND_ROWS) {
+    return spaciousRows;
+  }
+
+  const compactRows =
+    availableRows -
+    BASH_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE -
+    titleRows;
+  return Math.max(1, Math.min(COMPACT_BASH_COMMAND_ROWS, compactRows));
+}
+
+export function bashCommandDisplayLines({
+  command,
+  width,
+}: {
+  readonly command: string;
+  readonly width: number;
+}): BashCommandDisplayLine[] {
+  const commandWidth = Math.max(MIN_BASH_COMMAND_WIDTH, width);
+  return command.split('\n').flatMap((line, index) =>
+    wrapAnsiToWidth(`${index === 0 ? '$ ' : '  '}${line}`, commandWidth)
+      .split('\n')
+      .map((text): BashCommandDisplayLine => ({ kind: 'command', text })),
+  );
+}
+
+export function maxBashCommandScrollOffset(
+  totalLines: number,
+  maxDisplayLines: number,
+): number {
+  if (
+    maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS ||
+    totalLines <= maxDisplayLines
+  ) {
+    return 0;
+  }
+  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+}
+
+function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
+  if (kind === 'previous') return `... ${count} previous rows`;
+  if (kind === 'hidden') return `... ${count} rows hidden`;
+  return `... ${count} more rows`;
+}
+
+export function boundedBashCommandDisplayLines({
+  command,
+  maxDisplayLines,
+  scrollOffset = 0,
+  width,
+}: {
+  readonly command: string;
+  readonly maxDisplayLines: number;
+  readonly scrollOffset?: number;
+  readonly width: number;
+}): BashCommandDisplayLine[] {
+  const lines = bashCommandDisplayLines({ command, width });
+  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
+
+  if (maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS) {
+    const visibleCount = Math.max(1, maxDisplayLines - 1);
+    const visible = lines.slice(0, visibleCount);
+    if (maxDisplayLines === 1) return visible;
+    return [
+      ...visible,
+      {
+        kind: 'overflow',
+        text: overflowText('hidden', lines.length - visible.length),
+      },
+    ];
+  }
+
+  const offset = Math.max(
+    0,
+    Math.min(
+      scrollOffset,
+      maxBashCommandScrollOffset(lines.length, maxDisplayLines),
+    ),
+  );
+  const hiddenBefore = offset;
+  const reserveBefore = hiddenBefore > 0 ? 1 : 0;
+  const contentSlotsWithoutAfter = Math.max(0, maxDisplayLines - reserveBefore);
+  const reserveAfter = offset + contentSlotsWithoutAfter < lines.length ? 1 : 0;
+  const visibleCount = Math.max(
+    0,
+    maxDisplayLines - reserveBefore - reserveAfter,
+  );
+  const visible = lines.slice(offset, offset + visibleCount);
+  const hiddenAfter = Math.max(0, lines.length - (offset + visibleCount));
+
+  return [
+    ...(hiddenBefore > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: overflowText('previous', hiddenBefore),
+          },
+        ]
+      : []),
+    ...visible,
+    ...(hiddenAfter > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: overflowText('more', hiddenAfter),
+          },
+        ]
+      : []),
+  ];
+}
+
 export function BashApproval(props: BashApprovalProps): React.JSX.Element {
+  const { columns } = useWindowSize();
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const commandWidth = Math.max(
+    MIN_BASH_COMMAND_WIDTH,
+    columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
+  );
+  const maxCommandRows = bashApprovalCommandRowsBudget({
+    availableRows: props.availableRows,
+    columns,
+  });
+  const commandRows = useMemo(
+    () =>
+      bashCommandDisplayLines({
+        command: props.payload.command,
+        width: commandWidth,
+      }).length,
+    [commandWidth, props.payload.command],
+  );
+  const maxScrollOffset = maxBashCommandScrollOffset(
+    commandRows,
+    maxCommandRows,
+  );
+  const scrollable = maxScrollOffset > 0;
+  const pageRows = Math.max(1, maxCommandRows - 2);
+  const maxScrollOffsetRef = useRef(maxScrollOffset);
+  const pageRowsRef = useRef(pageRows);
+  const compactCommandLayout = maxCommandRows <= COMPACT_BASH_COMMAND_ROWS;
+  const displayLines = boundedBashCommandDisplayLines({
+    command: props.payload.command,
+    maxDisplayLines: maxCommandRows,
+    scrollOffset,
+    width: commandWidth,
+  });
+
+  function scrollTo(next: number | ((currentOffset: number) => number)): void {
+    setScrollOffset((current) => {
+      const requested = typeof next === 'function' ? next(current) : next;
+      return Math.max(0, Math.min(maxScrollOffsetRef.current, requested));
+    });
+  }
+
+  useEffect(() => {
+    maxScrollOffsetRef.current = maxScrollOffset;
+    setScrollOffset((current) =>
+      Math.max(0, Math.min(maxScrollOffset, current)),
+    );
+  }, [maxScrollOffset]);
+
+  useEffect(() => {
+    pageRowsRef.current = pageRows;
+  }, [pageRows]);
+
+  useInput(
+    (_input, key) => {
+      if (key.downArrow) scrollTo((current) => current + 1);
+      else if (key.upArrow) scrollTo((current) => current - 1);
+      else if (key.pageDown)
+        scrollTo((current) => current + pageRowsRef.current);
+      else if (key.pageUp) scrollTo((current) => current - pageRowsRef.current);
+    },
+    { isActive: scrollable },
+  );
+
   return (
     <ConfirmCard
       borderStyle="double"
       color="yellow"
-      title="Run bash command?"
+      title={BASH_APPROVAL_TITLE}
       alwaysAllow={{ kind: 'bash', label: 'approve session' }}
       onDecide={props.onDecide}
     >
-      <Box marginY={1}>
-        <Text>$ {props.payload.command}</Text>
+      <Box
+        marginY={scrollable || compactCommandLayout ? 0 : 1}
+        flexDirection="column"
+      >
+        {displayLines.map((line, index) => (
+          <Text key={index} dimColor={line.kind === 'overflow'}>
+            {line.text}
+          </Text>
+        ))}
       </Box>
+      {scrollable ? (
+        <KeyHints
+          confirmCancel={false}
+          hints={[
+            { key: '↑/↓', action: 'scroll command' },
+            { key: 'PgUp/PgDn', action: 'page' },
+          ]}
+        />
+      ) : null}
     </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -91,6 +91,22 @@ function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
   return `... ${count} more rows`;
 }
 
+function compactHiddenCommandText({
+  firstLine,
+  hiddenLines,
+  width,
+}: {
+  readonly firstLine: string;
+  readonly hiddenLines: number;
+  readonly width: number;
+}): string {
+  const suffix = ` ${overflowText('hidden', hiddenLines)}`;
+  const prefixWidth = width - suffix.length;
+  if (prefixWidth <= 0) return overflowText('hidden', hiddenLines);
+
+  return `${firstLine.slice(0, prefixWidth).trimEnd()}${suffix}`;
+}
+
 export function boundedBashCommandDisplayLines({
   command,
   maxDisplayLines,
@@ -106,9 +122,21 @@ export function boundedBashCommandDisplayLines({
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
 
   if (maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS) {
+    if (maxDisplayLines === 1) {
+      return [
+        {
+          kind: 'overflow',
+          text: compactHiddenCommandText({
+            firstLine: lines[0]?.text ?? '',
+            hiddenLines: lines.length - 1,
+            width,
+          }),
+        },
+      ];
+    }
+
     const visibleCount = Math.max(1, maxDisplayLines - 1);
     const visible = lines.slice(0, visibleCount);
-    if (maxDisplayLines === 1) return visible;
     return [
       ...visible,
       {

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { BashPermission } from '@shared/schemas';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
+import {
+  maxScrollableRowOffset,
+  scrollBoundedRows,
+} from '../render/scrollBounds';
+import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
@@ -76,13 +81,11 @@ export function maxBashCommandScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (
-    maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS ||
-    totalLines <= maxDisplayLines
-  ) {
-    return 0;
-  }
-  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+  return maxScrollableRowOffset({
+    compactRows: COMPACT_BASH_COMMAND_ROWS,
+    maxDisplayLines,
+    totalLines,
+  });
 }
 
 function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
@@ -101,10 +104,11 @@ function compactHiddenCommandText({
   readonly width: number;
 }): string {
   const suffix = ` ${overflowText('hidden', hiddenLines)}`;
-  const prefixWidth = width - suffix.length;
-  if (prefixWidth <= 0) return overflowText('hidden', hiddenLines);
+  const prefixWidth = width - textDisplayWidth(suffix);
+  if (prefixWidth <= 0)
+    return clipToWidth(overflowText('hidden', hiddenLines), width);
 
-  return `${firstLine.slice(0, prefixWidth).trimEnd()}${suffix}`;
+  return `${clipToWidth(firstLine, prefixWidth).trimEnd()}${suffix}`;
 }
 
 export function boundedBashCommandDisplayLines({
@@ -146,23 +150,12 @@ export function boundedBashCommandDisplayLines({
     ];
   }
 
-  const offset = Math.max(
-    0,
-    Math.min(
-      scrollOffset,
-      maxBashCommandScrollOffset(lines.length, maxDisplayLines),
-    ),
-  );
-  const hiddenBefore = offset;
-  const reserveBefore = hiddenBefore > 0 ? 1 : 0;
-  const contentSlotsWithoutAfter = Math.max(0, maxDisplayLines - reserveBefore);
-  const reserveAfter = offset + contentSlotsWithoutAfter < lines.length ? 1 : 0;
-  const visibleCount = Math.max(
-    0,
-    maxDisplayLines - reserveBefore - reserveAfter,
-  );
-  const visible = lines.slice(offset, offset + visibleCount);
-  const hiddenAfter = Math.max(0, lines.length - (offset + visibleCount));
+  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+    compactRows: COMPACT_BASH_COMMAND_ROWS,
+    maxDisplayLines,
+    rows: lines,
+    scrollOffset,
+  });
 
   return [
     ...(hiddenBefore > 0
@@ -173,7 +166,7 @@ export function boundedBashCommandDisplayLines({
           },
         ]
       : []),
-    ...visible,
+    ...visibleRows,
     ...(hiddenAfter > 0
       ? [
           {
@@ -210,8 +203,6 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   );
   const scrollable = maxScrollOffset > 0;
   const pageRows = Math.max(1, maxCommandRows - 2);
-  const maxScrollOffsetRef = useRef(maxScrollOffset);
-  const pageRowsRef = useRef(pageRows);
   const compactCommandLayout = maxCommandRows <= COMPACT_BASH_COMMAND_ROWS;
   const displayLines = boundedBashCommandDisplayLines({
     command: props.payload.command,
@@ -223,28 +214,22 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {
       const requested = typeof next === 'function' ? next(current) : next;
-      return Math.max(0, Math.min(maxScrollOffsetRef.current, requested));
+      return Math.max(0, Math.min(maxScrollOffset, requested));
     });
   }
 
   useEffect(() => {
-    maxScrollOffsetRef.current = maxScrollOffset;
     setScrollOffset((current) =>
       Math.max(0, Math.min(maxScrollOffset, current)),
     );
   }, [maxScrollOffset]);
 
-  useEffect(() => {
-    pageRowsRef.current = pageRows;
-  }, [pageRows]);
-
   useInput(
     (_input, key) => {
       if (key.downArrow) scrollTo((current) => current + 1);
       else if (key.upArrow) scrollTo((current) => current - 1);
-      else if (key.pageDown)
-        scrollTo((current) => current + pageRowsRef.current);
-      else if (key.pageUp) scrollTo((current) => current - pageRowsRef.current);
+      else if (key.pageDown) scrollTo((current) => current + pageRows);
+      else if (key.pageUp) scrollTo((current) => current - pageRows);
     },
     { isActive: scrollable },
   );

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -9,6 +9,8 @@ import { structuredPatch, type StructuredPatchHunk } from 'diff';
 import stringWidth from 'string-width';
 
 import { wrapAnsiToWidth } from './ansiWrap';
+import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
+import { clipToWidth } from './terminalText';
 
 export type Hunk = StructuredPatchHunk;
 
@@ -180,22 +182,11 @@ export function maxDiffScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (
-    maxDisplayLines <= COMPACT_DIFF_DISPLAY_LINES ||
-    totalLines <= maxDisplayLines
-  ) {
-    return 0;
-  }
-  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
-}
-
-function clipToWidth(text: string, width: number): string {
-  let clipped = '';
-  for (const char of text) {
-    if (stringWidth(clipped + char) > width) break;
-    clipped += char;
-  }
-  return clipped;
+  return maxScrollableRowOffset({
+    compactRows: COMPACT_DIFF_DISPLAY_LINES,
+    maxDisplayLines,
+    totalLines,
+  });
 }
 
 function overflowMarkerText(
@@ -270,20 +261,12 @@ export function scrollBoundedDiffDisplayLines(
     return compactBoundedDiffDisplayLines(lines, maxDisplayLines, width);
   }
 
-  const offset = Math.max(
-    0,
-    Math.min(scrollOffset, maxDiffScrollOffset(lines.length, maxDisplayLines)),
-  );
-  const hiddenBefore = offset;
-  const reserveBefore = hiddenBefore > 0 ? 1 : 0;
-  const contentSlotsWithoutAfter = Math.max(0, maxDisplayLines - reserveBefore);
-  const reserveAfter = offset + contentSlotsWithoutAfter < lines.length ? 1 : 0;
-  const visibleCount = Math.max(
-    0,
-    maxDisplayLines - reserveBefore - reserveAfter,
-  );
-  const visibleLines = lines.slice(offset, offset + visibleCount);
-  const hiddenAfter = Math.max(0, lines.length - (offset + visibleCount));
+  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+    compactRows: COMPACT_DIFF_DISPLAY_LINES,
+    maxDisplayLines,
+    rows: lines,
+    scrollOffset,
+  });
   return [
     ...(hiddenBefore > 0
       ? [
@@ -293,7 +276,7 @@ export function scrollBoundedDiffDisplayLines(
           },
         ]
       : []),
-    ...visibleLines,
+    ...visibleRows,
     ...(hiddenAfter > 0
       ? [
           {

--- a/packages/cli/src/chat/tui/render/scrollBounds.ts
+++ b/packages/cli/src/chat/tui/render/scrollBounds.ts
@@ -1,0 +1,69 @@
+export interface ScrollBoundedRows<T> {
+  readonly hiddenAfter: number;
+  readonly hiddenBefore: number;
+  readonly visibleRows: readonly T[];
+}
+
+export function maxScrollableRowOffset({
+  compactRows,
+  maxDisplayLines,
+  totalLines,
+}: {
+  readonly compactRows: number;
+  readonly maxDisplayLines: number;
+  readonly totalLines: number;
+}): number {
+  if (maxDisplayLines <= compactRows || totalLines <= maxDisplayLines) {
+    return 0;
+  }
+  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+}
+
+export function scrollBoundedRows<T>({
+  compactRows,
+  maxDisplayLines,
+  rows,
+  scrollOffset = 0,
+}: {
+  readonly compactRows: number;
+  readonly maxDisplayLines: number;
+  readonly rows: readonly T[];
+  readonly scrollOffset?: number;
+}): ScrollBoundedRows<T> {
+  if (maxDisplayLines <= 0 || rows.length <= maxDisplayLines) {
+    return { hiddenAfter: 0, hiddenBefore: 0, visibleRows: rows };
+  }
+
+  if (maxDisplayLines <= compactRows) {
+    const visibleRows = rows.slice(0, Math.max(0, maxDisplayLines));
+    return {
+      hiddenAfter: Math.max(0, rows.length - visibleRows.length),
+      hiddenBefore: 0,
+      visibleRows,
+    };
+  }
+
+  const offset = Math.max(
+    0,
+    Math.min(
+      scrollOffset,
+      maxScrollableRowOffset({
+        compactRows,
+        maxDisplayLines,
+        totalLines: rows.length,
+      }),
+    ),
+  );
+  const hiddenBefore = offset;
+  const reserveBefore = hiddenBefore > 0 ? 1 : 0;
+  const contentSlotsWithoutAfter = Math.max(0, maxDisplayLines - reserveBefore);
+  const reserveAfter = offset + contentSlotsWithoutAfter < rows.length ? 1 : 0;
+  const visibleCount = Math.max(
+    0,
+    maxDisplayLines - reserveBefore - reserveAfter,
+  );
+  const visibleRows = rows.slice(offset, offset + visibleCount);
+  const hiddenAfter = Math.max(0, rows.length - (offset + visibleCount));
+
+  return { hiddenAfter, hiddenBefore, visibleRows };
+}

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,0 +1,14 @@
+import stringWidth from 'string-width';
+
+export function textDisplayWidth(text: string): number {
+  return stringWidth(text);
+}
+
+export function clipToWidth(text: string, width: number): string {
+  let clipped = '';
+  for (const char of text) {
+    if (textDisplayWidth(clipped + char) > width) break;
+    clipped += char;
+  }
+  return clipped;
+}

--- a/src/test-kernel/cli/BashApproval.vitest.mts
+++ b/src/test-kernel/cli/BashApproval.vitest.mts
@@ -83,9 +83,8 @@ describe('CLI bash approval layout', () => {
     });
 
     expect(visible).toHaveLength(1);
-    expect(visible.at(0)).toEqual({
-      kind: 'command',
-      text: "$ python3 << 'EOF'",
-    });
+    expect(visible[0]?.text).toContain("$ python3 << 'EOF'");
+    expect(visible[0]?.text).toContain('rows hidden');
+    expect(visible[0]?.text.length).toBeLessThanOrEqual(76);
   });
 });

--- a/src/test-kernel/cli/BashApproval.vitest.mts
+++ b/src/test-kernel/cli/BashApproval.vitest.mts
@@ -6,6 +6,7 @@ import {
   boundedBashCommandDisplayLines,
   maxBashCommandScrollOffset,
 } from '@cli/chat/tui/modals/BashApproval';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 
 const HEREDOC_COMMAND = [
   "python3 << 'EOF'",
@@ -86,5 +87,16 @@ describe('CLI bash approval layout', () => {
     expect(visible[0]?.text).toContain("$ python3 << 'EOF'");
     expect(visible[0]?.text).toContain('rows hidden');
     expect(visible[0]?.text.length).toBeLessThanOrEqual(76);
+  });
+
+  it('clips one-row compact previews by terminal column width', () => {
+    const visible = boundedBashCommandDisplayLines({
+      command: `echo ${'界'.repeat(20)}`,
+      maxDisplayLines: 1,
+      width: 24,
+    });
+
+    expect(visible).toHaveLength(1);
+    expect(textDisplayWidth(visible[0]?.text ?? '')).toBeLessThanOrEqual(24);
   });
 });

--- a/src/test-kernel/cli/BashApproval.vitest.mts
+++ b/src/test-kernel/cli/BashApproval.vitest.mts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bashApprovalCommandRowsBudget,
+  bashCommandDisplayLines,
+  boundedBashCommandDisplayLines,
+  maxBashCommandScrollOffset,
+} from '@cli/chat/tui/modals/BashApproval';
+
+const HEREDOC_COMMAND = [
+  "python3 << 'EOF'",
+  'solutions = []',
+  'for y in range(1, 100):',
+  '    x2 = 1 + 2 * y * y',
+  '    x = int(x2 ** 0.5)',
+  '    if x * x == x2:',
+  '        solutions.append((x, y))',
+  '        if x != 0:',
+  '            solutions.append((-x, y))',
+  'solutions.sort()',
+  'print("All integer pairs (x,y) with 0<y<100:")',
+  'print(solutions)',
+  'EOF',
+].join('\n');
+
+describe('CLI bash approval layout', () => {
+  it('caps long commands so the approval footer stays visible', () => {
+    const budget = bashApprovalCommandRowsBudget({
+      availableRows: 16,
+      columns: 80,
+    });
+    const allRows = bashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      width: 76,
+    });
+
+    expect(budget).toBe(8);
+    expect(allRows.length).toBeGreaterThan(budget);
+
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: budget,
+      width: 76,
+    });
+
+    expect(visible).toHaveLength(budget);
+    expect(visible.at(-1)).toEqual({
+      kind: 'overflow',
+      text: '... 6 more rows',
+    });
+    expect(visible.map((line) => line.text)).not.toContain(
+      '  print(solutions)',
+    );
+  });
+
+  it('lets users scroll to the hidden command tail', () => {
+    const budget = 8;
+    const allRows = bashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      width: 76,
+    });
+    const offset = maxBashCommandScrollOffset(allRows.length, budget);
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: budget,
+      scrollOffset: offset,
+      width: 76,
+    });
+
+    expect(visible.at(0)).toEqual({
+      kind: 'overflow',
+      text: `... ${offset} previous rows`,
+    });
+    expect(visible.map((line) => line.text)).toContain('  print(solutions)');
+    expect(visible.map((line) => line.text)).toContain('  EOF');
+  });
+
+  it('keeps one-row compact previews within their row budget', () => {
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: 1,
+      width: 76,
+    });
+
+    expect(visible).toHaveLength(1);
+    expect(visible.at(0)).toEqual({
+      kind: 'command',
+      text: "$ python3 << 'EOF'",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- cap bash approval command previews to the foreground row budget
- add scroll/page controls for hidden command rows
- extend the TUI harness with a long heredoc approval scenario

Closes #4790

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/BashApproval.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/BashApproval.tsx packages/cli/src/chat/tui/modals/ApprovalModal.tsx packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/BashApproval.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only approval UI and layout helpers; behavior is covered by new unit and validate-tui scenarios with no auth or data-path changes.
> 
> **Overview**
> The bash approval modal no longer dumps the full command into a single line. It **sizes the command preview to the foreground row budget**, wraps multiline commands, and shows **overflow hints** (`... more rows`, `... rows hidden`) when content does not fit.
> 
> When there is room to scroll, **↑/↓ and PgUp/PgDn** move through hidden command lines, with key hints on the card. **`ApprovalModal`** passes **`availableRows`** into **`BashApproval`**, matching edit approval.
> 
> Scroll/limit logic is **factored into** `scrollBounds.ts` and `terminalText.ts`; **`DiffView`** uses the same helpers instead of duplicating clipping and scroll math.
> 
> The **TUI harness** accepts **`HARNESS_BASH_APPROVAL_COMMAND`**, and **`validate-tui`** adds **long** and **compact** heredoc bash-approval scenarios. **`BashApproval.vitest.mts`** covers row budgets, scrolling, and compact one-line previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cae1bbf29878c4ca2d34695b20c0a33dadd3c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->