### PR TITLE
fix(agent): keep review reports in-band

### DIFF
--- a/packages/extension/resources/tool_use_agents/review.yaml
+++ b/packages/extension/resources/tool_use_agents/review.yaml
@@ -8,8 +8,6 @@ settings:
     - todo_write
     - bash
     - read_file
-    - write_file
-    - edit_file
     - glob
     - grep
     - ls
@@ -75,7 +73,7 @@ prompts:
     (2) When the text attributes a specific claim to a reference, use arxiv_search, arxiv_metadata, or crossref_doi to verify the claim matches the cited work.
     (3) Check for self-consistency of citations.
 
-    Report: Organize findings by category — Stated Goals (goal, status, evidence), Mathematical Verification (equation reference, status, details), Notation Issues (symbol, locations, description), Code Issues, Figure/Table Issues, Reference Issues, and a Summary of Findings. After completing the audit, use write_file to save the report in the workspace.
+    Report: Organize findings by category — Stated Goals (goal, status, evidence), Mathematical Verification (equation reference, status, details), Notation Issues (symbol, locations, description), Code Issues, Figure/Table Issues, Reference Issues, and a Summary of Findings. Return the report in your final response by default. Only save a report file in the workspace when the user explicitly asks for a file artifact, the task is inherently an edit, or a file is genuinely required for verification.
 
     Guidelines:
     (1) Be systematic: use todo_write to track what you have and have not checked.
@@ -83,7 +81,7 @@ prompts:
     (3) Show your verification work: include your reasoning and any computational checks.
     (4) Distinguish between confirmed errors and items that need clarification.
     (5) Prioritize checking the main results and key derivations over peripheral content.
-    (6) When editing files, always ask for user confirmation before making changes.
+    (6) Do not edit workspace files while auditing unless the user explicitly requests edits. If edits are requested and no editing tool is available, state the needed changes in your final response.
     {% if IS_ANTHROPIC_MODEL %}
     (7) Do not create excessive markdown files or documentation unless explicitly requested.
     {% endif %}

--- a/src/test-kernel/agent/ReviewAgentPrompt.vitest.mts
+++ b/src/test-kernel/agent/ReviewAgentPrompt.vitest.mts
@@ -1,0 +1,46 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import * as yaml from 'yaml';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+interface ReviewAgentYaml {
+  settings: {
+    tools: string[];
+  };
+  prompts: {
+    systemPrompt: string;
+  };
+}
+
+function readReviewAgent(): ReviewAgentYaml {
+  const text = readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/resources/tool_use_agents/review.yaml',
+    ),
+    'utf8',
+  );
+  return yaml.parse(text) as ReviewAgentYaml;
+}
+
+describe('review agent prompt', () => {
+  it('returns audit reports in-band unless the user requested a file', () => {
+    const agent = readReviewAgent();
+    const systemPrompt = agent.prompts.systemPrompt;
+
+    expect(systemPrompt).toContain('Return the report in your final response');
+    expect(systemPrompt).toContain('when the user explicitly asks');
+    expect(systemPrompt).not.toContain('use write_file to save the report');
+    expect(agent.settings.tools).not.toContain('write_file');
+    expect(agent.settings.tools).not.toContain('edit_file');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4984.

The built-in `review` tool-use agent no longer has direct `write_file`/`edit_file` tools, and its report instruction now says to return audits in the final response by default. If edits are requested, it should describe the needed changes rather than creating surprise workspace artifacts.

I first tried a prompt-only softening, but a live CLI rerun still attempted to write `verification_report.md`. Removing the direct write/edit tools is the narrower robust product fix for a review/audit specialist.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/ReviewAgentPrompt.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run texra-local:build && npm run texra-local:link`
- Live TTY dogfood: `texra-local multi-agent run mathematician ... --approval-policy ask ...` with delegated `review` subagent completed in-band; saved reviewer execution `5e0bea079c3b` has no `write_file`, `edit_file`, or `verification_report` transcript hits, and no `verification_report.md` appeared in the workspace.
- `git diff --check`
- `npm run lint` (passes with 11 existing import-order warnings)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and tool-list changes for a single specialist agent; no auth, data, or core runtime logic touched.
> 
> **Overview**
> The built-in **review** tool-use agent is tightened so audits stay **in the final chat response** instead of creating workspace files by default.
> 
> **Tooling:** `write_file` and `edit_file` are removed from the agent’s allowed tools list.
> 
> **Prompt:** The report section no longer instructs saving via `write_file`; it tells the model to return the structured audit in the final response and only write a file when the user explicitly wants an artifact, the task is inherently an edit, or a file is needed for verification. Guideline (6) now forbids editing the workspace during audits unless the user asks; if edits are requested without edit tools, describe changes in the response.
> 
> **Tests:** A new Vitest spec loads `review.yaml` and asserts the in-band reporting language and absence of write/edit tools and the old `write_file` report instruction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771e45829e485d25b1ed0d523f5a367eb2a62b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->