### PR TITLE
fix(cli): support odyssey plan approval

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -52,6 +52,8 @@ const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
 const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
+const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
+const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const EXTERNAL_INQUIRY_QUESTION =
@@ -211,6 +213,32 @@ function makeBashApprovalPayload() {
   };
 }
 
+function makePlanApprovalPayload() {
+  return {
+    approvalId: 'harness-plan-approval',
+    streamId: STREAM_ID,
+    odysseyEnabled: PLAN_APPROVAL_ODYSSEY,
+    plan: {
+      summary: 'Coordinate a short math proof through CLI chat.',
+      steps: [
+        {
+          title: 'Split the finite and symbolic cases',
+          description:
+            'Separate the bounded search from the algebraic simplification.',
+          files: ['proof.md'],
+          status: TODO_STATUS.PENDING,
+        },
+        {
+          title: 'Ask a checker to verify the enumeration',
+          description: 'Use a delegated agent before writing the final answer.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+      ],
+    },
+  };
+}
+
 function applyHarnessApprovalDecision(decision: ApprovalDecision): void {
   if (decision.accepted && decision.bypass === 'bash') {
     patchStream(STREAM_ID, (slice) => ({
@@ -224,6 +252,16 @@ function applyHarnessApprovalDecision(decision: ApprovalDecision): void {
       bypass: { ...slice.bypass, toolEdit: true },
     }));
   }
+}
+
+function appendHarnessPlanDecision(decision: ApprovalDecision): void {
+  if (decision.planAction === 'approve_and_odyssey') {
+    appendHarnessAssistantTranscript('PLAN-ODYSSEY');
+    return;
+  }
+  appendHarnessAssistantTranscript(
+    decision.accepted ? 'PLAN-APPROVED' : 'PLAN-REJECTED',
+  );
 }
 
 cliState.sessionMeta.set({
@@ -395,6 +433,16 @@ if (SHOW_EXTERNAL_INQUIRY) {
     },
     { onPresent: () => notify({ kind: 'approvalNeeded' }) },
   ).then(applyHarnessApprovalDecision);
+}
+
+if (SHOW_PLAN_APPROVAL) {
+  void enqueueApproval(
+    {
+      kind: 'plan',
+      payload: makePlanApprovalPayload(),
+    },
+    { onPresent: () => notify({ kind: 'approvalNeeded' }) },
+  ).then(appendHarnessPlanDecision);
 }
 
 function markHarnessInterrupted(): void {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -37,6 +37,7 @@ import { spawnSync } from 'node:child_process';
 
 const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
+const DC2 = String.fromCharCode(18); // Ctrl-R
 const DOWN = ESC + '[B';
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
@@ -261,6 +262,62 @@ const SCENARIOS = [
     ],
     unexpect: ['└─Degenerate triples', '[/model]models'],
     maxBlankLinesBetween: [{ from: '└', to: 'Tip:', max: 1 }],
+  },
+  {
+    name: 'plan-approval',
+    env: { HARNESS_ENTRIES: '4', HARNESS_PLAN_APPROVAL: '1' },
+    bootExpect: 'Use foreground panel shortcuts',
+    expect: [
+      'Approve plan?',
+      'Coordinate a short math proof through CLI chat.',
+      'y approve',
+      'n reject',
+    ],
+    unexpect: ['r approve & run', '[/model]models'],
+  },
+  {
+    name: 'plan-approval-odyssey',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_PLAN_APPROVAL: '1',
+      HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    expect: [
+      'Approve plan?',
+      'Coordinate a short math proof through CLI chat.',
+      'Split the finite and symbolic cases',
+      'r approve & run',
+      'y approve',
+      'n reject',
+    ],
+    unexpect: ['[/model]models'],
+  },
+  {
+    name: 'plan-approval-approve-odyssey',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_PLAN_APPROVAL: '1',
+      HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: ['r'],
+    frame: 'tail',
+    expect: ['PLAN-ODYSSEY', '[/status]details', '[/model]models'],
+    unexpect: ['Approve plan?', '1 approval'],
+  },
+  {
+    name: 'plan-approval-ctrl-r-ignored',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_PLAN_APPROVAL: '1',
+      HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: [DC2],
+    frame: 'tail',
+    expect: ['Approve plan?', 'r approve & run', '1 approval'],
+    unexpect: ['PLAN-ODYSSEY', '[/model]models'],
   },
   {
     name: 'edit-approval-reject',

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -94,6 +94,7 @@ export function ConfirmCard({
           setFeedbackActive(true);
           return;
         case 'ignore':
+          if (key.ctrl || key.meta) return;
           for (const action of extraActions) {
             if (input.toLowerCase() === action.key.toLowerCase()) {
               onDecide(action.decision);

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -9,6 +9,8 @@ export type ConfirmCardKeyAction =
 
 export interface ConfirmCardKey {
   readonly escape?: boolean;
+  readonly ctrl?: boolean;
+  readonly meta?: boolean;
 }
 
 export interface ConfirmCardHintAction {
@@ -33,6 +35,7 @@ export function confirmCardKeyAction(
   allowAlways: boolean,
 ): ConfirmCardKeyAction {
   if (key.escape) return 'reject';
+  if (key.ctrl || key.meta) return 'ignore';
   switch (input.toLowerCase()) {
     case 'y':
       return 'approve';

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -1,9 +1,8 @@
 import { Box, Text } from 'ink';
-import { ConfirmInput } from '@inkjs/ui';
 
 import type { PlanApprovalPermission } from '@shared/schemas';
 
-import { KeyHints } from '../ui/KeyHints';
+import { ConfirmCard } from './ConfirmCard';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface PlanApprovalProps {
@@ -15,15 +14,27 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
   const { summary, steps } = props.payload.plan;
 
   return (
-    <Box
+    <ConfirmCard
       borderStyle="double"
-      borderColor="blue"
-      flexDirection="column"
-      paddingX={1}
+      color="blue"
+      title="Approve plan?"
+      extraActions={
+        props.payload.odysseyEnabled
+          ? [
+              {
+                key: 'r',
+                label: 'approve & run',
+                decision: {
+                  accepted: true,
+                  planAction: 'approve_and_odyssey',
+                },
+              },
+            ]
+          : []
+      }
+      feedbackPlaceholder="Feedback to send with rejection"
+      onDecide={props.onDecide}
     >
-      <Text bold color="blue">
-        Approve plan?
-      </Text>
       {summary ? (
         <Box marginY={1}>
           <Text>{summary}</Text>
@@ -37,21 +48,6 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
           </Text>
         ))}
       </Box>
-      <Box marginTop={1}>
-        <ConfirmInput
-          onConfirm={() => props.onDecide({ accepted: true })}
-          onCancel={() => props.onDecide({ accepted: false })}
-        />
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'y', action: 'approve' },
-            { key: 'n', action: 'reject' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -16,6 +16,7 @@ import type {
   ApprovalDecision as SharedApprovalDecision,
   BashPermission,
   ExternalInquiryPermission,
+  PlanApprovalAction,
   PlanApprovalPermission,
   RetryPermission,
   UserQuestionPermission,
@@ -44,6 +45,8 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */
   readonly apiMode?: CliApiMode;
+  /** Plan-only approval action when plain approve/reject is not specific enough. */
+  readonly planAction?: Extract<PlanApprovalAction, 'approve_and_odyssey'>;
 }
 
 export interface PendingApproval {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -285,7 +285,7 @@ function dispatchPlan(
 ): void {
   const feedback = feedbackOnReject(decision);
   resolvePlanApproval(payload.approvalId, {
-    action: decision.accepted ? 'approve' : 'reject',
+    action: decision.accepted ? (decision.planAction ?? 'approve') : 'reject',
     ...(feedback ? { feedback } : {}),
   });
 }


### PR DESCRIPTION
## Summary
- Add the CLI TUI `r approve & run` action for plan approvals when `odysseyEnabled` is true.
- Route that action through the existing `approve_and_odyssey` plan coordinator result instead of collapsing every accepted plan to plain `approve`.
- Move the plan modal onto the shared confirmation card so it gets consistent hints, Esc cancel, and reject-with-feedback behavior.
- Keep confirmation-card extra actions from firing on Ctrl/meta chords, so Ctrl-R does not approve and run.
- Add TUI harness coverage for default plan approval, Odyssey rendering/dispatch, and Ctrl-R safety.

Closes #4798.

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- plan-approval plan-approval-odyssey plan-approval-approve-odyssey plan-approval-ctrl-r-ignored`
- `corepack pnpm --filter @texra-ai/cli validate:tui` (36 scenarios)
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (exited 0; existing import-order warnings outside this patch remain)
