### PR TITLE
fix(cli): await headless subagent delegation

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -57,6 +57,8 @@ export interface AgentLaunchContext extends AgentCore {
   coordinators: RunCoordinators;
   /** Whether approval or user prompts cannot be answered by the current host. */
   approvalPromptsUnavailable?: boolean;
+  /** Whether this tool-use run exits after one cycle instead of idling. */
+  stopAfterCycle?: boolean;
   /**
    * Dispose the run-trace subscribers (channel sink + transcript recorder)
    * registered by {@link createRunTrace}. Must be called once at end-of-run
@@ -105,6 +107,7 @@ export async function withExecutionRunContext<T>(
     delegationDepth: ctx.delegationDepth,
     delegationConfig: ctx.delegationConfig,
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
+    stopAfterCycle: ctx.stopAfterCycle,
   });
   const release = retainRunCoordinatorsForStream(
     ctx.streamId,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -44,6 +44,8 @@ export interface RunContext {
   readonly delegationConfig?: NestedDelegationConfig;
   /** Whether approval or user prompts cannot be answered by the current host. */
   readonly approvalPromptsUnavailable?: boolean;
+  /** Whether this run should stop after one tool-use cycle instead of idling. */
+  readonly stopAfterCycle?: boolean;
 }
 
 export interface CreateRunContextOptions {
@@ -62,6 +64,7 @@ export interface CreateRunContextOptions {
   delegationDepth?: number;
   delegationConfig?: NestedDelegationConfig;
   approvalPromptsUnavailable?: boolean;
+  stopAfterCycle?: boolean;
 }
 
 const runContextScope = new AsyncLocalStorage<RunContext>();
@@ -83,6 +86,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     delegationDepth: options.delegationDepth,
     delegationConfig: options.delegationConfig,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    stopAfterCycle: options.stopAfterCycle,
   });
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -395,6 +395,7 @@ export async function executeAgent(
   });
   ctx.delegationDepth = options.delegationDepth ?? 0;
   ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
