### PR TITLE
[codex] Keep desktop packaging out of PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,11 @@ jobs:
       - name: Compile
         run: pnpm run compile
 
-      - name: Build extension package
+      # Desktop app packaging is intentionally not part of PR CI. Keep this
+      # check scoped to the VS Code extension package.
+      - name: Build extension VSIX package
         if: runner.os == 'Linux'
-        run: pnpm run build:fast
+        run: pnpm --filter texra build:fast
 
       - name: Check extension VSIX contents
         if: runner.os == 'Linux'


### PR DESCRIPTION
Fixes #4889.

## Summary
- rename the Linux package step to make the VSIX-only scope explicit
- call the extension workspace package build directly with `pnpm --filter texra build:fast`
- document that desktop app/installer packaging belongs in the dedicated Desktop Package workflow, not PR CI

## Validation
- `corepack pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application, auth, or data-path impact.
> 
> **Overview**
> PR CI on Linux now **only builds the VS Code extension VSIX**, not desktop installers. The Linux step is renamed to **Build extension VSIX package**, comments state that desktop packaging belongs in the dedicated Desktop Package workflow, and the command is **`pnpm --filter texra build:fast`** instead of the repo-root **`pnpm run build:fast`** so the job targets the `texra` workspace package explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd490017e8651f94012070c5e6effdcb37ca3063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->