### PR TITLE
[codex] Show tiny CLI task detail output

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -622,7 +622,6 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Tasks and sub-workflows', 'latex build'],
-    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'task-picker',
@@ -646,7 +645,6 @@ const SCENARIOS = [
         to: 'Tasks and sub-workflows',
         max: 3,
       },
-      { from: '╰', to: '╭', max: 1 },
     ],
   },
   {
@@ -793,7 +791,6 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['strategy sub-wo…', 'sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-subagent-picker-second',
@@ -816,7 +813,6 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['leanSolver sub-wor…', 'sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-task-picker',
@@ -838,7 +834,6 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['sub-workfl\now', '\n────╯', 'Esc cl…'],
-    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'tiny-subagent-picker',
@@ -890,11 +885,11 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       'Task details',
-      'Task details · Description',
-      'Esc back',
+      'stream · strategy',
+      'strategy is checking the harness',
       '[main]* 1:strategy*',
     ],
-    unexpect: ['╰─Output:', '*    y*'],
+    unexpect: ['│ ›', 'Task details · Description', '*    y*'],
   },
   {
     name: 'tiny-task-process-detail',
@@ -908,8 +903,12 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
     frame: 'tail',
-    expect: ['Task details', 'Command: latex build', 'Esc back'],
-    unexpect: ['╰─Output:', '*    y*'],
+    expect: [
+      'Task details',
+      'shell · latex build',
+      'main.tex: Proof sketch needs one',
+    ],
+    unexpect: ['│ ›', 'Task details · Command', '*    y*'],
   },
   {
     name: 'stopped-subagent-picker',
@@ -931,7 +930,6 @@ const SCENARIOS = [
       'k kill',
       'Harness kill requested for harness-child-strategy.\n\nHarness kill requested for harness-child-strategy.',
     ],
-    maxBlankLinesBetween: [{ from: '╰', to: '╭', max: 1 }],
   },
   {
     name: 'focused-stopped-subagent',
@@ -965,7 +963,6 @@ const SCENARIOS = [
         to: 'Tasks and sub-workflows',
         max: 4,
       },
-      { from: '╰', to: '╭', max: 1 },
     ],
   },
   {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -67,18 +67,21 @@ const PINNED_CHROME_ROWS = {
 } as const;
 
 function pinnedChromeRows({
+  inputVisible = true,
   reverseSearchOpen,
   slashPaletteOpen,
   tipVisible = true,
 }: {
+  readonly inputVisible?: boolean;
   readonly reverseSearchOpen: boolean;
   readonly slashPaletteOpen: boolean;
   readonly tipVisible?: boolean;
 }): number {
-  const { tip, ...alwaysVisibleRows } = PINNED_CHROME_ROWS;
   const baseRows =
-    Object.values(alwaysVisibleRows).reduce((sum, rows) => sum + rows, 0) +
-    (tipVisible ? tip : 0);
+    PINNED_CHROME_ROWS.streamTabsWorstCase +
+    PINNED_CHROME_ROWS.status +
+    (inputVisible ? PINNED_CHROME_ROWS.input : 0) +
+    (tipVisible ? PINNED_CHROME_ROWS.tip : 0);
   return (
     baseRows +
     (slashPaletteOpen ? SLASH_PALETTE_ROWS : 0) +
@@ -89,6 +92,7 @@ function pinnedChromeRows({
 export function allocateMiddleRows({
   foregroundMaxRows,
   foregroundOpen,
+  inputVisible = true,
   reverseSearchOpen,
   rows,
   slashPaletteOpen,
@@ -96,6 +100,7 @@ export function allocateMiddleRows({
 }: {
   readonly foregroundMaxRows?: number;
   readonly foregroundOpen: boolean;
+  readonly inputVisible?: boolean;
   readonly reverseSearchOpen: boolean;
   readonly rows: number;
   readonly slashPaletteOpen: boolean;
@@ -108,6 +113,7 @@ export function allocateMiddleRows({
     0,
     rows -
       pinnedChromeRows({
+        inputVisible,
         reverseSearchOpen,
         slashPaletteOpen,
         tipVisible,
@@ -310,6 +316,7 @@ export function App(props: AppProps): React.JSX.Element {
     transcriptViewerOpen;
   const tipRowVisible = shouldShowTipRow({ foregroundOpen });
   const inputDisabled = props.inputDisabled === true || foregroundOpen;
+  const inputBarVisible = !foregroundOpen;
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const subagentControlTarget = resolveChildControlStreamTarget({
@@ -345,6 +352,7 @@ export function App(props: AppProps): React.JSX.Element {
           ? FORM_FOREGROUND_MAX_ROWS
           : undefined,
     foregroundOpen,
+    inputVisible: inputBarVisible,
     reverseSearchOpen,
     rows,
     slashPaletteOpen,
@@ -551,6 +559,7 @@ export function App(props: AppProps): React.JSX.Element {
         {tipRowVisible ? <TipRow /> : null}
         <InputBar
           onSubmit={props.onSubmit}
+          collapseWhenDisabled={!inputBarVisible}
           disabled={inputDisabled}
           history={props.history}
         />

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -369,11 +369,13 @@ export function computePickerListLayout({
 function TaskOutput({
   childStreamId,
   tailLines,
+  truncateLines = false,
   visibleTail,
   visibleLineCount,
 }: {
   readonly childStreamId: StreamTabId | undefined;
   readonly tailLines: readonly string[];
+  readonly truncateLines?: boolean;
   readonly visibleTail: readonly string[];
   readonly visibleLineCount: number;
 }): React.JSX.Element | null {
@@ -382,7 +384,11 @@ function TaskOutput({
     return (
       <>
         {visibleTail.map((line, index) => (
-          <Text key={`${index}:${line}`} dimColor>
+          <Text
+            key={`${index}:${line}`}
+            dimColor
+            wrap={truncateLines ? 'truncate-end' : undefined}
+          >
             {line}
           </Text>
         ))}
@@ -526,6 +532,7 @@ function TaskDetailView({
         <TaskOutput
           childStreamId={item.childStreamId}
           tailLines={item.tailLines}
+          truncateLines={layout.compact}
           visibleTail={visibleTail}
           visibleLineCount={visibleLineCount}
         />

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -21,6 +21,8 @@ export interface InputBarProps {
   readonly onSubmit: (value: string) => void;
   /** Disable the input while an approval modal is owning the screen. */
   readonly disabled?: boolean;
+  /** Preserve component state while giving foreground panels the input rows. */
+  readonly collapseWhenDisabled?: boolean;
   /** Prompt prefix (e.g. `>`). */
   readonly prompt?: string;
   /** Persistent input history (optional — undefined disables Ctrl-R). */
@@ -143,6 +145,8 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     cliState.reverseSearchOpen.set(reverseSearchOpen);
     return () => cliState.reverseSearchOpen.set(false);
   }, [reverseSearchOpen]);
+
+  if (disabled && props.collapseWhenDisabled) return <></>;
 
   return (
     <Box flexDirection="column">

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -194,6 +194,20 @@ describe('CLI TUI row allocation', () => {
     expect(shouldShowTipRow({ foregroundOpen: true })).toBe(false);
   });
 
+  it('returns disabled input rows to tiny foreground surfaces', () => {
+    const layout = allocateMiddleRows({
+      foregroundOpen: true,
+      inputVisible: false,
+      reverseSearchOpen: false,
+      rows: 10,
+      slashPaletteOpen: false,
+      tipVisible: false,
+    });
+
+    expect(layout.transcriptRows).toBe(1);
+    expect(layout.foregroundRows).toBe(6);
+  });
+
   it('can cap compact foreground surfaces on tall terminals', () => {
     const layout = allocateMiddleRows({
       foregroundMaxRows: 12,


### PR DESCRIPTION
## Summary

Fixes #4861.

- collapse the disabled chat input while foreground panels own input so tiny task detail views get those rows back
- truncate compact task-output rows so the detail layout's row budget matches rendered terminal rows
- tighten TUI harness coverage so 40x10 task details must show actual output and no disabled prompt frame

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tiny-task-after subagent-picker task-picker narrow-subagent-picker narrow-subagent-picker-second narrow-task-picker stopped-subagent-picker empty-task-picker tiny-task-subworkflow-detail tiny-task-process-detail task-subworkflow-detail task-process-detail tiny-status-separators`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 12 import-order warnings)
- `git diff --check`

Note: current GitHub Actions runs are blocked by the repository Actions budget (`The job was not started because an Actions budget is preventing further use.`), so validation above is local.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI layout and validation changes with no auth, persistence, or API surface impact.
> 
> **Overview**
> Fixes cramped **40×10** (and similar) CLI task-detail views by reclaiming vertical space when foreground panels own the keyboard.
> 
> While a foreground surface is open, the chat **input bar no longer reserves three terminal rows**—`allocateMiddleRows` takes an `inputVisible` flag, and `InputBar` can **collapse** when disabled so the disabled `›` prompt frame does not appear. **Compact task detail** output lines use **end truncation** so tail text fits the layout’s row budget instead of wrapping to extra lines.
> 
> Harness expectations for tiny subworkflow/process details now require **stream/shell metadata and real output**, and drop obsolete blank-line spacing rules between box-drawing characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f9b6a3a8fd31c0e98afde6c710e2091412a0d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->