### PR TITLE
fix(cli): let compact bash approvals scroll

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -45,6 +45,7 @@ const DC4 = String.fromCharCode(20); // Ctrl-T
 const NAK = String.fromCharCode(21); // Ctrl-U
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
+const PAGE_DOWN = ESC + '[6~';
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
   'solutions = []',
@@ -453,11 +454,67 @@ const SCENARIOS = [
     expect: [
       'Run bash command?',
       "$ python3 << 'EOF'",
-      'rows hidden',
+      'more rows',
+      'scroll command',
       'y approve',
       'Use foreground panel shortcuts',
     ],
-    unexpect: ['╚═    print', 'scroll command', '[Option-p]tasks'],
+    unexpect: ['╚═    print', '[Option-p]tasks'],
+  },
+  {
+    name: 'compact-long-bash-approval-scroll',
+    rows: 14,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: [DOWN, DOWN, DOWN],
+    frame: 'tail',
+    expect: [
+      'Run bash command?',
+      'x2 = 1 + 2 * y * y',
+      'previous',
+      'more rows',
+      'scroll command',
+      'y approve',
+    ],
+    unexpect: ["$ python3 << 'EOF'", '[Option-p]tasks'],
+  },
+  {
+    name: 'compact-long-bash-approval-page',
+    rows: 14,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: [PAGE_DOWN],
+    frame: 'tail',
+    expect: [
+      'Run bash command?',
+      'for y in range(1, 100):',
+      'x2 = 1 + 2 * y * y',
+      'previous',
+      'more rows',
+      'PgUp/PgDn page',
+    ],
+    unexpect: ["$ python3 << 'EOF'", 'solutions = []', '[Option-p]tasks'],
+  },
+  {
+    name: 'tiny-compact-long-bash-approval',
+    rows: 11,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
+    },
+    bootExpect: 'Use foreground panel shortcuts',
+    frame: 'tail',
+    expect: ['Run bash command?', 'rows hidden', 'y approve'],
+    unexpect: ['scroll command', '[Option-p]tasks'],
   },
   {
     name: 'bash-approval-approve-session',

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -81,11 +81,25 @@ export function maxBashCommandScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
+  if (
+    maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS &&
+    totalLines > maxDisplayLines
+  ) {
+    const contentRows = Math.max(1, maxDisplayLines - 1);
+    return Math.max(0, totalLines - contentRows);
+  }
+
   return maxScrollableRowOffset({
     compactRows: COMPACT_BASH_COMMAND_ROWS,
     maxDisplayLines,
     totalLines,
   });
+}
+
+export function bashApprovalPageRows(maxCommandRows: number): number {
+  return maxCommandRows <= COMPACT_BASH_COMMAND_ROWS
+    ? Math.max(1, maxCommandRows - 1)
+    : Math.max(1, maxCommandRows - 2);
 }
 
 function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
