### PR TITLE
fix(cli): keep idle btw from starting runs

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -61,6 +61,8 @@ const STREAM_ID = 'harness-stream-1';
 const HARNESS_APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
 const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 const HARNESS_BTW_USAGE = 'Usage: /btw <message>';
+const HARNESS_BTW_IDLE_MESSAGE =
+  'No active run to attach a follow-up to. Send a normal message to start a run.';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
@@ -69,6 +71,7 @@ const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
 const SHOW_AGENT_PROPOSAL = process.env.HARNESS_AGENT_PROPOSAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
+const BTW_IDLE = process.env.HARNESS_BTW_IDLE === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
 const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
@@ -719,6 +722,10 @@ function queueHarnessFollowUp(input: string): void {
   const message = input.trim();
   if (!message) {
     appendHarnessAssistantTranscript(HARNESS_BTW_USAGE);
+    return;
+  }
+  if (BTW_IDLE) {
+    appendHarnessAssistantTranscript(HARNESS_BTW_IDLE_MESSAGE);
     return;
   }
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -212,6 +212,21 @@ const SCENARIOS = [
     unexpect: ['registered but has no harness action'],
   },
   {
+    name: 'btw-idle-warning',
+    env: { HARNESS_ENTRIES: '0', HARNESS_BTW_IDLE: '1' },
+    keys: ['/btw check the finite case later', '\r'],
+    frame: 'tail',
+    expect: [
+      'No active run to attach a follow-up to.',
+      'Send a normal message to start a run.',
+    ],
+    unexpect: [
+      'Queued follow-up: check the finite case later',
+      'queued 1',
+      'Harness received',
+    ],
+  },
+  {
     name: 'plain-submit',
     cols: 120,
     env: { HARNESS_ENTRIES: '2' },

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -131,6 +131,9 @@ export function parseBtwFollowUpMessage(line: string): string | undefined {
   return parsed.remainder.trim();
 }
 
+export const BTW_IDLE_MESSAGE =
+  'No active run to attach a follow-up to. Send a normal message to start a run.';
+
 export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
   executionId: string | undefined;
@@ -248,6 +251,16 @@ export function chatTuiShouldAnnounceQueuedFollowUp(
 ): boolean {
   if (!targetStreamId) return true;
   return !chatTuiStreamStatuses(targetStreamId).includes(STREAM_STATUS.WAITING);
+}
+
+export function chatTuiCanSubmitBtwFollowUp(
+  session: PendingTuiRunSessionState,
+): boolean {
+  return (
+    !chatTuiCanStartRootRun(session) ||
+    chatTuiActiveChildFollowUpTarget() !== undefined ||
+    chatTuiRejectedChildFollowUpTarget() !== undefined
+  );
 }
 
 interface SlashCommandContext {
@@ -1023,6 +1036,11 @@ export async function runChat(
       if (!btwMessage) {
         appendLocalUserTranscript(line.trim());
         appendLocalAssistantTranscript('Usage: /btw <message>');
+        return;
+      }
+      if (!chatTuiCanSubmitBtwFollowUp(session)) {
+        appendLocalUserTranscript(line.trim());
+        appendLocalAssistantTranscript(BTW_IDLE_MESSAGE);
         return;
       }
       await submitChatMessage(btwMessage);

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -59,6 +59,7 @@ import {
   chatTuiCanStopActiveRun,
   chatTuiCanStopVisibleRun,
   chatTuiCanStartRootRun,
+  chatTuiCanSubmitBtwFollowUp,
   chatTuiActiveChildFollowUpTarget,
   chatTuiRejectedChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
@@ -781,6 +782,40 @@ describe('CLI TUI row allocation', () => {
     expect(parseBtwFollowUpMessage('/btw')).toBe('');
     expect(parseBtwFollowUpMessage('ordinary prompt')).toBeUndefined();
     expect(parseBtwFollowUpMessage('/status')).toBeUndefined();
+  });
+
+  it('does not treat idle /btw input as a new root run', () => {
+    const runPromise = Promise.resolve();
+
+    expect(
+      chatTuiCanSubmitBtwFollowUp({
+        runCompleted: false,
+        runPromise: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      chatTuiCanSubmitBtwFollowUp({
+        runCompleted: false,
+        runPromise,
+      }),
+    ).toBe(true);
+    expect(
+      chatTuiCanSubmitBtwFollowUp({
+        runCompleted: true,
+        runPromise,
+      }),
+    ).toBe(false);
+
+    cliState.activeStreamId.set(child1);
+    setParentStream(child1, root);
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+
+    expect(
+      chatTuiCanSubmitBtwFollowUp({
+        runCompleted: true,
+        runPromise,
+      }),
+    ).toBe(true);
   });
 
   it('clears stale resume ids when clearing chat session run state', () => {


### PR DESCRIPTION
Closes #4908.

## Summary
- prevent `/btw <message>` at an idle chat prompt from starting a new root run
- show a local warning that there is no active run to attach a follow-up to
- keep active-run `/btw` queue behavior covered by the PTY harness

## Dogfooding
- Reproduced in a real PTY with `texra-local chat --approval-policy ask`: idle `/btw ...` stripped the command and started a relay run.
- Rebuilt the CLI and verified `node packages/cli/dist/bin/texra.js chat --approval-policy ask` now shows:
  `No active run to attach a follow-up to. Send a normal message to start a run.`

## Verification
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui btw-idle-warning btw-submit`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/runChatTui.tsx packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli build`
- `git diff --check`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-handling change for `/btw` at idle; active-run follow-up queue behavior is unchanged and covered by harness and unit tests.
> 
> **Overview**
> Idle **`/btw <message>`** at the chat prompt no longer starts a new root agent run. The TUI now checks **`chatTuiCanSubmitBtwFollowUp`** (active run, in-flight root work, or a focused child that can accept follow-ups) before queueing; otherwise it echoes the user line and shows **`BTW_IDLE_MESSAGE`** locally.
> 
> The TUI harness mirrors that path via **`HARNESS_BTW_IDLE`**, and **`validate-tui`** adds a **`btw-idle-warning`** scenario. **`TuiStateAndFocus`** tests cover the new gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6bba2245539c94cfc35fa7ef01783f6ec77bf10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->