### PR TITLE
fix(cli): warn multi-agent when approvals unavailable

### DIFF
--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -1,0 +1,27 @@
+export type ApprovalInstructionContext = {
+  readonly approvalPolicy: 'ask' | 'never' | 'yolo';
+  readonly mode: 'headless' | 'interactive';
+};
+
+const PRIVILEGED_ACTION_GUIDANCE =
+  'Do not call approval-gated tools such as bash/shell commands, file edits, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
+
+export function formatUnavailableApprovalInstruction(
+  context: ApprovalInstructionContext,
+): string | undefined {
+  if (context.approvalPolicy === 'never') {
+    return [
+      'Approval policy for this run is "never": privileged actions that require approval will be rejected automatically.',
+      PRIVILEGED_ACTION_GUIDANCE,
+    ].join(' ');
+  }
+
+  if (context.mode === 'headless' && context.approvalPolicy === 'ask') {
+    return [
+      'This is a headless run with approval policy "ask": approval prompts cannot be answered, so privileged actions that require approval will be rejected automatically.',
+      PRIVILEGED_ACTION_GUIDANCE,
+    ].join(' ');
+  }
+
+  return undefined;
+}

--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -1,0 +1,39 @@
+import {
+  formatUnavailableApprovalInstruction,
+  type ApprovalInstructionContext,
+} from './approvalPolicyInstruction';
+
+interface MultiAgentInstructionPreset {
+  readonly name: string;
+  readonly description: string;
+}
+
+export function formatMultiAgentRunInstruction(
+  preset: MultiAgentInstructionPreset,
+  init: {
+    readonly inputFiles: readonly string[];
+    readonly instruction: string;
+    readonly approvalContext: ApprovalInstructionContext;
+  },
+): string {
+  const parts = [
+    `Run the "${preset.name}" multi-agent team preset.`,
+    preset.description,
+    'Use the visible workflow and tool-use agents as the team available for delegation.',
+  ];
+  const approvalInstruction = formatUnavailableApprovalInstruction(
+    init.approvalContext,
+  );
+  if (approvalInstruction) parts.push(approvalInstruction);
+
+  const instruction = init.instruction.trim();
+  if (instruction) {
+    parts.push(
+      init.inputFiles.length > 0
+        ? 'Additional user instruction:'
+        : 'User instruction:',
+      instruction,
+    );
+  }
+  return parts.join('\n\n');
+}

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -24,7 +24,6 @@ import {
   planCliMultiAgentPresetRun,
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
-  type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
@@ -34,6 +33,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from './_helpers/modelArg';
+import { formatMultiAgentRunInstruction } from './_helpers/multiAgentInstruction';
 import { emitCliResult } from './_helpers/output';
 import {
   GLOBAL_ARGS,
@@ -114,27 +114,6 @@ export function writeMissingPresetAgents(
   writeTextStderr(
     `WARN preset ${plan.preset.id} references unavailable agents: ${missing.join(', ')}`,
   );
-}
-
-function formatMultiAgentRunInstruction(
-  preset: CliMultiAgentPreset,
-  init: Pick<MultiAgentRunInit, 'inputFiles' | 'instruction'>,
-): string {
-  const parts = [
-    `Run the "${preset.name}" multi-agent team preset.`,
-    preset.description,
-    'Use the visible workflow and tool-use agents as the team available for delegation.',
-  ];
-  const instruction = init.instruction.trim();
-  if (instruction) {
-    parts.push(
-      init.inputFiles.length > 0
-        ? 'Additional user instruction:'
-        : 'User instruction:',
-      instruction,
-    );
-  }
-  return parts.join('\n\n');
 }
 
 function writeMultiAgentRunResult(
@@ -231,6 +210,7 @@ export async function runMultiAgentPreset(
     instruction: formatMultiAgentRunInstruction(plan.preset, {
       inputFiles,
       instruction: init.instruction,
+      approvalContext: runContext,
     }),
     workingDirectory: runContext.cwd,
     agentCategory: AgentCategory.ToolUse,

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatUnavailableApprovalInstruction } from '@cli/commands/_helpers/approvalPolicyInstruction';
+import { formatMultiAgentRunInstruction } from '@cli/commands/_helpers/multiAgentInstruction';
+
+const preset = {
+  id: 'mathematician',
+  name: 'Mathematician',
+  description: 'Coordinate proof-oriented agents.',
+  workflowAgents: ['polish'],
+  toolUseAgents: ['team'],
+  source: 'built-in',
+};
+
+describe('formatUnavailableApprovalInstruction', () => {
+  it('describes never as an automatic approval rejection', () => {
+    for (const mode of ['headless', 'interactive'] as const) {
+      const instruction = formatUnavailableApprovalInstruction({
+        mode,
+        approvalPolicy: 'never',
+      });
+
+      expect(instruction).toContain('Approval policy for this run is "never"');
+      expect(instruction).toContain('will be rejected automatically');
+    }
+  });
+
+  it('warns headless ask runs that approval prompts cannot be answered', () => {
+    const instruction = formatUnavailableApprovalInstruction({
+      mode: 'headless',
+      approvalPolicy: 'ask',
+    });
+
+    expect(instruction).toContain('headless run with approval policy "ask"');
+    expect(instruction).toContain('approval prompts cannot be answered');
+  });
+
+  it('does not warn for interactive ask because prompts are available', () => {
+    const instruction = formatUnavailableApprovalInstruction({
+      mode: 'interactive',
+      approvalPolicy: 'ask',
+    });
+
+    expect(instruction).toBeUndefined();
+  });
+
+  it('does not warn for yolo because approvals are automatic', () => {
+    for (const mode of ['headless', 'interactive'] as const) {
+      const instruction = formatUnavailableApprovalInstruction({
+        mode,
+        approvalPolicy: 'yolo',
+      });
+
+      expect(instruction).toBeUndefined();
+    }
+  });
+});
+
+describe('formatMultiAgentRunInstruction', () => {
+  it('warns the orchestrator when approval policy never denies tools', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: ['problem.md'],
+      instruction: 'Solve the problem.',
+      approvalContext: { mode: 'headless', approvalPolicy: 'never' },
+    });
+
+    expect(instruction).toContain('Approval policy for this run is "never"');
+    expect(instruction).toContain('will be rejected automatically');
+    expect(instruction).toContain('Do not call approval-gated tools');
+    expect(instruction).toContain('Additional user instruction:');
+  });
+
+  it('warns headless ask runs that approval prompts cannot be answered', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: [],
+      instruction: 'Solve the problem.',
+      approvalContext: { mode: 'headless', approvalPolicy: 'ask' },
+    });
+
+    expect(instruction).toContain('headless run with approval policy "ask"');
+    expect(instruction).toContain('approval prompts cannot be answered');
+    expect(instruction).toContain('User instruction:');
+  });
+
+  it('does not add approval warnings when yolo can auto-approve', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: ['problem.md'],
+      instruction: '',
+      approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+    });
+
+    expect(instruction).not.toContain('approval prompts cannot be answered');
+    expect(instruction).not.toContain('Do not call approval-gated tools');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a reusable CLI approval-constraint instruction for runs where approvals are unavailable.
- Include that constraint in `multi-agent run` orchestrator prompts for `approval-policy=never` and headless `ask`.
- Cover the approval helper and multi-agent instruction wording with focused kernel tests.

Fixes #4930

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts packages/cli/src/commands/_helpers/multiAgentInstruction.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with 11 existing import-order warnings)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only CLI changes with no auth or execution-path logic; behavior is limited to instruction text for specific approval/mode combinations.
> 
> **Overview**
> Adds reusable CLI text that tells agents when **approval-gated tools cannot succeed**, and folds that into **`multi-agent run`** orchestrator prompts.
> 
> A new `formatUnavailableApprovalInstruction` helper emits guidance for **`approval-policy=never`** (any mode) and **headless `ask`** (prompts cannot be answered), including a line to avoid bash, edits, plan/retry approvals, and extra delegations. `formatMultiAgentRunInstruction` is moved out of `multiAgent.ts`, takes `approvalContext` from the headless run context, and appends the warning when applicable. **Interactive `ask`** and **`yolo`** stay unchanged (no extra paragraph). Kernel tests cover the helper and composed instruction wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc364be61cbacae1d2bc8c8bfa879ed0d39d032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->