### PR TITLE
refactor(github): split PRPollingSource into domain/infra/value-object layers

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -33,16 +33,30 @@ import {
   formatReview,
   formatReviewComment,
   formatSubscriptionError,
-  isPassingConclusion,
 } from './formatPREvent';
 import { getNewestTimestamp, trimSet } from './formatUtils';
 import {
-  type ConditionalResponse,
   ghGet,
   GitHubAuthError,
   GitHubPermanentError,
   GitHubRateLimitError,
 } from './githubClient';
+import {
+  annotationFetchBudget,
+  AnnotationFetchBudgetExhaustedError,
+} from './annotationFetchBudget';
+import {
+  fetchAllCheckRuns as fetchAllCheckRunsClient,
+  fetchAnnotations as fetchAnnotationsClient,
+  type CheckRunsCache,
+} from './checkRunsClient';
+import {
+  checkKey,
+  ciTerminalStatus,
+  computeNewCheckFailures,
+  isCheckFailure,
+  planAnnotationCandidates,
+} from './prCheckRunDomain';
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,
@@ -107,76 +121,10 @@ const COALESCE_THRESHOLD = 3;
 // Per-resource id history is trimmed to this many entries so long-running
 // subscriptions don't grow the state map unboundedly.
 const MAX_SEEN_IDS = 1000;
-// GitHub caps the check-runs endpoint at 100 per page.
-const CHECK_RUNS_PAGE_SIZE = 100;
-// Hard ceiling on how many check-runs pages we'll walk in a single fetch.
-// 50 pages = 5,000 runs — well above any realistic monorepo matrix build.
-// Without a cap a malformed/runaway `total_count` could fan out into
-// hundreds of GETs per tick.
-const MAX_CHECK_RUNS_PAGES = 50;
-// Use GitHub's maximum page size so filtering by level does not miss failures
-// that appear after a long run of warnings or notices.
-const ANNOTATIONS_PAGE_SIZE = 100;
-// Same order of magnitude as the check-runs page cap. This is a malformed
-// response guard, not a normal truncation policy.
-const MAX_ANNOTATION_PAGES_PER_RUN = 50;
 // Bound the per-subscription fan-out across runs (e.g. a matrix build
 // lighting up a fleet of checks). Excess candidates stay in
 // `pendingAnnotationRuns` and are drained on subsequent ticks.
 const MAX_ANNOTATION_RUNS_PER_SUBSCRIPTION_TICK = 3;
-// Bound annotation endpoint traffic across all PR subscriptions in this
-// process. Pagination claims one unit per annotations page, so this 60s budget
-// window permits at most 3,000 annotation requests per hour, leaving room for
-// the rest of the PR polling endpoints under GitHub's primary 5,000/hour limit.
-// Keep it independent of the poll interval so tuning PR_POLL_INTERVAL_MS does
-// not silently raise the hourly ceiling.
-const MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW = 50;
-const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 60_000;
-
-class AnnotationFetchBudgetExhaustedError extends Error {
-  constructor() {
-    super('Annotation fetch budget exhausted');
-  }
-}
-
-class AnnotationFetchBudget {
-  private windowStartMs: number;
-  private remainingRequests: number;
-
-  constructor(
-    private readonly maxRequestsPerWindow: number,
-    private readonly windowMs: number,
-  ) {
-    this.windowStartMs = Date.now();
-    this.remainingRequests = maxRequestsPerWindow;
-  }
-
-  tryClaim(nowMs = Date.now()): boolean {
-    if (nowMs - this.windowStartMs >= this.windowMs) {
-      this.windowStartMs = nowMs;
-      this.remainingRequests = this.maxRequestsPerWindow;
-    }
-    if (this.remainingRequests <= 0) return false;
-    this.remainingRequests -= 1;
-    return true;
-  }
-
-  resetForTests(
-    remainingRequests = this.maxRequestsPerWindow,
-    nowMs = Date.now(),
-  ): void {
-    this.windowStartMs = nowMs;
-    this.remainingRequests = Math.max(
-      0,
-      Math.min(this.maxRequestsPerWindow, remainingRequests),
-    );
-  }
-}
-
-const annotationFetchBudget = new AnnotationFetchBudget(
-  MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW,
-  ANNOTATION_FETCH_BUDGET_WINDOW_MS,
-);
 
 export interface PRKey {
   owner: string;
@@ -251,11 +199,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * `lastTotalCount` is the most recent `total_count` from a 200 response;
    * it tells us how many pages to walk when page 1 returns 304.
    */
-  checkRunsCache?: {
-    etagsByPage: Map<number, string>;
-    pagesByPage: Map<number, GhCheckRun[]>;
-    lastTotalCount: number;
-  };
+  checkRunsCache?: CheckRunsCache;
   // ISO `since` cursors for server-side filtering on the comments endpoints.
   // Advance to the newest seen item's timestamp so PRs with >100 comments
   // still surface new activity (default sort is oldest-first; without
@@ -336,30 +280,6 @@ export class PRPollingSource extends PollingSourceBase<
       onEvent,
       minAnnotationLevel,
     );
-  }
-
-  /**
-   * Compute the CI-terminal status for a tick.
-   *
-   * `complete` is true only when we have the head SHA, a non-empty run set,
-   * the full set (length >= total_count — `fetchAllCheckRuns` dedupes by id and
-   * returns the latest total_count, so this is safe against mid-walk page
-   * shifts), and every run has completed. `passed` requires `complete` plus
-   * every run passing.
-   */
-  private static ciTerminalStatus(
-    headSha: string | undefined,
-    runs: GhCheckRun[],
-    totalCount: number,
-  ): { complete: boolean; passed: boolean } {
-    const complete =
-      !!headSha &&
-      runs.length > 0 &&
-      runs.length >= totalCount &&
-      runs.every((r) => r.status === 'completed');
-    const passed =
-      complete && runs.every((r) => isPassingConclusion(r.conclusion));
-    return { complete, passed };
   }
 
   protected emitKeysChangedEvent(
@@ -502,7 +422,13 @@ export class PRPollingSource extends PollingSourceBase<
           state.etags.reviews,
         ),
         state.headSha
