### PR TITLE
refactor(anthropic): extract model-trait and thinking config into module

### DIFF
--- a/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
@@ -1,0 +1,135 @@
+// Server-tool (web_search / web_fetch) content handling for Anthropic responses.
+//
+// Anthropic returns web_search / web_fetch results as paired blocks: a
+// `server_tool_use` call followed by a `*_tool_result`. The API rejects any
+// follow-up message that echoes a `server_tool_use` without its matching
+// result block, so orphaned calls must be stripped before the assistant turn is
+// re-sent for context. Both the display-extraction path and the
+// context-continuation path need this stripping, so it lives here in one place.
+
+// Type imports - agent
+import type { AgentTrace } from '@agent/trace';
+
+// Local imports - model handlers
+import { LONG_CACHE_CONTROL } from './anthropicContextManagement';
+import {
+  extractAnthropicWebFetchResults,
+  extractAnthropicWebSearchResults,
+  isAnthropicServerToolContent,
+  isAnthropicServerToolUse,
+  isAnthropicWebFetchResult,
+  isAnthropicWebSearchResult,
+  type ServerToolExtractionResult,
+} from '../types/ServerToolTypes';
+
+// Type imports - Anthropic SDK
+import type {
+  BetaContentBlock,
+  BetaMessage,
+} from '@anthropic-ai/sdk/resources/beta/messages';
+import type {
+  ServerToolUseBlock,
+  WebSearchToolResultBlock,
+  WebFetchToolResultBlock,
+} from '@anthropic-ai/sdk/resources/messages';
+
+/**
+ * Partitions content blocks, dropping `server_tool_use` blocks (web_search /
+ * web_fetch) that have no matching result block. Returns the kept blocks plus
+ * the IDs of the stripped orphans (for diagnostics).
+ */
+export function stripOrphanedServerToolUse<T extends BetaContentBlock>(
+  blocks: readonly T[],
+): { kept: T[]; orphanedIds: string[] } {
+  const searchResultIds = new Set(
+    blocks.filter(isAnthropicWebSearchResult).map((b) => b.tool_use_id),
+  );
+  const fetchResultIds = new Set(
+    blocks.filter(isAnthropicWebFetchResult).map((b) => b.tool_use_id),
+  );
+
+  const orphanedIds: string[] = [];
+  const kept = blocks.filter((block) => {
+    if (!isAnthropicServerToolUse(block)) return true;
+    if (block.name === 'web_search') {
+      if (searchResultIds.has(block.id)) return true;
+      orphanedIds.push(block.id);
+      return false;
+    }
+    if (block.name === 'web_fetch') {
+      if (fetchResultIds.has(block.id)) return true;
+      orphanedIds.push(block.id);
+      return false;
+    }
+    return true;
+  });
+
+  return { kept, orphanedIds };
+}
+
+/**
+ * Extracts server-tool data from a response in a single pass: normalized
+ * web-search / web-fetch results for display, plus the raw server-tool content
+ * blocks (orphaned `server_tool_use` blocks stripped) for context continuation.
+ */
+export function extractAnthropicServerToolData(
+  responseObject: BetaMessage,
+): ServerToolExtractionResult {
+  if (!Array.isArray(responseObject?.content)) {
+    return { webSearchResults: [], webFetchResults: [], contentBlocks: [] };
+  }
+
+  // Filter for server tool content (server_tool_use, web_search_tool_result,
+  // web_fetch_tool_result). Cast needed because BetaContentBlock has slightly
+  // different types than the regular API.
+  const serverToolBlocks = responseObject.content.filter(
+    isAnthropicServerToolContent,
+  ) as (ServerToolUseBlock | WebSearchToolResultBlock | WebFetchToolResultBlock)[];
+
+  const { kept: contentBlocks } = stripOrphanedServerToolUse(serverToolBlocks);
+
+  return {
+    webSearchResults: extractAnthropicWebSearchResults(responseObject.content),
+    webFetchResults: extractAnthropicWebFetchResults(responseObject.content),
+    contentBlocks,
+  };
+}
+
+/**
+ * Builds the assistant content blocks to replay for context continuation,
+ * excluding `tool_use` blocks and stripping orphaned `server_tool_use` blocks.
+ * Preserves thinking, text, server_tool_use, and tool-result blocks. When
+ * prompt caching is supported, the compaction block is tagged with a 1h cache
+ * breakpoint.
+ */
+export function buildAnthropicAssistantContent(
+  responseObject: BetaMessage,
+  options: { supportsPromptCaching: boolean },
+  logger: AgentTrace,
+): unknown[] {
+  if (!Array.isArray(responseObject?.content)) {
+    return [];
+  }
+
+  const nonToolUse = responseObject.content.filter(
+    (block) => block.type !== 'tool_use',
+  );
+  const { kept, orphanedIds } = stripOrphanedServerToolUse(nonToolUse);
+
+  if (orphanedIds.length > 0) {
+    logger.debug(
+      `Stripping ${orphanedIds.length} orphaned server_tool_use block(s) without matching result: ${orphanedIds.join(', ')}. ` +
+        `Response content types: [${responseObject.content.map((b) => b.type).join(', ')}]`,
+    );
+  }
+
+  if (!options.supportsPromptCaching) {
+    return kept;
+  }
+
+  return kept.map((block) =>
+    block.type === 'compaction'
+      ? { ...block, cache_control: LONG_CACHE_CONTROL }
+      : block,
+  );
+}

