### PR TITLE
test: dogfood transcript viewer output

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -17,7 +17,9 @@ import {
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
+  TOOL_USE_STATUS,
   type ActiveChildInfo,
+  type NormalizedToolUse,
 } from '@shared/schemas';
 import { getDefaultStreamLogStore } from '@transcript';
 
@@ -60,6 +62,7 @@ const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
 const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
+const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const EXTERNAL_INQUIRY_QUESTION =
@@ -132,6 +135,43 @@ function makeEntries(count: number): ConversationEntry[] {
     });
   }
   return entries;
+}
+
+function makeLongToolOutput(): NormalizedToolUse {
+  return {
+    parsed: {},
+    toolName: 'bash',
+    errorText: '',
+    outputText: Array.from(
+      { length: 18 },
+      (_, index) =>
+        `tool-output-line-${String(index + 1).padStart(2, '0')}${index === 9 ? ' hidden-middle' : ''}`,
+    ).join('\n'),
+    userInstructionText: '',
+    input: { command: 'python3 enumerate_triples.py' },
+    isError: false,
+    isUserFeedback: false,
+    headerSummary: 'python3 enumerate_triples.py',
+    status: TOOL_USE_STATUS.COMPLETED,
+  };
+}
+
+function makeLongToolOutputEntries(): ConversationEntry[] {
+  return [
+    {
+      id: 'long-tool-user',
+      role: 'user',
+      text: 'Enumerate Pythagorean triples and show the complete output.',
+      finalized: true,
+    },
+    {
+      id: 'long-tool-output',
+      role: 'tool',
+      text: '',
+      finalized: true,
+      toolUse: makeLongToolOutput(),
+    },
+  ];
 }
 
 function seedSubagentFollowupTranscript(): void {
@@ -315,7 +355,9 @@ patchStream(STREAM_ID, (slice) => ({
   status: QUEUED_FOLLOW_UPS.length > 0 ? STREAM_STATUS.RUNNING : slice.status,
   runStartedAt:
     QUEUED_FOLLOW_UPS.length > 0 ? Date.now() - 42_000 : slice.runStartedAt,
-  entries: makeEntries(ENTRY_COUNT),
+  entries: SHOW_LONG_TOOL_OUTPUT
+    ? makeLongToolOutputEntries()
+    : makeEntries(ENTRY_COUNT),
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -38,6 +38,7 @@ import { spawnSync } from 'node:child_process';
 const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
 const DC2 = String.fromCharCode(18); // Ctrl-R
+const DC4 = String.fromCharCode(20); // Ctrl-T
 const DOWN = ESC + '[B';
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
@@ -84,6 +85,7 @@ const SCENARIOS = [
       HARNESS_QUEUED_FOLLOWUPS:
         'First queued follow-up||Second queued follow-up',
     },
+    bootExpect: 'queued 2',
     frame: 'tail',
     expect: ['queued 2', 'First queued', 'Second queued'],
   },
@@ -98,6 +100,29 @@ const SCENARIOS = [
       'rate limit: <tokens> & retries exhausted',
     ],
     unexpect: ['<subagent-progress', '<subagent-result', '<subagent-error'],
+  },
+  {
+    name: 'long-tool-output-elided',
+    env: { HARNESS_ENTRIES: '0', HARNESS_LONG_TOOL_OUTPUT: '1' },
+    expect: [
+      '● bash (python3 enumerate_triples.py)',
+      'tool-output-line-01',
+      '… +9 lines (ctrl + t to view transcript)',
+      'tool-output-line-18',
+    ],
+    unexpect: ['tool-output-line-10 hidden-middle'],
+  },
+  {
+    name: 'transcript-viewer-long-tool-output',
+    env: { HARNESS_ENTRIES: '0', HARNESS_LONG_TOOL_OUTPUT: '1' },
+    keys: [DC4],
+    frame: 'tail',
+    expect: [
+      'tool-output-line-10 hidden-middle',
+      'tool-output-line-18',
+      'PgUp/PgDn page',
+      'Esc close',
+    ],
   },
   {
     name: 'slash-palette',


### PR DESCRIPTION
Closes #4806

## Summary
- add a TUI harness mode that seeds long completed bash/tool output
- validate the main transcript keeps long output elided with the Ctrl-T hint
- validate the Ctrl-T transcript viewer exposes the hidden middle of the same tool output
- stabilize the queued-followups harness scenario by waiting for the queued status before snapshotting

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- long-tool-output-elided transcript-viewer-long-tool-output`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- queued-followups long-tool-output-elided transcript-viewer-long-tool-output`
- `corepack pnpm --filter @texra-ai/cli validate:tui` (post-rebase, all 39 scenarios passed)
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the TUI test harness and validate-tui scenarios; no production chat or transcript rendering logic is modified.
> 
> **Overview**
> Adds **TUI harness/validator coverage** for long completed tool output and the **Ctrl-T transcript viewer**, without changing production UI logic.
> 
> When `HARNESS_LONG_TOOL_OUTPUT=1`, the harness seeds a completed **bash** tool with 18 lines (including a distinctive middle line) instead of generic chat entries. **`validate-tui`** gains **`long-tool-output-elided`** (elision hint, first/last visible lines, middle hidden) and **`transcript-viewer-long-tool-output`** (sends **Ctrl-T** via `DC4`, asserts the full middle line and viewer chrome). The **queued-followups** scenario now uses **`bootExpect: 'queued 2'`** so snapshots wait for the queued status before asserting.
> 
> **Risk:** Low — harness and PTY scenario changes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec26b324d6119cdbb00d353781b9e5042342abed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->