+  ctx.stopAfterCycle = options.stopAfterCycle;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
     const { agent: agentName } = config;

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { DelegateAgentTool } from '@tools/DelegationTools';
+
+const mocks = vi.hoisted(() => ({
+  enableYoloOnChildStream: vi.fn(),
+  executeAgent: vi.fn(),
+  getExecutionStore: vi.fn(),
+  getVisibleAgents: vi.fn(),
+  isApprovalBypassedForStream: vi.fn(),
+  isProposalBypassedForStream: vi.fn(),
+  registerExecution: vi.fn(),
+  writeReport: vi.fn(),
+  computeModelOptionsData: vi.fn(),
+}));
+
+vi.mock('@agent/index/agentRegistry', () => ({
+  getVisibleAgents: mocks.getVisibleAgents,
+}));
+
+vi.mock('@agent/runtime/executeAgent', () => ({
+  executeAgent: mocks.executeAgent,
+}));
+
+vi.mock('@agent/runtime/delegationPolicy', () => ({
+  readNestedDelegationConfig: () => ({
+    enabled: true,
+    maxDepth: 3,
+  }),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: mocks.getExecutionStore,
+  registerExecution: mocks.registerExecution,
+}));
+
+vi.mock('@model/computeModelOptions', () => ({
+  computeModelOptionsData: mocks.computeModelOptionsData,
+}));
+
+vi.mock('@tools/approval', () => ({
+  enableYoloOnChildStream: mocks.enableYoloOnChildStream,
+  isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
+  isProposalBypassedForStream: mocks.isProposalBypassedForStream,
+}));
+
+function runtimeHost() {
+  return { emit: vi.fn() };
+}
+
+describe('headless delegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getVisibleAgents.mockReturnValue([
+      {
+        name: 'review',
+        description: 'Review work.',
+        tools: [],
+      },
+    ]);
+    mocks.computeModelOptionsData.mockResolvedValue([
+      {
+        value: 'deepseekT',
+        label: 'DeepSeek',
+        disabled: false,
+        requiresKey: false,
+      },
+    ]);
+    mocks.isProposalBypassedForStream.mockReturnValue(true);
+    mocks.isApprovalBypassedForStream.mockReturnValue(false);
+    mocks.registerExecution.mockResolvedValue(undefined);
+    mocks.writeReport.mockResolvedValue(undefined);
+    mocks.getExecutionStore.mockReturnValue({
+      writeReport: mocks.writeReport,
+    });
+    mocks.executeAgent.mockResolvedValue({
+      category: 'toolUse',
+      status: 'stopped',
+      executionId: 'child-exec',
+      streamId: 'child-stream',
+      lastResponse: 'The proof is correct.',
+      touchedFiles: [],
+    });
+  });
+
+  it('awaits child delegation during one-shot tool-use runs', async () => {
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: runtimeHost(),
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+        stopAfterCycle: true,
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        instruction: 'Check the proof.',
+        model: 'deepseekT',
+      }),
+      expect.any(String),
+      expect.objectContaining({
+        isSubagent: true,
+        parentStreamId: 'parent-stream',
+        stopAfterCycle: true,
+      }),
+    );
+    expect(result.summary).toBe("Completed 'review'");
+    expect(result.output).toContain('<subagent-result');
+    expect(result.output).toContain('<response>');
+    expect(result.output).toContain('The proof is correct.');
+    expect(mocks.writeReport).toHaveBeenCalledWith(result.output);
+  });
+
+  it('formats returned child error results as subagent errors', async () => {
+    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
+      await options.onError?.(new Error('review model failed'));
+      return {
+        category: 'toolUse',
+        status: 'error',
+        executionId: 'child-exec',
+        streamId: 'child-stream',
+      };
+    });
+
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: runtimeHost(),
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+        stopAfterCycle: true,
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(result.summary).toBe("Subagent 'review' failed");
+    expect(result.isError).toBe(true);
+    expect(result.error).toBe('review model failed');
+    expect(result.output).toContain('<subagent-error');
+    expect(result.output).toContain('review model failed');
+    expect(mocks.writeReport).toHaveBeenCalledWith(result.output);
+  });
+
+  it('keeps interactive delegations asynchronous', async () => {
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: runtimeHost(),
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(result.summary).toBe("Launched 'review' (async)");
+    expect(result.output).toContain(
+      "Subagent 'review' launched. Result will be delivered automatically",
+    );
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.not.objectContaining({ stopAfterCycle: true }),
+    );
+  });
+});

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -3,7 +3,9 @@
  * - delegate_workflow: For workflow agents (structured file I/O, fixed-round full-document rewrite)
  * - delegate_agent: For tool-use agents (new delegation or resume via execution_id)
  *
- * All subagents execute asynchronously — result delivered via follow-up queue.
+ * Interactive subagents execute asynchronously — result delivered via follow-up
+ * queue. One-shot/headless parent runs execute subagents in-band because there
+ * is no later interactive follow-up turn to consume async delivery.
  */
 
 // Third-party imports
@@ -26,6 +28,7 @@ import {
   getHandle,
   AgentExecutionHandle,
 } from '@agent/runtime/executionRegistry';
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
@@ -52,7 +55,6 @@ import {
   evaluateDelegationGate,
   type NestedDelegationConfig,
 } from '@shared/constants/delegationPolicy';
-import { hasExtension } from '@utils/core/pathCore';
 import { getBasename } from '@shared/utils/path';
 import { formatBytes } from '@shared/utils/string';
 
@@ -91,6 +93,7 @@ import { displayToStoragePath } from '@tools/memory/memoryUtils';
 // Local imports - utils
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { generateExecutionId } from '@utils/core/executionId';
+import { hasExtension } from '@utils/core/pathCore';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 // ============================================================================
@@ -230,6 +233,47 @@ interface ApprovalMeta {
   requestedAgent?: string;
 }
 