--- a/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
@@ -84,7 +84,11 @@ export function extractAnthropicServerToolData(
   // different types than the regular API.
   const serverToolBlocks = responseObject.content.filter(
     isAnthropicServerToolContent,
-  ) as (ServerToolUseBlock | WebSearchToolResultBlock | WebFetchToolResultBlock)[];
+  ) as (
+    | ServerToolUseBlock
+    | WebSearchToolResultBlock
+    | WebFetchToolResultBlock
+  )[];
 
   const { kept: contentBlocks } = stripOrphanedServerToolUse(serverToolBlocks);
 

--- a/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
@@ -23,30 +23,29 @@ import {
 } from '../types/ServerToolTypes';
 
 // Type imports - Anthropic SDK
-import type {
-  BetaContentBlock,
-  BetaMessage,
-} from '@anthropic-ai/sdk/resources/beta/messages';
-import type {
-  ServerToolUseBlock,
-  WebSearchToolResultBlock,
-  WebFetchToolResultBlock,
-} from '@anthropic-ai/sdk/resources/messages';
+import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
 /**
  * Partitions content blocks, dropping `server_tool_use` blocks (web_search /
  * web_fetch) that have no matching result block. Returns the kept blocks plus
  * the IDs of the stripped orphans (for diagnostics).
+ *
+ * Guards are applied via `if` narrowing (not `array.filter(guard)`) so the
+ * element type is preserved for any caller-supplied block array.
  */
