### PR TITLE
docs(cli): add TUI performance & rendering audit

### DIFF
--- a/docs/tui-performance-audit.md
+++ b/docs/tui-performance-audit.md
@@ -173,6 +173,43 @@ source. Each was independently verified as a non-issue.
 
 ---
 
+## What shipped on this branch
+
+The adversarial pass showed the naive fixes for #1/#2/#4 were no-ops because the
+data path hands fresh array/object identities every render. The clean fix is one
+structural change at the *source* rather than memo boilerplate at every consumer:
+
+**`cliState.activeSlice` — a `Signal.Computed` for the active stream's slice**
+(`state/cliState.ts`). `patchStream` rebuilds the streams Map but keeps every
+*untouched* slice's reference (`new Map(current)` + `out.set(id, next)`), so the
+computed returns the **same `StreamSlice`** whenever the active stream is
+unchanged — even while a *background* stream streams tokens. `useSignal` is built
+on `useSyncExternalStore`, and `Signal.Computed` skips propagation via `Object.is`
+(same trick the webview's `activeStreamInfo$` uses), so subscribers don't re-render
+on unrelated streams.
+
+Three panes that only read the active slice now subscribe to it instead of the
+whole Map — and each got *shorter* (3 lines → 1):
+
+- `panes/ConversationPane.tsx` (the hot streaming pane)
+- `panes/TodosPlanPanel.tsx`
+- `panes/SubagentList.tsx`
+
+Net **+16 / −11** across 4 files. This addresses the *real* form of #1 (the active
+pane no longer re-renders on background-stream tokens) and makes #2/#4 moot for
+those panes (they now re-render only when their own data's identity changes — the
+correct granularity, achieved at the source, no `useMemo`/`React.memo` needed).
+
+Deliberately left alone: `App.tsx` and `StatusBar.tsx` still read the full
+`streams` Map because they genuinely need cross-stream data (child-control
+resolution, focus targets). #3 (cross-stream batching), #5, #6 remain unaddressed
+per the verdicts above — measurement-gated or skip.
+
+Verification: `compile:fast` builds clean; CLI `tsc -p packages/cli/tsconfig.json`
+typechecks clean (the only error in this sandbox is a missing `@types/node`
+type-lib, unrelated to the change). Behavior unchanged — same slice value reaches
+each pane; only the *subscription granularity* narrowed.
+
 ## Meta-conclusion
 
 After the adversarial pass, the audit's own headline shrinks: nothing here is a

--- a/docs/tui-performance-audit.md
+++ b/docs/tui-performance-audit.md
@@ -3,13 +3,15 @@
 Scope: the Ink/React CLI TUI under `packages/cli/src/chat/tui/`.
 Branch: `claude/tui-performance-rendering-VxWB9`.
 Method: read the hot-path files directly (`App.tsx`, `panes/ConversationPane.tsx`,
-`state/subscribeStreamLog.ts`, `state/useSignal.ts`, `state/useLiveNowMs.ts`) and
-cross-checked two fan-out investigations. Severity reflects what was verified in
-source, not what was asserted.
+`panes/transcriptViewport.ts`, `panes/transcriptEntries.ts`,
+`state/subscribeStreamLog.ts`, `state/cliState.ts`, `state/useSignal.ts`,
+`state/useLiveNowMs.ts`) and cross-checked two fan-out investigations. Severity
+reflects what was verified in source, not what was asserted.
 
 This audit frames findings against the recurring pain points of agent TUIs:
 routing, concurrent updates, unmounting renderers for invisible views, viewport
-painting, terminal compatibility, and keybinding consistency.
+painting, terminal compatibility, and keybinding consistency. Each gap carries an
+**Adversarial** counter-argument and a severity revised *after* that scrutiny.
 
 ---
 
@@ -44,68 +46,124 @@ These are not gaps — recording them so the report is honest about the baseline
 
 ## Verified gaps (prioritized)
 
-### 1. Coarse-grained `streams` signal re-renders the whole App tree — HIGH
+Each finding below carries an **Adversarial** counter-argument (the strongest case
+for *not* acting, or for the proposed fix backfiring) and a severity revised
+*after* that scrutiny. Net effect: most ratings dropped, and two of the original
+"easy wins" turned out to be no-ops as first stated. See the meta-conclusion — the
+honest next step is to *measure*, not to patch blind.
+
+| # | Finding | Original | Revised |
+|---|---------|----------|---------|
+| 1 | Coarse `streams` signal re-renders whole App tree | HIGH | **MED (measure first)** |
+| 2 | Viewport slice not memoized | MED | **LOW** (naive fix is a no-op) |
+| 3 | No cross-stream frame coalescing | MED | **LOW–MED** (scenario-gated) |
+| 4 | Hot panes lack `React.memo` | MED | **LOW** (no-op on the entry rows) |
+| 5 | Bracketed paste not capability-gated | LOW | **NON-ISSUE / risky to "fix"** |
+| 6 | Shift+Enter in modals undocumented | LOW | **SKIP** |
+
+### 1. Coarse-grained `streams` signal re-renders the whole App tree
 `ConversationPane` subscribes to the entire streams Map
 (`panes/ConversationPane.tsx:28`, `useSignal(cliState.streams)`), and
