### PR TITLE
fix(cli): prefer task shortcut in narrow status

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -849,9 +849,9 @@ const SCENARIOS = [
       HARNESS_TODOS: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: ']subagents',
-    expect: [']subagents', '[Ctrl-C]stop'],
-    unexpect: [']tasks'],
+    bootExpect: ']tasks',
+    expect: [']tasks', '[Ctrl-C]stop'],
+    unexpect: [']subagents'],
   },
   {
     name: 'subagent-picker',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -378,6 +378,25 @@ export function statusBarBindingsText(
   ]);
   if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
 
+  if (hasMultipleStreams) {
+    const taskFocusedBindings = joinStatusBindings([
+      '[Tab]streams',
+      `[${modifierLabel}-p]tasks`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(taskFocusedBindings, maxColumns)) {
+      return taskFocusedBindings;
+    }
+  }
+
+  const bareTaskBindings = joinStatusBindings([
+    `[${modifierLabel}-p]tasks`,
+    `[Ctrl-C]${ctrlCAction}`,
+  ]);
+  if (fitsStatusBindings(bareTaskBindings, maxColumns)) {
+    return bareTaskBindings;
+  }
+
   if (subagentControlsAvailable) {
     const subagentFocusedBindings = joinStatusBindings([
       ...(hasMultipleStreams ? ['[Tab]streams'] : []),

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -211,6 +211,32 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[Ctrl-C]stop');
   });
 
+  it('prefers the task picker when one child-control shortcut fits', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 88_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 3,
+      activeProcesses: 1,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Option',
+      ctrlCAction: 'stop',
+      width: 44,
+    });
+
+    expect(display.bindings).toBe('[Option-p]tasks  [Ctrl-C]stop');
+    expect(display.bindings).not.toContain('[Option-s]subagents');
+  });
+
   it('drops low-priority status details before narrow footers lose separators', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary

- prefer the tasks/sub-workflows shortcut when a narrow status footer only has room for one child-control shortcut
- update the narrow TUI harness scenario to assert `Option-p`/`Alt-p` stays discoverable
- add a focused StatusBar display-model regression test

Closes #4988

## Validation

- `npm run test:kernel -- src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-statusbar-fix-broad subagents-with-todos-narrow-status subagents-with-todos-compact subagents task-picker compact-task-picker stopped-task-picker focused-stopped-subagent`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status footer binding order and test updates; no auth, data, or runtime behavior changes beyond discoverability of shortcuts.
> 
> **Overview**
> When the CLI status footer is too narrow to show both **tasks** and **subagents** shortcuts, binding selection now tries **task-only** fallbacks (with or without `[Tab]streams`) **before** the subagent-only narrow layouts.
> 
> The **44-column** TUI harness scenario and a **StatusBar** unit test now assert that **`Option-p` / `Alt-p` tasks** stays visible instead of **`Option-s` subagents** in that tight width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241e21001ad4c023b19ca92b15587d8614eb773e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->