### PR TITLE
Hide approval-gated tools in headless CLI runs

### DIFF
--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -6,6 +6,15 @@ export type ApprovalInstructionContext = {
 const PRIVILEGED_ACTION_GUIDANCE =
   'Do not call approval-gated tools such as bash/shell commands, file edits, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
 
+export function approvalPromptsUnavailable(
+  context: ApprovalInstructionContext,
+): boolean {
+  return (
+    context.approvalPolicy === 'never' ||
+    (context.mode === 'headless' && context.approvalPolicy === 'ask')
+  );
+}
+
 export function formatUnavailableApprovalInstruction(
   context: ApprovalInstructionContext,
 ): string | undefined {

--- a/packages/cli/src/commands/_helpers/runExecution.ts
+++ b/packages/cli/src/commands/_helpers/runExecution.ts
@@ -6,6 +6,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
+import { approvalPromptsUnavailable } from './approvalPolicyInstruction';
 import {
   readCliTerminalStatus,
   type ExecuteAgentResult,
@@ -49,6 +50,7 @@ export async function executeCliRequest(
       enforceCategory: options.enforceCategory,
       registerExecution: options.registerExecution,
       stopAfterCycle: options.stopAfterCycle,
+      approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
     });
 
   let result: ExecuteAgentResult;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -43,6 +43,7 @@ import {
   availableModelNamesFromOptions,
   withDelegationModelAvailability,
 } from '@tools/delegationModelAvailability';
+import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -64,6 +65,8 @@ export interface RunToolUseFlowInput<
   onFollowUpConsumed?: () => void;
   /** When true, delegation tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
+  /** When true, approval-gated tools are filtered out before model invocation. */
+  approvalPromptsUnavailable?: boolean;
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
   onBeforeWaiting?: (
     lastResponse: string | undefined,
@@ -116,11 +119,14 @@ async function availableDelegationModelNamesForTools(
   }
 }
 
-async function resolveTools(
+export async function resolveToolUseTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
-  delegationBlocked: boolean,
+  options: {
+    readonly approvalPromptsUnavailable?: boolean;
+    readonly delegationBlocked: boolean;
+  },
 ): Promise<{ tools: ToolDefinition[]; delegationTrimmed: boolean }> {
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
@@ -136,8 +142,14 @@ async function resolveTools(
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
-      if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
+      if (DELEGATION_TOOLS.has(def.name) && options.delegationBlocked) {
         delegationTrimmed = true;
+        return false;
+      }
+      if (
+        options.approvalPromptsUnavailable === true &&
+        isApprovalGatedToolName(def.name)
+      ) {
         return false;
       }
       if (disabled.has(def.name)) return false;
@@ -153,6 +165,16 @@ async function resolveTools(
   for (const injection of listToolInjections()) {
     if (!injection.shouldInject()) continue;
     if (resolvedNames.has(injection.toolName)) continue;
+    if (DELEGATION_TOOLS.has(injection.toolName) && options.delegationBlocked) {
+      delegationTrimmed = true;
+      continue;
+    }
+    if (
+      options.approvalPromptsUnavailable === true &&
+      isApprovalGatedToolName(injection.toolName)
+    ) {
+      continue;
+    }
     const tool = registry.get(injection.toolName);
     if (tool) {
       resolved.push(tool.definition);
@@ -194,11 +216,14 @@ export async function runToolUseFlow<C = unknown>(
     delegationDepth,
     delegationConfig,
   );
-  const { tools: resolvedTools, delegationTrimmed } = await resolveTools(
+  const { tools: resolvedTools, delegationTrimmed } = await resolveToolUseTools(
     setting.tools,
     registry,
     logger,
-    !delegationGate.allowed,
+    {
+      approvalPromptsUnavailable: input.approvalPromptsUnavailable,
+      delegationBlocked: !delegationGate.allowed,
+    },
   );
 
   const kv = getExecutionStore(executionId);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -367,6 +367,8 @@ export interface ExecuteAgentOptions {
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Stop a tool-use execution after one model/tool cycle instead of waiting for follow-up input. */
   stopAfterCycle?: boolean;
+  /** Hide tools whose approval prompts cannot be answered in this host mode. */
+  approvalPromptsUnavailable?: boolean;
   /** Fires after flow completes but BEFORE untrackExecution, so follow-ups are enqueued before waiters resolve. */
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
@@ -449,6 +451,7 @@ export async function executeAgent(
             onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
             setting,
             isSubagent,
+            approvalPromptsUnavailable: options.approvalPromptsUnavailable,
             onBeforeWaiting: options.onBeforeWaiting,
             stopAfterCycle: options.stopAfterCycle,
             onProgress: (update) => {

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -13,6 +13,7 @@ export interface RunAgentOptions {
   enforceCategory?: boolean;
   registerExecution?: boolean;
   stopAfterCycle?: boolean;
+  approvalPromptsUnavailable?: boolean;
 }
 
 /**
@@ -51,6 +52,7 @@ export async function runAgent(
     runtimeHost: options.runtimeHost,
     enforceCategory: options.enforceCategory,
     stopAfterCycle: options.stopAfterCycle,
+    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
   });
   if (result.category === 'workflow') {
     await options.openWorkflowOutput?.(result);

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
+import { resolveToolUseTools } from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import {
+  __resetToolInjectionRegistry,
+  registerToolInjection,
+} from '@agent/runtime/toolInjection';
+import type { ToolDefinition } from '@model';
+import type { ToolResult } from '@tools/result';
+
+const logger = { warn: () => {} };
+
+function testTool(name: string): ITool {
+  return {
+    definition: { name },
+    call: async (): Promise<ToolResult> => ({
+      summary: `${name} called`,
+      output: '',
+    }),
+  };
+}
+
+function registryFor(names: readonly string[]): MapToolRegistry {
+  return new MapToolRegistry(
+    Object.fromEntries(names.map((name) => [name, testTool(name)])),
+  );
+}
+
+function toolDefs(names: readonly string[]): ToolDefinition[] {
+  return names.map((name) => ({ name }));
+}
+
+describe('tool-use tool resolution', () => {
+  beforeEach(() => {
+    __resetToolInjectionRegistry();
+  });
+
+  it('filters approval-gated tools when approval prompts are unavailable', async () => {
+    const registry = registryFor([
+      'apply_path',
+      'ask_user_question',
+      'bash',
+      'delegate_agent',
+      'grep',
+      'plan',
+      'send_to_terminal',
+      'wolfram',
+      'write_file',
+    ]);
+
+    const { tools, delegationTrimmed } = await resolveToolUseTools(
+      toolDefs([
+        'apply_path',
+        'ask_user_question',
+        'bash',
+        'delegate_agent',
+        'grep',
+        'plan',
+        'send_to_terminal',
+        'wolfram',
+        'write_file',
+      ]),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: true,
+        delegationBlocked: false,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual(['grep', 'wolfram']);
+    expect(delegationTrimmed).toBe(false);
+  });
+
+  it('keeps approval-gated tools when approval prompts are available', async () => {
+    const registry = registryFor([
+      'apply_path',
+      'ask_user_question',
+      'bash',
+      'delegate_agent',
+      'grep',
+      'plan',
+    ]);
+
+    const { tools } = await resolveToolUseTools(
+      toolDefs([
+        'apply_path',
+        'ask_user_question',
+        'bash',
+        'delegate_agent',
+        'grep',
+        'plan',
+      ]),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: false,
+        delegationBlocked: false,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'apply_path',
+      'ask_user_question',
+      'bash',
+      'delegate_agent',
+      'grep',
+      'plan',
+    ]);
+  });
+
+  it('still reports delegation tools trimmed by delegation depth separately', async () => {
+    const registry = registryFor(['delegate_agent', 'grep']);
+
+    const { tools, delegationTrimmed } = await resolveToolUseTools(
+      toolDefs(['delegate_agent', 'grep']),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: false,
+        delegationBlocked: true,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual(['grep']);
+    expect(delegationTrimmed).toBe(true);
+  });
+
+  it('also trims injected delegation tools by delegation depth', async () => {
+    const registry = registryFor(['delegate_agent', 'grep']);
+    registerToolInjection({
+      toolName: 'delegate_agent',
+      shouldInject: () => true,
+    });
+
+    const { tools, delegationTrimmed } = await resolveToolUseTools(
+      toolDefs(['grep']),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: false,
+        delegationBlocked: true,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual(['grep']);
+    expect(delegationTrimmed).toBe(true);
+  });
+});

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatUnavailableApprovalInstruction } from '@cli/commands/_helpers/approvalPolicyInstruction';
+import {
+  approvalPromptsUnavailable,
+  formatUnavailableApprovalInstruction,
+} from '@cli/commands/_helpers/approvalPolicyInstruction';
 import { formatMultiAgentRunInstruction } from '@cli/commands/_helpers/multiAgentInstruction';
 
 const preset = {
@@ -13,6 +16,33 @@ const preset = {
 };
 
 describe('formatUnavailableApprovalInstruction', () => {
+  it('classifies approval-unavailable CLI contexts', () => {
+    expect(
+      approvalPromptsUnavailable({
+        mode: 'headless',
+        approvalPolicy: 'never',
+      }),
+    ).toBe(true);
+    expect(
+      approvalPromptsUnavailable({
+        mode: 'headless',
+        approvalPolicy: 'ask',
+      }),
+    ).toBe(true);
+    expect(
+      approvalPromptsUnavailable({
+        mode: 'headless',
+        approvalPolicy: 'yolo',
+      }),
+    ).toBe(false);
+    expect(
+      approvalPromptsUnavailable({
+        mode: 'interactive',
+        approvalPolicy: 'ask',
+      }),
+    ).toBe(false);
+  });
+
   it('describes never as an automatic approval rejection', () => {
     for (const mode of ['headless', 'interactive'] as const) {
       const instruction = formatUnavailableApprovalInstruction({

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createCliRuntimeHost: vi.fn(),
+  readCliTerminalStatus: vi.fn(),
+  runAgent: vi.fn(),
+  writeTerminalStatus: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/runAgent', () => ({
+  runAgent: mocks.runAgent,
+}));
+
+vi.mock('@agent/storage', () => ({
+  writeTerminalStatus: mocks.writeTerminalStatus,
+}));
+
+vi.mock('@cli/runtime/runtimeHost', () => ({
+  createCliRuntimeHost: mocks.createCliRuntimeHost,
+}));
+
+vi.mock('@cli/commands/_helpers/terminalStatus', () => ({
+  readCliTerminalStatus: mocks.readCliTerminalStatus,
+}));
+
+function cliContext(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/project',
+    mode: 'headless',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    stderrIsTty: false,
+    colorEnabled: false,
+    version: '0.0.0',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+describe('executeCliRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.close.mockResolvedValue(undefined);
+    mocks.createCliRuntimeHost.mockReturnValue({
+      emit: vi.fn(),
+      close: mocks.close,
+    });
+    mocks.readCliTerminalStatus.mockResolvedValue('completed');
+    mocks.runAgent.mockResolvedValue({
+      category: 'toolUse',
+      executionId: 'exec-1',
+      status: 'completed',
+      streamId: 'stream-1',
+    });
+  });
+
+  it('marks headless never runs as approval-unavailable for agent execution', async () => {
+    const { executeCliRequest } =
+      await import('@cli/commands/_helpers/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(request, cliContext());
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        approvalPromptsUnavailable: true,
+      }),
+    );
+  });
+
+  it('marks headless ask runs as approval-unavailable for agent execution', async () => {
+    const { executeCliRequest } =
+      await import('@cli/commands/_helpers/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(request, cliContext({ approvalPolicy: 'ask' }));
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        approvalPromptsUnavailable: true,
+      }),
+    );
+  });
+
+  it('keeps yolo runs approval-available for agent execution', async () => {
+    const { executeCliRequest } =
+      await import('@cli/commands/_helpers/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(request, cliContext({ approvalPolicy: 'yolo' }));
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        approvalPromptsUnavailable: false,
+      }),
+    );
+  });
+});

--- a/src/tools/approvalGatedTools.ts
+++ b/src/tools/approvalGatedTools.ts
@@ -1,0 +1,29 @@
+import type { RegisteredToolName } from './registry';
+
+// Tools hidden when approval or user prompts cannot be answered. This includes
+// tools that already ask for approval, interaction-gated prompts, plus direct
+// privileged mutators like apply_path, which would otherwise bypass the CLI
+// approval policy.
+const APPROVAL_GATED_TOOL_NAME_LIST = [
+  'accept_run_files',
+  'apply_path',
+  'ask_user_question',
+  'bash',
+  'claude_code',
+  'codex',
+  'delegate_agent',
+  'delegate_workflow',
+  'edit_file',
+  'plan',
+  'send_to_terminal',
+  'str_replace_editor',
+  'write_file',
+] as const satisfies readonly RegisteredToolName[];
+
+export const APPROVAL_GATED_TOOL_NAMES: ReadonlySet<string> = new Set(
+  APPROVAL_GATED_TOOL_NAME_LIST,
+);
+
+export function isApprovalGatedToolName(name: string): boolean {
+  return APPROVAL_GATED_TOOL_NAMES.has(name);
+}


### PR DESCRIPTION
## Summary
- classify headless `ask` and `never` approval policies as approval-unavailable for CLI executions
- pass that host mode through agent execution into tool-use tool resolution
- filter guaranteed approval-gated tools before model invocation while preserving read/search/math tools and normal `yolo` / interactive `ask` behavior

Fixes #4959

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`

## Dogfood
- Real `multi-agent run mathematician --approval-policy never` on the Pell prompt returned the complete sign-aware solution.
- TUI validator snapshots for nested subagent and task/sub-workflow views passed and were inspected manually: `/tmp/texra-tui-display-snapshots/index.html`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows which tools agents can invoke in headless CLI modes and touches privileged-tool gating; behavior is scoped and tested but changes production agent capabilities.
> 
> **Overview**
> Headless CLI runs where approvals cannot be honored (`never`, or `ask` in headless mode) now set **`approvalPromptsUnavailable`** on the agent path (`executeCliRequest` → `runAgent` → tool-use flow). That flag strips **approval-gated** tools from the model’s tool list **before** invocation, including injected tools, while **yolo** and interactive **`ask`** keep the full set.
> 
> A shared **`isApprovalGatedToolName`** list covers privileged mutators and prompt/approval tools (`bash`, file edits, `plan`, delegations, etc.). Tool resolution is refactored to exported **`resolveToolUseTools`** with the same delegation-depth filtering as before. Vitest coverage was added for resolution, CLI forwarding, and the new **`approvalPromptsUnavailable`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738d28b6b3403776a6fc4e452076d6e8db9da60a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->