### PR TITLE
fix(cli): explain empty model list

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -39,6 +39,25 @@ export function listableModelAccessEntries(
   return models.filter(({ available }) => available);
 }
 
+export function formatNoListableModelsMessage(
+  apiMode: CliContext['apiMode'],
+  options: { readonly includeUnavailable?: boolean } = {},
+): string {
+  const accessHint =
+    apiMode === 'personal'
+      ? 'Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.'
+      : apiMode === 'included'
+        ? 'Run `texra login`, or retry with `--api-mode personal` after configuring a provider API key.'
+        : 'Run `texra login` for included relay access, retry with `--api-mode included`, or configure a provider API key.';
+  const statusHint =
+    options.includeUnavailable === true
+      ? 'No model records were returned for this installation.'
+      : 'Run `texra models list --all` to see unavailable models and access status.';
+  return ['No models are currently available.', statusHint, accessHint].join(
+    '\n',
+  );
+}
+
 async function loadModelAccessList(
   context: CliContext,
 ): Promise<ModelAccessList | { error: string }> {
@@ -63,6 +82,9 @@ async function listModels(
   }
 
   const listedModels = listableModelAccessEntries(result, options);
+  if (context.outputFormat === 'text' && listedModels.length === 0) {
+    writeTextStderr(formatNoListableModelsMessage(context.apiMode, options));
+  }
   emitCliResult(context, {
     json: listedModels.map(({ model }) => cliModelRecord(model)),
     ndjson: listedModels.map(({ model }) => ({

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   cliModelRecord,
+  formatNoListableModelsMessage,
   listableModelAccessEntries,
 } from '@cli/commands/models';
 import type { CliModelAccess } from '@cli/runtime/modelAccess';
@@ -102,5 +103,44 @@ describe('CLI model list filtering', () => {
         (entry) => entry.model.value,
       ),
     ).toEqual(['sonnet46T', 'opus48T']);
+  });
+});
+
+describe('CLI model list empty-state text', () => {
+  it('points personal-key users at included access and model status diagnostics', () => {
+    expect(formatNoListableModelsMessage('personal')).toBe(
+      [
+        'No models are currently available.',
+        'Run `texra models list --all` to see unavailable models and access status.',
+        'Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
+      ].join('\n'),
+    );
+  });
+
+  it('points included-mode users at login or personal API key setup', () => {
+    expect(formatNoListableModelsMessage('included')).toContain(
+      'Run `texra login`, or retry with `--api-mode personal` after configuring a provider API key.',
+    );
+  });
+
+  it('uses a combined hint when no API mode was explicitly selected', () => {
+    expect(formatNoListableModelsMessage(undefined)).toBe(
+      [
+        'No models are currently available.',
+        'Run `texra models list --all` to see unavailable models and access status.',
+        'Run `texra login` for included relay access, retry with `--api-mode included`, or configure a provider API key.',
+      ].join('\n'),
+    );
+  });
+
+  it('does not suggest --all when unavailable models were already requested', () => {
+    const text = formatNoListableModelsMessage('personal', {
+      includeUnavailable: true,
+    });
+
+    expect(text).toContain(
+      'No model records were returned for this installation.',
+    );
+    expect(text).not.toContain('models list --all');
   });
 });


### PR DESCRIPTION
## Summary

- Print a short text-mode diagnostic when `texra models list` has no runnable models.
- Keep stdout empty for the default table output and keep JSON output as `[]` for scripts/completions.
- Cover the no-models message for personal and included API modes.

Fixes #4923

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelsRecord.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- Clean-HOME text command verification: `texra models list --api-mode personal` exits 0 with empty stdout and the new stderr guidance.
- Clean-HOME JSON command verification: `texra models list --api-mode personal --output-format json` exits 0 with stdout `[]` and empty stderr.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and tests only; no auth, data, or model-selection logic changes beyond when stderr text is printed.
> 
> **Overview**
> When **`texra models list`** finds no runnable models in **text** mode, the CLI now prints a short **stderr** diagnostic instead of leaving users with a blank table. **Stdout** stays empty for the default table; **JSON/NDJSON** still emit **`[]`** so scripts and completions behave the same.
> 
> A new **`formatNoListableModelsMessage`** helper tailors next steps to **`--api-mode`** (`personal`, `included`, or unset) and whether **`--all`** was used—e.g. suggesting **`texra models list --all`**, **`texra login`**, or switching API modes—without duplicating the **`--all`** hint when unavailable models were already requested.
> 
> Unit tests cover the message variants in **`ModelsRecord.vitest.mts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c602c0c83a1f6559f906c98419f27d70bd6e3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->