-export function stripOrphanedServerToolUse<T extends BetaContentBlock>(
-  blocks: readonly T[],
-): { kept: T[]; orphanedIds: string[] } {
-  const searchResultIds = new Set(
-    blocks.filter(isAnthropicWebSearchResult).map((b) => b.tool_use_id),
-  );
-  const fetchResultIds = new Set(
-    blocks.filter(isAnthropicWebFetchResult).map((b) => b.tool_use_id),
-  );
+export function stripOrphanedServerToolUse<T>(blocks: readonly T[]): {
+  kept: T[];
+  orphanedIds: string[];
+} {
+  const searchResultIds = new Set<string>();
+  const fetchResultIds = new Set<string>();
+  for (const block of blocks) {
+    if (isAnthropicWebSearchResult(block)) {
+      searchResultIds.add(block.tool_use_id);
+    } else if (isAnthropicWebFetchResult(block)) {
+      fetchResultIds.add(block.tool_use_id);
+    }
+  }
 
   const orphanedIds: string[] = [];
   const kept = blocks.filter((block) => {
@@ -79,23 +78,19 @@ export function extractAnthropicServerToolData(
     return { webSearchResults: [], webFetchResults: [], contentBlocks: [] };
   }
 
-  // Filter for server tool content (server_tool_use, web_search_tool_result,
-  // web_fetch_tool_result). Cast needed because BetaContentBlock has slightly
-  // different types than the regular API.
+  // Keep only server tool content (server_tool_use, web_search_tool_result,
+  // web_fetch_tool_result), then drop orphaned calls.
   const serverToolBlocks = responseObject.content.filter(
     isAnthropicServerToolContent,
-  ) as (
-    | ServerToolUseBlock
-    | WebSearchToolResultBlock
-    | WebFetchToolResultBlock
-  )[];
-
-  const { kept: contentBlocks } = stripOrphanedServerToolUse(serverToolBlocks);
+  );
+  const { kept } = stripOrphanedServerToolUse(serverToolBlocks);
 
   return {
     webSearchResults: extractAnthropicWebSearchResults(responseObject.content),
     webFetchResults: extractAnthropicWebFetchResults(responseObject.content),
-    contentBlocks,
+    // Cast needed because BetaContentBlock has slightly different types than the
+    // regular API; the runtime filter guarantees these are server-tool blocks.
+    contentBlocks: kept as ServerToolExtractionResult['contentBlocks'],
   };
 }
 

--- a/src/agent/modelHandlers/anthropic/anthropicThinking.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicThinking.ts
@@ -1,0 +1,185 @@
+// Model-trait and thinking-configuration logic for Anthropic Claude models.
+//
+// These are pure functions of the model's fullName (and, for effort, the
+// configured reasoning effort). Keeping them out of the handler class makes the
+// model-specific rules independently testable and lets the handler read as
+// orchestration rather than a tangle of version checks.
+
+// Third-party imports
+import { ReasoningEffort } from 'llm-zoo';
+
+// Type imports - Anthropic SDK
+import type {
+  BetaOutputConfig,
+  MessageCreateParams,
+} from '@anthropic-ai/sdk/resources/beta/messages';
+
+const OPUS_46_FULLNAME = 'claude-opus-4-6';
+const OPUS_47_FULLNAME = 'claude-opus-4-7';
+const OPUS_48_FULLNAME = 'claude-opus-4-8';
+const SONNET_46_FULLNAME = 'claude-sonnet-4-6';
+
+// 1M context window is available natively for Opus 4.6, Opus 4.7, Opus 4.8, and
+// Sonnet 4.6 at standard pricing (no beta header needed). Context window sizes
+// come from llm-zoo. Other Claude models use 200K.
+
+/**
+ * Model patterns that require temperature removal when thinking is enabled.
+ * Per Anthropic docs, Claude 4 models don't support temperature with thinking.
+ */
+const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
+  'claude-opus-4',
+  'claude-sonnet-4',
+  'claude-haiku-4',
+];
+
+export const isClaudeOpus46 = (fullName: string): boolean =>
+  fullName.startsWith(OPUS_46_FULLNAME);
+
+export const isClaudeOpus47 = (fullName: string): boolean =>
+  fullName.startsWith(OPUS_47_FULLNAME);
+
+export const isClaudeOpus48 = (fullName: string): boolean =>
+  fullName.startsWith(OPUS_48_FULLNAME);
+
+export const isClaudeSonnet46 = (fullName: string): boolean =>
+  fullName.startsWith(SONNET_46_FULLNAME);
+
+/**
+ * Whether this model supports adaptive thinking with the effort parameter.
+ * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6 support
+ * adaptive thinking. Opus 4.7+ only accepts adaptive thinking — manual
+ * budget_tokens returns 400.
+ */
+export const supportsAdaptiveThinking = (fullName: string): boolean =>
+  isClaudeOpus46(fullName) ||
+  isClaudeOpus47(fullName) ||
+  isClaudeOpus48(fullName) ||
+  isClaudeSonnet46(fullName);
+
+/** Whether this model supports Anthropic's native server-side context compaction. */
+export const isCompactionEligibleModel = (fullName: string): boolean =>
+  isClaudeOpus46(fullName) ||
+  isClaudeOpus47(fullName) ||
+  isClaudeOpus48(fullName) ||
+  isClaudeSonnet46(fullName);
+
+/**
+ * Whether temperature must be removed when thinking is enabled.
+ * Claude 4 models don't support temperature alongside thinking.
+ */
+export const requiresNoTemperatureWithThinking = (fullName: string): boolean =>
+  THINKING_TEMPERATURE_EXCLUDED_PATTERNS.some((pattern) =>
+    fullName.includes(pattern),
+  );
+
+/**
+ * Returns the Anthropic effort level for the current model.
+ * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
+ * Falls back to 'high' (the API default) when no specific effort is configured.
+ * The above-'high' tiers are only valid for Opus-tier models: Opus 4.8 accepts
+ * both the distinct 'xhigh' ("extra") tier and the top 'max' tier, while Opus
+ * 4.6/4.7 predate that split and only accept 'max'.
+ */
+export function mapAnthropicEffort(
+  fullName: string,
+  reasoningEffort: ReasoningEffort | null,
+): BetaOutputConfig['effort'] {
+  if (!reasoningEffort) {
+    return 'high';
+  }
+
+  switch (reasoningEffort) {
+    case 'max':
+      // The top tier ("Max"). Opus 4.8/4.7/4.6 all accept Anthropic's 'max'
+      // effort; everything else caps at 'high'.
+      return isClaudeOpus48(fullName) ||
+        isClaudeOpus47(fullName) ||
+        isClaudeOpus46(fullName)
+        ? 'max'
+        : 'high';
+    case 'xhigh':
+      // Opus 4.8 exposes the distinct 'xhigh' ("extra") effort tier the SDK
+      // added in 0.100.0, which is exactly what TeXRA's "Extra High" selector
+      // means — map to it directly. Opus 4.6/4.7 predate the tier split and
+      // only accept 'max'; everything else caps at 'high'.
+      if (isClaudeOpus48(fullName)) return 'xhigh';
+      return isClaudeOpus46(fullName) || isClaudeOpus47(fullName)
+        ? 'max'
+        : 'high';
+    case 'high':
+      return 'high';
+    case 'medium':
+      return 'medium';
+    case 'low':
+    case 'none':
+      // Anthropic doesn't support fully disabling thinking; 'low' is the minimum.
+      return 'low';
+    default:
+      return 'high';
+  }
+}
+
+/** Inputs needed to build the thinking/effort portion of a create request. */
+export interface ThinkingConfigInput {
+  fullName: string;
+  reasoningEffort: ReasoningEffort | null;
+  maxTokens: number;
+  useStreaming: boolean;
+}
+
+/** Resolved thinking configuration to apply onto the create-request params. */
+export interface ThinkingConfigResult {
+  thinking: NonNullable<MessageCreateParams['thinking']>;
+  /** Present only for adaptive-thinking models; merge onto output_config. */
+  outputConfig?: Pick<BetaOutputConfig, 'effort'>;
+  /** Whether temperature must be removed for this model. */
+  removeTemperature: boolean;
+}
+
+/**
+ * Builds the thinking configuration for a create request.
+ *
+ * Adaptive-thinking models (Opus 4.6/4.7/4.8, Sonnet 4.6) use the effort
+ * parameter and let the model decide its budget; interleaved thinking is enabled
+ * automatically. Older models use a manual budget_tokens cap.
+ */
+export function buildThinkingConfig({
+  fullName,
+  reasoningEffort,
+  maxTokens,
+  useStreaming,
+}: ThinkingConfigInput): ThinkingConfigResult {
+  const removeTemperature = requiresNoTemperatureWithThinking(fullName);
+
+  if (supportsAdaptiveThinking(fullName)) {
+    // Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6: use adaptive thinking
+    // with the effort parameter. Adaptive thinking lets the model decide
+    // when and how much to think, and automatically enables interleaved
+    // thinking between tool calls. budget_tokens is deprecated on these
+    // models.
+    const effort = mapAnthropicEffort(fullName, reasoningEffort);
+    // Opus 4.7+ defaults display to 'omitted', which suppresses reasoning
+    // output. Request 'summarized' so thinking tokens still stream to the
+    // user — older adaptive-thinking models already emit reasoning by
+    // default and are unaffected.
+    const thinking: ThinkingConfigResult['thinking'] =
+      isClaudeOpus47(fullName) || isClaudeOpus48(fullName)
+        ? { type: 'adaptive', display: 'summarized' }
+        : { type: 'adaptive' };
+
+    return { thinking, outputConfig: { effort }, removeTemperature };
+  }
+
+  // Older models: use manual thinking with budget_tokens
+  // budget_tokens must be < max_tokens; use 50% to leave room for actual output
+  const maxBudget = Math.floor(maxTokens * 0.5);
+
+  const defaultBudget = useStreaming ? 32768 : 4096;
+  const thinkingBudget = Math.min(defaultBudget, maxBudget);
+
+  return {
+    thinking: { type: 'enabled', budget_tokens: thinkingBudget },
+    removeTemperature,
+  };
+}

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -103,6 +103,11 @@ import {
   uploadToolAttachments,
   type UploadedAnthropicAttachment,
 } from './anthropicTools';
+import {
+  buildThinkingConfig,
+  isCompactionEligibleModel,
+  supportsAdaptiveThinking,
+} from './anthropicThinking';
 
 // Type imports
 import type { ProviderStopReason } from '../types/StopReasonTypes';
@@ -175,25 +180,6 @@ const isBetaToolUseBlock = (block: BetaContentBlock): block is ToolUseBlock =>
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 
-const OPUS_46_FULLNAME = 'claude-opus-4-6';
-const OPUS_47_FULLNAME = 'claude-opus-4-7';
-const OPUS_48_FULLNAME = 'claude-opus-4-8';
-const SONNET_46_FULLNAME = 'claude-sonnet-4-6';
-
-// 1M context window is available natively for Opus 4.6, Opus 4.7, Opus 4.8, and
-// Sonnet 4.6 at standard pricing (no beta header needed). Context window sizes
-// come from llm-zoo. Other Claude models use 200K.
-
-/**
- * Model patterns that require temperature removal when thinking is enabled.
- * Per Anthropic docs, Claude 4 models don't support temperature with thinking.
- */
-const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
-  'claude-opus-4',
-  'claude-sonnet-4',
-  'claude-haiku-4',
-];
-
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   AnthropicUsage,
@@ -243,97 +229,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
-  private isClaudeOpus46(): boolean {
-    return this.config.fullName.startsWith(OPUS_46_FULLNAME);
-  }
-
-  private isClaudeOpus47(): boolean {
-    return this.config.fullName.startsWith(OPUS_47_FULLNAME);
-  }
-
-  private isClaudeOpus48(): boolean {
-    return this.config.fullName.startsWith(OPUS_48_FULLNAME);
-  }
-
-  private isClaudeSonnet46(): boolean {
-    return this.config.fullName.startsWith(SONNET_46_FULLNAME);
-  }
-
   /** Returns the PDF page limit based on the model's effective context window. */
   private getMaxPdfPages(): number {
     return getAnthropicMaxPdfPages(this.getEffectiveContextWindow());
   }
 
