### PR TITLE
fix(cli): clarify tools form status labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -257,8 +257,13 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],
     frame: 'tail',
-    expect: ['/tools', 'Toggle available external integrations'],
-    unexpect: ['[TeXRA]', 'toolUtils'],
+    expect: [
+      '/tools',
+      'Toggle available external integrations',
+      'always on ·',
+      'enabled · detected · available',
+    ],
+    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 8 },
     ],
@@ -311,7 +316,7 @@ const SCENARIOS = [
       '+1 earlier, +6 more',
       'Esc close',
     ],
-    unexpect: ['[TeXRA]', 'toolUtils'],
+    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 2 },
     ],

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -5,7 +5,6 @@ import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import {
-  formatCliBoolean,
   readCliToolStatuses,
   setCliToolEnabled,
   type CliToolStatusRecord,
@@ -25,11 +24,31 @@ export interface ToolsListFormProps {
   readonly onClose: () => void;
 }
 
-function toolDescription(tool: CliToolStatusRecord): string {
-  const enabled = `enabled ${formatCliBoolean(tool.enabled)}`;
-  const detected = `detected ${formatCliBoolean(tool.detected)}`;
-  const status = tool.statusLabel ?? tool.status;
-  return `${enabled}; ${detected}; ${status}`;
+function formatToolEnablementForTui(tool: CliToolStatusRecord): string {
+  if (tool.comingSoon) return 'coming soon';
+  if (!tool.toggleable) return 'always on';
+  return tool.enabled === false ? 'disabled' : 'enabled';
+}
+
+function formatToolDetectionForTui(
+  detected: CliToolStatusRecord['detected'],
+): string {
+  if (detected === true) return 'detected';
+  if (detected === false) return 'not detected';
+  return 'detection unknown';
+}
+
+function formatToolStatusForTui(tool: CliToolStatusRecord): string {
+  if (tool.comingSoon) return 'not yet usable';
+  return tool.statusLabel ?? tool.status;
+}
+
+export function formatToolDescriptionForTui(tool: CliToolStatusRecord): string {
+  return [
+    formatToolEnablementForTui(tool),
+    formatToolDetectionForTui(tool.detected),
+    formatToolStatusForTui(tool),
+  ].join(' · ');
 }
 
 function toolsSelectWindow(args: {
@@ -74,7 +93,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
   const items = tools.map((tool) => ({
     value: tool.id,
     label: tool.name,
-    description: toolDescription(tool),
+    description: formatToolDescriptionForTui(tool),
     disabled: !tool.toggleable || tool.comingSoon,
   }));
 

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { formatToolDescriptionForTui } from '@cli/chat/tui/forms/ToolsListForm';
 import {
   cliToolIds,
   formatCliBoolean,
@@ -50,5 +51,41 @@ describe('CLI tools runtime', () => {
     expect(
       formatCliToolStatus(record({ statusDetail: 'Codex not found.' })),
     ).toContain('authCommand: codex login\n\nCodex not found.');
+  });
+
+  it('formats interactive tool descriptions with human state labels', () => {
+    expect(
+      formatToolDescriptionForTui(
+        record({
+          enabled: null,
+          detected: true,
+          toggleable: false,
+          status: 'available',
+        }),
+      ),
+    ).toBe('always on · detected · available');
+
+    expect(
+      formatToolDescriptionForTui(
+        record({
+          enabled: true,
+          detected: false,
+          status: 'not-found',
+          statusLabel: 'Needs setup',
+        }),
+      ),
+    ).toBe('enabled · not detected · Needs setup');
+
+    expect(
+      formatToolDescriptionForTui(
+        record({
+          enabled: null,
+          detected: true,
+          toggleable: false,
+          comingSoon: true,
+          status: 'coming-soon',
+        }),
+      ),
+    ).toBe('coming soon · detected · not yet usable');
   });
 });


### PR DESCRIPTION
## Summary
- Replace table-style `/tools` TUI descriptions such as `enabled -; detected yes; available` with human-facing state labels.
- Keep `texra tools list` unchanged for scripts while making the interactive form read as `always on · detected · available`, `enabled · not detected · Needs setup`, and `coming soon · detected · not yet usable`.
- Add unit coverage for the TUI formatter and harness assertions that reject the old `enabled -` label.

Fixes #4865

## Validation
- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/forms/ToolsListForm.tsx src/test-kernel/cli/CliTools.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui tools-form compact-tools-form`
- `corepack pnpm --filter @texra-ai/cli run --if-present typecheck`
- `git diff --check`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy/formatting in the /tools form with no changes to tool enablement logic or CLI list formatting.
> 
> **Overview**
> The **`/tools`** TUI list no longer shows script-style lines like `enabled -; detected yes; available`. Each integration’s subtitle is built by **`formatToolDescriptionForTui`**, using short phrases joined with **` · `** (e.g. **`always on · detected · available`**, **`enabled · not detected · Needs setup`**, **`coming soon · detected · not yet usable`**), including special cases for non-toggleable, disabled, unknown detection, and coming-soon tools.
> 
> **`texra tools list`** tabular output is unchanged. Coverage adds Vitest cases for the formatter and tightens **`validate-tui`** expectations so regressions to the old **`enabled -`** style fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4678e93325edba09c708517774c00be580422185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->