### PR TITLE
fix(cli): keep queued followups above stable input

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -103,6 +103,27 @@ const SCENARIOS = [
     unexpect: ['Tip: Ctrl-C exits idle chats', 'First queued follo…'],
   },
   {
+    name: 'compact-queued-followups',
+    rows: 8,
+    cols: 60,
+    env: {
+      HARNESS_ENTRIES: '2',
+      HARNESS_QUEUED_FOLLOWUPS:
+        'First queued follow-up||Second queued follow-up',
+    },
+    bootExpect: 'queued 2',
+    frame: 'tail',
+    expect: [
+      'Queued follow-ups (2)',
+      '1. First queued follow-up',
+      '2. Second queued follow-up',
+      '│ ›',
+      'queued 2',
+      '[Ctrl-C]stop',
+    ],
+    unexpect: ['Tip: Ctrl-C exits idle chats', 'agent: chat · model'],
+  },
+  {
     name: 'subagent-followup-summary',
     env: { HARNESS_ENTRIES: '0', HARNESS_SUBAGENT_FOLLOWUPS: '1' },
     expect: [

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -24,7 +24,10 @@ import {
   queuedFollowUpPanelRowCount,
 } from './panes/QueuedFollowUpsPanel';
 import { StatusBar } from './panes/StatusBar';
-import { StreamTabsStrip } from './panes/StreamTabsStrip';
+import {
+  StreamTabsStrip,
+  streamTabsDisplayItems,
+} from './panes/StreamTabsStrip';
 import { SubagentList } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel } from './panes/TodosPlanPanel';
@@ -68,6 +71,8 @@ const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation or push the input bar off-screen.
 const BOTTOM_PANEL_MAX_ROWS = 10;
+const COMPACT_STATIC_TRANSCRIPT_MAX_ROWS = 14;
+const COMPACT_LIVE_TRANSCRIPT_RESERVE_ROWS = 2;
 
 const PINNED_CHROME_ROWS = {
   tip: 1,
@@ -81,19 +86,24 @@ function pinnedChromeRows({
   queuedFollowUpPanelRows = 0,
   reverseSearchOpen,
   slashPaletteOpen,
+  streamTabsVisible = true,
+  staticTranscriptRows = 0,
   tipVisible = true,
 }: {
   readonly inputVisible?: boolean;
   readonly queuedFollowUpPanelRows?: number;
   readonly reverseSearchOpen: boolean;
   readonly slashPaletteOpen: boolean;
+  readonly streamTabsVisible?: boolean;
+  readonly staticTranscriptRows?: number;
   readonly tipVisible?: boolean;
 }): number {
   const baseRows =
-    PINNED_CHROME_ROWS.streamTabsWorstCase +
     PINNED_CHROME_ROWS.status +
     (inputVisible ? PINNED_CHROME_ROWS.input : 0) +
+    (streamTabsVisible ? PINNED_CHROME_ROWS.streamTabsWorstCase : 0) +
     queuedFollowUpPanelRows +
+    staticTranscriptRows +
     (tipVisible ? PINNED_CHROME_ROWS.tip : 0);
   return (
     baseRows +
@@ -110,6 +120,8 @@ export function allocateMiddleRows({
   reverseSearchOpen,
   rows,
   slashPaletteOpen,
+  streamTabsVisible = true,
+  staticTranscriptRows = 0,
   tipVisible = true,
 }: {
   readonly foregroundMaxRows?: number;
@@ -119,6 +131,8 @@ export function allocateMiddleRows({
   readonly reverseSearchOpen: boolean;
   readonly rows: number;
   readonly slashPaletteOpen: boolean;
+  readonly streamTabsVisible?: boolean;
+  readonly staticTranscriptRows?: number;
   readonly tipVisible?: boolean;
 }): {
   readonly foregroundRows: number;
@@ -132,6 +146,8 @@ export function allocateMiddleRows({
         queuedFollowUpPanelRows,
         reverseSearchOpen,
         slashPaletteOpen,
+        streamTabsVisible,
+        staticTranscriptRows,
         tipVisible,
       }),
   );
@@ -190,6 +206,34 @@ export function allocateSidePanelRows({
     subagentRows,
     todosPlanRows: availableRows - subagentRows,
   };
+}
+
+export function staticTranscriptRowBudget({
+  footerRows,
+  foregroundOpen,
+  queuedFollowUpPanelRows = 0,
+  rows,
+  tipVisible = true,
+}: {
+  readonly footerRows: number;
+  readonly foregroundOpen: boolean;
+  readonly queuedFollowUpPanelRows?: number;
+  readonly rows: number;
+  readonly tipVisible?: boolean;
+}): number | undefined {
+  if (foregroundOpen || rows > COMPACT_STATIC_TRANSCRIPT_MAX_ROWS) {
+    return undefined;
+  }
+  const optionalRows =
+    rows -
+    footerRows -
+    queuedFollowUpPanelRows -
+    (tipVisible ? PINNED_CHROME_ROWS.tip : 0);
+  const liveTranscriptReserveRows = Math.min(
+    COMPACT_LIVE_TRANSCRIPT_RESERVE_ROWS,
+    Math.max(0, optionalRows),
+  );
+  return Math.max(0, optionalRows - liveTranscriptReserveRows);
 }
 
 export function shouldShowTipRow({
@@ -373,14 +417,36 @@ export function App(props: AppProps): React.JSX.Element {
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
-  const queuedFollowUpPanelVisible =
+  const queuedFollowUpPanelWanted =
     !foregroundOpen && queuedFollowUpMessages.length > 0;
-  const queuedFollowUpPanelRows = queuedFollowUpPanelVisible
+  const streamTabItems = streamTabsDisplayItems({
+    activeStreamId,
+    parentStream,
+    streams,
+    width: columns,
+  });
+  const streamTabsVisible = streamTabItems.length > 0;
+  const footerRows =
+    PINNED_CHROME_ROWS.status +
+    (inputBarVisible ? PINNED_CHROME_ROWS.input : 0) +
+    (streamTabsVisible ? PINNED_CHROME_ROWS.streamTabsWorstCase : 0);
+  const requestedQueuedFollowUpPanelRows = queuedFollowUpPanelWanted
     ? queuedFollowUpPanelRowCount(queuedFollowUpMessages)
     : 0;
+  const queuedFollowUpPanelRows = queuedFollowUpPanelWanted
+    ? Math.min(requestedQueuedFollowUpPanelRows, Math.max(0, rows - footerRows))
+    : 0;
+  const queuedFollowUpPanelVisible = queuedFollowUpPanelRows > 0;
   const tipRowVisible = shouldShowTipRow({
     foregroundOpen,
-    hasQueuedFollowUps: queuedFollowUpPanelVisible,
+    hasQueuedFollowUps: queuedFollowUpPanelWanted,
+  });
+  const staticTranscriptRows = staticTranscriptRowBudget({
+    footerRows,
+    foregroundOpen,
+    queuedFollowUpPanelRows,
+    rows,
+    tipVisible: tipRowVisible,
   });
   const subagentControlTarget = resolveChildControlStreamTarget({
     activeStreamId,
@@ -434,6 +500,8 @@ export function App(props: AppProps): React.JSX.Element {
     reverseSearchOpen,
     rows,
     slashPaletteOpen,
+    streamTabsVisible,
+    staticTranscriptRows: staticTranscriptRows ?? 0,
     tipVisible: tipRowVisible,
   });
   // The subagent/todos panels live at the bottom of the same vertical
@@ -601,7 +669,10 @@ export function App(props: AppProps): React.JSX.Element {
 
   return (
     <>
-      <StaticConversationTranscript width={transcriptWidth} />
+      <StaticConversationTranscript
+        maxRows={staticTranscriptRows}
+        width={transcriptWidth}
+      />
       <Box flexDirection="column">
         <Box flexDirection="column" overflowY="hidden">
           {conversationRows > 0 ? (
@@ -642,7 +713,7 @@ export function App(props: AppProps): React.JSX.Element {
           disabled={inputDisabled}
           history={props.history}
         />
-        <StreamTabsStrip width={columns} />
+        <StreamTabsStrip items={streamTabItems} width={columns} />
         <StatusBar
           canStopActiveRun={canStopActiveRun}
           queuedFollowUpPreview={!queuedFollowUpPanelVisible}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -17,6 +17,7 @@ import {
   type SessionMeta,
   type StreamSlice,
 } from '../state/cliState';
+import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { TranscriptEntry } from './TranscriptEntry';
 
@@ -24,6 +25,7 @@ export type StaticTranscriptItem =
   | {
       readonly id: string;
       readonly kind: 'header';
+      readonly compact: boolean;
       readonly meta: SessionMeta;
     }
   | {
@@ -52,13 +54,30 @@ export function sessionHeaderIdentityLine(meta: SessionMeta): string {
 }
 
 function SessionHeaderBlock({
+  compact,
   meta,
   width,
 }: {
+  readonly compact: boolean;
   readonly meta: SessionMeta;
   readonly width?: number;
 }): React.JSX.Element {
   const columns = Math.max(1, Math.floor(width ?? 80));
+  if (compact) {
+    return (
+      <Box paddingX={1}>
+        <Text wrap="truncate-end">
+          <Text bold color="cyan">
+            TeXRA
+          </Text>{' '}
+          <Text dimColor>v{meta.version}</Text>{' '}
+          <Text dimColor>{shortCliApiMode(meta.apiMode)}</Text>{' '}
+          <Text>{sessionHeaderIdentityLine(meta)}</Text>
+        </Text>
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column">
       <Box>
@@ -90,23 +109,80 @@ function SessionHeaderBlock({
 // stream-scoped key would treat the moved rows as new and print them
 // twice.
 const SESSION_HEADER_ID = 'session-header';
+const FULL_SESSION_HEADER_ROWS = 4;
+const COMPACT_SESSION_HEADER_ROWS = 1;
+
+function staticTranscriptItemRowCount(
+  item: StaticTranscriptItem,
+  width?: number,
+): number {
+  if (item.kind === 'header') {
+    return item.compact
+      ? COMPACT_SESSION_HEADER_ROWS
+      : FULL_SESSION_HEADER_ROWS;
+  }
+  // Compact budgeting can over-count tool rows because the transcript viewer
+  // keeps full tool output while the static scrollback renderer elides it.
+  return transcriptEntryLines(item.entry, Math.max(1, Math.floor(width ?? 80)))
+    .length;
+}
+
+function canAppendStaticTranscriptItem({
+  currentRows,
+  item,
+  maxRows,
+  width,
+}: {
+  readonly currentRows: number;
+  readonly item: StaticTranscriptItem;
+  readonly maxRows?: number;
+  readonly width?: number;
+}): boolean {
+  if (maxRows === undefined) return true;
+  return currentRows + staticTranscriptItemRowCount(item, width) <= maxRows;
+}
 
 export function appendStaticTranscriptItems({
   activeStreamId,
   currentItems,
   streams,
   meta,
+  maxRows,
+  width,
 }: {
   readonly activeStreamId: string | undefined;
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly meta: SessionMeta;
+  readonly maxRows?: number;
+  readonly width?: number;
 }): readonly StaticTranscriptItem[] {
   const seen = new Set(currentItems.map((item) => item.id));
   const nextItems: StaticTranscriptItem[] = [...currentItems];
+  let currentRows = nextItems.reduce(
+    (total, item) => total + staticTranscriptItemRowCount(item, width),
+    0,
+  );
   if (!seen.has(SESSION_HEADER_ID)) {
-    nextItems.push({ id: SESSION_HEADER_ID, kind: 'header', meta });
-    seen.add(SESSION_HEADER_ID);
+    const header: StaticTranscriptItem = {
+      id: SESSION_HEADER_ID,
+      kind: 'header',
+      compact: maxRows !== undefined && maxRows < FULL_SESSION_HEADER_ROWS,
+      meta,
+    };
+    if (
+      maxRows === undefined ||
+      canAppendStaticTranscriptItem({
+        currentRows,
+        item: header,
+        maxRows,
+        width,
+      })
+    ) {
+      nextItems.push(header);
+      currentRows += staticTranscriptItemRowCount(header, width);
+      seen.add(SESSION_HEADER_ID);
+    }
   }
 
   // Only the active stream feeds the shared `<Static>` scrollback. Dumping
@@ -119,7 +195,19 @@ export function appendStaticTranscriptItems({
   for (const entry of slice?.entries ?? []) {
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
-    nextItems.push({ id: entry.id, kind: 'entry', entry });
+    const item: StaticTranscriptItem = { id: entry.id, kind: 'entry', entry };
+    if (
+      !canAppendStaticTranscriptItem({
+        currentRows,
+        item,
+        maxRows,
+        width,
+      })
+    ) {
+      break;
+    }
+    nextItems.push(item);
+    currentRows += staticTranscriptItemRowCount(item, width);
     seen.add(entry.id);
   }
   // Same reference when nothing was appended so the `setItems` functional
@@ -128,8 +216,10 @@ export function appendStaticTranscriptItems({
 }
 
 export function StaticConversationTranscript({
+  maxRows,
   width,
 }: {
+  readonly maxRows?: number;
   readonly width?: number;
 }): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
@@ -149,16 +239,22 @@ export function StaticConversationTranscript({
         currentItems: isHardReset ? [] : currentItems,
         streams,
         meta: sessionMeta,
+        maxRows,
+        width,
       }),
     );
-  }, [activeStreamId, streams, sessionMeta]);
+  }, [activeStreamId, maxRows, streams, sessionMeta, width]);
 
   return (
     <Static items={[...items]}>
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
           {item.kind === 'header' ? (
-            <SessionHeaderBlock meta={item.meta} width={width} />
+            <SessionHeaderBlock
+              compact={item.compact}
+              meta={item.meta}
+              width={width}
+            />
           ) : (
             <TranscriptEntry entry={item.entry} width={width} />
           )}

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -281,20 +281,15 @@ export function streamTabsDisplayItems(init: {
   return collapseMiddle(items, init.width);
 }
 
-export function StreamTabsStrip(props: {
+function StreamTabsStripView(props: {
+  readonly items: readonly StreamTabDisplayItem[];
   readonly width: number;
 }): React.JSX.Element | null {
-  const activeStreamId = useSignal(cliState.activeStreamId);
-  const streams = useSignal(cliState.streams);
-  const parentStream = useSignal(cliState.parentStream);
-  const items = streamTabsDisplayItems({
-    activeStreamId,
-    streams,
-    parentStream,
-    width: props.width,
-  });
-  if (items.length === 0) return null;
-  const segments = streamTabsLineSegments(items, Math.max(0, props.width - 2));
+  if (props.items.length === 0) return null;
+  const segments = streamTabsLineSegments(
+    props.items,
+    Math.max(0, props.width - 2),
+  );
 
   return (
     <Box
@@ -324,4 +319,29 @@ export function StreamTabsStrip(props: {
       ))}
     </Box>
   );
+}
+
+function StreamTabsStripFromState(props: {
+  readonly width: number;
+}): React.JSX.Element | null {
+  const activeStreamId = useSignal(cliState.activeStreamId);
+  const streams = useSignal(cliState.streams);
+  const parentStream = useSignal(cliState.parentStream);
+  const items = streamTabsDisplayItems({
+    activeStreamId,
+    streams,
+    parentStream,
+    width: props.width,
+  });
+  return <StreamTabsStripView items={items} width={props.width} />;
+}
+
+export function StreamTabsStrip(props: {
+  readonly items?: readonly StreamTabDisplayItem[];
+  readonly width: number;
+}): React.JSX.Element | null {
+  if (props.items !== undefined) {
+    return <StreamTabsStripView items={props.items} width={props.width} />;
+  }
+  return <StreamTabsStripFromState width={props.width} />;
 }

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -292,6 +292,71 @@ describe('CLI conversation transcript splitting', () => {
     expect(again).toHaveLength(1);
   });
 
+  it('caps static transcript rows for short terminal layouts', () => {
+    const user = entry('u1', 'user', 'What is a tensor network?', true);
+    const assistant = entry('a1', 'assistant', 'A decomposition.', true);
+
+    const compact = appendStaticTranscriptItems({
+      activeStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [user, assistant]),
+      meta: SESSION_META,
+      maxRows: 2,
+      width: 80,
+    });
+
+    expect(compact).toHaveLength(2);
+    expect(compact[0]).toMatchObject({
+      id: 'session-header',
+      kind: 'header',
+      compact: true,
+    });
+    expect(compact[1]?.id).toBe('u1');
+
+    expect(
+      appendStaticTranscriptItems({
+        activeStreamId: STREAM_ID,
+        currentItems: [],
+        streams: streamsFromEntries(STREAM_ID, [user, assistant]),
+        meta: SESSION_META,
+        maxRows: 0,
+        width: 80,
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves static transcript order when one entry does not fit', () => {
+    const first = entry('u1', 'user', 'first', true);
+    const large = entry('a1', 'assistant', 'line 1\nline 2\nline 3', true);
+    const later = entry('u2', 'user', 'later', true);
+
+    const compact = appendStaticTranscriptItems({
+      activeStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [first, large, later]),
+      meta: SESSION_META,
+      maxRows: 2,
+      width: 80,
+    });
+
+    expect(compact.map((item) => item.id)).toEqual(['session-header', 'u1']);
+
+    const expanded = appendStaticTranscriptItems({
+      activeStreamId: STREAM_ID,
+      currentItems: compact,
+      streams: streamsFromEntries(STREAM_ID, [first, large, later]),
+      meta: SESSION_META,
+      width: 80,
+    });
+
+    expect(expanded.map((item) => item.id)).toEqual([
+      'session-header',
+      'u1',
+      'a1',
+      'u2',
+    ]);
+  });
+
   it('labels preset-launched sessions with team and root identity', () => {
     expect(
       sessionHeaderIdentityLine({

--- a/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
+++ b/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
@@ -46,6 +46,17 @@ describe('CLI queued follow-up panel display model', () => {
     expect(display.hiddenCount).toBe(2);
   });
 
+  it('uses an overflow row when only one message slot fits', () => {
+    const display = queuedFollowUpPanelDisplay({
+      messages: ['first', 'second'],
+      maxRows: 2,
+      width: 80,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual(['… 2 more queued']);
+    expect(display.hiddenCount).toBe(2);
+  });
+
   it('keeps hidden count nonnegative when callers pass extra rows', () => {
     const display = queuedFollowUpPanelDisplay({
       messages: ['only queued follow-up'],

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -28,6 +28,7 @@ import {
   foregroundSurfaceJustifyContent,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
+  staticTranscriptRowBudget,
 } from '@cli/chat/tui/App';
 import {
   nextFocusBack,
@@ -391,6 +392,75 @@ describe('CLI TUI row allocation', () => {
 
     expect(layout.transcriptRows).toBe(15);
     expect(layout.foregroundRows).toBe(0);
+  });
+
+  it('accounts for capped static transcript rows above the stable input chrome', () => {
+    const layout = allocateMiddleRows({
+      foregroundOpen: false,
+      queuedFollowUpPanelRows: 3,
+      reverseSearchOpen: false,
+      rows: 10,
+      slashPaletteOpen: false,
+      staticTranscriptRows: 2,
+      tipVisible: false,
+    });
+
+    expect(layout.transcriptRows).toBe(0);
+    expect(layout.foregroundRows).toBe(0);
+  });
+
+  it('caps static transcript rows only in compact layouts', () => {
+    expect(
+      staticTranscriptRowBudget({
+        footerRows: 5,
+        foregroundOpen: false,
+        queuedFollowUpPanelRows: 3,
+        rows: 10,
+        tipVisible: false,
+      }),
+    ).toBe(0);
+    expect(
+      staticTranscriptRowBudget({
+        footerRows: 5,
+        foregroundOpen: false,
+        queuedFollowUpPanelRows: 3,
+        rows: 14,
+        tipVisible: false,
+      }),
+    ).toBe(4);
+    expect(
+      staticTranscriptRowBudget({
+        footerRows: 5,
+        foregroundOpen: false,
+        queuedFollowUpPanelRows: 3,
+        rows: 24,
+        tipVisible: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps the compact live reserve aligned with stream tab visibility', () => {
+    const staticRows = staticTranscriptRowBudget({
+      footerRows: 5,
+      foregroundOpen: false,
+      queuedFollowUpPanelRows: 3,
+      rows: 14,
+      tipVisible: false,
+    });
+
+    expect(staticRows).toBe(4);
+    expect(
+      allocateMiddleRows({
+        foregroundOpen: false,
+        queuedFollowUpPanelRows: 3,
+        reverseSearchOpen: false,
+        rows: 14,
+        slashPaletteOpen: false,
+        staticTranscriptRows: staticRows,
+        streamTabsVisible: false,
+        tipVisible: false,
+      }).transcriptRows,
+    ).toBe(2);
   });
 
   it('reserves rows for reverse-search input chrome', () => {


### PR DESCRIPTION
## Summary

- Budget static transcript rows alongside the live TUI chrome so short terminals keep the input and status visible.
- Cap queued follow-up panel rows to the remaining footer-safe viewport while preserving queued counts/overflow display.
- Add a compact queued-followups TUI harness scenario that verifies the 60x8 frame keeps queued messages, input, status, and stop shortcut visible.

Fixes #4920

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui queued-followups compact-queued-followups --snapshot-dir /tmp/texra-4920-after-scenarios`
- manual PTY capture at 80x10 and 60x8 in `/tmp/texra-4920-after-manual`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `git diff --check`
- `npm run lint` (passes with 11 existing import-order warnings)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal layout and scrollback budgeting only; no auth, networking, or persistence changes.
> 
> **Overview**
> Short terminals now **budget vertical space** so queued follow-ups, input, status, and stream tabs stay visible instead of being pushed off-screen.
> 
> **`App`** caps the queued follow-up panel to rows left after the footer chrome, hides the idle tip when follow-ups are queued (even if the panel is truncated), and applies a **compact static transcript budget** on layouts ≤14 rows—reserving live transcript rows and folding static scrollback into row allocation. Stream tab items are computed once and passed into **`StreamTabsStrip`**, which can render from props or internal state.
> 
> **`StaticConversationTranscript`** honors `maxRows` with row counting, a one-line compact session header when space is tight, and stops appending entries that would overflow the budget.
> 
> Adds a **60×8 TUI harness** scenario and unit tests for compact queued follow-ups, static transcript caps, and row allocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01005e4c5834f8e1750772e79183c44036361a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->