### PR TITLE
[codex] Persist tool-use workspace files

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -4,6 +4,7 @@ import {
   deleteAllExecutions,
   deleteExecution,
   getExecutionStore,
+  listExecutionWorkspaceFiles,
   listExecutions,
   type ExecutionListingEntry,
   type ExecutionMeta,
@@ -18,7 +19,7 @@ import {
   ExecutionIdSchema,
   type ExecutionId,
 } from '@shared/schemas';
-import { AbsoluteFS, StorageFS } from '@utils/files';
+import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
@@ -32,6 +33,7 @@ const KV_FILES = new Set([
   'conversation.json',
   'todos.json',
   'report.json',
+  'workspace-files.json',
   'result-meta.json',
 ]);
 
@@ -104,6 +106,7 @@ export async function readCliHistoryDetails(
     resultMeta,
     report,
     conversation,
+    persistedWorkspaceFilePaths,
     generatedFiles,
     hasFlowRecord,
   ] = await Promise.all([
@@ -112,11 +115,16 @@ export async function readCliHistoryDetails(
     store.readResultMeta(),
     store.readReport(),
     store.readConversation(),
+    store.readWorkspaceFiles(),
     listGeneratedFiles(id),
     store.exists(flowKey(id)),
   ]);
   const conversationPreview = createConversationPreview(conversation);
-  const workspaceFiles = await listWorkspaceToolFiles(config, conversation);
+  const workspaceFiles = await listWorkspaceToolFiles(
+    config,
+    persistedWorkspaceFilePaths,
+    conversation,
+  );
   const files = mergeHistoryFiles(generatedFiles, workspaceFiles);
 
   if (!meta && !config && !conversationPreview && !hasFlowRecord) return null;
@@ -399,28 +407,20 @@ async function walkStorageDirectory(
 
 async function listWorkspaceToolFiles(
   config: AgentConfig | null,
+  persistedPaths: readonly string[],
   conversation: readonly unknown[] | null,
 ): Promise<CliHistoryFile[]> {
-  const workspaceRoot = config?.workingDirectory?.trim();
-  if (!workspaceRoot || !conversation?.length) return [];
-
-  const files = new Map<string, CliHistoryFile>();
-  for (const toolPath of extractWorkspaceFileToolPaths(conversation)) {
-    const resolved = resolveWorkspaceToolPath(workspaceRoot, toolPath);
-    if (!resolved || files.has(resolved.displayPath)) continue;
-
-    const stat = await AbsoluteFS.stat(resolved.absolutePath).catch(
-      () => undefined,
-    );
-    if (!stat) continue;
-
-    files.set(resolved.displayPath, {
-      path: resolved.displayPath,
-      size: stat.size,
-      isDirectory: isDirectory(stat.type),
-    });
-  }
-  return [...files.values()].sort((a, b) => a.path.localeCompare(b.path));
+  const filePaths = persistedPaths.length
+    ? persistedPaths
+    : conversation?.length
+      ? extractWorkspaceFileToolPaths(conversation)
+      : [];
+  const workspaceFiles = await listExecutionWorkspaceFiles(config, filePaths);
+  return workspaceFiles.map((file) => ({
+    path: file.displayPath,
+    size: file.size,
+    isDirectory: file.isDirectory,
+  }));
 }
 
 function extractWorkspaceFileToolPaths(
@@ -520,28 +520,6 @@ function parseToolArguments(
   } catch {
     return undefined;
   }
-}
-
-function resolveWorkspaceToolPath(
-  workspaceRoot: string,
-  toolPath: string,
-): { readonly absolutePath: string; readonly displayPath: string } | undefined {
-  const absoluteRoot = path.resolve(workspaceRoot);
-  const absolutePath = path.isAbsolute(toolPath)
-    ? path.normalize(toolPath)
-    : path.resolve(absoluteRoot, toolPath);
-  const relativePath = path.relative(absoluteRoot, absolutePath);
-  if (
-    !relativePath ||
-    relativePath.startsWith('..') ||
-    path.isAbsolute(relativePath)
-  ) {
-    return undefined;
-  }
-  return {
-    absolutePath,
-    displayPath: `workspace/${relativePath.replaceAll('\\', '/')}`,
-  };
 }
 
 function mergeHistoryFiles(

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -276,7 +276,6 @@ export class HistoryItemElement extends LitElement {
 
     const extraDetails: Array<TemplateResult> = [];
 
-    // File fields only exist on workflow configs (discriminated union)
     if (config.agentCategory === AGENT_CATEGORY.WORKFLOW) {
       const contextSection = this.renderConfigSection('Context', [
         ['ContextFiles', config.contextFiles],
@@ -298,6 +297,11 @@ export class HistoryItemElement extends LitElement {
         );
         if (toolSection) extraDetails.push(toolSection);
       }
+    } else if (config.agentCategory === AGENT_CATEGORY.TOOL_USE) {
+      const editedSection = this.renderConfigSection('Edited Files', [
+        ['Files', config.editedFiles],
+      ]);
+      if (editedSection) extraDetails.push(editedSection);
     }
 
     const titleText = instructionText ?? descriptionText ?? '(no instruction)';

--- a/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
@@ -111,6 +111,14 @@ export function getHistorySearchText(item: HistoryItem): string {
     if (hasMoreDetails) {
       parts.push('More details');
     }
+  } else if (config.agentCategory === 'toolUse') {
+    const hasMoreDetails = addConfigSection(parts, 'Edited Files', [
+      ['Files', config.editedFiles],
+    ]);
+
+    if (hasMoreDetails) {
+      parts.push('More details');
+    }
   }
 
   return normalizeSearchText(parts.join('\n'));

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -325,6 +325,10 @@ export async function runToolUseFlow<C = unknown>(
       const todos = s.stateSlices?.workspaceSnapshot?.workPlan?.todos;
       if (Array.isArray(todos) && todos.length) await store.writeTodos(todos);
       if (s.messages.length) await store.writeConversation(s.messages);
+      const currentTouchedFiles = extractTouchedFiles(s.stateSlices);
+      if (currentTouchedFiles.length) {
+        await store.writeWorkspaceFiles(currentTouchedFiles);
+      }
     });
     await pf.run(shared);
     // Re-read shared from the flow record — PersistedFlow deep-clones the

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -27,6 +27,7 @@ const KEYS = {
   REPORT: 'report',
   TODOS: 'todos',
   CONVERSATION: 'conversation',
+  WORKSPACE_FILES: 'workspace-files',
   RESULT_META: 'result-meta',
   child: (id: string) => `child-${id}`,
 } as const;
@@ -63,6 +64,7 @@ export const TodoEntrySchema = z.object({
 export type TodoEntry = z.infer<typeof TodoEntrySchema>;
 
 const TodoArraySchema = z.array(TodoEntrySchema);
+const WorkspaceFilePathArraySchema = z.array(z.string()).catch([]);
 
 /** Parse a raw array into validated TodoEntry[]. Returns empty on failure. */
 function parseTodoArray(raw: unknown[]): TodoEntry[] {
@@ -121,6 +123,7 @@ export interface ExecutionKVStore {
   readReport(): Promise<string | null>;
   readTodos(): Promise<TodoEntry[]>;
   readConversation(): Promise<unknown[] | null>;
+  readWorkspaceFiles(): Promise<string[]>;
   readChildren(): Promise<ChildRecord[]>;
   readResultMeta(): Promise<ResultMeta | null>;
 
@@ -130,6 +133,7 @@ export interface ExecutionKVStore {
   writeReport(report: string): Promise<void>;
   writeTodos(todos: TodoEntry[]): Promise<void>;
   writeConversation(messages: unknown[]): Promise<void>;
+  writeWorkspaceFiles(paths: readonly string[]): Promise<void>;
   writeChild(childId: ExecutionId, data: ChildRecordData): Promise<void>;
   writeResultMeta(data: ResultMeta): Promise<void>;
 }
@@ -194,6 +198,11 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     return Array.isArray(raw) && raw.length > 0 ? raw : null;
   }
 
+  async readWorkspaceFiles(): Promise<string[]> {
+    const raw = await this.read(KEYS.WORKSPACE_FILES);
+    return normalizeWorkspaceFilePaths(WorkspaceFilePathArraySchema.parse(raw));
+  }
+
   /** Read children: per-child KV keys with schema validation. */
   async readChildren(): Promise<ChildRecord[]> {
     const childKeys = await this.listKeys('child-');
@@ -240,6 +249,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     await this.write(KEYS.CONVERSATION, messages);
   }
 
+  async writeWorkspaceFiles(paths: readonly string[]): Promise<void> {
+    await this.write(KEYS.WORKSPACE_FILES, normalizeWorkspaceFilePaths(paths));
+  }
+
   async writeChild(childId: ExecutionId, data: ChildRecordData): Promise<void> {
     await this.write(KEYS.child(childId), data);
   }
@@ -247,6 +260,15 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   async writeResultMeta(data: ResultMeta): Promise<void> {
     await this.write(KEYS.RESULT_META, data);
   }
+}
+
+function normalizeWorkspaceFilePaths(paths: readonly string[]): string[] {
+  const normalized = new Set<string>();
+  for (const rawPath of paths) {
+    const pathValue = rawPath.trim().replaceAll('\\', '/');
+    if (pathValue) normalized.add(pathValue);
+  }
+  return [...normalized].sort((a, b) => a.localeCompare(b));
 }
 
 // ============================================================================

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -12,6 +12,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getAgent, isAgentRegistryReady } from '@agent/index/agentRegistry';
 
 import type { ExecutionId } from '@shared/schemas';
+import { WorkspaceFS } from '@utils/files';
 import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
 import { invalidateListingCache } from './executionListing';
 
@@ -37,6 +38,12 @@ export function normalizeWriterCategory(
   if (!isAgentRegistryReady()) return config;
   if (getAgent(agentName)?.category === AgentCategory.ToolUse) return config;
   return { ...config, agentCategory: AgentCategory.Workflow };
+}
+
+function pinExecutionWorkingDirectory(config: AgentConfig): AgentConfig {
+  const workingDirectory =
+    config.workingDirectory?.trim() || WorkspaceFS.getPath()?.trim();
+  return workingDirectory ? { ...config, workingDirectory } : config;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,9 +101,13 @@ export async function registerExecution(
   const meta: ExecutionMeta = { timestamp, parentExecutionId };
   if (category) meta.category = category;
   if (delegationDepth !== undefined) meta.delegationDepth = delegationDepth;
+  const persistedConfig = normalizeWriterCategory(
+    pinExecutionWorkingDirectory(config),
+    agentName,
+  );
 
   const writes: Promise<void>[] = [
-    store.writeConfig(normalizeWriterCategory(config, agentName)),
+    store.writeConfig(persistedConfig),
     store.writeMeta(meta),
   ];
 

--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -1,0 +1,71 @@
+import * as path from 'path';
+
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { isDirectory } from '@common/files/fsEntryType';
+import { AbsoluteFS } from '@utils/files';
+
+export interface ExecutionWorkspaceFile {
+  readonly path: string;
+  readonly displayPath: string;
+  readonly absolutePath: string;
+  readonly size: number;
+  readonly isDirectory: boolean;
+}
+
+export function resolveExecutionWorkspaceFilePath(
+  config: AgentConfig | null,
+  filePath: string,
+): { readonly absolutePath: string; readonly path: string } | undefined {
+  const workspaceRoot = executionWorkspaceRoot(config);
+  const cleanedPath = filePath.trim();
+  if (!workspaceRoot || !cleanedPath) return undefined;
+
+  const absoluteRoot = path.resolve(workspaceRoot);
+  const absolutePath = path.isAbsolute(cleanedPath)
+    ? path.normalize(cleanedPath)
+    : path.resolve(absoluteRoot, cleanedPath);
+  const relativePath = path.relative(absoluteRoot, absolutePath);
+  if (
+    !relativePath ||
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    return undefined;
+  }
+
+  return {
+    absolutePath,
+    path: relativePath.replaceAll('\\', '/'),
+  };
+}
+
+export async function listExecutionWorkspaceFiles(
+  config: AgentConfig | null,
+  filePaths: readonly string[],
+): Promise<ExecutionWorkspaceFile[]> {
+  const files = new Map<string, ExecutionWorkspaceFile>();
+  for (const filePath of filePaths) {
+    const resolved = resolveExecutionWorkspaceFilePath(config, filePath);
+    if (!resolved || files.has(resolved.path)) continue;
+
+    const stat = await AbsoluteFS.stat(resolved.absolutePath).catch(
+      () => undefined,
+    );
+    if (!stat) continue;
+
+    files.set(resolved.path, {
+      path: resolved.path,
+      displayPath: `workspace/${resolved.path}`,
+      absolutePath: resolved.absolutePath,
+      size: stat.size,
+      isDirectory: isDirectory(stat.type),
+    });
+  }
+  return [...files.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function executionWorkspaceRoot(
+  config: AgentConfig | null,
+): string | undefined {
+  return config?.workingDirectory?.trim() || undefined;
+}

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -19,6 +19,11 @@ export {
   clearStoreCache,
 } from './ExecutionKVStore';
 export {
+  type ExecutionWorkspaceFile,
+  listExecutionWorkspaceFiles,
+  resolveExecutionWorkspaceFilePath,
+} from './executionWorkspaceFiles';
+export {
   detectWaitingStreams,
   hasPersistedFlowRecord,
 } from './detectWaitingStreams';

--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -35,6 +35,7 @@ const WorkflowConfigSummarySchema = BaseConfigSummarySchema.extend({
 /** Tool-use agents only have the base fields. */
 const ToolUseConfigSummarySchema = BaseConfigSummarySchema.extend({
   agentCategory: z.literal(AGENT_CATEGORY.TOOL_USE),
+  editedFiles: z.array(z.string()).optional(),
 });
 
 const AgentConfigSummarySchema = z.discriminatedUnion('agentCategory', [

--- a/src/shared/settingsView/handlers/historyHandlers.ts
+++ b/src/shared/settingsView/handlers/historyHandlers.ts
@@ -5,7 +5,7 @@
  * `HistoryItem` shape for the settings UI. Action handlers (delete, rerun,
  * export) remain host-specific because they touch host-only UI surfaces.
  */
-import { listExecutions } from '@agent/storage';
+import { getExecutionStore, listExecutions } from '@agent/storage';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
 import type {
   HistoryItem,
@@ -14,23 +14,31 @@ import type {
 
 export async function buildHistoryMessage(): Promise<UpdateHistoryMessage> {
   const entries = await listExecutions();
-  const historyItems = entries
-    .filter(
-      (entry) => entry.agentConfig !== null && entry.category !== 'process',
-    )
-    .map((entry): HistoryItem => {
+  const visibleEntries = entries.filter(
+    (entry) => entry.agentConfig !== null && entry.category !== 'process',
+  );
+  const historyItems = await Promise.all(
+    visibleEntries.map(async (entry): Promise<HistoryItem> => {
       const cfg = entry.agentConfig!;
       const base = {
         agent: cfg.agent,
         model: cfg.model,
         instruction: cfg.instruction,
       };
+      const editedFiles =
+        cfg.agentCategory === 'toolUse'
+          ? await getExecutionStore(entry.id).readWorkspaceFiles()
+          : [];
       return {
         id: entry.id,
         timestamp: entry.timestamp,
         agentConfig:
           cfg.agentCategory === 'toolUse'
-            ? { agentCategory: 'toolUse' as const, ...base }
+            ? {
+                agentCategory: 'toolUse' as const,
+                ...base,
+                editedFiles,
+              }
             : {
                 agentCategory: 'workflow' as const,
                 ...base,
@@ -42,7 +50,8 @@ export async function buildHistoryMessage(): Promise<UpdateHistoryMessage> {
               },
         description: entry.description,
       };
-    });
+    }),
+  );
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,
     historyItems,

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -1,0 +1,65 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ExecutionId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const mocks = vi.hoisted(() => ({
+  getExecutionStore: vi.fn(),
+  writeConfig: vi.fn(),
+  writeMeta: vi.fn(),
+}));
+
+vi.mock('@agent/storage/ExecutionKVStore', () => ({
+  getExecutionStore: mocks.getExecutionStore,
+}));
+
+vi.mock('@agent/storage/executionListing', () => ({
+  invalidateListingCache: vi.fn(),
+}));
+
+import { registerExecution } from '@agent/storage/executionLifecycle';
+
+const baseConfig = {
+  agent: 'chat',
+  model: 'deepseekT',
+  instruction: 'Check the proof.',
+  agentCategory: 'toolUse',
+  inputFiles: [],
+  outputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  editedFile: null,
+  editedFiles: [],
+  memories: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+} as AgentConfig;
+
+describe('registerExecution', () => {
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const { createFakePlatform } = await import('@test/support/FakePlatform');
+    initPlatform(createFakePlatform({ workspacePath: '/workspace/root' }));
+    vi.clearAllMocks();
+    mocks.getExecutionStore.mockReturnValue({
+      writeConfig: mocks.writeConfig,
+      writeMeta: mocks.writeMeta,
+    });
+  });
+
+  it('pins the active workspace path when a config has no working directory', async () => {
+    await registerExecution(
+      'abc123' as ExecutionId,
+      baseConfig,
+      'chat',
+      undefined,
+      'toolUse',
+    );
+
+    expect(mocks.writeConfig).toHaveBeenCalledWith({
+      ...baseConfig,
+      workingDirectory: '/workspace/root',
+    });
+  });
+});

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -12,6 +12,7 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
   readConversation: vi.fn(),
+  readWorkspaceFiles: vi.fn(),
   readMeta: vi.fn(),
   readResultMeta: vi.fn(),
   readReport: vi.fn(),
@@ -21,19 +22,25 @@ const mocks = vi.hoisted(() => ({
   deleteAllExecutions: vi.fn(),
 }));
 
-vi.mock('@agent/storage', () => ({
-  getExecutionStore: vi.fn(() => ({
-    readConfig: mocks.readConfig,
-    readConversation: mocks.readConversation,
-    readMeta: mocks.readMeta,
-    readResultMeta: mocks.readResultMeta,
-    readReport: mocks.readReport,
-    exists: mocks.exists,
-  })),
-  listExecutions: mocks.listExecutions,
-  deleteExecution: mocks.deleteExecution,
-  deleteAllExecutions: mocks.deleteAllExecutions,
-}));
+vi.mock('@agent/storage', async () => {
+  const actual =
+    await vi.importActual<typeof import('@agent/storage')>('@agent/storage');
+  return {
+    ...actual,
+    getExecutionStore: vi.fn(() => ({
+      readConfig: mocks.readConfig,
+      readConversation: mocks.readConversation,
+      readWorkspaceFiles: mocks.readWorkspaceFiles,
+      readMeta: mocks.readMeta,
+      readResultMeta: mocks.readResultMeta,
+      readReport: mocks.readReport,
+      exists: mocks.exists,
+    })),
+    listExecutions: mocks.listExecutions,
+    deleteExecution: mocks.deleteExecution,
+    deleteAllExecutions: mocks.deleteAllExecutions,
+  };
+});
 
 vi.mock('@utils/files/taskRunStorage', () => ({
   resolveStoragePath: vi.fn(async () => undefined),
@@ -79,6 +86,7 @@ describe('CLI history runtime', () => {
     vi.clearAllMocks();
     mocks.readConfig.mockResolvedValue(config);
     mocks.readConversation.mockResolvedValue(null);
+    mocks.readWorkspaceFiles.mockResolvedValue([]);
     mocks.readMeta.mockResolvedValue(null);
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
@@ -174,6 +182,64 @@ describe('CLI history runtime', () => {
 
     expect(text).toContain('Report:\nStructured report.');
     expect(text).not.toContain('Conversation (');
+  });
+
+  it('surfaces persisted workspace files without parsing provider messages', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
+    try {
+      await writeFile(path.join(workspace, 'durable.md'), '# durable');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readWorkspaceFiles.mockResolvedValue(['durable.md']);
+      mocks.readConversation.mockResolvedValue([
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              type: 'function',
+              function: {
+                name: 'write_file',
+                arguments: JSON.stringify({ path: 'legacy.md' }),
+              },
+            },
+          ],
+        },
+      ]);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([
+        { path: 'workspace/durable.md', size: 9, isDirectory: false },
+      ]);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves persisted paths inside a top-level workspace directory', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
+    try {
+      await mkdir(path.join(workspace, 'workspace'));
+      await writeFile(path.join(workspace, 'review.md'), 'wrong');
+      await writeFile(path.join(workspace, 'workspace', 'review.md'), 'nested');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        agentCategory: 'toolUse',
+        workingDirectory: workspace,
+      });
+      mocks.readWorkspaceFiles.mockResolvedValue(['workspace/review.md']);
+
+      const details = await readCliHistoryDetails('a1' as ExecutionId);
+
+      expect(details?.files).toEqual([
+        { path: 'workspace/workspace/review.md', size: 6, isDirectory: false },
+      ]);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
   });
 
   it('surfaces workspace files written by tool-use calls', async () => {

--- a/src/test-kernel/settings/HistoryHandlers.vitest.ts
+++ b/src/test-kernel/settings/HistoryHandlers.vitest.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
+
+const mocks = vi.hoisted(() => ({
+  listExecutions: vi.fn(),
+  readWorkspaceFiles: vi.fn(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({
+    readWorkspaceFiles: mocks.readWorkspaceFiles,
+  })),
+  listExecutions: mocks.listExecutions,
+}));
+
+import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
+
+describe('settings history handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readWorkspaceFiles.mockResolvedValue([]);
+  });
+
+  it('includes persisted edited files for tool-use history items', async () => {
+    mocks.listExecutions.mockResolvedValue([
+      {
+        id: 'abc123',
+        timestamp: '2026-05-31T12:00:00.000Z',
+        agentConfig: {
+          agent: 'chat',
+          model: 'deepseekT',
+          instruction: 'Check a proof.',
+          agentCategory: AGENT_CATEGORY.TOOL_USE,
+        },
+        category: 'toolUse',
+      },
+    ]);
+    mocks.readWorkspaceFiles.mockResolvedValue(['proofs/lemma.md']);
+
+    const message = await buildHistoryMessage();
+
+    expect(message.historyItems).toEqual([
+      {
+        id: 'abc123',
+        timestamp: '2026-05-31T12:00:00.000Z',
+        agentConfig: {
+          agentCategory: 'toolUse',
+          agent: 'chat',
+          model: 'deepseekT',
+          instruction: 'Check a proof.',
+          editedFiles: ['proofs/lemma.md'],
+        },
+        description: undefined,
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/settings/HistorySearchPrefilter.vitest.ts
+++ b/src/test-kernel/settings/HistorySearchPrefilter.vitest.ts
@@ -35,6 +35,18 @@ const minimalWorkflowHistoryItem: HistoryItem = {
   },
 };
 
+const toolUseHistoryItem: HistoryItem = {
+  id: 'execution-3',
+  timestamp: '2026-01-03T00:00:00.000Z',
+  agentConfig: {
+    agentCategory: 'toolUse',
+    agent: 'researcher',
+    model: 'test-model',
+    instruction: 'Check the lemma.',
+    editedFiles: ['proofs/lemma.md'],
+  },
+};
+
 describe('history search prefilter', () => {
   it('matches rendered history fields without requiring DOM construction', () => {
     const searchText = getHistorySearchText(workflowHistoryItem);
@@ -71,6 +83,20 @@ describe('history search prefilter', () => {
       historySearchTextMatches(
         searchText,
         getHistorySearchTokens('missing variational'),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches edited files rendered for tool-use history items', () => {
+    const searchText = getHistorySearchText(toolUseHistoryItem);
+
+    expect(
+      historySearchTextMatches(searchText, getHistorySearchTokens('lemma.md')),
+    ).toBe(true);
+    expect(
+      historySearchTextMatches(
+        searchText,
+        getHistorySearchTokens('more details'),
       ),
     ).toBe(true);
   });

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const mocks = vi.hoisted(() => ({
+  readConfig: vi.fn(),
+  readWorkspaceFiles: vi.fn(),
+  listExecutions: vi.fn(),
+}));
+
+vi.mock('@agent/storage', async () => {
+  const actual =
+    await vi.importActual<typeof import('@agent/storage')>('@agent/storage');
+  return {
+    ...actual,
+    getExecutionStore: vi.fn(() => ({
+      readConfig: mocks.readConfig,
+      readWorkspaceFiles: mocks.readWorkspaceFiles,
+    })),
+    listExecutions: mocks.listExecutions,
+  };
+});
+
+import { ExecutionsTool } from '@tools/ExecutionsTool';
+
+const config = {
+  agent: 'chat',
+  model: 'deepseekT',
+  instruction: 'Check the proof.',
+  agentCategory: 'toolUse',
+  inputFiles: [],
+  outputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  editedFile: null,
+  editedFiles: [],
+  memories: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+} as AgentConfig;
+
+describe('ExecutionsTool workspace files', () => {
+  beforeEach(async () => {
+    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@platform/defaults/nodeFilesystem'),
+        import('@test/support/FakePlatform'),
+      ]);
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+    vi.clearAllMocks();
+    mocks.listExecutions.mockResolvedValue([]);
+    mocks.readWorkspaceFiles.mockResolvedValue([]);
+  });
+
+  it('lists and reads persisted workspace files for tool-use executions', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
+    try {
+      await writeFile(path.join(workspace, 'review.md'), '# report\n');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        workingDirectory: workspace,
+      });
+      mocks.readWorkspaceFiles.mockResolvedValue(['review.md']);
+
+      const tool = new ExecutionsTool();
+      const listResult = await tool.call({
+        path: '/executions/abc123/workspace-files',
+      });
+      const readResult = await tool.call({
+        path: '/executions/abc123/workspace-files/review.md',
+      });
+
+      expect(listResult.output).toContain('review.md');
+      expect(readResult.summary).toBe(
+        'Read /executions/abc123/workspace-files/review.md',
+      );
+      expect(readResult.output).toContain('# report');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses unrecorded workspace file reads', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
+    try {
+      await writeFile(path.join(workspace, 'secret.md'), 'secret');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        workingDirectory: workspace,
+      });
+      mocks.readWorkspaceFiles.mockResolvedValue(['review.md']);
+
+      const result = await new ExecutionsTool().call({
+        path: '/executions/abc123/workspace-files/secret.md',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Workspace file not found');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('reads recorded files inside a top-level workspace directory', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
+    try {
+      await mkdir(path.join(workspace, 'workspace'));
+      await writeFile(path.join(workspace, 'review.md'), 'wrong');
+      await writeFile(path.join(workspace, 'workspace', 'review.md'), 'nested');
+      mocks.readConfig.mockResolvedValue({
+        ...config,
+        workingDirectory: workspace,
+      });
+      mocks.readWorkspaceFiles.mockResolvedValue(['workspace/review.md']);
+
+      const result = await new ExecutionsTool().call({
+        path: '/executions/abc123/workspace-files/workspace/review.md',
+      });
+
+      expect(result.summary).toBe(
+        'Read /executions/abc123/workspace-files/workspace/review.md',
+      );
+      expect(result.output).toContain('nested');
+      expect(result.output).not.toContain('wrong');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -16,10 +16,13 @@ import { platform } from '@platform/platform';
 // Local imports - agent
 import {
   getExecutionStore,
+  listExecutionWorkspaceFiles,
   type ChildRecord,
   type TodoEntry,
   listExecutions,
+  resolveExecutionWorkspaceFilePath,
 } from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { flowKey } from '@agent/node/persistedFlow';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import {
@@ -49,7 +52,7 @@ import {
   type ExecutionId,
 } from '@shared/schemas';
 import { requireRunStream } from '@tools/contextHelpers';
-import { StorageFS } from '@utils/files';
+import { AbsoluteFS, StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
@@ -116,7 +119,7 @@ function listenForFollowUp(ac: AbortController): () => void {
 // ============================================================================
 
 const ExecutionsToolInputSchema = z.strictObject({
-  /** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/files/{path} */
+  /** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
   path: z.string().describe('Path starting with /executions'),
 
   /** Action to perform. */
@@ -242,6 +245,8 @@ Paths:
 - /executions/{id}/output - stdout/stderr (background processes only)
 - /executions/{id}/files - Generated files (workflows only)
 - /executions/{id}/files/{path} - Read specific generated file (workflows only)
+- /executions/{id}/workspace-files - Workspace files edited by tool-use runs
+- /executions/{id}/workspace-files/{path} - Read a workspace file edited by a tool-use run
 
 Use "current" as {id} to access the active execution.
 Use offset/limit to paginate the /executions listing (default: offset 0, limit 100).
@@ -322,6 +327,15 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
           // Schema enforces length 2; cast since Zod infers number[]
           input.view_range as [number, number] | undefined,
         );
+      case 'workspace-files':
+        if (rest.length === 0) {
+          return this.listWorkspaceFiles(executionId);
+        }
+        return this.readWorkspaceFile(
+          executionId,
+          rest.join('/'),
+          input.view_range as [number, number] | undefined,
+        );
     }
 
     throw new ToolError(
@@ -334,7 +348,8 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         `- /executions/{id}/todos        - Task list (tool-use subagents)\n` +
         `- /executions/{id}/children     - Child executions\n` +
         `- /executions/{id}/output       - stdout/stderr (background processes)\n` +
-        `- /executions/{id}/files        - Generated files (workflows)`,
+        `- /executions/{id}/files        - Generated files (workflows)\n` +
+        `- /executions/{id}/workspace-files - Workspace files edited by tool-use runs`,
     );
   }
 
@@ -854,6 +869,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     'conversation.json',
     'todos.json',
     'report.json',
+    'workspace-files.json',
     'result-meta.json',
   ]);
 
@@ -960,6 +976,102 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       viewRange,
       maxLines: Infinity,
     });
+  }
+
+  private async listWorkspaceFiles(
+    executionId: ExecutionId,
+  ): Promise<ToolResult> {
+    const store = getExecutionStore(executionId);
+    const [config, paths] = await Promise.all([
+      store.readConfig(),
+      store.readWorkspaceFiles(),
+    ]);
+    const entries = await listExecutionWorkspaceFiles(config, paths);
+
+    if (entries.length === 0) {
+      return {
+        output: `No workspace files recorded for execution ${executionId}.`,
+      };
+    }
+
+    const lines = entries.map((entry) => {
+      const sizeStr = entry.isDirectory ? '<dir>' : this.formatSize(entry.size);
+      return `${sizeStr.padStart(8)}  ${entry.path}`;
+    });
+
+    return {
+      output:
+        `Workspace files for /executions/${executionId}/workspace-files:\n\n` +
+        lines.join('\n'),
+    };
+  }
+
+  private async readWorkspaceFile(
+    executionId: ExecutionId,
+    filePath: string,
+    viewRange?: [number, number],
+  ): Promise<ToolResult> {
+    const store = getExecutionStore(executionId);
+    const [config, paths] = await Promise.all([
+      store.readConfig(),
+      store.readWorkspaceFiles(),
+    ]);
+    const recordedPaths = this.recordedWorkspacePathSet(config, paths);
+    const resolved = this.resolveRecordedWorkspaceFile(
+      config,
+      recordedPaths,
+      filePath,
+    );
+    if (!resolved) {
+      throw new ToolError(
+        `Workspace file not found: /executions/${executionId}/workspace-files/${filePath}`,
+      );
+    }
+
+    const stats = await AbsoluteFS.stat(resolved.absolutePath);
+    if (isDirectory(stats.type)) {
+      throw new ToolError(
+        `Path is a directory: /executions/${executionId}/workspace-files/${filePath}. Use without trailing path to list.`,
+      );
+    }
+
+    const content = await AbsoluteFS.read(resolved.absolutePath);
+    return formatFileView({
+      path: `/executions/${executionId}/workspace-files/${resolved.path}`,
+      lines: splitContentLines(content),
+      viewRange,
+      maxLines: Infinity,
+    });
+  }
+
+  private resolveRecordedWorkspaceFile(
+    config: AgentConfig | null,
+    recordedPaths: ReadonlySet<string>,
+    filePath: string,
+  ): { readonly absolutePath: string; readonly path: string } | undefined {
+    const direct = resolveExecutionWorkspaceFilePath(config, filePath);
+    if (direct && recordedPaths.has(direct.path)) {
+      return direct;
+    }
+    const displayPrefix = 'workspace/';
+    if (!filePath.startsWith(displayPrefix)) return undefined;
+    const stripped = resolveExecutionWorkspaceFilePath(
+      config,
+      filePath.slice(displayPrefix.length),
+    );
+    return stripped && recordedPaths.has(stripped.path) ? stripped : undefined;
+  }
+
+  private recordedWorkspacePathSet(
+    config: AgentConfig | null,
+    paths: readonly string[],
+  ): Set<string> {
+    return new Set(
+      paths.flatMap((candidate) => {
+        const resolved = resolveExecutionWorkspaceFilePath(config, candidate);
+        return resolved ? [resolved.path] : [];
+      }),
+    );
   }
 
   private formatSize(bytes: number): string {

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -28,13 +28,20 @@ export function getAvailablePaths(
   if (hasChildren) common.push('children');
   switch (category) {
     case 'toolUse':
-      return [...common, 'conversation', 'todos'];
+      return [...common, 'conversation', 'todos', 'workspace-files'];
     case 'workflow':
       return [...common, 'files'];
     case 'process':
       return [...common, 'output'];
     default:
-      return [...common, 'conversation', 'todos', 'files', 'output'];
+      return [
+        ...common,
+        'conversation',
+        'todos',
+        'files',
+        'workspace-files',
+        'output',
+      ];
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #4873.

This persists workspace files edited by tool-use runs as durable execution metadata, then reads that generic source from user-visible history surfaces instead of depending on provider-shaped conversation records for future runs.

## Changes

- Add `workspace-files.json` to the execution KV store with typed read/write helpers.
- Persist tool-use edited files from the tool-use flow projection so partial/errored runs can retain edits already observed by the flow.
- Pin each new execution's `workingDirectory` at registration time and avoid resolving old missing configs against the current workspace.
- Show persisted workspace files in `texra history show` while keeping the conversation parser as legacy fallback for older runs.
- Add `/executions/{id}/workspace-files` and `/executions/{id}/workspace-files/{path}` for tool-use edited workspace files.
- Show/search edited files in Settings history for tool-use sessions.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts src/test-kernel/settings/HistoryHandlers.vitest.ts src/test-kernel/settings/HistorySearchPrefilter.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing 12 import-order warnings)
- `npm run compile:safe`
- `git diff --check`
- Rebuilt and linked `texra-local` with `corepack pnpm run texra-local:build && corepack pnpm run texra-local:link`
- Real CLI checks: old math-scout execution still shows `workspace/review-false-claim.md`; synthetic durable `workspace-files.json` history record preserves a real top-level `workspace/review.md` as `workspace/workspace/review.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds filesystem-backed reads gated by persisted path allowlists and workspace-root checks; incorrect pinning or path normalization could hide files or block legitimate reads, but scope is bounded to execution metadata and known surfaces.
> 
> **Overview**
> Tool-use runs now **persist edited workspace file paths** in execution KV (`workspace-files.json`), written during the tool-use flow projection from `touchedFiles` and normalized on read/write.
> 
> **Consumers** prefer that durable list over scraping provider-shaped conversations: `texra history show` (conversation parsing remains a fallback for older runs), Settings history (**Edited Files** display + search), and new **`/executions/{id}/workspace-files`** list/read paths on `ExecutionsTool` (reads are limited to recorded paths under the execution’s pinned `workingDirectory`).
> 
> Shared **`listExecutionWorkspaceFiles` / `resolveExecutionWorkspaceFilePath`** centralize workspace-relative resolution and stat listing; **`registerExecution`** pins the active workspace path when config has no `workingDirectory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b37ed604b6e02ca7413ab66453b915a8f188b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->