### PR TITLE
fix(cli): route help command paths

### DIFF
--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,9 +1,35 @@
-import { defineCommand, showUsage } from 'citty';
+import { defineCommand } from 'citty';
+
+import { CliUsageError } from '../runtime/cliContext';
+
+import {
+  detectUnknownCliCommand,
+  formatUnknownCliCommand,
+  resolveDeepestSubCommand,
+  showUsage,
+} from './_helpers/dispatch';
 
 export const helpCommand = defineCommand({
   meta: { name: 'help', description: 'Show TeXRA CLI commands' },
-  async run() {
+  async run(ctx) {
     const { rootCommand } = await import('./root');
-    await showUsage(rootCommand);
+    if (ctx.rawArgs.length === 0) {
+      await showUsage(rootCommand);
+      return;
+    }
+
+    const unknownCommand = await detectUnknownCliCommand(
+      rootCommand,
+      ctx.rawArgs,
+    );
+    if (unknownCommand) {
+      throw new CliUsageError(formatUnknownCliCommand(unknownCommand));
+    }
+
+    const [target, parent] = await resolveDeepestSubCommand(
+      rootCommand,
+      ctx.rawArgs,
+    );
+    await showUsage(target, parent);
   },
 });

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -620,4 +620,28 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('Ctrl-C');
     expect(stderr).toBe('');
   });
+
+  it('shows command-specific usage for help command paths', async () => {
+    const result = await runCli(['help', 'chat']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('Interactive tool-use chat session');
+    expect(stdout).toContain('USAGE texra chat');
+    expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stderr).toBe('');
+  });
+
+  it('shows nested command-specific usage for help command paths', async () => {
+    const result = await runCli(['help', 'multi-agent', 'run']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('Run a multi-agent team preset');
+    expect(stdout).toContain('USAGE multi-agent run');
+    expect(stderr).toBe('');
+  });
+
+  it('reports unknown command paths passed to help', async () => {
+    const result = await runCli(['help', 'bogus']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain('Unknown command: texra bogus');
+    expect(stdout).toBe('');
+  });
 });


### PR DESCRIPTION
Closes #4905.

## Summary
- route `texra help <command...>` through the CLI subcommand resolver
- render the same command-specific usage helper used by explicit `--help`
- return a usage error for unknown help command paths instead of silently showing root help

## Dogfooding
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood transcript slash-palette btw-submit edit-approval bash-approval task-subworkflow-detail task-subworkflow-detail-wide-line-scroll agent-form model-form tools-form tiny-status-separators`
- confirmed `texra help chat` previously showed root help while `texra chat --help` showed `INTERACTIVE CONTROLS`

## Verification
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js help chat`
- `node packages/cli/dist/bin/texra.js help multi-agent run`
- `node packages/cli/dist/bin/texra.js help bogus` (exits 2 with unknown-command guidance)
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI help routing and tests only; no auth, data, or runtime execution changes.
> 
> **Overview**
> **`texra help`** now accepts optional command paths and shows the same per-command usage as **`--help`**, instead of always printing root help.
> 
> With no extra arguments, behavior is unchanged (root usage). With **`texra help <command...>`**, the CLI walks the subcommand tree via shared dispatch helpers, renders command-specific usage (including nested paths like **`multi-agent run`**), and throws a usage error for unknown paths instead of falling back to root help.
> 
> Vitest coverage was added for targeted help, nested help, and unknown **`help`** paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d19d205fc76aabc6e703170975510de307fd084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->