### PR TITLE
[codex] Keep compact CLI foreground forms readable

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -334,7 +334,13 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
     bootExpect: 'Use foreground panel shortcuts',
     frame: 'tail',
-    expect: ['Apply edit to draft.tex?', 'Esc cancel', 'approval'],
+    expect: [
+      'Apply edit to draft.tex?',
+      'y approve',
+      'n reject',
+      'Esc cancel',
+      'approval',
+    ],
     unexpect: [' · …', '╚═y approve'],
   },
   {
@@ -358,7 +364,6 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
-    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'narrow-bash-approval',
@@ -375,7 +380,6 @@ const SCENARIOS = [
       'Esc cancel',
     ],
     unexpect: [' · …', 'a session'],
-    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'long-bash-approval',
@@ -395,7 +399,6 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['╚═    print', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'compact-long-bash-approval',
@@ -415,7 +418,6 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['╚═    print', 'scroll command', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'bash-approval-approve-session',
@@ -443,7 +445,6 @@ const SCENARIOS = [
       'n reject',
     ],
     unexpect: ['confirmation of correctness', '[Option-p]tasks'],
-    maxBlankLinesBetween: [{ from: '╚', to: '╭', max: 1 }],
   },
   {
     name: 'external-inquiry-long',
@@ -461,7 +462,6 @@ const SCENARIOS = [
       'Esc skip',
     ],
     unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
-    maxBlankLinesBetween: [{ from: '└', to: '╭', max: 1 }],
   },
   {
     name: 'external-inquiry-long-80-cols',
@@ -480,7 +480,6 @@ const SCENARIOS = [
       'Esc skip',
     ],
     unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
-    maxBlankLinesBetween: [{ from: '└', to: '╭', max: 1 }],
   },
   {
     name: 'plan-approval',

--- a/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
@@ -8,8 +8,10 @@ export interface SelectWindowSize {
   readonly showOverflow: boolean;
 }
 
+export const COMPACT_FORM_MAX_ROWS = 8;
+
 export function isCompactFormRows(availableRows: number | undefined): boolean {
-  return availableRows !== undefined && availableRows <= 6;
+  return availableRows !== undefined && availableRows <= COMPACT_FORM_MAX_ROWS;
 }
 
 /**

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -127,22 +127,48 @@ export function ConfirmCard({
               : CONFIRM_CARD_HORIZONTAL_DECORATION),
         ),
       });
+  const stackedCompactHints = feedbackMode
+    ? hints
+    : confirmCardKeyHintsForWidth({
+        approveLabel,
+        rejectLabel,
+        alwaysAllowLabel: alwaysAllow?.label,
+        extraActions: extraActions.map((action) => ({
+          key: action.key,
+          action: action.label,
+        })),
+        maxColumns: columns,
+      });
+  const stackCompactHints =
+    compact &&
+    !feedbackMode &&
+    hints.some((hint) => hint.key === 'Esc') &&
+    stackedCompactHints.length > hints.length;
 
   if (compact) {
     return (
       <Box flexDirection="column">
-        <Text bold color={color} wrap="truncate-end">
-          {title}
-          <Text dimColor>{KEY_HINT_SEPARATOR}</Text>
-          <Text dimColor>
-            {hints.map((hint, index) => (
-              <Text key={`${hint.key}-${hint.action}-${index}`}>
-                {index > 0 ? KEY_HINT_SEPARATOR : ''}
-                <Text bold>{hint.key}</Text> {hint.action}
-              </Text>
-            ))}
+        {stackCompactHints ? (
+          <>
+            <Text bold color={color} wrap="truncate-end">
+              {title}
+            </Text>
+            <KeyHints hints={stackedCompactHints} confirmCancel={false} />
+          </>
+        ) : (
+          <Text bold color={color} wrap="truncate-end">
+            {title}
+            <Text dimColor>{KEY_HINT_SEPARATOR}</Text>
+            <Text dimColor>
+              {hints.map((hint, index) => (
+                <Text key={`${hint.key}-${hint.action}-${index}`}>
+                  {index > 0 ? KEY_HINT_SEPARATOR : ''}
+                  <Text bold>{hint.key}</Text> {hint.action}
+                </Text>
+              ))}
+            </Text>
           </Text>
-        </Text>
+        )}
         {feedbackMode ? (
           <Box>
             <Text>{'> '}</Text>

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -21,6 +21,7 @@ const EDIT_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 8;
 const EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 const EDIT_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;
 const EDIT_APPROVAL_FEEDBACK_PREFIX_COLUMNS = 2;
+export const COMPACT_EDIT_APPROVAL_MAX_ROWS = 8;
 const MIN_EDIT_DIFF_WIDTH = 20;
 const EDIT_APPROVAL_FEEDBACK_PLACEHOLDER = 'Why reject?';
 
@@ -138,7 +139,8 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const pageRows = Math.max(1, maxDiffLines - 2);
   const compactDiffLayout = maxDiffLines <= COMPACT_DIFF_DISPLAY_LINES;
   const compactCard =
-    props.availableRows !== undefined && props.availableRows <= 7;
+    props.availableRows !== undefined &&
+    props.availableRows <= COMPACT_EDIT_APPROVAL_MAX_ROWS;
 
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -11,13 +11,15 @@ export interface PlanApprovalProps {
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
-const COMPACT_PLAN_APPROVAL_ROWS = 4;
+export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 6;
 
-function isCompactPlanApprovalRows(availableRows: number | undefined): boolean {
+export function isCompactPlanApprovalRows(
+  availableRows: number | undefined,
+): boolean {
   return (
     availableRows !== undefined &&
     availableRows > 0 &&
-    availableRows <= COMPACT_PLAN_APPROVAL_ROWS
+    availableRows <= COMPACT_PLAN_APPROVAL_MAX_ROWS
   );
 }
 

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  COMPACT_EDIT_APPROVAL_MAX_ROWS,
   editApprovalDiffRowsBudget,
   editApprovalFeedbackRows,
 } from '@cli/chat/tui/modals/EditApproval';
@@ -51,13 +52,14 @@ describe('CLI edit approval layout', () => {
   });
 
   it('uses compact diff rows on short terminals', () => {
+    expect(COMPACT_EDIT_APPROVAL_MAX_ROWS).toBe(8);
     expect(
       editApprovalDiffRowsBudget({
-        availableRows: 10,
+        availableRows: 8,
         columns: 80,
         title: 'Apply edit to draft.tex?',
       }),
-    ).toBe(3);
+    ).toBe(2);
   });
 
   it('keeps a usable diff line on very short terminals', () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -7,6 +7,10 @@ import {
   modelSelectWindow,
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
+  COMPACT_FORM_MAX_ROWS,
+  isCompactFormRows,
+} from '@cli/chat/tui/forms/_shared/selectWindow';
+import {
   nextSelectHighlightIndex,
   selectInlineOverflowText,
   selectInitialHighlightIndex,
@@ -305,6 +309,12 @@ describe('CLI Select disabled-row focus', () => {
 });
 
 describe('CLI ModelListForm row budget', () => {
+  it('uses compact slash forms before bordered content clips titles', () => {
+    expect(COMPACT_FORM_MAX_ROWS).toBe(8);
+    expect(isCompactFormRows(8)).toBe(true);
+    expect(isCompactFormRows(9)).toBe(false);
+  });
+
   it('removes the row floor on short terminals', () => {
     expect(modelSelectWindow({ availableRows: 6, itemCount: 8 })).toEqual({
       maxVisibleItems: 1,

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPACT_PLAN_APPROVAL_MAX_ROWS,
+  isCompactPlanApprovalRows,
+} from '@cli/chat/tui/modals/PlanApproval';
+
+describe('CLI plan approval layout', () => {
+  it('switches to compact rendering before the bordered card clips plan text', () => {
+    expect(COMPACT_PLAN_APPROVAL_MAX_ROWS).toBe(6);
+    expect(isCompactPlanApprovalRows(6)).toBe(true);
+    expect(isCompactPlanApprovalRows(7)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4872.

- switch slash forms to compact rendering before bordered content clips command titles in split-terminal heights
- switch edit and plan approvals to compact cards before titles/body rows are hidden
- let compact approval cards split title and action hints onto separate rows when narrow columns would otherwise drop `y approve` / `n reject`
- update the full TUI validator for the collapsed-input behavior while keeping assertions for visible titles, approval hints, and compact plan content

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-full-validator-targeted-2 compact-agent-form compact-model-form compact-api-form compact-tools-form narrow-edit-approval compact-plan-approval-odyssey`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-dogfood-full-fixed`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 12 import-order warnings)
- `git diff --check`

Note: current GitHub Actions runs are blocked by the repository Actions budget (`The job was not started because an Actions budget is preventing further use.`), so validation above is local.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and test-only changes; no auth, data, or runtime API surface changes beyond display thresholds.
> 
> **Overview**
> Raises **compact** layout thresholds so slash forms and approval modals switch earlier on short terminals, and improves how compact approval cards show action hints.
> 
> **Slash forms** (`/agent`, `/model`, `/api`, `/tools`) now treat up to **8** foreground rows as compact (`COMPACT_FORM_MAX_ROWS`, was 6), so bordered titles and lists clip less in split-terminal heights.
> 
> **Edit** and **plan** approvals use new row caps (**8** and **6**) to pick compact cards and diff/body budgets sooner. **ConfirmCard** in compact mode can put the title on one line and **stack** full-width key hints on the next when inline hints would truncate away `y approve` / `n reject`.
> 
> **TUI validator** expectations were updated (e.g. narrow edit approval must show approve/reject hints; several `maxBlankLinesBetween` checks removed as layout changed). Kernel tests lock the new thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c3f2a2669e5014179d3c2d4bd669f358e7233f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->