### PR TITLE
Show diffs in CLI edit approvals

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { structuredPatch } from 'diff';
+
 // Local imports - runtime
 import {
   cancelRetry,
@@ -36,6 +39,11 @@ const APPROVAL_EVENTS = [
   'showRetryRequest',
 ] as const;
 type ApprovalEvent = (typeof APPROVAL_EVENTS)[number];
+
+const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
+const TOOL_EDIT_APPROVAL_DIFF_MAX_CHARS = 12_000;
+const TOOL_EDIT_APPROVAL_DIFF_MAX_LINES = 80;
+const TOOL_EDIT_APPROVAL_DIFF_MAX_LINE_CHARS = 240;
 
 export const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to personal API keys.';
@@ -422,13 +430,105 @@ function handleUserQuestion(
   })();
 }
 
+function formatDiffRange(start: number, lineCount: number): string {
+  return lineCount === 1 ? String(start) : `${start},${lineCount}`;
+}
+
+function toolEditDiffLines(
+  request: ToolEditApprovalRequest,
+): readonly string[] {
+  const patch = structuredPatch(
+    request.path,
+    request.path,
+    request.originalContent,
+    request.proposedContent,
+    '',
+    '',
+    { context: 3 },
+  );
+  if (patch.hunks.length === 0) return [];
+
+  return [
+    `--- ${request.path}`,
+    `+++ ${request.path}`,
+    ...patch.hunks.flatMap((hunk) => [
+      `@@ -${formatDiffRange(hunk.oldStart, hunk.oldLines)} +${formatDiffRange(
+        hunk.newStart,
+        hunk.newLines,
+      )} @@`,
+      ...hunk.lines,
+    ]),
+  ];
+}
+
+function truncateDiffLine(line: string): string {
+  if (line.length <= TOOL_EDIT_APPROVAL_DIFF_MAX_LINE_CHARS) return line;
+  const prefixLength = Math.max(
+    0,
+    TOOL_EDIT_APPROVAL_DIFF_MAX_LINE_CHARS - TRUNCATED_DIFF_LINE_MARKER.length,
+  );
+  return `${line.slice(0, prefixLength)}${TRUNCATED_DIFF_LINE_MARKER}`;
+}
+
+function boundedToolEditDiffLines(
+  diffLines: readonly string[],
+): readonly string[] {
+  const visibleLines: string[] = [];
+  let visibleChars = 0;
+  let hiddenLineCount = 0;
+
+  for (let index = 0; index < diffLines.length; index++) {
+    const line = truncateDiffLine(diffLines[index]!);
+    const separatorLength = visibleLines.length === 0 ? 0 : 1;
+    const nextVisibleChars = visibleChars + separatorLength + line.length;
+    if (
+      visibleLines.length >= TOOL_EDIT_APPROVAL_DIFF_MAX_LINES ||
+      nextVisibleChars > TOOL_EDIT_APPROVAL_DIFF_MAX_CHARS
+    ) {
+      hiddenLineCount = diffLines.length - index;
+      break;
+    }
+
+    visibleLines.push(line);
+    visibleChars = nextVisibleChars;
+  }
+
+  if (hiddenLineCount > 0) {
+    visibleLines.push(`… +${hiddenLineCount} diff lines hidden`);
+  }
+
+  return visibleLines;
+}
+
+export function formatToolEditApprovalSummary(
+  request: ToolEditApprovalRequest,
+): string {
+  const header = `Tool edit requested by ${request.sourceTool}: ${request.path}`;
+  const diffLines = toolEditDiffLines(request);
+  if (diffLines.length === 0) {
+    return `${header}\nNo content changes proposed.`;
+  }
+
+  const visibleLines = boundedToolEditDiffLines(diffLines);
+
+  return `${header}\nProposed diff:\n${visibleLines.join('\n')}`;
+}
+
 async function decideToolEdit(
   request: ToolEditApprovalRequest,
   context: CliContext,
 ): Promise<ToolEditApprovalResult> {
-  const summary = `Tool edit requested by ${request.sourceTool}: ${request.path}`;
   const immediate = immediateDecision(context);
-  const decision = immediate ?? (await askApproval(context, summary));
+  if (immediate) {
+    return immediate.accepted
+      ? { accepted: true, appliedContent: request.proposedContent }
+      : { accepted: false, userMessage: immediate.userMessage };
+  }
+
+  const decision = await askApproval(
+    context,
+    formatToolEditApprovalSummary(request),
+  );
   return decision.accepted
     ? { accepted: true, appliedContent: request.proposedContent }
     : { accepted: false, userMessage: decision.userMessage };

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,13 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   appendCliApiSwitchHint,
   formatRetryRequestMessage,
+  formatToolEditApprovalSummary,
   immediateDecisionForApproval,
+  installCliApprovalHandlers,
   isCliApiSwitchableRetry,
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import {
+  requestToolEditApproval,
+  setToolEditApprovalHandler,
+} from '@tools/approval/toolEditApproval';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {
@@ -33,6 +39,10 @@ const credentialExhaustedRetry: ProgressEventPayloads['showRetryRequest'] = {
     statusCode: 429,
   },
 };
+
+afterEach(() => {
+  setToolEditApprovalHandler();
+});
 
 describe('immediateDecisionForApproval', () => {
   it('shows the interactive retry panel for exhausted credentials', () => {
@@ -61,6 +71,98 @@ describe('immediateDecisionForApproval', () => {
         context({ mode: 'headless' }),
       ),
     ).toMatchObject({ accepted: false });
+  });
+});
+
+describe('formatToolEditApprovalSummary', () => {
+  it('includes the proposed edit diff in interactive CLI prompts', () => {
+    const summary = formatToolEditApprovalSummary({
+      path: '/tmp/proof.tex',
+      originalContent: 'Let G be a group.\nThis is wrong.\n',
+      proposedContent: 'Let G be a group.\nThis is correct.\n',
+      sourceTool: 'edit_file',
+    });
+
+    expect(summary).toContain('Tool edit requested by edit_file');
+    expect(summary).toContain('Proposed diff:');
+    expect(summary).toContain('-This is wrong.');
+    expect(summary).toContain('+This is correct.');
+  });
+
+  it('passes the diff summary to the interactive approval prompt', async () => {
+    let promptSummary = '';
+    installCliApprovalHandlers(
+      context({
+        approvalPrompt: async (request) => {
+          promptSummary = request.summary;
+          return 'n';
+        },
+      }),
+    );
+
+    const result = await requestToolEditApproval({
+      path: '/tmp/new-proof.tex',
+      originalContent: '',
+      proposedContent: '\\section{Proof}\nA concise proof.\n',
+      sourceTool: 'write_file',
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(promptSummary).toContain('Tool edit requested by write_file');
+    expect(promptSummary).toContain('+\\section{Proof}');
+    expect(promptSummary).toContain('+A concise proof.');
+  });
+
+  it('bounds long diff lines before prompting', () => {
+    const longLine = 'x'.repeat(1_000);
+    const summary = formatToolEditApprovalSummary({
+      path: '/tmp/generated.json',
+      originalContent: '',
+      proposedContent: `${longLine}\n`,
+      sourceTool: 'write_file',
+    });
+
+    expect(summary).toContain('[line truncated]');
+    expect(summary).not.toContain(longLine);
+    expect(summary.length).toBeLessThan(1_000);
+  });
+
+  it('marks hidden diff lines when the line budget is exceeded', () => {
+    const proposedContent = Array.from(
+      { length: 100 },
+      (_, index) => `generated line ${index + 1}`,
+    ).join('\n');
+    const summary = formatToolEditApprovalSummary({
+      path: '/tmp/generated.tex',
+      originalContent: '',
+      proposedContent,
+      sourceTool: 'write_file',
+    });
+
+    expect(summary).toContain('diff lines hidden');
+  });
+
+  it('skips prompting for auto-approved edits', async () => {
+    installCliApprovalHandlers(
+      context({
+        approvalPolicy: 'yolo',
+        approvalPrompt: async () => {
+          throw new Error('approval prompt should not be called');
+        },
+      }),
+    );
+
+    const result = await requestToolEditApproval({
+      path: '/tmp/auto-approved.tex',
+      originalContent: '',
+      proposedContent: '\\section{Auto-approved}\n',
+      sourceTool: 'write_file',
+    });
+
+    expect(result).toMatchObject({
+      accepted: true,
+      appliedContent: '\\section{Auto-approved}\n',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Show a bounded unified diff in non-chat CLI tool-edit approval prompts.
- Reuse that summary for `write_file`/`edit_file` approvals handled by `approvalAdapter`.
- Cover both the formatter and the interactive approval prompt path in kernel tests.

Closes #4966.

## Dogfood Evidence

Ran `texra-local multi-agent run mathematician --api-mode included --approval-policy ask --model deepseekT` on a group-theory task (`|G| = p^2 => G` abelian). The run completed, but edit approval prompts only showed the tool and absolute path, leaving no way to review the proposed file content before approving.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm run lint` (0 errors, existing 12 import-order warnings)
- `corepack pnpm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to approval prompt text with limits to avoid huge prompts; approval policy behavior is unchanged aside from richer summaries.
> 
> **Overview**
> Non-chat CLI **tool-edit** approvals (`write_file` / `edit_file`) now show a **bounded unified diff** of proposed content instead of only the tool name and path.
> 
> `approvalAdapter` builds the diff with `structuredPatch`, caps visible output (line count, total characters, and per-line length), and surfaces a “hidden lines” footer when truncated. Interactive prompts use the new `formatToolEditApprovalSummary`; **yolo** / non-interactive paths still auto-approve or deny without calling the prompt. Kernel tests cover the formatter, the live approval handler wiring, truncation, and auto-approve behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4913631ca5dbe4d2a58f3109af1800fc3e5231ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->