### PR TITLE
refactor: consolidate duplicate logic and use native methods

### DIFF
--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -26,6 +26,7 @@ import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
 import type { ManualCriticismEntry } from '@tools/AddCriticismTool';
 import { AbsoluteFS } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'InlineCriticism';
 const COLLECTION_NAME = 'texra-criticism';
@@ -73,7 +74,7 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
   const activeCollection = collection;
   if (!activeCollection) return;
   const absolutePath = file.location.absolutePath;
-  if (!absolutePath.toLowerCase().endsWith('.tex')) return;
+  if (!hasExtension(absolutePath, '.tex')) return;
 
   let text: string;
   try {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -126,6 +126,7 @@ import {
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 import { readGitAuthorSettingsFromState } from '@utils/system/gitAuthorSettings';
 import { setToolUseMemoryEnabled } from '@utils/config/constants';
 import {
@@ -1083,7 +1084,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       const fileUri = vscode.Uri.file(absolutePath);
 
       // Open markdown files in preview mode (read-only rendered view)
-      if (absolutePath.toLowerCase().endsWith('.md')) {
+      if (hasExtension(absolutePath, '.md')) {
         await vscode.commands.executeCommand('markdown.showPreview', fileUri);
       } else {
         const doc = await vscode.workspace.openTextDocument(fileUri);

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -139,8 +139,12 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const tildeLettersMathbf = [...'axpvwz'];
     const tildeLettersMathbfUppercase = [...'MTX'];
     const tildeLettersMathcal = [...'HQSW'];
-    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(' ');
-    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(' ');
+    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(
+      ' ',
+    );
+    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(
+      ' ',
+    );
 
     // Hat variables
     const hatLetters = [...'HFP'];
@@ -213,17 +217,47 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       // Mathbf uppercase: \mathbf{X} -> \bX
       ...generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
       // Normalize legacy font commands {\rm X}, {\bf X}, {\cal X}
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathrm',
+        'rm',
+      ),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathbf',
+        'bf',
+      ),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathcal',
+        'cal',
+      ),
       // Tilde variables: \tilde{x} -> \tx, \tilde{B} -> \tB
       ...generateDecoratorShortcuts('tilde', tildeLetters, 't'),
       // Tilde with mathbf lowercase: \tilde{\mathbf{x}} -> \tbx
-      ...generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbf, 't', 'b'),
+      ...generateNestedDecoratorShortcuts(
+        'tilde',
+        'mathbf',
+        tildeLettersMathbf,
+        't',
+        'b',
+      ),
       // Tilde with mathbf uppercase: \tilde{\mathbf{M}} -> \tbM
-      ...generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbfUppercase, 't', 'b'),
+      ...generateNestedDecoratorShortcuts(
+        'tilde',
+        'mathbf',
+        tildeLettersMathbfUppercase,
+        't',
+        'b',
+      ),
       // Tilde with mathcal: \tilde{\mathcal{H}} -> \tcH
-      ...generateNestedDecoratorShortcuts('tilde', 'mathcal', tildeLettersMathcal, 't', 'c'),
+      ...generateNestedDecoratorShortcuts(
+        'tilde',
+        'mathcal',
+        tildeLettersMathcal,
+        't',
+        'c',
+      ),
       // Tilde with Greek: \tilde{\gamma} -> \tga
       ...Object.fromEntries(
         tildeGreekLetters.map((letter) => [
@@ -248,7 +282,13 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
         ]),
       ),
       // Hat with mathbf: \hat{\mathbf{n}} -> \hbn
