### PR TITLE
ci: skip desktop workspace validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
-      - name: Type check workspace packages
-        run: pnpm run workspace:typecheck
+      - name: Type check core package
+        run: pnpm --filter @texra/core typecheck
 
       - name: Lint
         run: pnpm run lint


### PR DESCRIPTION
## Summary
- replace the recursive workspace package typecheck in regular CI with a scoped core package typecheck
- keep the root typecheck, lint, kernel tests, extension build, and VSIX checks in the normal CI path
- leave the manual Desktop Package workflow as the desktop build/package path

Closes #4840.

## Validation
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @texra/core typecheck`
- `corepack pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that narrows CI typecheck scope; desktop and other packages are intentionally deferred to a separate workflow.
> 
> **Overview**
> **CI no longer runs recursive workspace typechecks** on every PR. The validate job drops `pnpm run workspace:typecheck` (which hit every package with a `typecheck` script, including desktop) and instead runs **`pnpm --filter @texra/core typecheck`** after the existing root `pnpm run typecheck`.
> 
> Everything else in the matrix—lint, kernel tests, extension compile/build, VSIX checks, and macOS webview smoke—is unchanged. **Desktop package validation stays on the manual Desktop Package workflow**, not the default CI path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf37013aaf0760eb48707bb9aaabfb80df3574f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->