-`patchStream` replaces the Map on every sync. A single token on *any* stream
-therefore re-renders every `useSignal(cliState.streams)` consumer plus the App
-(8 signal subscriptions at `App.tsx:251-259`) and all of its child panes. This is
-the "concurrent updates" cost from the brief: work scales with mounted panes, not
-with what actually changed.
+`patchStream` does `new Map(current)` → `streams.set(out)` on every sync
+(`state/cliState.ts:202-204`), so the premise holds: a single token on *any*
+stream re-renders every `useSignal(cliState.streams)` consumer plus the App
+(8 subscriptions at `App.tsx:251-259`) and its child panes.
 
-*Direction:* split per-stream subscriptions (e.g. a derived signal keyed by
-`activeStreamId`) so only the active stream's pane reacts to its own tokens; or
-isolate the conversation subtree so unrelated stream mutations don't reach it.
+**Adversarial:** what re-renders here is *React reconciliation* of a ~dozen-node
+tree — building elements, microseconds. The expensive part of a TUI is Ink's
+Yoga layout + ANSI frame diff, and (a) Ink already coalesces terminal output, and
+(b) `patchStream` is gated behind the 16ms per-stream throttle. During streaming
+the conversation pane's content *is* changing, so it has to relayout regardless;
+splitting the signal only spares the *sibling* panes (StatusBar, StreamTabsStrip,
+InputBar) a reconcile pass they'd do in microseconds anyway. The refactor also
+adds a real footgun: `useSignal` binds a watcher to a specific signal instance
+(`state/useSignal.ts:18-26`), so a per-stream signal whose identity changes on
+stream-switch must force the hook to re-subscribe, or the active pane goes stale.
+**Verdict:** premise true, payoff uncertain. Revised **MED, and only with a
+before/after render-count or frame measurement** — do not refactor the state model
+on a hunch.
 
-### 2. Viewport slice recomputed every render, no memo — MEDIUM
-`selectPendingEntriesForViewport(pending, maxRows, width)` runs on every render
-(`panes/ConversationPane.tsx:33`). It is pure (re-estimates wrapped rows and
-rebuilds the `rowLimits` Map from the same inputs) but is not wrapped in
-`useMemo`. Bounded by the 16ms throttle, so it is wasted work rather than a hang,
-but it recomputes on every stream tick.
+### 2. Viewport slice recomputed every render
+`selectPendingEntriesForViewport(pending, maxRows, width)` runs every render
+(`panes/ConversationPane.tsx:33`) with no `useMemo`.
 
-*Direction:* `useMemo` keyed on `(pending, maxRows, width)`.
+**Adversarial:** the obvious fix — `useMemo([pending, maxRows, width])` — is a
+**no-op**. `splitTranscriptEntries` pushes into a *fresh* `pending` array on every
+call (`panes/transcriptEntries.ts:29-30,37,45`), so the dep identity changes every
+render and the memo never hits; it would only add comparison + storage overhead.
+To memoize for real you'd have to memoize `splitTranscriptEntries` too, or key on
+a stable signature (last entry id + text length + count + maxRows + width) — more
+surface for a stale-view bug. And the work being "saved" is already small:
+`pending` is only the *non-finalized* tail, and the assistant estimate is
+pre-sliced to the tail window and capped at `LIVE_TAIL_ROWS`
+(`panes/transcriptViewport.ts:54-61`), so it never folds a multi-MB reply.
+**Verdict:** **LOW.** Not worth the stale-key risk unless profiling fingers it.
 
-### 3. No cross-stream frame coalescing — MEDIUM
-Each stream gets its own 16ms `setTimeout` (`state/subscribeStreamLog.ts:271`).
-With several concurrent child streams, one 16ms window can fire multiple
-independent `patchStream` calls → multiple App re-renders instead of one
-coordinated frame.
+### 3. No cross-stream frame coalescing
+Each stream gets its own 16ms `setTimeout` (`state/subscribeStreamLog.ts:271`);
+N concurrent child streams can fire N `patchStream` calls in one window.
 
-*Direction:* a single shared frame timer that drains all dirty stream ids in one
-`patchStream`/render pass.
+**Adversarial:** this only bites with *parallel subagent* streaming — the common
+single-stream case has exactly one timer and zero cascade. Even at N=3 the worst
+case is bounded (~3 patches/16ms, and Ink still coalesces the actual write). A
+shared frame batcher also risks *delaying a finalization paint*: the code
+deliberately flushes per-stream (`flushPendingRunTraces`,
+`state/subscribeStreamLog.ts:291`), and a global drain could hold a stream's last
+frame behind a busier sibling. **Verdict:** **LOW–MED, scenario-gated.** Worth it
+only if multi-agent runs are a headline use case and measurement shows the
+cascade.
 
-### 4. Hot panes lack `React.memo` — MEDIUM
+### 4. Hot panes lack `React.memo`
 `ConversationPane`, `BoundedTranscriptEntry`, `LiveTranscriptEntry` are not