@@ -111,6 +125,24 @@ function compactHiddenCommandText({
   return `${clipToWidth(firstLine, prefixWidth).trimEnd()}${suffix}`;
 }
 
+function compactScrollStatusText({
+  hiddenAfter,
+  hiddenBefore,
+  width,
+}: {
+  readonly hiddenAfter: number;
+  readonly hiddenBefore: number;
+  readonly width: number;
+}): string {
+  const text =
+    hiddenBefore > 0 && hiddenAfter > 0
+      ? `... ${hiddenBefore} previous, ${hiddenAfter} more rows`
+      : hiddenBefore > 0
+        ? overflowText('previous', hiddenBefore)
+        : overflowText('more', hiddenAfter);
+  return clipToWidth(text, width);
+}
+
 export function boundedBashCommandDisplayLines({
   command,
   maxDisplayLines,
@@ -126,12 +158,21 @@ export function boundedBashCommandDisplayLines({
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
 
   if (maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS) {
+    const contentRows = Math.max(1, maxDisplayLines - 1);
+    const offset = Math.max(
+      0,
+      Math.min(
+        scrollOffset,
+        maxBashCommandScrollOffset(lines.length, maxDisplayLines),
+      ),
+    );
+
     if (maxDisplayLines === 1) {
       return [
         {
           kind: 'overflow',
           text: compactHiddenCommandText({
-            firstLine: lines[0]?.text ?? '',
+            firstLine: lines[offset]?.text ?? '',
             hiddenLines: lines.length - 1,
             width,
           }),
@@ -139,13 +180,18 @@ export function boundedBashCommandDisplayLines({
       ];
     }
 
-    const visibleCount = Math.max(1, maxDisplayLines - 1);
-    const visible = lines.slice(0, visibleCount);
+    const visible = lines.slice(offset, offset + contentRows);
+    const hiddenBefore = offset;
+    const hiddenAfter = Math.max(0, lines.length - (offset + visible.length));
     return [
       ...visible,
       {
         kind: 'overflow',
-        text: overflowText('hidden', lines.length - visible.length),
+        text: compactScrollStatusText({
+          hiddenAfter,
+          hiddenBefore,
+          width,
+        }),
       },
     ];
   }
@@ -202,8 +248,9 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
     maxCommandRows,
   );
   const scrollable = maxScrollOffset > 0;
-  const pageRows = Math.max(1, maxCommandRows - 2);
+  const pageRows = bashApprovalPageRows(maxCommandRows);
   const compactCommandLayout = maxCommandRows <= COMPACT_BASH_COMMAND_ROWS;
+  const showScrollHints = scrollable && maxCommandRows > 1;
   const displayLines = boundedBashCommandDisplayLines({
     command: props.payload.command,
     maxDisplayLines: maxCommandRows,
@@ -252,7 +299,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
           </Text>
         ))}
       </Box>
-      {scrollable ? (
+      {showScrollHints ? (
         <KeyHints
           confirmCancel={false}
           hints={[

--- a/src/test-kernel/cli/BashApproval.vitest.mts
+++ b/src/test-kernel/cli/BashApproval.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  bashApprovalPageRows,
   bashApprovalCommandRowsBudget,
   bashCommandDisplayLines,
   boundedBashCommandDisplayLines,
@@ -74,6 +75,51 @@ describe('CLI bash approval layout', () => {
     });
     expect(visible.map((line) => line.text)).toContain('  print(solutions)');
     expect(visible.map((line) => line.text)).toContain('  EOF');
+  });
+
+  it('lets users scroll compact command previews', () => {
+    const budget = 3;
+    const allRows = bashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      width: 76,
+    });
+    const offset = maxBashCommandScrollOffset(allRows.length, budget);
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: budget,
+      scrollOffset: 3,
+      width: 76,
+    });
+
+    expect(offset).toBeGreaterThan(0);
+    expect(visible).toHaveLength(budget);
+    expect(visible.map((line) => line.text)).toContain(
+      '      x2 = 1 + 2 * y * y',
+    );
+    expect(visible.at(-1)).toEqual({
+      kind: 'overflow',
+      text: '... 3 previous, 8 more rows',
+    });
+  });
+
+  it('pages compact command previews by visible content rows', () => {
+    expect(bashApprovalPageRows(1)).toBe(1);
+    expect(bashApprovalPageRows(3)).toBe(2);
+    expect(bashApprovalPageRows(8)).toBe(6);
+  });
+
+  it('lets users scroll one-row compact previews', () => {
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: 1,
+      scrollOffset: 2,
+      width: 76,
+    });
+
+    expect(maxBashCommandScrollOffset(13, 1)).toBe(12);
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.text).toContain('for y in range(1, 100):');
+    expect(visible[0]?.text).toContain('rows hidden');
   });
 
   it('keeps one-row compact previews within their row budget', () => {


### PR DESCRIPTION
Fixes #4912.

## Summary
- make compact bash approval previews scrollable instead of static hidden-row summaries
- keep compact row budgets intact while showing previous/more counts as the user scrolls
- suppress the separate scroll-hint row in the one-row command viewport so tiny terminals keep approve/reject visible
- page compact previews by visible content rows instead of matching a single-arrow scroll
- add PTY harness coverage for Down, PgDn, and the 11-row tiny approval case

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/BashApproval.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui long-bash-approval compact-long-bash-approval compact-long-bash-approval-scroll bash-approval-approve-session
- corepack pnpm --filter @texra-ai/cli validate:tui tiny-compact-long-bash-approval compact-long-bash-approval compact-long-bash-approval-scroll --snapshot-dir /tmp/texra-compact-bash-review-fix
- corepack pnpm --filter @texra-ai/cli validate:tui compact-long-bash-approval-page compact-long-bash-approval-scroll tiny-compact-long-bash-approval --snapshot-dir /tmp/texra-compact-bash-page-fix
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/BashApproval.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/BashApproval.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- git diff --check
- npm run lint (passes with 11 existing import-order warnings outside this change)
- npm run compile:safe