### PR TITLE
fix(cli): show live root status for stopped child focus

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1356,7 +1356,12 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: [ESC + 'p', 'k', ESC + 's', DOWN, DOWN, '\r'],
     frame: 'tail',
-    expect: ['[3:strategy](stopped)', '◆ stopped api', '[Ctrl-C]stop root'],
+    expect: [
+      '[3:strategy](stopped)',
+      '◆ running',
+      '2 sub 1 proc',
+      '[Ctrl-C]stop root',
+    ],
   },
   {
     name: 'focused-stopped-subagent-submit',
@@ -1380,6 +1385,7 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       '[3:strategy](stopped)',
+      '◆ running',
       'The selected subagent is no longer accepting follow-ups.',
     ],
     unexpect: ['Harness received: can you still receive this?'],

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -23,6 +23,7 @@ import {
   cliState,
   NO_BYPASS,
   type BypassState,
+  type StreamSlice,
 } from '../state/cliState';
 import { resolveChildControlStreamTarget } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
@@ -454,8 +455,56 @@ function statusBarCanStopStatus(status: StreamStatus | undefined): boolean {
   );
 }
 
+function statusBarCanRepresentFocusedSlice(
+  status: StreamStatus | undefined,
+): boolean {
+  return (
+    status === undefined ||
+    status === STREAM_STATUS.INITIALIZING ||
+    status === STREAM_STATUS.RUNNING ||
+    status === STREAM_STATUS.RESUMING ||
+    status === STREAM_STATUS.WAITING
+  );
+}
+
+function statusBarCanRepresentLiveAncestor(
+  status: StreamStatus | undefined,
+): boolean {
+  return (
+    status === STREAM_STATUS.INITIALIZING ||
+    status === STREAM_STATUS.RUNNING ||
+    status === STREAM_STATUS.RESUMING
+  );
+}
+
 interface StatusBarVisibleStream {
   readonly status: StreamStatus | undefined;
+}
+
+function statusBarFindAncestorStream<T extends StatusBarVisibleStream>({
+  activeStreamId,
+  parentStream,
+  streams,
+  canUseStream,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, T>;
+  readonly canUseStream: (stream: T) => boolean;
+}): T | undefined {
+  if (activeStreamId === undefined) return undefined;
+
+  const visited = new Set<StreamTabId>([activeStreamId]);
+  let parentStreamId = parentStream.get(activeStreamId);
+  while (parentStreamId && !visited.has(parentStreamId)) {
+    visited.add(parentStreamId);
+    const parentStreamSlice = streams.get(parentStreamId);
+    if (parentStreamSlice && canUseStream(parentStreamSlice)) {
+      return parentStreamSlice;
+    }
+    parentStreamId = parentStream.get(parentStreamId);
+  }
+  return undefined;
 }
 
 export function statusBarCanStopVisibleRun({
@@ -470,10 +519,38 @@ export function statusBarCanStopVisibleRun({
   readonly streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>;
 }): boolean {
   if (statusBarCanStopStatus(status)) return true;
-  const parentStreamId =
-    activeStreamId === undefined ? undefined : parentStream.get(activeStreamId);
-  if (parentStreamId === undefined) return false;
-  return statusBarCanStopStatus(streams.get(parentStreamId)?.status);
+  return (
+    statusBarFindAncestorStream({
+      activeStreamId,
+      parentStream,
+      streams,
+      canUseStream: (stream) => statusBarCanStopStatus(stream.status),
+    }) !== undefined
+  );
+}
+
+export function statusBarDisplaySlice({
+  activeStreamId,
+  parentStream,
+  streams,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): StreamSlice | undefined {
+  const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  if (activeSlice && statusBarCanRepresentFocusedSlice(activeSlice.status)) {
+    return activeSlice;
+  }
+  return (
+    statusBarFindAncestorStream({
+      activeStreamId,
+      parentStream,
+      streams,
+      canUseStream: (stream) =>
+        statusBarCanRepresentLiveAncestor(stream.status),
+    }) ?? activeSlice
+  );
 }
 
 export function buildStatusBarDisplay(
@@ -591,6 +668,11 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const statusSlice = statusBarDisplaySlice({
+    activeStreamId,
+    parentStream,
+    streams,
+  });
   const subagentControlTarget = resolveChildControlStreamTarget({
     activeStreamId,
     mode: 'subagents',
@@ -599,21 +681,23 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   });
 
   const runStartedAt =
-    slice?.status === STREAM_STATUS.RUNNING ? slice.runStartedAt : undefined;
+    statusSlice?.status === STREAM_STATUS.RUNNING
+      ? statusSlice.runStartedAt
+      : undefined;
   const now = useLiveNowMs(runStartedAt !== undefined, runStartedAt);
 
   const display = buildStatusBarDisplay({
-    status: slice?.status,
+    status: statusSlice?.status,
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     pendingExitHint,
     pendingExitResumeId,
-    bypass: slice?.bypass ?? NO_BYPASS,
-    queuedFollowUpMessages: slice?.queuedFollowUpMessages ?? [],
+    bypass: statusSlice?.bypass ?? NO_BYPASS,
+    queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],
     queuedFollowUpPreview: props.queuedFollowUpPreview,
-    usage: slice?.usage,
-    conversation: slice?.conversation,
-    activeSubagents: slice?.activeSubagents.length ?? 0,
-    activeProcesses: slice?.activeProcesses.length ?? 0,
+    usage: statusSlice?.usage,
+    conversation: statusSlice?.conversation,
+    activeSubagents: statusSlice?.activeSubagents.length ?? 0,
+    activeProcesses: statusSlice?.activeProcesses.length ?? 0,
     approvalDepth: approvals,
     subagentControlsAvailable: canShowSubagentControls(
       sessionMeta,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -6,9 +6,10 @@ import {
   defaultShortcutModifierLabel,
   queuedFollowUpsSummary,
   statusBarCanStopVisibleRun,
+  statusBarDisplaySlice,
   statusBarSegmentText,
 } from '@cli/chat/tui/panes/StatusBar';
-import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
+import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
 describe('CLI StatusBar display model', () => {
@@ -443,9 +444,11 @@ describe('CLI StatusBar display model', () => {
   it('treats visible live stream status as stoppable', () => {
     const root = 'root';
     const child = 'child';
+    const grandchild = 'grandchild';
     const streams = new Map([
       [root, { streamId: root, status: STREAM_STATUS.RUNNING }],
       [child, { streamId: child, status: STREAM_STATUS.STOPPED }],
+      [grandchild, { streamId: grandchild, status: STREAM_STATUS.STOPPED }],
     ]);
 
     expect(
@@ -466,6 +469,17 @@ describe('CLI StatusBar display model', () => {
     ).toBe(true);
     expect(
       statusBarCanStopVisibleRun({
+        activeStreamId: grandchild,
+        parentStream: new Map([
+          [child, root],
+          [grandchild, child],
+        ]),
+        status: STREAM_STATUS.STOPPED,
+        streams,
+      }),
+    ).toBe(true);
+    expect(
+      statusBarCanStopVisibleRun({
         activeStreamId: root,
         parentStream: new Map([[child, root]]),
         status: STREAM_STATUS.WAITING,
@@ -474,6 +488,45 @@ describe('CLI StatusBar display model', () => {
         ]),
       }),
     ).toBe(false);
+  });
+
+  it('uses live ancestor status when a stopped child stream is focused', () => {
+    const rootSlice = {
+      status: STREAM_STATUS.RUNNING,
+    } as StreamSlice;
+    const childSlice = {
+      status: STREAM_STATUS.STOPPED,
+    } as StreamSlice;
+    const waitingChildSlice = {
+      status: STREAM_STATUS.WAITING,
+    } as StreamSlice;
+    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
+      ['root', rootSlice],
+      ['child', childSlice],
+      ['waiting-child', waitingChildSlice],
+    ]);
+
+    expect(
+      statusBarDisplaySlice({
+        activeStreamId: 'child',
+        parentStream: new Map([['child', 'root']]),
+        streams,
+      }),
+    ).toBe(rootSlice);
+    expect(
+      statusBarDisplaySlice({
+        activeStreamId: 'waiting-child',
+        parentStream: new Map([['waiting-child', 'root']]),
+        streams,
+      }),
+    ).toBe(waitingChildSlice);
+    expect(
+      statusBarDisplaySlice({
+        activeStreamId: 'root',
+        parentStream: new Map([['child', 'root']]),
+        streams,
+      }),
+    ).toBe(rootSlice);
   });
 
   it('keeps status discoverable in narrow single-stream sessions', () => {


### PR DESCRIPTION
## Summary

- make the status footer use the nearest live ancestor stream when focus is on a stopped child stream
- keep stopped child focus visible in the stream strip while showing live root status/counts in the footer
- update focused-stopped harness coverage and add StatusBar model coverage for live ancestors

Closes #4990

## Validation

- `npm run test:kernel -- src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-focused-stopped-fix-broad focused-stopped-subagent focused-stopped-subagent-submit stopped-task-picker stopped-task-subworkflow-detail subagents task-picker subagents-with-todos-narrow-status`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI status-bar display logic only; behavior is covered by unit and harness tests with no security or data-path changes.
> 
> **Overview**
> When focus is on a **stopped** child subagent stream, the status footer no longer mirrors that stream’s stopped/idle state. It now resolves **`statusBarDisplaySlice`**: keep the focused tab’s own slice when its status is still representable (including **waiting**), otherwise walk the parent chain and use the nearest **live** ancestor (**initializing**, **running**, or **resuming**) for the ◆ label, elapsed time, usage, queued follow-ups, and subagent/process counts.
> 
> **`statusBarCanStopVisibleRun`** uses the same ancestor walk (not only the immediate parent), so **Ctrl-C** can still offer **stop root** when a stopped or deeply nested child is focused but the root run is active. Harness expectations for focused-stopped subagent flows and **StatusBar** unit tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e212b76b65e0549478caa5dd92ef28deadeeea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->