### PR TITLE
fix(cli): show workspace files in history

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -18,12 +18,13 @@ import {
   ExecutionIdSchema,
   type ExecutionId,
 } from '@shared/schemas';
-import { StorageFS } from '@utils/files';
+import { AbsoluteFS, StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
 const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
 const CONVERSATION_PREVIEW_CONTENT_LIMIT = 4000;
+const WORKSPACE_FILE_TOOL_NAMES = new Set(['write_file', 'edit_file']);
 
 const KV_FILES = new Set([
   'meta.json',
@@ -97,17 +98,26 @@ export async function readCliHistoryDetails(
   id: ExecutionId,
 ): Promise<CliHistoryDetails | null> {
   const store = getExecutionStore(id);
-  const [meta, config, resultMeta, report, conversation, files, hasFlowRecord] =
-    await Promise.all([
-      store.readMeta(),
-      store.readConfig(),
-      store.readResultMeta(),
-      store.readReport(),
-      store.readConversation(),
-      listGeneratedFiles(id),
-      store.exists(flowKey(id)),
-    ]);
+  const [
+    meta,
+    config,
+    resultMeta,
+    report,
+    conversation,
+    generatedFiles,
+    hasFlowRecord,
+  ] = await Promise.all([
+    store.readMeta(),
+    store.readConfig(),
+    store.readResultMeta(),
+    store.readReport(),
+    store.readConversation(),
+    listGeneratedFiles(id),
+    store.exists(flowKey(id)),
+  ]);
   const conversationPreview = createConversationPreview(conversation);
+  const workspaceFiles = await listWorkspaceToolFiles(config, conversation);
+  const files = mergeHistoryFiles(generatedFiles, workspaceFiles);
 
   if (!meta && !config && !conversationPreview && !hasFlowRecord) return null;
   return {
@@ -385,4 +395,163 @@ async function walkStorageDirectory(
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function listWorkspaceToolFiles(
+  config: AgentConfig | null,
+  conversation: readonly unknown[] | null,
+): Promise<CliHistoryFile[]> {
+  const workspaceRoot = config?.workingDirectory?.trim();
+  if (!workspaceRoot || !conversation?.length) return [];
+
+  const files = new Map<string, CliHistoryFile>();
+  for (const toolPath of extractWorkspaceFileToolPaths(conversation)) {
+    const resolved = resolveWorkspaceToolPath(workspaceRoot, toolPath);
+    if (!resolved || files.has(resolved.displayPath)) continue;
+
+    const stat = await AbsoluteFS.stat(resolved.absolutePath).catch(
+      () => undefined,
+    );
+    if (!stat) continue;
+
+    files.set(resolved.displayPath, {
+      path: resolved.displayPath,
+      size: stat.size,
+      isDirectory: isDirectory(stat.type),
+    });
+  }
+  return [...files.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function extractWorkspaceFileToolPaths(
+  conversation: readonly unknown[],
+): string[] {
+  const paths: string[] = [];
+  for (const message of conversation) {
+    if (!isRecord(message)) continue;
+
+    const responseToolPath = extractResponseFunctionCallFilePath(message);
+    if (responseToolPath) paths.push(responseToolPath);
+
+    const toolCalls = Array.isArray(message.tool_calls)
+      ? message.tool_calls
+      : [];
+    for (const toolCall of toolCalls) {
+      const toolPath = extractOpenAiToolCallFilePath(toolCall);
+      if (toolPath) paths.push(toolPath);
+    }
+
+    const contentBlocks = Array.isArray(message.content) ? message.content : [];
+    for (const block of contentBlocks) {
+      const toolPath = extractContentToolUseFilePath(block);
+      if (toolPath) paths.push(toolPath);
+    }
+
+    const parts = Array.isArray(message.parts) ? message.parts : [];
+    for (const part of parts) {
+      const toolPath = extractGoogleFunctionCallFilePath(part);
+      if (toolPath) paths.push(toolPath);
+    }
+  }
+  return paths;
+}
+
+function extractResponseFunctionCallFilePath(
+  message: Record<string, unknown>,
+): string | undefined {
+  if (message.type !== 'function_call') return undefined;
+  if (
+    typeof message.name !== 'string' ||
+    !WORKSPACE_FILE_TOOL_NAMES.has(message.name)
+  ) {
+    return undefined;
+  }
+  return extractToolArgumentsFilePath(message.arguments);
+}
+
+function extractOpenAiToolCallFilePath(toolCall: unknown): string | undefined {
+  if (!isRecord(toolCall)) return undefined;
+  const fn = isRecord(toolCall.function) ? toolCall.function : {};
+  if (typeof fn.name !== 'string' || !WORKSPACE_FILE_TOOL_NAMES.has(fn.name)) {
+    return undefined;
+  }
+  return extractToolArgumentsFilePath(fn.arguments);
+}
+
+function extractContentToolUseFilePath(block: unknown): string | undefined {
+  if (!isRecord(block) || block.type !== 'tool_use') return undefined;
+  if (
+    typeof block.name !== 'string' ||
+    !WORKSPACE_FILE_TOOL_NAMES.has(block.name)
+  ) {
+    return undefined;
+  }
+  return extractToolArgumentsFilePath(block.input);
+}
+
+function extractGoogleFunctionCallFilePath(part: unknown): string | undefined {
+  if (!isRecord(part) || !isRecord(part.functionCall)) return undefined;
+  const { functionCall } = part;
+  if (
+    typeof functionCall.name !== 'string' ||
+    !WORKSPACE_FILE_TOOL_NAMES.has(functionCall.name)
+  ) {
+    return undefined;
+  }
+  return extractToolArgumentsFilePath(functionCall.args);
+}
+
+function extractToolArgumentsFilePath(
+  argumentsValue: unknown,
+): string | undefined {
+  const args = parseToolArguments(argumentsValue);
+  const toolPath = typeof args?.path === 'string' ? args.path.trim() : '';
+  return toolPath || undefined;
+}
+
+function parseToolArguments(
+  argumentsValue: unknown,
+): Record<string, unknown> | undefined {
+  if (isRecord(argumentsValue)) return argumentsValue;
+  if (typeof argumentsValue !== 'string') return undefined;
+  try {
+    const parsed: unknown = JSON.parse(argumentsValue);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveWorkspaceToolPath(
+  workspaceRoot: string,
+  toolPath: string,
+): { readonly absolutePath: string; readonly displayPath: string } | undefined {
+  const absoluteRoot = path.resolve(workspaceRoot);
+  const absolutePath = path.isAbsolute(toolPath)
+    ? path.normalize(toolPath)
+    : path.resolve(absoluteRoot, toolPath);
+  const relativePath = path.relative(absoluteRoot, absolutePath);
+  if (
+    !relativePath ||
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    return undefined;
+  }
+  return {
+    absolutePath,
+    displayPath: `workspace/${relativePath.replaceAll('\\', '/')}`,
+  };
+}
+
+function mergeHistoryFiles(
+  ...fileGroups: readonly (readonly CliHistoryFile[])[]
+): CliHistoryFile[] {
+  const files = new Map<string, CliHistoryFile>();
+  for (const group of fileGroups) {
+    for (const file of group) {
+      if (!files.has(file.path)) files.set(file.path, file);
+    }
+  }
+  return [...files.values()].sort((a, b) => a.path.localeCompare(b.path));
 }

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1,3 +1,8 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -35,7 +40,6 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 }));
 
 // Imported after vi.mock so the mocked dependencies are in place.
-// eslint-disable-next-line import/order
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
@@ -64,7 +68,14 @@ const config = {
 } as AgentConfig;
 
 describe('CLI history runtime', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@platform/defaults/nodeFilesystem'),
+        import('@test/support/FakePlatform'),
+      ]);
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
     vi.clearAllMocks();
     mocks.readConfig.mockResolvedValue(config);
     mocks.readConversation.mockResolvedValue(null);
@@ -163,6 +174,171 @@ describe('CLI history runtime', () => {
 
     expect(text).toContain('Report:\nStructured report.');
     expect(text).not.toContain('Conversation (');
+  });
+
+  it('surfaces workspace files written by tool-use calls', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
+    try {
+      await writeFile(path.join(workspace, 'review.md'), '# report');
+      await writeFile(path.join(workspace, 'draft.tex'), 'old text');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readConversation.mockResolvedValue([
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              type: 'function',
+              function: {
+                name: 'write_file',
+                arguments: JSON.stringify({
+                  path: 'review.md',
+                  content: '# report',
+                }),
+              },
+            },
+            {
+              type: 'function',
+              function: {
+                name: 'edit_file',
+                arguments: {
+                  path: 'draft.tex',
+                  old_str: 'old',
+                  new_str: 'new',
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([
+        { path: 'workspace/draft.tex', size: 8, isDirectory: false },
+        { path: 'workspace/review.md', size: 8, isDirectory: false },
+      ]);
+      expect(formatCliHistoryDetailsText(details!)).toContain(
+        '8\tworkspace/review.md',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces workspace files from Responses function call records', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
+    try {
+      await writeFile(path.join(workspace, 'response.md'), 'response');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readConversation.mockResolvedValue([
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'write_file',
+          arguments: JSON.stringify({ path: 'response.md' }),
+        },
+      ]);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([
+        { path: 'workspace/response.md', size: 8, isDirectory: false },
+      ]);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces workspace files from Google functionCall parts', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
+    try {
+      await mkdir(path.join(workspace, 'subdir'));
+      await writeFile(path.join(workspace, 'subdir', 'gemini.md'), 'gemini');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readConversation.mockResolvedValue([
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'edit_file',
+                args: { path: 'subdir/gemini.md' },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([
+        { path: 'workspace/subdir/gemini.md', size: 6, isDirectory: false },
+      ]);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('does not surface missing files or tool paths outside the workspace', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'texra-history-root-'));
+    const workspace = path.join(root, 'workspace');
+    const outsidePath = path.join(root, 'outside.md');
+    try {
+      await mkdir(workspace);
+      await writeFile(outsidePath, 'outside');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readConversation.mockResolvedValue([
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              type: 'function',
+              function: {
+                name: 'write_file',
+                arguments: JSON.stringify({ path: '../outside.md' }),
+              },
+            },
+            {
+              type: 'function',
+              function: {
+                name: 'edit_file',
+                arguments: JSON.stringify({ path: outsidePath }),
+              },
+            },
+            {
+              type: 'function',
+              function: {
+                name: 'write_file',
+                arguments: JSON.stringify({ path: 'missing.md' }),
+              },
+            },
+          ],
+        },
+      ]);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it('reports not-found deletion through the structured result', async () => {


### PR DESCRIPTION
## Summary
- derive workspace file entries from persisted write_file/edit_file tool calls in CLI history
- include only files that still exist under the execution workingDirectory, with a workspace/ prefix
- add regression coverage for surfacing written files and ignoring missing/out-of-workspace paths

Fixes #4867

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/History.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json
- npm run lint (passes with 12 existing import-order warnings)
- git diff --check
- texra-local history show 546c88524ba6 --cwd=/tmp/texra-math-scout-9SOwD1 --output-format=json -> workspace/review-false-claim.md:5828

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only display logic with workspace path containment; no changes to execution, auth, or persistence writes.
> 
> **Overview**
> **CLI history `show` now lists workspace files** that agents touched via `write_file` / `edit_file`, not only artifacts under execution storage.
> 
> `readCliHistoryDetails` scans the persisted conversation for those tool paths across **OpenAI-style `tool_calls`, Responses `function_call` records, `tool_use` content blocks, and Google `functionCall` parts**, then **stats paths still present under the run’s `workingDirectory`**. Entries appear with a **`workspace/`** prefix and are **merged** with the existing storage scan (first wins on duplicate paths). Paths that **escape the workspace** (`..`, absolute paths outside the root) or **no longer exist** are omitted.
> 
> Vitest coverage uses real temp workspaces and asserts inclusion, multi-format parsing, and the negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2404a11cb4e99256195cb3c99a2f973fba38dc4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->