-      ...generateNestedDecoratorShortcuts('hat', 'mathbf', hatMathbfLetters, 'h', 'b'),
+      ...generateNestedDecoratorShortcuts(
+        'hat',
+        'mathbf',
+        hatMathbfLetters,
+        'h',
+        'b',
+      ),
       // Hat with boldsymbol+Greek: \hat{\boldsymbol{\zeta}} -> \hbze
       ...Object.fromEntries(
         hatBoldsymbolLetters.map((letter) => [

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -46,17 +46,9 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
   description: 'Automatically generated maximum style replacements for LaTeX',
   isRegex: false,
   patterns: (() => {
-    // Initialize patterns object
-    const patterns: { [key: string]: string } = {};
-
     // ====================================================================
     // Backslash and command fixes
     // ====================================================================
-
-    // Fix for double backslashes in various commands
-    // Examples: \\alpha -> \alpha, \\mathbf -> \mathbf
-
-    // Math Operators, Greek Letters, Symbols, and common commands
     // prettier-ignore
     const backslashFixCommands = [
       // Common custom shortcuts (max-specific only)
@@ -66,9 +58,6 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'effH', 'ceffH', 'peq', 'qeq', 'rhoeq', 'rhost', 'nimplies', 'bna', 'bdiv',
       'ddt', 'dddt', 'nn', 'da', 'bksl', 'Ra', 'tauf', 'beps'
     ];
-
-    // Generate backslash fixes for all the above commands
-    Object.assign(patterns, generateBackslashFixes(backslashFixCommands));
 
     // ====================================================================
     // Specialized handling for math operators and text commands
@@ -81,44 +70,10 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'argmin','argmax','tr','Tr','sign','sort','argsort','Cov','Cat','Bern','Unif','ReLU','Concat','Skip','Upsample','Softmax','Conv','BatchNorm','LayerNorm','MaxPool','Dropout','TransformerEncoder','Attention','MultiHead','AdaLN',
     ];
 
-    // Direct mapping: \mathrm{op} -> \op and \text{op} -> \op
-    Object.assign(
-      patterns,
-      Object.fromEntries(
-        mathOperators.flatMap((op) => [
-          [`\\mathrm{${op}}`, `\\${op}`],
-          [`\\text{${op}}`, `\\${op}`],
-          [`\\mbox{${op}}`, `\\${op}`],
-          [`\\textrm{${op}}`, `\\${op}`],
-          [`{\\rm ${op}}`, `\\${op}`],
-          [`_\\op`, `_{\\${op}}`],
-          [`^\\op`, `^{\\${op}}`],
-        ]),
-      ),
-    );
-
     // 2. Text Commands (defined with \newcommand{\cmd}{{\text{name}}})
     // These allow direct subscript/superscript like P_\cmd
     // prettier-ignore
     const textCommands = ['sys', 'bath', 'tot', 'const', 'discrete', 'decoder', 'encoder', 'pool', 'data', 'mar', 'model', 'prior', 'target', 'full', 'observed', 'accept', 'aux', 'eq', 'st', 'nc', 'irr', 'rev', 'hkp', 'adi', 'nadi', 'exc', 'pos', 'head', 'PE', 'class', 'window', 'Output', 'FFN', 'Strat', 'Ito', 'diss'];
-
-    // Direct mapping: \text{cmd} -> \cmd
-    Object.assign(
-      patterns,
-      Object.fromEntries(
-        textCommands.flatMap((cmd) => [
-          [`\\text{${cmd}}`, `\\${cmd}`],
-          [`\\mathrm{${cmd}}`, `\\${cmd}`],
-          [`\\mbox{${cmd}}`, `\\${cmd}`],
-          [`\\textrm{${cmd}}`, `\\${cmd}`],
-          [`{\\rm ${cmd}}`, `\\${cmd}`],
-          [`_{\\${cmd}}`, `_\\${cmd}`],
-          [`^{\\${cmd}}`, `^\\${cmd}`],
-          [`_{${cmd}}`, `_\\${cmd}`],
-          [`^{${cmd}}`, `^\\${cmd}`],
-        ]),
-      ),
-    );
 
     // prettier-ignore
     const symbolOperators = [
@@ -128,53 +83,14 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'tit', 'wtit', 'tif', 'ttf', 'ttauf', 'tze', 'tzero', 'tone', 'tauf', 'tf', 'ttau', 'tau', 'ttf',
       'bu', 'ta'
     ];
-    // these variables might occur as lower indices, but they do not need {..}
-    Object.assign(
-      patterns,
-      Object.fromEntries(
-        symbolOperators.flatMap((op) => [
-          [`_{\\${op}}`, `_\\${op}`],
-          [`^{\\${op}}`, `^\\${op}`],
-        ]),
-      ),
-    );
 
     // ====================================================================
     // Auto-generated differential notation patterns
     // ====================================================================
-
-    // Variables that need differential spacing
     // prettier-ignore
     const differentialVariables = ['x', 't', 'tau', 'ttau', 'beta', 'bx', 'bz', 'bze', 'bxi', 'tbx'];
-
-    // Generate differential spacing patterns
-    Object.assign(
-      patterns,
-      generateDifferentialSpacing(differentialVariables, '~'),
-    );
-
-    // Variables that need differential replacement in fractions and integrals
     // prettier-ignore
     const fractionDiffVariables = ['t', 'x', 'tau', 'ttau', 'beta', 'bx', 'bz', 'bze', 'bxi', 'S'];
-
-    // Generate patterns for each variable
-    Object.assign(
-      patterns,
-      Object.fromEntries(
-        fractionDiffVariables.flatMap((variable) => [
-          // Handle cases like {dx} -> {\\dd x}
-          [`{d${variable}}`, `{\\dd${variable}}`],
-          // Handle cases like \\frac{dx} -> \\frac{\\dd x}
-          [`\\frac{d${variable}`, `\\frac{\\dd${variable}`],
-          // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
-          [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
-        ]),
-      ),
-    );
-
-    // Integration patterns
-    patterns['\\int d\\'] = '\\int \\dd\\';
-    patterns['\\int \\dd \\bx \\'] = '\\int \\dd \\bx~ \\';
 
     // Arrows and Relations
     // Examples: \rightarrow -> \ra, \Leftrightarrow -> \LRa
@@ -187,248 +103,170 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       Leftrightarrow: 'LRa',
       Longleftrightarrow: 'LRa',
     };
-    Object.assign(patterns, generateArrowRelationShortcuts(arrowRelationMap));
 
-    // Calculus command shortcuts
-    // Examples: \partial -> \der, \nabla -> \na
+    // Calculus command shortcuts: \partial -> \der, \nabla -> \na
     const calculusCommandMap = {
       partial: 'der',
       nabla: 'na',
     };
-    Object.assign(patterns, generateCommandShortcuts(calculusCommandMap));
 
-    // Vector Variables
-    // Examples:
-    // \vec{p} -> \vp (momentum vector)
-    // \vec{x} -> \vx (position vector)
+    // Vector Variables: \vec{p} -> \vp, \vec{x} -> \vx
     const vectorLetters = [...'pqvxyz'];
-    Object.assign(patterns, generateVectorShortcuts(vectorLetters));
 
-    // Greek Letters (Regular)
-    // Map full Greek letter names to shorter versions
-    // Examples:
-    // \alpha -> \al
-    // \theta -> \ta
-
-    // Exclude Delta to prevent it from being shortened to De
+    // Greek Letters (Regular): exclude Delta to prevent it from being shortened to De
     const { Delta: _, ...greekShortcuts } = GREEK_LETTER_SHORTCUTS;
 
-    Object.assign(patterns, generateMathCommandShortcuts(greekShortcuts));
-
-    // Greek Letters (Bold)
-    // Generate patterns for bold Greek letters with \b prefix
+    // Greek Letters (Bold): bold Greek letters with \b prefix
     // prettier-ignore
     const commonGreekSet = new Set(['alpha', 'beta', 'gamma', 'epsilon', 'eta', 'theta', 'mu', 'nu', 'omega', 'phi', 'sigma', 'xi', 'zeta']);
     const commonGreekLetters = GREEK_LETTERS.filter((letter) =>
       commonGreekSet.has(letter),
     );
-
     // prettier-ignore
     const greekBoldLetters = [...commonGreekLetters, 'chi', 'pi', 'varphi', 'Sigma', 'lambda', 'Gamma', 'Lambda'];
-    Object.assign(
-      patterns,
-      generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
-    );
 
-    // Mathcal Letters
-    // Map \mathcal{X} to shorter \cX versions for all uppercase letters
+    // Math font letter sets
     const upperLetters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
-    );
-
-    // Mathbb Letters
-    // Map \mathbb{X} to shorter \eX versions for specific letters
     const mathbbLetters = [...'CEINPQRTV'];
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
-    );
-
-    // Mathbf Letters (Lowercase)
-    // Map \mathbf{x} to shorter \bx versions
     const lowerLetters = [...'abcdefghjnpqrsuvwxyz'];
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
-    );
-
-    // Mathbf Letters (Uppercase)
-    // Map \mathbf{X} to shorter \bX versions for uppercase letters
     const mathbfUpperLetters = [...'ABCDEFGIJKMQRUVWXYZ'];
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
-    );
-
-    // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
     const alphabetLetters = [
       ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
     ];
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
-    );
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
-    );
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
-    );
 