-memoized (`panes/ConversationPane.tsx`, `panes/TranscriptEntry.tsx`). Because
-they sit under App, an unrelated signal change (e.g. `slashPaletteOpen` toggling,
-`App.tsx:257`) re-renders the conversation subtree even though its inputs are
-unchanged.
+memoized.
 
-*Direction:* `React.memo` on the conversation panes; note that components reading
-signals directly via `useSignal` still re-render on their own signal changes, so
-memo helps specifically against *unrelated* App re-renders.
+**Adversarial:** memo only helps when the *parent* re-renders with *equal props*.
+For the entry rows that never happens — `splitTranscriptEntries` hands them fresh
+`pending` slices and the sync path clones entries (`{...entry, finalized:true}`,
+`state/subscribeStreamLog.ts:239`), so prop identity changes every render and
+`React.memo` is a **no-op** there. For `ConversationPane` itself the props are
+primitive (`width`, `maxRows`) and stable across *unrelated* App re-renders — so
+memo *would* skip a render when e.g. `slashPaletteOpen` toggles (`App.tsx:257`).
+But that toggle happens on a keystroke, not during streaming; during streaming the
+pane subscribes to `streams` and re-renders anyway. So the only thing memo buys is
+skipping reconciliation during non-streaming UI interactions, where there's no
+perf pressure. **Verdict:** **LOW** — at most memo `ConversationPane` alone;
+memoing the entry rows is wasted code.
 
-### 5. Bracketed paste not capability-gated — LOW (consistency)
-`usePaste` is called unconditionally in `input/BaseTextInput.tsx` while the
-DA1-sentinel flow already detects `bracketedPaste`
-(`state/terminalCapabilities.ts`). Ink degrades gracefully, so impact is low, but
-it is inconsistent with the rest of the capability-gating discipline.
+### 5. Bracketed paste not capability-gated
+`usePaste` is called unconditionally in `input/BaseTextInput.tsx` while
+`state/terminalCapabilities.ts` already detects `bracketedPaste`.
 
-### 6. Shift+Enter behavior in modals is undocumented — LOW (clarity)
+**Adversarial:** gating it would likely make things *worse*. Capability discovery
+is async with a 250ms timeout; gate `usePaste` on it and every paste in that first
+window is unprotected (the exact case — a fast paste right after launch — where
+you most want protection). And enabling mode 2004 on a terminal that ignores it is
+harmless; the unknown sequence is dropped. The current unconditional call may be
+the pragmatically correct choice. **Verdict:** **NON-ISSUE**, possibly
+intentional. Don't "fix" without a concrete terminal that breaks.
+
+### 6. Shift+Enter behavior in modals is undocumented
 Modals (`modals/ConfirmCard.tsx`, `modals/UserQuestion.tsx`, `ui/Select.tsx`)
-treat Enter as confirm without discriminating Shift+Enter. This is effectively
-correct (modals have no multiline field) but relies on an unstated assumption; a
-one-line comment would prevent a future "Shift+Enter should newline" regression.
+treat Enter as confirm without discriminating Shift+Enter.
+
+**Adversarial:** the behavior is already correct (modals have no multiline field),
+and a comment documenting an *absence* of behavior is the kind of note that rots
+the moment someone adds a textarea. The code is self-evident. **Verdict:**
+**SKIP.**
 
 ---
 
 ## Corrections to overstated findings
 
+The fan-out investigation flagged three things that do not survive a read of the
+source. Each was independently verified as a non-issue.
+
 - **StatusBar "ticks every second even when hidden" — NOT a real issue.** The
   `useLiveNowMs` interval is local to StatusBar and cleans up on
   `shouldTick=false` (`state/useLiveNowMs.ts:6-11`). It re-renders only StatusBar
-  itself (not App), once per second, while a run is active. Negligible.
+  itself (not App), once per second, while a run is active. *Mild caveat:* that is
+  one live-region repaint of the bottom chrome per second while idle-but-running —
+  not literally zero, but negligible.
 - **SubagentList "timer runs while hidden" — NOT a real issue.** SubagentList is
   mounted only when `bottomPanelBudget > 0` (`App.tsx:526-531`); when hidden it is
   unmounted and its interval is cleared. No leak.
@@ -115,11 +173,27 @@ one-line comment would prevent a future "Shift+Enter should newline" regression.
 
 ---
 
-## Suggested order of work
+## Meta-conclusion
 
