### PR TITLE
fix: preserve orchestrate scrollback

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 import {
+  chmodSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -56,6 +59,7 @@ const { collectTexraThreads } = require(
 const validationEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
 const validationFlagEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';
 const validationFlagContent = 'texra-cli-run-validation\n';
+const ESC = String.fromCharCode(27);
 
 function run(command, args, options = {}) {
   const env = {
@@ -140,6 +144,118 @@ function validateBinarySmoke() {
       (record) => record.kind === 'agent',
     ),
     'agents list NDJSON records should have kind=agent',
+  );
+}
+
+function ensureNodePtySpawnHelperExecutable() {
+  if (process.platform === 'win32') return;
+
+  try {
+    const packageRoot = path.dirname(require.resolve('node-pty/package.json'));
+    const helperPath = path.join(
+      packageRoot,
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      'spawn-helper',
+    );
+    if (!existsSync(helperPath)) return;
+
+    const mode = statSync(helperPath).mode;
+    if ((mode & 0o111) === 0) chmodSync(helperPath, mode | 0o755);
+  } catch {
+    // node-pty will report the underlying PTY load/spawn failure below.
+  }
+}
+
+async function validateOrchestratePreservesScrollback() {
+  ensureNodePtySpawnHelperExecutable();
+  const ptyMod = await import('node-pty');
+  const ptySpawn = ptyMod.spawn ?? ptyMod.default?.spawn;
+  assert(
+    typeof ptySpawn === 'function',
+    'node-pty should expose spawn for orchestration validation',
+  );
+
+  const env = {
+    ...process.env,
+    TERM: 'xterm-256color',
+    FORCE_COLOR: '3',
+    TEXRA_NO_UPDATE_CHECK: '1',
+  };
+  // Exercise the same interactive path a real terminal uses. CI markers make
+  // Ink switch render modes, which hides the behavior this PTY check covers.
+  delete env.CI;
+  delete env.NO_COLOR;
+
+  const result = await new Promise((resolve, reject) => {
+    let output = '';
+    let exitSent = false;
+    let exited = false;
+    let fallbackExitTimer;
+    let promptExitTimer;
+
+    const child = ptySpawn(process.execPath, [binaryPath, 'orchestrate'], {
+      name: 'xterm-256color',
+      cols: 100,
+      rows: 30,
+      cwd: cliRoot,
+      env,
+    });
+
+    const sendExit = () => {
+      if (exitSent || exited) return;
+      exitSent = true;
+      try {
+        child.write(ESC);
+      } catch (err) {
+        if (!exited) reject(err);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      if (!exited) {
+        try {
+          child.kill();
+        } catch {}
+      }
+      clearTimeout(fallbackExitTimer);
+      clearTimeout(promptExitTimer);
+      reject(new Error(`texra orchestrate did not exit\noutput:\n${output}`));
+    }, 12_000);
+
+    child.onData((data) => {
+      output += data;
+      if (
+        !exitSent &&
+        promptExitTimer == null &&
+        output.includes('Choose how to start this CLI session')
+      ) {
+        promptExitTimer = setTimeout(sendExit, 100);
+      }
+    });
+
+    fallbackExitTimer = setTimeout(sendExit, 4_000);
+
+    child.onExit((exit) => {
+      exited = true;
+      clearTimeout(timeout);
+      clearTimeout(fallbackExitTimer);
+      clearTimeout(promptExitTimer);
+      resolve({ output, exit });
+    });
+  });
+
+  assert(
+    result.exit.exitCode === 0 && !result.exit.signal,
+    `texra orchestrate Esc exit should succeed (exit ${result.exit.exitCode}, signal ${result.exit.signal || 'none'})`,
+  );
+  assert(
+    result.output.includes(`${ESC}[2J`),
+    'texra orchestrate should clear the visible launcher screen on exit',
+  );
+  assert(
+    !result.output.includes(`${ESC}[3J`),
+    'texra orchestrate should not erase terminal scrollback on exit',
   );
 }
 
@@ -802,6 +918,7 @@ async function validateCliRunArtifacts() {
   });
   assertSuccess(buildResult, 'pnpm run build');
   validateBinarySmoke();
+  await validateOrchestratePreservesScrollback();
   validateRunCommand();
   validateToolUseAgentRunCommand();
   await validateCodeReviewActionHelpers();

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -7,6 +7,7 @@ const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';
 // `/clear` since the TUI no longer uses the alternate screen, so prior
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
 const CLEAR_SCREEN_AND_SCROLLBACK = '\x1b[2J\x1b[3J\x1b[H';
+const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
 
 export interface CleanupTerminalModesOptions {
   readonly clearItermProgress?: boolean;
@@ -26,6 +27,14 @@ export function cleanupTerminalModes(
 export function clearTerminalScrollback(): void {
   try {
     writeSync(1, CLEAR_SCREEN_AND_SCROLLBACK);
+  } catch {
+    // The terminal may have been closed mid-clear; nothing to do.
+  }
+}
+
+export function clearTerminalVisibleScreen(): void {
+  try {
+    writeSync(1, CLEAR_VISIBLE_SCREEN);
   } catch {
     // The terminal may have been closed mid-clear; nothing to do.
   }

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -2,7 +2,7 @@ import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
 
 import { Select } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
-import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
+import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import type {
   CliOrchestrationAction,
   CliOrchestrationItem,
@@ -78,11 +78,10 @@ export async function runOrchestrationTui(
       },
     );
 
-    // Wipe the picker out of primary-buffer scrollback once Ink has
-    // finished unmounting; the chat / resume / help screen that follows
-    // then starts on a clean buffer instead of stacking under the menu.
+    // Wipe the picker out of the visible screen once Ink has finished
+    // unmounting without erasing the user's primary-buffer scrollback.
     void instance.waitUntilExit().then(() => {
-      clearTerminalScrollback();
+      clearTerminalVisibleScreen();
       resolve(chosen ?? { kind: 'exit' });
     });
   });


### PR DESCRIPTION
Closes #4808

## Summary
- split visible-screen cleanup from destructive scrollback clearing
- use the visible-screen cleanup when `texra orchestrate` exits
- add a PTY validation in `validate:run` that presses `Esc` in `texra orchestrate` and asserts the output does not include `ESC[3J`

## Root Cause
`runOrchestrationTui` reused `clearTerminalScrollback()`, which writes `ESC[2J ESC[3J ESC[H`. That is appropriate for explicit `/clear` behavior, but it erases the user's primary-buffer scrollback when leaving the launcher.

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal cleanup behavior change is scoped to orchestrate exit; chat /clear still erases scrollback, and the new PTY test guards regressions.
> 
> **Overview**
> Fixes **`texra orchestrate`** wiping the user’s terminal history when leaving the launcher. On exit, the orchestration TUI now calls **`clearTerminalVisibleScreen()`** (`ESC[2J` + home) instead of **`clearTerminalScrollback()`** (`ESC[2J`, **`ESC[3J`**, home), so the picker is cleared from the visible screen without erasing primary-buffer scrollback. **`/clear`** in chat still uses the full scrollback clear.
> 
> **`validate:run`** gains a PTY integration test that spawns **`texra orchestrate`**, exits with **Esc**, and asserts **`ESC[2J`** is present while **`ESC[3J`** is not, plus a small **`node-pty`** spawn-helper chmod helper on Unix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4e19ade162dfc145fed016f1d5fdb237964275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->