### PR TITLE
fix(cli): summarize agent proposal approvals

### DIFF
--- a/packages/cli/src/chat/tui/modals/AgentProposalDisplay.ts
+++ b/packages/cli/src/chat/tui/modals/AgentProposalDisplay.ts
@@ -1,9 +1,1 @@
-import { AGENT_CATEGORY, type AgentProposalPermission } from '@shared/schemas';
-
-export function agentProposalCategoryLabel(
-  agentCategory: AgentProposalPermission['agentCategory'],
-): string {
-  return agentCategory === AGENT_CATEGORY.WORKFLOW
-    ? 'workflow agent'
-    : 'tool-use agent';
-}
+export { agentProposalCategoryLabel } from '@shared/schemas';

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -9,7 +9,12 @@ import {
   triggerRetry,
 } from '@agent/runtime/runCoordinators';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import type { ApprovalDecision as SharedApprovalDecision } from '@shared/schemas';
+import {
+  agentProposalCategoryLabel,
+  getProposalFileGroups,
+  type AgentProposalPermission,
+  type ApprovalDecision as SharedApprovalDecision,
+} from '@shared/schemas';
 
 // Local imports - tools
 import { handleUserQuestionAction } from '@tools/userQuestion';
@@ -44,6 +49,10 @@ const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
 const TOOL_EDIT_APPROVAL_DIFF_MAX_CHARS = 12_000;
 const TOOL_EDIT_APPROVAL_DIFF_MAX_LINES = 80;
 const TOOL_EDIT_APPROVAL_DIFF_MAX_LINE_CHARS = 240;
+const AGENT_PROPOSAL_INSTRUCTION_MAX_CHARS = 6_000;
+const AGENT_PROPOSAL_INSTRUCTION_MAX_LINES = 40;
+const AGENT_PROPOSAL_INSTRUCTION_MAX_LINE_CHARS = 240;
+const AGENT_PROPOSAL_FILE_GROUP_MAX_FILES = 10;
 
 export const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to personal API keys.';
@@ -192,6 +201,94 @@ async function askApproval(
   };
 }
 
+function truncateAgentProposalInstructionLine(line: string): string {
+  if (line.length <= AGENT_PROPOSAL_INSTRUCTION_MAX_LINE_CHARS) return line;
+  const prefixLength = Math.max(
+    0,
+    AGENT_PROPOSAL_INSTRUCTION_MAX_LINE_CHARS -
+      TRUNCATED_DIFF_LINE_MARKER.length,
+  );
+  return `${line.slice(0, prefixLength)}${TRUNCATED_DIFF_LINE_MARKER}`;
+}
+
+function boundedAgentProposalInstructionLines(
+  instruction: string,
+): readonly string[] {
+  const instructionLines = instruction
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .split('\n');
+  const visibleLines: string[] = [];
+  let visibleChars = 0;
+  let hiddenLineCount = 0;
+
+  for (let index = 0; index < instructionLines.length; index++) {
+    const line = truncateAgentProposalInstructionLine(instructionLines[index]!);
+    const separatorLength = visibleLines.length === 0 ? 0 : 1;
+    const nextVisibleChars = visibleChars + separatorLength + line.length;
+    if (
+      visibleLines.length >= AGENT_PROPOSAL_INSTRUCTION_MAX_LINES ||
+      nextVisibleChars > AGENT_PROPOSAL_INSTRUCTION_MAX_CHARS
+    ) {
+      hiddenLineCount = instructionLines.length - index;
+      break;
+    }
+
+    visibleLines.push(line);
+    visibleChars = nextVisibleChars;
+  }
+
+  if (hiddenLineCount > 0) {
+    visibleLines.push(`… +${hiddenLineCount} instruction lines hidden`);
+  }
+
+  return visibleLines;
+}
+
+function optionalAgentProposalLine(label: string, value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? [`${label}: ${trimmed}`] : [];
+}
+
+function formatAgentProposalFileGroup(
+  label: string,
+  files: readonly string[],
+): string {
+  const visibleFiles = files.slice(0, AGENT_PROPOSAL_FILE_GROUP_MAX_FILES);
+  const hiddenCount = files.length - visibleFiles.length;
+  const suffix = hiddenCount > 0 ? `, +${hiddenCount} more` : '';
+  return `${label}: ${visibleFiles.join(', ')}${suffix}`;
+}
+
+function agentProposalFileGroupLines(
+  proposal: AgentProposalPermission,
+): string[] {
+  return getProposalFileGroups(proposal).map((group) =>
+    formatAgentProposalFileGroup(group.label, group.files),
+  );
+}
+
+export function formatAgentProposalApprovalSummary(
+  proposal: AgentProposalPermission,
+): string {
+  const instructionLines = boundedAgentProposalInstructionLines(
+    proposal.instruction,
+  );
+  return [
+    `Agent proposal requested: ${proposal.agent} (${agentProposalCategoryLabel(
+      proposal.agentCategory,
+    )})`,
+    `Model: ${proposal.model}`,
+    ...optionalAgentProposalLine(
+      'Working directory',
+      proposal.workingDirectory ?? undefined,
+    ),
+    ...agentProposalFileGroupLines(proposal),
+    'Instruction:',
+    ...instructionLines.map((line) => `  ${line}`),
+  ].join('\n');
+}
+
 function summarizeApprovalEvent<K extends ApprovalEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
