### PR TITLE
fix(cli): compact slash forms before clipping

### DIFF
--- a/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
@@ -8,7 +8,7 @@ export interface SelectWindowSize {
   readonly showOverflow: boolean;
 }
 
-export const COMPACT_FORM_MAX_ROWS = 8;
+export const COMPACT_FORM_MAX_ROWS = 9;
 
 export function isCompactFormRows(availableRows: number | undefined): boolean {
   return availableRows !== undefined && availableRows <= COMPACT_FORM_MAX_ROWS;

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -310,9 +310,9 @@ describe('CLI Select disabled-row focus', () => {
 
 describe('CLI ModelListForm row budget', () => {
   it('uses compact slash forms before bordered content clips titles', () => {
-    expect(COMPACT_FORM_MAX_ROWS).toBe(8);
-    expect(isCompactFormRows(8)).toBe(true);
-    expect(isCompactFormRows(9)).toBe(false);
+    expect(COMPACT_FORM_MAX_ROWS).toBe(9);
+    expect(isCompactFormRows(9)).toBe(true);
+    expect(isCompactFormRows(10)).toBe(false);
   });
 
   it('removes the row floor on short terminals', () => {


### PR DESCRIPTION
Fixes #4928.

## Summary
- Treat 9-row slash-form foregrounds as compact so `/api` and `/model` use the compact frame before Ink clips the title row.
- Update the row-budget unit expectation for the compact threshold.

## Validation
- `env -i PATH="$PATH" HOME=/tmp/texra-compact-forms-home TERM=xterm-256color FORCE_COLOR=0 OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-compact-forms-after compact-model-form compact-api-form`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-compact-forms-wide-check agent-form-80-cols compact-agent-form compact-tools-form compact-model-form compact-api-form`
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/SlashPalette.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/forms/_shared/selectWindow.ts src/test-kernel/cli/ModelListForm.vitest.mts`
- `git diff --check`
