### PR TITLE
fix(cli): correct chat option hints

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -282,16 +282,34 @@ const SCENARIOS = [
     name: 'agent-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
-    expect: ['/agent', 'Tool-use agents', 'Esc close'],
-    unexpect: ['Platform not initialized', '/agent - error'],
+    expect: [
+      '/agent',
+      'Tool-use agents',
+      'texra chat --agent=<name>',
+      'Esc close',
+    ],
+    unexpect: [
+      'Platform not initialized',
+      '/agent - error',
+      'texra --agent=<name>',
+    ],
   },
   {
     name: 'agent-form-80-cols',
     cols: 80,
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
-    expect: ['/agent', 'Tool-use agents', 'Esc close'],
-    unexpect: ['Platform not initialized', '/agent - error'],
+    expect: [
+      '/agent',
+      'Tool-use agents',
+      'texra chat --agent=<name>',
+      'Esc close',
+    ],
+    unexpect: [
+      'Platform not initialized',
+      '/agent - error',
+      'texra --agent=<name>',
+    ],
     maxLineColumns: 80,
   },
   {
@@ -299,8 +317,16 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/model', '\r'],
     frame: 'tail',
-    expect: ['/model · personal API keys', 'Available models'],
-    unexpect: ['Platform not initialized', '/model - error'],
+    expect: [
+      '/model · personal API keys',
+      'Available models',
+      'texra chat --model=<name>',
+    ],
+    unexpect: [
+      'Platform not initialized',
+      '/model - error',
+      'texra --model=<name>',
+    ],
   },
   {
     name: 'api-form',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -209,7 +209,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       <Text dimColor wrap="truncate-end">
         {selectable
           ? 'Choose the root tool-use agent for the first message.'
-          : 'Available agents. Start a new chat with texra --agent=<name> to choose the root tool-use agent.'}
+          : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root tool-use agent.'}
       </Text>
       <Box marginTop={1} flexDirection="column">
         <Text bold>Tool-use agents</Text>

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -168,7 +168,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
       <Text dimColor>
         {selectable
           ? 'Choose the root model for the first message.'
-          : 'Available models. Start a new chat with texra --model=<name> to choose the root model.'}
+          : 'Available models. Start a new chat with texra chat --model=<name> to choose the root model.'}
       </Text>
       {items.length === 0 ? (
         <EmptyModelListState onClose={props.onClose} />

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -290,7 +290,7 @@ function applyInitialCliAgentSelection(
 ): void {
   if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
-      'Agent changes are only available before the first message. Start a new chat with texra --agent=<name> to choose a different root agent.',
+      'Agent changes are only available before the first message. Start a new chat with texra chat --agent=<name> to choose a different root agent.',
     );
     return;
   }
@@ -329,7 +329,7 @@ async function applyInitialCliModelSelection(
 ): Promise<void> {
   if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
-      'Model changes are only available before the first message. Start a new chat with texra --model=<name> to choose a different root model.',
+      'Model changes are only available before the first message. Start a new chat with texra chat --model=<name> to choose a different root model.',
     );
     return;
   }


### PR DESCRIPTION
Closes #4964.

## Summary
- updates `/agent` and `/model` TUI hints to use `texra chat --agent=<name>` / `texra chat --model=<name>`
- updates blocked post-first-message transcripts with the same command shape
- strengthens TUI validator coverage so the stale top-level `texra --agent` / `texra --model` hints do not regress

## Validation
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-hints-20260601 agent-form agent-form-80-cols model-form`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing string and test expectation updates only; no runtime behavior or auth/data paths change.
> 
> **Overview**
> Updates CLI chat guidance so **agent** and **model** overrides are shown as `texra chat --agent=<name>` and `texra chat --model=<name>` instead of the incorrect top-level `texra --agent` / `texra --model` forms.
> 
> The copy changes appear in the read-only **`/agent`** and **`/model`** TUI forms, in assistant messages when root agent/model cannot be changed after the first message, and in **`validate-tui.mjs`** expectations so stale hints cannot slip back in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df549a64b1c12fb4491ec3a11bc719bbdac6e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->