### PR TITLE
fix(cli): clamp agent picker width

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -202,6 +202,15 @@ const SCENARIOS = [
     unexpect: ['Platform not initialized', '/agent - error'],
   },
   {
+    name: 'agent-form-80-cols',
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/agent', '\r'],
+    expect: ['/agent', 'Tool-use agents', 'Esc close'],
+    unexpect: ['Platform not initialized', '/agent - error'],
+    maxLineColumns: 80,
+  },
+  {
     name: 'model-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/model', '\r'],
@@ -1096,6 +1105,10 @@ function blankLinesBetween(frame, from, to) {
     .filter((line) => line.trim().length === 0).length;
 }
 
+function lineColumns(line) {
+  return [...line].length;
+}
+
 function snapshotFileName(index, name, extension = 'txt') {
   const prefix = String(index + 1).padStart(2, '0');
   return `${prefix}-${name.replace(/[^a-z0-9._-]+/gi, '-')}.${extension}`;
@@ -1320,6 +1333,23 @@ async function runScenario(scenario) {
     } else if (actual > check.max) {
       failures.push(
         `too many blank lines between ${JSON.stringify(check.from)} and ${JSON.stringify(check.to)}: ${actual} > ${check.max}`,
+      );
+    }
+  }
+  if (scenario.maxLineColumns != null) {
+    const maxColumns = Number(scenario.maxLineColumns);
+    const tooWide = frame
+      .split('\n')
+      .map((line, index) => ({
+        index: index + 1,
+        columns: lineColumns(line),
+        line,
+      }))
+      .filter((line) => line.columns > maxColumns);
+    if (tooWide.length > 0) {
+      const first = tooWide[0];
+      failures.push(
+        `line ${first.index} exceeds ${maxColumns} columns: ${first.columns} (${JSON.stringify(first.line)})`,
       );
     }
   }

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -1,7 +1,7 @@
 // `/agent` form. It lists visible tool-use agents and workflows. Before the
 // first message, tool-use agents can be chosen as the root chat agent.
 
-import { Box, Text } from 'ink';
+import { Box, Text, useWindowSize } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import { computeAgentOptionsData } from '@agent/index';
@@ -27,6 +27,16 @@ export interface AgentListFormProps {
 interface AgentGroups {
   readonly toolUse: readonly AgentOptionData[];
   readonly workflow: readonly AgentOptionData[];
+}
+
+const AGENT_FORM_MAX_WIDTH = 80;
+
+export function agentFormWidth(columns: number | undefined): number {
+  const normalized =
+    columns != null && Number.isFinite(columns) && columns > 0
+      ? Math.floor(columns)
+      : AGENT_FORM_MAX_WIDTH;
+  return Math.max(1, Math.min(normalized, AGENT_FORM_MAX_WIDTH));
 }
 
 function agentDescription(agent: AgentOptionData): string {
@@ -102,6 +112,7 @@ export function agentSelectWindow({
 }
 
 export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
+  const { columns } = useWindowSize();
   const { data, loading, error } = useAsyncListForm<AgentGroups>({
     load: async () => {
       const options = await computeAgentOptionsData();
@@ -183,11 +194,12 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       borderColor="cyan"
       flexDirection="column"
       paddingX={1}
+      width={agentFormWidth(columns)}
     >
       <Text bold color="cyan">
         /agent
       </Text>
-      <Text dimColor>
+      <Text dimColor wrap="truncate-end">
         {selectable
           ? 'Choose the root tool-use agent for the first message.'
           : 'Available agents. Start a new chat with texra --agent=<name> to choose the root tool-use agent.'}

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentSelectWindow } from '@cli/chat/tui/forms/AgentListForm';
+import {
+  agentFormWidth,
+  agentSelectWindow,
+} from '@cli/chat/tui/forms/AgentListForm';
 
 describe('CLI AgentListForm row budget', () => {
+  it('clamps the regular form width to the terminal columns', () => {
+    expect(agentFormWidth(120)).toBe(80);
+    expect(agentFormWidth(80)).toBe(80);
+    expect(agentFormWidth(60)).toBe(60);
+  });
+
   it('windows long agent lists inside the available foreground rows', () => {
     expect(
       agentSelectWindow({


### PR DESCRIPTION
## Summary
- clamp the regular `/agent` picker to the terminal width, capped at 80 columns
- truncate the long `/agent` description row inside the card instead of letting agent descriptions widen the panel
- add an 80-column TUI harness check that fails when captured frame lines exceed the scenario width

Closes #4842.

## Dogfood Evidence
- `texra-local chat --cwd /tmp/texra-cli-dogfood --api-mode included --approval-policy ask --model deepseekT`
- typed `/agent` and opened the picker in a normal 80-column PTY
- observed the old card overflow/right-border loss, then verified the patched harness snapshot keeps every line within 80 codepoints

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-agent-overflow-after agent-form-80-cols agent-form compact-agent-form`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/forms/AgentListForm.tsx src/test-kernel/cli/AgentListForm.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and harness-only assertions; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes `/agent` picker layout overflow in narrow terminals by **capping the form width** to the live terminal column count (maximum **80** columns) and **truncating** the long instructional line instead of letting descriptions stretch the bordered card.
> 
> Adds exported **`agentFormWidth`** (unit-tested) and wires the regular (non-compact) `AgentListForm` to **`useWindowSize`**. The TUI validator gains **`maxLineColumns`** plus an **`agent-form-80-cols`** scenario so captured frames fail if any rendered line exceeds the scenario width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53e2d9e114c557288316fea532cafe7fd262aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->