### PR TITLE
fix(cli): restore LaTeX before table layout

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -18,6 +18,7 @@ import stringWidth from 'string-width';
 import {
   createMarkdownProcessor,
   createMarkdownRenderer,
+  type MarkdownProcessorRenderEnv,
   type MarkdownItInstance,
   type MarkdownProcessor,
 } from '@shared/markdown';
@@ -124,6 +125,12 @@ function renderAnsiTable(
   });
   for (const row of rows) table.push([...row]);
   return table.toString();
+}
+
+function restoreProtectedLatexInCell(cell: string, env: unknown): string {
+  const restore = (env as MarkdownProcessorRenderEnv | undefined)
+    ?.restoreProtectedLatex;
+  return restore ? restore(cell) : cell;
 }
 
 function configureAnsi(
@@ -324,7 +331,12 @@ function configureAnsi(
             break;
           }
           case 'inline':
-            cells.push(renderInline(token.children ?? [], options, env));
+            cells.push(
+              restoreProtectedLatexInCell(
+                renderInline(token.children ?? [], options, env),
+                env,
+              ),
+            );
             break;
         }
       }

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -66,6 +66,10 @@ export type MarkdownProcessor = ((content: string) => string) & {
   readonly stats: MarkdownProcessorStats;
 };
 
+export interface MarkdownProcessorRenderEnv {
+  readonly restoreProtectedLatex?: (content: string) => string;
+}
+
 interface ProtectedRef {
   readonly refType: string;
   readonly label: string;
@@ -217,13 +221,25 @@ export function createMarkdownProcessor(
     // heading mid-sentence (".**Heading**" → no break). Force one.
     const formatted = protectedContent.replaceAll(/\.(\*\*[A-Z])/g, '.\n$1');
 
-    const rendered = config.renderer.render(formatted);
+    const restoreProtectedLatex = (value: string): string => {
+      let restored = value;
+      if (config.protectLatexMath) {
+        restored = restoreLatexMacros(restored, macros);
+        restored = restoreLatexMath(restored, spans);
+      }
+      return restoreLatexReferences(restored, refs, format);
+    };
+
+    const renderWithEnv = config.renderer.render as unknown as (
+      this: MarkdownItInstance,
+      src: string,
+      env: MarkdownProcessorRenderEnv,
+    ) => string;
+    const rendered = renderWithEnv.call(config.renderer, formatted, {
+      restoreProtectedLatex,
+    });
     let result = rendered;
-    if (config.protectLatexMath) {
-      result = restoreLatexMacros(result, macros);
-      result = restoreLatexMath(result, spans);
-    }
-    result = restoreLatexReferences(result, refs, format);
+    result = restoreProtectedLatex(result);
 
     // lru-cache's `sizeCalculation` rejects zero, so skip caching the empty
     // render (e.g. content that's only a link-reference definition).

--- a/src/shared/markdown/index.ts
+++ b/src/shared/markdown/index.ts
@@ -15,4 +15,5 @@ export {
   type LatexReferenceFormatter,
   type MarkdownProcessor,
   type MarkdownProcessorConfig,
+  type MarkdownProcessorRenderEnv,
 } from './createMarkdownProcessor';

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -242,6 +242,20 @@ describe('renderAnsiMarkdown', () => {
     expect(stripAnsi(out)).toContain('993.3');
   });
 
+  it('does not leak protected LaTeX placeholders from wrapped table cells', () => {
+    _resetAnsiMarkdownForTests();
+    const md = [
+      '| Seed | n=0 | n=1 | Next exceeds bound? |',
+      '|---|---|---|---|',
+      '| $3+\\sqrt{5}$ | \\((3,1)\\) | \\((47,21)\\) | $123 > 100$ (stop) |',
+    ].join('\n');
+    const out = renderAnsiMarkdown(md, { width: 52 });
+    const plain = stripAnsi(out);
+    expect(plain).not.toContain('@@LATEX');
+    expect(plain).toContain('$3+\\sqrt{');
+    expect(plain).toContain('\\((47,21)');
+  });
+
   it('memoises identical inputs (second call hits the cache)', () => {
     _resetAnsiMarkdownForTests();
     const first = renderAnsiMarkdown('# Title\n\nParagraph.');


### PR DESCRIPTION
Fixes #4847.

## Summary

- Pass the Markdown processor's protected-LaTeX restore hook through the MarkdownIt render env.
- Restore protected LaTeX inside CLI ANSI table cells before `cli-table3` measures/wraps the table.
- Add a regression test for a narrow math table so `@@LATEX-*` sentinels cannot leak into the TUI.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AnsiMarkdown.vitest.mts`
- `npm run typecheck`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to CLI ANSI markdown rendering and shared processor render env; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **#4847** by ensuring protected LaTeX is restored **before** the CLI ANSI table path measures and wraps cells, so `@@LATEX-*` sentinels no longer appear in the TUI.
> 
> The shared `createMarkdownProcessor` now exposes a **`restoreProtectedLatex`** callback on the markdown-it render **`env`** (`MarkdownProcessorRenderEnv`), while still running a final restore on the full rendered string. The CLI **`ansiMarkdown`** table collapser calls that hook on each **inline** cell after `renderInline`, so math like `$3+\sqrt{5}$` and `\((47,21)\)` is real text when **`cli-table3`** computes widths and word-wrap.
> 
> Adds a regression test for a **narrow** math-heavy GFM table at width 52.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b27ec8db56cb2dacfa67b04125bcf7aa23d2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->