### PR TITLE
fix(cli): preserve slash command labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -203,6 +203,27 @@ const SCENARIOS = [
     expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
   },
   {
+    name: 'narrow-slash-palette-command-names',
+    rows: 16,
+    cols: 52,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/'],
+    frame: 'tail',
+    expect: [
+      '/api',
+      'Switch between included relay',
+      '/yolo',
+      'Approve privileged actions',
+    ],
+    unexpect: [
+      '/ap  Switch',
+      '/yol  Approve',
+      'personal API keys',
+      'automatically',
+    ],
+    maxLineColumns: 52,
+  },
+  {
     name: 'slash-palette-ctrl-u-clears-raw-control',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/', `${NAK}/model\r`],

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -23,6 +23,8 @@ export interface SlashPaletteProps {
 const MAX_VISIBLE_COMMANDS = 8;
 export const SLASH_PALETTE_ROWS = 13;
 
+const COMMAND_DESCRIPTION_GAP = 2;
+
 export interface SlashPaletteWindow {
   readonly start: number;
   readonly end: number;
@@ -111,6 +113,16 @@ export function slashPaletteEnterHintAction(
   return slashPickIntent(command, 'enter') === 'submit' ? 'run' : 'complete';
 }
 
+export function slashPaletteCommandLabelWidth(
+  commands: readonly SlashCommand[],
+): number {
+  return commands.reduce(
+    (width, command) =>
+      Math.max(width, `  /${command.name}`.length + COMMAND_DESCRIPTION_GAP),
+    0,
+  );
+}
+
 export function SlashPalette(
   props: SlashPaletteProps,
 ): React.JSX.Element | null {
@@ -176,6 +188,7 @@ export function SlashPalette(
   const window = slashPaletteWindow({ highlight, itemCount: matchCount });
   const visible = matches.slice(window.start, window.end);
   const highlightedCommand = matches[highlight];
+  const commandLabelWidth = slashPaletteCommandLabelWidth(visible);
 
   return (
     <Box
@@ -190,11 +203,17 @@ export function SlashPalette(
       {visible.map((cmd, offset) => {
         const i = window.start + offset;
         return (
-          <Box key={cmd.name}>
-            <Text color={i === highlight ? 'cyan' : undefined}>
-              {i === highlight ? '›' : ' '} /{cmd.name}
-            </Text>
-            <Text dimColor>{`  ${cmd.description}`}</Text>
+          <Box key={cmd.name} flexDirection="row">
+            <Box flexShrink={0} width={commandLabelWidth}>
+              <Text color={i === highlight ? 'cyan' : undefined}>
+                {i === highlight ? '›' : ' '} /{cmd.name}
+              </Text>
+            </Box>
+            <Box flexShrink={1}>
+              <Text dimColor wrap="truncate-end">
+                {cmd.description}
+              </Text>
+            </Box>
           </Box>
         );
       })}

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   nextSlashPaletteHighlight,
+  slashPaletteCommandLabelWidth,
   slashPaletteEnterHintAction,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
@@ -81,5 +82,14 @@ describe('SlashPalette navigation', () => {
         formComponent: () => null,
       }),
     ).toBe('open');
+  });
+
+  it('reserves enough row width for full slash command names', () => {
+    expect(
+      slashPaletteCommandLabelWidth([
+        { name: 'api', description: 'Switch API mode' },
+        { name: 'yolo', description: 'Approve automatically' },
+      ]),
+    ).toBe('  /yolo  '.length);
   });
 });


### PR DESCRIPTION
Fixes #4937.

## Summary

- reserve a non-shrinking command-label column in the slash palette
- truncate narrow descriptions instead of clipping command names or growing the palette height
- add a 52-column TUI harness regression for `/api` and `/yolo`

## Evidence

Dogfood repro on current `origin/main` showed `/api` rendered as `/ap` and `/yolo` rendered as `/yol` at 52 columns.

After the final fix, the captured harness frame at `/tmp/texra-slash-palette-review-fix/02-narrow-slash-palette-command-names.txt` shows:

```text
│   /api       Switch between included relay and … │
│   /yolo      Approve privileged actions automat… │
```

The command labels stay complete and descriptions stay single-row, preserving the fixed `SLASH_PALETTE_ROWS` reservation.

## Validation

```sh
corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashPalette.vitest.mts
corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-slash-palette-review-fix narrow-slash-palette-command-names slash-palette slash-palette-overflow
corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-slash-palette-full
corepack pnpm --filter @texra-ai/cli typecheck
corepack pnpm exec prettier --check packages/cli/src/chat/tui/commands/SlashPalette.tsx src/test-kernel/cli/SlashPalette.vitest.mts packages/cli/scripts/validate-tui.mjs
git diff --check
```

Full TUI result: all 78 scenarios passed.
