### PR TITLE
[codex] Hide chat tips under foreground TUI panels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -349,7 +349,7 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
-    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-bash-approval',
@@ -366,7 +366,7 @@ const SCENARIOS = [
       'Esc cancel',
     ],
     unexpect: [' · …', 'a session'],
-    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'long-bash-approval',
@@ -386,7 +386,7 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['╚═    print', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'compact-long-bash-approval',
@@ -406,7 +406,7 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['╚═    print', 'scroll command', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'bash-approval-approve-session',
@@ -434,7 +434,7 @@ const SCENARIOS = [
       'n reject',
     ],
     unexpect: ['confirmation of correctness', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'external-inquiry-long',
@@ -452,7 +452,7 @@ const SCENARIOS = [
       'Esc skip',
     ],
     unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
-    maxBlankLinesBetween: [{ from: '└', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '└', to: '╭', max: 1 }],
   },
   {
     name: 'external-inquiry-long-80-cols',
@@ -471,7 +471,7 @@ const SCENARIOS = [
       'Esc skip',
     ],
     unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
-    maxBlankLinesBetween: [{ from: '└', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '└', to: '╭', max: 1 }],
   },
   {
     name: 'plan-approval',
@@ -613,7 +613,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Tasks and sub-workflows', 'latex build'],
-    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'task-picker',
@@ -637,7 +637,7 @@ const SCENARIOS = [
         to: 'Tasks and sub-workflows',
         max: 3,
       },
-      { from: '╰', to: 'Tip:', max: 1 },
+      { from: '╰', to: '╭', max: 1 },
     ],
   },
   {
@@ -784,7 +784,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['strategy sub-wo…', 'sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-subagent-picker-second',
@@ -807,7 +807,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['leanSolver sub-wor…', 'sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-task-picker',
@@ -829,7 +829,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'tiny-subagent-picker',
@@ -907,7 +907,7 @@ const SCENARIOS = [
       'k kill',
       'Harness kill requested for harness-child-strategy.\n\nHarness kill requested for harness-child-strategy.',
     ],
-    maxBlankLinesBetween: [{ from: '╰', to: 'Tip:', max: 1 }],
+    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'focused-stopped-subagent',
@@ -941,7 +941,7 @@ const SCENARIOS = [
         to: 'Tasks and sub-workflows',
         max: 4,
       },
-      { from: '╰', to: 'Tip:', max: 1 },
+      { from: '╰', to: '╭', max: 1 },
     ],
   },
   {
@@ -1405,6 +1405,15 @@ async function runScenario(scenario) {
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  const slashPaletteVisible =
+    frame.includes('Tab complete') && frame.includes('↑/↓ navigate');
+  if (
+    !slashPaletteVisible &&
+    frame.includes('Use foreground panel shortcuts') &&
+    frame.includes('Tip:')
+  ) {
+    failures.push('foreground panel rendered the normal chat tip row');
+  }
   for (const check of scenario.maxBlankLinesBetween ?? []) {
     const actual = blankLinesBetween(frame, check.from, check.to);
     if (actual === undefined) {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -69,14 +69,16 @@ const PINNED_CHROME_ROWS = {
 function pinnedChromeRows({
   reverseSearchOpen,
   slashPaletteOpen,
+  tipVisible = true,
 }: {
   readonly reverseSearchOpen: boolean;
   readonly slashPaletteOpen: boolean;
+  readonly tipVisible?: boolean;
 }): number {
-  const baseRows = Object.values(PINNED_CHROME_ROWS).reduce(
-    (sum, rows) => sum + rows,
-    0,
-  );
+  const { tip, ...alwaysVisibleRows } = PINNED_CHROME_ROWS;
+  const baseRows =
+    Object.values(alwaysVisibleRows).reduce((sum, rows) => sum + rows, 0) +
+    (tipVisible ? tip : 0);
   return (
     baseRows +
     (slashPaletteOpen ? SLASH_PALETTE_ROWS : 0) +
@@ -90,19 +92,26 @@ export function allocateMiddleRows({
   reverseSearchOpen,
   rows,
   slashPaletteOpen,
+  tipVisible = true,
 }: {
   readonly foregroundMaxRows?: number;
   readonly foregroundOpen: boolean;
   readonly reverseSearchOpen: boolean;
   readonly rows: number;
   readonly slashPaletteOpen: boolean;
+  readonly tipVisible?: boolean;
 }): {
   readonly foregroundRows: number;
   readonly transcriptRows: number;
 } {
   const availableRows = Math.max(
     0,
-    rows - pinnedChromeRows({ reverseSearchOpen, slashPaletteOpen }),
+    rows -
+      pinnedChromeRows({
+        reverseSearchOpen,
+        slashPaletteOpen,
+        tipVisible,
+      }),
   );
   if (!foregroundOpen) {
     return { foregroundRows: 0, transcriptRows: availableRows };
@@ -159,6 +168,14 @@ export function allocateSidePanelRows({
     subagentRows,
     todosPlanRows: availableRows - subagentRows,
   };
+}
+
+export function shouldShowTipRow({
+  foregroundOpen,
+}: {
+  readonly foregroundOpen: boolean;
+}): boolean {
+  return !foregroundOpen;
 }
 
 export function shouldShowTodosPlanPanel({
@@ -291,6 +308,7 @@ export function App(props: AppProps): React.JSX.Element {
     activeForm !== undefined ||
     childControlMode !== undefined ||
     transcriptViewerOpen;
+  const tipRowVisible = shouldShowTipRow({ foregroundOpen });
   const inputDisabled = props.inputDisabled === true || foregroundOpen;
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
@@ -330,6 +348,7 @@ export function App(props: AppProps): React.JSX.Element {
     reverseSearchOpen,
     rows,
     slashPaletteOpen,
+    tipVisible: tipRowVisible,
   });
   // The subagent/todos panels live at the bottom of the same vertical
   // column. Carve a bounded slice off the transcript area so the
@@ -529,7 +548,7 @@ export function App(props: AppProps): React.JSX.Element {
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}
-        <TipRow />
+        {tipRowVisible ? <TipRow /> : null}
         <InputBar
           onSubmit={props.onSubmit}
           disabled={inputDisabled}

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -22,6 +22,7 @@ import {
   appEscapeInterruptActive,
   appFocusShortcutsActive,
   foregroundSurfaceKind,
+  shouldShowTipRow,
   shouldShowTodosPlanPanel,
 } from '@cli/chat/tui/App';
 import {
@@ -181,10 +182,16 @@ describe('CLI TUI row allocation', () => {
       reverseSearchOpen: false,
       rows: 24,
       slashPaletteOpen: false,
+      tipVisible: false,
     });
 
     expect(layout.transcriptRows).toBe(1);
-    expect(layout.foregroundRows).toBe(16);
+    expect(layout.foregroundRows).toBe(17);
+  });
+
+  it('hides the normal chat tip row while foreground surfaces own input', () => {
+    expect(shouldShowTipRow({ foregroundOpen: false })).toBe(true);
+    expect(shouldShowTipRow({ foregroundOpen: true })).toBe(false);
   });
 
   it('can cap compact foreground surfaces on tall terminals', () => {


### PR DESCRIPTION
## Summary

Fixes #4854.

- Hide the normal chat `TipRow` while foreground panels own input, including approvals, forms, transcript viewer, subagent controls, and task/sub-workflow controls.
- Reclaim the hidden tip row in middle-row allocation so foreground panels get the row instead of leaving dead space.
- Tighten the TUI frame validator so foreground-panel frames fail if `Tip:` is visible, while preserving live slash-palette behavior.

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-approval-tip-full3` (all 61 scenarios passed)
- `npm run compile:safe`
- `npm run lint` (passes with the existing 12 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and test-only validator changes; no auth, data, or runtime execution paths affected.
> 
> **Overview**
> Hides the normal chat **`Tip:`** row while **foreground panels** (approvals, slash forms, transcript viewer, subagent/task pickers) own input, and **gives that row back** to middle layout so panels grow by one line instead of leaving a blank gap.
> 
> **`shouldShowTipRow`** drives conditional rendering and **`tipVisible`** in **`allocateMiddleRows`** / pinned chrome math. The TUI harness validator now measures compactness to the next panel chrome (`╭`) instead of **`Tip:`**, and **fails** if a foreground frame still shows both **"Use foreground panel shortcuts"** and **`Tip:`** (slash palette open is exempt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf71954748296ac71515899578965080f5b01511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->