### PR TITLE
test(cli): validate multi-agent run

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -409,6 +409,81 @@ function validateToolUseAgentRunCommand() {
   }
 }
 
+function validateMultiAgentRunCommand() {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'texra-cli-multi-agent-run-'));
+  try {
+    const inputPath = path.join(cwd, 'math-problem.md');
+    const validationFlagPath = path.join(
+      cwd,
+      '.texra-internal-validation-model-handler',
+    );
+    writeFileSync(
+      inputPath,
+      'Problem: Prove that if n is odd, then n^2 is congruent to 1 modulo 8.\n',
+    );
+    writeFileSync(validationFlagPath, validationFlagContent);
+
+    const baseArgs = [
+      binaryPath,
+      'multi-agent',
+      'run',
+      'mathematician',
+      '--input',
+      'math-problem.md',
+      '--cwd',
+      cwd,
+      '--approval-policy',
+      'never',
+      '--print',
+    ];
+
+    const json = run(
+      process.execPath,
+      [...baseArgs, '--output-format', 'json'],
+      { cwd: repoRoot, validationModel: true, validationFlagPath },
+    );
+    assertSuccess(json, 'texra multi-agent run JSON');
+    const jsonResult = JSON.parse(json.stdout);
+    assert(
+      jsonResult.preset?.id === 'mathematician',
+      'multi-agent JSON output should identify the preset',
+    );
+    assert(
+      typeof jsonResult.rootAgent === 'string' &&
+        jsonResult.rootAgent.length > 0,
+      'multi-agent run should select an available preset root agent',
+    );
+    assert(
+      jsonResult.result?.category === 'toolUse',
+      'multi-agent JSON output should serialize the tool-use result',
+    );
+    assert(
+      String(jsonResult.result?.lastResponse ?? '').includes(
+        'Validated CLI Runtime',
+      ),
+      'multi-agent run should return the validation model response',
+    );
+
+    const ndjson = run(
+      process.execPath,
+      [...baseArgs, '--output-format', 'ndjson'],
+      { cwd: repoRoot, validationModel: true, validationFlagPath },
+    );
+    assertSuccess(ndjson, 'texra multi-agent run NDJSON');
+    assert(
+      parseNdjson(ndjson.stdout, 'multi-agent run NDJSON').some(
+        (record) =>
+          record.kind === 'multi-agent-result' &&
+          record.preset?.id === 'mathematician' &&
+          record.rootAgent === jsonResult.rootAgent,
+      ),
+      'multi-agent run NDJSON should include a preset result record with the selected root agent',
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
 async function validateCodeReviewActionHelpers() {
   assert(
     parseModelJson('{"body":"direct"}').body === 'direct',
@@ -921,6 +996,7 @@ async function validateCliRunArtifacts() {
   await validateOrchestratePreservesScrollback();
   validateRunCommand();
   validateToolUseAgentRunCommand();
+  validateMultiAgentRunCommand();
   await validateCodeReviewActionHelpers();
   console.log('CLI run validation passed');
 }


### PR DESCRIPTION
## Summary

- add a deterministic `texra multi-agent run mathematician` package validation case
- use the internal validation model with a small math prompt to exercise preset resolution, root-agent execution, JSON output, and NDJSON output

Fixes #4838

## Validation

- `corepack pnpm install`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run format -- --log-level warn`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the CLI validation script; no production runtime behavior is modified.
> 
> **Overview**
> Adds **package validation** for `texra multi-agent run` in `validate-run.mjs`, following the same pattern as existing `run` and `agents run` checks.
> 
> A new `validateMultiAgentRunCommand` runs the **`mathematician`** preset against a small math input with the internal validation model, then asserts JSON output includes preset id, a non-empty **root agent**, and a tool-use result with the validation response. It also asserts NDJSON emits a **`multi-agent-result`** record matching that preset and root agent. The function is invoked from **`validateCliRunArtifacts`** after the tool-use agent validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b57f5350791c89014d7ca3559842d000b61e174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->