### PR TITLE
fix(cli): preserve narrow status separators

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -862,6 +862,21 @@ const SCENARIOS = [
     unexpect: ['*    y*', 'dle)          r*'],
   },
   {
+    name: 'tiny-status-separators',
+    cols: 30,
+    rows: 10,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'TeXRA',
+    keys: [ESC + 's'], // Option/Alt-s
+    frame: 'tail',
+    expect: ['◆ running 75s api 3 sub'],
+    unexpect: ['◆running', 'api3', '3 sub 1 proc'],
+  },
+  {
     name: 'tiny-task-subworkflow-detail',
     cols: 40,
     rows: 10,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -131,6 +131,7 @@ const QUEUED_FOLLOW_UP_PREVIEW_LENGTH = 48;
 const QUEUED_FOLLOW_UP_PREVIEW_ITEMS = 2;
 const QUEUED_FOLLOW_UP_MIN_ITEM_PREVIEW = 8;
 const QUEUED_FOLLOW_UP_SEPARATOR = ' · ';
+const PENDING_EXIT_HINT_TEXT = 'Press Ctrl-C again to exit';
 const STATUS_BAR_HORIZONTAL_PADDING = 2;
 const STATUS_BAR_MIN_RIGHT_PREVIEW = 12;
 // Preserve a readable separator between the left status group and right preview.
@@ -225,6 +226,48 @@ function statusBarSegmentsWidth(segments: readonly StatusBarSegment[]): number {
       total + statusBarSegmentWidth(segment) + (index === 0 ? 0 : 1),
     0,
   );
+}
+
+function fitStatusBarLeftSegments(
+  segments: readonly StatusBarSegment[],
+  width: number | undefined,
+): readonly StatusBarSegment[] {
+  if (width === undefined) return segments;
+
+  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
+  const fitted = [...segments];
+  while (fitted.length > 1 && statusBarSegmentsWidth(fitted) > innerWidth) {
+    fitted.pop();
+  }
+  return fitted;
+}
+
+function fitPendingExitStatusBarLeftSegments(
+  segments: readonly StatusBarSegment[],
+  width: number | undefined,
+): readonly StatusBarSegment[] {
+  if (width === undefined) return segments;
+
+  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
+  const fitted = [...segments];
+  while (fitted.length > 2 && statusBarSegmentsWidth(fitted) > innerWidth) {
+    fitted.pop();
+  }
+
+  const icon = fitted[0];
+  const prompt = fitted[1];
+  if (icon && prompt && statusBarSegmentsWidth(fitted) > innerWidth) {
+    const iconAndGapWidth = statusBarSegmentWidth(icon) + 1;
+    fitted[1] = {
+      ...prompt,
+      text: truncateSummaryToColumns(
+        prompt.text,
+        Math.max(0, innerWidth - iconAndGapWidth),
+      ),
+    };
+  }
+
+  return fitted;
 }
 
 function rightStatusBudget(
@@ -362,7 +405,7 @@ export function buildStatusBarDisplay(
   const left: StatusBarSegment[] = [{ text: '◆', color: 'cyan' }];
 
   if (input.pendingExitHint) {
-    left.push({ text: 'Press Ctrl-C again to exit', color: 'yellow' });
+    left.push({ text: PENDING_EXIT_HINT_TEXT, color: 'yellow' });
   } else {
     left.push({ text: formatCliStatusLabel(input.status), color: 'dim' });
     if (
@@ -411,12 +454,20 @@ export function buildStatusBarDisplay(
     left.push({ text: 'AUTO-APPROVE', badge: true, badgeColor: 'yellow' });
   }
 
+  const fittedLeft = input.pendingExitHint
+    ? fitPendingExitStatusBarLeftSegments(left, input.width)
+    : fitStatusBarLeftSegments(left, input.width);
+  const queuedCountVisible =
+    queued === undefined || fittedLeft.includes(queued);
+
   return {
-    left,
-    right: queuedFollowUpsSummary(
-      input.queuedFollowUpMessages,
-      rightStatusBudget(left, input.width),
-    ),
+    left: fittedLeft,
+    right: queuedCountVisible
+      ? queuedFollowUpsSummary(
+          input.queuedFollowUpMessages,
+          rightStatusBudget(fittedLeft, input.width),
+        )
+      : undefined,
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -209,6 +209,41 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[Ctrl-C]stop');
   });
 
+  it('drops trailing status details before narrow footers lose separators', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 75_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 3,
+      activeProcesses: 1,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      width: 30,
+      shortcutsActive: false,
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'running',
+      '75s',
+      'api',
+      '3 sub',
+    ]);
+    expect(display.left.map(statusBarSegmentText).join(' ')).not.toContain(
+      'api3',
+    );
+  });
+
   it('scopes Ctrl-C stop to the root when focus is on a child stream', () => {
     const parentStream = new Map([['child', 'root']]);
 
@@ -502,6 +537,35 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'Press Ctrl-C again to exit',
       'api',
+    ]);
+    expect(display.bindings).toBe(
+      'Resume this session with: texra --resume abc123',
+    );
+  });
+
+  it('keeps the exit confirmation visible in very narrow footers', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: true,
+      pendingExitResumeId: 'abc123',
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      width: 29,
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'Press Ctrl-C again to ex…',
     ]);
     expect(display.bindings).toBe(
       'Resume this session with: texra --resume abc123',


### PR DESCRIPTION
## Summary
- Cap the CLI status bar's left segment group to the available terminal width before rendering.
- Drop trailing low-priority status details instead of letting Ink collapse gaps between segments.
- Add a 30-column TUI regression that exercises the subagent picker footer.

Fixes #4859

## Validation
- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui tiny-status-separators tiny-subagent-picker narrow-subagent-picker`
- `corepack pnpm --filter @texra-ai/cli run --if-present typecheck`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only layout logic in the CLI TUI status bar with unit and harness regression tests; no auth, data, or API behavior changes.
> 
> **Overview**
> The CLI status bar now **fits its left segment group to the terminal width** before Ink renders it, so narrow terminals keep readable **spaces between** status chips instead of crushed text like `◆running` or `api3`.
> 
> When space is tight, **trailing low-priority segments** (e.g. process count) are dropped first; the **pending exit** path keeps the diamond and **truncates** the “Press Ctrl-C again to exit” line if needed. The **queued follow-up preview** on the right is omitted when the `queued N` chip had to be dropped from the left.
> 
> Coverage adds **unit tests** for 30- and 29-column footers and a **`tiny-status-separators`** PTY scenario in `validate-tui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6668761fb35cb4f96908968436f831c33778aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->