-1. **#2 + #4** — low risk, local, immediate win: memoize the viewport slice and
-   add `React.memo` to the conversation panes. No state-model changes.
-2. **#1 + #3** — highest payoff, but touches the state model
-   (`cliState.streams` granularity and the sync scheduler), so it needs the most
-   careful testing.
-3. **#5 + #6** — small consistency/clarity fixes; bundle opportunistically.
+After the adversarial pass, the audit's own headline shrinks: nothing here is a
+confirmed hang, two of the "easy wins" (#2 viewport `useMemo`, #4 `React.memo` on
+entry rows) are **no-ops** because the data path hands fresh array/object
+identities every render, and two more (#5, #6) are best left alone. What remains
+is bounded wasted work whose real-world cost is unknown because the expensive
+layer (Ink Yoga layout + ANSI diff) is already output-throttled and gated by the
+16ms patch throttle.
+
+**The honest next step is to measure, not to patch.** Concretely:
+
+1. Add a render-count / frame-write probe (e.g. count `patchStream` calls, App
+   renders, and Ink frame writes per second) and capture a baseline under
+   (a) a single long streaming reply and (b) a parallel multi-subagent run.
+2. Only if the numbers show a real ceiling being hit:
+   - #1 (per-stream signal isolation) is the one structural change with plausible
+     payoff — but it touches the state model, so do it behind the measurement.
+   - #3 (shared frame batcher) only if the multi-stream cascade is what shows up.
+3. #2/#4 should be done *correctly* (stable memo keys) or not at all; as naively
+   stated they cost more than they save.
+
+In short: this branch may legitimately ship **no code change** and instead land
+the measurement harness that tells you whether any of #1/#3 are worth it.

--- a/docs/tui-performance-audit.md
+++ b/docs/tui-performance-audit.md
@@ -1,0 +1,125 @@
+# TUI Performance & Rendering Audit
+
+Scope: the Ink/React CLI TUI under `packages/cli/src/chat/tui/`.
+Branch: `claude/tui-performance-rendering-VxWB9`.
+Method: read the hot-path files directly (`App.tsx`, `panes/ConversationPane.tsx`,
+`state/subscribeStreamLog.ts`, `state/useSignal.ts`, `state/useLiveNowMs.ts`) and
+cross-checked two fan-out investigations. Severity reflects what was verified in
+source, not what was asserted.
+
+This audit frames findings against the recurring pain points of agent TUIs:
+routing, concurrent updates, unmounting renderers for invisible views, viewport
+painting, terminal compatibility, and keybinding consistency.
+
+---
+
+## What is already handled well
+
+These are not gaps — recording them so the report is honest about the baseline.
+
+- **Invisible views are truly unmounted (routing).** Foreground surfaces
+  (approval / form / child-controls / transcript viewer) are conditionally
+  rendered through a single `foregroundKind` switch and dropped on close
+  (`App.tsx:347-415`). The bottom panels (`SubagentList`, `TodosPlanPanel`)
+  mount only when `bottomPanelBudget > 0` (`App.tsx:526-531`). Forms are stored
+  as render functions in a signal and discarded on close. No hidden view keeps a
+  subtree mounted.
+- **Finalized history belongs to the terminal.** Finalized entries print once
+  via `<Static>` (`panes/StaticConversationTranscript.tsx`); the live region
+  renders only in-flight content and is explicitly capped
+  (`selectPendingEntriesForViewport`, `BOTTOM_PANEL_MAX_ROWS`). Matches the
+  documented TUI discipline.
+- **Single keyboard owner (keybinding consistency).** One App-level `useInput`
+  gates internally on `focusShortcutsActive` / `inputDisabled` instead of
+  several hooks racing on the same chord (`App.tsx:427-499`). Kitty keypad Enter
+  is re-dispatched as CR so every `key.return` path keeps working
+  (`App.tsx:276-288`). Escape is consistently "cancel" across modals/forms.
+- **Terminal compatibility is negotiated.** DA1-sentinel capability discovery
+  (`state/terminalCapabilities.ts`); notifications go OSC 99 / OSC 9 → BEL with
+  capability gating (`notifications/terminalNotifier.ts:38-48`).
+- **Stream chunks are throttled.** Per-stream coalescing at one animation frame
+  (`STREAM_SYNC_THROTTLE_MS = 16`, `state/subscribeStreamLog.ts:257-276`).
+
+---
+
+## Verified gaps (prioritized)
+
+### 1. Coarse-grained `streams` signal re-renders the whole App tree — HIGH
+`ConversationPane` subscribes to the entire streams Map
+(`panes/ConversationPane.tsx:28`, `useSignal(cliState.streams)`), and
+`patchStream` replaces the Map on every sync. A single token on *any* stream
+therefore re-renders every `useSignal(cliState.streams)` consumer plus the App
+(8 signal subscriptions at `App.tsx:251-259`) and all of its child panes. This is
+the "concurrent updates" cost from the brief: work scales with mounted panes, not
+with what actually changed.
+
+*Direction:* split per-stream subscriptions (e.g. a derived signal keyed by
+`activeStreamId`) so only the active stream's pane reacts to its own tokens; or
+isolate the conversation subtree so unrelated stream mutations don't reach it.
+
+### 2. Viewport slice recomputed every render, no memo — MEDIUM
+`selectPendingEntriesForViewport(pending, maxRows, width)` runs on every render
+(`panes/ConversationPane.tsx:33`). It is pure (re-estimates wrapped rows and
+rebuilds the `rowLimits` Map from the same inputs) but is not wrapped in
+`useMemo`. Bounded by the 16ms throttle, so it is wasted work rather than a hang,
+but it recomputes on every stream tick.
+
+*Direction:* `useMemo` keyed on `(pending, maxRows, width)`.
+
+### 3. No cross-stream frame coalescing — MEDIUM
+Each stream gets its own 16ms `setTimeout` (`state/subscribeStreamLog.ts:271`).
+With several concurrent child streams, one 16ms window can fire multiple
+independent `patchStream` calls → multiple App re-renders instead of one
+coordinated frame.
+
+*Direction:* a single shared frame timer that drains all dirty stream ids in one
+`patchStream`/render pass.
+
+### 4. Hot panes lack `React.memo` — MEDIUM
+`ConversationPane`, `BoundedTranscriptEntry`, `LiveTranscriptEntry` are not
+memoized (`panes/ConversationPane.tsx`, `panes/TranscriptEntry.tsx`). Because
+they sit under App, an unrelated signal change (e.g. `slashPaletteOpen` toggling,
+`App.tsx:257`) re-renders the conversation subtree even though its inputs are
+unchanged.
+
+*Direction:* `React.memo` on the conversation panes; note that components reading
+signals directly via `useSignal` still re-render on their own signal changes, so
+memo helps specifically against *unrelated* App re-renders.
+
+### 5. Bracketed paste not capability-gated — LOW (consistency)
+`usePaste` is called unconditionally in `input/BaseTextInput.tsx` while the
+DA1-sentinel flow already detects `bracketedPaste`
+(`state/terminalCapabilities.ts`). Ink degrades gracefully, so impact is low, but
+it is inconsistent with the rest of the capability-gating discipline.
+
+### 6. Shift+Enter behavior in modals is undocumented — LOW (clarity)
+Modals (`modals/ConfirmCard.tsx`, `modals/UserQuestion.tsx`, `ui/Select.tsx`)
+treat Enter as confirm without discriminating Shift+Enter. This is effectively
+correct (modals have no multiline field) but relies on an unstated assumption; a
+one-line comment would prevent a future "Shift+Enter should newline" regression.
+
+---
+
+## Corrections to overstated findings
+
+- **StatusBar "ticks every second even when hidden" — NOT a real issue.** The
+  `useLiveNowMs` interval is local to StatusBar and cleans up on
+  `shouldTick=false` (`state/useLiveNowMs.ts:6-11`). It re-renders only StatusBar
+  itself (not App), once per second, while a run is active. Negligible.
+- **SubagentList "timer runs while hidden" — NOT a real issue.** SubagentList is
+  mounted only when `bottomPanelBudget > 0` (`App.tsx:526-531`); when hidden it is
+  unmounted and its interval is cleared. No leak.
+- **Forms/modals "remain mounted while inactive" — NOT a real issue.** They are
+  conditionally rendered via `foregroundKind` and unmounted on close
+  (`App.tsx:347-415`).
+
+---
+
+## Suggested order of work
+
+1. **#2 + #4** — low risk, local, immediate win: memoize the viewport slice and
+   add `React.memo` to the conversation panes. No state-model changes.
+2. **#1 + #3** — highest payoff, but touches the state model
+   (`cliState.streams` granularity and the sync scheduler), so it needs the most
+   careful testing.
+3. **#5 + #6** — small consistency/clarity fixes; bundle opportunistically.

--- a/docs/tui-performance-audit.md
+++ b/docs/tui-performance-audit.md
@@ -11,7 +11,7 @@ reflects what was verified in source, not what was asserted.
 This audit frames findings against the recurring pain points of agent TUIs:
 routing, concurrent updates, unmounting renderers for invisible views, viewport
 painting, terminal compatibility, and keybinding consistency. Each gap carries an
-**Adversarial** counter-argument and a severity revised *after* that scrutiny.
+**Adversarial** counter-argument and a severity revised _after_ that scrutiny.
 
 ---
 
@@ -47,34 +47,35 @@ These are not gaps — recording them so the report is honest about the baseline
 ## Verified gaps (prioritized)
 
 Each finding below carries an **Adversarial** counter-argument (the strongest case
-for *not* acting, or for the proposed fix backfiring) and a severity revised
-*after* that scrutiny. Net effect: most ratings dropped, and two of the original
+for _not_ acting, or for the proposed fix backfiring) and a severity revised
+_after_ that scrutiny. Net effect: most ratings dropped, and two of the original
 "easy wins" turned out to be no-ops as first stated. See the meta-conclusion — the
