### PR TITLE
fix(cli): show compact slash form overflow

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -235,7 +235,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
     frame: 'tail',
-    expect: ['/agent', 'Tool-use agents', 'Esc close'],
+    expect: ['/agent', 'Tool-use agents', 'Esc close', '+', ' more'],
     unexpect: ['Platform not initialized', '/agent - error'],
   },
   {
@@ -245,7 +245,13 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/model', '\r'],
     frame: 'tail',
-    expect: ['/model · personal API keys', 'Available models', 'Esc close'],
+    expect: [
+      '/model · personal API keys',
+      'Available models',
+      'Esc close',
+      '+',
+      ' more',
+    ],
     unexpect: ['Platform not initialized', '/model - error'],
   },
   {
@@ -265,7 +271,13 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],
     frame: 'tail',
-    expect: ['/tools', 'Toggle available external integrations', 'Esc close'],
+    expect: [
+      '/tools',
+      'Toggle available external integrations',
+      'Esc close',
+      '+',
+      ' more',
+    ],
     unexpect: ['[TeXRA]', 'toolUtils'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 2 },

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -135,6 +135,21 @@ export function selectItemRenderKey<T>(
   return `${index}:${item.label}`;
 }
 
+export function selectInlineOverflowText({
+  hiddenBefore,
+  hiddenAfter,
+}: {
+  readonly hiddenBefore: number;
+  readonly hiddenAfter: number;
+}): string | undefined {
+  const earlier = Math.max(0, hiddenBefore);
+  const more = Math.max(0, hiddenAfter);
+  if (earlier > 0 && more > 0) return `+${earlier} earlier, +${more} more`;
+  if (earlier > 0) return `+${earlier} earlier`;
+  if (more > 0) return `+${more} more`;
+  return undefined;
+}
+
 /**
  * Single-key shortcut for a row: `1`-`9` for the first nine, then `a`-`z` for
  * rows 10-35. Rows beyond that have no shortcut (undefined).
@@ -180,6 +195,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const hiddenBefore = visibleRange.start;
   const hiddenAfter = props.items.length - visibleRange.end;
   const visibleItems = props.items.slice(visibleRange.start, visibleRange.end);
+  const inlineOverflowText =
+    props.showOverflow !== true && props.maxVisibleItems === 1
+      ? selectInlineOverflowText({ hiddenBefore, hiddenAfter })
+      : undefined;
 
   useInput((input, key) => {
     if (key.escape) {
@@ -256,11 +275,18 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
                 {item.label}
               </Text>
             </Box>
-            {item.description ? (
-              <Text
-                dimColor
-                wrap="truncate-end"
-              >{` — ${item.description}`}</Text>
+            {focused && inlineOverflowText ? (
+              <Box flexShrink={0}>
+                <Text dimColor>{` ${inlineOverflowText}`}</Text>
+              </Box>
+            ) : null}
+            {item.description && !(focused && inlineOverflowText) ? (
+              <Box flexShrink={1} minWidth={0}>
+                <Text
+                  dimColor
+                  wrap="truncate-end"
+                >{` — ${item.description}`}</Text>
+              </Box>
             ) : null}
           </Box>
         );

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -8,6 +8,7 @@ import {
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
   nextSelectHighlightIndex,
+  selectInlineOverflowText,
   selectInitialHighlightIndex,
   selectItemRenderKey,
   visibleSelectRange,
@@ -174,6 +175,23 @@ describe('CLI Select visible range', () => {
         maxVisibleItems: 5,
       }),
     ).toEqual({ start: 3, end: 8 });
+  });
+});
+
+describe('CLI Select compact inline overflow text', () => {
+  it('summarizes hidden rows around the compact selected row', () => {
+    expect(selectInlineOverflowText({ hiddenBefore: 0, hiddenAfter: 3 })).toBe(
+      '+3 more',
+    );
+    expect(selectInlineOverflowText({ hiddenBefore: 2, hiddenAfter: 0 })).toBe(
+      '+2 earlier',
+    );
+    expect(selectInlineOverflowText({ hiddenBefore: 2, hiddenAfter: 4 })).toBe(
+      '+2 earlier, +4 more',
+    );
+    expect(
+      selectInlineOverflowText({ hiddenBefore: 0, hiddenAfter: 0 }),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Show an inline `+N more` / `+N earlier` marker when compact slash forms can only render one selected row.
- Suppress long row descriptions in that one-row overflow state so the form stays a single stable line.
- Tighten the TUI harness checks for compact `/agent`, `/model`, and `/tools` forms.

Closes #4832

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- compact-agent-form compact-model-form compact-tools-form compact-api-form`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelListForm.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing 12 import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI display and test-only changes with no auth, data, or API impact.
> 
> **Overview**
> Compact slash forms that only show **one** selected row now append an inline **`+N earlier` / `+N more`** hint on the focused line so users still see that more options exist off-screen.
> 
> When that inline overflow is shown, long row **descriptions** are hidden so the line stays stable instead of truncating awkwardly. TUI harness expectations for compact `/agent`, `/model`, and `/tools` forms were updated accordingly, and unit tests cover the new overflow text helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866587ffce6fb1600c04882451a0d57faecddacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->