### PR TITLE
fix(cli): retain stopped subworkflows in task picker

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -958,6 +958,42 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'stopped-task-picker',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', 'k', ESC + 'p', DOWN, DOWN],
+    expect: [
+      'Tasks and sub-workflows',
+      'Stream: main',
+      '› 3. strategy — stopped',
+      'Enter view',
+      'Esc close',
+    ],
+    unexpect: ['k kill'],
+  },
+  {
+    name: 'stopped-task-subworkflow-detail',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 'p', 'k', ESC + 'p', DOWN, DOWN, '\r'],
+    expect: [
+      'Task details',
+      'stream · strategy · stopped',
+      'Please handle the harness-child-strategy sub-workflow.',
+      'f focus stream',
+      'Esc back',
+    ],
+    unexpect: ['k kill'],
+  },
+  {
     name: 'focused-stopped-subagent',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -214,9 +214,15 @@ export function buildChildControlItems(
     );
   }
 
+  const activeKeys = new Set(slice.activeSubagents.map(childKey));
   return [
-    ...slice.activeSubagents.map((child) =>
-      buildSubagentItem(child, streamsById, nowMs),
+    ...visibleSubagentRows(slice).map((child) =>
+      buildSubagentItem(
+        child,
+        streamsById,
+        nowMs,
+        activeKeys.has(childKey(child)),
+      ),
     ),
     ...slice.activeProcesses.map((child) =>
       buildProcessItem(
@@ -235,11 +241,13 @@ function hasVisibleSubagents(
 }
 
 function hasVisibleTasks(
-  slice: Pick<StreamSlice, 'activeProcesses' | 'activeSubagents'> | undefined,
+  slice:
+    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
+    | undefined,
 ): boolean {
   return (
     slice !== undefined &&
-    (slice.activeSubagents.length > 0 || slice.activeProcesses.length > 0)
+    (visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0)
   );
 }
 

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -200,6 +200,15 @@ describe('CLI child execution controls', () => {
           elapsed: '12s',
         },
       ],
+      childStreams: [
+        {
+          executionId: 'agent-2',
+          agentName: 'reviewer',
+          childStreamId: 'child-b',
+          status: 'stopped',
+          elapsed: '20s',
+        },
+      ],
       activeProcesses: [
         {
           executionId: 'proc-1',
@@ -222,6 +231,16 @@ describe('CLI child execution controls', () => {
         killable: true,
         tailLines: [],
       },
+      {
+        executionId: 'agent-2',
+        childStreamId: 'child-b',
+        kind: 'subagent',
+        label: 'reviewer',
+        command: 'reviewer',
+        description: 'stopped · 20s',
+        killable: false,
+        tailLines: [],
+      },
     ]);
     expect(buildChildControlItems(state, 'tasks')).toMatchObject([
       {
@@ -231,6 +250,15 @@ describe('CLI child execution controls', () => {
         label: 'critic',
         command: 'critic',
         killable: true,
+      },
+      {
+        executionId: 'agent-2',
+        childStreamId: 'child-b',
+        kind: 'subagent',
+        label: 'reviewer',
+        command: 'reviewer',
+        description: 'stopped · 20s',
+        killable: false,
       },
       {
         executionId: 'proc-1',
@@ -679,6 +707,45 @@ describe('CLI child execution controls', () => {
         childStreamId: 'review-stream',
         kind: 'subagent',
         label: 'review',
+      },
+    ]);
+  });
+
+  it('falls back to retained parent task rows when only stopped child streams remain', () => {
+    const child = slice({ streamId: 'review-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'review-stream',
+      mode: 'tasks',
+      parentStream: new Map([['review-stream', 'main']]),
+      streams: new Map([
+        [
+          'main',
+          slice({
+            streamId: 'main',
+            childStreams: [
+              {
+                executionId: 'agent-1',
+                agentName: 'review',
+                childStreamId: 'review-stream',
+                status: 'stopped',
+              },
+            ],
+          }),
+        ],
+        ['review-stream', child],
+      ]),
+    });
+
+    expect(target.streamId).toBe('main');
+    expect(target.fallbackFromStreamId).toBe('review-stream');
+    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        childStreamId: 'review-stream',
+        kind: 'subagent',
+        label: 'review',
+        status: 'stopped',
+        killable: false,
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- include retained child streams in the `Tasks and sub-workflows` picker, matching the subagent picker and stream strip
- keep stopped/completed retained sub-workflow rows non-killable so their picker/detail actions do not advertise stale `k kill`
- add kernel and PTY coverage for stopped task picker rows and stopped sub-workflow detail inspection

Fixes #4879.

## Validation

- `npm run format -- --log-level warn`
- `npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-stopped-task-fixed stopped-task-picker stopped-task-subworkflow-detail stopped-subagent-picker focused-stopped-subagent task-picker task-subworkflow-detail`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-stopped-task-full`
- `npm run compile:safe`
- `npm run lint` (0 errors; existing 12 import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI child-control state and test-only harness scenarios; no auth, persistence, or network surface.
> 
> **Overview**
> The **Tasks and sub-workflows** picker now lists **retained** sub-workflow rows from `childStreams` (via `visibleSubagentRows`), not only currently active subagents—aligned with the subagent picker and stream strip.
> 
> Stopped or completed retained rows are **`killable: false`**, so picker and task-detail UIs no longer show **`k kill`** for work that is already finished. Task visibility checks (`hasVisibleTasks`) use the same retained-row model.
> 
> **Tests:** kernel expectations for mixed active/stopped rows; parent fallback when only stopped child streams remain; PTY harness scenarios **`stopped-task-picker`** and **`stopped-task-subworkflow-detail`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbeaaf215219a9d8c5acbfaba2991251e2a3bffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->