### PR TITLE
fix(cli): normalize raw control input bytes

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -42,6 +42,7 @@ const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
 const DC2 = String.fromCharCode(18); // Ctrl-R
 const DC4 = String.fromCharCode(20); // Ctrl-T
+const NAK = String.fromCharCode(21); // Ctrl-U
 const DOWN = ESC + '[B';
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
@@ -170,6 +171,14 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],
     expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
+  },
+  {
+    name: 'slash-palette-ctrl-u-clears-raw-control',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/', `${NAK}/model\r`],
+    frame: 'tail',
+    expect: ['/model · personal API keys', 'Available models'],
+    unexpect: ['/\u0015/model', '/model - error'],
   },
   {
     name: 'btw-palette',

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -14,12 +14,16 @@ import {
   deletePreviousWord,
   deleteToEnd,
   deleteToStart,
+  applyTerminalInputChunk,
   insertText,
   type TextEdit,
 } from './textInputEditing';
 import {
   isPlainReturnInput,
   isShiftReturnInput,
+  isCtrlInput,
+  isEscapeInput,
+  isUnhandledControlInput,
   metaChordInput,
 } from './inputKeys';
 
@@ -36,6 +40,7 @@ export interface BaseTextInputProps {
   readonly cursor?: number;
   readonly onCursorChange?: (cursor: number) => void;
   readonly onSubmit: (value: string) => void;
+  readonly onInputChunkSubmit?: (value: string) => void;
   readonly onChange: (value: string) => void;
 }
 
@@ -175,6 +180,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     placeholder,
     focus = true,
     onChange,
+    onInputChunkSubmit,
     onSubmit,
     onCursorChange,
   } = props;
