### PR TITLE
fix(cli): exit cleanly on interrupt signals

### DIFF
--- a/packages/cli/src/runtime/exitCodes.ts
+++ b/packages/cli/src/runtime/exitCodes.ts
@@ -9,6 +9,7 @@ export const CliExitCode = {
   ApprovalDenied: 4,
   Cancelled: 124,
   Interrupted: 130,
+  Terminated: 143,
 } as const;
 
 export type CliExitCode = (typeof CliExitCode)[keyof typeof CliExitCode];

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -37,6 +37,7 @@ import { writeTextStderr } from './logSinks';
 import { workspaceCliConfigPath } from './cliConfig';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
+import { CliExitCode } from './exitCodes';
 
 // Type imports - platform and CLI runtime
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
@@ -48,6 +49,7 @@ let serverSideKeysInitialized = false;
 let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
 let shutdownHandlersInstalled = false;
+type CliShutdownSignal = 'SIGINT' | 'SIGTERM';
 
 type CliPlatformInitOptions = Pick<
   CliContext,
@@ -77,14 +79,25 @@ const cliPlatformLog: LogBackend = {
   },
 };
 
-function installCliShutdownSignalHandlers(lifecycle: LifecycleHost): void {
+export function installCliShutdownSignalHandlers(
+  lifecycle: LifecycleHost,
+): void {
   if (shutdownHandlersInstalled) return;
   shutdownHandlersInstalled = true;
 
-  const install = (signal: NodeJS.Signals) => {
+  const exitCodeForSignal = (signal: CliShutdownSignal): number => {
+    switch (signal) {
+      case 'SIGINT':
+        return CliExitCode.Interrupted;
+      case 'SIGTERM':
+        return CliExitCode.Terminated;
+    }
+  };
+
+  const install = (signal: CliShutdownSignal) => {
     const handler = () => {
       void lifecycle.runShutdown().finally(() => {
-        process.kill(process.pid, signal);
+        process.exit(exitCodeForSignal(signal));
       });
     };
     process.once(signal, handler);

--- a/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
+++ b/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { LifecycleHost } from '@platform/interfaces/lifecycle';
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('CLI platform signal handlers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits with signal codes after shutdown instead of re-emitting signals', async () => {
+    vi.resetModules();
+    const handlers = new Map<string, () => void>();
+    vi.spyOn(process, 'once').mockImplementation(((
+      event: string | symbol,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      if (event === 'SIGINT' || event === 'SIGTERM') {
+        handlers.set(event, () => listener());
+      }
+      return process;
+    }) as typeof process.once);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as typeof process.exit);
+    const killSpy = vi
+      .spyOn(process, 'kill')
+      .mockImplementation((() => true) as typeof process.kill);
+    const runShutdown = vi.fn().mockResolvedValue(undefined);
+    const lifecycle: LifecycleHost = {
+      onShutdown: vi.fn(() => ({ dispose: vi.fn() })),
+      runShutdown,
+    };
+
+    const { installCliShutdownSignalHandlers } =
+      await import('@cli/runtime/initPlatform');
+    installCliShutdownSignalHandlers(lifecycle);
+
+    expect(handlers.has('SIGINT')).toBe(true);
+    expect(handlers.has('SIGTERM')).toBe(true);
+
+    handlers.get('SIGINT')?.();
+    await flushPromises();
+    expect(runShutdown).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenLastCalledWith(130);
+
+    handlers.get('SIGTERM')?.();
+    await flushPromises();
+    expect(runShutdown).toHaveBeenCalledTimes(2);
+    expect(exitSpy).toHaveBeenLastCalledWith(143);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #4971.

## Summary
- Exit the CLI process with conventional signal codes after lifecycle shutdown instead of re-emitting the signal back into Node.
- Add a `SIGTERM` exit code constant alongside the existing interrupt code.
- Cover the signal handler so Ctrl-C/Ctrl-Term no longer depends on Node's default top-level-await shutdown path.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- Real TTY dogfood: `texra-local multi-agent run mathematician ...`, then Ctrl-C during the active non-TUI run exits 130 with no top-level-await warning or bundled source dump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI shutdown/signal handling and exit codes; covered by a focused unit test with no auth or data-path changes.
> 
> **Overview**
> **CLI shutdown on Ctrl-C / SIGTERM** now runs lifecycle cleanup, then **`process.exit`** with standard signal exit codes (**130** for `SIGINT`, **143** for `SIGTERM`) instead of re-sending the signal to the process with `process.kill`. That avoids relying on Node’s default signal path (e.g. noisy top-level-await shutdown during long runs).
> 
> Adds **`CliExitCode.Terminated` (143)** next to the existing interrupt code, maps each handled signal explicitly, and **exports** `installCliShutdownSignalHandlers` for tests. New Vitest coverage asserts shutdown runs and **`process.kill` is not used**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6b25740d5765b6e69465eba608c0e51037e2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->