### PR TITLE
[codex] Keep TUI approval modals near context

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -401,6 +401,9 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    maxBlankLinesBetween: [
+      { from: 'entry-4 chat history line', to: 'Run bash command?', max: 3 },
+    ],
   },
   {
     name: 'narrow-bash-approval',
@@ -529,6 +532,9 @@ const SCENARIOS = [
       'n reject',
     ],
     unexpect: ['r approve & run', '[/model]models'],
+    maxBlankLinesBetween: [
+      { from: 'entry-4 chat history line', to: 'Approve plan?', max: 3 },
+    ],
   },
   {
     name: 'plan-approval-odyssey',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -61,6 +61,7 @@ const MIN_FOREGROUND_ROWS_WITH_TRANSCRIPT = 6;
 const CHILD_CONTROL_FOREGROUND_MAX_ROWS = 12;
 const EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS = 6;
 const FORM_FOREGROUND_MAX_ROWS = 18;
+const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation or push the input bar off-screen.
 const BOTTOM_PANEL_MAX_ROWS = 10;
@@ -281,6 +282,12 @@ export function childControlForegroundMaxRows({
     : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
 }
 
+function foregroundSurfaceJustifyContent(
+  kind: ForegroundSurfaceKind | undefined,
+): 'flex-start' | 'flex-end' {
+  return kind === 'childControls' ? 'flex-end' : 'flex-start';
+}
+
 export interface AppProps {
   readonly onSubmit: (line: string) => void;
   readonly onKillExecution: (executionId: string) => void;
@@ -395,7 +402,9 @@ export function App(props: AppProps): React.JSX.Element {
         ? childControlForegroundMaxRows({ hasItems: childControlHasItems })
         : foregroundKind === 'form'
           ? FORM_FOREGROUND_MAX_ROWS
-          : undefined,
+          : foregroundKind === 'approval'
+            ? APPROVAL_FOREGROUND_MAX_ROWS
+            : undefined,
     foregroundOpen,
     inputVisible: inputBarVisible,
     queuedFollowUpPanelRows,
@@ -583,9 +592,7 @@ export function App(props: AppProps): React.JSX.Element {
               flexDirection="column"
               height={foregroundRows}
               alignItems="flex-start"
-              justifyContent={
-                foregroundKind === 'form' ? 'flex-start' : 'flex-end'
-              }
+              justifyContent={foregroundSurfaceJustifyContent(foregroundKind)}
               overflowY="hidden"
             >
               {foregroundSurface}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -10,6 +10,7 @@ import {
   type StreamStatus,
 } from '@shared/schemas';
 
+import { assertNever } from './assertNever';
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
 import { REVERSE_SEARCH_ROWS } from './input/ReverseSearch';
 import { ApprovalModal } from './modals/ApprovalModal';
@@ -27,7 +28,7 @@ import { StreamTabsStrip } from './panes/StreamTabsStrip';
 import { SubagentList } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
-import { currentApproval } from './state/approvalQueue';
+import { currentApproval, type PendingApproval } from './state/approvalQueue';
 import {
   isKittyKeypadEnter,
   metaChordDigit,
@@ -61,6 +62,8 @@ const MIN_FOREGROUND_ROWS_WITH_TRANSCRIPT = 6;
 const CHILD_CONTROL_FOREGROUND_MAX_ROWS = 12;
 const EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS = 6;
 const FORM_FOREGROUND_MAX_ROWS = 18;
+// Match form sizing for approval modals that already budget or scroll their
+// content. Natural-height approvals stay uncapped until they grow row budgets.
 const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation or push the input bar off-screen.
@@ -282,10 +285,30 @@ export function childControlForegroundMaxRows({
     : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
 }
 
-function foregroundSurfaceJustifyContent(
+export function foregroundSurfaceJustifyContent(
   kind: ForegroundSurfaceKind | undefined,
 ): 'flex-start' | 'flex-end' {
-  return kind === 'childControls' ? 'flex-end' : 'flex-start';
+  return kind === 'form' || kind === 'approval' ? 'flex-start' : 'flex-end';
+}
+
+export function approvalForegroundMaxRows(
+  pending: PendingApproval | undefined,
+): number | undefined {
+  if (pending === undefined) return undefined;
+
+  switch (pending.payload.kind) {
+    case 'bash':
+    case 'toolEdit':
+    case 'proposal':
+    case 'externalInquiry':
+      return APPROVAL_FOREGROUND_MAX_ROWS;
+    case 'plan':
+    case 'retry':
+    case 'userQuestion':
+      return undefined;
+    default:
+      return assertNever(pending.payload, 'Unhandled approval payload kind');
+  }
 }
 
 export interface AppProps {
@@ -403,7 +426,7 @@ export function App(props: AppProps): React.JSX.Element {
         : foregroundKind === 'form'
           ? FORM_FOREGROUND_MAX_ROWS
           : foregroundKind === 'approval'
-            ? APPROVAL_FOREGROUND_MAX_ROWS
+            ? approvalForegroundMaxRows(pending)
             : undefined,
     foregroundOpen,
     inputVisible: inputBarVisible,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -22,8 +22,10 @@ import {
   allocateSidePanelRows,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
+  approvalForegroundMaxRows,
   childControlForegroundMaxRows,
   foregroundSurfaceKind,
+  foregroundSurfaceJustifyContent,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
 } from '@cli/chat/tui/App';
@@ -76,6 +78,7 @@ import {
 } from '@cli/chat/tui/state/transcript';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
+  AGENT_CATEGORY,
   MESSAGE_TYPES,
   STREAM_STATUS,
   type StreamTabId,
@@ -243,6 +246,125 @@ describe('CLI TUI row allocation', () => {
   it('uses a smaller row cap for empty child-control pickers', () => {
     expect(childControlForegroundMaxRows({ hasItems: false })).toBe(6);
     expect(childControlForegroundMaxRows({ hasItems: true })).toBe(12);
+  });
+
+  it('does not cap natural-height approval prompts that lack row budgeting', () => {
+    const decide = () => {};
+
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'plan',
+          payload: {
+            approvalId: 'plan-1',
+            streamId: root,
+            odysseyEnabled: false,
+            plan: {
+              summary: 'Coordinate a proof.',
+              steps: [],
+            },
+          },
+        },
+        decide,
+      }),
+    ).toBeUndefined();
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'retry',
+          payload: { streamId: root, operation: 'Model invocation' },
+        },
+        decide,
+      }),
+    ).toBeUndefined();
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'userQuestion',
+          payload: {
+            requestId: 'question-1',
+            allowBypass: false,
+            streamId: root,
+            context: 'Pick a proof style.',
+            questions: [
+              {
+                question: 'Which style?',
+                options: [{ label: 'direct' }, { label: 'detailed' }],
+              },
+            ],
+          },
+        },
+        decide,
+      }),
+    ).toBeUndefined();
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'bash',
+          payload: {
+            requestId: 'bash-1',
+            allowBypass: true,
+            streamId: root,
+            command: 'echo ok',
+          },
+        },
+        decide,
+      }),
+    ).toBe(18);
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'toolEdit',
+          request: {
+            path: 'draft.tex',
+            originalContent: 'old',
+            proposedContent: 'new',
+            sourceTool: 'test',
+            streamId: root,
+          },
+        },
+        decide,
+      }),
+    ).toBe(18);
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'proposal',
+          payload: {
+            proposalId: 'proposal-1',
+            streamId: root,
+            agentCategory: AGENT_CATEGORY.TOOL_USE,
+            agent: 'review',
+            model: 'harness-model',
+            instruction: 'Review the proof.',
+            memories: [],
+            workingDirectory: '/tmp',
+          },
+        },
+        decide,
+      }),
+    ).toBe(18);
+    expect(
+      approvalForegroundMaxRows({
+        payload: {
+          kind: 'externalInquiry',
+          payload: {
+            requestId: 'inquiry-1',
+            allowBypass: false,
+            streamId: root,
+            question: 'Can you check this claim?',
+          },
+        },
+        decide,
+      }),
+    ).toBe(18);
+  });
+
+  it('top-aligns forms and approvals without moving transcript viewer', () => {
+    expect(foregroundSurfaceJustifyContent('form')).toBe('flex-start');
+    expect(foregroundSurfaceJustifyContent('approval')).toBe('flex-start');
+    expect(foregroundSurfaceJustifyContent('childControls')).toBe('flex-end');
+    expect(foregroundSurfaceJustifyContent('transcript')).toBe('flex-end');
   });
 
   it('uses the whole middle region for the transcript without foreground UI', () => {


### PR DESCRIPTION
## Summary

- Top-align approval foreground surfaces so bash and plan approval prompts appear next to the recent transcript instead of after a large blank vertical gap.
- Keep child-control and transcript-viewer foreground surfaces bottom-aligned while forms and approvals top-align near recent context.
- Cap only approval modals that already budget or scroll their own content (bash, edit, proposal, external inquiry); leave plan, retry, and user-question approvals uncapped until they have full row budgeting.
- Add TUI harness blank-line assertions for bash and plan approval snapshots to prevent regressions.

Fixes #4910.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-align edit-approval narrow-edit-approval bash-approval narrow-bash-approval long-bash-approval compact-long-bash-approval plan-approval plan-approval-odyssey compact-plan-approval compact-plan-approval-odyssey task-picker task-subworkflow-detail`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/App.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui bash-approval plan-approval narrow-bash-approval compact-long-bash-approval transcript-viewer-long-tool-output`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ink layout and sizing helpers only, with focused unit and snapshot tests; no auth, persistence, or runtime execution changes.
> 
> **Overview**
> Approval and form **foreground panels** are **top-aligned** (`flex-start`) so bash/plan prompts sit near recent transcript instead of below a large empty gap; child-control and transcript viewer surfaces stay **bottom-aligned**.
> 
> **Row caps** for approval modals now follow payload kind: **18 rows** (same as forms) for bash, edit, proposal, and external-inquiry approvals that already scroll/budget content; **plan**, **retry**, and **user-question** approvals stay **uncapped** until they get full row budgeting.
> 
> The TUI harness adds **`maxBlankLinesBetween`** checks on bash and plan approval snapshots so spacing regressions fail CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b2149fda60d11cb520020b9932c41e0083dd53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->