### PR TITLE
fix(cli): keep narrow child controls readable

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -816,7 +816,6 @@ const SCENARIOS = [
       HARNESS_CAN_INTERRUPT: '1',
     },
     bootExpect: 'TeXRA',
-    bootQuietMs: 0,
     keys: [ESC + 's'], // Option/Alt-s
     frame: 'tail',
     expect: [
@@ -838,7 +837,6 @@ const SCENARIOS = [
       HARNESS_CAN_INTERRUPT: '1',
     },
     bootExpect: 'TeXRA',
-    bootQuietMs: 0,
     keys: [ESC + 'p', '\r'],
     frame: 'tail',
     expect: [
@@ -859,7 +857,6 @@ const SCENARIOS = [
       HARNESS_CAN_INTERRUPT: '1',
     },
     bootExpect: 'TeXRA',
-    bootQuietMs: 0,
     keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
     frame: 'tail',
     expect: ['Task details', 'Command: latex build', 'Esc back'],
@@ -1330,14 +1327,13 @@ async function runScenario(scenario) {
   // width-adaptive and may omit labels such as /status in narrow terminals.
   const bootDeadline = Date.now() + 15000;
   const bootExpect = scenario.bootExpect ?? '◆';
-  const bootQuietMs = scenario.bootQuietMs ?? 600;
   let booted = false;
   while (Date.now() < bootDeadline) {
     await sleep(150);
     if (exited) break;
     if (
       (await frameSnapshot()).includes(bootExpect) &&
-      Date.now() - lastData > bootQuietMs
+      Date.now() - lastData > 600
     ) {
       booted = true;
       break;

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -807,6 +807,65 @@ const SCENARIOS = [
     maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
   },
   {
+    name: 'tiny-subagent-picker',
+    cols: 40,
+    rows: 10,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'TeXRA',
+    bootQuietMs: 0,
+    keys: [ESC + 's'], // Option/Alt-s
+    frame: 'tail',
+    expect: [
+      'strategy',
+      '+2 more',
+      'Enter focus',
+      'Esc close',
+      '[main]* 1:strategy*',
+    ],
+    unexpect: ['*    y*', 'dle)          r*'],
+  },
+  {
+    name: 'tiny-task-subworkflow-detail',
+    cols: 40,
+    rows: 10,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'TeXRA',
+    bootQuietMs: 0,
+    keys: [ESC + 'p', '\r'],
+    frame: 'tail',
+    expect: [
+      'Task details',
+      'Task details · Description',
+      'Esc back',
+      '[main]* 1:strategy*',
+    ],
+    unexpect: ['╰─Output:', '*    y*'],
+  },
+  {
+    name: 'tiny-task-process-detail',
+    cols: 40,
+    rows: 10,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'TeXRA',
+    bootQuietMs: 0,
+    keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
+    frame: 'tail',
+    expect: ['Task details', 'Command: latex build', 'Esc back'],
+    unexpect: ['╰─Output:', '*    y*'],
+  },
+  {
     name: 'stopped-subagent-picker',
     env: {
       HARNESS_ENTRIES: '4',
@@ -1271,13 +1330,14 @@ async function runScenario(scenario) {
   // width-adaptive and may omit labels such as /status in narrow terminals.
   const bootDeadline = Date.now() + 15000;
   const bootExpect = scenario.bootExpect ?? '◆';
+  const bootQuietMs = scenario.bootQuietMs ?? 600;
   let booted = false;
   while (Date.now() < bootDeadline) {
     await sleep(150);
     if (exited) break;
     if (
       (await frameSnapshot()).includes(bootExpect) &&
-      Date.now() - lastData > 600
+      Date.now() - lastData > bootQuietMs
     ) {
       booted = true;
       break;

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -399,6 +399,15 @@ function TaskDetailView({
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
   const compactMeta = metaParts.join(' · ');
   const commandLabel = taskDetailCommandLabel(item.kind);
+  const ultraCompact = isUltraCompactPickerRows(availableRows);
+  const showScrollHint =
+    item.tailLines.length > visibleLineCount && !ultraCompact;
+  const hints: KeyHint[] = [
+    ...(showScrollHint ? [{ key: '↑/↓', action: 'scroll' }] : []),
+    ...(item.childStreamId ? [{ key: 'f', action: 'focus stream' }] : []),
+    ...(item.killable ? [{ key: 'k', action: 'kill' }] : []),
+    { key: 'Esc', action: 'back' },
+  ];
 
   useEffect(() => {
     setScrollState((current) =>
@@ -430,6 +439,17 @@ function TaskDetailView({
     }
     if (input.toLowerCase() === 'f' && item.childStreamId) onFocusStream();
   });
+
+  if (ultraCompact) {
+    return (
+      <Box flexDirection="column" minWidth={0} width={availableColumns}>
+        <Text bold color="cyan" wrap="truncate-end">
+          {`Task details · ${commandLabel}: ${item.command}`}
+        </Text>
+        <KeyHints hints={hints} confirmCancel={false} />
+      </Box>
+    );
+  }
 
   return (
     <Box
@@ -473,19 +493,7 @@ function TaskDetailView({
       </Box>
       {layout.showHints ? (
         <Box marginTop={layout.compact ? 0 : 1}>
-          <KeyHints
-            hints={[
-              ...(item.tailLines.length > visibleLineCount
-                ? [{ key: '↑/↓', action: 'scroll' }]
-                : []),
-              ...(item.childStreamId
-                ? [{ key: 'f', action: 'focus stream' }]
-                : []),
-              ...(item.killable ? [{ key: 'k', action: 'kill' }] : []),
-              { key: 'Esc', action: 'back' },
-            ]}
-            confirmCancel={false}
-          />
+          <KeyHints hints={hints} confirmCancel={false} />
         </Box>
       ) : null}
     </Box>

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -91,10 +91,44 @@ export function streamTabsLineText(
   items: readonly StreamTabDisplayItem[],
   width?: number,
 ): string {
-  const text = items.map(streamTabSegmentText).join(' ');
-  if (width === undefined || text.length <= width) return text;
-  if (width <= 1) return '…';
-  return `${text.slice(0, width - 1)}…`;
+  return streamTabsLineSegments(items, width)
+    .map((segment) => `${segment.leadingSpace ? ' ' : ''}${segment.text}`)
+    .join('');
+}
+
+export interface StreamTabLineSegment {
+  readonly item: StreamTabDisplayItem;
+  readonly leadingSpace: boolean;
+  readonly text: string;
+}
+
+export function streamTabsLineSegments(
+  items: readonly StreamTabDisplayItem[],
+  width?: number,
+): readonly StreamTabLineSegment[] {
+  let remaining = width === undefined ? Number.POSITIVE_INFINITY : width;
+  if (remaining <= 0) return [];
+  const segments: StreamTabLineSegment[] = [];
+  for (const [index, item] of items.entries()) {
+    const leadingSpace = index > 0;
+    const text = streamTabSegmentText(item);
+    const totalWidth = text.length + (leadingSpace ? 1 : 0);
+    if (totalWidth <= remaining) {
+      segments.push({ item, leadingSpace, text });
+      remaining -= totalWidth;
+      continue;
+    }
+
+    const textWidth = remaining - (leadingSpace ? 1 : 0);
+    if (textWidth <= 0) break;
+    segments.push({
+      item,
+      leadingSpace,
+      text: textWidth <= 1 ? '…' : `${text.slice(0, textWidth - 1)}…`,
+    });
+    break;
+  }
+  return segments;
 }
 
 function streamTabsTextLength(items: readonly StreamTabDisplayItem[]): number {
@@ -211,6 +245,7 @@ export function StreamTabsStrip(props: {
     width: props.width,
   });
   if (items.length === 0) return null;
+  const segments = streamTabsLineSegments(items, Math.max(0, props.width - 2));
 
   return (
     <Box
@@ -221,15 +256,21 @@ export function StreamTabsStrip(props: {
       overflowY="hidden"
       paddingX={1}
     >
-      {items.map((item, index) => (
+      {segments.map((segment, index) => (
         <Text
-          key={`${item.id}:${index}`}
-          bold={item.active}
-          dimColor={!item.active && !item.running}
-          color={item.active ? 'cyan' : item.running ? 'green' : undefined}
+          key={`${segment.item.id}:${index}`}
+          bold={segment.item.active}
+          dimColor={!segment.item.active && !segment.item.running}
+          color={
+            segment.item.active
+              ? 'cyan'
+              : segment.item.running
+                ? 'green'
+                : undefined
+          }
         >
-          {index === 0 ? '' : ' '}
-          {streamTabSegmentText(item)}
+          {segment.leadingSpace ? ' ' : ''}
+          {segment.text}
         </Text>
       ))}
     </Box>

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -70,6 +70,37 @@ function orderedStreamTree(init: {
   return out;
 }
 
+export function streamTabSegmentText(item: StreamTabDisplayItem): string {
+  if (item.id === 'ellipsis') return '…';
+  const labeled =
+    item.shortcutIndex === undefined
+      ? item.label
+      : `${item.shortcutIndex}:${item.label}`;
+  const label = item.active ? `[${labeled}]` : labeled;
+  const running = item.running ? '*' : '';
+  const status =
+    item.status &&
+    item.status !== 'running' &&
+    (!item.active || item.status === 'stopped')
+      ? `(${item.status})`
+      : '';
+  return `${label}${running}${status}`;
+}
+
+export function streamTabsLineText(
+  items: readonly StreamTabDisplayItem[],
+  width?: number,
+): string {
+  const text = items.map(streamTabSegmentText).join(' ');
+  if (width === undefined || text.length <= width) return text;
+  if (width <= 1) return '…';
+  return `${text.slice(0, width - 1)}…`;
+}
+
+function streamTabsTextLength(items: readonly StreamTabDisplayItem[]): number {
+  return streamTabsLineText(items).length;
+}
+
 function activeTreeRoot(
   activeStreamId: StreamTabId | undefined,
   parentStream: ReadonlyMap<StreamTabId, StreamTabId>,
@@ -83,12 +114,10 @@ function collapseMiddle(
   items: readonly StreamTabDisplayItem[],
   width: number,
 ): readonly StreamTabDisplayItem[] {
-  const total = items.reduce(
-    (sum, item) =>
-      sum + item.label.length + (item.shortcutIndex !== undefined ? 2 : 0) + 8,
-    0,
-  );
-  if (total <= width || items.length <= 4) return items;
+  const usableWidth = Math.max(0, width - 2);
+  if (streamTabsTextLength(items) <= usableWidth || items.length <= 2) {
+    return items;
+  }
   const activeIndex = items.findIndex((item) => item.active);
   const keep = new Set([0, items.length - 1]);
   if (activeIndex > 0 && activeIndex < items.length - 1) {
@@ -169,23 +198,6 @@ export function streamTabsDisplayItems(init: {
   return collapseMiddle(items, init.width);
 }
 
-export function streamTabSegmentText(item: StreamTabDisplayItem): string {
-  if (item.id === 'ellipsis') return '…';
-  const labeled =
-    item.shortcutIndex === undefined
-      ? item.label
-      : `${item.shortcutIndex}:${item.label}`;
-  const label = item.active ? `[${labeled}]` : labeled;
-  const running = item.running ? '*' : '';
-  const status =
-    item.status &&
-    item.status !== 'running' &&
-    (!item.active || item.status === 'stopped')
-      ? `(${item.status})`
-      : '';
-  return `${label}${running}${status}`;
-}
-
 export function StreamTabsStrip(props: {
   readonly width: number;
 }): React.JSX.Element | null {
@@ -201,7 +213,14 @@ export function StreamTabsStrip(props: {
   if (items.length === 0) return null;
 
   return (
-    <Box paddingX={1}>
+    <Box
+      flexDirection="row"
+      flexWrap="nowrap"
+      height={1}
+      minWidth={0}
+      overflowY="hidden"
+      paddingX={1}
+    >
       {items.map((item, index) => (
         <Text
           key={`${item.id}:${index}`}

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -102,7 +102,36 @@ export interface StreamTabLineSegment {
   readonly text: string;
 }
 
-export function streamTabsLineSegments(
+function ellipsisTabItem(): StreamTabDisplayItem {
+  return {
+    id: 'ellipsis',
+    label: '…',
+    active: false,
+    running: false,
+  };
+}
+
+function activeAnchoredItems(
+  items: readonly StreamTabDisplayItem[],
+  activeIndex: number,
+): readonly StreamTabDisplayItem[] {
+  const activeItem = items[activeIndex];
+  const lastItem = items.at(-1);
+  if (!activeItem) return items;
+  const out: StreamTabDisplayItem[] = [];
+  if (activeIndex > 0) {
+    out.push(items[0]);
+    if (activeIndex > 1) out.push(ellipsisTabItem());
+  }
+  out.push(activeItem);
+  if (lastItem && activeIndex < items.length - 1) {
+    if (activeIndex < items.length - 2) out.push(ellipsisTabItem());
+    out.push(lastItem);
+  }
+  return out;
+}
+
+function buildLineSegments(
   items: readonly StreamTabDisplayItem[],
   width?: number,
 ): readonly StreamTabLineSegment[] {
@@ -131,6 +160,31 @@ export function streamTabsLineSegments(
   return segments;
 }
 
+export function streamTabsLineSegments(
+  items: readonly StreamTabDisplayItem[],
+  width?: number,
+): readonly StreamTabLineSegment[] {
+  const segments = buildLineSegments(items, width);
+  const activeIndex = items.findIndex((item) => item.active);
+  const activeItem = activeIndex === -1 ? undefined : items[activeIndex];
+  if (
+    width === undefined ||
+    !activeItem ||
+    segments.some((segment) => segment.item === activeItem)
+  ) {
+    return segments;
+  }
+
+  const activeSegments = buildLineSegments(
+    activeAnchoredItems(items, activeIndex),
+    width,
+  );
+  if (activeSegments.some((segment) => segment.item === activeItem)) {
+    return activeSegments;
+  }
+  return buildLineSegments([activeItem], width);
+}
+
 function streamTabsTextLength(items: readonly StreamTabDisplayItem[]): number {
   return streamTabsLineText(items).length;
 }
@@ -156,7 +210,7 @@ function collapseMiddle(
   const keep = new Set([0, items.length - 1]);
   if (activeIndex > 0 && activeIndex < items.length - 1) {
     keep.add(activeIndex);
-  } else {
+  } else if (activeIndex <= 0) {
     keep.add(1);
   }
 
@@ -166,12 +220,7 @@ function collapseMiddle(
     const item = items[i];
     if (keep.has(i)) {
       if (elided) {
-        out.push({
-          id: 'ellipsis',
-          label: '…',
-          active: false,
-          running: false,
-        });
+        out.push(ellipsisTabItem());
         elided = false;
       }
       out.push(item);

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   streamTabSegmentText,
+  streamTabsLineText,
   streamTabsDisplayItems,
 } from '@cli/chat/tui/panes/StreamTabsStrip';
 import {
@@ -292,5 +293,63 @@ describe('CLI stream tabs strip', () => {
       '…',
       '5:subagent-5',
     ]);
+  });
+
+  it('keeps a four-stream child strip within one narrow terminal row', () => {
+    const root = streamId('root');
+    const strategy = streamId('strategy-stream');
+    const leanSolver = streamId('lean-stream');
+    const reviewer = streamId('reviewer-stream');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          status: STREAM_STATUS.RUNNING,
+          activeSubagents: [
+            child({
+              executionId: 'strategy',
+              childStreamId: strategy,
+              agentName: 'strategy',
+              status: STREAM_STATUS.RUNNING,
+            }),
+            child({
+              executionId: 'lean',
+              childStreamId: leanSolver,
+              agentName: 'leanSolver',
+              status: STREAM_STATUS.WAITING,
+            }),
+            child({
+              executionId: 'review',
+              childStreamId: reviewer,
+              agentName: 'reviewer',
+              status: STREAM_STATUS.RUNNING,
+            }),
+          ],
+        }),
+      ],
+      [strategy, slice('strategy-stream', { status: STREAM_STATUS.RUNNING })],
+      [leanSolver, slice('lean-stream', { status: STREAM_STATUS.WAITING })],
+      [reviewer, slice('reviewer-stream', { status: STREAM_STATUS.RUNNING })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: root,
+      streams,
+      parentStream: new Map([
+        [strategy, root],
+        [leanSolver, root],
+        [reviewer, root],
+      ]),
+      width: 40,
+    });
+    const line = streamTabsLineText(items, 38);
+
+    expect(items.map(streamTabSegmentText)).toEqual([
+      '[main]*',
+      '1:strategy*',
+      '…',
+      '3:reviewer*',
+    ]);
+    expect(line.length).toBeLessThanOrEqual(38);
   });
 });

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -408,4 +408,87 @@ describe('CLI stream tabs strip', () => {
     expect(segments[1]?.text).toBe('1:strat…');
     expect(streamTabsLineText([active, running], 16)).toBe('[main]* 1:strat…');
   });
+
+  it('keeps the active tab visible when earlier tabs fill the row', () => {
+    const active = {
+      id: streamId('active'),
+      label: 'active-target',
+      active: true,
+      running: true,
+      shortcutIndex: 2,
+    };
+    const segments = streamTabsLineSegments(
+      [
+        {
+          id: streamId('root'),
+          label: 'main',
+          active: false,
+          running: true,
+        },
+        {
+          id: streamId('middle'),
+          label: 'very-long-middle',
+          active: false,
+          running: true,
+          shortcutIndex: 1,
+        },
+        active,
+      ],
+      20,
+    );
+    const line = segments
+      .map((segment) => `${segment.leadingSpace ? ' ' : ''}${segment.text}`)
+      .join('');
+
+    expect(segments.some((segment) => segment.item === active)).toBe(true);
+    expect(line).toHaveLength(20);
+    expect(line).toContain('[2:active');
+    expect(line).toContain('…');
+  });
+
+  it('collapses a middle tab before an active last tab in tight rows', () => {
+    const root = streamId('root');
+    const middle = streamId('middle-stream');
+    const active = streamId('active-stream');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          status: STREAM_STATUS.RUNNING,
+          activeSubagents: [
+            child({
+              executionId: 'middle',
+              childStreamId: middle,
+              agentName: 'veryLongMiddleAgent',
+              status: STREAM_STATUS.RUNNING,
+            }),
+            child({
+              executionId: 'active',
+              childStreamId: active,
+              agentName: 'activeTarget',
+              status: STREAM_STATUS.RUNNING,
+            }),
+          ],
+        }),
+      ],
+      [middle, slice('middle-stream', { status: STREAM_STATUS.RUNNING })],
+      [active, slice('active-stream', { status: STREAM_STATUS.RUNNING })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: active,
+      streams,
+      parentStream: new Map([
+        [middle, root],
+        [active, root],
+      ]),
+      width: 28,
+    });
+
+    expect(items.map(streamTabSegmentText)).toEqual([
+      'main*',
+      '…',
+      '[2:activeTarget]*',
+    ]);
+  });
 });

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   streamTabSegmentText,
+  streamTabsLineSegments,
   streamTabsLineText,
   streamTabsDisplayItems,
 } from '@cli/chat/tui/panes/StreamTabsStrip';
@@ -351,5 +352,60 @@ describe('CLI stream tabs strip', () => {
       '3:reviewer*',
     ]);
     expect(line.length).toBeLessThanOrEqual(38);
+  });
+
+  it('truncates stream tab text at terminal row edges', () => {
+    const items = [
+      {
+        id: streamId('root'),
+        label: 'main',
+        active: true,
+        running: true,
+      },
+      {
+        id: streamId('strategy'),
+        label: 'strategy',
+        active: false,
+        running: true,
+        shortcutIndex: 1,
+      },
+    ];
+    const fullText = streamTabsLineText(items);
+
+    expect(streamTabsLineText(items, 0)).toBe('');
+    expect(streamTabsLineText(items, 1)).toBe('…');
+    expect(streamTabsLineText(items, fullText.length)).toBe(fullText);
+    expect(streamTabsLineText(items, fullText.length - 1)).toHaveLength(
+      fullText.length - 1,
+    );
+    expect(streamTabsLineText(items, fullText.length - 1)).toMatch(/…$/);
+  });
+
+  it('keeps truncation attached to styled tab segments', () => {
+    const active = {
+      id: streamId('root'),
+      label: 'main',
+      active: true,
+      running: true,
+    };
+    const running = {
+      id: streamId('strategy'),
+      label: 'strategy',
+      active: false,
+      running: true,
+      shortcutIndex: 1,
+    };
+    const segments = streamTabsLineSegments([active, running], 16);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      item: active,
+      leadingSpace: false,
+      text: '[main]*',
+    });
+    expect(segments[1]?.item).toBe(running);
+    expect(segments[1]?.leadingSpace).toBe(true);
+    expect(segments[1]?.text).toBe('1:strat…');
+    expect(streamTabsLineText([active, running], 16)).toBe('[main]* 1:strat…');
   });
 });


### PR DESCRIPTION
## Summary

- keep the CLI stream-tab strip on one clipped row so narrow subagent views do not wrap labels into unreadable continuation lines
- add an ultra-compact task/sub-workflow detail rendering that keeps the task identity and back/focus/kill controls visible in tiny terminals
- add 40x10 TUI validation scenarios for subagent picker and task/sub-workflow detail views

Fixes #4843

## Validation

- `corepack pnpm install`
- `npm run test:kernel -- src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-display-fix-rebased tiny-subagent-picker tiny-task-subworkflow-detail tiny-task-process-detail narrow-subagent-picker narrow-task-picker`
- `npm run format -- --log-level warn`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and display-only logic with harness/tests; no auth, data, or runtime API changes.
> 
> **Overview**
> Improves **CLI TUI readability on very narrow terminals** by clipping the **stream tab strip** to a single row and simplifying **task detail** panels when vertical space is tiny.
> 
> The **stream tabs** logic now builds width-aware **line segments** (ellipsis collapse, edge truncation, and **active-tab anchoring** so the focused tab stays visible). The strip renders as one non-wrapping row with per-segment truncated text instead of letting labels wrap into broken continuation lines.
> 
> **Task / sub-workflow details** gain an **ultra-compact** mode (very few available rows): a single truncated title line plus key hints, skipping the bordered layout and output block that previously garbled tiny screens.
> 
> Coverage adds **40×10 `validate-tui` scenarios** for subagent picker and task detail flows, plus **unit tests** for tab line length, truncation, and collapse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1897c2b566611105d11f56e5ac8ff21b6d42c51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->