### PR TITLE
fix: show task detail tool output

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -13,7 +13,12 @@ import { formatDuration } from '@utils/core';
 import { isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
 import { orderedDescendantsFromTree } from './focusCycle';
-import type { ProcessOutputTail, StreamSlice } from './cliState';
+import { transcriptEntryLines } from './transcriptLines';
+import type {
+  ConversationEntry,
+  ProcessOutputTail,
+  StreamSlice,
+} from './cliState';
 
 export type ChildControlMode = 'subagents' | 'tasks';
 
@@ -102,6 +107,18 @@ function streamDescription(
     : undefined;
 }
 
+const TASK_DETAIL_TRANSCRIPT_COLUMNS = 120;
+
+function streamEntryTailLines(entry: ConversationEntry): readonly string[] {
+  if (entry.role === 'tool' || entry.role === 'process') {
+    return transcriptEntryLines(entry, TASK_DETAIL_TRANSCRIPT_COLUMNS);
+  }
+  return entry.text
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+}
+
 function streamTranscriptLines(
   child: Pick<ActiveChildInfo, 'childStreamId'>,
   streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
@@ -110,10 +127,7 @@ function streamTranscriptLines(
   const stream = streamsById.get(child.childStreamId);
   if (!stream) return [];
   return stream.entries.flatMap((entry) =>
-    entry.text
-      .split('\n')
-      .map((line) => line.trimEnd())
-      .filter((line) => line.length > 0),
+    streamEntryTailLines(entry).filter((line) => line.trim().length > 0),
   );
 }
 

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -18,7 +18,10 @@ function wrap(text: string, cols: number, prefix = ''): string[] {
     );
 }
 
-function entryLines(entry: ConversationEntry, cols: number): readonly string[] {
+export function transcriptEntryLines(
+  entry: ConversationEntry,
+  cols: number,
+): readonly string[] {
   switch (entry.role) {
     case 'tool':
       return entry.toolUse
@@ -72,7 +75,7 @@ export function transcriptToLines(
   let previousEntry: ConversationEntry | undefined;
   let previousLines: readonly string[] = [];
   for (const entry of slice.entries) {
-    const lines = entryLines(entry, cols);
+    const lines = transcriptEntryLines(entry, cols);
     if (lines.length === 0) continue;
     if (
       out.length > 0 &&

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -29,8 +29,31 @@ import type {
   StreamSlice,
 } from '@cli/chat/tui/state/cliState';
 
+// Local imports - shared schemas
+import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+
 function tail(stdout: string, stderr = ''): ProcessOutputTail {
   return { stdout, stderr };
+}
+
+function toolUse(
+  toolName: string,
+  input: unknown,
+  overrides: Partial<NormalizedToolUse> = {},
+): NormalizedToolUse {
+  return {
+    parsed: {},
+    toolName,
+    errorText: '',
+    outputText: '',
+    userInstructionText: '',
+    input,
+    isError: false,
+    isUserFeedback: false,
+    headerSummary: '',
+    status: TOOL_USE_STATUS.COMPLETED,
+    ...overrides,
+  };
 }
 
 function slice(
@@ -331,6 +354,68 @@ describe('CLI child execution controls', () => {
         label: 'bash',
         command: 'timeout 1800 texra run paper',
         tailLines: ['line one', 'line two'],
+      },
+    ]);
+  });
+
+  it('includes tool and process transcript rows in task details', () => {
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'bash',
+          childStreamId: 'child-a',
+          status: 'completed',
+        },
+      ],
+    });
+    const streams = new Map([
+      [
+        'child-a',
+        slice({
+          entries: [
+            {
+              id: 'tool-1',
+              role: 'tool',
+              text: '',
+              finalized: true,
+              toolUse: toolUse(
+                'bash',
+                { command: 'pnpm test' },
+                {
+                  headerSummary: 'pnpm test',
+                  outputText: 'ok\nsecond line',
+                },
+              ),
+            },
+            {
+              id: 'process-1',
+              role: 'process',
+              text: '',
+              finalized: true,
+              process: {
+                executionId: 'proc-1',
+                title: 'latexmk',
+                status: 'completed',
+                isError: false,
+                tailLines: ['built pdf'],
+              },
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    expect(buildChildControlItems(state, 'tasks', streams)).toMatchObject([
+      {
+        executionId: 'agent-1',
+        tailLines: [
+          '● bash (pnpm test)',
+          '⎿ ok',
+          '  second line',
+          'latexmk · completed',
+          '⎿ built pdf',
+        ],
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- reuse the shared full-fidelity transcript entry renderer for tool and process rows in task/sub-workflow detail previews
- keep existing plain-text transcript handling for assistant/user/error entries
- add a child-control regression covering a sub-workflow detail pane with bash tool output and a completed process row

## Root Cause

The task/sub-workflow picker built child stream detail output by splitting only `entry.text`. Tool and process transcript entries intentionally keep `text` empty and store display content on `entry.toolUse` or `entry.process`, so the detail pane could omit the useful command output.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

Closes #4802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI display logic for child-control task details with a focused regression test; no auth, data, or API surface changes.
> 
> **Overview**
> **Task and sub-workflow detail previews** now show real output for **tool** and **process** transcript rows instead of appearing empty when `entry.text` is blank.
> 
> Child stream tail lines for the task picker route those roles through the shared **`transcriptEntryLines`** renderer (same full-fidelity formatting as the ctrl+t transcript viewer), while assistant/user/error entries still use plain **`entry.text`** line splitting. A **ChildControls** regression test covers bash tool output and a completed process row in **`tailLines`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31e78c38f16d901b544888fc26e2573001ae0f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->