### PR TITLE
fix(cli): keep foreground detail panels readable

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -43,8 +43,22 @@ const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
+const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
+const EXTERNAL_INQUIRY_QUESTION =
+  process.env.HARNESS_EXTERNAL_INQUIRY_QUESTION ??
+  [
+    'I need an independent verification of an enumeration of Pythagorean triples.',
+    '',
+    'Problem: Find all integer triples (a,b,c) with 0 <= a <= b <= c <= 60 and a^2 + b^2 = c^2, whose perimeter is at most 120.',
+    '',
+    'Please enumerate them independently and verify these results:',
+    '',
+    'Non-degenerate triples: (3,4,5), (5,12,13), (6,8,10), (7,24,25), (8,15,17), (9,12,15), (9,40,41), (10,24,26), (12,16,20), (12,35,37), (14,48,50), (15,20,25), (15,36,39), (16,30,34), (18,24,30), (20,21,29), (20,48,52), (21,28,35), (24,32,40), (24,45,51), (27,36,45), (30,40,50).',
+    '',
+    'Degenerate triples: (0,b,b) for 0 <= b <= 60.',
+  ].join('\n');
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
@@ -336,6 +350,22 @@ if (SHOW_BASH_APPROVAL) {
     {
       kind: 'bash',
       payload: makeBashApprovalPayload(),
+    },
+    { onPresent: () => notify({ kind: 'approvalNeeded' }) },
+  ).then(applyHarnessApprovalDecision);
+}
+
+if (SHOW_EXTERNAL_INQUIRY) {
+  void enqueueApproval(
+    {
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'harness-external-inquiry',
+        question: EXTERNAL_INQUIRY_QUESTION,
+        threadId: 'ei_123456abcdef',
+        allowBypass: false,
+        streamId: STREAM_ID,
+      },
     },
     { onPresent: () => notify({ kind: 'approvalNeeded' }) },
   ).then(applyHarnessApprovalDecision);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -53,6 +53,8 @@ const LONG_BASH_APPROVAL_COMMAND = [
   'print(solutions)',
   'EOF',
 ].join('\n');
+const LONG_EXTERNAL_INQUIRY_ANSWER =
+  'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -199,6 +201,23 @@ const SCENARIOS = [
     frame: 'tail',
     expect: ['AUTO-BASH', '[/status]details', '[/model]models'],
     unexpect: ['AUTO-APPROVE', 'Run bash command?', '1 approval'],