-    // Tilde variables - simple letters
-    // Examples: \tilde{x} -> \tx, \tilde{B} -> \tB
+    // Tilde variables
     const tildeLetters = [...'xzpqBFJMPTZ'];
-    Object.assign(
-      patterns,
-      generateDecoratorShortcuts('tilde', tildeLetters, 't'),
-    );
-
-    // Tilde with mathbf - lowercase
-    // Example: \tilde{\mathbf{x}} -> \tbx
     const tildeLettersMathbf = [...'axpvwz'];
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathbf',
-        tildeLettersMathbf,
-        't',
-        'b',
-      ),
-    );
-
-    // Tilde with mathbf - uppercase
-    // Example: \tilde{\mathbf{M}} -> \tbM
     const tildeLettersMathbfUppercase = [...'MTX'];
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathbf',
-        tildeLettersMathbfUppercase,
-        't',
-        'b',
-      ),
-    );
-
-    // Tilde with mathcal - uppercase
-    // Example: \tilde{\mathcal{H}} -> \tcH
     const tildeLettersMathcal = [...'HQSW'];
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathcal',
-        tildeLettersMathcal,
-        't',
-        'c',
-      ),
-    );
+    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(' ');
+    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(' ');
 
-    // Tilde with Greek letters
-    // Example: \tilde{\gamma} -> \tga
-    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(
-      ' ',
-    );
-    Object.assign(
-      patterns,
-      Object.fromEntries(
+    // Hat variables
+    const hatLetters = [...'HFP'];
+    const hatGreekLetters = 'sigma Sigma pi rho'.split(' ');
+    const hatMathbfLetters = [...'nv'];
+    const hatBoldsymbolLetters = ['zeta'];
+
+    // Function names: \F_ -> F_, \G( -> G(
+    const functionNames = ['F', 'G'];
+
+    return {
+      ...generateBackslashFixes(backslashFixCommands),
+      // Math Operators: \mathrm{op} -> \op and \text{op} -> \op
+      ...Object.fromEntries(
+        mathOperators.flatMap((op) => [
+          [`\\mathrm{${op}}`, `\\${op}`],
+          [`\\text{${op}}`, `\\${op}`],
+          [`\\mbox{${op}}`, `\\${op}`],
+          [`\\textrm{${op}}`, `\\${op}`],
+          [`{\\rm ${op}}`, `\\${op}`],
+          [`_\\op`, `_{\\${op}}`],
+          [`^\\op`, `^{\\${op}}`],
+        ]),
+      ),
+      // Text Commands: \text{cmd} -> \cmd
+      ...Object.fromEntries(
+        textCommands.flatMap((cmd) => [
+          [`\\text{${cmd}}`, `\\${cmd}`],
+          [`\\mathrm{${cmd}}`, `\\${cmd}`],
+          [`\\mbox{${cmd}}`, `\\${cmd}`],
+          [`\\textrm{${cmd}}`, `\\${cmd}`],
+          [`{\\rm ${cmd}}`, `\\${cmd}`],
+          [`_{\\${cmd}}`, `_\\${cmd}`],
+          [`^{\\${cmd}}`, `^\\${cmd}`],
+          [`_{${cmd}}`, `_\\${cmd}`],
+          [`^{${cmd}}`, `^\\${cmd}`],
+        ]),
+      ),
+      // Symbol operators: _{op} -> _\op (no braces needed)
+      ...Object.fromEntries(
+        symbolOperators.flatMap((op) => [
+          [`_{\\${op}}`, `_\\${op}`],
+          [`^{\\${op}}`, `^\\${op}`],
+        ]),
+      ),
+      ...generateDifferentialSpacing(differentialVariables, '~'),
+      ...Object.fromEntries(
+        fractionDiffVariables.flatMap((variable) => [
+          // Handle cases like {dx} -> {\\dd x}
+          [`{d${variable}}`, `{\\dd${variable}}`],
+          // Handle cases like \\frac{dx} -> \\frac{\\dd x}
+          [`\\frac{d${variable}`, `\\frac{\\dd${variable}`],
+          // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
+          [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
+        ]),
+      ),
+      '\\int d\\': '\\int \\dd\\',
+      '\\int \\dd \\bx \\': '\\int \\dd \\bx~ \\',
+      ...generateArrowRelationShortcuts(arrowRelationMap),
+      ...generateCommandShortcuts(calculusCommandMap),
+      ...generateVectorShortcuts(vectorLetters),
+      ...generateMathCommandShortcuts(greekShortcuts),
+      ...generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
+      // Mathcal: \mathcal{X} -> \cX
+      ...generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
+      // Mathbb: \mathbb{X} -> \eX
+      ...generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
+      // Mathbf lowercase: \mathbf{x} -> \bx
+      ...generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
+      // Mathbf uppercase: \mathbf{X} -> \bX
+      ...generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
+      // Normalize legacy font commands {\rm X}, {\bf X}, {\cal X}
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
+      // Tilde variables: \tilde{x} -> \tx, \tilde{B} -> \tB
+      ...generateDecoratorShortcuts('tilde', tildeLetters, 't'),
+      // Tilde with mathbf lowercase: \tilde{\mathbf{x}} -> \tbx
+      ...generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbf, 't', 'b'),
+      // Tilde with mathbf uppercase: \tilde{\mathbf{M}} -> \tbM
+      ...generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbfUppercase, 't', 'b'),
+      // Tilde with mathcal: \tilde{\mathcal{H}} -> \tcH
+      ...generateNestedDecoratorShortcuts('tilde', 'mathcal', tildeLettersMathcal, 't', 'c'),
+      // Tilde with Greek: \tilde{\gamma} -> \tga
+      ...Object.fromEntries(
         tildeGreekLetters.map((letter) => [
           `\\tilde{\\${letter}}`,
           `\\t${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
         ]),
       ),
-    );
-
-    // Tilde with boldsymbol+Greek
-    // Example: \tilde{\boldsymbol{\zeta}} -> \tbze
-    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(
-      ' ',
-    );
-    Object.assign(
-      patterns,
-      Object.fromEntries(
+      // Tilde with boldsymbol+Greek: \tilde{\boldsymbol{\zeta}} -> \tbze
+      ...Object.fromEntries(
         tildeGreekBoldLetters.map((letter) => [
           `\\tilde{\\boldsymbol{\\${letter}}}`,
           `\\tb${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
         ]),
       ),
-    );
-
-    // Hat variables
-    // Example: \hat{H} -> \hH
-    const hatLetters = [...'HFP'];
-    Object.assign(patterns, generateDecoratorShortcuts('hat', hatLetters, 'h'));
-
-    // Hat with Greek letters
-    // Example: \hat{\sigma} -> \hsg
-    const hatGreekLetters = 'sigma Sigma pi rho'.split(' ');
-    Object.assign(
-      patterns,
-      Object.fromEntries(
+      // Hat variables: \hat{H} -> \hH
+      ...generateDecoratorShortcuts('hat', hatLetters, 'h'),
+      // Hat with Greek: \hat{\sigma} -> \hsg
+      ...Object.fromEntries(
         hatGreekLetters.map((letter) => [
           `\\hat{\\${letter}}`,
           `\\h${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
         ]),
       ),
-    );
-
-    // Hat with mathbf
-    // Example: \hat{\mathbf{n}} -> \hbn
-    const hatMathbfLetters = [...'nv'];
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
-        'hat',
-        'mathbf',
-        hatMathbfLetters,
-        'h',
-        'b',
-      ),
-    );
-
-    // Hat with boldsymbol+Greek
-    // Example: \hat{\boldsymbol{\zeta}} -> \hbze
-    const hatBoldsymbolLetters = ['zeta'];
-    Object.assign(
-      patterns,
-      Object.fromEntries(
+      // Hat with mathbf: \hat{\mathbf{n}} -> \hbn
+      ...generateNestedDecoratorShortcuts('hat', 'mathbf', hatMathbfLetters, 'h', 'b'),
+      // Hat with boldsymbol+Greek: \hat{\boldsymbol{\zeta}} -> \hbze
+      ...Object.fromEntries(
         hatBoldsymbolLetters.map((letter) => [
           `\\hat{\\boldsymbol{\\${letter}}}`,
           `\\hb${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
         ]),
       ),
-    );
-
-    // Fix for extra backslashes in bold symbols
-    // Automatically generate fixes for lowercase bold letters (e.g., \\ba -> \ba)
-    Object.assign(patterns, generateBoldBackslashFixes('b', lowerLetters));
-
-    // Automatically generate fixes for uppercase bold letters (e.g., \\bA -> \bA)
-    Object.assign(
-      patterns,
-      generateBoldBackslashFixes('b', mathbfUpperLetters),
-    );
-
-    // Convert functions to simpler forms (e.g., F_/G_)
-    // Examples: \F_ -> F_, \G( -> G(
-    const functionNames = ['F', 'G'];
-    Object.assign(
-      patterns,
-      Object.fromEntries(
+      // Bold backslash fixes: \\ba -> \ba (lowercase), \\bA -> \bA (uppercase)
+      ...generateBoldBackslashFixes('b', lowerLetters),
+      ...generateBoldBackslashFixes('b', mathbfUpperLetters),
+      ...Object.fromEntries(
         functionNames.flatMap((name) => [
           [`\\${name}_`, `${name}_`],
           [`\\${name}^`, `${name}^`],
           [`\\${name}(`, `${name}(`],
         ]),
       ),
-    );
-
-    return patterns;
+    };
   })(),
 };
 

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -83,7 +83,6 @@ function issue(
   return { severity, code, message, ...options };
 }
 
-
 function firstZodMessage(error: ZodError): string {
   return error.issues[0]?.message ?? 'Invalid skill metadata';
 }

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -7,6 +7,7 @@ import { ZodError } from 'zod';
 
 // Local imports - common
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
+import { isObject } from '@utils/core';
 
 // Local imports - skill parsing
 import { collapseWhitespace } from '@utils/text/stringUtils';
@@ -82,9 +83,6 @@ function issue(
   return { severity, code, message, ...options };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function firstZodMessage(error: ZodError): string {
   return error.issues[0]?.message ?? 'Invalid skill metadata';
@@ -209,7 +207,7 @@ async function loadSkillDirectory(
   try {
     const content = await fs.readFile(skillPath, 'utf8');
     const { frontmatter, body } = extractFrontmatter(content);
-    if (!isRecord(frontmatter)) {
+    if (!isObject(frontmatter)) {
       return {
         errors: [
           issue(

--- a/src/tools/setup/InstallVscodeExtensionTool.ts
+++ b/src/tools/setup/InstallVscodeExtensionTool.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { ToolError, type ToolResult } from '@tools/result';
 import { LEAN4_EXTENSION_ID } from '@tools/lean/leanConstants';
+import { delay } from '@utils/core';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -59,7 +60,7 @@ export class InstallVscodeExtensionTool extends defineTool({
     await platform.extensions.install(id);
 
     // Give VS Code a brief moment to register the new extension.
-    await new Promise((r) => setTimeout(r, 250));
+    await delay(250);
     const installed = platform.extensions.isInstalled(id);
 
     return {


### PR DESCRIPTION
## Summary

Four targeted clean-ups found by auditing the codebase for duplicate logic and custom re-implementations of things the standard library already provides.

- **Remove duplicate `isRecord` in `loadSkills.ts`** — the local function was byte-for-byte identical to `isObject()` already exported from `@utils/core/typeGuards`. Replaced with an import.

- **Use `delay()` in `InstallVscodeExtensionTool.ts`** — `new Promise((r) => setTimeout(r, 250))` was the only remaining ad-hoc sleep in non-test production code. The `delay` package is already re-exported from `@utils/core` and used everywhere else; switched to it for consistency.

- **Refactor `maxRules.ts` patterns IIFE** — 31 sequential `Object.assign(patterns, …)` mutation calls replaced by a single declarative spread-based return object. All intermediate `const` variable declarations are hoisted to the top of the IIFE; the return statement is one `{ ...spread1, ...spread2, … }` literal. Net: −161 lines, same runtime output.

- **Use `hasExtension()` for extension checks** — two inline `.toLowerCase().endsWith('.tex'/.md')` comparisons in `inlineCriticism.ts` and `SettingsViewMessageHandler.ts` replaced with `hasExtension()` from `@utils/core/pathCore`, which already does the same case-insensitive check.

## Test plan

- [ ] `npm run compile:fast` — build passes (verified locally, exit 0)
- [ ] `npm run lint` — zero errors in changed files (verified locally)
- [ ] `maxRules.ts` — IIFE produces identical output: all spreads are pure functions, no logic changed, only the accumulation pattern changed from mutation to spread
- [ ] `loadSkills.ts` — `isObject` and the removed `isRecord` had identical implementations; behaviour unchanged
- [ ] `InstallVscodeExtensionTool.ts` — `delay(250)` is semantically equivalent to `new Promise((r) => setTimeout(r, 250))`
- [ ] Extension checks — `hasExtension(path, '.tex')` is the exact same case-insensitive endsWith check

https://claude.ai/code/session_01312HCQ2wdEc4Dk7yQVLMAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01312HCQ2wdEc4Dk7yQVLMAZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors to existing helpers and a structural rewrite of rule assembly with no new features; regression risk is limited to equivalent path/extension checks and identical replacement maps.
> 
> **Overview**
> This PR **deduplicates small utilities** and **simplifies how max LaTeX replacement rules are built**, without changing intended behavior.
> 
> **Extension and path checks:** Inline criticism only refreshes diagnostics for paths that `hasExtension(..., '.tex')` uses instead of a manual case-insensitive `.endsWith`. Opening memory files from settings uses the same helper for `.md` vs other files (preview vs text editor).
> 
> **Skills loading:** SKILL.md frontmatter validation drops a local `isRecord` guard in favor of shared `isObject` from `@utils/core`.
> 
> **Setup tool:** After installing an allowlisted VS Code extension, the post-install wait uses shared `delay(250)` instead of an inline `setTimeout` promise.
> 
> **Max style rules:** The large auto-pattern IIFE no longer mutates a `patterns` object with many `Object.assign` calls; it returns one object built from spreads over the same generator helpers. Pattern content is unchanged; structure is flatter and shorter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c669ec9b9abf6b4559115664e658c17ccce224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->