### PR TITLE
[codex] Preserve compact CLI picker labels

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -38,7 +38,8 @@ export interface ChildControlPickerProps {
 }
 
 export const TASK_DETAIL_LABEL_WIDTH = 13;
-export const ULTRA_COMPACT_PICKER_MAX_ROWS = 4;
+export const ULTRA_COMPACT_PICKER_MAX_ROWS = 6;
+export const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
 export const NARROW_PICKER_HINT_MAX_COLUMNS = 64;
 export const MIN_COLUMNS_FOR_JUMP_HINT = 58;
 export const MIN_COLUMNS_FOR_KILL_HINT = 44;
@@ -59,6 +60,15 @@ export function isUltraCompactPickerRows(
   return (
     availableRows !== undefined &&
     availableRows <= ULTRA_COMPACT_PICKER_MAX_ROWS
+  );
+}
+
+export function isUltraCompactTaskDetailRows(
+  availableRows: number | undefined,
+): boolean {
+  return (
+    availableRows !== undefined &&
+    availableRows <= ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS
   );
 }
 
@@ -444,7 +454,7 @@ function TaskDetailView({
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
   const compactMeta = metaParts.join(' · ');
   const commandLabel = taskDetailCommandLabel(item.kind);
-  const ultraCompact = isUltraCompactPickerRows(availableRows);
+  const ultraCompact = isUltraCompactTaskDetailRows(availableRows);
   const showScrollHint =
     item.tailLines.length > visibleLineCount && !ultraCompact;
   const hints: KeyHint[] = [

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -8,6 +8,7 @@ import {
   computeTaskDetailLayout,
   emptyPickerText,
   isUltraCompactPickerRows,
+  isUltraCompactTaskDetailRows,
   moveTaskDetailScrollState,
   pickerKeyHints,
   pickerKeyHintsForColumns,
@@ -799,11 +800,15 @@ describe('CLI child execution controls', () => {
     expect(emptyPickerText('tasks')).toBe('No active tasks or sub-workflows.');
   });
 
-  it('switches child pickers to ultra-compact rendering only at very small budgets', () => {
+  it('switches child pickers to ultra-compact rendering before bordered content clips', () => {
     expect(isUltraCompactPickerRows(3)).toBe(true);
     expect(isUltraCompactPickerRows(4)).toBe(true);
-    expect(isUltraCompactPickerRows(5)).toBe(false);
+    expect(isUltraCompactPickerRows(5)).toBe(true);
+    expect(isUltraCompactPickerRows(6)).toBe(true);
+    expect(isUltraCompactPickerRows(7)).toBe(false);
     expect(isUltraCompactPickerRows(undefined)).toBe(false);
+    expect(isUltraCompactTaskDetailRows(4)).toBe(true);
+    expect(isUltraCompactTaskDetailRows(5)).toBe(false);
     expect(
       compactPickerOverflowText({
         itemCount: 3,


### PR DESCRIPTION
## Summary

Fixes #4869.

- switch child list pickers to their unboxed ultra-compact rendering at six foreground rows, before bordered content clips titles and overflow counts
- keep task detail's emergency ultra-compact breakpoint at four rows so tiny task details still show output
- add unit coverage for the separate picker/detail row thresholds

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-display-audit-fixed compact-subagent-picker compact-task-picker compact-task-picker-process-overflow tiny-subagent-picker tiny-task-subworkflow-detail tiny-task-process-detail`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-display-audit-fixed-full subagents subagent-picker task-picker compact-subagent-picker compact-task-picker compact-task-picker-process-overflow task-subworkflow-detail task-subworkflow-detail-long-output task-process-detail narrow-subagent-picker narrow-subagent-picker-second narrow-task-picker tiny-subagent-picker tiny-status-separators tiny-task-subworkflow-detail tiny-task-process-detail stopped-subagent-picker focused-stopped-subagent empty-task-picker task-picker-parent-fallback`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 12 import-order warnings)
- `git diff --check`

Note: current GitHub Actions runs are blocked by the repository Actions budget (`The job was not started because an Actions budget is preventing further use.`), so validation above is local.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout thresholds and display-mode helpers only; no auth, data, or API behavior changes.
> 
> **Overview**
> Child list pickers (subagents / tasks) now switch to **unboxed ultra-compact** layout when there are **up to six** foreground rows (was four), so titles and overflow text are less likely to clip inside the bordered view.
> 
> **Task detail** no longer shares that threshold: it uses a dedicated **four-row** cutoff via `isUltraCompactTaskDetailRows`, so medium-height pickers can stay compact while task details still show output until the viewport is very small.
> 
> Unit tests in `ChildControls.vitest.mts` cover the separate picker vs. detail breakpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0d281eec86d7e28d2919c54ffc2d977b25372c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->