### PR TITLE
fix(cli): clarify included access diagnostics

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -42,6 +42,8 @@ export function formatModelStatusForCliMode(
       return 'relay: included';
     case 'not-included':
       return 'relay: not included';
+    case 'included-login-required':
+      return 'relay: login required';
     case 'relay-quota-exhausted':
       return 'relay: quota exhausted';
     case 'provider-key':
@@ -92,7 +94,7 @@ function EmptyModelListState(props: { readonly onClose: () => void }) {
 
 export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   const { data, loading, error } = useAsyncListForm<readonly CliModelAccess[]>({
-    load: getCliModelAccessList,
+    load: () => getCliModelAccessList({ apiMode: props.apiMode }),
     onClose: props.onClose,
     isEmpty: (models) => !hasRunnableModelSelectItems(models),
   });

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -43,6 +43,7 @@ import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr } from '@cli/runtime/logSinks';
+import { dumbTerminalMessage } from '@cli/runtime/terminalRequirements';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
@@ -347,12 +348,18 @@ async function applyInitialCliModelSelection(
 
 async function reconcileRootModelAfterApiModeChange(
   context: SlashCommandContext | undefined,
+  apiMode: CliApiMode,
 ): Promise<string | undefined> {
   if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
 
   const currentModel = cliState.sessionMeta.get().model;
   const resolution = await resolveCliRunnableModel(currentModel, {
     allowFallback: true,
+    apiMode,
+    noAvailableModelsMessage:
+      apiMode === 'included'
+        ? 'Run `texra login` for included relay access, or switch to personal API keys with `/api personal` after configuring a provider API key.'
+        : undefined,
   });
   if (resolution.model === currentModel) return undefined;
 
@@ -400,16 +407,19 @@ async function applyCliApiModeSelection(
   const apiMode = parseCliApiMode(normalized);
   if (apiMode) {
     await setCliApiMode(apiMode);
-    let modelNotice: string | undefined;
-    try {
-      modelNotice = await reconcileRootModelAfterApiModeChange(context);
-    } catch (error: unknown) {
-      modelNotice = toErrorMessage(error);
-    }
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       apiMode,
     });
+    let modelNotice: string | undefined;
+    try {
+      modelNotice = await reconcileRootModelAfterApiModeChange(
+        context,
+        apiMode,
+      );
+    } catch (error: unknown) {
+      modelNotice = toErrorMessage(error);
+    }
     appendLocalAssistantTranscript(
       [
         `API mode set to ${formatCliApiMode(apiMode)}.`,
@@ -755,7 +765,9 @@ export async function runChat(
     writeTextStderr(
       isHeadless
         ? 'texra chat requires an interactive terminal (TTY stdin and stdout). For scripting or piped input, use `texra run`.'
-        : 'texra chat needs a capable terminal — TERM=dumb strips the cursor controls Ink uses. For non-interactive runs, use `texra run`.',
+        : dumbTerminalMessage('chat', {
+            nonInteractiveFallback: '`texra run`',
+          }),
     );
     return { exitCode: CliExitCode.Usage };
   }
@@ -775,8 +787,15 @@ export async function runChat(
   try {
     modelResolution = await resolveCliRunnableModel(defaults.model, {
       allowFallback: !explicitModelRequested,
+      apiMode: context.apiMode,
+      noAvailableModelsMessage:
+        context.apiMode === 'included'
+          ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
+          : undefined,
       noAvailableModelsHint:
-        'Run `texra chat --api-mode included` to try included relay access',
+        context.apiMode === 'included'
+          ? undefined
+          : 'Run `texra chat --api-mode included` to try included relay access',
     });
   } catch (error: unknown) {
     writeTextStderr(toErrorMessage(error));

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -55,6 +55,11 @@ export async function resolveCliRunModel(
   try {
     const resolution = await resolveCliRunnableModel(model, {
       allowFallback: !explicitModelRequested,
+      apiMode: context.apiMode,
+      noAvailableModelsMessage:
+        context.apiMode === 'included'
+          ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
+          : undefined,
     });
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -64,7 +64,7 @@ async function loadModelAccessList(
   try {
     return await suppressCliFetchStackLogs(async () => {
       await initCliPlatform({ ...context, quietLogs: true });
-      return getCliModelAccessList();
+      return getCliModelAccessList({ apiMode: context.apiMode });
     });
   } catch (error) {
     return { error: formatCliModelListError(error) };

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -7,6 +7,7 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { listCliHistoryEntries } from '../runtime/history';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
+import { dumbTerminalMessage } from '../runtime/terminalRequirements';
 import {
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
@@ -36,7 +37,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     writeTextStderr(
       isHeadless
         ? 'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run` or a concrete subcommand.'
-        : 'texra orchestrate needs a capable terminal — TERM=dumb strips the cursor controls Ink uses.',
+        : dumbTerminalMessage('orchestrate'),
     );
     return CliExitCode.Usage;
   }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -5,6 +5,9 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
 
+import type { CliApiMode } from './apiAccessMode';
+import { getCliAuthProvider } from './supabaseAuth';
+
 export interface CliModelAccess {
   readonly model: ModelOptionData;
   readonly available: boolean;
@@ -18,7 +21,13 @@ export interface CliRunnableModelResolution {
 
 export interface CliRunnableModelOptions {
   readonly allowFallback: boolean;
+  readonly apiMode?: CliApiMode;
   readonly noAvailableModelsHint?: string;
+  readonly noAvailableModelsMessage?: string;
+}
+
+export interface CliModelAccessListOptions {
+  readonly apiMode?: CliApiMode;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
@@ -39,9 +48,40 @@ function toCliModelAccess(model: ModelOptionData): CliModelAccess {
   };
 }
 
-export async function getCliModelAccessList(): Promise<CliModelAccess[]> {
+function toIncludedLoginRequiredAccess(entry: CliModelAccess): CliModelAccess {
+  return {
+    model: {
+      ...entry.model,
+      availability: 'included-login-required',
+      availabilityLabel: 'Login required',
+      requiresKey: false,
+      disabled: true,
+    },
+    available: false,
+    status: 'login required',
+  };
+}
+
+async function includedAccessRequiresLogin(
+  options: CliModelAccessListOptions,
+): Promise<boolean> {
+  if (options.apiMode !== 'included') return false;
+  try {
+    return !(await getCliAuthProvider().isAuthenticated());
+  } catch {
+    return true;
+  }
+}
+
+export async function getCliModelAccessList(
+  options: CliModelAccessListOptions = {},
+): Promise<CliModelAccess[]> {
   const models = await computeModelOptionsData();
-  return models.map(toCliModelAccess);
+  const access = models.map(toCliModelAccess);
+  if (await includedAccessRequiresLogin(options)) {
+    return access.map(toIncludedLoginRequiredAccess);
+  }
+  return access;
 }
 
 function findModelAccess(
@@ -78,11 +118,17 @@ function getCanonicalModelConfigId(model: string): string | undefined {
 
 function formatAvailableModels(
   ids: readonly string[],
-  noAvailableModelsHint?: string,
+  options: Pick<
+    CliRunnableModelOptions,
+    'noAvailableModelsHint' | 'noAvailableModelsMessage'
+  >,
 ): string {
   if (ids.length > 0) return `Available models: ${ids.join(', ')}.`;
+  if (options.noAvailableModelsMessage) {
+    return `No models are currently available. ${options.noAvailableModelsMessage}`;
+  }
   const modeHint =
-    noAvailableModelsHint ??
+    options.noAvailableModelsHint ??
     'Retry with `--api-mode included` to try included relay access';
   return `No models are currently available. ${modeHint}, run \`texra login\`, or configure a provider API key.`;
 }
@@ -91,10 +137,13 @@ function formatUnavailableModelMessage(
   model: string,
   entry: CliModelAccess | undefined,
   availableIds: readonly string[],
-  options: Pick<CliRunnableModelOptions, 'noAvailableModelsHint'>,
+  options: Pick<
+    CliRunnableModelOptions,
+    'noAvailableModelsHint' | 'noAvailableModelsMessage'
+  >,
 ): string {
   const status = entry ? ` (${entry.status})` : '';
-  return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds, options.noAvailableModelsHint)}`;
+  return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds, options)}`;
 }
 
 export function resolveCliRunnableModelFromAccessList(
@@ -128,7 +177,7 @@ export async function resolveCliRunnableModel(
   model: string,
   options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
-  const models = await getCliModelAccessList();
+  const models = await getCliModelAccessList({ apiMode: options.apiMode });
   const trimmed = model.trim();
   const hiddenModelId =
     trimmed && !findModelAccess(models, trimmed)
@@ -145,6 +194,9 @@ export async function resolveCliRunnableModel(
       );
     }
     hiddenModel = toCliModelAccess(hiddenModelOption);
+    if (await includedAccessRequiresLogin(options)) {
+      hiddenModel = toIncludedLoginRequiredAccess(hiddenModel);
+    }
   }
 
   return resolveCliRunnableModelFromAccessList(

--- a/packages/cli/src/runtime/terminalRequirements.ts
+++ b/packages/cli/src/runtime/terminalRequirements.ts
@@ -1,0 +1,10 @@
+export function dumbTerminalMessage(
+  command: string,
+  options: { nonInteractiveFallback?: string } = {},
+): string {
+  const fallback =
+    options.nonInteractiveFallback == null
+      ? ''
+      : ` For non-interactive runs, use ${options.nonInteractiveFallback}.`;
+  return `texra ${command} needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with \`TERM=xterm-256color\`.${fallback}`;
+}

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -53,6 +53,12 @@ const AVAILABILITY_STATUS: Record<
     available: false,
     requiresKey: false,
   },
+  'included-login-required': {
+    kind: 'included-login-required',
+    label: 'Login required',
+    available: false,
+    requiresKey: false,
+  },
   'relay-quota-exhausted': {
     kind: 'relay-quota-exhausted',
     label: 'Relay quota exhausted',

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -78,6 +78,7 @@ export const ModelAvailabilityKindSchema = z.enum([
   'openrouter-key',
   'missing-key',
   'not-included',
+  'included-login-required',
   'relay-quota-exhausted',
 ]);
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  getCliModelAccessList,
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
   type CliModelAccess,
@@ -8,8 +9,18 @@ import {
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
 
+const mocks = vi.hoisted(() => ({
+  authProvider: {
+    isAuthenticated: vi.fn(),
+  },
+}));
+
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProvider: () => mocks.authProvider,
 }));
 
 vi.mock('llm-zoo', () => ({
@@ -35,6 +46,8 @@ function model(
 describe('CLI model access resolution', () => {
   beforeEach(() => {
     computeModelOptionsDataMock.mockReset();
+    mocks.authProvider.isAuthenticated.mockReset();
+    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
   });
 
   it('keeps the requested model when it is currently runnable', () => {
@@ -99,13 +112,67 @@ describe('CLI model access resolution', () => {
         'gemini31p',
         {
           allowFallback: true,
-          noAvailableModelsHint:
-            'Run `texra chat --api-mode included` to try included relay access',
+          noAvailableModelsMessage:
+            'Run `texra login` for included relay access.',
         },
       ),
     ).toThrow(
-      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra chat --api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra login` for included relay access.',
     );
+  });
+
+  it('marks explicitly included-mode models as login-required when signed out', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('deepseekT', {
+        availability: 'missing-key',
+        availabilityLabel: 'Missing API key',
+        requiresKey: true,
+        disabled: true,
+      }),
+    ]);
+    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+
+    await expect(
+      getCliModelAccessList({ apiMode: 'included' }),
+    ).resolves.toMatchObject([
+      {
+        available: false,
+        status: 'login required',
+        model: {
+          value: 'deepseekT',
+          availability: 'included-login-required',
+          availabilityLabel: 'Login required',
+          requiresKey: false,
+          disabled: true,
+        },
+      },
+    ]);
+  });
+
+  it('preserves relay quota status for signed-in included-mode users', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('deepseekT', {
+        availability: 'relay-quota-exhausted',
+        availabilityLabel: 'Relay quota exhausted',
+        requiresKey: false,
+        disabled: true,
+      }),
+    ]);
+    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+
+    await expect(
+      getCliModelAccessList({ apiMode: 'included' }),
+    ).resolves.toMatchObject([
+      {
+        available: false,
+        status: 'relay quota exhausted',
+        model: {
+          value: 'deepseekT',
+          availability: 'relay-quota-exhausted',
+          availabilityLabel: 'Relay quota exhausted',
+        },
+      },
+    ]);
   });
 
   it('checks access for explicit models hidden from the visible model list', async () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -78,6 +78,22 @@ describe('CLI ModelListForm status text', () => {
       ),
     ).toBe('relay: quota exhausted');
   });
+
+  it('shows signed-out included mode as a relay login requirement', () => {
+    expect(
+      formatModelStatusForCliMode(
+        access(
+          {
+            availability: 'included-login-required',
+            availabilityLabel: 'Login required',
+            disabled: true,
+          },
+          'login required',
+        ),
+        'included',
+      ),
+    ).toBe('relay: login required');
+  });
 });
 
 describe('CLI ModelListForm model visibility', () => {

--- a/src/test-kernel/cli/TerminalRequirements.vitest.mts
+++ b/src/test-kernel/cli/TerminalRequirements.vitest.mts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { dumbTerminalMessage } from '@cli/runtime/terminalRequirements';
+
+describe('terminal requirement diagnostics', () => {
+  it('gives interactive PTY users an exact TERM recovery hint', () => {
+    expect(dumbTerminalMessage('chat')).toBe(
+      'texra chat needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`.',
+    );
+  });
+
+  it('keeps the non-interactive fallback when one applies', () => {
+    expect(
+      dumbTerminalMessage('chat', { nonInteractiveFallback: '`texra run`' }),
+    ).toBe(
+      'texra chat needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra run`.',
+    );
+  });
+});

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -119,7 +119,7 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith(
       'staleConfiguredModel',
-      { allowFallback: true },
+      expect.objectContaining({ allowFallback: true }),
     );
     expect(mocks.initCliPlatform).toHaveBeenCalledWith({
       ...context,
@@ -145,6 +145,8 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       allowFallback: false,
+      apiMode: undefined,
+      noAvailableModelsMessage: undefined,
     });
   });
 
@@ -158,6 +160,8 @@ describe('resolveCliRunModel precedence', () => {
 
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       allowFallback: false,
+      apiMode: undefined,
+      noAvailableModelsMessage: undefined,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Treat explicitly selected included/relay mode as relay-scoped when the user is signed out, so model availability reports `login required` instead of `missing api key`.
- Point signed-out included-mode chat/run failures at `texra login` instead of suggesting the same `--api-mode included` command again.
- Add an actionable `TERM=xterm-256color` hint for interactive PTYs that launch chat/orchestrate with `TERM=dumb`.

Closes #4953

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/TerminalRequirements.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm run texra-local:build`
- signed-out `texra models list --api-mode included --all --quiet --output-format text` shows `login required`
- signed-out PTY `texra chat --api-mode included --model deepseekT` points to `texra login`
- PTY `TERM=dumb texra chat ...` points to `TERM=xterm-256color`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-cli-dogfood-after-fix model-form compact-model-form api-form compact-api-form`
- `corepack pnpm run lint` (0 errors; unrelated pre-existing import-order warnings)
- `corepack pnpm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI model availability labeling, error copy, and terminal hints; signed-in relay quota and personal-key paths are preserved by tests.
> 
> **Overview**
> Improves **included relay** diagnostics when the CLI user is signed out: model lists and resolution now treat **included** API mode as relay-scoped and surface **`login required`** (new `included-login-required` availability) instead of **missing API key**.
> 
> **Chat**, **run**, **`texra models`**, and the **`/model`** TUI pass **`apiMode`** into model access and use **`texra login`** / **`/api personal`** recovery text when nothing is runnable in included mode—avoiding telling users to retry the same `--api-mode included` flag.
> 
> Adds shared **`dumbTerminalMessage`** for **`TERM=dumb`** on **`chat`** and **`orchestrate`**, suggesting **`TERM=xterm-256color`** on interactive PTYs (with **`texra run`** fallback where relevant).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5edbfba03add41151a3d7c8dedfcf9386cf9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->