@@ -207,7 +304,7 @@ function summarizeApprovalEvent<K extends ApprovalEvent>(
     }
     case 'showAgentProposal': {
       const data = payload as ProgressEventPayloads['showAgentProposal'];
-      return `Agent proposal requested:\n${JSON.stringify(data, null, 2)}`;
+      return formatAgentProposalApprovalSummary(data);
     }
     case 'showRetryRequest': {
       const data = payload as ProgressEventPayloads['showRetryRequest'];

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { AgentCategory } from './agent';
 import { ToolConfigSchema } from './toolConfig';
 
 export const BaseProposalFieldsSchema = z.object({
@@ -55,4 +56,12 @@ export function getProposalFileGroups(data: FileFields): ProposalFileGroup[] {
     { label: 'Output', files: data.outputFiles ?? [], clickable: true },
     { label: 'Memories', files: data.memories ?? [], clickable: false },
   ].filter((g) => g.files.length > 0);
+}
+
+export function agentProposalCategoryLabel(
+  agentCategory: AgentCategory,
+): string {
+  return agentCategory === AgentCategory.Workflow
+    ? 'workflow agent'
+    : 'tool-use agent';
 }

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   appendCliApiSwitchHint,
+  formatAgentProposalApprovalSummary,
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
   immediateDecisionForApproval,
@@ -10,6 +11,7 @@ import {
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { AGENT_CATEGORY, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
 import {
   requestToolEditApproval,
   setToolEditApprovalHandler,
@@ -163,6 +165,81 @@ describe('formatToolEditApprovalSummary', () => {
       accepted: true,
       appliedContent: '\\section{Auto-approved}\n',
     });
+  });
+});
+
+describe('formatAgentProposalApprovalSummary', () => {
+  it('formats subagent approvals without raw JSON internals', () => {
+    const summary = formatAgentProposalApprovalSummary({
+      proposalId: 'proposal-1',
+      streamId: 'root@deepseekT#abc',
+      agent: 'review',
+      model: 'deepseekT',
+      instruction:
+        'Please verify the proof carefully.\nReport any gaps or hidden cases.',
+      memories: [],
+      agentCategory: AGENT_CATEGORY.TOOL_USE,
+    });
+
+    expect(summary).toContain(
+      'Agent proposal requested: review (tool-use agent)',
+    );
+    expect(summary).toContain('Model: deepseekT');
+    expect(summary).toContain('Instruction:');
+    expect(summary).toContain('  Please verify the proof carefully.');
+    expect(summary).not.toContain('proposalId');
+    expect(summary).not.toContain('streamId');
+    expect(summary).not.toContain('{');
+  });
+
+  it('bounds long subagent instructions before prompting', () => {
+    const longLine = 'verify '.repeat(200);
+    const instruction = Array.from(
+      { length: 60 },
+      (_, index) => `${index + 1}. ${longLine}`,
+    ).join('\n');
+
+    const summary = formatAgentProposalApprovalSummary({
+      proposalId: 'proposal-1',
+      streamId: 'root@deepseekT#abc',
+      agent: 'review',
+      model: 'deepseekT',
+      instruction,
+      memories: ['/memories/proof-style.md'],
+      workingDirectory: '/tmp/project',
+      agentCategory: AGENT_CATEGORY.TOOL_USE,
+    });
+
+    expect(summary).toContain('Working directory: /tmp/project');
+    expect(summary).toContain('Memories: /memories/proof-style.md');
+    expect(summary).toContain('[line truncated]');
+    expect(summary).toContain('instruction lines hidden');
+    expect(summary).not.toContain(longLine);
+  });
+
+  it('includes workflow proposal file groups', () => {
+    const summary = formatAgentProposalApprovalSummary({
+      proposalId: 'proposal-1',
+      streamId: 'root@deepseekT#abc',
+      agent: 'polish',
+      model: 'deepseekT',
+      instruction: 'Polish the draft and write the revised file.',
+      memories: [],
+      inputFiles: ['draft.tex'],
+      contextFiles: ['notes.md'],
+      mediaFiles: ['figure.png'],
+      outputFiles: ['draft-polished.tex'],
+      toolConfig: DEFAULT_TOOL_CONFIG,
+      agentCategory: AGENT_CATEGORY.WORKFLOW,
+    });
+
+    expect(summary).toContain(
+      'Agent proposal requested: polish (workflow agent)',
+    );
+    expect(summary).toContain('Input: draft.tex');
+    expect(summary).toContain('Context: notes.md');
+    expect(summary).toContain('Media: figure.png');
+    expect(summary).toContain('Output: draft-polished.tex');
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace raw JSON subagent approval prompts in the plain CLI adapter with a structured agent/model/instruction summary.
- Bound long proposed instructions by line length, total characters, and line count before prompting.
- Add focused approval adapter coverage for readable agent proposal summaries.

Closes #4970.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (0 errors; existing import-order warnings remain)
- `corepack pnpm run compile:safe`
- Rebuilt/relinked `texra-local` and verified a live `multi-agent run mathematician` reviewer approval now shows a readable summary instead of raw JSON.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Approval prompt formatting and shared label helper only; no changes to approval resolution, auth, or delegation behavior.
> 
> **Overview**
> Plain CLI **agent proposal** approvals no longer dump the full payload as JSON. `showAgentProposal` now uses **`formatAgentProposalApprovalSummary`**, which shows agent name and category, model, optional working directory, file groups (via shared **`getProposalFileGroups`**), and a bounded, indented instruction block.
> 
> Long instructions are capped (per-line length, line count, and total characters) with truncation markers, mirroring the existing tool-edit approval diff limits. **`agentProposalCategoryLabel`** moves into **`@shared/schemas`** so the TUI re-exports it and the CLI adapter shares one definition.
> 
> Tests in **`ApprovalAdapter.vitest.mts`** cover readable summaries, truncation, and workflow file groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51578b0cfdb603c94b8ccf8dcc239f31d765fcf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->