### PR TITLE
fix(cli): label sub-workflow task details clearly

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -273,6 +273,43 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'task-subworkflow-detail',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', '\r'],
+    expect: [
+      'Task details',
+      'stream · strategy',
+      'Description: strategy sub-workflow',
+      'Please handle the harness-child-strategy sub-workflow.',
+      'f focus stream',
+      'Esc back',
+    ],
+    unexpect: ['Command:  strategy sub-workflow'],
+  },
+  {
+    name: 'task-process-detail',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
+    expect: [
+      'Task details',
+      'shell · latex build',
+      'Command:     latex build',
+      'main.tex: Proof sketch needs one missing reference',
+      'k kill',
+      'Esc back',
+    ],
+  },
+  {
     name: 'narrow-subagent-picker',
     cols: 60,
     rows: 18,

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -124,6 +124,10 @@ export interface PickerListLayout {
   readonly visibleCount: number;
 }
 
+export function taskDetailCommandLabel(kind: ChildControlItem['kind']): string {
+  return kind === 'process' ? 'Command' : 'Description';
+}
+
 export function computeTaskDetailLayout({
   availableRows,
   hasTailLines,
@@ -268,6 +272,7 @@ function TaskDetailView({
   const offset = Math.min(scrollOffset, maxOffset);
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
   const compactMeta = metaParts.join(' · ');
+  const commandLabel = taskDetailCommandLabel(item.kind);
 
   useEffect(() => {
     setScrollOffset((current) => Math.min(current, maxOffset));
@@ -319,8 +324,8 @@ function TaskDetailView({
       )}
       {layout.showCommand ? (
         <Box marginTop={layout.compact ? 0 : 1}>
-          <Box width={10}>
-            <Text bold>Command:</Text>
+          <Box width={13}>
+            <Text bold>{`${commandLabel}:`}</Text>
           </Box>
           <Text wrap="truncate-end">{item.command}</Text>
         </Box>

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -8,6 +8,7 @@ import {
   emptyPickerText,
   pickerKeyHints,
   pickerTitle,
+  taskDetailCommandLabel,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
@@ -682,6 +683,11 @@ describe('CLI child execution controls', () => {
     expect(pickerTitle('tasks')).toBe('Tasks and sub-workflows');
     expect(emptyPickerText('subagents')).toBe('No active subagents.');
     expect(emptyPickerText('tasks')).toBe('No active tasks or sub-workflows.');
+  });
+
+  it('labels task detail metadata by execution type', () => {
+    expect(taskDetailCommandLabel('process')).toBe('Command');
+    expect(taskDetailCommandLabel('subagent')).toBe('Description');
   });
 
   it('preserves output rows in compact task detail views', () => {


### PR DESCRIPTION
## Summary

- show `Description:` instead of `Command:` when task details are for a sub-workflow/stream row
- keep `Command:` for shell process detail rows
- add TUI harness coverage for opening sub-workflow and process detail views

Fixes #4792.

## Validation

- `npm run format`
- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-subworkflow-detail-label-full`
- `npm run compile:safe`
- `npm run lint` (exits 0; existing 12 import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only changes in the task detail modal, plus test additions; no auth, data, or execution logic changes.
> 
> **Overview**
> Task detail views in the CLI TUI now use **Description:** for sub-workflow/stream rows and **Command:** for shell process rows, via a new `taskDetailCommandLabel` helper and a slightly wider label column in `TaskDetailView`.
> 
> Unit tests cover the label mapping; the TUI harness adds **`task-subworkflow-detail`** and **`task-process-detail`** scenarios so regressions (e.g. showing `Command:` on sub-workflows) are caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbbb547ce95cdeb77fd3d201b9cd2360c15e957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->