### PR TITLE
fix(cli): keep subagent hint in compact status

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -801,6 +801,41 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'subagents-with-todos-compact',
+    rows: 14,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_TODOS: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    expect: [
+      '+4 more child executions',
+      '3 sub',
+      '1 proc',
+      '[Tab]streams',
+      ']subagents',
+      ']tasks',
+      '[Ctrl-C]stop',
+    ],
+  },
+  {
+    name: 'subagents-with-todos-narrow-status',
+    rows: 14,
+    cols: 44,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_TODOS: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: ']subagents',
+    expect: [']subagents', '[Ctrl-C]stop'],
+    unexpect: [']tasks'],
+  },
+  {
     name: 'subagent-picker',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -373,9 +373,29 @@ export function statusBarBindingsText(
   const minimalBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
     `[${modifierLabel}-p]tasks`,
+    ...(subagentControlsAvailable ? [`[${modifierLabel}-s]subagents`] : []),
     `[Ctrl-C]${ctrlCAction}`,
   ]);
   if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
+
+  if (subagentControlsAvailable) {
+    const subagentFocusedBindings = joinStatusBindings([
+      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+      `[${modifierLabel}-s]subagents`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(subagentFocusedBindings, maxColumns)) {
+      return subagentFocusedBindings;
+    }
+
+    const bareSubagentBindings = joinStatusBindings([
+      `[${modifierLabel}-s]subagents`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(bareSubagentBindings, maxColumns)) {
+      return bareSubagentBindings;
+    }
+  }
 
   return `[Ctrl-C]${ctrlCAction}`;
 }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -205,7 +205,9 @@ describe('CLI StatusBar display model', () => {
       width: 60,
     });
 
-    expect(display.bindings).toBe('[Tab]streams  [Alt-p]tasks  [Ctrl-C]stop');
+    expect(display.bindings).toBe(
+      '[Tab]streams  [Alt-p]tasks  [Alt-s]subagents  [Ctrl-C]stop',
+    );
     expect(display.bindings).toContain('[Ctrl-C]stop');
   });
 


### PR DESCRIPTION
Closes #4968.

## Summary
- keeps the subagent picker shortcut in the minimal status bindings when subagent controls are available
- adds a compact children+todos TUI scenario so cramped combined bottom-panel states keep a visible subagent affordance

## Dogfood Evidence
- Real `texra multi-agent run mathematician` solved a bounded math prompt and surfaced the combined children/todos display gap via the harness stress case
- `subagents-with-todos-compact` now captures the 14x80 combined state with `3 sub`, `1 proc`, `]subagents`, and `]tasks`

## Validation
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-combined-fix-loop subagents-with-todos-compact subagents task-picker todos`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status binding order and test harness updates; no auth, data, or API behavior changes.
> 
> **Overview**
> **Keeps the subagent picker shortcut on the CLI status bar when horizontal space is tight**, instead of dropping it once bindings shrink past the “compact” tier.
> 
> `statusBarBindingsText` now includes **`[Alt/Option-s]subagents` in the minimal binding set** when subagent controls are available, and adds **narrower fallbacks** that prefer streams + subagents + stop, then subagents + stop alone, before collapsing to only `[Ctrl-C]`.
> 
> **Regression coverage:** two **TUI harness scenarios** exercise a **14×80 children+todos** layout (expecting both `]subagents` and `]tasks`) and a **14×44** footer (subagents hint kept, tasks hint dropped). A **StatusBar unit test** at width 60 now expects the subagents binding alongside tasks and streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7013f3c9436731288b989549e88df506f3698c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->