### PR TITLE
fix(cli): remind multi-agent runs to check domains

### DIFF
--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -8,6 +8,9 @@ interface MultiAgentInstructionPreset {
   readonly description: string;
 }
 
+const COMPLETENESS_GUIDANCE =
+  'Before claiming a result is complete, check the full domain stated by the user, including sign choices, zero and boundary cases, and symmetry branches.';
+
 export function formatMultiAgentRunInstruction(
   preset: MultiAgentInstructionPreset,
   init: {
@@ -20,6 +23,7 @@ export function formatMultiAgentRunInstruction(
     `Run the "${preset.name}" multi-agent team preset.`,
     preset.description,
     'Use the visible workflow and tool-use agents as the team available for delegation.',
+    COMPLETENESS_GUIDANCE,
   ];
   const approvalInstruction = formatUnavailableApprovalInstruction(
     init.approvalContext,

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -57,6 +57,25 @@ describe('formatUnavailableApprovalInstruction', () => {
 });
 
 describe('formatMultiAgentRunInstruction', () => {
+  it('reminds the orchestrator to check domain edge cases before claiming completeness', () => {
+    for (const mode of ['headless', 'interactive'] as const) {
+      for (const approvalPolicy of ['never', 'ask', 'yolo'] as const) {
+        const instruction = formatMultiAgentRunInstruction(preset, {
+          inputFiles: [],
+          instruction: 'Solve x^2 - 2y^2 = 1 for integer x and 0 < y < 20.',
+          approvalContext: { mode, approvalPolicy },
+        });
+
+        expect(instruction).toContain(
+          'check the full domain stated by the user',
+        );
+        expect(instruction).toContain('sign choices');
+        expect(instruction).toContain('zero and boundary cases');
+        expect(instruction).toContain('symmetry branches');
+      }
+    }
+  });
+
   it('warns the orchestrator when approval policy never denies tools', () => {
     const instruction = formatMultiAgentRunInstruction(preset, {
       inputFiles: ['problem.md'],


### PR DESCRIPTION
## Summary

- Add a short completeness reminder to generated `multi-agent run` orchestrator instructions.
- Steer team roots to check the user's full stated domain, including signs, zero/boundary cases, and symmetry branches before claiming completeness.
- Cover the reminder in the existing multi-agent instruction helper tests.

Fixes #4935

## Dogfood evidence

Baseline command on `origin/main` omitted the negative-`x` Pell solutions:

```sh
node packages/cli/dist/bin/texra.js multi-agent run mathematician \
  --approval-policy never \
  --instruction "Solve x^2 - 2y^2 = 1 for integer x and 0 < y < 20. List every solution and explain why complete." \
  --output-format json
```

After this prompt reminder, the same real CLI command returned all four solutions `(-17, 12)`, `(-3, 2)`, `(3, 2)`, `(17, 12)` and explicitly checked the negative-`x` branch.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/commands/_helpers/multiAgentInstruction.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli bundle`
- real CLI rerun of the Pell prompt above
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with 11 existing import-order warnings)
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to CLI orchestration text with no auth, data, or execution-path changes.
> 
> **Overview**
> Adds a fixed **completeness reminder** to every orchestrator prompt built by `formatMultiAgentRunInstruction` for `multi-agent run`, so team roots are told to verify the user’s full stated domain (signs, zero/boundary cases, symmetry) before claiming a solution is complete.
> 
> A new Vitest case asserts that reminder appears across headless/interactive modes and all approval policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb4a07803013c40a6da3c481b9a905f305b0607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->