-honest next step is to *measure*, not to patch blind.
+honest next step is to _measure_, not to patch blind.
 
-| # | Finding | Original | Revised |
-|---|---------|----------|---------|
-| 1 | Coarse `streams` signal re-renders whole App tree | HIGH | **MED (measure first)** |
-| 2 | Viewport slice not memoized | MED | **LOW** (naive fix is a no-op) |
-| 3 | No cross-stream frame coalescing | MED | **LOW–MED** (scenario-gated) |
-| 4 | Hot panes lack `React.memo` | MED | **LOW** (no-op on the entry rows) |
-| 5 | Bracketed paste not capability-gated | LOW | **NON-ISSUE / risky to "fix"** |
-| 6 | Shift+Enter in modals undocumented | LOW | **SKIP** |
+| #   | Finding                                           | Original | Revised                           |
+| --- | ------------------------------------------------- | -------- | --------------------------------- |
+| 1   | Coarse `streams` signal re-renders whole App tree | HIGH     | **MED (measure first)**           |
+| 2   | Viewport slice not memoized                       | MED      | **LOW** (naive fix is a no-op)    |
+| 3   | No cross-stream frame coalescing                  | MED      | **LOW–MED** (scenario-gated)      |
+| 4   | Hot panes lack `React.memo`                       | MED      | **LOW** (no-op on the entry rows) |
+| 5   | Bracketed paste not capability-gated              | LOW      | **NON-ISSUE / risky to "fix"**    |
+| 6   | Shift+Enter in modals undocumented                | LOW      | **SKIP**                          |
 
 ### 1. Coarse-grained `streams` signal re-renders the whole App tree
