### PR TITLE
fix(cli): anchor task detail manual scroll

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -433,9 +433,21 @@ export function compactPickerOverflowText({
 }
 
 export interface TaskDetailScrollState {
+  readonly anchor?: TaskDetailScrollAnchor;
   readonly executionId: string;
   readonly followsTail: boolean;
   readonly offset: number;
+}
+
+export interface TaskDetailScrollAnchor {
+  readonly lineIndex: number;
+  readonly wrappedRowOffset: number;
+}
+
+export interface TaskDetailScrollContext {
+  readonly availableColumns?: number;
+  readonly compact: boolean;
+  readonly tailLines: readonly string[];
 }
 
 export function taskDetailCommandLabel(kind: ChildControlItem['kind']): string {
@@ -486,18 +498,117 @@ export function taskDetailInitialScrollOffset(
   return Math.max(0, tailLineCount - Math.max(0, visibleLineCount));
 }
 
+function taskDetailLineRowCount(
+  context: TaskDetailScrollContext,
+  lineIndex: number,
+): number {
+  if (!context.compact) return 1;
+  return taskDetailWrappedRowCount(
+    context.tailLines[lineIndex] ?? '',
+    taskDetailOutputColumnCount(context.availableColumns),
+  );
+}
+
+function taskDetailScrollAnchorFromOffset(
+  context: TaskDetailScrollContext,
+  offset: number,
+): TaskDetailScrollAnchor | undefined {
+  if (context.tailLines.length === 0) return undefined;
+
+  let remainingRows = Math.max(0, offset);
+  for (
+    let lineIndex = 0;
+    lineIndex < context.tailLines.length;
+    lineIndex += 1
+  ) {
+    const rowCount = taskDetailLineRowCount(context, lineIndex);
+    if (remainingRows < rowCount) {
+      return { lineIndex, wrappedRowOffset: remainingRows };
+    }
+    remainingRows -= rowCount;
+  }
+
+  const lineIndex = context.tailLines.length - 1;
+  return {
+    lineIndex,
+    wrappedRowOffset: Math.max(
+      0,
+      taskDetailLineRowCount(context, lineIndex) - 1,
+    ),
+  };
+}
+
+function taskDetailScrollOffsetFromAnchor(
+  context: TaskDetailScrollContext,
+  anchor: TaskDetailScrollAnchor,
+  maxOffset: number,
+): number {
+  if (context.tailLines.length === 0) return 0;
+
+  const lineIndex = Math.min(
+    Math.max(0, anchor.lineIndex),
+    context.tailLines.length - 1,
+  );
+  let offset = 0;
+  for (let index = 0; index < lineIndex; index += 1) {
+    offset += taskDetailLineRowCount(context, index);
+  }
+  const rowCount = taskDetailLineRowCount(context, lineIndex);
+  offset += Math.min(Math.max(0, anchor.wrappedRowOffset), rowCount - 1);
+  return Math.min(offset, maxOffset);
+}
+
+function taskDetailScrollContextKey(context: TaskDetailScrollContext): string {
+  return [
+    context.availableColumns,
+    context.compact ? 1 : 0,
+    ...context.tailLines.map((_, lineIndex) =>
+      taskDetailLineRowCount(context, lineIndex),
+    ),
+  ].join(':');
+}
+
+function taskDetailScrollStateWithAnchor(
+  state: Omit<TaskDetailScrollState, 'anchor'>,
+  anchor: TaskDetailScrollAnchor | undefined,
+): TaskDetailScrollState {
+  return anchor ? { ...state, anchor } : state;
+}
+
+function taskDetailScrollStateWithoutAnchor(
+  state: TaskDetailScrollState,
+  offset: number,
+): TaskDetailScrollState {
+  return {
+    executionId: state.executionId,
+    followsTail: state.followsTail,
+    offset,
+  };
+}
+
 export function syncTaskDetailScrollState(
   state: TaskDetailScrollState,
   executionId: string,
   maxOffset: number,
   followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
 ): TaskDetailScrollState {
   const clampedFollowOffset = Math.min(followOffset, maxOffset);
   if (state.executionId !== executionId) {
     return { executionId, followsTail: true, offset: clampedFollowOffset };
   }
   if (state.followsTail) {
-    return { ...state, offset: clampedFollowOffset };
+    return taskDetailScrollStateWithoutAnchor(state, clampedFollowOffset);
+  }
+  if (context && state.anchor) {
+    return {
+      ...state,
+      offset: taskDetailScrollOffsetFromAnchor(
+        context,
+        state.anchor,
+        maxOffset,
+      ),
+    };
   }
   return { ...state, offset: Math.min(state.offset, maxOffset) };
 }
@@ -506,8 +617,12 @@ export function taskDetailVisibleScrollOffset(
   state: TaskDetailScrollState,
   maxOffset: number,
   followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
 ): number {
   if (state.followsTail) return Math.min(followOffset, maxOffset);
+  if (context && state.anchor) {
+    return taskDetailScrollOffsetFromAnchor(context, state.anchor, maxOffset);
+  }
   return Math.min(state.offset, maxOffset);
 }
 
@@ -524,30 +639,35 @@ export function moveTaskDetailScrollState(
   maxOffset: number,
   direction: 'down' | 'up',
   followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
 ): TaskDetailScrollState {
-  const offset = taskDetailVisibleScrollOffset(state, maxOffset, followOffset);
-  if (direction === 'up') {
-    const nextOffset = Math.max(0, offset - 1);
-    return {
-      ...state,
-      followsTail: taskDetailScrollOffsetFollowsTail(
-        nextOffset,
-        maxOffset,
-        followOffset,
-      ),
+  const offset = taskDetailVisibleScrollOffset(
+    state,
+    maxOffset,
+    followOffset,
+    context,
+  );
+  const nextOffset =
+    direction === 'up'
+      ? Math.max(0, offset - 1)
+      : Math.min(maxOffset, offset + 1);
+  const followsTail = taskDetailScrollOffsetFollowsTail(
+    nextOffset,
+    maxOffset,
+    followOffset,
+  );
+  return taskDetailScrollStateWithAnchor(
+    {
+      executionId: state.executionId,
+      followsTail,
       offset: nextOffset,
-    };
-  }
-  const nextOffset = Math.min(maxOffset, offset + 1);
-  return {
-    ...state,
-    followsTail: taskDetailScrollOffsetFollowsTail(
-      nextOffset,
-      maxOffset,
-      followOffset,
-    ),
-    offset: nextOffset,
-  };
+    },
+    followsTail
+      ? undefined
+      : context
+        ? taskDetailScrollAnchorFromOffset(context, nextOffset)
+        : state.anchor,
+  );
 }
 
 export function computePickerListLayout({
@@ -680,6 +800,12 @@ function TaskDetailView({
     tailLines: item.tailLines,
     visibleRowBudget: layout.visibleLineCount,
   });
+  const scrollContext: TaskDetailScrollContext = {
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+  };
+  const scrollContextKey = taskDetailScrollContextKey(scrollContext);
   const [scrollState, setScrollState] = useState<TaskDetailScrollState>(() => ({
     executionId: item.executionId,
     followsTail: true,
@@ -689,6 +815,7 @@ function TaskDetailView({
     scrollState,
     maxOffset,
     followOffset,
+    scrollContext,
   );
   const visibleLineCount = layout.visibleLineCount;
   const visibleTail = taskDetailVisibleOutputRowsFromOffsetForColumns({
@@ -717,9 +844,10 @@ function TaskDetailView({
         item.executionId,
         maxOffset,
         followOffset,
+        scrollContext,
       ),
     );
-  }, [item.executionId, followOffset, maxOffset]);
+  }, [item.executionId, followOffset, maxOffset, scrollContextKey]);
 
   useInput((input, key) => {
     const action = childPickerKeyAction({
@@ -735,12 +863,24 @@ function TaskDetailView({
     if (action.kind === 'kill' && item.killable) onKill();
     if (action.kind === 'up') {
       setScrollState((current) =>
-        moveTaskDetailScrollState(current, maxOffset, 'up', followOffset),
+        moveTaskDetailScrollState(
+          current,
+          maxOffset,
+          'up',
+          followOffset,
+          scrollContext,
+        ),
       );
     }
     if (action.kind === 'down') {
       setScrollState((current) =>
-        moveTaskDetailScrollState(current, maxOffset, 'down', followOffset),
+        moveTaskDetailScrollState(
+          current,
+          maxOffset,
+          'down',
+          followOffset,
+          scrollContext,
+        ),
       );
     }
     if (input.toLowerCase() === 'f' && item.childStreamId) onFocusStream();

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -1092,6 +1092,83 @@ describe('CLI child execution controls', () => {
     });
   });
 
+  it('anchors manual task detail scrolling when earlier output rewraps', () => {
+    const availableColumns = 20;
+    const visibleRowBudget = 1;
+    const beforeLines = ['intro', 'target marker', 'after'];
+    const beforeContext = {
+      availableColumns,
+      compact: true,
+      tailLines: beforeLines,
+    };
+    const beforeScrollableRows =
+      taskDetailScrollableOutputRowCountForColumns(beforeContext);
+    const beforeMaxOffset = taskDetailInitialScrollOffset(
+      beforeScrollableRows,
+      visibleRowBudget,
+    );
+    const beforeFollowOffset = taskDetailFollowTailScrollOffsetForColumns({
+      ...beforeContext,
+      visibleRowBudget,
+    });
+
+    const manual = moveTaskDetailScrollState(
+      { executionId: 'task-1', followsTail: true, offset: beforeFollowOffset },
+      beforeMaxOffset,
+      'up',
+      beforeFollowOffset,
+      beforeContext,
+    );
+
+    expect(manual).toEqual({
+      anchor: { lineIndex: 1, wrappedRowOffset: 0 },
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 1,
+    });
+
+    const afterLines = [
+      'intro expanded before anchor '.repeat(2),
+      'target marker',
+      'after',
+    ];
+    const afterContext = {
+      availableColumns,
+      compact: true,
+      tailLines: afterLines,
+    };
+    const afterMaxOffset = taskDetailInitialScrollOffset(
+      taskDetailScrollableOutputRowCountForColumns(afterContext),
+      visibleRowBudget,
+    );
+    const afterFollowOffset = taskDetailFollowTailScrollOffsetForColumns({
+      ...afterContext,
+      visibleRowBudget,
+    });
+    const synced = syncTaskDetailScrollState(
+      manual,
+      'task-1',
+      afterMaxOffset,
+      afterFollowOffset,
+      afterContext,
+    );
+    const visibleOffset = taskDetailVisibleScrollOffset(
+      synced,
+      afterMaxOffset,
+      afterFollowOffset,
+      afterContext,
+    );
+
+    expect(visibleOffset).toBeGreaterThan(manual.offset);
+    expect(
+      taskDetailVisibleOutputRowsFromOffsetForColumns({
+        ...afterContext,
+        offset: visibleOffset,
+        visibleRowBudget,
+      }),
+    ).toEqual(['target marker']);
+  });
+
   it('moves task detail scroll from the visible tail position', () => {
     const tailing = { executionId: 'task-1', followsTail: true, offset: 7 };
     expect(moveTaskDetailScrollState(tailing, 9, 'up')).toEqual({


### PR DESCRIPTION
Fixes #4922.

## Summary

- store a logical task-detail scroll anchor when users manually scroll away from tail
- recompute the visual row offset from that anchor when compact output before it rewraps
- keep existing follow-tail behavior unchanged for default task-detail views

## Evidence

The new unit regression models the #4922 failure mode:

1. open a compact task detail view at the tail
2. manually scroll up to `target marker`
3. grow an earlier line so it wraps to more visual rows
4. assert the visible row is still `target marker`, not a different row from the expanded earlier line

## Validation

```sh
corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChildControls.vitest.mts
corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-task-scroll-anchor-focused task-subworkflow-detail-long-output task-subworkflow-detail-wide-line-scroll tiny-task-subworkflow-detail-wrapped-scroll task-process-detail
corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-task-scroll-anchor-full
corepack pnpm --filter @texra-ai/cli typecheck
corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/ChildControlPicker.tsx src/test-kernel/cli/ChildControls.vitest.mts
git diff --check
```

Full TUI result: all 78 scenarios passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI scroll math and state in ChildControlPicker; follow-tail unchanged and covered by new regression test.
> 
> **Overview**
> Fixes manual scroll in **compact task detail** views jumping when earlier output **rewraps** (e.g. terminal width or longer lines above the viewport).
> 
> When the user scrolls off the tail, scroll state now keeps a **logical anchor** (`lineIndex` + `wrappedRowOffset` within that line) instead of relying only on a flat visual row offset. **`syncTaskDetailScrollState`**, **`taskDetailVisibleScrollOffset`**, and **`moveTaskDetailScrollState`** take optional **`TaskDetailScrollContext`** (columns, compact mode, tail lines) to map the anchor back to the correct visual offset after layout changes. **Follow-tail** behavior still drops the anchor and uses the follow offset as before.
> 
> **`TaskDetailView`** passes that context through scroll sync and ↑/↓ handling, with effect deps keyed on wrapped row layout. A unit test covers scroll-up to a marker line, then growth of an earlier line, and asserts the same line stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89dd70dd9f575d116cec8d75b82cd68141204aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->