### PR TITLE
fix(cli): show approval bypasses in status

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -986,6 +986,7 @@ function appendHarnessStatus(): void {
       teamName: meta.teamName,
       api: meta.apiMode,
       approval: formatApprovalPolicyForCli(harnessApprovalPolicy),
+      approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       queuedFollowUpMessages:
         streamId === undefined ? [] : ToolUseFollowUpQueue.getAll(streamId),

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -568,6 +568,19 @@ const SCENARIOS = [
     unexpect: ['AUTO-APPROVE', 'Run bash command?', '1 approval'],
   },
   {
+    name: 'bash-approval-session-status',
+    env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
+    bootExpect: 'Use foreground panel shortcuts',
+    keys: ['a', '/status', '\r'],
+    frame: 'tail',
+    expect: [
+      'approval: ask before privileged actions',
+      'auto-approvals: bash commands',
+      'AUTO-BASH',
+    ],
+    unexpect: ['Run bash command?', '1 approval'],
+  },
+  {
     name: 'agent-proposal-long',
     rows: 24,
     cols: 80,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -675,6 +675,7 @@ async function handleTuiSlashCommand(
           teamName: meta.teamName,
           api: formatCliApiMode(getCliApiMode()),
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
+          approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
           queuedFollowUpMessages:
             activeStreamId === undefined

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,6 +1,8 @@
 import { STREAM_STATUS } from '@shared/schemas';
 import { truncateSummary } from '@utils/text/stringUtils';
 
+import type { BypassState } from './state/cliState';
+
 const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
 
 export interface CliSessionStatusInput {
@@ -9,6 +11,7 @@ export interface CliSessionStatusInput {
   readonly teamName?: string;
   readonly api: string;
   readonly approval: string;
+  readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
   readonly queuedFollowUpMessages: readonly string[];
 }
@@ -42,13 +45,28 @@ function queuedFollowUpStatusLines(messages: readonly string[]): string[] {
   ];
 }
 
+function activeApprovalBypassLabels(
+  bypasses: Partial<BypassState> | undefined,
+): string[] {
+  if (!bypasses) return [];
+  const labels: string[] = [];
+  if (bypasses.superYolo) labels.push('delegated tasks');
+  if (bypasses.bash) labels.push('bash commands');
+  if (bypasses.toolEdit) labels.push('file edits');
+  return labels;
+}
+
 export function formatCliSessionStatus(input: CliSessionStatusInput): string {
+  const bypassLabels = activeApprovalBypassLabels(input.approvalBypasses);
   return [
     ...(input.teamName ? [`team: ${input.teamName}`] : []),
     `agent: ${input.agent}`,
     `model: ${input.model}`,
     `api: ${input.api}`,
     `approval: ${input.approval}`,
+    ...(bypassLabels.length > 0
+      ? [`auto-approvals: ${bypassLabels.join(', ')}`]
+      : []),
     `status: ${formatCliStatusLabel(input.status)}`,
     ...queuedFollowUpStatusLines(input.queuedFollowUpMessages),
   ].join('\n');

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -70,6 +70,23 @@ describe('CLI session status formatter', () => {
     ).toContain('queued follow-ups: 0');
   });
 
+  it('reports active session approval bypasses', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask before privileged actions',
+      approvalBypasses: { superYolo: true, bash: true, toolEdit: true },
+      status: 'waiting',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain(
+      'auto-approvals: delegated tasks, bash commands, file edits',
+    );
+    expect(status).not.toContain('all privileged actions');
+  });
+
   it('includes team identity when a chat was launched from a preset', () => {
     expect(
       formatCliSessionStatus({


### PR DESCRIPTION
## Summary

- Add active approval bypasses to `/status` output, e.g. `auto-approvals: bash commands`.
- Pass per-stream bypass state from the real chat TUI and the harness status command.
- Cover the live approval-session flow with a focused TUI validator scenario.

Fixes #4951.

## Dogfood Notes

I reproduced this in the TUI harness by launching a bash approval, pressing `a` to approve bash for the session, and then running `/status`. Before this change the footer showed `AUTO-BASH`, but `/status` only showed the global approval policy. The new focused snapshot now shows both the global policy and active bypass state.

## Validation

- `corepack pnpm install`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js chat --help`
- `node packages/cli/dist/bin/texra.js orchestrate --help`
- `HARNESS_BASH_APPROVAL=1 node packages/cli/dist/bin/tui-harness.js` (manual: press `a`, run `/status`)
- `rm -rf /tmp/texra-approval-dogfood && corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-dogfood bash-approval long-bash-approval compact-long-bash-approval tiny-compact-long-bash-approval plan-approval plan-approval-odyssey edit-approval agent-proposal-long external-inquiry-long`
- `xmllint --noout /tmp/texra-approval-dogfood/*.svg`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SessionStatus.vitest.mts`
- `rm -rf /tmp/texra-approval-status-fix && corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-status-fix bash-approval-session-status`
- `xmllint --noout /tmp/texra-approval-status-fix/01-bash-approval-session-status.svg`
- `npm run format`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to session status text with targeted tests; no auth or execution-path changes.
> 
> **Overview**
> **`/status` now reflects session-scoped auto-approvals**, not only the global approval policy. When the active stream has bypass flags set (e.g. after approving bash for the session), the status block adds a line like `auto-approvals: bash commands`, alongside the existing `approval:` line.
> 
> `formatCliSessionStatus` accepts optional **`approvalBypasses`** from per-stream `BypassState` (`bash`, `toolEdit`, `superYolo`) and maps them to readable labels. The live chat TUI and the TUI harness both pass the active stream’s `slice.bypass` into `/status`.
> 
> Coverage adds a **unit test** for the formatter and a **`bash-approval-session-status`** PTY scenario (approve session → `/status` → expect policy + auto-approvals + `AUTO-BASH`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e58531e67533cae145c2a30bc7895f3028ad01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->