### PR TITLE
fix(cli): reject invalid multi-agent root override

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -174,10 +174,6 @@ export async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
 ): Promise<number> {
-  // A team run drives a tool-use orchestrator, so it follows the `chat`
-  // (tool-use) model config rather than `run` (workflow agents).
-  const model = await resolveCliRunModel(context, init.model, 'chat');
-  const runContext = buildHeadlessRunContext(context, model);
   const hasInlineInstruction = init.instruction.trim().length > 0;
   if (init.inputFiles.length === 0 && !hasInlineInstruction) {
     throw new CliUsageError('Provide --input or --instruction.');
@@ -185,15 +181,19 @@ export async function runMultiAgentPreset(
   const { inputFiles, contextFiles } = await expandRunInputs(
     init.inputFiles,
     init.contextFiles,
-    runContext.cwd,
+    context.cwd,
     { allowEmptyInput: hasInlineInstruction },
   );
 
-  await initCliPlatform(runContext);
-  installCliApprovalHandlers(runContext);
+  await initCliPlatform({ ...context, quietLogs: true });
   await loadAgents({ includeRemote: false });
 
   const plan = await fillMultiAgentRunPlanGaps(init);
+  if (plan.missingAgentOverride) {
+    throw new CliUsageError(
+      `Tool-use agent not found: ${plan.missingAgentOverride}. Use \`texra agents list\` to see available agents.`,
+    );
+  }
   if (!plan.rootAgent) {
     writeTextStderr(
       `Multi-agent preset "${init.preset}" has no available tool-use agent to run. Use --agent with an installed tool-use agent, or enable a team with an orchestrator.`,
@@ -201,6 +201,14 @@ export async function runMultiAgentPreset(
     return CliExitCode.Usage;
   }
   writeMissingPresetAgents(plan);
+
+  // A team run drives a tool-use orchestrator, so it follows the `chat`
+  // (tool-use) model config rather than `run` (workflow agents). Resolve the
+  // model after agent validation so usage errors stay focused on bad agents.
+  const model = await resolveCliRunModel(context, init.model, 'chat');
+  const runContext = buildHeadlessRunContext(context, model);
+  await initCliPlatform(runContext);
+  installCliApprovalHandlers(runContext);
 
   const config: AgentConfigPayload = {
     agent: plan.rootAgent.name,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -18,6 +18,7 @@ export interface CliMultiAgentPreset extends AgentModePreset {
 export interface CliMultiAgentPresetRunPlan {
   readonly preset: CliMultiAgentPreset;
   readonly rootAgent?: AgentEntry;
+  readonly missingAgentOverride?: string;
   readonly workflowAgentKeys: readonly string[];
   readonly toolUseAgentKeys: readonly string[];
   readonly missingWorkflowAgents: readonly string[];
@@ -115,6 +116,7 @@ export function cliMultiAgentPlanHasGaps(
 ): boolean {
   return (
     !plan.rootAgent ||
+    plan.missingAgentOverride !== undefined ||
     plan.missingWorkflowAgents.length > 0 ||
     plan.missingToolUseAgents.length > 0
   );
@@ -136,12 +138,12 @@ export function planCliMultiAgentPresetRun(
     preset.toolUseAgents,
     options.toolUseAgents,
   );
-  const overrideAgent = resolveAgentOverride(
+  const override = resolveAgentOverride(
     options.agentOverride,
     options.toolUseAgents,
   );
   const rootAgent =
-    overrideAgent ??
+    override.agent ??
     selectPresetRootAgent(toolUse.resolved, preset.toolUseAgents);
   const toolUseAgents = rootAgent
     ? includeAgent(toolUse.resolved, rootAgent)
@@ -150,6 +152,7 @@ export function planCliMultiAgentPresetRun(
   return {
     preset,
     rootAgent,
+    missingAgentOverride: override.missing,
     workflowAgentKeys: workflow.resolved.map(toAgentKey),
     toolUseAgentKeys: toolUseAgents.map(toAgentKey),
     missingWorkflowAgents: workflow.missing,
@@ -217,12 +220,13 @@ function resolvePresetAgents(
 function resolveAgentOverride(
   override: string | undefined,
   agents: readonly AgentEntry[],
-): AgentEntry | undefined {
+): { agent?: AgentEntry; missing?: string } {
   const query = override?.trim();
-  if (!query) return undefined;
-  return agents.find(
+  if (!query) return {};
+  const agent = agents.find(
     (agent) => agent.name === query || toAgentKey(agent) === query,
   );
+  return agent ? { agent } : { missing: query };
 }
 
 function selectPresetRootAgent(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -181,8 +181,41 @@ describe('CLI multi-agent presets', () => {
       ],
       agentOverride: 'review',
     });
+    const sourceQualifiedPlan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse),
+        agent('review', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+      agentOverride: 'builtInToolUse:review',
+    });
 
     expect(plan.rootAgent?.name).toBe('review');
     expect(plan.toolUseAgentKeys).toContain('builtInToolUse:review');
+    expect(sourceQualifiedPlan.missingAgentOverride).toBeUndefined();
+    expect(sourceQualifiedPlan.rootAgent?.name).toBe('review');
+  });
+
+  it('tracks a missing root override as a plan gap', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: preset.toolUseAgents.map((name) =>
+        agent(
+          name,
+          AgentCategory.ToolUse,
+          name === 'leanOrchestrator' ? ['delegate_agent'] : [],
+        ),
+      ),
+      agentOverride: 'definitely-not-real',
+    });
+
+    expect(plan.missingAgentOverride).toBe('definitely-not-real');
+    expect(plan.rootAgent?.name).toBe('leanOrchestrator');
+    expect(plan.missingToolUseAgents).toEqual([]);
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- track unresolved `multi-agent run --agent` overrides in the preset run plan
- reject a still-missing override with a CLI usage error instead of falling back to the preset root
- defer model resolution until after agent validation so bad-agent errors stay focused
- extend multi-agent preset planner coverage for source-qualified and missing overrides

Closes #4972.

## Validation

- `npm run test:kernel -- src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js multi-agent run mathematician --agent definitely-not-real --api-mode personal --approval-policy never --instruction "Dry run should fail before model execution if the root override is invalid." -p --output-format json` exits 2 with `Tool-use agent not found: definitely-not-real...`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing 12 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only planning and validation ordering; no auth, data, or execution-path changes beyond clearer errors before model runs.
> 
> **Overview**
> **Invalid `multi-agent run --agent` values are now rejected** instead of silently using the preset’s default orchestrator. The preset planner records an unresolved override as `missingAgentOverride`, treats it as a plan gap (so authenticated runs can still retry after remote agent load), and `runMultiAgentPreset` fails fast with a focused usage error when the override is still missing.
> 
> **Startup order in `runMultiAgentPreset` is adjusted** so input expansion uses the base CLI context, agents are validated (including the new override check) before **chat** model resolution and approval setup—avoiding model-related errors when the root agent name is wrong.
> 
> Tests cover source-qualified overrides and missing override gap behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd0512bcc4acb8429d92623110595572a1069e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->