### PR TITLE
[codex] Keep CLI terminal progress status stable

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -3,6 +3,9 @@ import path from 'node:path';
 // Local imports - progress events
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
+// Local imports - shared schemas
+import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
 import type { CliContext } from './cliContext';
@@ -57,6 +60,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private lastLine = '';
   private liveLine = false;
   private rootStreamId: string | undefined;
+  private rootStreamTerminal = false;
 
   constructor(init: RunProgressRendererInit) {
     this.write = init.write ?? writeRawStderr;
@@ -85,12 +89,14 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         }
         return true;
       case 'updateActiveProcesses':
+        if (this.rootStreamTerminal) return true;
         this.applyActiveProcesses(
           payload as ProgressEventPayloads['updateActiveProcesses'],
         );
         this.render(true);
         return true;
       case 'updateActiveSubagents':
+        if (this.rootStreamTerminal) return true;
         this.applyActiveSubagents(
           payload as ProgressEventPayloads['updateActiveSubagents'],
         );
@@ -102,13 +108,20 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
             (payload as ProgressEventPayloads['updateStreamStatus']).streamId,
           )
         ) {
-          this.state.phase = String(
-            (payload as ProgressEventPayloads['updateStreamStatus']).status,
-          );
+          const status = (
+            payload as ProgressEventPayloads['updateStreamStatus']
+          ).status;
+          this.state.phase = String(status);
+          this.rootStreamTerminal = isTerminalStreamStatus(status);
+          if (this.rootStreamTerminal) {
+            this.state.activeProcesses = undefined;
+            this.state.activeSubagents = undefined;
+          }
           this.render(true);
         }
         return true;
       case 'updateStreamDescription':
+        if (this.rootStreamTerminal) return true;
         if (
           this.isRootStream(
             (payload as ProgressEventPayloads['updateStreamDescription'])
@@ -236,6 +249,10 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     parts.push(formatElapsed(now - this.startedAt));
     return parts.join(' · ');
   }
+}
+
+function isTerminalStreamStatus(status: StreamStatus): boolean {
+  return status === STREAM_STATUS.STOPPED || status === STREAM_STATUS.ERROR;
 }
 
 function safeBasename(file: string | undefined): string | undefined {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -8,6 +8,7 @@ import {
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { STREAM_STATUS } from '@shared/schemas';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {
@@ -256,6 +257,69 @@ describe('CLI run progress renderer', () => {
 
     expect(output).toBe(
       'polish paper.tex · 0s\npolish paper.tex · tool: latexmk · 0s\n',
+    );
+  });
+
+  it('does not overwrite a terminal status with late root descriptions', () => {
+    let now = 0;
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        minIntervalMs: 0,
+        nowMs: () => now,
+      },
+    );
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    renderer?.handle('updateActiveProcesses', {
+      parentStreamId: 'root-stream',
+      processes: [
+        {
+          executionId: 'tool-1',
+          agentName: 'bash',
+          toolName: 'Bash',
+          status: 'running',
+        },
+      ],
+    });
+    now = 11000;
+    renderer?.handle('updateStreamStatus', {
+      streamId: 'root-stream',
+      status: STREAM_STATUS.STOPPED,
+      previousStatus: STREAM_STATUS.RUNNING,
+    });
+    renderer?.handle('updateStreamDescription', {
+      streamId: 'root-stream',
+      description: 'Running Mathematician multi-agent preset',
+    });
+    renderer?.handle('updateActiveProcesses', {
+      parentStreamId: 'root-stream',
+      processes: [
+        {
+          executionId: 'tool-2',
+          agentName: 'late-tool',
+          toolName: 'LateTool',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(output).toBe(
+      'orchestrator · 0s\n' +
+        'orchestrator · tool: Bash · 0s\n' +
+        'orchestrator · stopped · 11s\n',
     );
   });
 


### PR DESCRIPTION
Fixes #4891.

## Summary
- keep the run progress renderer in a terminal state after the root stream reports stopped/error
- clear active child labels when the root stream reaches a terminal status
- ignore late root descriptions/child updates so stale progress does not appear after the final `--print` result

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with 11 existing import-order warnings outside this patch)
- `git diff --check`
- `corepack pnpm run texra-local:build`
- redirected live repro: `texra-local --api-mode included --approval-policy yolo multi-agent run mathematician --model deepseekT --instruction 'Say only OK.' --print >/tmp/texra-multi-out.txt 2>/tmp/texra-multi-err.txt` now ends stderr at the stopped status, with no late `Running ...` line after it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to stderr progress rendering with no auth, data, or execution-path impact.
> 
> **Overview**
> The CLI **run progress renderer** now **locks** once the root stream reports **stopped** or **error**: it clears active tool/subagent labels and **ignores** later root stream descriptions and child-process updates so stderr does not show stale “running” lines after the final status (fixes late events after `--print` output).
> 
> A **Vitest** case asserts that a late description and active-process update do not replace the terminal **stopped** line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d807b3dfe06b5886f10d65d0f1c0434088365f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->