### PR TITLE
fix(cli): keep active child progress ticking

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -33,6 +33,9 @@ export interface RunProgressRendererInit {
   readonly write?: (text: string) => void;
   readonly nowMs?: () => number;
   readonly minIntervalMs?: number;
+  readonly heartbeatIntervalMs?: number;
+  readonly setInterval?: typeof setInterval;
+  readonly clearInterval?: typeof clearInterval;
 }
 
 export function shouldRenderRunProgress(
@@ -55,17 +58,26 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private readonly write: (text: string) => void;
   private readonly nowMs: () => number;
   private readonly minIntervalMs: number;
+  private readonly heartbeatIntervalMs: number;
+  private readonly setInterval: typeof setInterval;
+  private readonly clearInterval: typeof clearInterval;
   private readonly ansi: boolean;
   private lastRenderAt = 0;
   private lastLine = '';
   private liveLine = false;
   private rootStreamId: string | undefined;
   private rootStreamTerminal = false;
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  private activeProcessCount = 0;
+  private activeSubagentCount = 0;
 
   constructor(init: RunProgressRendererInit) {
     this.write = init.write ?? writeRawStderr;
     this.nowMs = init.nowMs ?? Date.now;
     this.minIntervalMs = init.minIntervalMs ?? 100;
+    this.heartbeatIntervalMs = init.heartbeatIntervalMs ?? 1000;
+    this.setInterval = init.setInterval ?? setInterval;
+    this.clearInterval = init.clearInterval ?? clearInterval;
     this.ansi = init.colorEnabled;
     this.startedAt = this.nowMs();
   }
@@ -94,6 +106,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         this.applyActiveProcesses(
           payload as ProgressEventPayloads['updateActiveProcesses'],
         );
+        this.updateHeartbeat();
         this.render(true);
         return true;
       case 'updateActiveSubagents':
@@ -101,6 +114,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         this.applyActiveSubagents(
           payload as ProgressEventPayloads['updateActiveSubagents'],
         );
+        this.updateHeartbeat();
         this.render(true);
         return true;
       case 'updateStreamStatus':
@@ -117,7 +131,10 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           if (this.rootStreamTerminal) {
             this.state.activeProcesses = undefined;
             this.state.activeSubagents = undefined;
+            this.activeProcessCount = 0;
+            this.activeSubagentCount = 0;
           }
+          this.updateHeartbeat();
           this.render(true);
         }
         return true;
