### PR TITLE
fix(cli): ignore late progress after terminal status

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -80,6 +80,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         }
         return true;
       case 'updateConversationProgress':
+        if (this.rootStreamTerminal) return true;
         if (
           this.applyConversationProgress(
             payload as ProgressEventPayloads['updateConversationProgress'],

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -304,6 +304,13 @@ describe('CLI run progress renderer', () => {
       streamId: 'root-stream',
       description: 'Running Mathematician multi-agent preset',
     });
+    renderer?.handle('updateConversationProgress', {
+      streamId: 'root-stream',
+      progress: {
+        conversationTurns: 3,
+        toolCallCount: 9,
+      },
+    });
     renderer?.handle('updateActiveProcesses', {
       parentStreamId: 'root-stream',
       processes: [


### PR DESCRIPTION
Fixes #4895.

## Summary
- ignore late conversation progress once the root stream reaches a terminal status
- extend the run-progress regression test to cover late conversation-progress updates after stopped

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint (passes with 11 pre-existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI display guard with a regression test; no auth, data, or execution-path changes.
> 
> **Overview**
> Fixes late **conversation progress** updates overwriting the CLI run status line after the root stream has already reached a terminal state (**stopped** or **error**).
> 
> `RunProgressRenderer` now ignores `updateConversationProgress` when `rootStreamTerminal` is set, matching the behavior already used for active processes, subagents, and stream descriptions. A regression test asserts that progress arriving after **stopped** does not change the final rendered line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3385bcddfa060097c4581c8f69f9857dd34c7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->