+
 `ConversationPane` subscribes to the entire streams Map
 (`panes/ConversationPane.tsx:28`, `useSignal(cliState.streams)`), and
 `patchStream` does `new Map(current)` → `streams.set(out)` on every sync
-(`state/cliState.ts:202-204`), so the premise holds: a single token on *any*
+(`state/cliState.ts:202-204`), so the premise holds: a single token on _any_
 stream re-renders every `useSignal(cliState.streams)` consumer plus the App
 (8 subscriptions at `App.tsx:251-259`) and its child panes.
 
-**Adversarial:** what re-renders here is *React reconciliation* of a ~dozen-node
+**Adversarial:** what re-renders here is _React reconciliation_ of a ~dozen-node
 tree — building elements, microseconds. The expensive part of a TUI is Ink's
 Yoga layout + ANSI frame diff, and (a) Ink already coalesces terminal output, and
 (b) `patchStream` is gated behind the 16ms per-stream throttle. During streaming
-the conversation pane's content *is* changing, so it has to relayout regardless;
-splitting the signal only spares the *sibling* panes (StatusBar, StreamTabsStrip,
+the conversation pane's content _is_ changing, so it has to relayout regardless;
+splitting the signal only spares the _sibling_ panes (StatusBar, StreamTabsStrip,
 InputBar) a reconcile pass they'd do in microseconds anyway. The refactor also
 adds a real footgun: `useSignal` binds a watcher to a specific signal instance
 (`state/useSignal.ts:18-26`), so a per-stream signal whose identity changes on
@@ -84,29 +85,31 @@ before/after render-count or frame measurement** — do not refactor the state m
 on a hunch.
 
 ### 2. Viewport slice recomputed every render
+
 `selectPendingEntriesForViewport(pending, maxRows, width)` runs every render
 (`panes/ConversationPane.tsx:33`) with no `useMemo`.
 
 **Adversarial:** the obvious fix — `useMemo([pending, maxRows, width])` — is a
-**no-op**. `splitTranscriptEntries` pushes into a *fresh* `pending` array on every
+**no-op**. `splitTranscriptEntries` pushes into a _fresh_ `pending` array on every
 call (`panes/transcriptEntries.ts:29-30,37,45`), so the dep identity changes every
 render and the memo never hits; it would only add comparison + storage overhead.
 To memoize for real you'd have to memoize `splitTranscriptEntries` too, or key on
 a stable signature (last entry id + text length + count + maxRows + width) — more
 surface for a stale-view bug. And the work being "saved" is already small:
-`pending` is only the *non-finalized* tail, and the assistant estimate is
+`pending` is only the _non-finalized_ tail, and the assistant estimate is
 pre-sliced to the tail window and capped at `LIVE_TAIL_ROWS`
 (`panes/transcriptViewport.ts:54-61`), so it never folds a multi-MB reply.
 **Verdict:** **LOW.** Not worth the stale-key risk unless profiling fingers it.
 
 ### 3. No cross-stream frame coalescing
+
 Each stream gets its own 16ms `setTimeout` (`state/subscribeStreamLog.ts:271`);
 N concurrent child streams can fire N `patchStream` calls in one window.
 
-**Adversarial:** this only bites with *parallel subagent* streaming — the common
+**Adversarial:** this only bites with _parallel subagent_ streaming — the common
 single-stream case has exactly one timer and zero cascade. Even at N=3 the worst
 case is bounded (~3 patches/16ms, and Ink still coalesces the actual write). A
-shared frame batcher also risks *delaying a finalization paint*: the code
+shared frame batcher also risks _delaying a finalization paint_: the code
 deliberately flushes per-stream (`flushPendingRunTraces`,
 `state/subscribeStreamLog.ts:291`), and a global drain could hold a stream's last
 frame behind a busier sibling. **Verdict:** **LOW–MED, scenario-gated.** Worth it
@@ -114,16 +117,17 @@ only if multi-agent runs are a headline use case and measurement shows the
 cascade.
 
 ### 4. Hot panes lack `React.memo`
+
 `ConversationPane`, `BoundedTranscriptEntry`, `LiveTranscriptEntry` are not
 memoized.
 
-**Adversarial:** memo only helps when the *parent* re-renders with *equal props*.
+**Adversarial:** memo only helps when the _parent_ re-renders with _equal props_.
 For the entry rows that never happens — `splitTranscriptEntries` hands them fresh
 `pending` slices and the sync path clones entries (`{...entry, finalized:true}`,
 `state/subscribeStreamLog.ts:239`), so prop identity changes every render and
 `React.memo` is a **no-op** there. For `ConversationPane` itself the props are
-primitive (`width`, `maxRows`) and stable across *unrelated* App re-renders — so
-memo *would* skip a render when e.g. `slashPaletteOpen` toggles (`App.tsx:257`).
+primitive (`width`, `maxRows`) and stable across _unrelated_ App re-renders — so
+memo _would_ skip a render when e.g. `slashPaletteOpen` toggles (`App.tsx:257`).
 But that toggle happens on a keystroke, not during streaming; during streaming the
 pane subscribes to `streams` and re-renders anyway. So the only thing memo buys is
 skipping reconciliation during non-streaming UI interactions, where there's no
@@ -131,10 +135,11 @@ perf pressure. **Verdict:** **LOW** — at most memo `ConversationPane` alone;
 memoing the entry rows is wasted code.
 
 ### 5. Bracketed paste not capability-gated
+
 `usePaste` is called unconditionally in `input/BaseTextInput.tsx` while
 `state/terminalCapabilities.ts` already detects `bracketedPaste`.
 
-**Adversarial:** gating it would likely make things *worse*. Capability discovery
+**Adversarial:** gating it would likely make things _worse_. Capability discovery
 is async with a 250ms timeout; gate `usePaste` on it and every paste in that first
 window is unprotected (the exact case — a fast paste right after launch — where
 you most want protection). And enabling mode 2004 on a terminal that ignores it is
@@ -143,11 +148,12 @@ the pragmatically correct choice. **Verdict:** **NON-ISSUE**, possibly
 intentional. Don't "fix" without a concrete terminal that breaks.
 
 ### 6. Shift+Enter behavior in modals is undocumented
+
 Modals (`modals/ConfirmCard.tsx`, `modals/UserQuestion.tsx`, `ui/Select.tsx`)
 treat Enter as confirm without discriminating Shift+Enter.
 
 **Adversarial:** the behavior is already correct (modals have no multiline field),
-and a comment documenting an *absence* of behavior is the kind of note that rots
+and a comment documenting an _absence_ of behavior is the kind of note that rots
 the moment someone adds a textarea. The code is self-evident. **Verdict:**
 **SKIP.**
 
@@ -161,7 +167,7 @@ source. Each was independently verified as a non-issue.
 - **StatusBar "ticks every second even when hidden" — NOT a real issue.** The
   `useLiveNowMs` interval is local to StatusBar and cleans up on
   `shouldTick=false` (`state/useLiveNowMs.ts:6-11`). It re-renders only StatusBar
-  itself (not App), once per second, while a run is active. *Mild caveat:* that is
+  itself (not App), once per second, while a run is active. _Mild caveat:_ that is
   one live-region repaint of the bottom chrome per second while idle-but-running —
   not literally zero, but negligible.
 - **SubagentList "timer runs while hidden" — NOT a real issue.** SubagentList is
@@ -177,25 +183,25 @@ source. Each was independently verified as a non-issue.
 
 The adversarial pass showed the naive fixes for #1/#2/#4 were no-ops because the
 data path hands fresh array/object identities every render. The clean fix is one
-structural change at the *source* rather than memo boilerplate at every consumer:
+structural change at the _source_ rather than memo boilerplate at every consumer:
 
 **`cliState.activeSlice` — a `Signal.Computed` for the active stream's slice**
 (`state/cliState.ts`). `patchStream` rebuilds the streams Map but keeps every
-*untouched* slice's reference (`new Map(current)` + `out.set(id, next)`), so the
+_untouched_ slice's reference (`new Map(current)` + `out.set(id, next)`), so the
 computed returns the **same `StreamSlice`** whenever the active stream is
-unchanged — even while a *background* stream streams tokens. `useSignal` is built
+unchanged — even while a _background_ stream streams tokens. `useSignal` is built
 on `useSyncExternalStore`, and `Signal.Computed` skips propagation via `Object.is`
 (same trick the webview's `activeStreamInfo$` uses), so subscribers don't re-render
 on unrelated streams.
 
 Three panes that only read the active slice now subscribe to it instead of the
-whole Map — and each got *shorter* (3 lines → 1):
+whole Map — and each got _shorter_ (3 lines → 1):
 
 - `panes/ConversationPane.tsx` (the hot streaming pane)
 - `panes/TodosPlanPanel.tsx`
 - `panes/SubagentList.tsx`
 
-Net **+16 / −11** across 4 files. This addresses the *real* form of #1 (the active
+Net **+16 / −11** across 4 files. This addresses the _real_ form of #1 (the active
 pane no longer re-renders on background-stream tokens) and makes #2/#4 moot for
 those panes (they now re-render only when their own data's identity changes — the
 correct granularity, achieved at the source, no `useMemo`/`React.memo` needed).
@@ -208,7 +214,7 @@ per the verdicts above — measurement-gated or skip.
 Verification: `compile:fast` builds clean; CLI `tsc -p packages/cli/tsconfig.json`
 typechecks clean (the only error in this sandbox is a missing `@types/node`
 type-lib, unrelated to the change). Behavior unchanged — same slice value reaches
-each pane; only the *subscription granularity* narrowed.
+each pane; only the _subscription granularity_ narrowed.
 
 ## Meta-conclusion
 
@@ -229,7 +235,7 @@ layer (Ink Yoga layout + ANSI diff) is already output-throttled and gated by the
    - #1 (per-stream signal isolation) is the one structural change with plausible
      payoff — but it touches the state model, so do it behind the measurement.
    - #3 (shared frame batcher) only if the multi-stream cascade is what shows up.
-3. #2/#4 should be done *correctly* (stable memo keys) or not at all; as naively
+3. #2/#4 should be done _correctly_ (stable memo keys) or not at all; as naively
    stated they cost more than they save.
 
 In short: this branch may legitimately ship **no code change** and instead land

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -24,9 +24,7 @@ export interface ConversationPaneProps {
 export function ConversationPane(
   props: ConversationPaneProps = {},
 ): React.JSX.Element {
-  const activeStreamId = useSignal(cliState.activeStreamId);
-  const streams = useSignal(cliState.streams);
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const slice = useSignal(cliState.activeSlice);
   const entries = slice?.entries ?? [];
   const { pending } = splitTranscriptEntries(entries, slice?.status);
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -142,9 +142,7 @@ export interface SubagentListProps {
 export function SubagentList(
   props: SubagentListProps = {},
 ): React.JSX.Element | null {
-  const activeStreamId = useSignal(cliState.activeStreamId);
-  const streams = useSignal(cliState.streams);
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const slice = useSignal(cliState.activeSlice);
   const activeProcesses = slice?.activeProcesses ?? [];
   const processOutput = slice?.processOutput;
   const subagents = slice ? visibleSubagentRows(slice) : [];

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -197,9 +197,7 @@ export interface TodosPlanPanelProps {
 export function TodosPlanPanel(
   props: TodosPlanPanelProps = {},
 ): React.JSX.Element | null {
-  const activeStreamId = useSignal(cliState.activeStreamId);
-  const streams = useSignal(cliState.streams);
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const slice = useSignal(cliState.activeSlice);
   if (!slice) return null;
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -5,7 +5,7 @@
 // process-output fields plus the per-stream bypass-state badges the
 // StatusBar consumes.
 
-import { signal, type Signal } from '@lit-labs/signals';
+import { signal, Signal } from '@lit-labs/signals';
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type {
@@ -117,6 +117,18 @@ const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
  *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
 const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 
+/** Derived: the active stream's slice (or `undefined`). Because `patchStream`
+ *  rebuilds the streams map but keeps each untouched slice's reference, this
+ *  returns the SAME `StreamSlice` when the active stream is unchanged — even
+ *  while a *background* stream is streaming. Panes that only read the active
+ *  slice subscribe here instead of the whole map, so a token on another stream
+ *  no longer re-renders them: `useSignal`'s `useSyncExternalStore` bails via
+ *  Object.is. Mirrors the webview's `activeStreamInfo$`. */
+const ACTIVE_SLICE = new Signal.Computed<StreamSlice | undefined>(() => {
+  const id = ACTIVE_STREAM_ID.get();
+  return id ? STREAMS.get().get(id) : undefined;
+});
+
 /** Active inline slash form, or `undefined` when the chat input owns the
  *  screen. The form's `onDone` clears this slot. Kept opaque (the form
  *  carries its own state) so the registry stays declarative. */
@@ -151,6 +163,7 @@ export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
   streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
+  activeSlice: ACTIVE_SLICE as Signal.Computed<StreamSlice | undefined>,
   parentStream: PARENT_STREAM as Signal.State<
     ReadonlyMap<StreamTabId, StreamTabId>
   >,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized subscription change with stable slice references and unchanged pane behavior; App still owns full-map reads for cross-stream UI.
> 
> **Overview**
> Adds **`docs/tui-performance-audit.md`**, a source-verified audit of the Ink/React CLI TUI (routing, stream fan-out, viewport work, throttling) with adversarial severity revisions and a **measure-first** follow-up plan.
> 
> Ships a targeted fix for coarse **`streams`** subscriptions: **`cliState.activeSlice`** is a **`Signal.Computed`** over the active stream’s **`StreamSlice`**, so panes bail out via **`Object.is`** when only background streams update. **`ConversationPane`**, **`SubagentList`**, and **`TodosPlanPanel`** now **`useSignal(cliState.activeSlice)`** instead of the full map; **`App`**, **`StatusBar`**, and tab/static surfaces still use **`streams`** where cross-stream data is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d72877e1726fb617a61f1570de1423a350e443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->