### PR TITLE
fix(cli): reject stopped child follow-ups

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -9,13 +9,16 @@ import path from 'node:path';
 import { render } from 'ink';
 import React from 'react';
 
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { tryPlatform } from '@platform/platform';
 import {
   AGENT_CATEGORY,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_STATUS,
+  StreamStatusSchema,
   STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
   TOOL_USE_STATUS,
@@ -723,6 +726,39 @@ function queueHarnessFollowUp(input: string): void {
   appendHarnessAssistantTranscript(`Queued follow-up: ${message}`);
 }
 
+function harnessActiveChildStreamId(): string | undefined {
+  const activeStreamId = cliState.activeStreamId.get();
+  if (!activeStreamId) return undefined;
+  return cliState.parentStream.get().has(activeStreamId)
+    ? activeStreamId
+    : undefined;
+}
+
+function harnessStreamStatuses(streamId: string): readonly string[] {
+  const streams = cliState.streams.get();
+  const parentStreamId = cliState.parentStream.get().get(streamId);
+  const childStreamStatus = parentStreamId
+    ? streams
+        .get(parentStreamId)
+        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
+    : undefined;
+  return [
+    childStreamStatus,
+    streams.get(streamId)?.status,
+    StreamStatusService.get(streamId),
+  ].filter((status): status is string => status !== undefined);
+}
+
+function harnessRejectsFocusedChildSubmit(): boolean {
+  const childStreamId = harnessActiveChildStreamId();
+  if (!childStreamId) return false;
+  const statuses = harnessStreamStatuses(childStreamId);
+  return statuses.some((status) => {
+    const parsed = StreamStatusSchema.safeParse(status);
+    return !parsed.success || !isInFlightStatus(parsed.data);
+  });
+}
+
 function findRegisteredSlashCommand(name: string): SlashCommand | undefined {
   const lower = name.toLowerCase();
   return listSlashCommands().find(
@@ -867,6 +903,12 @@ function markHarnessExecutionStopped(executionId: string): void {
 
 function handleHarnessSubmit(line: string): void {
   if (handleHarnessSlashCommand(line)) return;
+  if (harnessRejectsFocusedChildSubmit()) {
+    appendHarnessAssistantTranscript(
+      'The selected subagent is no longer accepting follow-ups.',
+    );
+    return;
+  }
   appendHarnessAssistantTranscript(`Harness received: ${line}`);
 }
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1013,6 +1013,32 @@ const SCENARIOS = [
     expect: ['[3:strategy](stopped)', '◆ stopped api', '[Ctrl-C]stop root'],
   },
   {
+    name: 'focused-stopped-subagent-submit',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [
+      ESC + 'p',
+      'k',
+      ESC + 's',
+      DOWN,
+      DOWN,
+      '\r',
+      'can you still receive this?',
+      '\r',
+    ],
+    frame: 'tail',
+    expect: [
+      '[3:strategy](stopped)',
+      'The selected subagent is no longer accepting follow-ups.',
+    ],
+    unexpect: ['Harness received: can you still receive this?'],
+  },
+  {
     name: 'empty-task-picker',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -52,10 +52,12 @@ import {
   formatCliMemoryList,
   formatCliMemoryPreview,
 } from '@cli/runtime/memory';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
+  StreamStatusSchema,
   type StreamStatus,
   type ExecutionId,
   type StreamTabId,
@@ -192,7 +194,7 @@ export function chatTuiCanStartRootRun(
   return !session.runPromise || session.runCompleted;
 }
 
-export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
+function chatTuiActiveChildStreamId(): StreamTabId | undefined {
   const activeStreamId = cliState.activeStreamId.get();
   if (!activeStreamId) return undefined;
   return cliState.parentStream.get().has(activeStreamId)
@@ -200,14 +202,52 @@ export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
     : undefined;
 }
 
+function chatTuiStreamStatuses(streamId: StreamTabId): readonly string[] {
+  const streams = cliState.streams.get();
+  const parentStreamId = cliState.parentStream.get().get(streamId);
+  const childStreamStatus = parentStreamId
+    ? streams
+        .get(parentStreamId)
+        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
+    : undefined;
+  return [
+    childStreamStatus,
+    streams.get(streamId)?.status,
+    StreamStatusService.get(streamId),
+  ].filter((status): status is string => status !== undefined);
+}
+
+function chatTuiCanAcceptFollowUp(statuses: readonly string[]): boolean {
+  // A focused child normally has at least one status source. Keep the previous
+  // permissive behavior during the brief edge where parent focus arrives first.
+  if (statuses.length === 0) return true;
+  return statuses.every((status) => {
+    const parsed = StreamStatusSchema.safeParse(status);
+    return parsed.success && isInFlightStatus(parsed.data);
+  });
+}
+
+export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
+  const activeStreamId = chatTuiActiveChildStreamId();
+  if (!activeStreamId) return undefined;
+  return chatTuiCanAcceptFollowUp(chatTuiStreamStatuses(activeStreamId))
+    ? activeStreamId
+    : undefined;
+}
+
+export function chatTuiRejectedChildFollowUpTarget(): StreamTabId | undefined {
+  const activeStreamId = chatTuiActiveChildStreamId();
+  if (!activeStreamId) return undefined;
+  return chatTuiCanAcceptFollowUp(chatTuiStreamStatuses(activeStreamId))
+    ? undefined
+    : activeStreamId;
+}
+
 export function chatTuiShouldAnnounceQueuedFollowUp(
   targetStreamId: StreamTabId | undefined,
 ): boolean {
   if (!targetStreamId) return true;
-  const status =
-    cliState.streams.get().get(targetStreamId)?.status ??
-    StreamStatusService.get(targetStreamId);
-  return status !== STREAM_STATUS.WAITING;
+  return !chatTuiStreamStatuses(targetStreamId).includes(STREAM_STATUS.WAITING);
 }
 
 interface SlashCommandContext {
@@ -995,6 +1035,14 @@ export async function runChat(
   };
 
   const submitChatMessage = async (line: string): Promise<void> => {
+    const rejectedChildFollowUpTarget = chatTuiRejectedChildFollowUpTarget();
+    if (rejectedChildFollowUpTarget) {
+      appendLocalAssistantTranscript(
+        'The selected subagent is no longer accepting follow-ups.',
+        rejectedChildFollowUpTarget,
+      );
+      return;
+    }
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
       startSession(line);

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -14,6 +14,7 @@ import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
@@ -71,6 +72,21 @@ export async function sendFollowUp(
   streamId: StreamTabId,
   text: string,
 ): Promise<SendFollowUpResult> {
+  const status = StreamStatusService.get(streamId);
+  const activeChildren = getActiveChildren(streamId);
+  const hasActiveChildren =
+    activeChildren.subagents.length > 0 || activeChildren.processes.length > 0;
+  if (status !== undefined && !isInFlightStatus(status)) {
+    if (hasActiveChildren) {
+      ToolUseFollowUpQueue.enqueue(streamId, text, { force: true });
+      return { status: 'queued', reason: 'children_running' };
+    }
+    logger.warn(
+      `No active session for follow-up on stream ${streamId}. Status: ${status}`,
+    );
+    return { status: 'no_session', streamStatus: status };
+  }
+
   // Try active flow context first
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
@@ -86,14 +102,12 @@ export async function sendFollowUp(
   }
 
   // Queue if session is waiting (paused, can be resumed)
-  const status = StreamStatusService.get(streamId);
   if (status === STREAM_STATUS.WAITING) {
     ToolUseFollowUpQueue.enqueue(streamId, text);
     return { status: 'queued', reason: 'waiting' };
   }
 
-  const { subagents, processes } = getActiveChildren(streamId);
-  if (subagents.length > 0 || processes.length > 0) {
+  if (hasActiveChildren) {
     // force:true reopens a queue sealed by sessionLifecycle disposal — the
     // caller must auto-resume the parent or re-release, or late child
     // deliveries will leak into the next run on this stream.

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -3,12 +3,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  AgentExecutionHandle,
+  trackExecution,
+  untrackExecution,
+} from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   registerInterruptible,
   unregisterInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { onFollowUpSent, sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
-import type { StreamTabId } from '@shared/schemas';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
 const streamId = 'stream:follow-up' as StreamTabId;
@@ -20,6 +28,7 @@ describe('tool-use follow-up progress events', () => {
     unsubscribeFollowUpObserver?.();
     unsubscribeFollowUpObserver = undefined;
     unregisterInterruptible(streamId);
+    StreamStatusService.clearAll({ emit: false });
   });
 
   it('publishes sent follow-up events through the active runtime host', async () => {
@@ -65,5 +74,60 @@ describe('tool-use follow-up progress events', () => {
     await sendFollowUp(streamId, 'after unsubscribe');
 
     expect(observed).toEqual([streamId]);
+  });
+
+  it('does not append through stale active contexts after final status', async () => {
+    const { host } = createRecordingHost();
+    const appendFollowUp = vi.fn();
+
+    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
+    registerInterruptible(streamId, {
+      session: { appendFollowUp },
+      modelHandler: {},
+      runtimeHost: host,
+      interrupt: vi.fn(),
+    } as unknown as ToolUseFlowContext);
+
+    const result = await sendFollowUp(streamId, 'late follow-up');
+
+    expect(result).toEqual({
+      status: 'no_session',
+      streamStatus: STREAM_STATUS.STOPPED,
+    });
+    expect(appendFollowUp).not.toHaveBeenCalled();
+  });
+
+  it('keeps terminal parents with active children on the children-running queue path', async () => {
+    const parentStreamId = 'stream:terminal-parent' as StreamTabId;
+    const childStreamId = 'stream:terminal-parent-child' as StreamTabId;
+    const executionId = 'exec-terminal-parent-child';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'critic',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+
+    StreamStatusService.set(parentStreamId, STREAM_STATUS.STOPPED, {
+      emit: false,
+    });
+    trackExecution(handle);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, 'continue child');
+
+      expect(result).toEqual({
+        status: 'queued',
+        reason: 'children_running',
+      });
+      expect(ToolUseFollowUpQueue.getAll(parentStreamId)).toEqual([
+        'continue child',
+      ]);
+    } finally {
+      untrackExecution(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -8,6 +8,7 @@ import {
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   cliState,
@@ -59,6 +60,7 @@ import {
   chatTuiCanStopVisibleRun,
   chatTuiCanStartRootRun,
   chatTuiActiveChildFollowUpTarget,
+  chatTuiRejectedChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
   clearTuiSessionRunState,
   parseBtwFollowUpMessage,
@@ -83,6 +85,7 @@ const child1 = 'child-1' as StreamTabId;
 const child2 = 'child-2' as StreamTabId;
 
 afterEach(() => {
+  StreamStatusService.clearAll({ emit: false });
   resetCliState();
 });
 
@@ -685,9 +688,75 @@ describe('CLI TUI row allocation', () => {
 
     cliState.activeStreamId.set(root);
     expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
 
     cliState.activeStreamId.set(child1);
     expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+  });
+
+  it('rejects follow-ups to a focused stopped child stream', () => {
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({
+      ...s,
+      childStreams: [
+        {
+          executionId: 'child-exec-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.STOPPED,
+        },
+      ],
+    }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    setParentStream(child1, root);
+
+    cliState.activeStreamId.set(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+  });
+
+  it('rejects focused children when any known status source is terminal', () => {
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({
+      ...s,
+      childStreams: [
+        {
+          executionId: 'child-exec-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.STOPPED }));
+    setParentStream(child1, root);
+
+    cliState.activeStreamId.set(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+  });
+
+  it('rejects focused children when only StreamStatusService is terminal', () => {
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({
+      ...s,
+      childStreams: [
+        {
+          executionId: 'child-exec-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    StreamStatusService.set(child1, STREAM_STATUS.STOPPED, { emit: false });
+    setParentStream(child1, root);
+
+    cliState.activeStreamId.set(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
   });
 
   it('announces queued follow-ups only when the target is not waiting', () => {


### PR DESCRIPTION
## Summary

- reject ordinary input when a focused child stream has any known terminal or unrecognized status, so stale parent child rows cannot mask a stopped child tab or `StreamStatusService` state
- guard `sendFollowUp` against stale active flow contexts after a stream reaches a final status, while preserving the `children_running` queue path for terminal parents with active children
- keep the PTY harness status check aligned with production and add kernel coverage for parent-row, child-slice, and service-only terminal status divergence

Fixes #4883.

## Validation

- `npm run format`
- `npm run test:kernel -- src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts` (69 tests)
- `npm run compile:safe`
- `npm run lint` (0 errors; existing 11 import-order warnings)
- `corepack pnpm --filter @texra-ai/cli bundle:harness`
- `TEXRA_TUI_HARNESS=$PWD/packages/cli/dist/bin/tui-harness.js node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-focused-stopped-submit-rebased focused-stopped-subagent-submit stopped-task-subworkflow-detail`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up routing in the CLI and `sendFollowUp`, where incorrect status aggregation could block valid child input or still allow stale delivery; mitigated by multi-source status checks and new tests.
> 
> **Overview**
> **Follow-ups to stopped or finished subagents are blocked** instead of being queued or sent through stale session state.
> 
> The CLI and PTY harness now treat a **focused child stream** as follow-up-eligible only when **every** known status (parent `childStreams` row, local stream slice, and `StreamStatusService`) parses as in-flight (`running`, `waiting`, etc.). Otherwise submit shows *The selected subagent is no longer accepting follow-ups.* `sendFollowUp` checks terminal status **before** using a registered flow context, so a leftover interruptible registration cannot accept messages after `STOPPED`; terminal parents with **active children** still enqueue on the `children_running` path.
> 
> Queued-follow-up announcements now consider **any** status source reporting `WAITING`, not only the slice/service pair used before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911bcd0c3baf05fededbc6e16a9d21b92a542d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->