+  },
+  {
+    name: 'external-inquiry-long',
+    rows: 24,
+    env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: [LONG_EXTERNAL_INQUIRY_ANSWER],
+    frame: 'tail',
+    expect: [
+      'Agent asks:',
+      'more rows',
+      'PgUp/PgDn question',
+      'Enter submit answer',
+      'Ctrl-R reject with note',
+    ],
+    unexpect: ['└─Degenerate triples', '[/model]models'],
+    maxBlankLinesBetween: [{ from: '└', to: 'Tip:', max: 1 }],
   },
   {
     name: 'edit-approval-reject',

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -27,6 +27,10 @@ export interface BaseTextInputProps {
   readonly value: string;
   readonly placeholder?: string;
   readonly focus?: boolean;
+  /** Clamp the rendered value to this many terminal rows while preserving
+   *  the full editable value passed to onChange/onSubmit. */
+  readonly maxDisplayRows?: number;
+  readonly displayWidth?: number;
   /** Pin the caret externally. When omitted, the component tracks the caret
    *  internally so arrow keys / Home/End / Ctrl-A,E,U,K,W work out of the box. */
   readonly cursor?: number;
@@ -35,9 +39,58 @@ export interface BaseTextInputProps {
   readonly onChange: (value: string) => void;
 }
 
+export interface TextInputDisplayWindow {
+  readonly value: string;
+  readonly cursor: number;
+  readonly clipped: boolean;
+}
+
+export function textInputDisplayWindow({
+  cursor,
+  maxDisplayRows,
+  value,
+  width,
+}: {
+  readonly cursor: number;
+  readonly maxDisplayRows?: number;
+  readonly value: string;
+  readonly width?: number;
+}): TextInputDisplayWindow {
+  const rowCount = Math.max(1, maxDisplayRows ?? 0);
+  const columnCount = Math.max(1, width ?? 0);
+  if (maxDisplayRows === undefined || width === undefined) {
+    return { value, cursor: clampCursor(cursor, value.length), clipped: false };
+  }
+
+  const budget = Math.max(1, rowCount * columnCount - 1);
+  if (value.length <= budget) {
+    return { value, cursor: clampCursor(cursor, value.length), clipped: false };
+  }
+
+  const sourceCursor = clampCursor(cursor, value.length);
+  const keepAfterCursor = Math.min(
+    value.length - sourceCursor,
+    Math.floor(budget / 4),
+  );
+  const end = Math.min(value.length, sourceCursor + keepAfterCursor);
+  const start = Math.max(0, end - budget);
+  const prefix = start > 0 ? '…' : '';
+  const displayValue = `${prefix}${value.slice(start, end)}`;
+  return {
+    value: displayValue,
+    cursor: clampCursor(
+      sourceCursor - start + prefix.length,
+      displayValue.length,
+    ),
+    clipped: true,
+  };
+}
+
 export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   const {
+    displayWidth,
     value,
+    maxDisplayRows,
     placeholder,
     focus = true,
     onChange,
@@ -161,11 +214,18 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     );
   }
 
-  if (!focus) return <Text>{value}</Text>;
+  const display = textInputDisplayWindow({
+    cursor,
+    maxDisplayRows,
+    value,
+    width: displayWidth,
+  });
 
-  const before = value.slice(0, cursor);
-  const ch = value[cursor];
-  const after = value.slice(cursor + 1);
+  if (!focus) return <Text>{display.value}</Text>;
+
+  const before = display.value.slice(0, display.cursor);
+  const ch = display.value[display.cursor];
+  const after = display.value.slice(display.cursor + 1);
   // Inverse-on-newline collapses to nothing visible; render the caret as a
   // leading space and let the literal newline carry the line break.
   if (ch === '\n') {

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -62,6 +62,8 @@ export function textInputDisplayWindow({
     return { value, cursor: clampCursor(cursor, value.length), clipped: false };
   }
 
+  // Reserve one cell for the leading ellipsis so clipped text never exceeds
+  // the requested terminal row/column window.
   const budget = Math.max(1, rowCount * columnCount - 1);
   if (value.length <= budget) {
     return { value, cursor: clampCursor(cursor, value.length), clipped: false };

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -45,6 +45,59 @@ export interface TextInputDisplayWindow {
   readonly clipped: boolean;
 }
 
+interface TextInputDisplayRow {
+  readonly start: number;
+  readonly end: number;
+  readonly breakKind: 'soft' | 'hard' | 'end';
+}
+
+function textInputDisplayRows(
+  value: string,
+  width: number,
+): TextInputDisplayRow[] {
+  const rows: TextInputDisplayRow[] = [];
+  let rowStart = 0;
+  let column = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const ch = value[index];
+    if (ch === '\n') {
+      rows.push({ start: rowStart, end: index, breakKind: 'hard' });
+      rowStart = index + 1;
+      column = 0;
+      continue;
+    }
+    if (column === width) {
+      rows.push({ start: rowStart, end: index, breakKind: 'soft' });
+      rowStart = index;
+      column = 0;
+    }
+    column += 1;
+  }
+
+  rows.push({ start: rowStart, end: value.length, breakKind: 'end' });
+  return rows;
+}
+
+function cursorDisplayRowIndex(
+  rows: readonly TextInputDisplayRow[],
+  cursor: number,
+): number {
+  const rowIndex = rows.findIndex((row, index) => {
+    if (cursor < row.start || cursor > row.end) return false;
+    if (cursor === row.end && row.breakKind === 'soft') {
+      return index === rows.length - 1;
+    }
+    return true;
+  });
+  return rowIndex < 0 ? Math.max(0, rows.length - 1) : rowIndex;
+}
+
+function leadingEllipsisText(text: string, width: number): string {
+  if (width <= 1) return '…';
+  return text.length >= width ? `…${text.slice(1)}` : `…${text}`;
+}
+
 export function textInputDisplayWindow({
   cursor,
   maxDisplayRows,
@@ -62,29 +115,55 @@ export function textInputDisplayWindow({
     return { value, cursor: clampCursor(cursor, value.length), clipped: false };
   }
 
-  // Reserve one cell for the leading ellipsis so clipped text never exceeds
-  // the requested terminal row/column window.
-  const budget = Math.max(1, rowCount * columnCount - 1);
-  if (value.length <= budget) {
-    return { value, cursor: clampCursor(cursor, value.length), clipped: false };
-  }
-
   const sourceCursor = clampCursor(cursor, value.length);
-  const keepAfterCursor = Math.min(
-    value.length - sourceCursor,
-    Math.floor(budget / 4),
-  );
-  const end = Math.min(value.length, sourceCursor + keepAfterCursor);
-  const start = Math.max(0, end - budget);
-  const prefix = start > 0 ? '…' : '';
-  const displayValue = `${prefix}${value.slice(start, end)}`;
+  const rows = textInputDisplayRows(value, columnCount);
+  const cursorRowIndex = cursorDisplayRowIndex(rows, sourceCursor);
+  const keepRowsAfterCursor =
+    rows.length <= rowCount
+      ? rows.length - cursorRowIndex - 1
+      : Math.min(rows.length - cursorRowIndex - 1, Math.floor(rowCount / 4));
+  const endRow =
+    rows.length <= rowCount
+      ? rows.length
+      : Math.min(rows.length, cursorRowIndex + keepRowsAfterCursor + 1);
+  const startRow = rows.length <= rowCount ? 0 : Math.max(0, endRow - rowCount);
+  const visibleRows = rows.slice(startRow, endRow);
+  const clipped = startRow > 0 || endRow < rows.length;
+  const firstRowOriginalLength =
+    visibleRows[0] === undefined
+      ? 0
+      : visibleRows[0].end - visibleRows[0].start;
+  const rowTexts = visibleRows.map((row) => value.slice(row.start, row.end));
+  if (clipped && startRow > 0) {
+    rowTexts[0] = leadingEllipsisText(rowTexts[0] ?? '', columnCount);
+  }
+  const displayValue = rowTexts.join('\n');
+  const displayCursorRow = Math.max(0, cursorRowIndex - startRow);
+  const cursorRow = visibleRows[displayCursorRow] ?? visibleRows.at(-1);
+  const cursorColumn =
+    cursorRow === undefined
+      ? 0
+      : clampCursor(
+          sourceCursor - cursorRow.start,
+          rowTexts[displayCursorRow]?.length ?? 0,
+        );
+  const ellipsisCursorColumn =
+    clipped && startRow > 0 && displayCursorRow === 0
+      ? firstRowOriginalLength >= columnCount
+        ? Math.max(1, cursorColumn)
+        : cursorColumn + 1
+      : cursorColumn;
+  const cursorPrefixLength = rowTexts
+    .slice(0, displayCursorRow)
+    .reduce((sum, row) => sum + row.length + 1, 0);
+
   return {
     value: displayValue,
     cursor: clampCursor(
-      sourceCursor - start + prefix.length,
+      cursorPrefixLength + ellipsisCursorColumn,
       displayValue.length,
     ),
-    clipped: true,
+    clipped,
   };
 }
 

--- a/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
+++ b/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
@@ -48,7 +48,13 @@ export function ApprovalModal(
     case 'retry':
       return <RetryRequest payload={payload.payload} onDecide={decide} />;
     case 'externalInquiry':
-      return <ExternalInquiry payload={payload.payload} onDecide={decide} />;
+      return (
+        <ExternalInquiry
+          availableRows={props.availableRows}
+          payload={payload.payload}
+          onDecide={decide}
+        />
+      );
     case 'userQuestion':
       return <UserQuestion payload={payload.payload} onDecide={decide} />;
   }

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -37,6 +37,8 @@ export interface ChildControlPickerProps {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
 
+export const TASK_DETAIL_LABEL_WIDTH = 13;
+
 export function pickerTitle(mode: ChildControlMode): string {
   return mode === 'subagents' ? 'Subagents' : 'Tasks and sub-workflows';
 }
@@ -100,7 +102,7 @@ function metaLine(
   if (!value) return null;
   return (
     <Box>
-      <Box width={10}>
+      <Box width={TASK_DETAIL_LABEL_WIDTH}>
         <Text bold>{label}:</Text>
       </Box>
       <Text>{value}</Text>
@@ -324,7 +326,7 @@ function TaskDetailView({
       )}
       {layout.showCommand ? (
         <Box marginTop={layout.compact ? 0 : 1}>
-          <Box width={13}>
+          <Box width={TASK_DETAIL_LABEL_WIDTH}>
             <Text bold>{`${commandLabel}:`}</Text>
           </Box>
           <Text wrap="truncate-end">{item.command}</Text>

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -216,6 +216,7 @@ export function ExternalInquiry(
     }
     if (key.pageUp) {
       scrollQuestion((current) => current - pageRows);
+      return;
     }
   });
 

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -55,6 +55,17 @@ function overflowText(kind: 'previous' | 'more' | 'hidden', count: number) {
   return `... ${count} more rows`;
 }
 
+function compactOverflowText(
+  hiddenBefore: number,
+  hiddenAfter: number,
+): string {
+  if (hiddenBefore > 0 && hiddenAfter > 0) {
+    return `... ${hiddenBefore} previous, ${hiddenAfter} more rows`;
+  }
+  if (hiddenBefore > 0) return overflowText('previous', hiddenBefore);
+  return overflowText('more', hiddenAfter);
+}
+
 export function externalInquiryQuestionLines({
   question,
   width,
@@ -74,6 +85,10 @@ export function maxExternalInquiryQuestionScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
+  if (totalLines <= maxDisplayLines) return 0;
+  if (maxDisplayLines <= COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS) {
+    return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+  }
   return maxScrollableRowOffset({
     compactRows: COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS,
     maxDisplayLines,
@@ -96,21 +111,25 @@ export function boundedExternalInquiryQuestionLines({
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
 
   if (maxDisplayLines <= COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS) {
-    if (maxDisplayLines === 1) {
-      return [
-        {
-          kind: 'overflow',
-          text: overflowText('hidden', lines.length),
-        },
-      ];
-    }
-    const visible = lines.slice(0, Math.max(1, maxDisplayLines - 1));
+    const visibleCount = Math.max(1, maxDisplayLines - 1);
+    const offset = Math.max(
+      0,
+      Math.min(scrollOffset, Math.max(0, lines.length - visibleCount)),
+    );
+    const visible = lines.slice(offset, offset + visibleCount);
+    const hiddenBefore = offset;
+    const hiddenAfter = Math.max(0, lines.length - (offset + visible.length));
+    if (maxDisplayLines === 1) return visible;
     return [
       ...visible,
-      {
-        kind: 'overflow',
-        text: overflowText('hidden', lines.length - visible.length),
-      },
+      ...(hiddenBefore > 0 || hiddenAfter > 0
+        ? [
+            {
+              kind: 'overflow' as const,
+              text: compactOverflowText(hiddenBefore, hiddenAfter),
+            },
+          ]
+        : []),
     ];
   }
 
@@ -231,7 +250,7 @@ export function ExternalInquiry(
       <Text bold color="green">
         Agent asks:
       </Text>
-      <Box marginY={questionScrollable ? 0 : 1} flexDirection="column">
+      <Box flexDirection="column">
         {questionDisplayLines.map((line, index) => (
           <Text key={index} dimColor={line.kind === 'overflow'}>
             {line.text || ' '}

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -1,21 +1,198 @@
-import { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { ExternalInquiryPermission } from '@shared/schemas';
 
+import { CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { BaseTextInput } from '../input/BaseTextInput';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
+import {
+  maxScrollableRowOffset,
+  scrollBoundedRows,
+} from '../render/scrollBounds';
 import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface ExternalInquiryProps {
+  readonly availableRows?: number;
   readonly payload: ExternalInquiryPermission;
   readonly onDecide: (decision: ApprovalDecision) => void;
+}
+
+export interface ExternalInquiryDisplayLine {
+  readonly kind: 'question' | 'overflow';
+  readonly text: string;
+}
+
+const MIN_EXTERNAL_INQUIRY_WIDTH = 20;
+const DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS = 16;
+const COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS = 3;
+const EXTERNAL_INQUIRY_FIXED_ROWS = 7;
+
+export function externalInquiryAnswerRowsBudget(
+  availableRows: number | undefined,
+): number {
+  if (availableRows === undefined || availableRows >= 18) return 3;
+  if (availableRows >= 13) return 2;
+  return 1;
+}
+
+export function externalInquiryQuestionRowsBudget({
+  answerRows,
+  availableRows,
+}: {
+  readonly answerRows: number;
+  readonly availableRows?: number;
+}): number {
+  if (availableRows === undefined)
+    return DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS;
+  return Math.max(1, availableRows - EXTERNAL_INQUIRY_FIXED_ROWS - answerRows);
+}
+
+function overflowText(kind: 'previous' | 'more' | 'hidden', count: number) {
+  if (kind === 'previous') return `... ${count} previous rows`;
+  if (kind === 'hidden') return `... ${count} rows hidden`;
+  return `... ${count} more rows`;
+}
+
+export function externalInquiryQuestionLines({
+  question,
+  width,
+}: {
+  readonly question: string;
+  readonly width: number;
+}): ExternalInquiryDisplayLine[] {
+  const questionWidth = Math.max(MIN_EXTERNAL_INQUIRY_WIDTH, width);
+  return question.split('\n').flatMap((line) =>
+    wrapAnsiToWidth(line, questionWidth)
+      .split('\n')
+      .map((text): ExternalInquiryDisplayLine => ({ kind: 'question', text })),
+  );
+}
+
+export function maxExternalInquiryQuestionScrollOffset(
+  totalLines: number,
+  maxDisplayLines: number,
+): number {
+  return maxScrollableRowOffset({
+    compactRows: COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS,
+    maxDisplayLines,
+    totalLines,
+  });
+}
+
+export function boundedExternalInquiryQuestionLines({
+  maxDisplayLines,
+  question,
+  scrollOffset = 0,
+  width,
+}: {
+  readonly maxDisplayLines: number;
+  readonly question: string;
+  readonly scrollOffset?: number;
+  readonly width: number;
+}): ExternalInquiryDisplayLine[] {
+  const lines = externalInquiryQuestionLines({ question, width });
+  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
+
+  if (maxDisplayLines <= COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS) {
+    if (maxDisplayLines === 1) {
+      return [
+        {
+          kind: 'overflow',
+          text: overflowText('hidden', lines.length),
+        },
+      ];
+    }
+    const visible = lines.slice(0, Math.max(1, maxDisplayLines - 1));
+    return [
+      ...visible,
+      {
+        kind: 'overflow',
+        text: overflowText('hidden', lines.length - visible.length),
+      },
+    ];
+  }
+
+  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+    compactRows: COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS,
+    maxDisplayLines,
+    rows: lines,
+    scrollOffset,
+  });
+
+  return [
+    ...(hiddenBefore > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: overflowText('previous', hiddenBefore),
+          },
+        ]
+      : []),
+    ...visibleRows,
+    ...(hiddenAfter > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: overflowText('more', hiddenAfter),
+          },
+        ]
+      : []),
+  ];
 }
 
 export function ExternalInquiry(
   props: ExternalInquiryProps,
 ): React.JSX.Element {
+  const { columns } = useWindowSize();
   const [answer, setAnswer] = useState('');
+  const [questionOffset, setQuestionOffset] = useState(0);
+  const contentWidth = Math.max(
+    MIN_EXTERNAL_INQUIRY_WIDTH,
+    columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
+  );
+  const answerRows = externalInquiryAnswerRowsBudget(props.availableRows);
+  const questionRows = externalInquiryQuestionRowsBudget({
+    answerRows,
+    availableRows: props.availableRows,
+  });
+  const questionLineCount = useMemo(
+    () =>
+      externalInquiryQuestionLines({
+        question: props.payload.question,
+        width: contentWidth,
+      }).length,
+    [contentWidth, props.payload.question],
+  );
+  const maxQuestionOffset = maxExternalInquiryQuestionScrollOffset(
+    questionLineCount,
+    questionRows,
+  );
+  const questionScrollable = maxQuestionOffset > 0;
+  const pageRows = Math.max(1, questionRows - 2);
+  const questionDisplayLines = boundedExternalInquiryQuestionLines({
+    maxDisplayLines: questionRows,
+    question: props.payload.question,
+    scrollOffset: questionOffset,
+    width: contentWidth,
+  });
+
+  function scrollQuestion(
+    next: number | ((currentOffset: number) => number),
+  ): void {
+    setQuestionOffset((current) => {
+      const requested = typeof next === 'function' ? next(current) : next;
+      return Math.max(0, Math.min(maxQuestionOffset, requested));
+    });
+  }
+
+  useEffect(() => {
+    setQuestionOffset((current) =>
+      Math.max(0, Math.min(maxQuestionOffset, current)),
+    );
+  }, [maxQuestionOffset]);
+
   useInput((input, key) => {
     if (key.escape) {
       props.onDecide({
@@ -31,6 +208,14 @@ export function ExternalInquiry(
         userMessage:
           feedback.length > 0 ? feedback : 'External inquiry rejected by user.',
       });
+      return;
+    }
+    if (key.pageDown) {
+      scrollQuestion((current) => current + pageRows);
+      return;
+    }
+    if (key.pageUp) {
+      scrollQuestion((current) => current - pageRows);
     }
   });
 
@@ -40,31 +225,43 @@ export function ExternalInquiry(
       borderColor="green"
       flexDirection="column"
       paddingX={1}
+      width={columns}
     >
       <Text bold color="green">
         Agent asks:
       </Text>
-      <Box marginY={1}>
-        <Text>{props.payload.question}</Text>
+      <Box marginY={questionScrollable ? 0 : 1} flexDirection="column">
+        {questionDisplayLines.map((line, index) => (
+          <Text key={index} dimColor={line.kind === 'overflow'}>
+            {line.text || ' '}
+          </Text>
+        ))}
       </Box>
-      <Box>
+      <Box marginTop={1}>
         <Text>{'> '}</Text>
-        <BaseTextInput
-          value={answer}
-          onChange={setAnswer}
-          onSubmit={(value) => {
-            const trimmed = value.trim();
-            if (trimmed.length === 0) {
-              props.onDecide({ accepted: false, userMessage: 'cancelled' });
-            } else {
-              props.onDecide({ accepted: true, userMessage: trimmed });
-            }
-          }}
-        />
+        <Box flexGrow={1} flexShrink={1} height={answerRows} overflowY="hidden">
+          <BaseTextInput
+            displayWidth={Math.max(1, contentWidth - 2)}
+            maxDisplayRows={answerRows}
+            value={answer}
+            onChange={setAnswer}
+            onSubmit={(value) => {
+              const trimmed = value.trim();
+              if (trimmed.length === 0) {
+                props.onDecide({ accepted: false, userMessage: 'cancelled' });
+              } else {
+                props.onDecide({ accepted: true, userMessage: trimmed });
+              }
+            }}
+          />
+        </Box>
       </Box>
       <Box marginTop={1}>
         <KeyHints
           hints={[
+            ...(questionScrollable
+              ? [{ key: 'PgUp/PgDn', action: 'question' }]
+              : []),
             { key: 'Enter', action: 'submit answer' },
             { key: 'Ctrl-R', action: 'reject with note' },
             { key: 'Esc', action: 'skip' },

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -27,7 +27,7 @@ export interface ExternalInquiryDisplayLine {
 const MIN_EXTERNAL_INQUIRY_WIDTH = 20;
 const DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS = 16;
 const COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS = 3;
-const EXTERNAL_INQUIRY_FIXED_ROWS = 7;
+const EXTERNAL_INQUIRY_FIXED_ROWS = 6;
 
 export function externalInquiryAnswerRowsBudget(
   availableRows: number | undefined,
@@ -46,7 +46,7 @@ export function externalInquiryQuestionRowsBudget({
 }): number {
   if (availableRows === undefined)
     return DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS;
-  return Math.max(1, availableRows - EXTERNAL_INQUIRY_FIXED_ROWS - answerRows);
+  return Math.max(0, availableRows - EXTERNAL_INQUIRY_FIXED_ROWS - answerRows);
 }
 
 function overflowText(kind: 'previous' | 'more' | 'hidden', count: number) {
@@ -85,6 +85,7 @@ export function maxExternalInquiryQuestionScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
+  if (maxDisplayLines <= 0) return 0;
   if (totalLines <= maxDisplayLines) return 0;
   if (maxDisplayLines <= COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS) {
     return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
@@ -108,7 +109,8 @@ export function boundedExternalInquiryQuestionLines({
   readonly width: number;
 }): ExternalInquiryDisplayLine[] {
   const lines = externalInquiryQuestionLines({ question, width });
-  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
+  if (maxDisplayLines <= 0) return [];
+  if (lines.length <= maxDisplayLines) return lines;
 
   if (maxDisplayLines <= COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS) {
     const visibleCount = Math.max(1, maxDisplayLines - 1);

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -8,6 +8,7 @@ import {
   emptyPickerText,
   pickerKeyHints,
   pickerTitle,
+  TASK_DETAIL_LABEL_WIDTH,
   taskDetailCommandLabel,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
@@ -688,6 +689,9 @@ describe('CLI child execution controls', () => {
   it('labels task detail metadata by execution type', () => {
     expect(taskDetailCommandLabel('process')).toBe('Command');
     expect(taskDetailCommandLabel('subagent')).toBe('Description');
+    expect(TASK_DETAIL_LABEL_WIDTH).toBeGreaterThanOrEqual(
+      'Description:'.length,
+    );
   });
 
   it('preserves output rows in compact task detail views', () => {

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -30,6 +30,27 @@ describe('CLI external inquiry modal', () => {
     });
   });
 
+  it('keeps compact long questions scrollable', () => {
+    const question = Array.from(
+      { length: 8 },
+      (_, index) => `Question detail row ${index + 1}`,
+    ).join('\n');
+    const lines = boundedExternalInquiryQuestionLines({
+      maxDisplayLines: 3,
+      question,
+      scrollOffset: 3,
+      width: 80,
+    });
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]?.text).toBe('Question detail row 4');
+    expect(lines.at(-1)).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('previous'),
+    });
+    expect(lines.at(-1)?.text).toContain('more rows');
+  });
+
   it('keeps the answer caret in the visible clipped input window', () => {
     const display = textInputDisplayWindow({
       cursor: 170,

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -43,4 +43,25 @@ describe('CLI external inquiry modal', () => {
     expect(display.cursor).toBeGreaterThan(0);
     expect(display.cursor).toBeLessThanOrEqual(display.value.length);
   });
+
+  it('counts literal newlines against the clipped input row budget', () => {
+    const value = [
+      'line one',
+      'line two',
+      'line three',
+      'line four',
+      'line five',
+    ].join('\n');
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 2,
+      value,
+      width: 80,
+    });
+
+    expect(display.clipped).toBe(true);
+    expect(display.value.split('\n')).toHaveLength(2);
+    expect(display.value.startsWith('…')).toBe(true);
+    expect(display.cursor).toBe(display.value.length);
+  });
 });

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  boundedExternalInquiryQuestionLines,
+  externalInquiryAnswerRowsBudget,
+  externalInquiryQuestionRowsBudget,
+} from '@cli/chat/tui/modals/ExternalInquiry';
+import { textInputDisplayWindow } from '@cli/chat/tui/input/BaseTextInput';
+
+describe('CLI external inquiry modal', () => {
+  it('bounds long question text to the foreground row budget', () => {
+    const answerRows = externalInquiryAnswerRowsBudget(18);
+    const questionRows = externalInquiryQuestionRowsBudget({
+      answerRows,
+      availableRows: 18,
+    });
+    const lines = boundedExternalInquiryQuestionLines({
+      maxDisplayLines: questionRows,
+      question: Array.from(
+        { length: 24 },
+        (_, index) => `Question detail row ${index + 1}`,
+      ).join('\n'),
+      width: 80,
+    });
+
+    expect(lines).toHaveLength(questionRows);
+    expect(lines.at(-1)).toMatchObject({
+      kind: 'overflow',
+      text: expect.stringContaining('more rows'),
+    });
+  });
+
+  it('keeps the answer caret in the visible clipped input window', () => {
+    const display = textInputDisplayWindow({
+      cursor: 170,
+      maxDisplayRows: 2,
+      value: 'Independent verification '.repeat(8),
+      width: 32,
+    });
+
+    expect(display.clipped).toBe(true);
+    expect(display.value.startsWith('…')).toBe(true);
+    expect(display.cursor).toBeGreaterThan(0);
+    expect(display.cursor).toBeLessThanOrEqual(display.value.length);
+  });
+});

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -51,6 +51,24 @@ describe('CLI external inquiry modal', () => {
     expect(lines.at(-1)?.text).toContain('more rows');
   });
 
+  it('does not exceed tiny foreground row budgets with question rows', () => {
+    const answerRows = externalInquiryAnswerRowsBudget(7);
+    const questionRows = externalInquiryQuestionRowsBudget({
+      answerRows,
+      availableRows: 7,
+    });
+
+    expect(answerRows).toBe(1);
+    expect(questionRows).toBe(0);
+    expect(
+      boundedExternalInquiryQuestionLines({
+        maxDisplayLines: questionRows,
+        question: 'hidden question',
+        width: 80,
+      }),
+    ).toEqual([]);
+  });
+
   it('keeps the answer caret in the visible clipped input window', () => {
     const display = textInputDisplayWindow({
       cursor: 170,


### PR DESCRIPTION
## Summary
- label task detail metadata as `Description` for sub-workflows while keeping process rows labeled as `Command`
- bound external inquiry questions to the foreground row budget with PgUp/PgDn scrolling
- clamp long external inquiry answers to a fixed rendered input window while preserving the submitted value
- add a TUI harness scenario for compact long external inquiries

Closes #4794

## Validation
- `corepack pnpm run test:kernel -- src/test-kernel/cli/ExternalInquiry.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui external-inquiry-long task-subworkflow-detail`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only layout and labeling changes; approval accept/reject payloads are unchanged aside from display clipping before submit.
> 
> **Overview**
> Improves **foreground panel** readability when approvals or task details use a lot of text.
> 
> The **external inquiry** modal now splits terminal height between a wrapped, scrollable agent question (**PgUp/PgDn**, overflow hints) and a fixed-height answer field. Long answers are **visually clipped** in the input (ellipsis + row/wrap limits) while **Enter still submits the full string**. `ApprovalModal` passes the foreground row budget into that flow.
> 
> **`BaseTextInput`** gains optional `displayWidth` / `maxDisplayRows` via `textInputDisplayWindow` so other inputs can reuse the same clipped rendering without changing edit/submit behavior.
> 
> In **task / sub-workflow detail**, metadata labels use a shared **`TASK_DETAIL_LABEL_WIDTH`** so **Description:** (sub-workflows) aligns like **Command:** (shell tasks).
> 
> Adds a **TUI harness** path and **`external-inquiry-long`** validator scenario, plus kernel tests for inquiry layout and clipped input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbc2189e98dfc1b76b1f00e956cb3d88b2aa51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->