+async function subagentDeliveryMessage(
+  executionId: string,
+  agentName: string,
+  result: AgentFlowResult,
+  options: {
+    readonly startedAt: number;
+    readonly workingDirectory?: string;
+  },
+): Promise<string> {
+  let diffInfos:
+    | Awaited<ReturnType<typeof computeAndWriteWorkflowDiffs>>
+    | undefined;
+  if (result.category === 'workflow' && result.outputs.length > 0) {
+    try {
+      diffInfos = await computeAndWriteWorkflowDiffs(
+        executionId,
+        result.outputs,
+      );
+    } catch {
+      // Diff computation failure is non-fatal — deliver without diffs.
+    }
+  }
+
+  return formatSubagentDelivery(agentName, result, {
+    diffInfos,
+    wallTimeMs: Date.now() - options.startedAt,
+    workingDirectory: options.workingDirectory,
+  });
+}
+
+async function writeSubagentReport(
+  executionId: string,
+  message: string,
+): Promise<void> {
+  try {
+    await getExecutionStore(executionId).writeReport(message);
+  } catch {
+    /* storage failure is non-fatal */
+  }
+}
+
 /**
  * Runtime depth gate shared by fresh delegations and resumes.
  * Tool-use flows pass the same max-depth snapshot used for tool resolution so
@@ -335,6 +379,75 @@ async function executeSubagent(
     undefined,
     parentDelegationDepth + 1,
   );
+
+  if (parentContext.stopAfterCycle) {
+    try {
+      let subagentError: unknown;
+      const result = await executeAgent(configPayload, executionId, {
+        runtimeHost,
+        isSubagent: true,
+        enforceCategory: true,
+        parentStreamId: orchestratorStreamId,
+        delegationDepth: parentDelegationDepth + 1,
+        approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+        stopAfterCycle: true,
+        onStreamResolved: (resolvedStreamId) => {
+          if (options?.enableYoloOnChild) {
+            enableYoloOnChildStream(resolvedStreamId);
+          }
+        },
+        onError: (err) => {
+          subagentError = err;
+        },
+      });
+      if (result.status === 'error') {
+        const msg = formatSubagentError(
+          executionId,
+          agentName,
+          subagentError ?? 'Subagent ended with error status.',
+          {
+            wallTimeMs: Date.now() - startedAt,
+            workingDirectory: configPayload.workingDirectory ?? undefined,
+          },
+        );
+        await writeSubagentReport(executionId, msg);
+        return {
+          summary: `Subagent '${agentName}' failed`,
+          output: msg,
+          error: toErrorMessage(
+            subagentError ?? 'Subagent ended with error status.',
+          ),
+          isError: true,
+        };
+      }
+      const msg = await subagentDeliveryMessage(
+        executionId,
+        agentName,
+        result,
+        {
+          startedAt,
+          workingDirectory: configPayload.workingDirectory ?? undefined,
+        },
+      );
+      await writeSubagentReport(executionId, msg);
+      return {
+        summary: `Completed '${agentName}'`,
+        output: msg,
+      };
+    } catch (err) {
+      const msg = formatSubagentError(executionId, agentName, err, {
+        wallTimeMs: Date.now() - startedAt,
+        workingDirectory: configPayload.workingDirectory ?? undefined,
+      });
+      await writeSubagentReport(executionId, msg);
+      return {
+        summary: `Subagent '${agentName}' failed`,
+        output: msg,
+        error: toErrorMessage(err),
+        isError: true,
+      };
+    }
+  }
 
   // Track delivery state in the module-level map so delegate_agent (resume)
   // can find live subagents and enqueue follow-up instructions.


### PR DESCRIPTION
Closes #4980.

## Summary
- Propagate `stopAfterCycle` through `RunContext` so tools can tell when the parent is a one-shot/headless run.
- Execute delegated subagents in-band for one-shot parents and return the subagent result as the tool output, while keeping interactive chat delegations asynchronous.
- Add focused coverage for both the headless synchronous path and the existing interactive async path.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with 11 existing import-order warnings outside the touched files)
- Real TTY dogfood: `texra-local multi-agent run mathematician ...` in included mode, approve reviewer proposal, command returns a final reviewed proof and exits normally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delegation behavior for a new execution mode but leaves the default interactive async path untouched; mis-flagging `stopAfterCycle` could block or duplicate delivery expectations.
> 
> **Overview**
> Adds **`stopAfterCycle`** to **`RunContext`**, launch context, and **`executeAgent`** so delegation tools can detect one-shot/headless parents that exit after a single tool-use cycle.
> 
> When the parent has **`stopAfterCycle`**, **`delegate_agent`** (via **`executeSubagent`**) **awaits** the child **`executeAgent`** and returns the formatted subagent result (or error) as the tool output, with reports written through shared **`subagentDeliveryMessage`** / **`writeSubagentReport`** helpers. **Interactive** parents keep the existing **async** launch and follow-up-queue delivery.
> 
> New **`DelegationHeadless.vitest.mts`** covers synchronous completion, error formatting, and unchanged async behavior without the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69bb51439e539b83fda52568a2f598f981ab453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->