### PR TITLE
[codex] Show queued follow-ups in CLI panel

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -91,7 +91,14 @@ const SCENARIOS = [
     },
     bootExpect: 'queued 2',
     frame: 'tail',
-    expect: ['queued 2', 'First queued', 'Second queued', '[Ctrl-C]stop'],
+    expect: [
+      'Queued follow-ups (2)',
+      '1. First queued follow-up',
+      '2. Second queued follow-up',
+      'queued 2',
+      '[Ctrl-C]stop',
+    ],
+    unexpect: ['Tip: Ctrl-C exits idle chats', 'First queued follo…'],
   },
   {
     name: 'subagent-followup-summary',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -18,6 +18,10 @@ import { TranscriptViewer } from './modals/TranscriptViewer';
 import { ConversationPane } from './panes/ConversationPane';
 import { StaticConversationTranscript } from './panes/StaticConversationTranscript';
 import { InputBar } from './panes/InputBar';
+import {
+  QueuedFollowUpsPanel,
+  queuedFollowUpPanelRowCount,
+} from './panes/QueuedFollowUpsPanel';
 import { StatusBar } from './panes/StatusBar';
 import { StreamTabsStrip } from './panes/StreamTabsStrip';
 import { SubagentList } from './panes/SubagentList';
@@ -70,11 +74,13 @@ const PINNED_CHROME_ROWS = {
 
 function pinnedChromeRows({
   inputVisible = true,
+  queuedFollowUpPanelRows = 0,
   reverseSearchOpen,
   slashPaletteOpen,
   tipVisible = true,
 }: {
   readonly inputVisible?: boolean;
+  readonly queuedFollowUpPanelRows?: number;
   readonly reverseSearchOpen: boolean;
   readonly slashPaletteOpen: boolean;
   readonly tipVisible?: boolean;
@@ -83,6 +89,7 @@ function pinnedChromeRows({
     PINNED_CHROME_ROWS.streamTabsWorstCase +
     PINNED_CHROME_ROWS.status +
     (inputVisible ? PINNED_CHROME_ROWS.input : 0) +
+    queuedFollowUpPanelRows +
     (tipVisible ? PINNED_CHROME_ROWS.tip : 0);
   return (
     baseRows +
@@ -95,6 +102,7 @@ export function allocateMiddleRows({
   foregroundMaxRows,
   foregroundOpen,
   inputVisible = true,
+  queuedFollowUpPanelRows = 0,
   reverseSearchOpen,
   rows,
   slashPaletteOpen,
@@ -103,6 +111,7 @@ export function allocateMiddleRows({
   readonly foregroundMaxRows?: number;
   readonly foregroundOpen: boolean;
   readonly inputVisible?: boolean;
+  readonly queuedFollowUpPanelRows?: number;
   readonly reverseSearchOpen: boolean;
   readonly rows: number;
   readonly slashPaletteOpen: boolean;
@@ -116,6 +125,7 @@ export function allocateMiddleRows({
     rows -
       pinnedChromeRows({
         inputVisible,
+        queuedFollowUpPanelRows,
         reverseSearchOpen,
         slashPaletteOpen,
         tipVisible,
@@ -180,10 +190,12 @@ export function allocateSidePanelRows({
 
 export function shouldShowTipRow({
   foregroundOpen,
+  hasQueuedFollowUps = false,
 }: {
   readonly foregroundOpen: boolean;
+  readonly hasQueuedFollowUps?: boolean;
 }): boolean {
-  return !foregroundOpen;
+  return !foregroundOpen && !hasQueuedFollowUps;
 }
 
 export function shouldShowTodosPlanPanel({
@@ -326,11 +338,20 @@ export function App(props: AppProps): React.JSX.Element {
     activeForm !== undefined ||
     childControlMode !== undefined ||
     transcriptViewerOpen;
-  const tipRowVisible = shouldShowTipRow({ foregroundOpen });
   const inputDisabled = props.inputDisabled === true || foregroundOpen;
   const inputBarVisible = !foregroundOpen;
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
+  const queuedFollowUpPanelVisible =
+    !foregroundOpen && queuedFollowUpMessages.length > 0;
+  const queuedFollowUpPanelRows = queuedFollowUpPanelVisible
+    ? queuedFollowUpPanelRowCount(queuedFollowUpMessages)
+    : 0;
+  const tipRowVisible = shouldShowTipRow({
+    foregroundOpen,
+    hasQueuedFollowUps: queuedFollowUpPanelVisible,
+  });
   const subagentControlTarget = resolveChildControlStreamTarget({
     activeStreamId,
     mode: 'subagents',
@@ -377,6 +398,7 @@ export function App(props: AppProps): React.JSX.Element {
           : undefined,
     foregroundOpen,
     inputVisible: inputBarVisible,
+    queuedFollowUpPanelRows,
     reverseSearchOpen,
     rows,
     slashPaletteOpen,
@@ -577,6 +599,13 @@ export function App(props: AppProps): React.JSX.Element {
           </Box>
         ) : null}
         {tipRowVisible ? <TipRow /> : null}
+        {queuedFollowUpPanelVisible ? (
+          <QueuedFollowUpsPanel
+            maxRows={queuedFollowUpPanelRows}
+            messages={queuedFollowUpMessages}
+            width={columns}
+          />
+        ) : null}
         <InputBar
           onSubmit={props.onSubmit}
           collapseWhenDisabled={!inputBarVisible}
@@ -586,6 +615,7 @@ export function App(props: AppProps): React.JSX.Element {
         <StreamTabsStrip width={columns} />
         <StatusBar
           canStopActiveRun={canStopActiveRun}
+          queuedFollowUpPreview={!queuedFollowUpPanelVisible}
           shortcutsActive={focusShortcutsActive}
         />
       </Box>

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -1,0 +1,120 @@
+import { Box, Text } from 'ink';
+import stringWidth from 'string-width';
+
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+export const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
+
+export interface QueuedFollowUpPanelRow {
+  readonly kind: 'message' | 'overflow';
+  readonly text: string;
+}
+
+export interface QueuedFollowUpPanelDisplay {
+  readonly title: string | undefined;
+  readonly rows: readonly QueuedFollowUpPanelRow[];
+  readonly hiddenCount: number;
+}
+
+function truncateToColumns(text: string, maxColumns: number): string {
+  const summary = collapseWhitespace(text);
+  if (stringWidth(summary) <= maxColumns) return summary;
+
+  const ellipsis = '…';
+  const contentColumns = Math.max(0, maxColumns - stringWidth(ellipsis));
+  let width = 0;
+  let truncated = '';
+  for (const char of summary) {
+    const charWidth = stringWidth(char);
+    if (width + charWidth > contentColumns) break;
+    truncated += char;
+    width += charWidth;
+  }
+  return `${truncated}${ellipsis}`;
+}
+
+export function queuedFollowUpPanelRowCount(
+  messages: readonly string[],
+): number {
+  if (messages.length === 0) return 0;
+  return Math.min(QUEUED_FOLLOW_UP_PANEL_MAX_ROWS, messages.length + 1);
+}
+
+export function queuedFollowUpPanelDisplay({
+  maxRows,
+  messages,
+  width,
+}: {
+  readonly maxRows: number;
+  readonly messages: readonly string[];
+  readonly width: number;
+}): QueuedFollowUpPanelDisplay {
+  if (messages.length === 0 || maxRows <= 0) {
+    return { title: undefined, rows: [], hiddenCount: 0 };
+  }
+
+  const contentWidth = Math.max(0, width - 2);
+  const title = truncateToColumns(
+    `Queued follow-ups (${messages.length})`,
+    contentWidth,
+  );
+  const messageSlots = Math.max(0, maxRows - 1);
+  if (messageSlots === 0) {
+    return { title, rows: [], hiddenCount: messages.length };
+  }
+
+  const hasOverflow = messages.length > messageSlots;
+  const visibleMessageCount = hasOverflow
+    ? Math.max(0, messageSlots - 1)
+    : Math.min(messages.length, messageSlots);
+  const rows: QueuedFollowUpPanelRow[] = messages
+    .slice(0, visibleMessageCount)
+    .map((message, index) => {
+      const prefix = `${index + 1}. `;
+      const bodyWidth = Math.max(0, contentWidth - stringWidth(prefix));
+      return {
+        kind: 'message',
+        text: `${prefix}${truncateToColumns(message, bodyWidth)}`,
+      };
+    });
+
+  const hiddenCount = messages.length - visibleMessageCount;
+  if (hiddenCount > 0) {
+    rows.push({
+      kind: 'overflow',
+      text: truncateToColumns(`… ${hiddenCount} more queued`, contentWidth),
+    });
+  }
+
+  return { title, rows, hiddenCount };
+}
+
+export function QueuedFollowUpsPanel({
+  maxRows,
+  messages,
+  width,
+}: {
+  readonly maxRows: number;
+  readonly messages: readonly string[];
+  readonly width: number;
+}): React.JSX.Element | null {
+  const display = queuedFollowUpPanelDisplay({ maxRows, messages, width });
+  if (!display.title) return null;
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text color="yellow" wrap="truncate-end">
+        {display.title}
+      </Text>
+      {display.rows.map((row, index) => (
+        <Text
+          key={`${row.kind}-${index}`}
+          dimColor={row.kind === 'overflow'}
+          wrap="truncate-end"
+        >
+          {row.text}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -49,6 +49,7 @@ export interface StatusBarDisplayInput {
   readonly pendingExitResumeId: string | undefined;
   readonly bypass: BypassState;
   readonly queuedFollowUpMessages: readonly string[];
+  readonly queuedFollowUpPreview?: boolean;
   readonly usage: TokenUsageStats | undefined;
   readonly conversation: ConversationProgress | undefined;
   readonly activeSubagents: number;
@@ -505,10 +506,12 @@ export function buildStatusBarDisplay(
     : fitStatusBarLeftSegments(left, input.width);
   const queuedCountVisible =
     queued === undefined || fittedLeft.includes(queued);
+  const queuedPreviewVisible =
+    input.queuedFollowUpPreview !== false && queuedCountVisible;
 
   return {
     left: fittedLeft,
-    right: queuedCountVisible
+    right: queuedPreviewVisible
       ? queuedFollowUpsSummary(
           input.queuedFollowUpMessages,
           rightStatusBudget(fittedLeft, input.width),
@@ -534,6 +537,7 @@ export function buildStatusBarDisplay(
 
 export interface StatusBarProps {
   readonly canStopActiveRun?: () => boolean;
+  readonly queuedFollowUpPreview?: boolean;
   readonly shortcutsActive?: boolean;
 }
 
@@ -566,6 +570,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     pendingExitResumeId,
     bypass: slice?.bypass ?? NO_BYPASS,
     queuedFollowUpMessages: slice?.queuedFollowUpMessages ?? [],
+    queuedFollowUpPreview: props.queuedFollowUpPreview,
     usage: slice?.usage,
     conversation: slice?.conversation,
     activeSubagents: slice?.activeSubagents.length ?? 0,

--- a/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
+++ b/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  queuedFollowUpPanelDisplay,
+  queuedFollowUpPanelRowCount,
+} from '@cli/chat/tui/panes/QueuedFollowUpsPanel';
+
+describe('CLI queued follow-up panel display model', () => {
+  it('uses no rows when there are no queued follow-ups', () => {
+    expect(queuedFollowUpPanelRowCount([])).toBe(0);
+    expect(
+      queuedFollowUpPanelDisplay({ messages: [], maxRows: 3, width: 80 }),
+    ).toEqual({ title: undefined, rows: [], hiddenCount: 0 });
+  });
+
+  it('uses a compact title plus readable message rows', () => {
+    expect(queuedFollowUpPanelRowCount(['first', 'second'])).toBe(3);
+
+    const display = queuedFollowUpPanelDisplay({
+      messages: ['First queued follow-up', 'Second queued follow-up'],
+      maxRows: 3,
+      width: 80,
+    });
+
+    expect(display.title).toBe('Queued follow-ups (2)');
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. First queued follow-up',
+      '2. Second queued follow-up',
+    ]);
+    expect(display.hiddenCount).toBe(0);
+  });
+
+  it('keeps the panel bounded when more messages are queued', () => {
+    expect(queuedFollowUpPanelRowCount(['first', 'second', 'third'])).toBe(3);
+
+    const display = queuedFollowUpPanelDisplay({
+      messages: ['first', 'second', 'third'],
+      maxRows: 3,
+      width: 80,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. first',
+      '… 2 more queued',
+    ]);
+    expect(display.hiddenCount).toBe(2);
+  });
+
+  it('keeps hidden count nonnegative when callers pass extra rows', () => {
+    const display = queuedFollowUpPanelDisplay({
+      messages: ['only queued follow-up'],
+      maxRows: 5,
+      width: 80,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. only queued follow-up',
+    ]);
+    expect(display.hiddenCount).toBe(0);
+  });
+
+  it('truncates wide messages by terminal columns', () => {
+    const display = queuedFollowUpPanelDisplay({
+      messages: ['Please keep the proof under one page.'],
+      maxRows: 2,
+      width: 24,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. Please keep the pr…',
+    ]);
+  });
+});

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -334,6 +334,32 @@ describe('CLI StatusBar display model', () => {
     expect(display.right).toBeUndefined();
   });
 
+  it('can hide queued follow-up previews while keeping the durable count', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: ['Keep the proof under one page.'],
+      queuedFollowUpPreview: false,
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      width: 80,
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toContain('queued 1');
+    expect(display.right).toBeUndefined();
+  });
+
   it('scopes Ctrl-C stop to the root when focus is on a child stream', () => {
     const parentStream = new Map([['child', 'root']]);
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -203,6 +203,9 @@ describe('CLI TUI row allocation', () => {
 
   it('hides the normal chat tip row while foreground surfaces own input', () => {
     expect(shouldShowTipRow({ foregroundOpen: false })).toBe(true);
+    expect(
+      shouldShowTipRow({ foregroundOpen: false, hasQueuedFollowUps: true }),
+    ).toBe(false);
     expect(shouldShowTipRow({ foregroundOpen: true })).toBe(false);
   });
 
@@ -247,6 +250,20 @@ describe('CLI TUI row allocation', () => {
     });
 
     expect(layout.transcriptRows).toBe(17);
+    expect(layout.foregroundRows).toBe(0);
+  });
+
+  it('reserves queued follow-up panel rows above the stable input chrome', () => {
+    const layout = allocateMiddleRows({
+      foregroundOpen: false,
+      queuedFollowUpPanelRows: 3,
+      reverseSearchOpen: false,
+      rows: 24,
+      slashPaletteOpen: false,
+      tipVisible: false,
+    });
+
+    expect(layout.transcriptRows).toBe(15);
     expect(layout.foregroundRows).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- add a compact queued follow-up panel above the CLI input while queued messages are waiting
- reserve panel rows explicitly and suppress the redundant footer preview so the input/status area stays stable
- tighten the queued-followups PTY scenario to require readable queued message rows

Fixes #4884

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-queued-panel queued-followups btw-submit slash-palette-overflow`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with 11 pre-existing import-order warnings outside this patch)
- `git diff --check`
- `corepack pnpm run texra-local:build && corepack pnpm run texra-local:link`
- Live `texra-local --api-mode included --approval-policy yolo chat --model deepseekT` TTY smoke: queued a `/btw` follow-up during a sqrt(2) proof run and saw the queued panel render/readably drain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and layout only; no auth, persistence, or agent execution path changes beyond display of existing queued state.
> 
> **Overview**
> Adds a **compact queued follow-ups panel** above the CLI input while messages are waiting on an active run, with numbered lines, overflow text, and column-aware truncation.
> 
> **Layout** reserves panel rows in the pinned chrome budget (alongside tip/input/status) and **hides the idle tip row** when the panel is shown. The status bar keeps the durable **`queued N`** count on the left but **suppresses the right-hand message preview** when the panel is visible to avoid duplicate UI.
> 
> PTY validation and unit tests cover the new display model, preview gating, and row allocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0064a78f2722bf59212118ec8f523c0ea9e12030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->