### PR TITLE
fix(cli): make doctor recovery hints reachable

### DIFF
--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -172,7 +172,7 @@ async function checkAuth(
       'auth',
       'Included access',
       'Not signed in for included model access.',
-      'Run `texra login`, or use `/api personal` in the chat TUI to use your own API keys.',
+      'Run `texra login` for included access, or configure a provider API key before using `--api-mode personal`.',
     );
   } catch (error) {
     return failFromError(
@@ -201,7 +201,7 @@ async function checkModels(
       'models',
       'Models',
       'No model is currently available.',
-      'Run `texra models list`, sign in with `texra login`, or use `/api personal` in the chat TUI.',
+      'Run `texra models list --all` to inspect access, sign in with `texra login`, or configure a provider API key.',
     );
   } catch (error) {
     return failFromError(

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -76,8 +76,13 @@ describe('CLI doctor', () => {
 
     const text = formatDoctorText(report);
 
-    expect(text).toContain('FAIL Models: No model is currently available.');
-    expect(text).toContain('/api personal');
+    expect(text).toContain(
+      [
+        'FAIL Models: No model is currently available.',
+        '     Run `texra models list --all` to inspect access, sign in with `texra login`, or configure a provider API key.',
+      ].join('\n'),
+    );
+    expect(text).not.toContain('/api personal');
     expect(text).toContain('SKIP Config: No workspace CLI config file found.');
   });
 


### PR DESCRIPTION
## Summary

- Replace `texra doctor` no-model hints that pointed into an unavailable chat TUI.
- Point users to pre-chat recovery paths: `texra models list --all`, `texra login`, or provider key configuration.
- Pin the no-model doctor hint in the focused doctor unit test.

Fixes #4955.

## Dogfood Notes

I reproduced this with a clean environment. `texra doctor --api-mode personal` suggested `/api personal` in chat, but `texra chat --api-mode personal -m deepseekT` exited before the TUI could open because no model was available.

## Validation

- `rm -rf /tmp/texra-child-display-sweep && corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-child-display-sweep subagents subagent-picker task-picker compact-subagent-picker compact-task-picker compact-task-picker-process-overflow task-subworkflow-detail task-subworkflow-detail-long-output task-subworkflow-detail-wide-line-scroll task-process-detail narrow-subagent-picker narrow-subagent-picker-second narrow-task-picker tiny-subagent-picker tiny-task-subworkflow-detail tiny-task-subworkflow-detail-wrapped-scroll tiny-task-process-detail stopped-subagent-picker stopped-task-picker stopped-task-subworkflow-detail focused-stopped-subagent focused-stopped-subagent-submit empty-task-picker task-picker-parent-fallback`
- `rm -rf /tmp/texra-nested-child-display && corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-nested-child-display nested-subagent-picker nested-task-picker task-picker-parent-fallback focused-stopped-subagent focused-stopped-subagent-submit`
- `rm -rf /tmp/texra-approval-current-scout && corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-current-scout narrow-edit-approval narrow-bash-approval compact-long-bash-approval`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Doctor.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `env -i HOME=/tmp/texra-zero-env-home-after PATH="$PATH" TERM=xterm-256color NO_COLOR=1 TEXRA_NO_UPDATE_CHECK=1 node packages/cli/dist/bin/texra.js doctor --api-mode personal --cwd /tmp/texra-zero-env-work-after`
- `npm run format`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to doctor hints and matching test expectations; no auth, model selection, or runtime behavior changes.
> 
> **Overview**
> **`texra doctor`** recovery text no longer tells users to use **`/api personal`** in the chat TUI when that path is unavailable (e.g. chat exits before the TUI opens because no model is configured).
> 
> For **included access** warnings and **no models** failures, hints now steer users to **`texra login`**, **`texra models list --all`**, and configuring a **provider API key** (including before **`--api-mode personal`**). The doctor unit test asserts the new models hint and that **`/api personal`** does not appear in formatted output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23f7f0a77fb8b7106919ce543995509cef4129f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->