### PR TITLE
fix(cli): add tui validator help

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1355,6 +1355,23 @@ const SCENARIOS = [
   },
 ];
 
+function formatUsage() {
+  return [
+    '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [scenario ...]',
+    '',
+    'Options:',
+    '  --snapshot-dir DIR  Write per-scenario .txt frames and an index.html report',
+    '  -h, --help          Show this help',
+    '',
+    'Available scenarios:',
+    `  ${SCENARIOS.map((s) => s.name).join('\n  ')}`,
+  ].join('\n');
+}
+
+function printUsage(stream = console.log) {
+  stream(formatUsage());
+}
+
 function parseArgs(argv) {
   const scenarios = [];
   let snapshotDir;
@@ -1363,11 +1380,15 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (!endOfOptions && arg === '--') {
       // pnpm forwards a leading separator to scripts (`pnpm run x -- --flag`).
-      // Treat only that package-manager separator as transparent; later `--`
-      // still follows normal end-of-options behavior.
-      if (index === 0 && argv[1]?.startsWith('--snapshot-dir')) continue;
+      // Treat that package-manager separator as transparent when it precedes a
+      // script option; later `--` still follows normal end-of-options behavior.
+      if (index === 0 && argv[1]?.startsWith('-')) continue;
       endOfOptions = true;
       continue;
+    }
+    if (!endOfOptions && (arg === '--help' || arg === '-h')) {
+      printUsage();
+      process.exit(0);
     }
     if (!endOfOptions && arg === '--snapshot-dir') {
       const value = argv[index + 1];
@@ -1390,9 +1411,7 @@ function parseArgs(argv) {
     }
     if (!endOfOptions && arg?.startsWith('--')) {
       console.error(`[validate-tui] unknown option: ${arg}`);
-      console.error(
-        '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [scenario ...]',
-      );
+      printUsage(console.error);
       process.exit(1);
     }
     scenarios.push(arg);

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -1,0 +1,38 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const VALIDATOR = path.join(
+  process.cwd(),
+  'packages/cli/scripts/validate-tui.mjs',
+);
+
+function runValidator(args: string[]) {
+  return spawnSync(process.execPath, [VALIDATOR, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+describe('TUI validator args', () => {
+  it('prints help without building the harness', () => {
+    const result = runValidator(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[validate-tui] usage:');
+    expect(result.stdout).toContain('--snapshot-dir DIR');
+    expect(result.stdout).toContain('Available scenarios:');
+    expect(result.stdout).toContain('nested-subagent-picker');
+    expect(result.stderr).not.toContain('building tui-harness bundle');
+  });
+
+  it('treats a leading package-manager separator as transparent for help', () => {
+    const result = runValidator(['--', '--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[validate-tui] usage:');
+    expect(result.stdout).toContain('Available scenarios:');
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Add real `-h` / `--help` output to the TUI validator.
- Treat the leading package-manager `--` separator as transparent for script options such as `--help`.
- Cover both direct and forwarded help forms with a subprocess test that verifies help exits before the harness build.

Fixes #4941.

## Dogfood Notes

- Re-ran nested subagent/sub-workflow snapshot scenarios with `--snapshot-dir`.
- Confirmed the generated `index.html` report can be rendered to `/tmp/texra-tui-report-scout.png` via local Chrome headless when the in-app browser backend is unavailable.

## Validation

- `node packages/cli/scripts/validate-tui.mjs --help`
- `node packages/cli/scripts/validate-tui.mjs -- --help`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --help`
- `corepack pnpm exec prettier --write packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-report-help-check nested-subagent-picker`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings outside this change)
- `npm run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only CLI validator argument parsing and tests; no runtime product or security paths.
> 
> **Overview**
> Adds **`-h` / `--help`** to `validate-tui.mjs` with shared usage text (options plus the full scenario list) and exits **before** the harness bundle build. Unknown flags now print the same usage on stderr.
> 
> **Leading `--`** from package managers (e.g. `pnpm validate:tui -- --help`) is skipped when the next token is any script option starting with `-`, not only `--snapshot-dir`.
> 
> New **`TuiValidatorArgs.vitest.mts`** subprocess checks that help succeeds without the “building tui-harness bundle” log and that `-- --help` works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e091b7806e1daabc68567377b2f93fbd0da1ce6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->