### PR TITLE
Propagate approval-unavailable state to subagents

### DIFF
--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -4,7 +4,7 @@ export type ApprovalInstructionContext = {
 };
 
 const PRIVILEGED_ACTION_GUIDANCE =
-  'Do not call approval-gated tools such as bash/shell commands, file edits, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
+  'Do not call approval-gated tools such as bash/shell commands, file edits, setup/config updates, user questions, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
 
 export function approvalPromptsUnavailable(
   context: ApprovalInstructionContext,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -55,6 +55,8 @@ export interface AgentLaunchContext extends AgentCore {
   storageKey: StorageKey;
   parentStage: StageHandle;
   coordinators: RunCoordinators;
+  /** Whether approval or user prompts cannot be answered by the current host. */
+  approvalPromptsUnavailable?: boolean;
   /**
    * Dispose the run-trace subscribers (channel sink + transcript recorder)
    * registered by {@link createRunTrace}. Must be called once at end-of-run
@@ -102,6 +104,7 @@ export async function withExecutionRunContext<T>(
     workingDirectory: ctx.workingDirectory,
     delegationDepth: ctx.delegationDepth,
     delegationConfig: ctx.delegationConfig,
+    approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
   });
   const release = retainRunCoordinatorsForStream(
     ctx.streamId,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -42,6 +42,8 @@ export interface RunContext {
    * aligned with the tool list shown to the model.
    */
   readonly delegationConfig?: NestedDelegationConfig;
+  /** Whether approval or user prompts cannot be answered by the current host. */
+  readonly approvalPromptsUnavailable?: boolean;
 }
 
 export interface CreateRunContextOptions {
@@ -59,6 +61,7 @@ export interface CreateRunContextOptions {
   workingDirectory?: string;
   delegationDepth?: number;
   delegationConfig?: NestedDelegationConfig;
+  approvalPromptsUnavailable?: boolean;
 }
 
 const runContextScope = new AsyncLocalStorage<RunContext>();
@@ -79,6 +82,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     workingDirectory: options.workingDirectory,
     delegationDepth: options.delegationDepth,
     delegationConfig: options.delegationConfig,
+    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
   });
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -394,6 +394,7 @@ export async function executeAgent(
     suppressErrorNotification: options.isSubagent,
   });
   ctx.delegationDepth = options.delegationDepth ?? 0;
+  ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
     const { agent: agentName } = config;

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -45,6 +45,7 @@ describe('tool-use tool resolution', () => {
       'grep',
       'plan',
       'send_to_terminal',
+      'update_config',
       'wolfram',
       'write_file',
     ]);
@@ -58,6 +59,7 @@ describe('tool-use tool resolution', () => {
         'grep',
         'plan',
         'send_to_terminal',
+        'update_config',
         'wolfram',
         'write_file',
       ]),
@@ -81,6 +83,7 @@ describe('tool-use tool resolution', () => {
       'delegate_agent',
       'grep',
       'plan',
+      'update_config',
     ]);
 
     const { tools } = await resolveToolUseTools(
@@ -91,6 +94,7 @@ describe('tool-use tool resolution', () => {
         'delegate_agent',
         'grep',
         'plan',
+        'update_config',
       ]),
       registry,
       logger,
@@ -107,6 +111,7 @@ describe('tool-use tool resolution', () => {
       'delegate_agent',
       'grep',
       'plan',
+      'update_config',
     ]);
   });
 
@@ -119,6 +124,23 @@ describe('tool-use tool resolution', () => {
       logger,
       {
         approvalPromptsUnavailable: false,
+        delegationBlocked: true,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual(['grep']);
+    expect(delegationTrimmed).toBe(true);
+  });
+
+  it('keeps delegation trimming when approval filtering is also active', async () => {
+    const registry = registryFor(['bash', 'delegate_agent', 'grep']);
+
+    const { tools, delegationTrimmed } = await resolveToolUseTools(
+      toolDefs(['bash', 'delegate_agent', 'grep']),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: true,
         delegationBlocked: true,
       },
     );
@@ -146,5 +168,26 @@ describe('tool-use tool resolution', () => {
 
     expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(true);
+  });
+
+  it('filters injected approval-gated tools when approval prompts are unavailable', async () => {
+    const registry = registryFor(['grep', 'update_config']);
+    registerToolInjection({
+      toolName: 'update_config',
+      shouldInject: () => true,
+    });
+
+    const { tools, delegationTrimmed } = await resolveToolUseTools(
+      toolDefs(['grep']),
+      registry,
+      logger,
+      {
+        approvalPromptsUnavailable: true,
+        delegationBlocked: false,
+      },
+    );
+
+    expect(tools.map((tool) => tool.name)).toEqual(['grep']);
+    expect(delegationTrimmed).toBe(false);
   });
 });

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -25,6 +25,12 @@ describe('formatUnavailableApprovalInstruction', () => {
     ).toBe(true);
     expect(
       approvalPromptsUnavailable({
+        mode: 'interactive',
+        approvalPolicy: 'never',
+      }),
+    ).toBe(true);
+    expect(
+      approvalPromptsUnavailable({
         mode: 'headless',
         approvalPolicy: 'ask',
       }),

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -369,6 +369,7 @@ async function executeSubagent(
     enforceCategory: true,
     parentStreamId: orchestratorStreamId,
     delegationDepth: parentDelegationDepth + 1,
+    approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       if (options?.enableYoloOnChild) {

--- a/src/tools/approvalGatedTools.ts
+++ b/src/tools/approvalGatedTools.ts
@@ -14,9 +14,14 @@ const APPROVAL_GATED_TOOL_NAME_LIST = [
   'delegate_agent',
   'delegate_workflow',
   'edit_file',
+  'install_vscode_extension',
+  'invoke_command',
   'plan',
   'send_to_terminal',
+  'set_api_key',
   'str_replace_editor',
+  'unset_api_key',
+  'update_config',
   'write_file',
 ] as const satisfies readonly RegisteredToolName[];
 


### PR DESCRIPTION
Follow-up to #4960 after the final TeXRA review.

## Summary
- carry `approvalPromptsUnavailable` through `RunContext` so delegated subagents inherit headless approval limits
- hide additional privileged setup/config tools when approval/user prompts cannot be answered
- cover combined delegation+approval filtering and injected approval-gated tool filtering

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 12 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools subagents can invoke and expands privileged-tool gating; mis-propagation could hide needed tools or leave risky tools visible in headless runs.
> 
> **Overview**
> This PR threads **`approvalPromptsUnavailable`** through **`RunContext`**, **`executeAgent`**, and **`delegate_agent` / `delegate_workflow`** so delegated subagents inherit the same “no approval / no user prompts” limits as the parent (e.g. CLI headless **`never`** or **`ask`**).
> 
> When that flag is set, tool-use resolution continues to strip **approval-gated** tools, now including more **setup/config** mutators (`update_config`, API key helpers, `invoke_command`, VS Code install, etc.). CLI copy in **`approvalPolicyInstruction`** is updated to tell the model not to use those privileged actions.
> 
> Tests cover **`update_config`** filtering, **combined** delegation-depth + approval filtering, and **injected** approval-gated tools; interactive **`never`** is asserted as approval-unavailable for classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838e802913ba061909e378998538f3f1fc999ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->