### PR TITLE
fix(cli): budget wrapped task detail output rows

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -19,6 +19,7 @@ import {
   type ChildControlMode,
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
@@ -145,6 +146,51 @@ export function taskDetailKeyHintsForColumns({
   }
   hints.push({ key: 'Esc', action: 'back' });
   return hints;
+}
+
+export function taskDetailOutputColumnCount(
+  availableColumns: number | undefined,
+): number | undefined {
+  return availableColumns === undefined
+    ? undefined
+    : Math.max(1, availableColumns - TASK_DETAIL_HORIZONTAL_CHROME_COLUMNS);
+}
+
+export function taskDetailWrappedRowCount(
+  line: string,
+  outputColumns: number | undefined,
+): number {
+  if (outputColumns === undefined) return 1;
+  return Math.max(1, wrapAnsiToWidth(line, outputColumns).split('\n').length);
+}
+
+export function taskDetailVisibleLineCountForColumns({
+  availableColumns,
+  compact,
+  tailLines,
+  visibleRowBudget,
+}: {
+  readonly availableColumns?: number;
+  readonly compact: boolean;
+  readonly tailLines: readonly string[];
+  readonly visibleRowBudget: number;
+}): number {
+  if (visibleRowBudget <= 0) return 0;
+  if (!compact || tailLines.length === 0) return visibleRowBudget;
+
+  const outputColumns = taskDetailOutputColumnCount(availableColumns);
+  if (outputColumns === undefined) return visibleRowBudget;
+
+  let usedRows = 0;
+  let visibleLines = 0;
+  for (let index = tailLines.length - 1; index >= 0; index -= 1) {
+    const rowCount = taskDetailWrappedRowCount(tailLines[index], outputColumns);
+    if (visibleLines > 0 && usedRows + rowCount > visibleRowBudget) break;
+    visibleLines += 1;
+    usedRows += rowCount;
+    if (usedRows >= visibleRowBudget) break;
+  }
+  return Math.max(1, visibleLines);
 }
 
 function renderItem(
@@ -467,18 +513,12 @@ function TaskDetailView({
     hasTailLines: item.tailLines.length > 0,
     metaRows: metaParts.length,
   });
-  const shouldReserveWrappedOutputRow =
-    layout.compact &&
-    availableColumns !== undefined &&
-    availableColumns <= NARROW_TASK_DETAIL_HINT_MAX_COLUMNS &&
-    item.tailLines.some(
-      (line) =>
-        line.length >
-        Math.max(1, availableColumns - TASK_DETAIL_HORIZONTAL_CHROME_COLUMNS),
-    );
-  const visibleLineCount = shouldReserveWrappedOutputRow
-    ? Math.max(1, layout.visibleLineCount - 1)
-    : layout.visibleLineCount;
+  const visibleLineCount = taskDetailVisibleLineCountForColumns({
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+    visibleRowBudget: layout.visibleLineCount,
+  });
   const maxOffset = taskDetailInitialScrollOffset(
     item.tailLines.length,
     visibleLineCount,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -18,7 +18,9 @@ import {
   taskDetailCommandLabel,
   taskDetailInitialScrollOffset,
   taskDetailKeyHintsForColumns,
+  taskDetailVisibleLineCountForColumns,
   taskDetailVisibleScrollOffset,
+  taskDetailWrappedRowCount,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
   buildChildControlItems,
@@ -887,6 +889,35 @@ describe('CLI child execution controls', () => {
       { key: 'k', action: 'kill' },
       { key: 'Esc', action: 'back' },
     ]);
+  });
+
+  it('budgets compact task detail output by wrapped terminal rows', () => {
+    expect(taskDetailWrappedRowCount('abcd', 4)).toBe(1);
+    expect(taskDetailWrappedRowCount('abcde', 4)).toBe(2);
+    expect(
+      taskDetailVisibleLineCountForColumns({
+        availableColumns: 80,
+        compact: true,
+        tailLines: ['x'.repeat(100), 'final line'],
+        visibleRowBudget: 3,
+      }),
+    ).toBe(2);
+    expect(
+      taskDetailVisibleLineCountForColumns({
+        availableColumns: 80,
+        compact: true,
+        tailLines: ['x'.repeat(100), 'final line'],
+        visibleRowBudget: 2,
+      }),
+    ).toBe(1);
+    expect(
+      taskDetailVisibleLineCountForColumns({
+        availableColumns: 48,
+        compact: true,
+        tailLines: ['final output wraps at this width'],
+        visibleRowBudget: 0,
+      }),
+    ).toBe(0);
   });
 
   it('labels the task picker as a combined task and sub-workflow view', () => {


### PR DESCRIPTION
Fixes #4900.

## Summary
- compute compact task-detail visible output from wrapped terminal row counts
- keep zero output-row budgets at zero
- use the existing ANSI wrapping helper so row counts match terminal wrapping behavior
- cover wider compact panes and zero-budget cases in ChildControls tests

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-wrap-budget task-subworkflow-detail-long-output
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/ChildControlPicker.tsx src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint (passes with 11 pre-existing import-order warnings)
- git diff --check main...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout-only change in child task detail scrolling with unit tests; no auth, data, or API impact.
> 
> **Overview**
> Compact **task detail** views in the CLI TUI no longer guess visible output with a single “long line → reserve one row” shortcut. They now **budget output rows using ANSI-aware wrap counts** (`wrapAnsiToWidth`), walking tail lines from the bottom so multi-line wraps fit the terminal row budget.
> 
> Exported helpers (`taskDetailOutputColumnCount`, `taskDetailWrappedRowCount`, `taskDetailVisibleLineCountForColumns`) replace the old inline logic in `TaskDetailView`. A **zero row budget stays at zero** (no forced minimum line). **Vitest** covers wrap row math and budgeting for wide compact panes and zero-budget cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e81154547ec7dba0dfd2eca05a5c4e4c66e6b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->