### PR TITLE
refactor(agent): extract Anthropic usage/pricing into pure functions

### DIFF
--- a/src/agent/modelHandlers/anthropic/anthropicUsage.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicUsage.ts
@@ -39,7 +39,7 @@ interface AnthropicUsageTokenTotals {
  * Gets Anthropic input/output/cache token totals.
  * Uses per-iteration usage when available so compaction requests are fully billed.
  */
-export function getAnthropicUsageTokenTotals(
+function getAnthropicUsageTokenTotals(
   responseUsage: AnthropicUsage,
 ): AnthropicUsageTokenTotals {
   const usageWithIterations = responseUsage as AnthropicUsage & {

--- a/src/agent/modelHandlers/anthropic/anthropicUsage.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicUsage.ts
@@ -1,0 +1,198 @@
+/**
+ * Anthropic usage accounting & pricing.
+ *
+ * Pure functions extracted from `ModelHandlerAnthropic` so token accounting and
+ * cache-aware price computation can be reasoned about and unit-tested without a
+ * live handler instance. The handler keeps thin `computePrice` / `normalizeUsage`
+ * overrides that delegate here with the model's pricing config.
+ */
+
+import type { AnthropicUsage } from '@agent/core/usage/ResponseUsage';
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+import {
+  CACHE_CREATION_COST_MULTIPLIER_5M,
+  CACHE_CREATION_COST_MULTIPLIER_1H,
+} from './anthropicContextManagement';
+import { normalizeUsage } from '../support/UsageNormalizer';
+import type { BetaUsage } from '@anthropic-ai/sdk/resources/beta/messages';
+
+/** Pricing inputs the handler supplies from its `config`/`capabilities`. */
+export interface AnthropicPricingConfig {
+  inputPrice: number;
+  outputPrice: number;
+  supportsPromptCaching: boolean;
+  cacheDiscountFactor: number;
+}
+
+interface AnthropicUsageTokenTotals {
+  baseInputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  cacheCreation5mTokens: number;
+  cacheCreation1hTokens: number;
+}
+
+/**
+ * Gets Anthropic input/output/cache token totals.
+ * Uses per-iteration usage when available so compaction requests are fully billed.
+ */
+export function getAnthropicUsageTokenTotals(
+  responseUsage: AnthropicUsage,
+): AnthropicUsageTokenTotals {
+  const usageWithIterations = responseUsage as AnthropicUsage & {
+    iterations?: BetaUsage['iterations'];
+  };
+  const iterations = usageWithIterations.iterations;
+  if (Array.isArray(iterations) && iterations.length > 0) {
+    let baseInputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheCreationTokens = 0;
+    let cacheCreation5mTokens = 0;
+    let cacheCreation1hTokens = 0;
+
+    for (const iteration of iterations) {
+      baseInputTokens += iteration.input_tokens;
+      outputTokens += iteration.output_tokens;
+      cacheReadTokens += iteration.cache_read_input_tokens;
+      cacheCreationTokens += iteration.cache_creation_input_tokens;
+      cacheCreation5mTokens +=
+        iteration.cache_creation?.ephemeral_5m_input_tokens ?? 0;
+      cacheCreation1hTokens +=
+        iteration.cache_creation?.ephemeral_1h_input_tokens ?? 0;
+    }
+
+    return {
+      baseInputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      cacheCreation5mTokens,
+      cacheCreation1hTokens,
+    };
+  }
+
+  return {
+    baseInputTokens: responseUsage.input_tokens ?? 0,
+    outputTokens: responseUsage.output_tokens ?? 0,
+    cacheReadTokens: responseUsage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: responseUsage.cache_creation_input_tokens ?? 0,
+    cacheCreation5mTokens:
+      responseUsage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+    cacheCreation1hTokens:
+      responseUsage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+  };
+}
+
+/** Calculates API usage cost based on input/output tokens and cache usage if supported. */
+export function computeAnthropicPrice(
+  responseUsage: AnthropicUsage,
+  config: AnthropicPricingConfig,
+): number {
+  if (!responseUsage) {
+    return 0;
+  }
+
+  // Note: Anthropic doesn't provide tool_use_tokens in their API response
+  const usageTotals = getAnthropicUsageTokenTotals(responseUsage);
+
+  // Standard pricing applies across the full context window (no long-context premium).
+  const inputPrice = config.inputPrice;
+  const outputPrice = config.outputPrice;
+
+  let basePrice = calculateTokenPrice(
+    usageTotals.baseInputTokens,
+    usageTotals.outputTokens,
+    inputPrice,
+    outputPrice,
+  );
+
+  if (config.supportsPromptCaching) {
+    if (usageTotals.cacheCreationTokens > 0) {
+      const pricedBreakdownTokens =
+        usageTotals.cacheCreation5mTokens + usageTotals.cacheCreation1hTokens;
+
+      if (pricedBreakdownTokens > 0) {
+        basePrice +=
+          (usageTotals.cacheCreation5mTokens *
+            inputPrice *
+            CACHE_CREATION_COST_MULTIPLIER_5M) /
+          1e6;
+        basePrice +=
+          (usageTotals.cacheCreation1hTokens *
+            inputPrice *
+            CACHE_CREATION_COST_MULTIPLIER_1H) /
+          1e6;
+
+        const unclassifiedCacheCreationTokens = Math.max(
+          usageTotals.cacheCreationTokens - pricedBreakdownTokens,
+          0,
+        );
+        basePrice +=
+          (unclassifiedCacheCreationTokens *
+            inputPrice *
+            CACHE_CREATION_COST_MULTIPLIER_5M) /
+          1e6;
+      } else {
+        basePrice +=
+          (usageTotals.cacheCreationTokens *
+            inputPrice *
+            CACHE_CREATION_COST_MULTIPLIER_5M) /
+          1e6;
+      }
+    }
+    if (usageTotals.cacheReadTokens > 0) {
+      basePrice +=
+        (usageTotals.cacheReadTokens *
+          inputPrice *
+          config.cacheDiscountFactor) /
+        1e6;
+    }
+  }
+
+  return basePrice;
+}
+
+/** Normalizes Anthropic usage data into a unified format. */
+export function normalizeAnthropicUsage(
+  rawUsage: AnthropicUsage,
+  responseTimeMs: number,
+  config: AnthropicPricingConfig,
+): NormalizedUsage {
+  return normalizeUsage(
+    {
+      provider: 'anthropic',
+      computePrice: (usage) => computeAnthropicPrice(usage, config),
+      extract: (usage) => {
+        const usageTotals = getAnthropicUsageTokenTotals(usage);
+        // Anthropic bills cache-read and cache-creation tokens separately, so
+        // total input is base + read + creation (matches percentageCached).
+        const totalInput =
+          usageTotals.baseInputTokens +
+          usageTotals.cacheReadTokens +
+          usageTotals.cacheCreationTokens;
+
+        return {
+          inputTokens: totalInput,
+          outputTokens: usageTotals.outputTokens,
+          cachedTokens: usageTotals.cacheReadTokens,
+          cacheCreationTokens: usageTotals.cacheCreationTokens,
+          cachePercentageBasis:
+            usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
+          // SDK 0.100.0 reports the thinking-token breakdown of output_tokens,
+          // so Anthropic surfaces reasoning tokens like OpenAI/Google/xAI. This
+          // is a subset of outputTokens (already billed), not an extra charge.
+          reasoningTokens: usage.output_tokens_details?.thinking_tokens ?? 0,
+          serverToolRequests:
+            (usage.server_tool_use?.web_search_requests ?? 0) +
+            (usage.server_tool_use?.web_fetch_requests ?? 0),
+        };
+      },
+    },
+    rawUsage,
+    responseTimeMs,
+  );
+}

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -25,7 +25,6 @@ import {
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
 
 // Local imports - common
 import { getConfig } from '@agent/core/config';
@@ -47,6 +46,11 @@ import type { ToolFileAttachment } from '@tools/result';
 import { AbsoluteFS, flexibleFS, type FileLocation } from '@utils/files';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
 import { objectToLogString } from '@utils/text/stringUtils';
+import {
+  computeAnthropicPrice,
+  normalizeAnthropicUsage,
+  type AnthropicPricingConfig,
+} from './anthropicUsage';
 
 // Local file imports
 import {
@@ -73,7 +77,6 @@ import {
   formatToolResultAsText,
   type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
-import { normalizeUsage } from '../support/UsageNormalizer';
 import { tagAnthropicSdkError } from '../support/sdkErrorAdapters';
 import {
   FILES_API_BETA,
@@ -83,8 +86,6 @@ import {
   SHORT_CACHE_CONTROL,
   LONG_CACHE_CONTROL,
   isLongCacheControl,
-  CACHE_CREATION_COST_MULTIPLIER_5M,
-  CACHE_CREATION_COST_MULTIPLIER_1H,
   ensureBeta,
   hasLongCacheControlMarker,
   setupContextManagement,
@@ -122,7 +123,6 @@ import type {
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
   BetaThinkingBlock,
-  BetaUsage,
   MessageCountTokensParams,
   MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/beta/messages';
@@ -1306,68 +1306,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /** Calculates API usage cost based on input/output tokens and cache usage if supported. */
   computePrice(responseUsage: AnthropicUsage): number {
-    if (!responseUsage) {
-      return 0;
-    }
-
-    // Note: Anthropic doesn't provide tool_use_tokens in their API response
-    const usageTotals = this.getUsageTokenTotals(responseUsage);
-
-    // Standard pricing applies across the full context window (no long-context premium).
-    const inputPrice = this.config.inputPrice;
-    const outputPrice = this.config.outputPrice;
-
-    let basePrice = calculateTokenPrice(
-      usageTotals.baseInputTokens,
-      usageTotals.outputTokens,
-      inputPrice,
-      outputPrice,
-    );
-
-    if (this.capabilities.supportsPromptCaching) {
-      if (usageTotals.cacheCreationTokens > 0) {
-        const pricedBreakdownTokens =
-          usageTotals.cacheCreation5mTokens + usageTotals.cacheCreation1hTokens;
-
-        if (pricedBreakdownTokens > 0) {
-          basePrice +=
-            (usageTotals.cacheCreation5mTokens *
-              inputPrice *
-              CACHE_CREATION_COST_MULTIPLIER_5M) /
-            1e6;
-          basePrice +=
-            (usageTotals.cacheCreation1hTokens *
-              inputPrice *
-              CACHE_CREATION_COST_MULTIPLIER_1H) /
-            1e6;
-
-          const unclassifiedCacheCreationTokens = Math.max(
-            usageTotals.cacheCreationTokens - pricedBreakdownTokens,
-            0,
-          );
-          basePrice +=
-            (unclassifiedCacheCreationTokens *
-              inputPrice *
-              CACHE_CREATION_COST_MULTIPLIER_5M) /
-            1e6;
-        } else {
-          basePrice +=
-            (usageTotals.cacheCreationTokens *
-              inputPrice *
-              CACHE_CREATION_COST_MULTIPLIER_5M) /
-            1e6;
-        }
-      }
-      if (usageTotals.cacheReadTokens > 0) {
-        basePrice +=
-          (usageTotals.cacheReadTokens *
-            inputPrice *
-            this.capabilities.cacheDiscountFactor) /
-          1e6;
-      }
-    }
-
-    return basePrice;
+    return computeAnthropicPrice(responseUsage, this.pricingConfig());
   }
 
   /** Normalizes Anthropic usage data into a unified format. */
@@ -1375,95 +1314,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
     rawUsage: AnthropicUsage,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeUsage(
-      {
-        provider: 'anthropic',
-        computePrice: (usage) => this.computePrice(usage),
-        extract: (usage) => {
-          const usageTotals = this.getUsageTokenTotals(usage);
-          // Anthropic bills cache-read and cache-creation tokens separately, so
-          // total input is base + read + creation (matches percentageCached).
-          const totalInput =
-            usageTotals.baseInputTokens +
-            usageTotals.cacheReadTokens +
-            usageTotals.cacheCreationTokens;
-
-          return {
-            inputTokens: totalInput,
-            outputTokens: usageTotals.outputTokens,
-            cachedTokens: usageTotals.cacheReadTokens,
-            cacheCreationTokens: usageTotals.cacheCreationTokens,
-            cachePercentageBasis:
-              usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
-            // SDK 0.100.0 reports the thinking-token breakdown of output_tokens,
-            // so Anthropic surfaces reasoning tokens like OpenAI/Google/xAI. This
-            // is a subset of outputTokens (already billed), not an extra charge.
-            reasoningTokens: usage.output_tokens_details?.thinking_tokens ?? 0,
-            serverToolRequests:
-              (usage.server_tool_use?.web_search_requests ?? 0) +
-              (usage.server_tool_use?.web_fetch_requests ?? 0),
-          };
-        },
-      },
+    return normalizeAnthropicUsage(
       rawUsage,
       responseTimeMs,
+      this.pricingConfig(),
     );
   }
 
-  /**
-   * Gets Anthropic input/output/cache token totals.
-   * Uses per-iteration usage when available so compaction requests are fully billed.
-   */
-  private getUsageTokenTotals(responseUsage: AnthropicUsage): {
-    baseInputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-    cacheCreation5mTokens: number;
-    cacheCreation1hTokens: number;
-  } {
-    const usageWithIterations = responseUsage as AnthropicUsage & {
-      iterations?: BetaUsage['iterations'];
-    };
-    const iterations = usageWithIterations.iterations;
-    if (Array.isArray(iterations) && iterations.length > 0) {
-      let baseInputTokens = 0;
-      let outputTokens = 0;
-      let cacheReadTokens = 0;
-      let cacheCreationTokens = 0;
-      let cacheCreation5mTokens = 0;
-      let cacheCreation1hTokens = 0;
-
-      for (const iteration of iterations) {
-        baseInputTokens += iteration.input_tokens;
-        outputTokens += iteration.output_tokens;
-        cacheReadTokens += iteration.cache_read_input_tokens;
-        cacheCreationTokens += iteration.cache_creation_input_tokens;
-        cacheCreation5mTokens +=
-          iteration.cache_creation?.ephemeral_5m_input_tokens ?? 0;
-        cacheCreation1hTokens +=
-          iteration.cache_creation?.ephemeral_1h_input_tokens ?? 0;
-      }
-
-      return {
-        baseInputTokens,
-        outputTokens,
-        cacheReadTokens,
-        cacheCreationTokens,
-        cacheCreation5mTokens,
-        cacheCreation1hTokens,
-      };
-    }
-
+  /** Pricing/caching inputs for the extracted usage helpers. */
+  private pricingConfig(): AnthropicPricingConfig {
     return {
-      baseInputTokens: responseUsage.input_tokens ?? 0,
-      outputTokens: responseUsage.output_tokens ?? 0,
-      cacheReadTokens: responseUsage.cache_read_input_tokens ?? 0,
-      cacheCreationTokens: responseUsage.cache_creation_input_tokens ?? 0,
-      cacheCreation5mTokens:
-        responseUsage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
-      cacheCreation1hTokens:
-        responseUsage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+      inputPrice: this.config.inputPrice,
+      outputPrice: this.config.outputPrice,
+      supportsPromptCaching: this.capabilities.supportsPromptCaching,
+      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
     };
   }
 

--- a/src/agent/modelHandlers/google/googleUsage.ts
+++ b/src/agent/modelHandlers/google/googleUsage.ts
@@ -1,0 +1,109 @@
+/**
+ * Google GenAI usage accounting & pricing.
+ *
+ * Pure functions extracted from `ModelHandlerGoogleGenAI` so token accounting
+ * and price computation can be reasoned about and unit-tested without a live
+ * handler instance. The handler keeps thin `computePrice` / `normalizeUsage`
+ * overrides that delegate here with the model's pricing config.
+ */
+
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+import { normalizeUsage } from '../support/UsageNormalizer';
+import type { GenerateContentResponseUsageMetadata } from '@google/genai';
+
+/** Pricing inputs the handler supplies from its `config`. */
+export interface GooglePricingConfig {
+  inputPrice: number;
+  outputPrice: number;
+}
+
+interface GoogleTokenCounts {
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+}
+
+/**
+ * Google token totals. Output prefers candidatesTokenCount + thoughtsTokenCount
+ * (candidatesTokenCount excludes thinking tokens per llm-gemini#75); when those
+ * fields are unpopulated (some models in streaming) it derives output from
+ * totalTokenCount - inputTokens.
+ *
+ * TODO: extract per-modality token breakdown from promptTokensDetails[],
+ * candidatesTokensDetails[], cacheTokensDetails[], toolUsePromptTokensDetails[]
+ * (ModalityTokenCount: TEXT/IMAGE/VIDEO/AUDIO/DOCUMENT; PDF pages report under
+ * IMAGE, not DOCUMENT) for modality-specific cost tracking.
+ */
+function computeGoogleTokenCounts(
+  usage: GenerateContentResponseUsageMetadata | null,
+): GoogleTokenCounts {
+  if (!usage) {
+    return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
+  }
+
+  const promptTokens = usage.promptTokenCount ?? 0;
+  const toolUseTokens = usage.toolUsePromptTokenCount ?? 0;
+  const candidatesTokens = usage.candidatesTokenCount ?? 0;
+  const reasoningTokens = usage.thoughtsTokenCount ?? 0;
+
+  const inputTokens = promptTokens + toolUseTokens;
+
+  // Per Google's formula: outputTokens = candidatesTokenCount + thoughtsTokenCount
+  // When these fields are populated, use them directly.
+  // When unpopulated (some models in streaming), derive from totalTokenCount.
+  const directOutput = candidatesTokens + reasoningTokens;
+  const derivedOutput =
+    usage.totalTokenCount !== undefined
+      ? Math.max(0, usage.totalTokenCount - inputTokens)
+      : 0;
+
+  // Use direct values when available; otherwise use derived calculation
+  const outputTokens = directOutput > 0 ? directOutput : derivedOutput;
+
+  return { inputTokens, outputTokens, reasoningTokens };
+}
+
+/** Computes cost based on token usage and model pricing. */
+export function computeGooglePrice(
+  responseUsage: GenerateContentResponseUsageMetadata | null,
+  config: GooglePricingConfig,
+): number {
+  if (!responseUsage) return 0.0;
+  const { inputTokens, outputTokens } = computeGoogleTokenCounts(responseUsage);
+
+  return calculateTokenPrice(
+    inputTokens,
+    outputTokens,
+    config.inputPrice,
+    config.outputPrice,
+  );
+}
+
+/** Normalizes Google GenAI usage data into a unified format. */
+export function normalizeGoogleUsage(
+  rawUsage: GenerateContentResponseUsageMetadata | null,
+  responseTimeMs: number,
+  config: GooglePricingConfig,
+): NormalizedUsage {
+  return normalizeUsage(
+    {
+      provider: 'google',
+      computePrice: (usage) => computeGooglePrice(usage, config),
+      extract: (usage) => {
+        const { inputTokens, outputTokens, reasoningTokens } =
+          computeGoogleTokenCounts(usage);
+        return {
+          inputTokens,
+          outputTokens,
+          cachedTokens: usage.cachedContentTokenCount ?? 0,
+          reasoningTokens,
+          toolUsePromptTokens: usage.toolUsePromptTokenCount ?? 0,
+        };
+      },
+    },
+    rawUsage,
+    responseTimeMs,
+  );
+}

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -45,7 +45,6 @@ import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
@@ -62,7 +61,11 @@ import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
-import { normalizeUsage } from '../support/UsageNormalizer';
+import {
+  computeGooglePrice,
+  normalizeGoogleUsage,
+  type GooglePricingConfig,
+} from './googleUsage';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagGoogleSdkError } from '../support/sdkErrorAdapters';
 import { TOOL_USE_SAFETY_BUFFER } from '../contextManagementConstants';
@@ -923,68 +926,18 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return { text: responseText, usage, stopReason };
   }
 
-  /**
-   * Computes input and output token counts from Gemini usageMetadata.
-   *
-   * Google's formula: totalTokenCount = promptTokenCount + candidatesTokenCount
-   *                                   + toolUsePromptTokenCount + thoughtsTokenCount
-   *
-   * For output tokens, we prefer the sum of candidatesTokenCount + thoughtsTokenCount
-   * when available. When individual fields are unpopulated (which can happen in
-   * streaming mode for some models), we derive output from totalTokenCount using
-   * the documented formula.
-   *
-   * Note: candidatesTokenCount does NOT include thinking tokens per llm-gemini#75.
-   *
-   * TODO: Future work - extract per-modality token breakdown from promptTokensDetails[],
-   * candidatesTokensDetails[], cacheTokensDetails[], and toolUsePromptTokensDetails[].
-   * Each array contains ModalityTokenCount objects with modality (TEXT, IMAGE, VIDEO,
-   * AUDIO, DOCUMENT) and tokenCount. Note that PDF pages are currently reported under
-   * IMAGE modality, not DOCUMENT. This would enable modality-specific cost tracking
-   * and better insights into multimodal token consumption.
-   */
-  private computeTokenCounts(
-    usage: GenerateContentResponseUsageMetadata | null,
-  ): { inputTokens: number; outputTokens: number; reasoningTokens: number } {
-    if (!usage) {
-      return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
-    }
-
-    const promptTokens = usage.promptTokenCount ?? 0;
-    const toolUseTokens = usage.toolUsePromptTokenCount ?? 0;
-    const candidatesTokens = usage.candidatesTokenCount ?? 0;
-    const reasoningTokens = usage.thoughtsTokenCount ?? 0;
-
-    const inputTokens = promptTokens + toolUseTokens;
-
-    // Per Google's formula: outputTokens = candidatesTokenCount + thoughtsTokenCount
-    // When these fields are populated, use them directly.
-    // When unpopulated (some models in streaming), derive from totalTokenCount.
-    const directOutput = candidatesTokens + reasoningTokens;
-    const derivedOutput =
-      usage.totalTokenCount !== undefined
-        ? Math.max(0, usage.totalTokenCount - inputTokens)
-        : 0;
-
-    // Use direct values when available; otherwise use derived calculation
-    const outputTokens = directOutput > 0 ? directOutput : derivedOutput;
-
-    return { inputTokens, outputTokens, reasoningTokens };
-  }
-
   computePrice(
     responseUsage: GenerateContentResponseUsageMetadata | null,
   ): number {
-    if (!responseUsage) return 0.0;
-    const { inputTokens, outputTokens } =
-      this.computeTokenCounts(responseUsage);
+    return computeGooglePrice(responseUsage, this.pricingConfig());
+  }
 
-    return calculateTokenPrice(
-      inputTokens,
-      outputTokens,
-      this.config.inputPrice,
-      this.config.outputPrice,
-    );
+  /** Pricing inputs for the extracted usage helpers. */
+  private pricingConfig(): GooglePricingConfig {
+    return {
+      inputPrice: this.config.inputPrice,
+      outputPrice: this.config.outputPrice,
+    };
   }
 
   /** Normalizes Google GenAI usage data into a unified format. */
@@ -992,25 +945,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     rawUsage: GenerateContentResponseUsageMetadata | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeUsage(
-      {
-        provider: 'google',
-        computePrice: (usage) => this.computePrice(usage),
-        extract: (usage) => {
-          const { inputTokens, outputTokens, reasoningTokens } =
-            this.computeTokenCounts(usage);
-          return {
-            inputTokens,
-            outputTokens,
-            cachedTokens: usage.cachedContentTokenCount ?? 0,
-            reasoningTokens,
-            toolUsePromptTokens: usage.toolUsePromptTokenCount ?? 0,
-          };
-        },
-      },
-      rawUsage,
-      responseTimeMs,
-    );
+    return normalizeGoogleUsage(rawUsage, responseTimeMs, this.pricingConfig());
   }
 
   addContinueMessageWithPrefill(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -29,7 +29,6 @@ import {
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@agent/core/constants';
 import { getConfig } from '@agent/core/config';
 import { toOpenAIReasoningEffort } from '@agent/runtime/reasoningEffort';
@@ -50,11 +49,15 @@ import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 import { extractMimeSubtype, objectToLogString } from '@utils/text/stringUtils';
-import { normalizeUsage } from '../support/UsageNormalizer';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagOpenAISdkError } from '../support/sdkErrorAdapters';
 
 // Local file imports
+import {
+  computeOpenAIPrice,
+  normalizeOpenAIUsage,
+  type OpenAIPricingConfig,
+} from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import {
   normalizeOpenAIMessageContent,
@@ -1213,40 +1216,16 @@ export class ModelHandlerOpenAI<
 
   /** Computes cost based on token usage and model pricing. */
   computePrice(responseUsage: ExtendedCompletionUsage | null): number {
-    if (!responseUsage) return 0;
+    return computeOpenAIPrice(responseUsage, this.pricingConfig());
+  }
 
-    const cachedTokens =
-      responseUsage.prompt_tokens_details?.cached_tokens ??
-      responseUsage.prompt_cache_hit_tokens ??
-      0;
-    const promptTokens =
-      responseUsage.prompt_tokens ??
-      cachedTokens + (responseUsage.prompt_cache_miss_tokens ?? 0);
-    const completionTokens = responseUsage.completion_tokens ?? 0;
-    // Note: OpenAI doesn't provide tool_use_tokens in their API response
-
-    let basePrice = calculateTokenPrice(
-      promptTokens,
-      completionTokens,
-      this.config.inputPrice,
-      this.config.outputPrice,
-    );
-
-    // Retrieve nested token details if present
-    const reasoningTokens =
-      responseUsage.completion_tokens_details?.reasoning_tokens ?? 0;
-    if (reasoningTokens) {
-      basePrice += (reasoningTokens * this.config.outputPrice) / 1e6;
-    }
-    if (cachedTokens) {
-      basePrice -=
-        (cachedTokens *
-          this.config.inputPrice *
-          (1 - this.capabilities.cacheDiscountFactor)) /
-        1e6;
-    }
-
-    return basePrice;
+  /** Pricing/caching inputs for the extracted usage helpers. */
+  private pricingConfig(): OpenAIPricingConfig {
+    return {
+      inputPrice: this.config.inputPrice,
+      outputPrice: this.config.outputPrice,
+      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
+    };
   }
 
   /**
@@ -1263,39 +1242,11 @@ export class ModelHandlerOpenAI<
     rawUsage: ExtendedCompletionUsage | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeUsage(
-      {
-        provider: this.usageProvider,
-        computePrice: (usage) => this.computePrice(usage),
-        extract: (usage) => {
-          // OpenAI: prompt_tokens_details.cached_tokens; DeepSeek: prompt_cache_hit_tokens
-          const cachedTokens =
-            usage.prompt_tokens_details?.cached_tokens ??
-            usage.prompt_cache_hit_tokens ??
-            0;
-          const cacheMissTokens = usage.prompt_cache_miss_tokens ?? 0;
-
-          // OpenAI's prompt_tokens is the TOTAL (includes cached tokens). DeepSeek
-          // also exposes cache hit/miss fields; use their sum as a fallback if
-          // prompt_tokens is absent from an OpenAI-compatible response.
-          const inputTokens =
-            usage.prompt_tokens ??
-            (cachedTokens > 0 || cacheMissTokens > 0
-              ? cachedTokens + cacheMissTokens
-              : 0);
-
-          return {
-            inputTokens,
-            outputTokens: usage.completion_tokens ?? 0,
-            cachedTokens,
-            cacheMissTokens,
-            reasoningTokens:
-              usage.completion_tokens_details?.reasoning_tokens ?? 0,
-          };
-        },
-      },
+    return normalizeOpenAIUsage(
       rawUsage,
       responseTimeMs,
+      this.usageProvider,
+      this.pricingConfig(),
     );
   }
 

--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -1,0 +1,102 @@
+/**
+ * OpenAI (and OpenAI-compatible) usage accounting & pricing.
+ *
+ * Pure functions extracted from `ModelHandlerOpenAI` so token accounting and
+ * cache-aware price computation can be reasoned about and unit-tested without a
+ * live handler instance. The handler keeps thin `computePrice` / `normalizeUsage`
+ * overrides that delegate here with the model's pricing config and provider id.
+ */
+import type { ExtendedCompletionUsage } from '@agent/core/usage/ResponseUsage';
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+import { normalizeUsage } from '../support/UsageNormalizer';
+
+/** Pricing inputs the handler supplies from its `config`/`capabilities`. */
+export interface OpenAIPricingConfig {
+  inputPrice: number;
+  outputPrice: number;
+  cacheDiscountFactor: number;
+}
+
+/** Computes cost based on token usage and model pricing. */
+export function computeOpenAIPrice(
+  responseUsage: ExtendedCompletionUsage | null,
+  config: OpenAIPricingConfig,
+): number {
+  if (!responseUsage) return 0;
+
+  const cachedTokens =
+    responseUsage.prompt_tokens_details?.cached_tokens ??
+    responseUsage.prompt_cache_hit_tokens ??
+    0;
+  const promptTokens =
+    responseUsage.prompt_tokens ??
+    cachedTokens + (responseUsage.prompt_cache_miss_tokens ?? 0);
+  const completionTokens = responseUsage.completion_tokens ?? 0;
+  // Note: OpenAI doesn't provide tool_use_tokens in their API response
+
+  let basePrice = calculateTokenPrice(
+    promptTokens,
+    completionTokens,
+    config.inputPrice,
+    config.outputPrice,
+  );
+
+  // Retrieve nested token details if present
+  const reasoningTokens =
+    responseUsage.completion_tokens_details?.reasoning_tokens ?? 0;
+  if (reasoningTokens) {
+    basePrice += (reasoningTokens * config.outputPrice) / 1e6;
+  }
+  if (cachedTokens) {
+    basePrice -=
+      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
+      1e6;
+  }
+
+  return basePrice;
+}
+
+/** Normalizes OpenAI usage data into a unified format. */
+export function normalizeOpenAIUsage(
+  rawUsage: ExtendedCompletionUsage | null,
+  responseTimeMs: number,
+  provider: NormalizedUsage['provider'],
+  config: OpenAIPricingConfig,
+): NormalizedUsage {
+  return normalizeUsage(
+    {
+      provider,
+      computePrice: (usage) => computeOpenAIPrice(usage, config),
+      extract: (usage) => {
+        // OpenAI: prompt_tokens_details.cached_tokens; DeepSeek: prompt_cache_hit_tokens
+        const cachedTokens =
+          usage.prompt_tokens_details?.cached_tokens ??
+          usage.prompt_cache_hit_tokens ??
+          0;
+        const cacheMissTokens = usage.prompt_cache_miss_tokens ?? 0;
+
+        // OpenAI's prompt_tokens is the TOTAL (includes cached tokens). DeepSeek
+        // also exposes cache hit/miss fields; use their sum as a fallback if
+        // prompt_tokens is absent from an OpenAI-compatible response.
+        const inputTokens =
+          usage.prompt_tokens ??
+          (cachedTokens > 0 || cacheMissTokens > 0
+            ? cachedTokens + cacheMissTokens
+            : 0);
+
+        return {
+          inputTokens,
+          outputTokens: usage.completion_tokens ?? 0,
+          cachedTokens,
+          cacheMissTokens,
+          reasoningTokens:
+            usage.completion_tokens_details?.reasoning_tokens ?? 0,
+        };
+      },
+    },
+    rawUsage,
+    responseTimeMs,
+  );
+}

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -9,7 +9,6 @@ import { AgentSetting, hasEndTag } from '@agent/core/definition/AgentDataclass';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE } from '@agent/core/constants';
 import { getConfig } from '@agent/core/config';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
@@ -17,10 +16,14 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 // Local imports - tools and utils
 import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
-import { extractMimeSubtype } from '@utils/text/stringUtils';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
-import { normalizeUsage } from '../support/UsageNormalizer';
+import { extractMimeSubtype } from '@utils/text/stringUtils';
+import {
+  computeOpenRouterPrice,
+  normalizeOpenRouterUsage,
+  type OpenRouterPricingConfig,
+} from './openRouterUsage';
 import { tagOpenRouterSdkError } from '../support/sdkErrorAdapters';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 
@@ -767,53 +770,27 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ---------------------------------------------------------------------------
 
   computePrice(responseUsage: ChatUsage | null): number {
-    if (!responseUsage) return 0;
+    return computeOpenRouterPrice(responseUsage, this.pricingConfig());
+  }
 
-    const promptTokens = responseUsage.promptTokens ?? 0;
-    const completionTokens = responseUsage.completionTokens ?? 0;
-
-    let basePrice = calculateTokenPrice(
-      promptTokens,
-      completionTokens,
-      this.config.inputPrice,
-      this.config.outputPrice,
-    );
-
-    const reasoningTokens =
-      responseUsage.completionTokensDetails?.reasoningTokens ?? 0;
-    const cachedTokens = responseUsage.promptTokensDetails?.cachedTokens ?? 0;
-
-    if (reasoningTokens) {
-      basePrice += (reasoningTokens * this.config.outputPrice) / 1e6;
-    }
-    if (cachedTokens) {
-      basePrice -=
-        (cachedTokens *
-          this.config.inputPrice *
-          (1 - this.capabilities.cacheDiscountFactor)) /
-        1e6;
-    }
-
-    return basePrice;
+  /** Pricing/caching inputs for the extracted usage helpers. */
+  private pricingConfig(): OpenRouterPricingConfig {
+    return {
+      inputPrice: this.config.inputPrice,
+      outputPrice: this.config.outputPrice,
+      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
+    };
   }
 
   normalizeUsage(
     rawUsage: ChatUsage | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeUsage(
-      {
-        provider: this.usageProvider,
-        computePrice: (usage) => this.computePrice(usage),
-        extract: (usage) => ({
-          inputTokens: usage.promptTokens ?? 0,
-          outputTokens: usage.completionTokens ?? 0,
-          cachedTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
-          reasoningTokens: usage.completionTokensDetails?.reasoningTokens ?? 0,
-        }),
-      },
+    return normalizeOpenRouterUsage(
       rawUsage,
       responseTimeMs,
+      this.usageProvider,
+      this.pricingConfig(),
     );
   }
 

--- a/src/agent/modelHandlers/openrouter/openRouterUsage.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterUsage.ts
@@ -1,0 +1,78 @@
+/**
+ * OpenRouter (native SDK) usage accounting & pricing.
+ *
+ * Pure functions extracted from `ModelHandlerOpenRouterNative` so token
+ * accounting and cache-aware price computation can be reasoned about and
+ * unit-tested without a live handler instance. The handler keeps thin
+ * `computePrice` / `normalizeUsage` overrides that delegate here with the
+ * model's pricing config and provider id.
+ */
+
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+import { normalizeUsage } from '../support/UsageNormalizer';
+import type { ChatUsage } from '@openrouter/sdk/models';
+
+/** Pricing inputs the handler supplies from its `config`/`capabilities`. */
+export interface OpenRouterPricingConfig {
+  inputPrice: number;
+  outputPrice: number;
+  cacheDiscountFactor: number;
+}
+
+/** Computes cost based on token usage and model pricing. */
+export function computeOpenRouterPrice(
+  responseUsage: ChatUsage | null,
+  config: OpenRouterPricingConfig,
+): number {
+  if (!responseUsage) return 0;
+
+  const promptTokens = responseUsage.promptTokens ?? 0;
+  const completionTokens = responseUsage.completionTokens ?? 0;
+
+  let basePrice = calculateTokenPrice(
+    promptTokens,
+    completionTokens,
+    config.inputPrice,
+    config.outputPrice,
+  );
+
+  const reasoningTokens =
+    responseUsage.completionTokensDetails?.reasoningTokens ?? 0;
+  const cachedTokens = responseUsage.promptTokensDetails?.cachedTokens ?? 0;
+
+  if (reasoningTokens) {
+    basePrice += (reasoningTokens * config.outputPrice) / 1e6;
+  }
+  if (cachedTokens) {
+    basePrice -=
+      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
+      1e6;
+  }
+
+  return basePrice;
+}
+
+/** Normalizes OpenRouter usage data into a unified format. */
+export function normalizeOpenRouterUsage(
+  rawUsage: ChatUsage | null,
+  responseTimeMs: number,
+  provider: NormalizedUsage['provider'],
+  config: OpenRouterPricingConfig,
+): NormalizedUsage {
+  return normalizeUsage(
+    {
+      provider,
+      computePrice: (usage) => computeOpenRouterPrice(usage, config),
+      extract: (usage) => ({
+        inputTokens: usage.promptTokens ?? 0,
+        outputTokens: usage.completionTokens ?? 0,
+        cachedTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
+        reasoningTokens: usage.completionTokensDetails?.reasoningTokens ?? 0,
+      }),
+    },
+    rawUsage,
+    responseTimeMs,
+  );
+}


### PR DESCRIPTION
## Summary

Continues the DDD refactoring of the agent core (follow-ups: #4858 organized `agent/core`, #4864 grouped `modelHandlers` by provider). This PR opens the **god-file decomposition** phase, starting with the lowest-risk seam in the largest Anthropic concern.

It extracts the **usage-accounting & cache-pricing** logic out of `anthropic/modelHandlerAnthropic.ts` (~2.1k LOC) into a new `anthropic/anthropicUsage.ts` of pure functions:

- `getAnthropicUsageTokenTotals` — per-iteration vs flat token totals
- `computeAnthropicPrice` — base + cache-creation/read pricing math
- `normalizeAnthropicUsage` — the unified `NormalizedUsage` shape

## Rationale

- **Separates a cohesive domain calculation** (token billing / cache pricing) from the handler entity. The functions are pure — they take the raw usage plus an explicit `AnthropicPricingConfig` (`inputPrice`/`outputPrice`/`supportsPromptCaching`/`cacheDiscountFactor`) — so the pricing math is now unit-testable without standing up a live handler.
- **Surface unchanged.** The handler keeps its `computePrice` / `normalizeUsage` overrides as thin delegators that pass `this.config` / `this.capabilities`. The `IModelHandler` contract is untouched, so this is a pure separation-of-concerns move with **no behavior change**.
- **Safest seam first.** This concern was already independently covered by `AnthropicCachePricing` / `AnthropicCacheBeta` tests, making it the right place to establish the extraction pattern before touching riskier streaming/response logic.

## Implementation

- New file `src/agent/modelHandlers/anthropic/anthropicUsage.ts` (+198).
- `modelHandlerAnthropic.ts` shrinks ~150 lines: methods replaced with delegators + a `pricingConfig()` helper; now-unused imports (`calculateTokenPrice`, the cache multipliers, `BetaUsage`, the `support/UsageNormalizer` re-import) dropped.

## Validation

- `npm run typecheck` — passes
- `npm run lint` — 0 errors (12 pre-existing import-order warnings; the 2 my new file introduced were auto-fixed)
- `npm run test:kernel` — 1383 tests pass (incl. Anthropic cache-pricing suites)

## Follow-ups

The same usage/pricing extraction applies to the OpenAI, Google, and OpenRouter handlers; within Anthropic the next seams are message/media construction and the ~400-LOC streaming `createResponse`.

https://claude.ai/code/session_01QBxJme5rm3rijW43hCm94o

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBxJme5rm3rijW43hCm94o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing and token normalization across four providers; logic is moved verbatim but any wiring mistake could skew reported cost or usage.
> 
> **Overview**
> This PR **pulls token accounting, cache-aware pricing, and `NormalizedUsage` mapping** out of the large provider model handlers into **provider-specific pure-function modules**, then leaves **`computePrice` / `normalizeUsage` as thin delegators** that pass explicit pricing config from `config` and `capabilities`.
> 
> **Anthropic** gains `anthropicUsage.ts` with iteration-aware token totals, cache creation/read pricing, and normalization (including thinking and server-tool request fields). **OpenAI**, **Google GenAI**, and **OpenRouter (native)** follow the same pattern via `openAIUsage.ts`, `googleUsage.ts`, and `openRouterUsage.ts` (Google keeps streaming fallbacks for output token derivation). Handlers shrink by dropping inlined helpers and unused imports; each adds a small `pricingConfig()` (and OpenAI/OpenRouter still pass `usageProvider` where needed).
> 
> The **`IModelHandler` surface is unchanged**—this is a separation-of-concerns refactor aimed at **unit-testing billing math without a live handler**, not a change to request/response behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db76abd66494de4e91060171c137e42e554597a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->