### PR TITLE
fix(cli): show compact select overflow

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -235,7 +235,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
     frame: 'tail',
-    expect: ['/agent', 'Tool-use agents', 'Esc close'],
+    expect: ['/agent', 'Tool-use agents', '+4 earlier, +13 more', 'Esc close'],
     unexpect: ['Platform not initialized', '/agent - error'],
   },
   {
@@ -245,7 +245,12 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/model', '\r'],
     frame: 'tail',
-    expect: ['/model · personal API keys', 'Available models', 'Esc close'],
+    expect: [
+      '/model · personal API keys',
+      'Available models',
+      '+3 more',
+      'Esc close',
+    ],
     unexpect: ['Platform not initialized', '/model - error'],
   },
   {
@@ -265,7 +270,12 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],
     frame: 'tail',
-    expect: ['/tools', 'Toggle available external integrations', 'Esc close'],
+    expect: [
+      '/tools',
+      'Toggle available external integrations',
+      '+1 earlier, +6 more',
+      'Esc close',
+    ],
     unexpect: ['[TeXRA]', 'toolUtils'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 2 },

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -128,6 +128,25 @@ export function visibleSelectRange({
   return { start, end: start + visibleCount };
 }
 
+export function selectInlineOverflowText({
+  hiddenAfter,
+  hiddenBefore,
+  showOverflow,
+}: {
+  readonly hiddenAfter: number;
+  readonly hiddenBefore: number;
+  readonly showOverflow: boolean | undefined;
+}): string | undefined {
+  if (showOverflow || (hiddenBefore === 0 && hiddenAfter === 0)) {
+    return undefined;
+  }
+  if (hiddenBefore > 0 && hiddenAfter > 0) {
+    return `+${hiddenBefore} earlier, +${hiddenAfter} more`;
+  }
+  if (hiddenBefore > 0) return `+${hiddenBefore} earlier`;
+  return `+${hiddenAfter} more`;
+}
+
 export function selectItemRenderKey<T>(
   item: SelectItem<T>,
   index: number,
@@ -180,6 +199,14 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const hiddenBefore = visibleRange.start;
   const hiddenAfter = props.items.length - visibleRange.end;
   const visibleItems = props.items.slice(visibleRange.start, visibleRange.end);
+  const inlineOverflowText =
+    visibleItems.length === 1
+      ? selectInlineOverflowText({
+          hiddenAfter,
+          hiddenBefore,
+          showOverflow: props.showOverflow,
+        })
+      : undefined;
 
   useInput((input, key) => {
     if (key.escape) {
@@ -256,11 +283,18 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
                 {item.label}
               </Text>
             </Box>
-            {item.description ? (
-              <Text
-                dimColor
-                wrap="truncate-end"
-              >{` — ${item.description}`}</Text>
+            {focused && inlineOverflowText ? (
+              <Box flexShrink={0}>
+                <Text dimColor>{` — ${inlineOverflowText}`}</Text>
+              </Box>
+            ) : null}
+            {item.description && !inlineOverflowText ? (
+              <Box minWidth={0} flexShrink={1}>
+                <Text
+                  dimColor
+                  wrap="truncate-end"
+                >{` — ${item.description}`}</Text>
+              </Box>
             ) : null}
           </Box>
         );

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -8,6 +8,7 @@ import {
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
   nextSelectHighlightIndex,
+  selectInlineOverflowText,
   selectInitialHighlightIndex,
   selectItemRenderKey,
   visibleSelectRange,
@@ -174,6 +175,42 @@ describe('CLI Select visible range', () => {
         maxVisibleItems: 5,
       }),
     ).toEqual({ start: 3, end: 8 });
+  });
+});
+
+describe('CLI Select inline overflow', () => {
+  it('summarizes hidden choices when separate overflow rows are disabled', () => {
+    expect(
+      selectInlineOverflowText({
+        hiddenBefore: 0,
+        hiddenAfter: 3,
+        showOverflow: false,
+      }),
+    ).toBe('+3 more');
+    expect(
+      selectInlineOverflowText({
+        hiddenBefore: 2,
+        hiddenAfter: 0,
+        showOverflow: false,
+      }),
+    ).toBe('+2 earlier');
+    expect(
+      selectInlineOverflowText({
+        hiddenBefore: 2,
+        hiddenAfter: 4,
+        showOverflow: false,
+      }),
+    ).toBe('+2 earlier, +4 more');
+  });
+
+  it('defers to separate overflow rows when they are enabled', () => {
+    expect(
+      selectInlineOverflowText({
+        hiddenBefore: 0,
+        hiddenAfter: 3,
+        showOverflow: true,
+      }),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- show inline overflow counts when compact Select lists can only render one row
- keep normal overflow rows unchanged for larger form layouts
- add kernel coverage and compact slash-form harness expectations

Fixes #4832

## Validation

- `npm run test:kernel -- src/test-kernel/cli/ModelListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-select-inline-overflow-4 compact-agent-form compact-model-form compact-tools-form compact-api-form agent-form model-form tools-form`
- `npm run compile:safe`
- `npm run lint` (passes with 12 existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI presentation and test-only changes; no auth, data, or runtime API impact.
> 
> **Overview**
> Compact CLI **Select** lists (slash forms with only one visible row and `showOverflow` off) now show **inline** hidden-item hints on the focused row—e.g. `— +3 more` or `— +4 earlier, +13 more`—via new `selectInlineOverflowText` in `Select.tsx`. When that hint is shown, the row’s description is suppressed so the line still fits; separate `... N earlier/more` overflow lines are unchanged when `showOverflow` is true.
> 
> **TUI harness** expectations for compact `/agent`, `/model`, and `/tools` scenarios were updated to assert those strings. **Kernel tests** cover the overflow text helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8562c305291862cb485b0bf7a9654f48e8a8d1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->