### PR TITLE
[codex] Improve CLI child control fallbacks

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -164,35 +164,6 @@ export function taskDetailWrappedRowCount(
   return Math.max(1, wrapAnsiToWidth(line, outputColumns).split('\n').length);
 }
 
-export function taskDetailVisibleLineCountForColumns({
-  availableColumns,
-  compact,
-  tailLines,
-  visibleRowBudget,
-}: {
-  readonly availableColumns?: number;
-  readonly compact: boolean;
-  readonly tailLines: readonly string[];
-  readonly visibleRowBudget: number;
-}): number {
-  if (visibleRowBudget <= 0) return 0;
-  if (!compact || tailLines.length === 0) return visibleRowBudget;
-
-  const outputColumns = taskDetailOutputColumnCount(availableColumns);
-  if (outputColumns === undefined) return visibleRowBudget;
-
-  let usedRows = 0;
-  let visibleLines = 0;
-  for (let index = tailLines.length - 1; index >= 0; index -= 1) {
-    const rowCount = taskDetailWrappedRowCount(tailLines[index], outputColumns);
-    if (visibleLines > 0 && usedRows + rowCount > visibleRowBudget) break;
-    visibleLines += 1;
-    usedRows += rowCount;
-    if (usedRows >= visibleRowBudget) break;
-  }
-  return Math.max(1, visibleLines);
-}
-
 export function taskDetailVisibleLineCountFromOffsetForColumns({
   availableColumns,
   compact,
@@ -265,25 +236,7 @@ export function taskDetailFollowTailScrollOffsetForColumns({
     scrollableRows,
     visibleRowBudget,
   );
-  if (!compact || visibleRowBudget <= 0 || tailLines.length === 0) {
-    return maxOffset;
-  }
-
-  const outputColumns = taskDetailOutputColumnCount(availableColumns);
-  if (outputColumns === undefined) return maxOffset;
-
-  const visibleLineCount = taskDetailVisibleLineCountForColumns({
-    availableColumns,
-    compact,
-    tailLines,
-    visibleRowBudget,
-  });
-  const firstTailLine = Math.max(0, tailLines.length - visibleLineCount);
-  let offset = 0;
-  for (let index = 0; index < firstTailLine; index += 1) {
-    offset += taskDetailWrappedRowCount(tailLines[index], outputColumns);
-  }
-  return Math.min(offset, maxOffset);
+  return maxOffset;
 }
 
 export function taskDetailVisibleOutputRowsFromOffsetForColumns({

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -282,13 +282,19 @@ export function resolveChildControlStreamTarget({
     return { streamId: activeStreamId, slice: activeSlice };
   }
 
-  const parentStreamId = parentStream.get(activeStreamId);
-  const parentSlice = parentStreamId ? streams.get(parentStreamId) : undefined;
-  const parentHasRows =
-    mode === 'subagents'
-      ? hasVisibleSubagents(parentSlice)
-      : hasVisibleTasks(parentSlice);
-  if (parentHasRows) {
+  const visited = new Set<StreamTabId>([activeStreamId]);
+  let parentStreamId = parentStream.get(activeStreamId);
+  while (parentStreamId && !visited.has(parentStreamId)) {
+    visited.add(parentStreamId);
+    const parentSlice = streams.get(parentStreamId);
+    const parentHasRows =
+      mode === 'subagents'
+        ? hasVisibleSubagents(parentSlice)
+        : hasVisibleTasks(parentSlice);
+    if (!parentHasRows) {
+      parentStreamId = parentStream.get(parentStreamId);
+      continue;
+    }
     return {
       fallbackFromStreamId: activeStreamId,
       streamId: parentStreamId,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -21,7 +21,6 @@ import {
   taskDetailKeyHintsForColumns,
   taskDetailScrollableOutputRowCountForColumns,
   taskDetailVisibleLineCountFromOffsetForColumns,
-  taskDetailVisibleLineCountForColumns,
   taskDetailVisibleOutputRowsFromOffsetForColumns,
   taskDetailVisibleScrollOffset,
   taskDetailWrappedRowCount,
@@ -681,6 +680,46 @@ describe('CLI child execution controls', () => {
     expect(target.slice).toBe(child);
   });
 
+  it('falls back to the nearest ancestor subagent list when a focused grandchild is a leaf', () => {
+    const main = slice({
+      streamId: 'main',
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const child = slice({ streamId: 'review-stream' });
+    const grandchild = slice({ streamId: 'detail-stream' });
+    const target = resolveChildControlStreamTarget({
+      activeStreamId: 'detail-stream',
+      mode: 'subagents',
+      parentStream: new Map([
+        ['review-stream', 'main'],
+        ['detail-stream', 'review-stream'],
+      ]),
+      streams: new Map([
+        ['main', main],
+        ['review-stream', child],
+        ['detail-stream', grandchild],
+      ]),
+    });
+
+    expect(target.streamId).toBe('main');
+    expect(target.fallbackFromStreamId).toBe('detail-stream');
+    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        childStreamId: 'review-stream',
+        kind: 'subagent',
+        label: 'review',
+      },
+    ]);
+  });
+
   it('falls back to the parent task list when the focused child is a leaf', () => {
     const child = slice({ streamId: 'review-stream' });
     const target = resolveChildControlStreamTarget({
@@ -899,30 +938,6 @@ describe('CLI child execution controls', () => {
     expect(taskDetailWrappedRowCount('abcd', 4)).toBe(1);
     expect(taskDetailWrappedRowCount('abcde', 4)).toBe(2);
     expect(
-      taskDetailVisibleLineCountForColumns({
-        availableColumns: 80,
-        compact: true,
-        tailLines: ['x'.repeat(100), 'final line'],
-        visibleRowBudget: 3,
-      }),
-    ).toBe(2);
-    expect(
-      taskDetailVisibleLineCountForColumns({
-        availableColumns: 80,
-        compact: true,
-        tailLines: ['x'.repeat(100), 'final line'],
-        visibleRowBudget: 2,
-      }),
-    ).toBe(1);
-    expect(
-      taskDetailVisibleLineCountForColumns({
-        availableColumns: 48,
-        compact: true,
-        tailLines: ['final output wraps at this width'],
-        visibleRowBudget: 0,
-      }),
-    ).toBe(0);
-    expect(
       taskDetailVisibleLineCountFromOffsetForColumns({
         availableColumns: 80,
         compact: true,
@@ -966,7 +981,7 @@ describe('CLI child execution controls', () => {
         tailLines: singleLongLine,
         visibleRowBudget: 1,
       }),
-    ).toBe(0);
+    ).toBe(2);
     expect(
       taskDetailVisibleOutputRowsFromOffsetForColumns({
         availableColumns: 10,
@@ -983,6 +998,20 @@ describe('CLI child execution controls', () => {
         tailLines: singleLongLine,
         visibleRowBudget: 1,
         offset: 2,
+      }),
+    ).toEqual(['mnop']);
+    expect(
+      taskDetailVisibleOutputRowsFromOffsetForColumns({
+        availableColumns: 10,
+        compact: true,
+        tailLines: singleLongLine,
+        visibleRowBudget: 1,
+        offset: taskDetailFollowTailScrollOffsetForColumns({
+          availableColumns: 10,
+          compact: true,
+          tailLines: singleLongLine,
+          visibleRowBudget: 1,
+        }),
       }),
     ).toEqual(['mnop']);
   });


### PR DESCRIPTION
## Summary

- Walk the child-control parent chain to the nearest ancestor that has visible subagent/task rows.
- Make compact task-detail tail-following use wrapped terminal rows so the tail lands on the actual bottom row.
- Add regression coverage for grandchild leaf fallback and wrapped-row tail behavior.

Closes #4978.

## Validation

- `npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts`
- `npm run test:kernel -- src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-fallback-tail-fix task-subworkflow-detail-long-output task-subworkflow-detail-wide-line-scroll tiny-task-subworkflow-detail tiny-task-subworkflow-detail-wrapped-scroll nested-subagent-picker nested-task-picker`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; known import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only picker/scroll behavior with targeted unit and snapshot validation; no auth, data, or API surface changes.
> 
> **Overview**
> Improves **CLI TUI child controls** when the focused stream is a leaf with no picker rows, and fixes **compact task detail** tail scrolling to use **wrapped terminal rows**.
> 
> **Child-control stream target** now walks the `parentStream` chain (with cycle protection) until it finds the nearest ancestor that still has visible subagent or task rows, instead of only checking the immediate parent. Deeply nested focus (e.g. a grandchild leaf) can fall back to `main` while recording `fallbackFromStreamId`.
> 
> **Compact task detail** removes line-based tail budgeting helpers and makes `taskDetailFollowTailScrollOffsetForColumns` use the same **scrollable wrapped-row** math as the rest of the detail view, so “follow tail” lands on the actual bottom wrapped segment (e.g. offset `2` for a 16-char line in 10 columns with budget `1`).
> 
> Tests drop coverage of the removed API and add a **grandchild leaf → ancestor subagent list** case plus assertions that follow-tail offset matches visible tail output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293654e03f27d8822c06238f65bb31a98e028fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->