### PR TITLE
test(cli): add orchestrate launcher TUI snapshots

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -44,12 +44,14 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
+import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../src/schemas/cliSettings';
 import { initLocalCliPlatform } from '../src/runtime/initPlatform';
 import { resolveCliResourcesPath } from '../src/runtime/resourcesPath';
+import type { CliOrchestrationItem } from '../src/runtime/orchestration';
 
 const STREAM_ID = 'harness-stream-1';
 const HARNESS_APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
@@ -63,6 +65,7 @@ const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const EXTERNAL_INQUIRY_QUESTION =
@@ -108,6 +111,67 @@ function parseList(value: string | undefined): string[] {
     .split('||')
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
+}
+
+const HARNESS_ORCHESTRATION_ITEMS: readonly CliOrchestrationItem[] = [
+  {
+    value: { kind: 'chat' },
+    label: 'New chat',
+    description: 'Start the default tool-use chat',
+  },
+  {
+    value: {
+      kind: 'preset',
+      preset: 'lean-project',
+      presetName: 'Lean Project',
+    },
+    label: 'Team Lean Project',
+    description: 'built-in; workflow:0; tool-use:7',
+  },
+  {
+    value: { kind: 'preset', preset: 'physicist', presetName: 'Physicist' },
+    label: 'Team Physicist',
+    description: 'built-in; workflow:4; tool-use:9',
+  },
+  {
+    value: {
+      kind: 'preset',
+      preset: 'mathematician',
+      presetName: 'Mathematician',
+    },
+    label: 'Team Mathematician',
+    description: 'built-in; workflow:5; tool-use:7',
+  },
+  {
+    value: {
+      kind: 'preset',
+      preset: 'computer-scientist',
+      presetName: 'Computer Scientist',
+    },
+    label: 'Team Computer Scientist',
+    description: 'built-in; workflow:5; tool-use:8',
+  },
+  {
+    value: { kind: 'help' },
+    label: 'Help',
+    description: 'Show CLI commands',
+  },
+];
+
+if (SHOW_ORCHESTRATION) {
+  const instance = render(
+    <OrchestrationApp
+      items={HARNESS_ORCHESTRATION_ITEMS}
+      onResolve={() => undefined}
+    />,
+    {
+      stdout: process.stdout,
+      stderr: process.stderr,
+      stdin: process.stdin,
+    },
+  );
+  await instance.waitUntilExit();
+  process.exit(0);
 }
 
 await initLocalCliPlatform({

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -128,6 +128,44 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'orchestrate-launcher',
+    env: { HARNESS_ORCHESTRATION: '1' },
+    bootExpect: 'Choose how to start this CLI session.',
+    exitKeys: [ESC],
+    expectExit: true,
+    expect: [
+      'TeXRA',
+      'Choose how to start this CLI session.',
+      'New chat',
+      'Team Lean Project',
+      'Team Physicist',
+      'Help',
+      '1-9/a-z/Enter open',
+      'Esc exit',
+    ],
+    unexpect: ['[/model]models', 'Tip:'],
+  },
+  {
+    name: 'compact-orchestrate-launcher',
+    rows: 10,
+    cols: 80,
+    env: { HARNESS_ORCHESTRATION: '1' },
+    bootExpect: 'Choose how to start this CLI session.',
+    exitKeys: [ESC],
+    expectExit: true,
+    frame: 'tail',
+    expect: [
+      'TeXRA',
+      'Choose how to start this CLI session.',
+      'New chat',
+      'Team Lean Project',
+      '... 2 more',
+      '1-9/a-z/Enter open',
+      'Esc exit',
+    ],
+    unexpect: ['[/model]models', 'Tip:'],
+  },
+  {
     name: 'slash-palette',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],
@@ -1108,11 +1146,15 @@ async function runScenario(scenario) {
   const frame =
     scenario.frame === 'tail' ? frameTail(fullFrame, rows) : fullFrame;
 
-  // exit cleanly: Ctrl-C (a second one if the first only interrupts a run)
-  for (let attempt = 0; attempt < 2 && !exited; attempt += 1) {
-    child.write(ETX);
-    const ctrlcDeadline = Date.now() + 2500;
-    while (!exited && Date.now() < ctrlcDeadline) await sleep(100);
+  // exit cleanly: Ctrl-C by default (a second one if the first only
+  // interrupts a run). Some surfaces, such as the orchestration launcher,
+  // specifically own Esc as their exit affordance.
+  const exitKeys = scenario.exitKeys ?? [ETX, ETX];
+  for (const exitKey of exitKeys) {
+    if (exited) break;
+    child.write(exitKey);
+    const exitDeadline = Date.now() + 2500;
+    while (!exited && Date.now() < exitDeadline) await sleep(100);
   }
   const exitedCleanly = exited?.exitCode === 0 && !exited.signal;
   if (!exited) {
@@ -1145,7 +1187,7 @@ async function runScenario(scenario) {
     const exitDetails = exited
       ? ` (exitCode ${exited.exitCode}, signal ${exited.signal || 'none'})`
       : '';
-    failures.push(`Ctrl-C did not exit the TUI cleanly${exitDetails}`);
+    failures.push(`exit keys did not close the TUI cleanly${exitDetails}`);
   }
 
   return {

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -8,7 +8,7 @@ import type {
   CliOrchestrationItem,
 } from '../runtime/orchestration';
 
-interface OrchestrationAppProps {
+export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
@@ -21,7 +21,9 @@ export function orchestrationKeyHints(): readonly KeyHint[] {
   ];
 }
 
-function OrchestrationApp(props: OrchestrationAppProps): React.JSX.Element {
+export function OrchestrationApp(
+  props: OrchestrationAppProps,
+): React.JSX.Element {
   const app = useApp();
   const { rows } = useWindowSize();
   const maxVisibleItems = Math.max(4, rows - 8);


### PR DESCRIPTION
## Summary
- export the orchestration Ink app so the TUI harness can render it directly
- add normal and compact orchestrate launcher snapshot scenarios
- allow validate-tui scenarios to use Esc as their expected clean-exit key

Closes #4815

## Validation
- corepack pnpm --filter @texra-ai/cli validate:tui -- orchestrate-launcher compact-orchestrate-launcher
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-orchestrate-snapshots orchestrate-launcher compact-orchestrate-launcher
- npm run test:kernel -- src/test-kernel/cli/Orchestration.vitest.mts
- npm run format
- corepack pnpm --filter @texra-ai/cli validate:tui
- corepack pnpm --filter @texra-ai/cli validate:run
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and harness-only changes; production orchestration behavior is unchanged aside from exporting components for the harness.
> 
> **Overview**
> Adds **deterministic TUI snapshot coverage** for the session-start orchestration launcher (the “choose how to start” screen).
> 
> **`OrchestrationApp`** and its props are **exported** from `runOrchestrationTui.tsx` so the harness can render the real Ink UI without going through full CLI boot. The TUI harness gains **`HARNESS_ORCHESTRATION`**: when set, it renders that app with fixed preset/help items and exits immediately after unmount.
> 
> **`validate-tui`** adds **`orchestrate-launcher`** and **`compact-orchestrate-launcher`** scenarios (full vs truncated list with `... 2 more`), asserting copy, key hints, and that chat-only chrome like `[/model]models` does not appear. Scenarios can now specify **`exitKeys`** (orchestration uses **Esc** instead of the default double **Ctrl-C**); failure messages refer to “exit keys” generically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9a7b86bbdb4ba123613820b742b3a28ea684d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->