-  /**
-   * Whether this model supports adaptive thinking with the effort parameter.
-   * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6 support
-   * adaptive thinking. Opus 4.7+ only accepts adaptive thinking — manual
-   * budget_tokens returns 400.
-   */
-  private supportsAdaptiveThinking(): boolean {
-    return (
-      this.isClaudeOpus46() ||
-      this.isClaudeOpus47() ||
-      this.isClaudeOpus48() ||
-      this.isClaudeSonnet46()
-    );
-  }
-
-  /**
-   * Returns the Anthropic effort level for the current model.
-   * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
-   * Falls back to 'high' (the API default) when no specific effort is configured.
-   * The above-'high' tiers are only valid for Opus-tier models: Opus 4.8 accepts
-   * both the distinct 'xhigh' ("extra") tier and the top 'max' tier, while Opus
-   * 4.6/4.7 predate that split and only accept 'max'.
-   */
-  private getAnthropicEffort(): BetaOutputConfig['effort'] {
-    const reasoningEffort = this.getEffectiveReasoningEffort();
-    if (!reasoningEffort) {
-      return 'high';
-    }
-
-    switch (reasoningEffort) {
-      case 'max':
-        // The top tier ("Max"). Opus 4.8/4.7/4.6 all accept Anthropic's 'max'
-        // effort; everything else caps at 'high'.
-        return this.isClaudeOpus48() ||
-          this.isClaudeOpus47() ||
-          this.isClaudeOpus46()
-          ? 'max'
-          : 'high';
-      case 'xhigh':
-        // Opus 4.8 exposes the distinct 'xhigh' ("extra") effort tier the SDK
-        // added in 0.100.0, which is exactly what TeXRA's "Extra High" selector
-        // means — map to it directly. Opus 4.6/4.7 predate the tier split and
-        // only accept 'max'; everything else caps at 'high'.
-        if (this.isClaudeOpus48()) return 'xhigh';
-        return this.isClaudeOpus46() || this.isClaudeOpus47() ? 'max' : 'high';
-      case 'high':
-        return 'high';
-      case 'medium':
-        return 'medium';
-      case 'low':
-      case 'none':
-        // Anthropic doesn't support fully disabling thinking; 'low' is the minimum.
-        return 'low';
-      default:
-        return 'high';
-    }
-  }
-
-  /** Whether this model supports Anthropic's native server-side context compaction. */
-  private isCompactionEligibleModel(): boolean {
-    return (
-      this.isClaudeOpus46() ||
-      this.isClaudeOpus47() ||
-      this.isClaudeOpus48() ||
-      this.isClaudeSonnet46()
-    );
-  }
-
   override get supportsManualCompaction(): boolean {
-    return this.isCompactionEligibleModel() && this.isToolUseMode();
+    return (
+      isCompactionEligibleModel(this.config.fullName) && this.isToolUseMode()
+    );
   }
 
   override requestCompaction(): void {
@@ -355,7 +259,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const consumed = setupContextManagement(
       opts,
       this.isToolUseMode(),
-      this.isCompactionEligibleModel(),
+      isCompactionEligibleModel(this.config.fullName),
       this.compactionRequested,
     );
     if (consumed) {
@@ -564,7 +468,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Only add the beta header for older models that need it explicitly.
       if (
         this.capabilities.supportsInterleavedThinking &&
-        !this.supportsAdaptiveThinking()
+        !supportsAdaptiveThinking(this.config.fullName)
       ) {
         ensureBeta(options, INTERLEAVED_THINKING_BETA);
       }
@@ -579,52 +483,30 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (this.capabilities.supportsReasoning) {
       this.logger.debug('Enabling thinking for model with reasoning support');
 
-      if (this.supportsAdaptiveThinking()) {
-        // Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6: use adaptive thinking
-        // with the effort parameter. Adaptive thinking lets the model decide
-        // when and how much to think, and automatically enables interleaved
-        // thinking between tool calls. budget_tokens is deprecated on these
-        // models.
-        const effort = this.getAnthropicEffort();
-        // Opus 4.7+ defaults display to 'omitted', which suppresses reasoning
-        // output. Request 'summarized' so thinking tokens still stream to the
-        // user — older adaptive-thinking models already emit reasoning by
-        // default and are unaffected.
-        options.thinking =
-          this.isClaudeOpus47() || this.isClaudeOpus48()
-            ? { type: 'adaptive', display: 'summarized' }
-            : { type: 'adaptive' };
+      const thinkingConfig = buildThinkingConfig({
+        fullName: this.config.fullName,
+        reasoningEffort: this.getEffectiveReasoningEffort(),
+        maxTokens: options.max_tokens,
+        useStreaming,
+      });
+      options.thinking = thinkingConfig.thinking;
+
+      if (thinkingConfig.thinking.type === 'adaptive') {
         options.output_config = {
           ...options.output_config,
-          effort,
+          ...thinkingConfig.outputConfig,
         };
-
         this.logger.debug(
-          `Set adaptive thinking with effort: ${effort} (max_tokens: ${options.max_tokens})`,
+          `Set adaptive thinking with effort: ${thinkingConfig.outputConfig?.effort} (max_tokens: ${options.max_tokens})`,
         );
-      } else {
-        // Older models: use manual thinking with budget_tokens
-        // budget_tokens must be < max_tokens; use 50% to leave room for actual output
-        const maxBudget = Math.floor(options.max_tokens * 0.5);
-
-        const defaultBudget = useStreaming ? 32768 : 4096;
-        const thinkingBudget = Math.min(defaultBudget, maxBudget);
-
-        options.thinking = {
-          type: 'enabled',
-          budget_tokens: thinkingBudget,
-        };
-
+      } else if (thinkingConfig.thinking.type === 'enabled') {
         this.logger.debug(
-          `Set thinking budget: ${thinkingBudget} tokens (max_tokens: ${options.max_tokens}, streaming: ${useStreaming})`,
+          `Set thinking budget: ${thinkingConfig.thinking.budget_tokens} tokens (max_tokens: ${options.max_tokens}, streaming: ${useStreaming})`,
         );
       }
 
       // Remove temperature for Claude 4 models when thinking is enabled as per Anthropic docs
-      const requiresNoTemperature = THINKING_TEMPERATURE_EXCLUDED_PATTERNS.some(
-        (pattern) => this.config.fullName.includes(pattern),
-      );
-      if (requiresNoTemperature) {
+      if (thinkingConfig.removeTemperature) {
         delete options.temperature;
       }
     }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -108,6 +108,10 @@ import {
   isCompactionEligibleModel,
   supportsAdaptiveThinking,
 } from './anthropicThinking';
+import {
+  buildAnthropicAssistantContent,
+  extractAnthropicServerToolData,
+} from './anthropicServerTools';
 
 // Type imports
 import type { ProviderStopReason } from '../types/StopReasonTypes';
@@ -1461,48 +1465,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   override extractServerToolData(
     responseObject: BetaMessage,
   ): ServerToolExtractionResult {
-    if (!Array.isArray(responseObject?.content)) {
-      return { webSearchResults: [], webFetchResults: [], contentBlocks: [] };
-    }
-
-    // Extract content blocks that need to be preserved
-    // Filter for server tool content (server_tool_use, web_search_tool_result, web_fetch_tool_result)
-    // Cast needed because BetaContentBlock has slightly different types than the regular API
-    let contentBlocks = responseObject.content.filter(
-      isAnthropicServerToolContent,
-    ) as (
-      | ServerToolUseBlock
-      | WebSearchToolResultBlock
-      | WebFetchToolResultBlock
-    )[];
-
-    // Collect IDs of result blocks that have matching server_tool_use calls.
-    const searchResultIds = new Set(
-      contentBlocks
-        .filter(isAnthropicWebSearchResult)
-        .map((b) => b.tool_use_id),
-    );
-    const fetchResultIds = new Set(
-      contentBlocks.filter(isAnthropicWebFetchResult).map((b) => b.tool_use_id),
-    );
-
-    // Strip orphaned server_tool_use blocks that lack a matching result.
-    contentBlocks = contentBlocks.filter((block) => {
-      if (!isAnthropicServerToolUse(block)) return true;
-      if (block.name === 'web_search') return searchResultIds.has(block.id);
-      if (block.name === 'web_fetch') return fetchResultIds.has(block.id);
-      return true;
-    });
-
-    // Extract normalized results for display
-    const webSearchResults = extractAnthropicWebSearchResults(
-      responseObject.content,
-    );
-    const webFetchResults = extractAnthropicWebFetchResults(
-      responseObject.content,
-    );
-
-    return { webSearchResults, webFetchResults, contentBlocks };
+    return extractAnthropicServerToolData(responseObject);
   }
 
   /**
@@ -1515,55 +1478,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * on the next API call.
    */
   override extractAssistantContent(responseObject: BetaMessage): unknown[] {
-    if (!Array.isArray(responseObject?.content)) {
-      return [];
-    }
-
-    let assistantContent = responseObject.content.filter(
-      (block) => block.type !== 'tool_use',
-    );
-
-    // Validate server_tool_use / result block pairing.
-    // The API rejects messages where a server_tool_use block exists
-    // without its corresponding result block.
-    const searchResultIds = new Set(
-      assistantContent
-        .filter(isAnthropicWebSearchResult)
-        .map((b) => b.tool_use_id),
-    );
-    const fetchResultIds = new Set(
-      assistantContent
-        .filter(isAnthropicWebFetchResult)
-        .map((b) => b.tool_use_id),
-    );
-    const orphanedIds: string[] = [];
-    for (const block of assistantContent) {
-      if (!isAnthropicServerToolUse(block)) continue;
-      if (block.name === 'web_search' && !searchResultIds.has(block.id)) {
-        orphanedIds.push(block.id);
-      } else if (block.name === 'web_fetch' && !fetchResultIds.has(block.id)) {
-        orphanedIds.push(block.id);
-      }
-    }
-    if (orphanedIds.length > 0) {
-      const orphanSet = new Set(orphanedIds);
-      this.logger.debug(
-        `Stripping ${orphanedIds.length} orphaned server_tool_use block(s) without matching result: ${orphanedIds.join(', ')}. ` +
-          `Response content types: [${responseObject.content.map((b) => b.type).join(', ')}]`,
-      );
-      assistantContent = assistantContent.filter(
-        (block) => !isAnthropicServerToolUse(block) || !orphanSet.has(block.id),
-      );
-    }
-
-    if (!this.capabilities.supportsPromptCaching) {
-      return assistantContent;
-    }
-
-    return assistantContent.map((block) =>
-      block.type === 'compaction'
-        ? { ...block, cache_control: LONG_CACHE_CONTROL }
-        : block,
+    return buildAnthropicAssistantContent(
+      responseObject,
+      { supportsPromptCaching: this.capabilities.supportsPromptCaching },
+      this.logger,
     );
   }
 

--- a/src/test-kernel/agent/modelHandlers/AnthropicServerTools.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicServerTools.vitest.ts
@@ -1,0 +1,153 @@
+// Third-party imports
+import { describe, it, expect } from 'vitest';
+
+// Local imports - functions under test
+import {
+  stripOrphanedServerToolUse,
+  extractAnthropicServerToolData,
+  buildAnthropicAssistantContent,
+} from '@agent/modelHandlers/anthropic/anthropicServerTools';
+
+// Type imports
+import type {
+  BetaContentBlock,
+  BetaMessage,
+} from '@anthropic-ai/sdk/resources/beta/messages';
+
+// Minimal block fixtures. The production guards discriminate on `type`, so these
+// runtime shapes are sufficient; cast through unknown to satisfy the SDK types.
+const textBlock = { type: 'text', text: 'hello', citations: null };
+const thinkingBlock = { type: 'thinking', thinking: 'hmm', signature: 'sig' };
+
+const serverUse = (id: string, name: 'web_search' | 'web_fetch') => ({
+  type: 'server_tool_use',
+  id,
+  name,
+  input: {},
+});
+const searchResult = (toolUseId: string) => ({
+  type: 'web_search_tool_result',
+  tool_use_id: toolUseId,
+  content: [],
+});
+const fetchResult = (toolUseId: string) => ({
+  type: 'web_fetch_tool_result',
+  tool_use_id: toolUseId,
+  content: { type: 'web_fetch_result', url: 'https://x', content: {} },
+});
+
+const asBlocks = (blocks: unknown[]): BetaContentBlock[] =>
+  blocks as BetaContentBlock[];
+
+const asMessage = (blocks: unknown[]): BetaMessage =>
+  ({ content: blocks } as unknown as BetaMessage);
+
+const typesOf = (blocks: unknown[]): string[] =>
+  blocks.map((b) => (b as { type: string }).type);
+
+describe('stripOrphanedServerToolUse', () => {
+  it('keeps server_tool_use blocks that have a matching result', () => {
+    const blocks = asBlocks([
+      textBlock,
+      serverUse('s1', 'web_search'),
+      searchResult('s1'),
+      serverUse('f1', 'web_fetch'),
+      fetchResult('f1'),
+    ]);
+    const { kept, orphanedIds } = stripOrphanedServerToolUse(blocks);
+    expect(orphanedIds).toEqual([]);
+    expect(kept).toHaveLength(5);
+  });
+
+  it('drops server_tool_use blocks missing their result and reports the ids', () => {
+    const blocks = asBlocks([
+      textBlock,
+      serverUse('s1', 'web_search'), // orphan: no result
+      serverUse('f1', 'web_fetch'),
+      fetchResult('f1'),
+    ]);
+    const { kept, orphanedIds } = stripOrphanedServerToolUse(blocks);
+    expect(orphanedIds).toEqual(['s1']);
+    expect(typesOf(kept)).toEqual([
+      'text',
+      'server_tool_use', // f1 kept (paired)
+      'web_fetch_tool_result',
+    ]);
+  });
+
+  it('never strips non-server-tool blocks', () => {
+    const blocks = asBlocks([textBlock, thinkingBlock]);
+    const { kept, orphanedIds } = stripOrphanedServerToolUse(blocks);
+    expect(orphanedIds).toEqual([]);
+    expect(kept).toHaveLength(2);
+  });
+});
+
+describe('extractAnthropicServerToolData', () => {
+  it('returns empty results when content is not an array', () => {
+    const result = extractAnthropicServerToolData({} as BetaMessage);
+    expect(result).toEqual({
+      webSearchResults: [],
+      webFetchResults: [],
+      contentBlocks: [],
+    });
+  });
+
+  it('keeps only server-tool content and strips orphaned calls', () => {
+    const message = asMessage([
+      textBlock, // dropped: not server-tool content
+      serverUse('s1', 'web_search'),
+      searchResult('s1'),
+      serverUse('s2', 'web_search'), // orphan
+    ]);
+    const { contentBlocks } = extractAnthropicServerToolData(message);
+    expect(typesOf(contentBlocks)).toEqual([
+      'server_tool_use',
+      'web_search_tool_result',
+    ]);
+  });
+});
+
+describe('buildAnthropicAssistantContent', () => {
+  const logger = { debug: () => {} } as never;
+
+  it('excludes tool_use blocks and strips orphaned server_tool_use', () => {
+    const message = asMessage([
+      thinkingBlock,
+      textBlock,
+      { type: 'tool_use', id: 't1', name: 'edit', input: {} },
+      serverUse('s1', 'web_search'), // orphan -> stripped
+    ]);
+    const out = buildAnthropicAssistantContent(
+      message,
+      { supportsPromptCaching: false },
+      logger,
+    );
+    expect(typesOf(out)).toEqual(['thinking', 'text']);
+  });
+
+  it('tags the compaction block with a cache breakpoint when caching is on', () => {
+    const message = asMessage([textBlock, { type: 'compaction', content: 'x' }]);
+    const out = buildAnthropicAssistantContent(
+      message,
+      { supportsPromptCaching: true },
+      logger,
+    );
+    const compaction = out.find(
+      (b) => (b as { type: string }).type === 'compaction',
+    ) as { cache_control?: { type: string; ttl?: string } };
+    expect(compaction.cache_control).toEqual({ type: 'ephemeral', ttl: '1h' });
+  });
+
+  it('leaves blocks untouched when caching is off', () => {
+    const message = asMessage([{ type: 'compaction', content: 'x' }]);
+    const out = buildAnthropicAssistantContent(
+      message,
+      { supportsPromptCaching: false },
+      logger,
+    );
+    expect(
+      (out[0] as { cache_control?: unknown }).cache_control,
+    ).toBeUndefined();
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/AnthropicServerTools.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicServerTools.vitest.ts
@@ -40,7 +40,7 @@ const asBlocks = (blocks: unknown[]): BetaContentBlock[] =>
   blocks as BetaContentBlock[];
 
 const asMessage = (blocks: unknown[]): BetaMessage =>
-  ({ content: blocks } as unknown as BetaMessage);
+  ({ content: blocks }) as unknown as BetaMessage;
 
 const typesOf = (blocks: unknown[]): string[] =>
   blocks.map((b) => (b as { type: string }).type);
@@ -127,7 +127,10 @@ describe('buildAnthropicAssistantContent', () => {
   });
 
   it('tags the compaction block with a cache breakpoint when caching is on', () => {
-    const message = asMessage([textBlock, { type: 'compaction', content: 'x' }]);
+    const message = asMessage([
+      textBlock,
+      { type: 'compaction', content: 'x' },
+    ]);
     const out = buildAnthropicAssistantContent(
       message,
       { supportsPromptCaching: true },

--- a/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
@@ -1,0 +1,138 @@
+// Third-party imports
+import { describe, it, expect } from 'vitest';
+import { ReasoningEffort } from 'llm-zoo';
+
+// Local imports - functions under test
+import {
+  buildThinkingConfig,
+  isCompactionEligibleModel,
+  mapAnthropicEffort,
+  requiresNoTemperatureWithThinking,
+  supportsAdaptiveThinking,
+} from '@agent/modelHandlers/anthropic/anthropicThinking';
+
+const OPUS_46 = 'claude-opus-4-6';
+const OPUS_47 = 'claude-opus-4-7';
+const OPUS_48 = 'claude-opus-4-8';
+const SONNET_46 = 'claude-sonnet-4-6';
+const SONNET_35 = 'claude-3-5-sonnet-20241022';
+
+describe('mapAnthropicEffort', () => {
+  it('defaults to the API default "high" when no effort is configured', () => {
+    expect(mapAnthropicEffort(OPUS_48, null)).toBe('high');
+  });
+
+  it('maps the internal "max" tier only on Opus models', () => {
+    expect(mapAnthropicEffort(OPUS_46, ReasoningEffort.MAX)).toBe('max');
+    expect(mapAnthropicEffort(OPUS_47, ReasoningEffort.MAX)).toBe('max');
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.MAX)).toBe('max');
+    // Non-Opus models cap at "high".
+    expect(mapAnthropicEffort(SONNET_46, ReasoningEffort.MAX)).toBe('high');
+    expect(mapAnthropicEffort(SONNET_35, ReasoningEffort.MAX)).toBe('high');
+  });
+
+  it('maps "xhigh" to the distinct tier only on Opus 4.8', () => {
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.XHIGH)).toBe('xhigh');
+    // Opus 4.6/4.7 predate the tier split and collapse "xhigh" to "max".
+    expect(mapAnthropicEffort(OPUS_46, ReasoningEffort.XHIGH)).toBe('max');
+    expect(mapAnthropicEffort(OPUS_47, ReasoningEffort.XHIGH)).toBe('max');
+    // Everything else caps at "high".
+    expect(mapAnthropicEffort(SONNET_46, ReasoningEffort.XHIGH)).toBe('high');
+  });
+
+  it('passes through high/medium and floors low/none at "low"', () => {
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.HIGH)).toBe('high');
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.MEDIUM)).toBe('medium');
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.LOW)).toBe('low');
+    expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.NONE)).toBe('low');
+  });
+});
+
+describe('supportsAdaptiveThinking / isCompactionEligibleModel', () => {
+  it('is true for Opus 4.6/4.7/4.8 and Sonnet 4.6', () => {
+    for (const model of [OPUS_46, OPUS_47, OPUS_48, SONNET_46]) {
+      expect(supportsAdaptiveThinking(model)).toBe(true);
+      expect(isCompactionEligibleModel(model)).toBe(true);
+    }
+  });
+
+  it('is false for older Claude models', () => {
+    expect(supportsAdaptiveThinking(SONNET_35)).toBe(false);
+    expect(isCompactionEligibleModel(SONNET_35)).toBe(false);
+  });
+});
+
+describe('requiresNoTemperatureWithThinking', () => {
+  it('is true for all Claude 4 families', () => {
+    expect(requiresNoTemperatureWithThinking(OPUS_48)).toBe(true);
+    expect(requiresNoTemperatureWithThinking(SONNET_46)).toBe(true);
+    expect(requiresNoTemperatureWithThinking('claude-haiku-4-5')).toBe(true);
+  });
+
+  it('is false for Claude 3.x models', () => {
+    expect(requiresNoTemperatureWithThinking(SONNET_35)).toBe(false);
+  });
+});
+
+describe('buildThinkingConfig', () => {
+  it('uses adaptive thinking with summarized display on Opus 4.7+', () => {
+    const config = buildThinkingConfig({
+      fullName: OPUS_48,
+      reasoningEffort: ReasoningEffort.HIGH,
+      maxTokens: 64000,
+      useStreaming: true,
+    });
+    expect(config.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+    expect(config.outputConfig).toEqual({ effort: 'high' });
+    expect(config.removeTemperature).toBe(true);
+  });
+
+  it('uses bare adaptive thinking on earlier adaptive models', () => {
+    const config = buildThinkingConfig({
+      fullName: SONNET_46,
+      reasoningEffort: ReasoningEffort.MEDIUM,
+      maxTokens: 64000,
+      useStreaming: false,
+    });
+    expect(config.thinking).toEqual({ type: 'adaptive' });
+    expect(config.outputConfig).toEqual({ effort: 'medium' });
+  });
+
+  it('falls back to a manual budget for non-adaptive models', () => {
+    // Streaming uses the larger default budget, capped at half of max_tokens.
+    const streaming = buildThinkingConfig({
+      fullName: SONNET_35,
+      reasoningEffort: null,
+      maxTokens: 100000,
+      useStreaming: true,
+    });
+    expect(streaming.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 32768,
+    });
+
+    // Non-streaming uses the smaller default budget.
+    const nonStreaming = buildThinkingConfig({
+      fullName: SONNET_35,
+      reasoningEffort: null,
+      maxTokens: 100000,
+      useStreaming: false,
+    });
+    expect(nonStreaming.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 4096,
+    });
+
+    // The budget never exceeds half of max_tokens.
+    const capped = buildThinkingConfig({
+      fullName: SONNET_35,
+      reasoningEffort: null,
+      maxTokens: 8000,
+      useStreaming: true,
+    });
+    expect(capped.thinking).toEqual({ type: 'enabled', budget_tokens: 4000 });
+  });
+});


