### PR TITLE
fix(cli): compact child-control foregrounds

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -873,6 +873,13 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Tasks and sub-workflows', 'latex build'],
+    maxBlankLinesBetween: [
+      {
+        from: 'entry-4 chat history line',
+        to: 'Subagents',
+        max: 0,
+      },
+    ],
   },
   {
     name: 'subagent-focused-submit',
@@ -963,7 +970,7 @@ const SCENARIOS = [
       {
         from: 'entry-4 chat history line',
         to: 'Tasks and sub-workflows',
-        max: 3,
+        max: 0,
       },
     ],
   },
@@ -988,6 +995,13 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Tasks and sub-workflows'],
+    maxBlankLinesBetween: [
+      {
+        from: 'entry-4 chat history line',
+        to: 'Subagents',
+        max: 0,
+      },
+    ],
   },
   {
     name: 'compact-task-picker',
@@ -1011,6 +1025,13 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: ['Subagents'],
+    maxBlankLinesBetween: [
+      {
+        from: 'entry-4 chat history line',
+        to: 'Tasks and sub-workflows',
+        max: 0,
+      },
+    ],
   },
   {
     name: 'compact-task-picker-process-overflow',
@@ -1408,7 +1429,7 @@ const SCENARIOS = [
       {
         from: 'entry-4 chat history line',
         to: 'Tasks and sub-workflows',
-        max: 4,
+        max: 0,
       },
     ],
   },

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -335,6 +335,16 @@ export function foregroundSurfaceJustifyContent(
   return kind === 'form' || kind === 'approval' ? 'flex-start' : 'flex-end';
 }
 
+export function foregroundSurfaceContainerHeight({
+  kind,
+  rows,
+}: {
+  readonly kind: ForegroundSurfaceKind | undefined;
+  readonly rows: number;
+}): number | undefined {
+  return kind === 'childControls' && rows >= 3 ? undefined : rows;
+}
+
 export function approvalForegroundMaxRows(
   pending: PendingApproval | undefined,
 ): number | undefined {
@@ -582,6 +592,10 @@ export function App(props: AppProps): React.JSX.Element {
     }
   }
   const foregroundSurface = renderForegroundSurface();
+  const foregroundContainerHeight = foregroundSurfaceContainerHeight({
+    kind: foregroundKind,
+    rows: foregroundRows,
+  });
 
   const focusShortcutsActive = appFocusShortcutsActive({
     inputDisabled,
@@ -684,7 +698,7 @@ export function App(props: AppProps): React.JSX.Element {
           {foregroundSurface ? (
             <Box
               flexDirection="column"
-              height={foregroundRows}
+              height={foregroundContainerHeight}
               alignItems="flex-start"
               justifyContent={foregroundSurfaceJustifyContent(foregroundKind)}
               overflowY="hidden"

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -24,6 +24,7 @@ import {
   appFocusShortcutsActive,
   approvalForegroundMaxRows,
   childControlForegroundMaxRows,
+  foregroundSurfaceContainerHeight,
   foregroundSurfaceKind,
   foregroundSurfaceJustifyContent,
   shouldShowTipRow,
@@ -366,6 +367,27 @@ describe('CLI TUI row allocation', () => {
     expect(foregroundSurfaceJustifyContent('approval')).toBe('flex-start');
     expect(foregroundSurfaceJustifyContent('childControls')).toBe('flex-end');
     expect(foregroundSurfaceJustifyContent('transcript')).toBe('flex-end');
+  });
+
+  it('lets child-control foregrounds shrink to their rendered height', () => {
+    expect(
+      foregroundSurfaceContainerHeight({
+        kind: 'childControls',
+        rows: 12,
+      }),
+    ).toBeUndefined();
+    expect(
+      foregroundSurfaceContainerHeight({
+        kind: 'childControls',
+        rows: 2,
+      }),
+    ).toBe(2);
+    expect(
+      foregroundSurfaceContainerHeight({
+        kind: 'approval',
+        rows: 12,
+      }),
+    ).toBe(12);
   });
 
   it('uses the whole middle region for the transcript without foreground UI', () => {


### PR DESCRIPTION
## Summary

- let task/subagent foreground controls shrink to their rendered height instead of reserving a tall fixed container
- keep hard clipping for very tiny row budgets
- tighten TUI harness blank-line assertions for task/subagent pickers and the empty task picker

Closes #4992

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-cli-frames-next`
- `corepack pnpm --filter @texra-ai/cli run --if-present typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI layout and snapshot assertions; behavior for forms/approvals and sub-3-row child controls is unchanged by design.
> 
> **Overview**
> Task and subagent foreground pickers no longer reserve a tall fixed Ink container when the layout has at least three foreground rows. **`foregroundSurfaceContainerHeight`** omits `height` for **`childControls`** in that case so the panel can sit flush under the transcript; very small row budgets still use a fixed height for clipping.
> 
> TUI harness scenarios for subagent/task pickers (including compact and empty states) now require **zero** blank lines between chat history and the picker header, matching the tighter layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682646ad5ebfe723f9bb4e51957c07cf97d02f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->