### PR TITLE
fix: keep compact child pickers readable

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -479,6 +479,49 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'compact-subagent-picker',
+    rows: 10,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 's'], // Option/Alt-s
+    frame: 'tail',
+    expect: [
+      'Subagents',
+      'Stream: main',
+      'strategy',
+      'Enter focus',
+      'Esc close',
+    ],
+    unexpect: ['Tasks and sub-workflows'],
+  },
+  {
+    name: 'compact-task-picker',
+    rows: 10,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p'], // Option/Alt-p
+    frame: 'tail',
+    expect: [
+      'Tasks and sub-workflows',
+      'Stream: main',
+      'strategy',
+      'Enter view',
+      'k kill',
+      'Esc close',
+    ],
+    unexpect: ['Subagents'],
+  },
+  {
     name: 'task-subworkflow-detail',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -38,6 +38,7 @@ export interface ChildControlPickerProps {
 }
 
 export const TASK_DETAIL_LABEL_WIDTH = 13;
+export const ULTRA_COMPACT_PICKER_MAX_ROWS = 4;
 
 export function pickerTitle(mode: ChildControlMode): string {
   return mode === 'subagents' ? 'Subagents' : 'Tasks and sub-workflows';
@@ -47,6 +48,15 @@ export function emptyPickerText(mode: ChildControlMode): string {
   return mode === 'subagents'
     ? 'No active subagents.'
     : 'No active tasks or sub-workflows.';
+}
+
+export function isUltraCompactPickerRows(
+  availableRows: number | undefined,
+): boolean {
+  return (
+    availableRows !== undefined &&
+    availableRows <= ULTRA_COMPACT_PICKER_MAX_ROWS
+  );
 }
 
 export function pickerKeyHints(
@@ -386,12 +396,14 @@ export function ChildControlPicker({
     undefined,
   );
   const streamScopeLabel = activeStreamLabel ?? activeStreamId;
+  const selectedIndex = clampPickerIndex(highlight, items.length);
+  const selectedItem = items[selectedIndex];
   const tailItem = tailExecutionId
     ? items.find((item) => item.executionId === tailExecutionId)
     : undefined;
   const listLayout = computePickerListLayout({
     availableRows,
-    highlight,
+    highlight: selectedIndex,
     itemCount: items.length,
     scopeLineCount: streamScopeLabel !== undefined ? 1 : 0,
   });
@@ -439,20 +451,18 @@ export function ChildControlPicker({
           if (action.index < items.length) setHighlight(action.index);
           return;
         case 'select': {
-          const item = items[highlight];
-          if (!item) return;
-          if (mode === 'subagents' && item.childStreamId) {
-            onFocusStream(item.childStreamId);
+          if (!selectedItem) return;
+          if (mode === 'subagents' && selectedItem.childStreamId) {
+            onFocusStream(selectedItem.childStreamId);
             onClose();
             return;
           }
-          setTailExecutionId(item.executionId);
+          setTailExecutionId(selectedItem.executionId);
           return;
         }
         case 'kill': {
-          const item = items[highlight];
-          if (!item?.killable) return;
-          onKillExecution(item.executionId);
+          if (!selectedItem?.killable) return;
+          onKillExecution(selectedItem.executionId);
           onClose();
           return;
         }
@@ -483,6 +493,31 @@ export function ChildControlPicker({
     );
   }
 
+  if (isUltraCompactPickerRows(availableRows)) {
+    return (
+      <Box flexDirection="column" minWidth={0} width={availableColumns}>
+        <Text bold color="cyan" wrap="truncate-end">
+          {streamScopeText
+            ? `${pickerTitle(mode)} · ${streamScopeText}`
+            : pickerTitle(mode)}
+        </Text>
+        {selectedItem ? (
+          renderItem(selectedItem, selectedIndex, true)
+        ) : (
+          <Text dimColor>{emptyPickerText(mode)}</Text>
+        )}
+        <KeyHints
+          hints={pickerKeyHints(
+            mode,
+            items.length,
+            selectedItem?.killable ?? false,
+          )}
+          confirmCancel={false}
+        />
+      </Box>
+    );
+  }
+
   return (
     <Box
       borderStyle="round"
@@ -507,7 +542,7 @@ export function ChildControlPicker({
             ) : null}
             {visibleItems.map((item, offset) => {
               const index = listLayout.start + offset;
-              return renderItem(item, index, index === highlight);
+              return renderItem(item, index, index === selectedIndex);
             })}
             {listLayout.hiddenAfter > 0 ? (
               <Text dimColor>{`... ${listLayout.hiddenAfter} more`}</Text>
@@ -522,7 +557,7 @@ export function ChildControlPicker({
           hints={pickerKeyHints(
             mode,
             items.length,
-            items[highlight]?.killable ?? false,
+            selectedItem?.killable ?? false,
           )}
           confirmCancel={false}
         />

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -6,6 +6,7 @@ import {
   computePickerListLayout,
   computeTaskDetailLayout,
   emptyPickerText,
+  isUltraCompactPickerRows,
   pickerKeyHints,
   pickerTitle,
   TASK_DETAIL_LABEL_WIDTH,
@@ -769,6 +770,13 @@ describe('CLI child execution controls', () => {
     expect(pickerTitle('tasks')).toBe('Tasks and sub-workflows');
     expect(emptyPickerText('subagents')).toBe('No active subagents.');
     expect(emptyPickerText('tasks')).toBe('No active tasks or sub-workflows.');
+  });
+
+  it('switches child pickers to ultra-compact rendering only at very small budgets', () => {
+    expect(isUltraCompactPickerRows(3)).toBe(true);
+    expect(isUltraCompactPickerRows(4)).toBe(true);
+    expect(isUltraCompactPickerRows(5)).toBe(false);
+    expect(isUltraCompactPickerRows(undefined)).toBe(false);
   });
 
   it('labels task detail metadata by execution type', () => {


### PR DESCRIPTION
## Summary
- add an ultra-compact child picker layout for very small foreground budgets so the title, stream scope, one highlighted item, and controls remain visible
- cover compact subagent and task pickers at 80x10 in the TUI validator
- add unit coverage for the ultra-compact row threshold

Closes #4813.

## Validation
- `TUI_VALIDATE_ROWS=10 TUI_VALIDATE_COLS=80 corepack pnpm --filter @texra-ai/cli validate:tui -- subagent-picker task-picker` (reproduces before the fix)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- compact-subagent-picker compact-task-picker`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- subagent-picker task-picker narrow-subagent-picker narrow-task-picker`
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and picker selection only; no auth, persistence, or execution-path changes.
> 
> **Overview**
> When the foreground panel has **≤4 rows**, subagent and task pickers now use an **ultra-compact** layout: combined title + stream scope, a single highlighted row (navigation still works), and key hints—**without** the bordered multi-item list that was clipping on short terminals.
> 
> Selection handling is tightened by clamping the highlight index and driving Enter/kill/hints off the same **selected** item. **TUI validator** scenarios at **80×10** cover compact subagent (`Alt-s`) and task (`Alt-p`) pickers; a unit test locks the row threshold at **4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025b3bebb998cfbb2262feef4341e183585801a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->