### PR DESCRIPTION
The Anthropic handler embedded all model-version checks, adaptive-thinking
eligibility, reasoning-effort mapping, and temperature rules as private
methods, growing modelHandlerAnthropic.ts past 1900 lines and tangling
orchestration with model-specific knowledge.

Move that logic into a new pure-function module anthropicThinking.ts,
mirroring the existing anthropic/* helper pattern (anthropicContextManagement,
anthropicTools, etc.):

- isClaudeOpus46/47/48, isClaudeSonnet46 predicates
- supportsAdaptiveThinking, isCompactionEligibleModel
- requiresNoTemperatureWithThinking
- mapAnthropicEffort (llm-zoo ReasoningEffort -> Anthropic effort tiers)
- buildThinkingConfig (adaptive vs manual budget_tokens)

The handler now delegates to these functions, shrinking it by ~120 lines and
reading as orchestration. Behavior is unchanged.

Adds AnthropicThinking.vitest.ts covering the effort mapping (previously
untested) and the thinking-config builder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with delegated call sites and new tests; no new auth or API surface, behavior preserved by design.
> 
> **Overview**
> Pulls Anthropic-specific logic out of `modelHandlerAnthropic.ts` into two helper modules aligned with existing `anthropic/*` patterns, so the handler mostly wires requests instead of embedding version checks and block surgery.
> 
> **`anthropicThinking.ts`** holds model predicates, adaptive-thinking and compaction eligibility, `ReasoningEffort` → Anthropic effort mapping (including Opus-only `max` / `xhigh`), temperature rules, and `buildThinkingConfig` for adaptive vs manual `budget_tokens`. Create-request setup now calls these pure functions.
> 
> **`anthropicServerTools.ts`** centralizes web_search / web_fetch handling: stripping orphaned `server_tool_use` blocks (to avoid follow-up 400s), server-tool extraction for display/context, and assistant content replay (excluding `tool_use`, optional compaction cache breakpoint).
> 
> Vitest suites cover effort mapping, thinking config, orphan stripping, and assistant content building. Intended as a no-behavior-change refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a3f386902de17245e58c648a71f844291431b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->