### PR TITLE
fix(cli): avoid active slice submit crash

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -204,6 +204,15 @@ const SCENARIOS = [
     unexpect: ['registered but has no harness action'],
   },
   {
+    name: 'plain-submit',
+    cols: 120,
+    env: { HARNESS_ENTRIES: '2' },
+    keys: ['prove the bounded case for n <= 20', '\r'],
+    frame: 'tail',
+    expect: ['Harness received: prove the bounded case for n <= 20'],
+    unexpect: ['signal read during notification phase', 'ERROR'],
+  },
+  {
     name: 'agent-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
@@ -621,6 +630,24 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Tasks and sub-workflows', 'latex build'],
+  },
+  {
+    name: 'subagent-focused-submit',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 's', '\r', 'child follow-up on focused stream', '\r'],
+    frame: 'tail',
+    expect: [
+      'Please handle the harness-child-strategy sub-workflow.',
+      'strategy is checking the harness-child-strategy details',
+      'Harness received: child follow-up on focused stream',
+    ],
+    unexpect: ['signal read during notification phase', 'ERROR'],
   },
   {
     name: 'task-picker',

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -24,7 +24,9 @@ export interface ConversationPaneProps {
 export function ConversationPane(
   props: ConversationPaneProps = {},
 ): React.JSX.Element {
-  const slice = useSignal(cliState.activeSlice);
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
   const { pending } = splitTranscriptEntries(entries, slice?.status);
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -142,7 +142,9 @@ export interface SubagentListProps {
 export function SubagentList(
   props: SubagentListProps = {},
 ): React.JSX.Element | null {
-  const slice = useSignal(cliState.activeSlice);
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const activeProcesses = slice?.activeProcesses ?? [];
   const processOutput = slice?.processOutput;
   const subagents = slice ? visibleSubagentRows(slice) : [];

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -197,7 +197,9 @@ export interface TodosPlanPanelProps {
 export function TodosPlanPanel(
   props: TodosPlanPanelProps = {},
 ): React.JSX.Element | null {
-  const slice = useSignal(cliState.activeSlice);
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (!slice) return null;
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -117,18 +117,6 @@ const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
  *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
 const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 
-/** Derived: the active stream's slice (or `undefined`). Because `patchStream`
- *  rebuilds the streams map but keeps each untouched slice's reference, this
- *  returns the SAME `StreamSlice` when the active stream is unchanged — even
- *  while a *background* stream is streaming. Panes that only read the active
- *  slice subscribe here instead of the whole map, so a token on another stream
- *  no longer re-renders them: `useSignal`'s `useSyncExternalStore` bails via
- *  Object.is. Mirrors the webview's `activeStreamInfo$`. */
-const ACTIVE_SLICE = new Signal.Computed<StreamSlice | undefined>(() => {
-  const id = ACTIVE_STREAM_ID.get();
-  return id ? STREAMS.get().get(id) : undefined;
-});
-
 /** Active inline slash form, or `undefined` when the chat input owns the
  *  screen. The form's `onDone` clears this slot. Kept opaque (the form
  *  carries its own state) so the registry stays declarative. */
@@ -163,7 +151,6 @@ export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
   streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
-  activeSlice: ACTIVE_SLICE as Signal.Computed<StreamSlice | undefined>,
   parentStream: PARENT_STREAM as Signal.State<
     ReadonlyMap<StreamTabId, StreamTabId>
   >,


### PR DESCRIPTION
## Summary

- remove the `cliState.activeSlice` computed selector that can read signals during a streams update notification
- have the TUI display panes select the active slice from `activeStreamId` and `streams` directly
- add PTY coverage for ordinary submit and focused-subagent submit paths

Fixes #4875.

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/TodosPlanPanel.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-submit-full-validate-2`
- `npm run compile:safe`
- `npm run lint` (0 errors; existing 12 import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI state subscription change with harness regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a TUI crash on **Enter** submit (including #4875) by removing the shared **`cliState.activeSlice`** computed signal, which could read signals while a **`streams`** update was still notifying subscribers.
> 
> **`ConversationPane`**, **`SubagentList`**, and **`TodosPlanPanel`** now subscribe to **`activeStreamId`** and **`streams`** and resolve the active **`StreamSlice`** in the component instead of via that computed.
> 
> PTY validation adds **`plain-submit`** and **`subagent-focused-submit`** scenarios that assert the harness receives input and that **"signal read during notification phase"** / **ERROR** do not appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf2ded2b7f8fe8933025d4534cbff9083928f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->