### PR TITLE
Consolidate duplicate isFiniteNumber guards and fix inconsistent error logging

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -889,9 +889,11 @@ export class ModelHandlerOpenAI<
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMediaContent);
       } catch (err) {
-        this.logger.error(
+        logSdkError(
+          this.logger,
           `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
-          { data: err },
+          err,
+          { operation: 'process media files' },
         );
       }
     }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -5,7 +5,12 @@ import {
   type ProviderError,
   type StreamDiagnostics,
 } from '@shared/schemas';
-import { extractErrorMessage, isFiniteNumber, isObject, isString } from '@utils/core';
+import {
+  extractErrorMessage,
+  isFiniteNumber,
+  isObject,
+  isString,
+} from '@utils/core';
 
 import { toErrorMessage } from './errorMessage';
 import { isDiskFullError } from './errorPredicates';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -5,7 +5,7 @@ import {
   type ProviderError,
   type StreamDiagnostics,
 } from '@shared/schemas';
-import { extractErrorMessage, isObject, isString } from '@utils/core';
+import { extractErrorMessage, isFiniteNumber, isObject, isString } from '@utils/core';
 
 import { toErrorMessage } from './errorMessage';
 import { isDiskFullError } from './errorPredicates';
@@ -319,9 +319,7 @@ type StatusCarrier = {
 };
 
 function pickStatus(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
+  return isFiniteNumber(value) ? value : undefined;
 }
 
 function detectStatusCode(err: unknown): number | undefined {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -11,7 +11,7 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
-import { isObject } from '@utils/core';
+import { isFiniteNumber, isObject } from '@utils/core';
 
 import {
   isRunningGroupEntry,
@@ -592,9 +592,7 @@ export class StreamLogStore {
   }
 
   private parseTimestamp(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value)
-      ? value
-      : undefined;
+    return isFiniteNumber(value) ? value : undefined;
   }
 
   private async writeStream(

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -14,5 +14,5 @@ export {
   serializeError,
   type SerializedError,
 } from './stringCore';
-export { isObject } from './typeGuards';
+export { isObject, isFiniteNumber } from './typeGuards';
 export { debounce, delay } from './async';

--- a/src/utils/core/typeGuards.ts
+++ b/src/utils/core/typeGuards.ts
@@ -6,3 +6,8 @@
 export function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
+
+/** Check if value is a finite number (excludes NaN and ±Infinity). */
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}


### PR DESCRIPTION
## Summary

- Add `isFiniteNumber(value)` type guard to `src/utils/core/typeGuards.ts` and export it from the `@utils/core` barrel, eliminating two identical private inline functions (`pickStatus` in `sdkErrorUtils.ts` and `parseTimestamp` in `StreamLogStore.ts`) that both computed `typeof value === 'number' && Number.isFinite(value)`.
- Fix an inconsistent media-processing error catch block in `modelHandlerOpenAI.ts` that used bare `this.logger.error()` (without operation context or SDK metadata) while every other model handler — and even the same file's `addMediaToUserMessage` — uses `logSdkError()` with an `{ operation }` tag.

## Changes

| File | Change |
|------|--------|
| `src/utils/core/typeGuards.ts` | Add `isFiniteNumber` export |
| `src/utils/core/index.ts` | Re-export `isFiniteNumber` |
| `src/common/errors/sdkErrorUtils.ts` | Use `isFiniteNumber` in `pickStatus`; import from `@utils/core` |
| `src/transcript/StreamLogStore.ts` | Use `isFiniteNumber` in `parseTimestamp`; import from `@utils/core` |
| `src/agent/modelHandlers/modelHandlerOpenAI.ts` | Switch follow-up-round media catch to `logSdkError` |

## Test plan

- [x] `npm run compile:fast` succeeds with no errors
- [ ] Verify media-processing error path in OpenAI handler produces structured log output consistent with other handlers

https://claude.ai/code/session_01Jbn7W32QBiTaSfKF1f7g8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jbn7W32QBiTaSfKF1f7g8T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deduplication and logging consistency changes with no auth, data, or API behavior changes beyond richer error logs on media failures.
> 
> **Overview**
> Introduces a shared **`isFiniteNumber`** type guard in `@utils/core` and uses it wherever persisted or error payloads need a safe numeric status/timestamp (SDK error status picking and stream log summary timestamps), replacing duplicated inline `typeof === 'number' && Number.isFinite` checks.
> 
> Aligns **OpenAI follow-up round** media handling with the rest of the handler: failures in `createRoundMessages` now go through **`logSdkError`** with an `{ operation: 'process media files' }` tag, matching `addMediaToUserMessage` and other model handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe5041b0d4c09f214e3836d1e1b6820f3ef542b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->