### PR TITLE
fix(cli): budget task detail wrapped rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -71,6 +71,8 @@ const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
 const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
+const SHOW_WIDE_FIRST_CHILD_LINE =
+  process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
@@ -290,10 +292,10 @@ function seedSubagentFollowupTranscript(): void {
 function makeChildEntries(agent: string, action: string): ConversationEntry[] {
   const assistantText =
     SHOW_LONG_CHILD_OUTPUT && agent === 'strategy'
-      ? Array.from(
-          { length: 18 },
-          (_, index) =>
-            `strategy detail line ${String(index + 1).padStart(2, '0')}${index === 17 ? ' final contradiction found' : ''}`,
+      ? Array.from({ length: 18 }, (_, index) =>
+          index === 0 && SHOW_WIDE_FIRST_CHILD_LINE
+            ? `strategy detail line 01 ${'wide output wraps '.repeat(10)}`
+            : `strategy detail line ${String(index + 1).padStart(2, '0')}${index === 17 ? ' final contradiction found' : ''}`,
         ).join('\n')
       : `${agent} is checking the ${action} details and preparing a concise result.`;
   return [

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -43,6 +43,7 @@ const ETX = String.fromCharCode(3); // Ctrl-C
 const DC2 = String.fromCharCode(18); // Ctrl-R
 const DC4 = String.fromCharCode(20); // Ctrl-T
 const NAK = String.fromCharCode(21); // Ctrl-U
+const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
@@ -786,6 +787,29 @@ const SCENARIOS = [
       'Esc back',
     ],
     unexpect: ['strategy detail line 01', 'final contr…'],
+  },
+  {
+    name: 'task-subworkflow-detail-wide-line-scroll',
+    rows: 12,
+    cols: 48,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+      HARNESS_LONG_CHILD_OUTPUT: '1',
+      HARNESS_WIDE_FIRST_CHILD_LINE: '1',
+    },
+    bootExpect: 'TeXRA',
+    keys: [ESC + 'p', '\r', ...Array.from({ length: 17 }, () => UP)],
+    frame: 'tail',
+    expect: [
+      'stream · strategy',
+      'strategy detail line 01',
+      'wide output wraps',
+      'f focus',
+      'Esc back',
+    ],
+    unexpect: ['strategy detail line 18', 'final contr…'],
   },
   {
     name: 'task-process-detail',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -193,6 +193,38 @@ export function taskDetailVisibleLineCountForColumns({
   return Math.max(1, visibleLines);
 }
 
+export function taskDetailVisibleLineCountFromOffsetForColumns({
+  availableColumns,
+  compact,
+  tailLines,
+  visibleRowBudget,
+  offset,
+}: {
+  readonly availableColumns?: number;
+  readonly compact: boolean;
+  readonly tailLines: readonly string[];
+  readonly visibleRowBudget: number;
+  readonly offset: number;
+}): number {
+  if (visibleRowBudget <= 0) return 0;
+  if (!compact || tailLines.length === 0) return visibleRowBudget;
+
+  const outputColumns = taskDetailOutputColumnCount(availableColumns);
+  if (outputColumns === undefined) return visibleRowBudget;
+
+  const start = Math.min(Math.max(0, offset), tailLines.length - 1);
+  let usedRows = 0;
+  let visibleLines = 0;
+  for (let index = start; index < tailLines.length; index += 1) {
+    const rowCount = taskDetailWrappedRowCount(tailLines[index], outputColumns);
+    if (visibleLines > 0 && usedRows + rowCount > visibleRowBudget) break;
+    visibleLines += 1;
+    usedRows += rowCount;
+    if (usedRows >= visibleRowBudget) break;
+  }
+  return Math.max(1, visibleLines);
+}
+
 function renderItem(
   item: ChildControlItem,
   index: number,
@@ -513,7 +545,7 @@ function TaskDetailView({
     hasTailLines: item.tailLines.length > 0,
     metaRows: metaParts.length,
   });
-  const visibleLineCount = taskDetailVisibleLineCountForColumns({
+  const tailVisibleLineCount = taskDetailVisibleLineCountForColumns({
     availableColumns,
     compact: layout.compact,
     tailLines: item.tailLines,
@@ -521,7 +553,7 @@ function TaskDetailView({
   });
   const maxOffset = taskDetailInitialScrollOffset(
     item.tailLines.length,
-    visibleLineCount,
+    tailVisibleLineCount,
   );
   const [scrollState, setScrollState] = useState<TaskDetailScrollState>(() => ({
     executionId: item.executionId,
@@ -529,6 +561,13 @@ function TaskDetailView({
     offset: maxOffset,
   }));
   const offset = taskDetailVisibleScrollOffset(scrollState, maxOffset);
+  const visibleLineCount = taskDetailVisibleLineCountFromOffsetForColumns({
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+    visibleRowBudget: layout.visibleLineCount,
+    offset,
+  });
   const visibleTail = item.tailLines.slice(offset, offset + visibleLineCount);
   const compactMeta = metaParts.join(' · ');
   const commandLabel = taskDetailCommandLabel(item.kind);

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -18,6 +18,7 @@ import {
   taskDetailCommandLabel,
   taskDetailInitialScrollOffset,
   taskDetailKeyHintsForColumns,
+  taskDetailVisibleLineCountFromOffsetForColumns,
   taskDetailVisibleLineCountForColumns,
   taskDetailVisibleScrollOffset,
   taskDetailWrappedRowCount,
@@ -918,6 +919,24 @@ describe('CLI child execution controls', () => {
         visibleRowBudget: 0,
       }),
     ).toBe(0);
+    expect(
+      taskDetailVisibleLineCountFromOffsetForColumns({
+        availableColumns: 80,
+        compact: true,
+        tailLines: ['x'.repeat(180), 'short 1', 'short 2', 'short 3'],
+        visibleRowBudget: 3,
+        offset: 0,
+      }),
+    ).toBe(1);
+    expect(
+      taskDetailVisibleLineCountFromOffsetForColumns({
+        availableColumns: 80,
+        compact: true,
+        tailLines: ['x'.repeat(180), 'short 1', 'short 2', 'short 3'],
+        visibleRowBudget: 3,
+        offset: 1,
+      }),
+    ).toBe(3);
   });
 
   it('labels the task picker as a combined task and sub-workflow view', () => {


### PR DESCRIPTION
Fixes #4899.

## Summary
- budget compact task-detail output from the current scroll offset, not only from the tail
- keep wrapped wide output lines within the reserved row budget so footer controls remain visible
- add a PTY TUI harness scenario that scrolls to a wide wrapped output line

## Validation
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/ChildControlPicker.tsx packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui task-subworkflow-detail-wide-line-scroll task-subworkflow-detail-long-output
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint (passes with 11 pre-existing import-order warnings outside this patch)
- git diff --check origin/main HEAD
