### PR TITLE
fix(cli): make no-model chat error actionable

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -775,6 +775,8 @@ export async function runChat(
   try {
     modelResolution = await resolveCliRunnableModel(defaults.model, {
       allowFallback: !explicitModelRequested,
+      noAvailableModelsHint:
+        'Run `texra chat --api-mode included` to try included relay access',
     });
   } catch (error: unknown) {
     writeTextStderr(toErrorMessage(error));

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -16,6 +16,11 @@ export interface CliRunnableModelResolution {
   readonly notice?: string;
 }
 
+export interface CliRunnableModelOptions {
+  readonly allowFallback: boolean;
+  readonly noAvailableModelsHint?: string;
+}
+
 function formatModelAccessStatus(model: ModelOptionData): string {
   if (model.availabilityLabel) return model.availabilityLabel.toLowerCase();
   if (!model.disabled && !model.requiresKey) return 'available';
@@ -71,24 +76,31 @@ function getCanonicalModelConfigId(model: string): string | undefined {
   return Object.keys(MODEL_CONFIGS).find((id) => id.toLowerCase() === lower);
 }
 
-function formatAvailableModels(ids: readonly string[]): string {
+function formatAvailableModels(
+  ids: readonly string[],
+  noAvailableModelsHint?: string,
+): string {
   if (ids.length > 0) return `Available models: ${ids.join(', ')}.`;
-  return 'No models are currently available. Run `texra login`, switch API mode, or configure a provider API key.';
+  const modeHint =
+    noAvailableModelsHint ??
+    'Retry with `--api-mode included` to try included relay access';
+  return `No models are currently available. ${modeHint}, run \`texra login\`, or configure a provider API key.`;
 }
 
 function formatUnavailableModelMessage(
   model: string,
   entry: CliModelAccess | undefined,
   availableIds: readonly string[],
+  options: Pick<CliRunnableModelOptions, 'noAvailableModelsHint'>,
 ): string {
   const status = entry ? ` (${entry.status})` : '';
-  return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds)}`;
+  return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds, options.noAvailableModelsHint)}`;
 }
 
 export function resolveCliRunnableModelFromAccessList(
   models: readonly CliModelAccess[],
   model: string,
-  options: { readonly allowFallback: boolean },
+  options: CliRunnableModelOptions,
 ): CliRunnableModelResolution {
   const trimmed = model.trim();
   const entry = findModelAccess(models, trimmed);
@@ -99,6 +111,7 @@ export function resolveCliRunnableModelFromAccessList(
     trimmed,
     entry,
     availableIds,
+    options,
   );
   if (!options.allowFallback || availableIds.length === 0) {
     throw new Error(unavailableMessage);
@@ -113,7 +126,7 @@ export function resolveCliRunnableModelFromAccessList(
 
 export async function resolveCliRunnableModel(
   model: string,
-  options: { readonly allowFallback: boolean },
+  options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
   const models = await getCliModelAccessList();
   const trimmed = model.trim();

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -88,7 +88,23 @@ describe('CLI model access resolution', () => {
         { allowFallback: true },
       ),
     ).toThrow(
-      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available.',
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
+    );
+  });
+
+  it('can format command-specific recovery hints for interactive chat', () => {
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(
+        [model('gemini31p', { available: false, status: 'missing api key' })],
+        'gemini31p',
+        {
+          allowFallback: true,
+          noAvailableModelsHint:
+            'Run `texra chat --api-mode included` to try included relay access',
+        },
+      ),
+    ).toThrow(
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra chat --api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
     );
   });
 


### PR DESCRIPTION
Fixes #4916.

## Summary
- replace the unreachable “switch API mode” startup hint with an explicit chat recovery command when `texra chat` cannot open the TUI
- keep shared model-access diagnostics command-neutral for non-chat callers
- update model-access coverage for both default and chat-specific no-runnable-models diagnostics

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/runtime/modelAccess.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ModelAccess.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm --filter @texra-ai/cli build
- git diff --check
- env -i PATH="$PATH" HOME=/tmp/texra-4916-home TERM=xterm-256color FORCE_COLOR=0 node packages/cli/dist/bin/texra.js chat --cwd /tmp/texra-4916-cwd --api-mode personal --approval-policy ask
- npm run lint (passes with 11 existing import-order warnings outside this change)
- npm run compile:safe