### PR TITLE
fix(cli): initialize TUI harness slash forms

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2,10 +2,15 @@
 // to the real terminal. Used to verify the ConversationPane viewport without
 // needing API access. Exits on Ctrl-C.
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { render } from 'ink';
 import React from 'react';
 
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { tryPlatform } from '@platform/platform';
 import {
   STREAM_STATUS,
   TODO_STATUS,
@@ -36,10 +41,13 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../src/schemas/cliSettings';
+import { initLocalCliPlatform } from '../src/runtime/initPlatform';
+import { resolveCliResourcesPath } from '../src/runtime/resourcesPath';
 
 const STREAM_ID = 'harness-stream-1';
 const HARNESS_APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
 const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
+const HARNESS_BTW_USAGE = 'Usage: /btw <message>';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
@@ -56,6 +64,15 @@ const EDIT_APPROVAL_DELAY_MS = Number(
 );
 const QUEUED_FOLLOW_UPS = parseList(process.env.HARNESS_QUEUED_FOLLOWUPS);
 const HARNESS_FOLLOW_UP_QUEUE = ToolUseFollowUpQueue.acquire(STREAM_ID);
+const HARNESS_CWD_INPUT = process.env.HARNESS_CWD?.trim();
+// Keep platform state writes out of the repository unless a scenario opts in.
+const HARNESS_CWD =
+  HARNESS_CWD_INPUT || mkdtempSync(path.join(tmpdir(), 'texra-tui-harness-'));
+if (!HARNESS_CWD_INPUT && process.env.HARNESS_KEEP_CWD !== '1') {
+  process.once('exit', () => {
+    rmSync(HARNESS_CWD, { recursive: true, force: true });
+  });
+}
 for (const followUp of QUEUED_FOLLOW_UPS) {
   HARNESS_FOLLOW_UP_QUEUE.enqueue(followUp);
 }
@@ -67,6 +84,15 @@ function parseList(value: string | undefined): string[] {
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
 }
+
+await initLocalCliPlatform({
+  apiMode: 'personal',
+  cwd: HARNESS_CWD,
+  installSignalHandlers: false,
+  resourcesPath: resolveCliResourcesPath(),
+  storageRoot: path.join(HARNESS_CWD, '.texra-storage'),
+  helperModel: 'harness-model',
+});
 
 function makeEntries(count: number): ConversationEntry[] {
   const entries: ConversationEntry[] = [];
@@ -189,7 +215,7 @@ function applyHarnessApprovalDecision(decision: ApprovalDecision): void {
 cliState.sessionMeta.set({
   agent: 'chat',
   model: 'harness-model',
-  cwd: process.cwd(),
+  cwd: HARNESS_CWD,
   apiMode: 'personal',
   canDelegate: CAN_DELEGATE,
   teamName: TEAM_NAME,
@@ -392,6 +418,33 @@ function appendHarnessAssistantTranscript(text: string): void {
   }));
 }
 
+function refreshHarnessFollowUpState(streamId: string): void {
+  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  patchStream(streamId, (slice) => ({
+    ...slice,
+    status: messages.length > 0 ? STREAM_STATUS.RUNNING : slice.status,
+    runStartedAt:
+      messages.length > 0 && slice.runStartedAt == null
+        ? Date.now()
+        : slice.runStartedAt,
+    queuedFollowUps: messages.length,
+    queuedFollowUpMessages: messages,
+  }));
+}
+
+function queueHarnessFollowUp(input: string): void {
+  const message = input.trim();
+  if (!message) {
+    appendHarnessAssistantTranscript(HARNESS_BTW_USAGE);
+    return;
+  }
+
+  const streamId = cliState.activeStreamId.get() ?? STREAM_ID;
+  ToolUseFollowUpQueue.enqueue(streamId, message, { force: true });
+  refreshHarnessFollowUpState(streamId);
+  appendHarnessAssistantTranscript(`Queued follow-up: ${message}`);
+}
+
 function findRegisteredSlashCommand(name: string): SlashCommand | undefined {
   const lower = name.toLowerCase();
   return listSlashCommands().find(
@@ -576,6 +629,9 @@ function handleHarnessSlashCommand(line: string): boolean {
     case 'yolo':
       applyHarnessApprovalPolicySelection(rest || 'yolo', HARNESS_YOLO_USAGE);
       return true;
+    case 'btw':
+      queueHarnessFollowUp(rest);
+      return true;
     default: {
       const command = findRegisteredSlashCommand(commandName);
       if (!command) {
@@ -636,11 +692,22 @@ const ink = render(
   },
 );
 
+let harnessExiting = false;
+async function exitHarness(exitCode: number): Promise<void> {
+  if (harnessExiting) return;
+  harnessExiting = true;
+  ink.unmount();
+  try {
+    await tryPlatform()?.lifecycle.runShutdown();
+  } finally {
+    process.exit(exitCode);
+  }
+}
+
 process.on('SIGINT', () => {
   if (canInterrupt) {
     markHarnessInterrupted();
     return;
   }
-  ink.unmount();
-  process.exit(0);
+  void exitHarness(0);
 });

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -676,13 +676,23 @@ registerBuiltinSlashCommands({
   },
 });
 
-const ink = render(
+let ink: ReturnType<typeof render>;
+function handleHarnessCtrlC(): void {
+  if (canInterrupt) {
+    markHarnessInterrupted();
+    return;
+  }
+  void exitHarness(0);
+}
+
+ink = render(
   <App
     onSubmit={handleHarnessSubmit}
     onKillExecution={markHarnessExecutionStopped}
     canInterruptActiveRun={() => canInterrupt}
     canStopActiveRun={() => canInterrupt}
     onInterruptActive={markHarnessInterrupted}
+    onCtrlC={handleHarnessCtrlC}
   />,
   {
     stdout: process.stdout,
@@ -704,10 +714,4 @@ async function exitHarness(exitCode: number): Promise<void> {
   }
 }
 
-process.on('SIGINT', () => {
-  if (canInterrupt) {
-    markHarnessInterrupted();
-    return;
-  }
-  void exitHarness(0);
-});
+process.on('SIGINT', handleHarnessCtrlC);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -101,6 +101,49 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'btw-submit',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/btw check the finite case later', '\r'],
+    frame: 'tail',
+    expect: [
+      'Queued follow-up: check the finite case later',
+      'queued 1',
+      'check the finite case later',
+    ],
+    unexpect: ['registered but has no harness action'],
+  },
+  {
+    name: 'agent-form',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/agent', '\r'],
+    expect: ['/agent', 'Tool-use agents', 'Esc close'],
+    unexpect: ['Platform not initialized', '/agent - error'],
+  },
+  {
+    name: 'model-form',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/model', '\r'],
+    frame: 'tail',
+    expect: ['/model · personal API keys', 'Available models'],
+    unexpect: ['Platform not initialized', '/model - error'],
+  },
+  {
+    name: 'api-form',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/api', '\r'],
+    frame: 'tail',
+    expect: ['/api', 'Personal API keys', 'Included relay'],
+    unexpect: ['ServerSideKeyService not initialized'],
+  },
+  {
+    name: 'tools-form',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/tools', '\r'],
+    frame: 'tail',
+    expect: ['/tools', 'Toggle available external integrations'],
+    unexpect: ['[TeXRA]', 'toolUtils'],
+  },
+  {
     name: 'slash-palette-overflow',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/', DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN],
@@ -432,6 +475,22 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: [ETX],
     expectExit: true,
+  },
+  {
+    name: 'ctrl-c-interrupt-active',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ETX],
+    frame: 'tail',
+    expect: [
+      'Harness interrupt requested.',
+      '[main](stopped)',
+      '◆ stopped api',
+    ],
   },
 ];
 

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -1,7 +1,5 @@
-import { existsSync } from 'node:fs';
 import { readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
@@ -19,6 +17,7 @@ import {
   type CliConfigValues,
   type CliOutputFormat,
 } from './cliConfig';
+import { resolveCliResourcesPath } from './resourcesPath';
 
 export type CliMode = 'headless' | 'interactive';
 
@@ -124,17 +123,6 @@ async function resolveCliVersion(): Promise<string> {
     }
   }
   return 'unknown';
-}
-
-function resolveResourcesPath(): string {
-  const currentFile = fileURLToPath(import.meta.url);
-  const currentDir = path.dirname(currentFile);
-  const candidates = [
-    path.resolve(currentDir, '../resources'),
-    path.resolve(currentDir, '../../../extension/resources'),
-    path.resolve(currentDir, '../../extension/resources'),
-  ];
-  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
 }
 
 export interface CliGlobalArgs {
@@ -290,7 +278,7 @@ export async function buildCliContext(
     stderrIsTty: ambient.stderrIsTty,
     colorEnabled: ambient.colorEnabled,
     version: await readCliVersion(),
-    resourcesPath: resolveResourcesPath(),
+    resourcesPath: resolveCliResourcesPath(),
     cliConfig: loadedConfig.values,
     configFilePath: loadedConfig.path,
     configWarnings,

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -47,6 +47,14 @@ let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
 let shutdownHandlersInstalled = false;
 
+type CliPlatformInitOptions = Pick<
+  CliContext,
+  'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel'
+> & {
+  readonly installSignalHandlers?: boolean;
+  readonly storageRoot?: string;
+};
+
 function logAt(
   level: 'debug' | 'info' | 'warn',
   channel: string,
@@ -101,10 +109,7 @@ export async function setCliHelperModel(
  * no provider calls), not safety. Destructive local operations belong here.
  */
 export async function initLocalCliPlatform(
-  context: Pick<
-    CliContext,
-    'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel'
-  >,
+  context: CliPlatformInitOptions,
 ): Promise<void> {
   await initCliPlatform({
     ...context,
@@ -114,10 +119,8 @@ export async function initLocalCliPlatform(
 }
 
 export async function initCliPlatform(
-  context: Pick<
-    CliContext,
-    'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel' | 'quietLogs'
-  > & { skipIncludedModelAccess?: boolean },
+  context: CliPlatformInitOptions &
+    Pick<CliContext, 'quietLogs'> & { skipIncludedModelAccess?: boolean },
 ): Promise<void> {
   cliWorkspaceCwd = context.cwd;
   quietPlatformLogs = context.quietLogs ?? false;
@@ -130,6 +133,7 @@ export async function initCliPlatform(
       workspaceCliConfigPath(cliWorkspaceCwd),
     );
     const stateStores = await createCliStateStores({
+      storageRoot: context.storageRoot,
       workspacePath: () => cliWorkspaceCwd,
     });
     const lifecycle = createLifecycleHost({
@@ -153,7 +157,9 @@ export async function initCliPlatform(
       lifecycle,
       agentResume: { tryResumeStream: async () => false },
     });
-    installCliShutdownSignalHandlers(lifecycle);
+    if (context.installSignalHandlers !== false) {
+      installCliShutdownSignalHandlers(lifecycle);
+    }
     // Direct LSP adapter for Lean tools — spawns `lake env lean --server`
     // lazily, one server per Lake project root. Errors are surfaced via the
     // Tools dashboard if `lake` isn't on PATH; nothing happens at startup

--- a/packages/cli/src/runtime/resourcesPath.ts
+++ b/packages/cli/src/runtime/resourcesPath.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function findCliPackageDir(startDir: string): string {
+  let dir = startDir;
+  while (true) {
+    if (
+      path.basename(dir) === 'cli' &&
+      existsSync(path.join(dir, 'package.json'))
+    ) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return startDir;
+    dir = parent;
+  }
+}
+
+export function resolveCliResourcesPath(anchorUrl = import.meta.url): string {
+  const currentDir = path.dirname(fileURLToPath(anchorUrl));
+  const packageDir = findCliPackageDir(currentDir);
+  const candidates = [
+    path.resolve(packageDir, 'dist/resources'),
+    path.resolve(packageDir, '../extension/resources'),
+    path.resolve(currentDir, '../resources'),
+    path.resolve(currentDir, '../../../extension/resources'),
+    path.resolve(currentDir, '../../extension/resources'),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+}


### PR DESCRIPTION
## Summary
- Initialize the TUI harness with the quiet local CLI platform so slash forms can read agent, model, API, and tool state without in-frame setup errors.
- Keep harness platform state and storage under a temp workspace by default, clean it up on exit, and run platform shutdown from the harness Ctrl-C exit path.
- Let harness callers opt out of CLI process signal handlers so active-run Ctrl-C interrupts do not double-fire into an exit.
- Share CLI resource-path resolution between normal CLI startup and the TUI harness.
- Add PTY scenarios for `/btw <message>`, `/agent`, `/model`, `/api`, `/tools`, and active-run Ctrl-C interruption.

Closes #4796.

## Validation
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli validate:tui` (31 scenarios)
- `npm run compile:safe`
- `npm run lint` (exited 0; existing import-order warnings outside this patch remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the TUI harness, shared resource-path helper, and optional platform init flags; production CLI signal handling remains default-on.
> 
> **Overview**
> The **TUI test harness** now boots the same **quiet local CLI platform** as other local-only commands, so slash forms (`/agent`, `/model`, `/api`, `/tools`) can load real state instead of showing “platform not initialized” errors. By default it uses a **temp workspace** (optional `HARNESS_CWD`) with storage under `.texra-storage`, cleans up on exit, and runs **platform shutdown** when leaving.
> 
> **Ctrl-C** is routed through `App`’s `onCtrlC`: interrupt an active run when `HARNESS_CAN_INTERRUPT` is set, otherwise exit after unmounting Ink. Harness init passes **`installSignalHandlers: false`** so CLI SIGINT handlers do not fight the harness. **`/btw`** queues follow-ups in the harness and updates queued-follow-up UI state.
> 
> **Resource path resolution** moves to shared `resolveCliResourcesPath` (used by normal `buildCliContext` and the harness). **`initLocalCliPlatform` / `initCliPlatform`** accept optional `storageRoot` and `installSignalHandlers`.
> 
> **`validate-tui`** adds PTY scenarios for `/btw` submit, slash forms, and Ctrl-C interrupt-vs-exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a371ee04723fca0342cf5bc17e7b4957cc096e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->