@@ -141,6 +158,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   clear(): void {
+    this.stopHeartbeat();
     if (this.ansi && this.liveLine) {
       this.write('\r\x1b[2K');
       this.liveLine = false;
@@ -148,6 +166,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   preserve(): void {
+    this.stopHeartbeat();
     if (this.ansi && this.liveLine) {
       this.write('\n');
       this.liveLine = false;
@@ -182,6 +201,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
+    this.activeProcessCount = payload.processes.length;
     this.state.activeProcesses = formatActiveChildren(
       'tool',
       payload.processes.map(
@@ -195,6 +215,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
+    this.activeSubagentCount = payload.children.length;
     this.state.activeSubagents = formatActiveChildren(
       'subagent',
       payload.children.map((child) => child.agentName),
@@ -225,6 +246,29 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
     this.lastLine = line;
     this.lastRenderAt = now;
+  }
+
+  private updateHeartbeat(): void {
+    if (this.rootStreamTerminal || !this.hasActiveChildren()) {
+      this.stopHeartbeat();
+      return;
+    }
+    if (!this.ansi || this.heartbeatTimer) return;
+
+    this.heartbeatTimer = this.setInterval(() => {
+      this.render(true);
+    }, this.heartbeatIntervalMs);
+    (this.heartbeatTimer as { unref?: () => void }).unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    this.clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = undefined;
+  }
+
+  private hasActiveChildren(): boolean {
+    return this.activeSubagentCount > 0 || this.activeProcessCount > 0;
   }
 
   private formatLine(now: number): string {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -194,6 +194,150 @@ describe('CLI run progress renderer', () => {
     );
   });
 
+  it('ticks the ANSI status line while an active subagent is quiet', () => {
+    let now = 0;
+    let output = '';
+    let heartbeat: (() => void) | undefined;
+    let clearCount = 0;
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => now,
+      setInterval: ((callback: () => void) => {
+        heartbeat = callback;
+        return { unref() {} } as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+      clearInterval: (() => {
+        clearCount += 1;
+      }) as typeof clearInterval,
+    });
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    now = 950;
+    renderer?.handle('updateActiveSubagents', {
+      parentStreamId: 'root-stream',
+      children: [
+        {
+          executionId: 'child-1',
+          childStreamId: 'child-stream',
+          agentName: 'review',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(heartbeat).toBeDefined();
+    now = 1000;
+    heartbeat?.();
+    now = 2300;
+    heartbeat?.();
+
+    expect(output).toContain('\r\x1b[2Korchestrator · subagent: review · 1s');
+    expect(output).toContain('\r\x1b[2Korchestrator · subagent: review · 2s');
+
+    renderer?.handle('updateStreamStatus', {
+      streamId: 'root-stream',
+      status: STREAM_STATUS.STOPPED,
+      previousStatus: STREAM_STATUS.RUNNING,
+    });
+    expect(clearCount).toBe(1);
+  });
+
+  it('keeps heartbeat alive when active child names are unavailable', () => {
+    let now = 0;
+    let output = '';
+    let heartbeat: (() => void) | undefined;
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => now,
+      setInterval: ((callback: () => void) => {
+        heartbeat = callback;
+        return { unref() {} } as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+    });
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    renderer?.handle('updateActiveSubagents', {
+      parentStreamId: 'root-stream',
+      children: [
+        {
+          executionId: 'child-1',
+          childStreamId: 'child-stream',
+          agentName: '',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(heartbeat).toBeDefined();
+    now = 1200;
+    heartbeat?.();
+
+    expect(output).toContain('\r\x1b[2Korchestrator · 1s');
+  });
+
+  it('stops active-child heartbeat when preserving the live line', () => {
+    let output = '';
+    let clearCount = 0;
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => 0,
+      setInterval: (() => {
+        return { unref() {} } as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+      clearInterval: (() => {
+        clearCount += 1;
+      }) as typeof clearInterval,
+    });
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    renderer?.handle('updateActiveSubagents', {
+      parentStreamId: 'root-stream',
+      children: [
+        {
+          executionId: 'child-1',
+          childStreamId: 'child-stream',
+          agentName: 'review',
+          status: 'running',
+        },
+      ],
+    });
+
+    renderer?.preserve();
+
+    expect(clearCount).toBe(1);
+    expect(output.endsWith('\n')).toBe(true);
+  });
+
   it('can claim the root stream from conversation progress', () => {
     let output = '';
     const renderer = createRunProgressRenderer(


### PR DESCRIPTION
## Summary

Fixes #4986.

The non-TUI text run progress renderer now starts a lightweight ANSI-only heartbeat while a child subagent or tool is active. That lets the existing live status line keep refreshing elapsed time during quiet child model/tool waits instead of looking frozen.

The heartbeat is disabled for non-ANSI output so redirected/plain log output does not get a new line every second, and it stops when active children clear, the root reaches a terminal status, or the renderer closes.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run texra-local:build && npm run texra-local:link`
- Live TTY dogfood: reproduced the quiet reviewer interval in `texra-local multi-agent run mathematician --approval-policy ask`; interrupted after the useful observation window because the child model call ran long. The unit test directly covers the heartbeat callback path that a raw terminal displays as carriage-return redraws.
- `git diff --check`
- `npm run lint` (passes with 11 existing import-order warnings)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change with guarded heartbeat (ANSI, active children, cleanup on terminal/clear); no auth, data, or execution-path changes.
> 
> **Overview**
> The non-TUI **text** run progress renderer now runs an **ANSI-only periodic heartbeat** while active subagents or tools are running, so the live status line keeps updating **elapsed time** when child work is quiet and no other progress events arrive.
> 
> Heartbeat timing and `setInterval`/`clearInterval` are **injectable** for tests; the timer is **unref**’d so it does not block process exit. It **does not** run for non-ANSI output (avoiding extra lines on redirected logs) and **stops** when children clear, the root stream hits a terminal status, or the renderer **clears** or **preserves** the line. Active-child counts are tracked separately so heartbeat still runs when child names are missing.
> 
> New **Vitest** coverage exercises tick updates, unnamed children, terminal status cleanup, and preserve stopping the interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ec0c76a14fcc7867ce508b1e4ab3e6d010d899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->