@@ -221,7 +227,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   useInput(
     (input, key) => {
-      if ((key.ctrl && input === 'j') || isShiftReturnInput(input, key)) {
+      if (isEscapeInput(input, key)) return;
+
+      if (isCtrlInput(input, key, 'j') || isShiftReturnInput(input, key)) {
         // Ctrl-J (universal) or Shift+Enter (Kitty-protocol terminals) →
         // literal newline. Kills the legacy `/multi` ceremony.
         applyEdit(insertText(value, cursor, '\n'));
@@ -247,29 +255,43 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         moveCursor(cursor + 1);
         return;
       }
-      if (key.home || (key.ctrl && input === 'a')) {
+      if (key.home || isCtrlInput(input, key, 'a')) {
         moveCursor(0);
         return;
       }
-      if (key.end || (key.ctrl && input === 'e')) {
+      if (key.end || isCtrlInput(input, key, 'e')) {
         moveCursor(value.length);
         return;
       }
-      if (key.ctrl && input === 'u') {
+      if (isCtrlInput(input, key, 'u')) {
         applyEdit(deleteToStart(value, cursor));
         return;
       }
-      if (key.ctrl && input === 'k') {
+      if (isCtrlInput(input, key, 'k')) {
         applyEdit(deleteToEnd(value, cursor));
         return;
       }
-      if (key.ctrl && input === 'w') {
+      if (isCtrlInput(input, key, 'w')) {
         applyEdit(deletePreviousWord(value, cursor));
         return;
       }
       // Drop unhandled control/meta combos; pass printable input through.
-      if (key.ctrl || key.meta || metaChordInput(input, key) || !input) return;
-      applyEdit(insertText(value, cursor, input));
+      if (
+        key.meta ||
+        metaChordInput(input, key) ||
+        (key.ctrl && input.length === 1) ||
+        isUnhandledControlInput(input) ||
+        !input
+      ) {
+        return;
+      }
+      const edit = applyTerminalInputChunk(value, cursor, input);
+      if (edit.submit) {
+        (onInputChunkSubmit ?? onSubmit)(edit.value);
+        return;
+      }
+      if (edit.value === value && edit.cursor === cursor) return;
+      applyEdit(edit);
     },
     { isActive: focus },
   );

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -9,6 +9,7 @@ import { Box, Text, useInput } from 'ink';
 
 import { KeyHints } from '../ui/KeyHints';
 import { BaseTextInput } from './BaseTextInput';
+import { isCtrlInput } from './inputKeys';
 import type { InputHistory } from '../history/inputHistory';
 
 export interface ReverseSearchProps {
@@ -29,11 +30,11 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
   const match = props.history.reverseFind(query, cursor);
 
   useInput((input, key) => {
-    if (key.escape || (key.ctrl && input.toLowerCase() === 'g')) {
+    if (key.escape || isCtrlInput(input, key, 'g')) {
       props.onCancel();
       return;
     }
-    if (key.upArrow || (key.ctrl && input.toLowerCase() === 'r')) {
+    if (key.upArrow || isCtrlInput(input, key, 'r')) {
       // Step to the next older match.
       if (!match) return;
       const next = props.history.reverseFind(query, match.index);

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -3,6 +3,51 @@ export interface ReturnKeyInput {
   readonly ctrl?: boolean;
   readonly meta?: boolean;
   readonly shift?: boolean;
+  readonly escape?: boolean;
+}
+
+const RAW_CONTROL_INPUTS = new Map<number, string>([
+  [1, 'a'],
+  [5, 'e'],
+  [7, 'g'],
+  [11, 'k'],
+  [18, 'r'],
+  [21, 'u'],
+  [23, 'w'],
+]);
+
+export function normalizedCtrlInput(
+  input: string,
+  key: Pick<ReturnKeyInput, 'ctrl' | 'meta'>,
+): string | undefined {
+  if (key.meta) return undefined;
+  if (input.length !== 1) return undefined;
+  return (
+    RAW_CONTROL_INPUTS.get(input.charCodeAt(0)) ??
+    (key.ctrl ? input.toLowerCase() : undefined)
+  );
+}
+
+export function isCtrlInput(
+  input: string,
+  key: Pick<ReturnKeyInput, 'ctrl' | 'meta'>,
+  expected: string,
+): boolean {
+  return normalizedCtrlInput(input, key) === expected.toLowerCase();
+}
+
+export function isEscapeInput(
+  input: string,
+  key: Pick<ReturnKeyInput, 'escape'>,
+): boolean {
+  return key.escape === true || input === '\u001B';
+}
+
+export function isUnhandledControlInput(input: string): boolean {
+  if (input.length !== 1) return false;
+  const code = input.charCodeAt(0);
+  if (input === '\r' || input === '\n' || input === '\t') return false;
+  return code < 32 || code === 127;
 }
 
 export function metaChordInput(

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -1,6 +1,16 @@
+import {
+  isEscapeInput,
+  isUnhandledControlInput,
+  normalizedCtrlInput,
+} from './inputKeys';
+
 export interface TextEdit {
   readonly value: string;
   readonly cursor: number;
+}
+
+export interface TextInputChunkEdit extends TextEdit {
+  readonly submit: boolean;
 }
 
 export function clampCursor(cursor: number, length: number): number {
@@ -61,4 +71,49 @@ export function deletePreviousWord(value: string, cursor: number): TextEdit {
     value: trimmed + value.slice(c),
     cursor: trimmed.length,
   };
+}
+
+export function applyTerminalInputChunk(
+  value: string,
+  cursor: number,
+  input: string,
+): TextInputChunkEdit {
+  let edit: TextEdit = { value, cursor: clampCursor(cursor, value.length) };
+  let submit = false;
+
+  for (const ch of input) {
+    if (ch === '\r' || ch === '\n') {
+      submit = true;
+      break;
+    }
+
+    const ctrl = normalizedCtrlInput(ch, {});
+    if (ctrl === 'a') {
+      edit = { value: edit.value, cursor: 0 };
+      continue;
+    }
+    if (ctrl === 'e') {
+      edit = { value: edit.value, cursor: edit.value.length };
+      continue;
+    }
+    if (ctrl === 'u') {
+      edit = deleteToStart(edit.value, edit.cursor);
+      continue;
+    }
+    if (ctrl === 'k') {
+      edit = deleteToEnd(edit.value, edit.cursor);
+      continue;
+    }
+    if (ctrl === 'w') {
+      edit = deletePreviousWord(edit.value, edit.cursor);
+      continue;
+    }
+    if (ctrl || isEscapeInput(ch, {}) || isUnhandledControlInput(ch)) {
+      continue;
+    }
+
+    edit = insertText(edit.value, edit.cursor, ch);
+  }
+
+  return { ...edit, submit };
 }

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -4,8 +4,15 @@ import { Box, Text, useInput } from 'ink';
 import { writeTextStderr } from '@cli/runtime/logSinks';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { ReverseSearch } from '../input/ReverseSearch';
+import { isCtrlInput } from '../input/inputKeys';
 import { SlashPalette } from '../commands/SlashPalette';
-import { matchSlashCommands, parseSlashInput } from '../commands/slashRegistry';
+import {
+  matchSlashCommands,
+  parseSlashInput,
+  slashPickIntent,
+  type SlashCommand,
+  type SlashPickIntent,
+} from '../commands/slashRegistry';
 import { cliState } from '../state/cliState';
 import type { InputHistory } from '../history/inputHistory';
 
@@ -32,7 +39,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   // chords so this handler still fires.
   useInput((input, key) => {
     if (disabled) return;
-    if (key.ctrl && input.toLowerCase() === 'r' && historyRef.current) {
+    if (isCtrlInput(input, key, 'r') && historyRef.current) {
       setReverseSearchOpen(true);
     }
   });
@@ -54,6 +61,55 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       onSubmit(trimmed);
     },
     [onSubmit],
+  );
+
+  const acceptSlashCommand = useCallback(
+    (cmd: SlashCommand, intent: SlashPickIntent, remainder: string): void => {
+      if (cmd.formComponent) {
+        // Structured forms own the screen — clear the input and let
+        // the active-form signal mount the component (see App.tsx).
+        const Form = cmd.formComponent;
+        setValue('');
+        cliState.activeForm.set({
+          commandName: cmd.name,
+          render: (close, availableRows) => (
+            <Form
+              remainder={remainder.trimStart()}
+              availableRows={availableRows}
+              onDone={() => close()}
+            />
+          ),
+        });
+        return;
+      }
+      if (intent === 'submit') {
+        handleSubmit(
+          `/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ''}`,
+        );
+        return;
+      }
+      setValue(`/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ' '}`);
+    },
+    [handleSubmit],
+  );
+
+  const handleInputChunkSubmit = useCallback(
+    (submitted: string) => {
+      const slash = parseSlashInput(submitted);
+      if (slash !== undefined && !/\s/.test(submitted.slice(1))) {
+        const chosen = matchSlashCommands(slash.name)[0];
+        if (chosen !== undefined) {
+          acceptSlashCommand(
+            chosen,
+            slashPickIntent(chosen, 'enter'),
+            slash.remainder,
+          );
+          return;
+        }
+      }
+      handleSubmit(submitted);
+    },
+    [acceptSlashCommand, handleSubmit],
   );
 
   // Slash palette pops up while typing /…
@@ -94,36 +150,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         <SlashPalette
           query={parsed.name}
           onPick={(cmd, intent) => {
-            if (cmd.formComponent) {
-              // Structured forms own the screen — clear the input and let
-              // the active-form signal mount the component (see App.tsx).
-              const Form = cmd.formComponent;
-              setValue('');
-              cliState.activeForm.set({
-                commandName: cmd.name,
-                render: (close, availableRows) => (
-                  <Form
-                    remainder={parsed.remainder.trimStart()}
-                    availableRows={availableRows}
-                    onDone={() => close()}
-                  />
-                ),
-              });
-              return;
-            }
-            if (intent === 'submit') {
-              handleSubmit(
-                `/${cmd.name}${
-                  parsed.remainder ? ` ${parsed.remainder.trimStart()}` : ''
-                }`,
-              );
-              return;
-            }
-            setValue(
-              `/${cmd.name}${
-                parsed.remainder ? ` ${parsed.remainder.trimStart()}` : ' '
-              }`,
-            );
+            acceptSlashCommand(cmd, intent, parsed.remainder);
           }}
           onCancel={() => {
             /* Esc clears the slash — caller can re-open by typing again. */
@@ -147,6 +174,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           value={value}
           focus={!disabled && !reverseSearchOpen}
           onChange={setValue}
+          onInputChunkSubmit={handleInputChunkSubmit}
           onSubmit={showPalette ? () => undefined : handleSubmit}
         />
       </Box>

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  applyTerminalInputChunk,
   deleteAtCursor,
   deleteBeforeCursor,
   deletePreviousWord,
@@ -9,11 +10,15 @@ import {
   insertText,
 } from '@cli/chat/tui/input/textInputEditing';
 import {
+  isCtrlInput,
+  isEscapeInput,
+  isUnhandledControlInput,
   isKittyKeypadEnter,
   isPlainReturnInput,
   isShiftReturnInput,
   metaChordDigit,
   metaChordInput,
+  normalizedCtrlInput,
 } from '@cli/chat/tui/input/inputKeys';
 
 const ESC = String.fromCharCode(27);
@@ -60,6 +65,29 @@ describe('CLI TUI text input editing', () => {
     expect(metaChordDigit('\u001B3', {})).toBe(3);
     expect(metaChordDigit('\u001Bp', {})).toBeUndefined();
     expect(metaChordDigit('\u001B0', {})).toBeUndefined();
+  });
+
+  it('normalizes raw terminal control bytes for readline-style shortcuts', () => {
+    expect(normalizedCtrlInput('\u0015', {})).toBe('u');
+    expect(isCtrlInput('\u0015', {}, 'u')).toBe(true);
+    expect(isCtrlInput('u', { ctrl: true }, 'u')).toBe(true);
+    expect(isCtrlInput('\u0015', { meta: true }, 'u')).toBe(false);
+    expect(isEscapeInput('\u001B', {})).toBe(true);
+    expect(isUnhandledControlInput('\u0006')).toBe(true);
+    expect(isUnhandledControlInput('\t')).toBe(false);
+  });
+
+  it('applies batched terminal input without leaking raw control bytes', () => {
+    expect(applyTerminalInputChunk('/', 1, '\u0015/model\r')).toEqual({
+      value: '/model',
+      cursor: 6,
+      submit: true,
+    });
+    expect(applyTerminalInputChunk('one two three', 8, '\u0017X')).toEqual({
+      value: 'one Xthree',
+      cursor: 5,
+      submit: false,
+    });
   });
 
   it('inserts pasted multi-line text without submitting embedded newlines', () => {


### PR DESCRIPTION
## Summary

- normalize raw terminal control bytes for readline-style shortcuts in the CLI input stack
- drop raw Escape/control bytes instead of rendering them in the prompt
- add a TUI harness regression for Ctrl-U from the slash palette opening /model

Fixes #4856.

## Validation

- corepack pnpm exec prettier --write packages/cli/src/chat/tui/input/inputKeys.ts packages/cli/src/chat/tui/input/BaseTextInput.tsx packages/cli/src/chat/tui/input/textInputEditing.ts packages/cli/src/chat/tui/panes/InputBar.tsx packages/cli/src/chat/tui/input/ReverseSearch.tsx src/test-kernel/cli/TextInputEditing.vitest.mts packages/cli/scripts/validate-tui.mjs
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TextInputEditing.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui slash-palette-ctrl-u-clears-raw-control
- npm run texra-local:build
- texra-local real TTY replay: /, Ctrl-U, /model, Enter opens model picker
- git diff --check
- corepack pnpm --filter @texra-ai/cli run --if-present typecheck
- npm run lint (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI input handling with tests and a harness scenario; no auth, data, or server changes.
> 
> **Overview**
> Fixes raw terminal control bytes (e.g. **Ctrl-U** as `\u0015`) being inserted into the prompt or left visible when Ink delivers them without `key.ctrl`, instead of behaving like readline shortcuts.
> 
> The input stack now **normalizes** common control characters via `normalizedCtrlInput` / `isCtrlInput`, **ignores** stray Escape and other unhandled control bytes, and processes **multi-character input chunks** with `applyTerminalInputChunk` so batched keystrokes (clear line + type `/model` + Enter) apply **Ctrl-U/K/W/A/E** correctly and can **submit** without leaking `\u0015` into the buffer. **`InputBar`** wires `onInputChunkSubmit` so a chunk like `/model` after Ctrl-U can open the model picker like a normal slash flow. **Reverse search** and **BaseTextInput** use the shared helpers consistently.
> 
> Adds unit tests and a **TUI harness** scenario (`slash-palette-ctrl-u-clears-raw-control`) for the slash-palette regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a64d315a5ca1f67557c2a48436697e329e3e030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->