### PR TITLE
fix(cli): keep narrow child picker close hint visible

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -60,6 +60,7 @@ const LONG_BASH_APPROVAL_COMMAND = [
 ].join('\n');
 const LONG_EXTERNAL_INQUIRY_ANSWER =
   'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
+const TRUNCATED_ESC_CLOSE_HINTS = ['Esc cl…', 'Esc clo…'];
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -646,8 +647,14 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: [ESC + 's'], // Option/Alt-s
     frame: 'tail',
-    expect: ['Subagents', 'Stream: main', 'strategy', 'Enter focus'],
-    unexpect: ['sub-workfl\now', '\n────╯'],
+    expect: [
+      'Subagents',
+      'Stream: main',
+      'strategy',
+      'Enter focus',
+      'Esc close',
+    ],
+    unexpect: ['sub-workfl\now', '\n────╯', ...TRUNCATED_ESC_CLOSE_HINTS],
     maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
@@ -667,8 +674,9 @@ const SCENARIOS = [
       'Stream: main',
       'strategy',
       'Enter view',
+      'Esc close',
     ],
-    unexpect: ['sub-workfl\now', '\n────╯'],
+    unexpect: ['sub-workfl\now', '\n────╯', ...TRUNCATED_ESC_CLOSE_HINTS],
     maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -39,6 +39,7 @@ export interface ChildControlPickerProps {
 
 export const TASK_DETAIL_LABEL_WIDTH = 13;
 export const ULTRA_COMPACT_PICKER_MAX_ROWS = 4;
+export const COMPACT_PICKER_HINT_COLUMNS = 64;
 
 export function pickerTitle(mode: ChildControlMode): string {
   return mode === 'subagents' ? 'Subagents' : 'Tasks and sub-workflows';
@@ -59,15 +60,27 @@ export function isUltraCompactPickerRows(
   );
 }
 
+export function shouldUseCompactPickerKeyHints(
+  availableColumns: number | undefined,
+): boolean {
+  return (
+    availableColumns !== undefined &&
+    availableColumns <= COMPACT_PICKER_HINT_COLUMNS
+  );
+}
+
 export function pickerKeyHints(
   mode: ChildControlMode,
   itemCount: number,
   canKill = itemCount > 0,
+  compact = false,
 ): readonly KeyHint[] {
   if (itemCount <= 0) {
     return [{ key: 'Esc', action: 'close' }];
   }
-  const hints: KeyHint[] = [{ key: '↑/↓', action: 'navigate' }];
+  const hints: KeyHint[] = [
+    { key: '↑/↓', action: compact ? 'nav' : 'navigate' },
+  ];
   if (itemCount > 1) hints.push({ key: '1-9', action: 'jump' });
   hints.push({ key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' });
   if (canKill) hints.push({ key: 'k', action: 'kill' });
@@ -511,6 +524,7 @@ export function ChildControlPicker({
             mode,
             items.length,
             selectedItem?.killable ?? false,
+            shouldUseCompactPickerKeyHints(availableColumns),
           )}
           confirmCancel={false}
         />
@@ -558,6 +572,7 @@ export function ChildControlPicker({
             mode,
             items.length,
             selectedItem?.killable ?? false,
+            shouldUseCompactPickerKeyHints(availableColumns),
           )}
           confirmCancel={false}
         />

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -9,6 +9,7 @@ import {
   isUltraCompactPickerRows,
   pickerKeyHints,
   pickerTitle,
+  shouldUseCompactPickerKeyHints,
   TASK_DETAIL_LABEL_WIDTH,
   taskDetailCommandLabel,
 } from '@cli/chat/tui/modals/ChildControlPicker';
@@ -747,6 +748,12 @@ describe('CLI child execution controls', () => {
       { key: 'k', action: 'kill' },
       { key: 'Esc', action: 'close' },
     ]);
+    expect(pickerKeyHints('tasks', 1, true, true)).toEqual([
+      { key: '↑/↓', action: 'nav' },
+      { key: 'Enter', action: 'view' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'close' },
+    ]);
     expect(childPickerKeyAction({ input: '3' })).toEqual({
       kind: 'jump',
       index: 2,
@@ -763,6 +770,8 @@ describe('CLI child execution controls', () => {
       key: 'k',
       action: 'kill',
     });
+    expect(shouldUseCompactPickerKeyHints(64)).toBe(true);
+    expect(shouldUseCompactPickerKeyHints(65)).toBe(false);
   });
 
   it('labels the task picker as a combined task and sub-workflow view', () => {


### PR DESCRIPTION
## Summary
- use compact child picker footer wording at narrow widths so `Esc close` remains visible
- tighten narrow subagent/task TUI scenarios to require the close hint and reject the truncated form
- add kernel coverage for compact picker hints

Closes #4818

## Validation
- npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- narrow-subagent-picker narrow-task-picker
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-compact-hint-snapshots narrow-subagent-picker narrow-task-picker
- corepack pnpm --filter @texra-ai/cli validate:tui -- subagent-picker task-picker narrow-subagent-picker narrow-task-picker compact-subagent-picker compact-task-picker task-subworkflow-detail task-process-detail
- npm run format
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI copy/layout and test-only changes; no auth, data, or runtime execution paths.
> 
> **Overview**
> Narrow terminals were truncating the child subagent/task picker footer so **`Esc close`** could disappear (e.g. `Esc cl…`). The picker now switches to **shorter key-hint labels** when width is ≤64 columns—**`navigate` → `nav`**—so the full close hint fits in the truncated `KeyHints` row.
> 
> **`validate-tui`** narrow subagent/task scenarios now require **`Esc close`** and reject truncated close-hint fragments; kernel tests cover the compact hint path and the 64-column threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28a42d2b8e0858b99cbe1a9820d3c4e1da3b688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->