### PR TITLE
test: dogfood subagent followup summaries

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -12,10 +12,14 @@ import React from 'react';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { tryPlatform } from '@platform/platform';
 import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
   STREAM_STATUS,
+  STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
   type ActiveChildInfo,
 } from '@shared/schemas';
+import { getDefaultStreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
@@ -37,6 +41,7 @@ import {
   enqueueApproval,
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
+import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
@@ -54,6 +59,7 @@ const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
 const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
 const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
+const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const EXTERNAL_INQUIRY_QUESTION =
@@ -126,6 +132,36 @@ function makeEntries(count: number): ConversationEntry[] {
     });
   }
   return entries;
+}
+
+function seedSubagentFollowupTranscript(): void {
+  const store = getDefaultStreamLogStore();
+  const timestamp = Date.now();
+  const followups = [
+    '<subagent-progress id="child-a" agent="strategy" type="round" current="2" total="3" />',
+    [
+      '<subagent-result id="child-b" agent="leanSolver" category="toolUse" status="completed">',
+      '<wall-time>2min, 3sec</wall-time>',
+      '<response>Proved &lt;/response> is escaped &amp; visible.</response>',
+      '</subagent-result>',
+    ].join('\n'),
+    [
+      '<subagent-error id="child-c" agent="reviewer" retryable="true">',
+      '<message>rate limit: &lt;tokens&gt; &amp; retries exhausted</message>',
+      '</subagent-error>',
+    ].join('\n'),
+  ];
+  for (const [index, text] of followups.entries()) {
+    store.append(STREAM_ID, {
+      id: `harness-subagent-followup-${index}`,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: timestamp + index,
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+      text: `<orchestrator-followup>${text}</orchestrator-followup>`,
+    });
+  }
+  syncStreamLog(STREAM_ID);
 }
 
 function makeChildEntries(agent: string, action: string): ConversationEntry[] {
@@ -283,6 +319,10 @@ patchStream(STREAM_ID, (slice) => ({
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));
+
+if (SHOW_SUBAGENT_FOLLOWUPS) {
+  seedSubagentFollowupTranscript();
+}
 
 if (SHOW_CHILDREN) {
   const startedAt = Date.now() - 74_000;

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -78,6 +78,7 @@ const SCENARIOS = [
   },
   {
     name: 'queued-followups',
+    cols: 120,
     env: {
       HARNESS_ENTRIES: '2',
       HARNESS_QUEUED_FOLLOWUPS:
@@ -85,6 +86,18 @@ const SCENARIOS = [
     },
     frame: 'tail',
     expect: ['queued 2', 'First queued', 'Second queued'],
+  },
+  {
+    name: 'subagent-followup-summary',
+    env: { HARNESS_ENTRIES: '0', HARNESS_SUBAGENT_FOLLOWUPS: '1' },
+    expect: [
+      '⟳ strategy · round 2/3',
+      '✓ leanSolver completed · 2min, 3sec',
+      'Proved </response> is escaped & visible.',
+      '✗ reviewer failed (retryable)',
+      'rate limit: <tokens> & retries exhausted',
+    ],
+    unexpect: ['<subagent-progress', '<subagent-result', '<subagent-error'],
   },
   {
     name: 'slash-palette',


### PR DESCRIPTION
## Summary

- add a TUI harness mode that appends real subagent progress/result/error follow-up log entries and syncs them through the production CLI transcript summarizer
- add a `subagent-followup-summary` `validate:tui` scenario that asserts visible parent transcript summaries and decoded response/error bodies
- make the existing `queued-followups` scenario width-stable so both queued messages are visible instead of depending on 100-column status truncation

## Root Cause

The PTY harness covered subagent panels and task pickers, but it did not seed actual parent transcript follow-up blocks for `<subagent-progress>`, `<subagent-result>`, or `<subagent-error>`. Regressions in the display path used by parent orchestrator follow-ups could therefore escape the main TUI dogfood suite.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- subagent-followup-summary`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- queued-followups subagent-followup-summary`
- `corepack pnpm --filter @texra-ai/cli validate:tui` (all 37 scenarios)
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

Closes #4804

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness and validator changes; no production CLI runtime behavior is modified.
> 
> **Overview**
> Adds **TUI dogfood coverage** for parent-stream subagent follow-ups: a harness flag seeds real `orchestrator-followup` log entries (progress, result, error) through the default stream log store and **`syncStreamLog`**, then a new **`subagent-followup-summary`** `validate:tui` scenario checks human-readable lines (round progress, completion timing, decoded/escaped bodies) and asserts raw `<subagent-*>` tags never appear on screen.
> 
> The **`queued-followups`** scenario now runs at **120 columns** so both queued messages stay visible instead of flaking on narrow status truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44445a4461b485200d5e8c2f7b7fb65598b1c7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->