### PR TITLE
[codex] Compact empty task picker

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -982,7 +982,13 @@ const SCENARIOS = [
       'No active tasks or sub-workflows.',
       'Esc close',
     ],
-    unexpect: ['Enter view', 'k kill', 'navigate'],
+    unexpect: [
+      'Enter view',
+      'k kill',
+      'navigate',
+      '│                                                                                                  │\n│ No active tasks or sub-workflows.',
+      '│ No active tasks or sub-workflows.                                                                │\n│                                                                                                  │',
+    ],
     maxBlankLinesBetween: [
       {
         from: 'entry-4 chat history line',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -30,6 +30,7 @@ import {
   metaChordInput,
 } from './input/inputKeys';
 import {
+  hasChildControlItems,
   hasChildExecutionRows,
   numericFocusTargetForActiveStream,
   resolveChildControlStreamTarget,
@@ -54,6 +55,7 @@ const MIN_TRANSCRIPT_WIDTH = 20;
 const FOREGROUND_TRANSCRIPT_ROWS = 1;
 const MIN_FOREGROUND_ROWS_WITH_TRANSCRIPT = 6;
 const CHILD_CONTROL_FOREGROUND_MAX_ROWS = 12;
+const EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS = 6;
 const FORM_FOREGROUND_MAX_ROWS = 18;
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation or push the input bar off-screen.
@@ -257,6 +259,16 @@ export function foregroundSurfaceKind({
   return undefined;
 }
 
+export function childControlForegroundMaxRows({
+  hasItems,
+}: {
+  readonly hasItems: boolean;
+}): number {
+  return hasItems
+    ? CHILD_CONTROL_FOREGROUND_MAX_ROWS
+    : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
+}
+
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
   readonly onKillExecution: (executionId: string) => void;
@@ -344,10 +356,22 @@ export function App(props: AppProps): React.JSX.Element {
     pendingApproval: pending !== undefined,
     transcriptViewerOpen,
   });
+  const childControlTarget =
+    childControlMode !== undefined
+      ? resolveChildControlStreamTarget({
+          activeStreamId,
+          mode: childControlMode,
+          parentStream,
+          streams,
+        })
+      : undefined;
+  const childControlHasItems =
+    childControlMode !== undefined &&
+    hasChildControlItems(childControlTarget?.slice, childControlMode);
   const { foregroundRows, transcriptRows } = allocateMiddleRows({
     foregroundMaxRows:
       foregroundKind === 'childControls'
-        ? CHILD_CONTROL_FOREGROUND_MAX_ROWS
+        ? childControlForegroundMaxRows({ hasItems: childControlHasItems })
         : foregroundKind === 'form'
           ? FORM_FOREGROUND_MAX_ROWS
           : undefined,
@@ -384,12 +408,8 @@ export function App(props: AppProps): React.JSX.Element {
         );
       case 'childControls': {
         if (!childControlMode) return null;
-        const target = resolveChildControlStreamTarget({
-          activeStreamId,
-          mode: childControlMode,
-          parentStream,
-          streams,
-        });
+        const target = childControlTarget;
+        if (!target) return null;
         const targetStreamLabel = target.streamId
           ? streamScopeDisplayLabel({
               parentStream,

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -582,17 +582,19 @@ export function ChildControlPicker({
   const streamScopeLabel = activeStreamLabel ?? activeStreamId;
   const selectedIndex = clampPickerIndex(highlight, items.length);
   const selectedItem = items[selectedIndex];
+  const hasItems = items.length > 0;
   const tailItem = tailExecutionId
     ? items.find((item) => item.executionId === tailExecutionId)
     : undefined;
-  const stackSelectedSubagent = mode === 'subagents' && items.length > 0;
+  const stackSelectedSubagent = mode === 'subagents' && hasItems;
+  const compactEmptyPicker = !hasItems;
   const listLayout = computePickerListLayout({
     availableRows,
     extraListRowCount: stackSelectedSubagent ? 1 : 0,
     highlight: selectedIndex,
-    hintsMarginRows: stackSelectedSubagent ? 0 : 1,
+    hintsMarginRows: stackSelectedSubagent || compactEmptyPicker ? 0 : 1,
     itemCount: items.length,
-    listMarginRows: stackSelectedSubagent ? 0 : 1,
+    listMarginRows: stackSelectedSubagent || compactEmptyPicker ? 0 : 1,
     scopeLineCount: streamScopeLabel !== undefined ? 1 : 0,
   });
   const visibleItems = items.slice(listLayout.start, listLayout.end);
@@ -727,8 +729,11 @@ export function ChildControlPicker({
           {streamScopeText}
         </Text>
       ) : null}
-      <Box flexDirection="column" marginTop={stackSelectedSubagent ? 0 : 1}>
-        {items.length > 0 ? (
+      <Box
+        flexDirection="column"
+        marginTop={stackSelectedSubagent || compactEmptyPicker ? 0 : 1}
+      >
+        {hasItems ? (
           <>
             {listLayout.hiddenBefore > 0 ? (
               <Text dimColor>{`... ${listLayout.hiddenBefore} earlier`}</Text>
@@ -751,7 +756,7 @@ export function ChildControlPicker({
           <Text dimColor>{emptyPickerText(mode)}</Text>
         )}
       </Box>
-      <Box marginTop={stackSelectedSubagent ? 0 : 1}>
+      <Box marginTop={stackSelectedSubagent || compactEmptyPicker ? 0 : 1}>
         <KeyHints
           hints={pickerKeyHintsForColumns(
             mode,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -243,6 +243,17 @@ function hasVisibleTasks(
   );
 }
 
+export function hasChildControlItems(
+  slice:
+    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
+    | undefined,
+  mode: ChildControlMode,
+): boolean {
+  return mode === 'subagents'
+    ? hasVisibleSubagents(slice)
+    : hasVisibleTasks(slice);
+}
+
 export function resolveChildControlStreamTarget({
   activeStreamId,
   mode,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -21,6 +21,7 @@ import {
   allocateSidePanelRows,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
+  childControlForegroundMaxRows,
   foregroundSurfaceKind,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
@@ -29,7 +30,10 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '@cli/chat/tui/state/focusCycle';
-import { hasChildExecutionRows } from '@cli/chat/tui/state/childControls';
+import {
+  hasChildControlItems,
+  hasChildExecutionRows,
+} from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import {
   finalizeSettledPrefix,
@@ -150,6 +154,12 @@ describe('cliState Phase 4 fields', () => {
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
 
     expect(hasChildExecutionRows(cliState.streams.get().get(root))).toBe(true);
+    expect(
+      hasChildControlItems(cliState.streams.get().get(root), 'tasks'),
+    ).toBe(true);
+    expect(
+      hasChildControlItems(cliState.streams.get().get(root), 'subagents'),
+    ).toBe(true);
     expect(nextFocusForward()).toBe(child1);
 
     removeStream(child1);
@@ -162,6 +172,8 @@ describe('cliState Phase 4 fields', () => {
     expect(parent.activeProcesses).toEqual([]);
     expect(visibleSubagentRows(parent)).toEqual([]);
     expect(hasChildExecutionRows(parent)).toBe(false);
+    expect(hasChildControlItems(parent, 'tasks')).toBe(false);
+    expect(hasChildControlItems(parent, 'subagents')).toBe(false);
     expect(nextFocusForward()).toBeUndefined();
   });
 
@@ -219,6 +231,11 @@ describe('CLI TUI row allocation', () => {
 
     expect(layout.transcriptRows).toBe(1);
     expect(layout.foregroundRows).toBe(12);
+  });
+
+  it('uses a smaller row cap for empty child-control pickers', () => {
+    expect(childControlForegroundMaxRows({ hasItems: false })).toBe(6);
+    expect(childControlForegroundMaxRows({ hasItems: true })).toBe(12);
   });
 
   it('uses the whole middle region for the transcript without foreground UI', () => {


### PR DESCRIPTION
## Summary

Fixes #4881.

This makes the CLI child-control picker use a compact foreground budget when there are no tasks/sub-workflows to show. Empty task picker frames now return unused rows to the transcript instead of rendering as a padded empty box.

## Changes

- Cap empty child-control foreground surfaces at 6 rows instead of the normal 12-row picker budget.
- Remove internal list/hint padding when the task/subagent picker has no items.
- Tighten the `empty-task-picker` PTY harness scenario so the old padded empty frame is rejected.
- Add a focused row-allocation unit check for populated vs empty child-control pickers.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-empty-picker empty-task-picker subagent-picker stopped-subagent-picker`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `git diff --check`
- `corepack pnpm run texra-local:build && corepack pnpm run texra-local:link`
- Manual `texra-local chat --approval-policy yolo --model deepseekT`, then Option-p: empty task picker renders as a compact three-line foreground surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and harness assertions only; no auth, persistence, or runtime execution changes.
> 
> **Overview**
> When the CLI **tasks/sub-workflows** (or subagent) picker has nothing to show, the foreground panel no longer reserves the full **12-row** picker budget. **`App`** now caps empty child-control surfaces at **6 rows** via `childControlForegroundMaxRows`, using **`hasChildControlItems`** on the resolved stream target so the extra rows go back to the transcript.
> 
> **`ChildControlPicker`** drops list/hint **margins** when the list is empty (`compactEmptyPicker`), so the empty state is a tight few lines instead of a tall padded box.
> 
> Regression coverage: **`empty-task-picker`** in `validate-tui.mjs` rejects the old wide empty frame; **`TuiStateAndFocus`** asserts the 6 vs 12 row cap and `hasChildControlItems` after stream removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c0106e0a9bb2db151b814d38ed2f28168dc51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->