-          ? this.fetchAllCheckRuns(pr.owner, pr.repo, state.headSha, state)
+          ? fetchAllCheckRunsClient(
+              pr.owner,
+              pr.repo,
+              state.headSha,
+              state.checkRunsCache,
+              this.logger,
+            )
           : Promise.resolve({
               response: { status: 304 as const },
               stagedCache: undefined,
@@ -547,8 +473,8 @@ export class PRPollingSource extends PollingSourceBase<
         // `state.checkRunsCache`; nothing to record on `state.etags` here.
         const runs = checksRes.data.check_runs;
         for (const r of runs) {
-          if (this.isCheckFailure(r)) {
-            state.lastFailedCheckKeys.add(this.checkKey(r));
+          if (isCheckFailure(r)) {
+            state.lastFailedCheckKeys.add(checkKey(r));
           }
           // Seed annotation keys so pre-subscription annotations don't
           // replay; the timestamp in the key lets re-runs re-emit.
@@ -556,7 +482,7 @@ export class PRPollingSource extends PollingSourceBase<
             r.status === 'completed' &&
             (r.output?.annotations_count ?? 0) > 0
           ) {
-            state.lastAnnotationKeys.add(this.checkKey(r));
+            state.lastAnnotationKeys.add(checkKey(r));
           }
         }
         if (state.headSha && runs.length > 0) {
@@ -566,7 +492,7 @@ export class PRPollingSource extends PollingSourceBase<
         // we only surface transitions that happen after subscribe. See
         // `ciTerminalStatus` for the gating rationale (empty/partial run sets,
         // page-shift safety).
-        const { complete, passed } = PRPollingSource.ciTerminalStatus(
+        const { complete, passed } = ciTerminalStatus(
           state.headSha,
           runs,
           checksRes.data.total_count,
@@ -657,14 +583,10 @@ export class PRPollingSource extends PollingSourceBase<
         }
       }
 
-      const newFailures: GhCheckRun[] = [];
-      const currentFailureKeys = new Set<string>();
-      for (const r of runs) {
-        if (!this.isCheckFailure(r)) continue;
-        const key = this.checkKey(r);
-        currentFailureKeys.add(key);
-        if (!state.lastFailedCheckKeys.has(key)) newFailures.push(r);
-      }
+      const { newFailures, currentFailureKeys } = computeNewCheckFailures(
+        runs,
+        state.lastFailedCheckKeys,
+      );
       state.lastFailedCheckKeys = currentFailureKeys;
       if (newFailures.length >= COALESCE_THRESHOLD) {
         this.emit(
@@ -685,7 +607,7 @@ export class PRPollingSource extends PollingSourceBase<
       //
       // See `ciTerminalStatus` for the gating rationale (empty/partial run
       // sets, page-shift safety).
-      const { complete, passed } = PRPollingSource.ciTerminalStatus(
+      const { complete, passed } = ciTerminalStatus(
         state.headSha,
         runs,
         checksRes.data.total_count,
@@ -726,268 +648,6 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   /**
-   * Fetch all check-runs for a commit, walking pages when `total_count > 100`.
-   *
-   * The check-runs endpoint caps at `per_page=100`. PRs with more registered
-   * runs (large monorepos, matrix builds) would otherwise have their terminal
-   * gates (`runs.length >= total_count`) stuck false forever, stranding agents
-   * waiting on "CI complete" / "CI passed".
-   *
-   * ## Mid-walk churn (additions, removals, dedupe)
-   *
-   * `total_count` and the per-page set of runs can both shift while we're
-   * paginating: GitHub may register new runs (pushing earlier runs onto a
-   * later page → duplicates across our pages), or runs may be removed/replaced
-   * (a page shrinks). We defend against both:
-   *
-   * - We accumulate runs into a `Map<id, GhCheckRun>` so duplicates collapse.
-   *   The terminal gate downstream (`runs.length >= total_count`) is evaluated
-   *   against the deduped count, not the raw appended count, so a page-shift
-   *   that fills our buffer with duplicates can't trick us into emitting
-   *   "CI complete" before a newly-registered run has actually been seen.
-   *
-   * - We re-read `total_count` from every 200 response and use the LAST seen
-   *   value (not the historical max). The server's `total_count` is its
-   *   current authoritative count at the moment of that page-N fetch; if a
-   *   transient mid-walk inflation later settles back down, taking the max
-   *   would strand the gate forever (`runs.length` can never reach an
-   *   inflated, no-longer-true total).
-   *
-   * The returned `total_count` is the latest observed server value (or, on
-   * a full-304 tick, the previously-committed value carried via cache),
-   * never page 1's stale snapshot.
-   *
-   * ## ETag caching (multi-page)
-   *
-   * Each page's ETag is cached on the subscription so subsequent ticks can
-   * issue conditional `If-None-Match` requests per page. A 304 means we
-   * reuse the previously-cached page contents; a 200 refreshes them.
-   *
-   * - Single-page (`total_count <= 100`): unchanged fast path — the page-1
-   *   ETag covers the whole result and a 304 short-circuits the entire call.
-   * - Multi-page: each page is independently conditional. In steady state
-   *   (no new push, all runs settled) every page returns 304 and we make
-   *   N HEAD-cheap requests instead of N full-page GETs, keeping the polling
-   *   cost bounded on large matrix builds.
-   *
-   * ## Runaway guard
-   *
-   * `MAX_CHECK_RUNS_PAGES` caps the walk at 50 pages (5,000 runs). If a
-   * misbehaving GitHub response or a runaway matrix would push us past it,
-   * we log a warning and return what we have — better to under-report than
-   * fan out into hundreds of GETs every 30s.
-   */
-  private async fetchAllCheckRuns(
-    owner: string,
-    repo: string,
-    sha: string,
-    state: SubscriptionState,
-  ): Promise<{
-    response: ConditionalResponse<{
-      total_count: number;
-      check_runs: GhCheckRun[];
-    }>;
-    /**
-     * New per-page cache value to commit only after the caller has
-     * successfully consumed the response. `undefined` means "no change" —
-     * either the single-page 304 fast path (existing cache is still valid)
-     * or this method itself short-circuited before fetching anything.
-     *
-     * Deferring the commit prevents a sibling rejection in `Promise.all`
-     * from advancing the cache while the diff branch never runs: a stale
-     * cache + 304 next tick would silently swallow check-run transitions.
-     */
-    stagedCache?: SubscriptionState['checkRunsCache'];
-  }> {
-    const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
-    const cache = state.checkRunsCache;
-
-    // Seed scratch caches we'll stage on the return value. We rebuild from
-    // scratch each tick (rather than mutating in-place) so any pages dropped
-    // on this tick — e.g. new push reduced page count from 5 to 3 — don't
-    // leave stale entries behind.
-    const nextEtags = new Map<number, string>();
-    const nextPages = new Map<number, GhCheckRun[]>();
-
-    // We need a place to record whether *every* page returned 304 so we can
-    // surface a true 304 to the caller (and skip the seeding/diff work).
-    let allPagesUnchanged = true;
-    // `latestTotal` tracks the most recent 200 response's `total_count`.
-    // Crucially we do NOT carry `cache.lastTotalCount` into this — that
-    // would let a transient prior-tick inflation persist forever once page-1
-    // starts returning 304 against the unchanged content (the cached
-    // `lastTotalCount` would seed the gate every tick and `runs.length`
-    // could never catch up to an inflated, no-longer-true total).
-    let latestTotal: number | undefined;
-
-    const fetchPage = async (
-      page: number,
-    ): Promise<{
-      runs: GhCheckRun[];
-      total: number | undefined;
-      was304: boolean;
-    }> => {
-      const pageEtag = cache?.etagsByPage.get(page);
-      const res = await ghGet<{
-        total_count: number;
-        check_runs: GhCheckRun[];
-      }>(`${basePath}&page=${page}`, pageEtag);
-      if (res.status === 304) {
-        // Reuse cached page. Carry forward the ETag we sent.
-        const cachedRuns = cache?.pagesByPage.get(page) ?? [];
-        if (pageEtag) nextEtags.set(page, pageEtag);
-        nextPages.set(page, cachedRuns);
-        return {
-          runs: cachedRuns,
-          // total_count isn't returned on 304. We deliberately return
-          // undefined here rather than falling back to `cache.lastTotalCount`,
-          // because that cached value may itself be stale (an inflated value
-          // committed during a prior mid-walk race). The terminal `latestTotal`
-          // is derived from this tick's 200 responses; only when *every* page
-          // is 304 do we reuse the cached total below — and that case
-          // genuinely means "nothing changed since we last committed".
-          total: undefined,
-          was304: true,
-        };
-      }
-      if (res.etag) nextEtags.set(page, res.etag);
-      nextPages.set(page, res.data.check_runs);
-      return {
-        runs: res.data.check_runs,
-        total: res.data.total_count,
-        was304: false,
-      };
-    };
-
-    // Page 1 always runs — we need its `total_count` (or a 304 fast-path
-    // when nothing changed).
-    const first = await fetchPage(1);
-    if (!first.was304) allPagesUnchanged = false;
-    if (first.total !== undefined) latestTotal = first.total;
-
-    // Single-page fast path. If page 1 was 304 and our last-known total fits
-    // in one page, we can short-circuit the whole call without touching any
-    // other state — this is the common steady-state for typical PRs. No
-    // staged cache: the existing `state.checkRunsCache` is still valid and
-    // we never built a replacement.
-    if (
-      first.was304 &&
-      cache &&
-      cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
-      cache.etagsByPage.size === 1
-    ) {
-      return { response: { status: 304 } };
-    }
-
-    // Dedupe by run id. Pagination is not transactional on GitHub: when a
-    // new run is registered mid-walk, runs can shift across page boundaries
-    // and we'd otherwise see the same id on two different pages (or miss
-    // one entirely). A `Map<id, run>` collapses duplicates and lets the
-    // downstream `runs.length >= total_count` gate evaluate against the
-    // true unique count.
-    const runsById = new Map<number, GhCheckRun>();
-    for (const r of first.runs) runsById.set(r.id, r);
-
-    // How many pages to walk this tick. We need a starting estimate before
-    // we've seen any 200 with a non-cached total, so we fall back to the
-    // cached `lastTotalCount` when page-1 was 304 (unchanged content → the
-    // server's view almost certainly matches what we last committed). If a
-    // 200 arrives later, `latestTotal` takes precedence and we recompute.
-    const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
-    let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
-    if (totalPages > MAX_CHECK_RUNS_PAGES) {
-      this.logger.warn(
-        `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-          `total_count=${seedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
-      );
-      totalPages = MAX_CHECK_RUNS_PAGES;
-    }
-    if (totalPages > 1) {
-      this.logger.info(
-        `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${seedTotal} → ${totalPages} pages`,
-      );
-    }
-
-    let page = 2;
-    while (page <= totalPages) {
-      const result = await fetchPage(page);
-      if (!result.was304) allPagesUnchanged = false;
-      for (const r of result.runs) runsById.set(r.id, r);
-
-      // Use the LATEST observed `total_count` (from this page's 200) as the
-      // authoritative server view. Walk-length adapts to it whether it grew
-      // OR shrank: a transient inflation that has since settled back down
-      // must be allowed to take effect, otherwise a max-style monotonic
-      // tracker would strand the terminal gate forever.
-      if (result.total !== undefined) {
-        latestTotal = result.total;
-        const newTotalPages = Math.max(
-          1,
-          Math.ceil(latestTotal / CHECK_RUNS_PAGE_SIZE),
-        );
-        if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
-          this.logger.warn(
-            `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-              `total_count is ${latestTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
-          );
-          totalPages = MAX_CHECK_RUNS_PAGES;
-        } else {
-          totalPages = newTotalPages;
-        }
-      }
-      page += 1;
-    }
-
-    // Resolve the total we'll surface and cache. Priority order:
-    //  1. The last 200's `total_count` (current server-authoritative value).
-    //  2. If every page was 304, the previously-committed `lastTotalCount`
-    //     — nothing actually changed, so the prior commit is still correct.
-    //  3. Fall back to the deduped run count (degenerate case, no 200s and
-    //     no cache; e.g. brand-new subscription with empty results).
-    const reportedTotal = latestTotal ?? cache?.lastTotalCount ?? runsById.size;
-
-    // Stage the per-page caches. The caller commits to `state.checkRunsCache`
-    // only after successfully consuming the response — see the type doc above.
-    // We always overwrite on commit: any pages from a previous tick that we
-    // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
-    const stagedCache = {
-      etagsByPage: nextEtags,
-      pagesByPage: nextPages,
-      lastTotalCount: reportedTotal,
-    };
-
-    // True end-to-end 304: every page came back unchanged. Caller can skip
-    // the diff/seed work entirely.
-    if (allPagesUnchanged) {
-      return { response: { status: 304 }, stagedCache };
-    }
-
-    return {
-      response: {
-        status: 200,
-        data: {
-          total_count: reportedTotal,
-          check_runs: [...runsById.values()],
-        },
-        // No single ETag covers a multi-page response. The per-page cache on
-        // `state.checkRunsCache` is what enables conditional reuse next tick.
-        etag: undefined,
-      },
-      stagedCache,
-    };
-  }
-
-  private isCheckFailure(r: GhCheckRun): boolean {
-    if (r.status !== 'completed') return false;
-    const c = r.conclusion;
-    return c === 'failure' || c === 'timed_out' || c === 'cancelled';
-  }
-
-  private checkKey(r: GhCheckRun): string {
-    return `${r.id}:${r.completed_at ?? ''}`;
-  }
-
-  /**
    * Replace `lastAnnotationKeys` with this tick's set and enqueue any newly-
    * appeared annotated runs. Replace-each-tick semantics (mirroring
    * `lastFailedCheckKeys`) keep the set bounded by the head SHA's check-run
@@ -998,34 +658,17 @@ export class PRPollingSource extends PollingSourceBase<
     state: SubscriptionState,
     runs: ReadonlyArray<GhCheckRun>,
   ): void {
-    const currentKeys = new Set<string>();
-    // Enforce at most one queue entry per check id. The annotations endpoint
-    // always returns the current state for a given id (there's no historical
-    // form), so queueing both A:T1 and A:T2 would produce two identical API
-    // calls and two events with mismatched headline `annotations_count`.
-    // Instead: on a rerun (new `completed_at` for an already-pending id),
-    // REPLACE the queued entry's run reference so the headline metadata
-    // matches what the fetch will actually return. `lastAnnotationKeys`
-    // still keys by full `checkKey`, so a rerun's new key always re-enters
-    // this loop rather than being silently skipped.
-    const pendingIndexById = new Map<number, number>();
-    for (let i = 0; i < state.pendingAnnotationRuns.length; i += 1) {
-      pendingIndexById.set(state.pendingAnnotationRuns[i].id, i);
+    const { toAppend, replacementsByIndex, newCurrentKeys } =
+      planAnnotationCandidates(
+        runs,
+        state.lastAnnotationKeys,
+        state.pendingAnnotationRuns,
+      );
+    for (const [index, run] of replacementsByIndex) {
+      state.pendingAnnotationRuns[index] = run;
     }
-    for (const run of runs) {
-      if (run.status !== 'completed') continue;
-      if ((run.output?.annotations_count ?? 0) <= 0) continue;
-      const key = this.checkKey(run);
-      currentKeys.add(key);
-      if (state.lastAnnotationKeys.has(key)) continue;
-      const existingIdx = pendingIndexById.get(run.id);
-      if (existingIdx !== undefined) {
-        state.pendingAnnotationRuns[existingIdx] = run;
-        continue;
-      }
-      state.pendingAnnotationRuns.push(run);
-    }
-    state.lastAnnotationKeys = currentKeys;
+    state.pendingAnnotationRuns.push(...toAppend);
+    state.lastAnnotationKeys = newCurrentKeys;
   }
 
   private async drainAnnotationQueues(
@@ -1198,27 +841,25 @@ export class PRPollingSource extends PollingSourceBase<
     }
   }
 
-  private async fetchAnnotations(
+  /**
+   * Thin delegator over the infrastructure `fetchAnnotations`, supplying this
+   * source's logger and the shared process-wide budget. Kept on the class
+   * (same arity) so internal callers and the annotation tests can drive it.
+   */
+  private fetchAnnotations(
     owner: string,
     repo: string,
     checkRunId: number,
     now = Date.now(),
   ): Promise<GhCheckAnnotation[]> {
-    const annotations: GhCheckAnnotation[] = [];
-    for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
-      if (!annotationFetchBudget.tryClaim(now)) {
-        throw new AnnotationFetchBudgetExhaustedError();
-      }
-      const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;
-      const res = await ghGet<GhCheckAnnotation[]>(path);
-      if (res.status !== 200) return annotations;
-      annotations.push(...res.data);
-      if (res.data.length < ANNOTATIONS_PAGE_SIZE) return annotations;
-    }
-    this.logger.warn(
-      `Reached annotation page cap (${MAX_ANNOTATION_PAGES_PER_RUN}) for check ${checkRunId}; emitting fetched annotations only.`,
+    return fetchAnnotationsClient(
+      owner,
+      repo,
+      checkRunId,
+      this.logger,
+      annotationFetchBudget,
+      now,
     );
-    return annotations;
   }
 }
 

--- a/src/tools/github/annotationFetchBudget.ts
+++ b/src/tools/github/annotationFetchBudget.ts
@@ -1,0 +1,68 @@
+/**
+ * Process-wide rate budget for the check-run annotations endpoint.
+ *
+ * The annotations endpoint is paginated and fans out per check-run, so a busy
+ * matrix build could otherwise burn through GitHub's primary 5,000/hour limit
+ * on annotations alone. This budget caps annotation-page requests across ALL
+ * PR subscriptions in the process to a fixed allowance per sliding window,
+ * independent of the poll interval.
+ *
+ * A single shared singleton (`annotationFetchBudget`) is the authority; the
+ * infrastructure `fetchAnnotations` claims against it and `PRPollingSource`
+ * exposes a test-only reset that targets the same instance.
+ */
+
+// Bound annotation endpoint traffic across all PR subscriptions in this
+// process. Pagination claims one unit per annotations page, so this 60s budget
+// window permits at most 3,000 annotation requests per hour, leaving room for
+// the rest of the PR polling endpoints under GitHub's primary 5,000/hour limit.
+// Keep it independent of the poll interval so tuning PR_POLL_INTERVAL_MS does
+// not silently raise the hourly ceiling.
+export const MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW = 50;
+export const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 60_000;
+
+export class AnnotationFetchBudgetExhaustedError extends Error {
+  constructor() {
+    super('Annotation fetch budget exhausted');
+  }
+}
+
+export class AnnotationFetchBudget {
+  private windowStartMs: number;
+  private remainingRequests: number;
+
+  constructor(
+    private readonly maxRequestsPerWindow: number,
+    private readonly windowMs: number,
+  ) {
+    this.windowStartMs = Date.now();
+    this.remainingRequests = maxRequestsPerWindow;
+  }
+
+  tryClaim(nowMs = Date.now()): boolean {
+    if (nowMs - this.windowStartMs >= this.windowMs) {
+      this.windowStartMs = nowMs;
+      this.remainingRequests = this.maxRequestsPerWindow;
+    }
+    if (this.remainingRequests <= 0) return false;
+    this.remainingRequests -= 1;
+    return true;
+  }
+
+  resetForTests(
+    remainingRequests = this.maxRequestsPerWindow,
+    nowMs = Date.now(),
+  ): void {
+    this.windowStartMs = nowMs;
+    this.remainingRequests = Math.max(
+      0,
+      Math.min(this.maxRequestsPerWindow, remainingRequests),
+    );
+  }
+}
+
+/** Process-wide singleton shared by every PR subscription. */
+export const annotationFetchBudget = new AnnotationFetchBudget(
+  MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW,
+  ANNOTATION_FETCH_BUDGET_WINDOW_MS,
+);

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -1,0 +1,337 @@
+/**
+ * GitHub check-runs & annotations transport for the PR poller.
+ *
+ * Infrastructure layer: everything here talks to the GitHub REST API and
+ * manages the conditional-request (ETag) caching that keeps steady-state
+ * polling cheap. It owns no subscription state — callers pass in the per-PR
+ * check-runs cache and receive a staged replacement to commit once they've
+ * consumed the response. Keeping this separate from `PRPollingSource` lets the
+ * pagination / cache-coherence reasoning be unit-tested without a live poller.
+ */
+
+import type { AgentTrace } from '@agent/trace';
+
+import {
+  AnnotationFetchBudget,
+  AnnotationFetchBudgetExhaustedError,
+} from './annotationFetchBudget';
+import { ghGet, type ConditionalResponse } from './githubClient';
+import type { GhCheckAnnotation, GhCheckRun } from './prTypes';
+
+// GitHub caps the check-runs endpoint at 100 per page.
+const CHECK_RUNS_PAGE_SIZE = 100;
+// Hard ceiling on how many check-runs pages we'll walk in a single fetch.
+// 50 pages = 5,000 runs — well above any realistic monorepo matrix build.
+// Without a cap a malformed/runaway `total_count` could fan out into
+// hundreds of GETs per tick.
+const MAX_CHECK_RUNS_PAGES = 50;
+// Use GitHub's maximum page size so filtering by level does not miss failures
+// that appear after a long run of warnings or notices.
+const ANNOTATIONS_PAGE_SIZE = 100;
+// Same order of magnitude as the check-runs page cap. This is a malformed
+// response guard, not a normal truncation policy.
+const MAX_ANNOTATION_PAGES_PER_RUN = 50;
+
+/**
+ * Per-page cache for the paginated check-runs endpoint. Single-page PRs touch
+ * only page 1 so still get the cheap 304 fast path; multi-page PRs issue
+ * conditional GETs per page so steady-state ticks make N HEAD-cheap 304s
+ * instead of N full-page GETs.
+ *
+ * `lastTotalCount` is the most recent `total_count` from a 200 response; it
+ * tells us how many pages to walk when page 1 returns 304.
+ *
+ * Exported as a standalone type so `SubscriptionState` can reference it
+ * without `checkRunsClient` importing back from `PRPollingSource` (cycle).
+ */
+export interface CheckRunsCache {
+  etagsByPage: Map<number, string>;
+  pagesByPage: Map<number, GhCheckRun[]>;
+  lastTotalCount: number;
+}
+
+export interface FetchAllCheckRunsResult {
+  response: ConditionalResponse<{
+    total_count: number;
+    check_runs: GhCheckRun[];
+  }>;
+  /**
+   * New per-page cache value to commit only after the caller has successfully
+   * consumed the response. `undefined` means "no change" — either the
+   * single-page 304 fast path (existing cache is still valid) or this function
+   * itself short-circuited before fetching anything.
+   *
+   * Deferring the commit prevents a sibling rejection in the caller's
+   * `Promise.all` from advancing the cache while the diff branch never runs: a
+   * stale cache + 304 next tick would silently swallow check-run transitions.
+   */
+  stagedCache?: CheckRunsCache;
+}
+
+/**
+ * Fetch all check-runs for a commit, walking pages when `total_count > 100`.
+ *
+ * The check-runs endpoint caps at `per_page=100`. PRs with more registered
+ * runs (large monorepos, matrix builds) would otherwise have their terminal
+ * gates (`runs.length >= total_count`) stuck false forever, stranding agents
+ * waiting on "CI complete" / "CI passed".
+ *
+ * ## Mid-walk churn (additions, removals, dedupe)
+ *
+ * `total_count` and the per-page set of runs can both shift while we're
+ * paginating: GitHub may register new runs (pushing earlier runs onto a
+ * later page → duplicates across our pages), or runs may be removed/replaced
+ * (a page shrinks). We defend against both:
+ *
+ * - We accumulate runs into a `Map<id, GhCheckRun>` so duplicates collapse.
+ *   The terminal gate downstream (`runs.length >= total_count`) is evaluated
+ *   against the deduped count, not the raw appended count, so a page-shift
+ *   that fills our buffer with duplicates can't trick us into emitting
+ *   "CI complete" before a newly-registered run has actually been seen.
+ *
+ * - We re-read `total_count` from every 200 response and use the LAST seen
+ *   value (not the historical max). The server's `total_count` is its
+ *   current authoritative count at the moment of that page-N fetch; if a
+ *   transient mid-walk inflation later settles back down, taking the max
+ *   would strand the gate forever (`runs.length` can never reach an
+ *   inflated, no-longer-true total).
+ *
+ * The returned `total_count` is the latest observed server value (or, on
+ * a full-304 tick, the previously-committed value carried via cache),
+ * never page 1's stale snapshot.
+ *
+ * ## ETag caching (multi-page)
+ *
+ * Each page's ETag is cached on the subscription so subsequent ticks can
+ * issue conditional `If-None-Match` requests per page. A 304 means we
+ * reuse the previously-cached page contents; a 200 refreshes them.
+ *
+ * - Single-page (`total_count <= 100`): unchanged fast path — the page-1
+ *   ETag covers the whole result and a 304 short-circuits the entire call.
+ * - Multi-page: each page is independently conditional. In steady state
+ *   (no new push, all runs settled) every page returns 304 and we make
+ *   N HEAD-cheap requests instead of N full-page GETs, keeping the polling
+ *   cost bounded on large matrix builds.
+ *
+ * ## Runaway guard
+ *
+ * `MAX_CHECK_RUNS_PAGES` caps the walk at 50 pages (5,000 runs). If a
+ * misbehaving GitHub response or a runaway matrix would push us past it,
+ * we log a warning and return what we have — better to under-report than
+ * fan out into hundreds of GETs every 30s.
+ */
+export async function fetchAllCheckRuns(
+  owner: string,
+  repo: string,
+  sha: string,
+  cache: CheckRunsCache | undefined,
+  logger: AgentTrace,
+): Promise<FetchAllCheckRunsResult> {
+  const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
+
+  // Seed scratch caches we'll stage on the return value. We rebuild from
+  // scratch each tick (rather than mutating in-place) so any pages dropped
+  // on this tick — e.g. new push reduced page count from 5 to 3 — don't
+  // leave stale entries behind.
+  const nextEtags = new Map<number, string>();
+  const nextPages = new Map<number, GhCheckRun[]>();
+
+  // We need a place to record whether *every* page returned 304 so we can
+  // surface a true 304 to the caller (and skip the seeding/diff work).
+  let allPagesUnchanged = true;
+  // `latestTotal` tracks the most recent 200 response's `total_count`.
+  // Crucially we do NOT carry `cache.lastTotalCount` into this — that
+  // would let a transient prior-tick inflation persist forever once page-1
+  // starts returning 304 against the unchanged content (the cached
+  // `lastTotalCount` would seed the gate every tick and `runs.length`
+  // could never catch up to an inflated, no-longer-true total).
+  let latestTotal: number | undefined;
+
+  const fetchPage = async (
+    page: number,
+  ): Promise<{
+    runs: GhCheckRun[];
+    total: number | undefined;
+    was304: boolean;
+  }> => {
+    const pageEtag = cache?.etagsByPage.get(page);
+    const res = await ghGet<{
+      total_count: number;
+      check_runs: GhCheckRun[];
+    }>(`${basePath}&page=${page}`, pageEtag);
+    if (res.status === 304) {
+      // Reuse cached page. Carry forward the ETag we sent.
+      const cachedRuns = cache?.pagesByPage.get(page) ?? [];
+      if (pageEtag) nextEtags.set(page, pageEtag);
+      nextPages.set(page, cachedRuns);
+      return {
+        runs: cachedRuns,
+        // total_count isn't returned on 304. We deliberately return
+        // undefined here rather than falling back to `cache.lastTotalCount`,
+        // because that cached value may itself be stale (an inflated value
+        // committed during a prior mid-walk race). The terminal `latestTotal`
+        // is derived from this tick's 200 responses; only when *every* page
+        // is 304 do we reuse the cached total below — and that case
+        // genuinely means "nothing changed since we last committed".
+        total: undefined,
+        was304: true,
+      };
+    }
+    if (res.etag) nextEtags.set(page, res.etag);
+    nextPages.set(page, res.data.check_runs);
+    return {
+      runs: res.data.check_runs,
+      total: res.data.total_count,
+      was304: false,
+    };
+  };
+
+  // Page 1 always runs — we need its `total_count` (or a 304 fast-path
+  // when nothing changed).
+  const first = await fetchPage(1);
+  if (!first.was304) allPagesUnchanged = false;
+  if (first.total !== undefined) latestTotal = first.total;
+
+  // Single-page fast path. If page 1 was 304 and our last-known total fits
+  // in one page, we can short-circuit the whole call without touching any
+  // other state — this is the common steady-state for typical PRs. No
+  // staged cache: the existing `state.checkRunsCache` is still valid and
+  // we never built a replacement.
+  if (
+    first.was304 &&
+    cache &&
+    cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
+    cache.etagsByPage.size === 1
+  ) {
+    return { response: { status: 304 } };
+  }
+
+  // Dedupe by run id. Pagination is not transactional on GitHub: when a
+  // new run is registered mid-walk, runs can shift across page boundaries
+  // and we'd otherwise see the same id on two different pages (or miss
+  // one entirely). A `Map<id, run>` collapses duplicates and lets the
+  // downstream `runs.length >= total_count` gate evaluate against the
+  // true unique count.
+  const runsById = new Map<number, GhCheckRun>();
+  for (const r of first.runs) runsById.set(r.id, r);
+
+  // How many pages to walk this tick. We need a starting estimate before
+  // we've seen any 200 with a non-cached total, so we fall back to the
+  // cached `lastTotalCount` when page-1 was 304 (unchanged content → the
+  // server's view almost certainly matches what we last committed). If a
+  // 200 arrives later, `latestTotal` takes precedence and we recompute.
+  const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
+  let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
+  if (totalPages > MAX_CHECK_RUNS_PAGES) {
+    logger.warn(
+      `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
+        `total_count=${seedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
+    );
+    totalPages = MAX_CHECK_RUNS_PAGES;
+  }
+  if (totalPages > 1) {
+    logger.info(
+      `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${seedTotal} → ${totalPages} pages`,
+    );
+  }
+
+  let page = 2;
+  while (page <= totalPages) {
+    const result = await fetchPage(page);
+    if (!result.was304) allPagesUnchanged = false;
+    for (const r of result.runs) runsById.set(r.id, r);
+
+    // Use the LATEST observed `total_count` (from this page's 200) as the
+    // authoritative server view. Walk-length adapts to it whether it grew
+    // OR shrank: a transient inflation that has since settled back down
+    // must be allowed to take effect, otherwise a max-style monotonic
+    // tracker would strand the terminal gate forever.
+    if (result.total !== undefined) {
+      latestTotal = result.total;
+      const newTotalPages = Math.max(
+        1,
+        Math.ceil(latestTotal / CHECK_RUNS_PAGE_SIZE),
+      );
+      if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
+        logger.warn(
+          `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
+            `total_count is ${latestTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
+        );
+        totalPages = MAX_CHECK_RUNS_PAGES;
+      } else {
+        totalPages = newTotalPages;
+      }
+    }
+    page += 1;
+  }
+
+  // Resolve the total we'll surface and cache. Priority order:
+  //  1. The last 200's `total_count` (current server-authoritative value).
+  //  2. If every page was 304, the previously-committed `lastTotalCount`
+  //     — nothing actually changed, so the prior commit is still correct.
+  //  3. Fall back to the deduped run count (degenerate case, no 200s and
+  //     no cache; e.g. brand-new subscription with empty results).
+  const reportedTotal = latestTotal ?? cache?.lastTotalCount ?? runsById.size;
+
+  // Stage the per-page caches. The caller commits to `state.checkRunsCache`
+  // only after successfully consuming the response — see the type doc above.
+  // We always overwrite on commit: any pages from a previous tick that we
+  // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
+  const stagedCache: CheckRunsCache = {
+    etagsByPage: nextEtags,
+    pagesByPage: nextPages,
+    lastTotalCount: reportedTotal,
+  };
+
+  // True end-to-end 304: every page came back unchanged. Caller can skip
+  // the diff/seed work entirely.
+  if (allPagesUnchanged) {
+    return { response: { status: 304 }, stagedCache };
+  }
+
+  return {
+    response: {
+      status: 200,
+      data: {
+        total_count: reportedTotal,
+        check_runs: [...runsById.values()],
+      },
+      // No single ETag covers a multi-page response. The per-page cache on
+      // `state.checkRunsCache` is what enables conditional reuse next tick.
+      etag: undefined,
+    },
+    stagedCache,
+  };
+}
+
+/**
+ * Fetch all annotations for a check-run, walking pages until a short page or
+ * the per-run page cap. Each page claims one unit from the shared annotation
+ * fetch `budget`; when the budget is exhausted mid-walk we throw
+ * `AnnotationFetchBudgetExhaustedError` so the caller can defer the run rather
+ * than partially emit.
+ */
+export async function fetchAnnotations(
+  owner: string,
+  repo: string,
+  checkRunId: number,
+  logger: AgentTrace,
+  budget: AnnotationFetchBudget,
+  now = Date.now(),
+): Promise<GhCheckAnnotation[]> {
+  const annotations: GhCheckAnnotation[] = [];
+  for (let page = 1; page <= MAX_ANNOTATION_PAGES_PER_RUN; page += 1) {
+    if (!budget.tryClaim(now)) {
+      throw new AnnotationFetchBudgetExhaustedError();
+    }
+    const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}&page=${page}`;
+    const res = await ghGet<GhCheckAnnotation[]>(path);
+    if (res.status !== 200) return annotations;
+    annotations.push(...res.data);
+    if (res.data.length < ANNOTATIONS_PAGE_SIZE) return annotations;
+  }
+  logger.warn(
+    `Reached annotation page cap (${MAX_ANNOTATION_PAGES_PER_RUN}) for check ${checkRunId}; emitting fetched annotations only.`,
+  );
+  return annotations;
+}

--- a/src/tools/github/prCheckRunDomain.ts
+++ b/src/tools/github/prCheckRunDomain.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure domain rules for GitHub PR check runs.
+ *
+ * No I/O, no subscription state, no `this`: every function here is a total
+ * transformation over plain check-run data, so the CI-status semantics (what
+ * counts as a failure, when CI is "complete"/"passed", which runs are newly
+ * failed, which annotated runs to enqueue) can be reasoned about and unit
+ * tested in isolation. `PRPollingSource` calls these and commits the results
+ * to its mutable per-subscription state.
+ */
+
+import { isPassingConclusion } from './formatPREvent';
+import type { GhCheckRun } from './prTypes';
+
+/** A completed check run with a non-passing conclusion. */
+export function isCheckFailure(r: GhCheckRun): boolean {
+  if (r.status !== 'completed') return false;
+  const c = r.conclusion;
+  return c === 'failure' || c === 'timed_out' || c === 'cancelled';
+}
+
+/**
+ * Stable per-run identity that also changes across reruns: the same check id
+ * with a new `completed_at` is treated as a distinct observation so a rerun
+ * re-emits failures/annotations.
+ */
+export function checkKey(r: GhCheckRun): string {
+  return `${r.id}:${r.completed_at ?? ''}`;
+}
+
+/**
+ * Compute the CI-terminal status for a tick.
+ *
+ * `complete` is true only when we have the head SHA, a non-empty run set,
+ * the full set (length >= total_count — the caller dedupes by id and uses the
+ * latest total_count, so this is safe against mid-walk page shifts), and every
+ * run has completed. `passed` requires `complete` plus every run passing.
+ */
+export function ciTerminalStatus(
+  headSha: string | undefined,
+  runs: GhCheckRun[],
+  totalCount: number,
+): { complete: boolean; passed: boolean } {
+  const complete =
+    !!headSha &&
+    runs.length > 0 &&
+    runs.length >= totalCount &&
+    runs.every((r) => r.status === 'completed');
+  const passed =
+    complete && runs.every((r) => isPassingConclusion(r.conclusion));
+  return { complete, passed };
+}
+
+/**
+ * Diff this tick's failing runs against the previously-seen failure keys.
+ * Returns the newly-appeared failures (to emit) and the full current key set
+ * (which the caller commits as the new `lastFailedCheckKeys`).
+ */
+export function computeNewCheckFailures(
+  runs: ReadonlyArray<GhCheckRun>,
+  lastFailedCheckKeys: Set<string>,
+): { newFailures: GhCheckRun[]; currentFailureKeys: Set<string> } {
+  const newFailures: GhCheckRun[] = [];
+  const currentFailureKeys = new Set<string>();
+  for (const r of runs) {
+    if (!isCheckFailure(r)) continue;
+    const key = checkKey(r);
+    currentFailureKeys.add(key);
+    if (!lastFailedCheckKeys.has(key)) newFailures.push(r);
+  }
+  return { newFailures, currentFailureKeys };
+}
+
+/** The mutations the caller applies to its annotation queue, plus the next key set. */
+export interface AnnotationQueuePlan {
+  /** Newly-appeared annotated runs to append to the pending queue. */
+  toAppend: GhCheckRun[];
+  /**
+   * In-place replacements keyed by the run's index in the *prior* pending
+   * queue. A rerun (new `completed_at` for an already-pending id) replaces the
+   * queued entry's run reference so the headline metadata matches what the
+   * fetch will actually return — without ever queueing the same id twice.
+   */
+  replacementsByIndex: Map<number, GhCheckRun>;
+  /** The set the caller commits as the new `lastAnnotationKeys`. */
+  newCurrentKeys: Set<string>;
+}
+
+/**
+ * Plan annotation-queue updates for a tick. Pure: it reads the current pending
+ * queue (by value) and returns the appends/replacements for the caller to
+ * apply, so the subtle replace-by-id-on-rerun semantics live in one testable
+ * place.
+ *
+ * `pendingIndexById` is built once from the prior queue and never updated
+ * during the scan, so a run appended this tick is never replaced in the same
+ * tick, and a duplicate id within `runs` resolves last-one-wins at its index —
+ * matching the original in-place pass exactly.
+ */
+export function planAnnotationCandidates(
+  runs: ReadonlyArray<GhCheckRun>,
+  lastAnnotationKeys: Set<string>,
+  currentPendingRuns: ReadonlyArray<GhCheckRun>,
+): AnnotationQueuePlan {
+  const pendingIndexById = new Map<number, number>();
+  for (let i = 0; i < currentPendingRuns.length; i += 1) {
+    pendingIndexById.set(currentPendingRuns[i].id, i);
+  }
+
+  const newCurrentKeys = new Set<string>();
+  const toAppend: GhCheckRun[] = [];
+  const replacementsByIndex = new Map<number, GhCheckRun>();
+
+  for (const run of runs) {
+    if (run.status !== 'completed') continue;
+    if ((run.output?.annotations_count ?? 0) <= 0) continue;
+    const key = checkKey(run);
+    newCurrentKeys.add(key);
+    if (lastAnnotationKeys.has(key)) continue;
+    const existingIdx = pendingIndexById.get(run.id);
+    if (existingIdx !== undefined) {
+      replacementsByIndex.set(existingIdx, run);
+      continue;
+    }
+    toAppend.push(run);
+  }
+
+  return { toAppend, replacementsByIndex, newCurrentKeys };
+}


### PR DESCRIPTION
PRPollingSource mixed four concerns in one 1226-line class. Separate them
along DDD lines so each is independently testable and the orchestrator only
wires them together:

- prCheckRunDomain.ts (pure domain): isCheckFailure, checkKey, ciTerminalStatus,
  computeNewCheckFailures, and planAnnotationCandidates — total transformations
  over plain check-run data, no I/O or subscription state.
- annotationFetchBudget.ts (value object): AnnotationFetchBudget, its exhausted
  error, the process-wide singleton, and the budget-window constants.
- checkRunsClient.ts (infrastructure): fetchAllCheckRuns / fetchAnnotations —
  the GitHub REST transport plus per-page ETag caching, taking a logger and the
  cache/budget by parameter. Exports a standalone CheckRunsCache type so the
  state can reference it without an import cycle.
- PRPollingSource.ts stays the orchestrator with thin delegators, preserving the
  same public/test-facing method surface and SubscriptionState shape.

Behavior is unchanged: typecheck passes and all 18 github polling tests stay
green without test edits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI completion, failure detection, and annotation fetching paths; behavior is intended unchanged but regressions would affect agent PR event timing and GitHub rate limiting.
> 
> **Overview**
> **`PRPollingSource`** is slimmed down to orchestration: it wires subscription ticks to extracted modules instead of embedding ~500 lines of check-run/annotation logic inline.
> 
> **New modules (moved code, same behavior):**
> - **`prCheckRunDomain`**: pure helpers for failures, CI complete/passed gates, new-failure diffs, and annotation queue planning.
> - **`annotationFetchBudget`**: process-wide annotation API rate limiter and its exhausted error.
> - **`checkRunsClient`**: paginated check-runs fetch with per-page ETag staging, plus paginated annotation fetch against the budget. Exports **`CheckRunsCache`** so subscription state types avoid an import cycle.
> 
> **`PRPollingSource` call-site changes:** uses `fetchAllCheckRunsClient` / `fetchAnnotationsClient`, domain functions instead of private methods, and `planAnnotationCandidates` for enqueue. Deferred cache commit and public/test surface (e.g. `resetAnnotationFetchBudgetForTests`, private `fetchAnnotations` delegator) are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd5390480c32e13cc9b7adb67dae346181b2285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->