### PR TITLE
[codex] Wait for settled TUI snapshots

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1269,6 +1269,14 @@ function frameTail(frame, rows) {
   return lines.slice(-Math.min(lines.length, rows)).join('\n');
 }
 
+function scenarioFrame(scenario, fullFrame, rows) {
+  return scenario.frame === 'tail' ? frameTail(fullFrame, rows) : fullFrame;
+}
+
+function expectedFrameTextVisible(scenario, frame) {
+  return (scenario.expect ?? []).every((text) => frame.includes(text));
+}
+
 function blankLinesBetween(frame, from, to) {
   const lines = frame.split('\n');
   const toIndex = lines.findLastIndex((line) => line.includes(to));
@@ -1466,15 +1474,23 @@ async function runScenario(scenario) {
     await sleep(500);
   }
 
-  // settle after keystrokes
+  // Settle after keystrokes. A quiet PTY is not quite enough: under a full
+  // suite, Ink/xterm can occasionally pause between chunks of the final frame,
+  // which used to snapshot partial lines such as a task detail output row
+  // ending at `Ple`. Prefer a frame where the scenario's expected visible text
+  // is present, but still time out with the best frame if the UI regresses.
   const settleDeadline = Date.now() + 4000;
-  while (Date.now() < settleDeadline && Date.now() - lastData < 500)
+  let fullFrame = await frameSnapshot();
+  let frame = scenarioFrame(scenario, fullFrame, rows);
+  while (Date.now() < settleDeadline) {
+    const quiet = Date.now() - lastData >= 500;
+    fullFrame = await frameSnapshot();
+    frame = scenarioFrame(scenario, fullFrame, rows);
+    if (quiet && expectedFrameTextVisible(scenario, frame)) break;
     await sleep(120);
-  await sleep(250);
-
-  const fullFrame = await frameSnapshot();
-  const frame =
-    scenario.frame === 'tail' ? frameTail(fullFrame, rows) : fullFrame;
+  }
+  fullFrame = await frameSnapshot();
+  frame = scenarioFrame(scenario, fullFrame, rows);
 
   // exit cleanly: Ctrl-C by default (a second one if the first only
   // interrupts a run). Some surfaces, such as the orchestration launcher,


### PR DESCRIPTION
Fixes #4887.

## Summary
- add a shared scenario-frame helper so tail/full snapshots use the same settled frame path
- wait for quiet PTY output and expected scenario text before asserting the final TUI frame
- keep the timeout behavior so real missing text still fails with the best captured frame

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-stopped-detail-settled stopped-task-subworkflow-detail`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-scout-full-settled` (67 scenarios)
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with 11 existing import-order warnings outside this patch)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the CLI TUI validation script timing; no production UI, auth, or data paths.
> 
> **Overview**
> The CLI **TUI validator** (`validate-tui.mjs`) now waits for a **settled** terminal frame before assertions, instead of relying on a short fixed sleep after a quiet PTY.
> 
> New helpers **`scenarioFrame`** and **`expectedFrameTextVisible`** unify full vs tail snapshots and gate the settle loop: polling continues until output has been quiet for 500ms **and** every `scenario.expect` string appears in the frame (up to 4s), then one final snapshot is taken. That targets flaky partial renders (e.g. truncated task-detail lines) when running the full scenario suite under Ink/xterm.
> 
> No product TUI behavior changes—only test harness timing and snapshot selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5af8ec4037277efd962ca3dbc4bf55f2811ff11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->