### PR TITLE
fix(cli): document chat interactive controls

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,6 +1,6 @@
-import { renderUsage, showUsage, type CommandDef } from 'citty';
+import { renderUsage, type CommandDef } from 'citty';
 
-import { writeRawStderr } from '@cli/runtime/logSinks';
+import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 
 import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
 
@@ -114,6 +114,43 @@ export function isCliError(error: unknown): error is Error & { code?: string } {
 
 export type AnyCommand = CommandDef<any>;
 
+export interface UsageSection {
+  readonly title: string;
+  readonly rows: readonly (readonly [label: string, description: string])[];
+}
+
+const usageSections = new WeakMap<AnyCommand, readonly UsageSection[]>();
+
+export function withUsageSections<T extends AnyCommand>(
+  command: T,
+  sections: readonly UsageSection[],
+): T {
+  usageSections.set(command, sections);
+  return command;
+}
+
+function formatUsageSection(section: UsageSection): string {
+  if (section.rows.length === 0) return section.title;
+  const labelWidth = Math.max(...section.rows.map(([label]) => label.length));
+  return [
+    section.title,
+    '',
+    ...section.rows.map(
+      ([label, description]) => `  ${label.padEnd(labelWidth)}  ${description}`,
+    ),
+  ].join('\n');
+}
+
+async function renderUsageWithSections(
+  cmd: AnyCommand,
+  parent?: AnyCommand,
+): Promise<string> {
+  const usage = await renderUsage(cmd, parent);
+  const sections = usageSections.get(cmd);
+  if (!sections?.length) return usage;
+  return `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`;
+}
+
 async function commandSubCommands(
   cmd: AnyCommand,
 ): Promise<Record<string, AnyCommand> | undefined> {
@@ -226,7 +263,12 @@ export async function showUsageStderr(
   cmd: AnyCommand,
   parent?: AnyCommand,
 ): Promise<void> {
-  writeRawStderr(`${await renderUsage(cmd, parent)}\n`);
+  writeRawStderr(`${await renderUsageWithSections(cmd, parent)}\n`);
 }
 
-export { showUsage };
+export async function showUsage(
+  cmd: AnyCommand,
+  parent?: AnyCommand,
+): Promise<void> {
+  writeRawStdout(`${await renderUsageWithSections(cmd, parent)}\n\n`);
+}

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 
 import { contextFromArgs } from './_helpers/context';
+import { withUsageSections } from './_helpers/dispatch';
 import { setExitCode } from './_helpers/exitCode';
 import {
   INTERACTIVE_GLOBAL_ARGS,
@@ -11,23 +12,43 @@ import {
 } from './_helpers/globalArgs';
 import { assertExplicitModelKnown } from './_helpers/modelArg';
 
-export const chatCommand = defineCommand({
-  meta: { name: 'chat', description: 'Interactive tool-use chat session' },
-  args: {
-    ...INTERACTIVE_GLOBAL_ARGS,
-    agent: { type: 'string', description: 'Tool-use agent for the session' },
-    model: { type: 'string', alias: 'm', description: 'Model for the session' },
-  },
-  async run(ctx) {
-    rejectHeadlessOnlyFlags(ctx.rawArgs, 'chat');
-    const modelOverride = assertExplicitModelKnown(optString(ctx.args.model));
-    const context = await contextFromArgs(ctx.args);
-    await notifyCliUpdate(context);
-    const { runChat } = await import('../chat/tui/runChatTui');
-    const result = await runChat(context, {
-      agentOverride: optString(ctx.args.agent),
-      modelOverride,
-    });
-    setExitCode(result.exitCode);
-  },
-});
+export const chatCommand = withUsageSections(
+  defineCommand({
+    meta: { name: 'chat', description: 'Interactive tool-use chat session' },
+    args: {
+      ...INTERACTIVE_GLOBAL_ARGS,
+      agent: { type: 'string', description: 'Tool-use agent for the session' },
+      model: {
+        type: 'string',
+        alias: 'm',
+        description: 'Model for the session',
+      },
+    },
+    async run(ctx) {
+      rejectHeadlessOnlyFlags(ctx.rawArgs, 'chat');
+      const modelOverride = assertExplicitModelKnown(optString(ctx.args.model));
+      const context = await contextFromArgs(ctx.args);
+      await notifyCliUpdate(context);
+      const { runChat } = await import('../chat/tui/runChatTui');
+      const result = await runChat(context, {
+        agentOverride: optString(ctx.args.agent),
+        modelOverride,
+      });
+      setExitCode(result.exitCode);
+    },
+  }),
+  [
+    {
+      title: 'INTERACTIVE CONTROLS',
+      rows: [
+        ['/help', 'show slash commands inside chat'],
+        ['/btw', 'ask a side question without interrupting the main task'],
+        ['/status', 'show session state'],
+        ['Ctrl-T', 'open the transcript viewer'],
+        ['Option-p', 'open tasks and sub-workflows (Alt-p on many terminals)'],
+        ['approvals', 'answer tool prompts when --approval-policy=ask'],
+        ['Ctrl-C', 'stop the running task or exit from the TUI'],
+      ],
+    },
+  ],
+);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -605,4 +605,19 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('USAGE');
     expect(stderr).toBe('');
   });
+
+  it('documents interactive chat controls in chat --help', async () => {
+    const result = await runCli(['chat', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stdout).toContain('/help');
+    expect(stdout).toContain('/btw');
+    expect(stdout).toContain('/status');
+    expect(stdout).toContain('Ctrl-T');
+    expect(stdout).toContain('Option-p');
+    expect(stdout).toContain('Alt-p');
+    expect(stdout).toContain('approvals');
+    expect(stdout).toContain('Ctrl-C');
+    expect(stderr).toBe('');
+  });
 });


### PR DESCRIPTION
Closes #4903.\n\n## Summary\n- append an INTERACTIVE CONTROLS section to texra chat --help\n- document /help, /btw, /status, Ctrl-T, Option-p/Alt-p, approvals, and Ctrl-C\n- add a CLI usage-output regression test for chat help\n\n## Verification\n- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts\n- corepack pnpm --filter @texra-ai/cli build\n- node packages/cli/dist/bin/texra.js chat --help\n- npm run format\n- npm run compile:safe\n- npm run lint (0 errors; existing import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only help text rendering and stdout usage output; no runtime chat, auth, or workflow behavior.
> 
> **Overview**
> Adds a **`withUsageSections`** helper so commands can append extra help blocks after citty’s standard usage. Both explicit **`--help`** (`showUsage` → stdout) and error-path usage (`showUsageStderr`) now render through **`renderUsageWithSections`**, with **`showUsage`** implemented locally via **`writeRawStdout`** instead of re-exporting citty’s version.
> 
> **`texra chat --help`** gains an **INTERACTIVE CONTROLS** section documenting slash commands (`/help`, `/btw`, `/status`), TUI keys (Ctrl-T, Option-p/Alt-p), approvals, and Ctrl-C. A regression test asserts those strings appear on stdout for `chat --help`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63b810c5d58dac506016764edd9f64e9917fa0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->