### PR TITLE
fix(cli): document orchestrate controls

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -15,6 +15,7 @@ import { buildCliOrchestrationItems } from '../runtime/orchestration';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 
 import { contextFromArgs } from './_helpers/context';
+import { withUsageSections } from './_helpers/dispatch';
 import { setExitCode } from './_helpers/exitCode';
 import {
   INTERACTIVE_GLOBAL_ARGS,
@@ -95,18 +96,31 @@ async function runOrchestration(context: CliContext): Promise<number> {
   }
 }
 
-export const orchestrationCommand = defineCommand({
-  meta: {
-    name: 'orchestrate',
-    description:
-      'Interactive launcher (runs by default on bare `texra` in a TTY): pick a chat, resume, or team preset',
-  },
-  args: {
-    ...INTERACTIVE_GLOBAL_ARGS,
-  },
-  async run(ctx) {
-    rejectHeadlessOnlyFlags(ctx.rawArgs, 'orchestrate');
-    const context = await contextFromArgs(ctx.args);
-    setExitCode(await runOrchestration(context));
-  },
-});
+export const orchestrationCommand = withUsageSections(
+  defineCommand({
+    meta: {
+      name: 'orchestrate',
+      description:
+        'Interactive launcher (runs by default on bare `texra` in a TTY): pick a chat, resume, or team preset',
+    },
+    args: {
+      ...INTERACTIVE_GLOBAL_ARGS,
+    },
+    async run(ctx) {
+      rejectHeadlessOnlyFlags(ctx.rawArgs, 'orchestrate');
+      const context = await contextFromArgs(ctx.args);
+      setExitCode(await runOrchestration(context));
+    },
+  }),
+  [
+    {
+      title: 'INTERACTIVE CONTROLS',
+      rows: [
+        ['↑/↓', 'navigate launcher items'],
+        ['1-9/a-z', 'open an item directly'],
+        ['Enter', 'open the selected item'],
+        ['Esc', 'exit the launcher'],
+      ],
+    },
+  ],
+);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -621,12 +621,36 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('documents launcher controls in orchestrate --help', async () => {
+    const result = await runCli(['orchestrate', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stdout).toContain('↑/↓');
+    expect(stdout).toContain('1-9/a-z');
+    expect(stdout).toContain('open an item directly');
+    expect(stdout).toContain('Enter');
+    expect(stdout).toContain('Esc');
+    expect(stderr).toBe('');
+  });
+
   it('shows command-specific usage for help command paths', async () => {
     const result = await runCli(['help', 'chat']);
     expect(result.exitCode).toBe(0);
     expect(stdout).toContain('Interactive tool-use chat session');
     expect(stdout).toContain('USAGE texra chat');
     expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stderr).toBe('');
+  });
+
+  it('shows orchestrate controls for help command paths', async () => {
+    const result = await runCli(['help', 'orchestrate']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('Interactive launcher');
+    expect(stdout).toContain('USAGE texra orchestrate');
+    expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stdout).toContain('1-9/a-z');
+    expect(stdout).toContain('open an item directly');
+    expect(stdout).toContain('Esc');
     expect(stderr).toBe('');
   });
 


### PR DESCRIPTION
## Summary

- Add an `INTERACTIVE CONTROLS` section to `texra orchestrate --help`.
- Document the launcher controls that already appear in the TUI: `↑/↓`, `1-9/a-z`, `Enter`, and `Esc`.
- Cover both `orchestrate --help` and `help orchestrate`.

Fixes #4944.

## Dogfood Notes

- Compared `chat --help` with `orchestrate --help` while checking interactive CLI affordances.
- Re-ran the launcher TUI scenarios to keep the documented keys aligned with the visible launcher hints.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/commands/orchestrate.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `node packages/cli/dist/bin/texra.js orchestrate --help`
- `node packages/cli/dist/bin/texra.js help orchestrate`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- orchestrate-launcher compact-orchestrate-launcher`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings outside this change)
- `npm run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text and tests only; no runtime launcher or orchestration behavior changes.
> 
> **Overview**
> Adds an **INTERACTIVE CONTROLS** block to `texra orchestrate --help` and `texra help orchestrate` by wrapping `orchestrationCommand` with `withUsageSections`, matching how interactive chat documents its keys.
> 
> The new section documents launcher shortcuts already shown in the TUI: **↑/↓** to move, **1-9/a-z** to jump to an item, **Enter** to open the selection, and **Esc** to quit.
> 
> Vitest coverage asserts those strings appear on both help entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e69f44bb6acbe3ef233021757c8acd9ad0d9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->