### PR TITLE
fix: escape subagent response delivery

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -82,7 +82,7 @@ export function summarizeSubagentFollowup(text: string): string {
     const wall = innerTag(trimmed, 'wall-time');
     const response = innerTag(trimmed, 'response');
     const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
-    return response ? `${head}\n${response}` : head;
+    return response ? `${head}\n${decodeXmlEntities(response)}` : head;
   }
 
   // <subagent-error>

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -58,6 +58,17 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
+  it('decodes escaped result responses for display', () => {
+    const xml = [
+      '<subagent-result id="abc" agent="research" category="toolUse" status="completed">',
+      '<response>Keep &lt;/response> literal &amp; inspect &lt;file&gt;</response>',
+      '</subagent-result>',
+    ].join('\n');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '✓ research completed\nKeep </response> literal & inspect <file>',
+    );
+  });
+
   it('summarizes a result without a response body', () => {
     expect(
       summarizeSubagentFollowup(

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -1,0 +1,26 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { ToolUseFlowResult } from '@agent/runtime/AgentFlowResult';
+import { formatSubagentDelivery } from '@tools/subagentResults';
+
+describe('formatSubagentDelivery', () => {
+  it('escapes tool-use response bodies at the XML boundary', () => {
+    const result = {
+      category: 'toolUse',
+      executionId: 'abc123',
+      streamId: 'child-stream',
+      status: 'stopped',
+      lastResponse:
+        'Keep </response> literal & preserve <subagent-result> text.',
+    } satisfies ToolUseFlowResult;
+
+    const delivery = formatSubagentDelivery('reviewer', result);
+
+    expect(delivery).toContain(
+      'Keep &lt;/response> literal &amp; preserve &lt;subagent-result> text.',
+    );
+    expect(delivery).not.toContain('Keep </response> literal');
+  });
+});

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -145,7 +145,7 @@ export function formatSubagentDelivery(
     }
   } else if (result.category === 'toolUse') {
     if (result.lastResponse) {
-      lines.push('<response>', result.lastResponse, '</response>');
+      lines.push('<response>', escapeText(result.lastResponse), '</response>');
     }
     if (result.touchedFiles && result.touchedFiles.length > 0) {
       lines.push(


### PR DESCRIPTION
## Summary

- escape tool-use subagent response bodies before embedding them in `<subagent-result>` XML
- decode escaped response bodies in the shared subagent follow-up summary path so CLI/progress display remains readable
- add regression coverage for malformed response-like text such as `</response>` and `<subagent-result>`

## Root Cause

`formatSubagentDelivery()` escaped subagent attributes, files, working directories, and error messages, but inserted `result.lastResponse` directly inside `<response>`. A subagent answer containing XML-like text could therefore corrupt or truncate the handoff block consumed by the parent orchestrator and display summarizers.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/cli/SubagentFollowup.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

Closes #4800

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how subagent results are serialized into orchestrator follow-up XML; incorrect escaping could still break parsing, but the change is narrow and covered by new tests.
> 
> **Overview**
> Fixes **subagent handoff XML** when a tool-use subagent’s answer contains markup-like text (e.g. `</response>` or nested tags).
> 
> **`formatSubagentDelivery`** now runs tool-use **`lastResponse`** through **`escapeText`** before embedding it in `<response>`, matching other escaped bodies in the same block. **`summarizeSubagentFollowup`** **decodes** those entities when building CLI/progress one-liners so humans still see the original text.
> 
> Regression tests cover delivery escaping and follow-up display decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f411c4b4d9bd7ec947f5bb11efd9092c57cf5448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->