### PR TITLE
fix(cli): open task details at latest output

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -65,6 +65,7 @@ const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
@@ -269,6 +270,14 @@ function seedSubagentFollowupTranscript(): void {
 }
 
 function makeChildEntries(agent: string, action: string): ConversationEntry[] {
+  const assistantText =
+    SHOW_LONG_CHILD_OUTPUT && agent === 'strategy'
+      ? Array.from(
+          { length: 18 },
+          (_, index) =>
+            `strategy detail line ${String(index + 1).padStart(2, '0')}${index === 17 ? ' final contradiction found' : ''}`,
+        ).join('\n')
+      : `${agent} is checking the ${action} details and preparing a concise result.`;
   return [
     {
       id: `${agent}-user`,
@@ -279,7 +288,7 @@ function makeChildEntries(agent: string, action: string): ConversationEntry[] {
     {
       id: `${agent}-assistant`,
       role: 'assistant',
-      text: `${agent} is checking the ${action} details and preparing a concise result.`,
+      text: assistantText,
       finalized: false,
     },
   ];

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -617,6 +617,26 @@ const SCENARIOS = [
     unexpect: ['Command:  strategy sub-workflow'],
   },
   {
+    name: 'task-subworkflow-detail-long-output',
+    rows: 16,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+      HARNESS_LONG_CHILD_OUTPUT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', '\r'],
+    expect: [
+      'Task details',
+      'stream · strategy',
+      'strategy detail line 18 final contradiction found',
+      'f focus stream',
+      'Esc back',
+    ],
+    unexpect: ['strategy detail line 01'],
+  },
+  {
     name: 'task-process-detail',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -165,6 +165,12 @@ export interface PickerListLayout {
   readonly visibleCount: number;
 }
 
+export interface TaskDetailScrollState {
+  readonly executionId: string;
+  readonly followsTail: boolean;
+  readonly offset: number;
+}
+
 export function taskDetailCommandLabel(kind: ChildControlItem['kind']): string {
   return kind === 'process' ? 'Command' : 'Description';
 }
@@ -203,6 +209,56 @@ export function computeTaskDetailLayout({
       hasTailLines && rows >= fixedRows + 1
         ? Math.max(1, availableOutputRows)
         : availableOutputRows,
+  };
+}
+
+export function taskDetailInitialScrollOffset(
+  tailLineCount: number,
+  visibleLineCount: number,
+): number {
+  return Math.max(0, tailLineCount - Math.max(0, visibleLineCount));
+}
+
+export function syncTaskDetailScrollState(
+  state: TaskDetailScrollState,
+  executionId: string,
+  maxOffset: number,
+): TaskDetailScrollState {
+  if (state.executionId !== executionId) {
+    return { executionId, followsTail: true, offset: maxOffset };
+  }
+  if (state.followsTail) {
+    return { ...state, offset: maxOffset };
+  }
+  return { ...state, offset: Math.min(state.offset, maxOffset) };
+}
+
+export function taskDetailVisibleScrollOffset(
+  state: TaskDetailScrollState,
+  maxOffset: number,
+): number {
+  if (state.followsTail) return maxOffset;
+  return Math.min(state.offset, maxOffset);
+}
+
+export function moveTaskDetailScrollState(
+  state: TaskDetailScrollState,
+  maxOffset: number,
+  direction: 'down' | 'up',
+): TaskDetailScrollState {
+  const offset = taskDetailVisibleScrollOffset(state, maxOffset);
+  if (direction === 'up') {
+    return {
+      ...state,
+      followsTail: false,
+      offset: Math.max(0, offset - 1),
+    };
+  }
+  const nextOffset = Math.min(maxOffset, offset + 1);
+  return {
+    ...state,
+    followsTail: nextOffset >= maxOffset,
+    offset: nextOffset,
   };
 }
 
@@ -296,7 +352,6 @@ function TaskDetailView({
   readonly onFocusStream: () => void;
   readonly onKill: () => void;
 }): React.JSX.Element {
-  const [scrollOffset, setScrollOffset] = useState(0);
   const metaParts = [
     item.kind === 'process' ? 'shell' : 'stream',
     item.label,
@@ -309,15 +364,25 @@ function TaskDetailView({
     metaRows: metaParts.length,
   });
   const visibleLineCount = layout.visibleLineCount;
-  const maxOffset = Math.max(0, item.tailLines.length - visibleLineCount);
-  const offset = Math.min(scrollOffset, maxOffset);
+  const maxOffset = taskDetailInitialScrollOffset(
+    item.tailLines.length,
+    visibleLineCount,
+  );
+  const [scrollState, setScrollState] = useState<TaskDetailScrollState>(() => ({
+    executionId: item.executionId,
+    followsTail: true,
+    offset: maxOffset,
+  }));
+  const offset = taskDetailVisibleScrollOffset(scrollState, maxOffset);
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
   const compactMeta = metaParts.join(' · ');
   const commandLabel = taskDetailCommandLabel(item.kind);
 
   useEffect(() => {
-    setScrollOffset((current) => Math.min(current, maxOffset));
-  }, [maxOffset]);
+    setScrollState((current) =>
+      syncTaskDetailScrollState(current, item.executionId, maxOffset),
+    );
+  }, [item.executionId, maxOffset]);
 
   useInput((input, key) => {
     const action = childPickerKeyAction({
@@ -332,10 +397,14 @@ function TaskDetailView({
     if (action.kind === 'close') onBack();
     if (action.kind === 'kill' && item.killable) onKill();
     if (action.kind === 'up') {
-      setScrollOffset((current) => Math.max(0, current - 1));
+      setScrollState((current) =>
+        moveTaskDetailScrollState(current, maxOffset, 'up'),
+      );
     }
     if (action.kind === 'down') {
-      setScrollOffset((current) => Math.min(maxOffset, current + 1));
+      setScrollState((current) =>
+        moveTaskDetailScrollState(current, maxOffset, 'down'),
+      );
     }
     if (input.toLowerCase() === 'f' && item.childStreamId) onFocusStream();
   });

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -7,11 +7,15 @@ import {
   computeTaskDetailLayout,
   emptyPickerText,
   isUltraCompactPickerRows,
+  moveTaskDetailScrollState,
   pickerKeyHints,
   pickerKeyHintsForColumns,
   pickerTitle,
+  syncTaskDetailScrollState,
   TASK_DETAIL_LABEL_WIDTH,
   taskDetailCommandLabel,
+  taskDetailInitialScrollOffset,
+  taskDetailVisibleScrollOffset,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
@@ -821,6 +825,70 @@ describe('CLI child execution controls', () => {
       showCommand: true,
       showHints: true,
       visibleLineCount: 5,
+    });
+  });
+
+  it('opens long task detail output at the latest visible tail', () => {
+    expect(taskDetailInitialScrollOffset(2, 5)).toBe(0);
+    expect(taskDetailInitialScrollOffset(12, 5)).toBe(7);
+    expect(taskDetailInitialScrollOffset(12, 0)).toBe(12);
+  });
+
+  it('preserves manual task detail scrolling while new output arrives', () => {
+    const tailing = { executionId: 'task-1', followsTail: true, offset: 7 };
+    expect(syncTaskDetailScrollState(tailing, 'task-1', 8)).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 8,
+    });
+    expect(taskDetailVisibleScrollOffset(tailing, 8)).toBe(8);
+
+    const scrolled = moveTaskDetailScrollState(tailing, 7, 'up');
+    expect(scrolled).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 6,
+    });
+    expect(taskDetailVisibleScrollOffset(scrolled, 8)).toBe(6);
+    expect(syncTaskDetailScrollState(scrolled, 'task-1', 8)).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 6,
+    });
+    expect(syncTaskDetailScrollState(scrolled, 'task-2', 3)).toEqual({
+      executionId: 'task-2',
+      followsTail: true,
+      offset: 3,
+    });
+  });
+
+  it('moves task detail scroll from the visible tail position', () => {
+    const tailing = { executionId: 'task-1', followsTail: true, offset: 7 };
+    expect(moveTaskDetailScrollState(tailing, 9, 'up')).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 8,
+    });
+    expect(moveTaskDetailScrollState(tailing, 9, 'down')).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 9,
+    });
+  });
+
+  it('clamps task detail scroll movement at output boundaries', () => {
+    const top = { executionId: 'task-1', followsTail: false, offset: 0 };
+    expect(moveTaskDetailScrollState(top, 9, 'up')).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 0,
+    });
+
+    const bottom = { executionId: 'task-1', followsTail: true, offset: 9 };
+    expect(moveTaskDetailScrollState(bottom, 9, 'down')).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 9,
     });
   });
 


### PR DESCRIPTION
## Summary
- open task/sub-workflow detail panels at the latest visible output instead of the oldest captured line
- add a long child-output TUI harness fixture and scenario that verifies the final output is visible first
- cover the initial scroll offset helper in the CLI child controls kernel tests

Closes #4820

## Validation
- npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-task-detail-tail-snapshots task-subworkflow-detail-long-output task-subworkflow-detail task-process-detail
- npm run format
- git diff --check
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI scrolling and test/harness coverage only; no auth, data, or runtime execution path changes beyond how task detail output is displayed.
> 
> **Overview**
> Task and sub-workflow **detail** panels in the CLI TUI now **open scrolled to the latest captured output** instead of the first line. Scroll behavior uses a small **tail-following** model: new output keeps the view at the bottom until the user scrolls up, then position is preserved across growth and resets when switching tasks.
> 
> A **TUI harness** flag (`HARNESS_LONG_CHILD_OUTPUT`) and a **`validate-tui`** scenario confirm the strategy sub-workflow detail shows the final line and not the start. **Kernel tests** cover the new scroll offset helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f013ab20683abbadf3013209fb236bec72e682f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->