### PR TITLE
fix(cli): hide empty task shortcut

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1414,31 +1414,22 @@ const SCENARIOS = [
     unexpect: ['Harness received: can you still receive this?'],
   },
   {
-    name: 'empty-task-picker',
+    name: 'empty-task-shortcut-hidden',
     env: {
       HARNESS_ENTRIES: '4',
     },
     keys: [ESC + 'p'],
     frame: 'tail',
-    expect: [
-      'Tasks and sub-workflows',
-      'Stream: main',
-      'No active tasks or sub-workflows.',
-      'Esc close',
-    ],
+    expect: ['entry-4 chat history line', '[/status]details', '[Ctrl-C]exit'],
     unexpect: [
+      '[Option-p]tasks',
+      '[Alt-p]tasks',
+      '[Esc p]tasks',
+      'Tasks and sub-workflows',
+      'No active tasks or sub-workflows.',
       'Enter view',
       'k kill',
       'navigate',
-      '│                                                                                                  │\n│ No active tasks or sub-workflows.',
-      '│ No active tasks or sub-workflows.                                                                │\n│                                                                                                  │',
-    ],
-    maxBlankLinesBetween: [
-      {
-        from: 'entry-4 chat history line',
-        to: 'Tasks and sub-workflows',
-        max: 0,
-      },
     ],
   },
   {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -464,6 +464,16 @@ export function App(props: AppProps): React.JSX.Element {
     parentStream,
     streams,
   });
+  const taskControlTarget = resolveChildControlStreamTarget({
+    activeStreamId,
+    mode: 'tasks',
+    parentStream,
+    streams,
+  });
+  const taskControlsAvailable = hasChildControlItems(
+    taskControlTarget.slice,
+    'tasks',
+  );
   const subagentControlsAvailable = canShowSubagentControls(
     sessionMeta,
     subagentControlTarget.slice,
@@ -651,7 +661,7 @@ export function App(props: AppProps): React.JSX.Element {
         return;
       }
       if (lower === 'p') {
-        setChildControlMode('tasks');
+        if (taskControlsAvailable) setChildControlMode('tasks');
         return;
       }
       const digit = metaChordDigit(input, key);

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -25,7 +25,10 @@ import {
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
-import { resolveChildControlStreamTarget } from '../state/childControls';
+import {
+  hasChildControlItems,
+  resolveChildControlStreamTarget,
+} from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -56,6 +59,7 @@ export interface StatusBarDisplayInput {
   readonly activeSubagents: number;
   readonly activeProcesses: number;
   readonly approvalDepth: number;
+  readonly taskControlsAvailable?: boolean;
   readonly subagentControlsAvailable: boolean;
   /** True when more than the root stream exists, i.e. a subagent or
    *  child stream is live. Gates the stream-navigation hints, which are
@@ -335,6 +339,7 @@ function metaShortcutLabel(modifierLabel: string, key: string): string {
 }
 
 export function statusBarBindingsText(
+  taskControlsAvailable = true,
   subagentControlsAvailable: boolean,
   hasMultipleStreams: boolean,
   modifierLabel = defaultShortcutModifierLabel(),
@@ -349,7 +354,7 @@ export function statusBarBindingsText(
     // Stream cycling / numeric focus only do something when there is more
     // than one stream — hide the hints in a plain single-stream chat.
     ...(hasMultipleStreams ? ['[Tab]streams', `${focusBinding}focus`] : []),
-    `${tasksBinding}tasks`,
+    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     '[/status]details',
     '[/model]models',
     '[/api]api',
@@ -358,18 +363,18 @@ export function statusBarBindingsText(
   ];
   if (subagentControlsAvailable) {
     const tasksIndex = bindings.indexOf(`${tasksBinding}tasks`);
-    bindings.splice(
-      tasksIndex >= 0 ? tasksIndex + 1 : bindings.length,
-      0,
-      `${subagentsBinding}subagents`,
-    );
+    const statusIndex = bindings.indexOf('[/status]details');
+    let insertSubagentsAt = bindings.length;
+    if (tasksIndex >= 0) insertSubagentsAt = tasksIndex + 1;
+    else if (statusIndex >= 0) insertSubagentsAt = statusIndex;
+    bindings.splice(insertSubagentsAt, 0, `${subagentsBinding}subagents`);
   }
   const fullBindings = joinStatusBindings(bindings);
   if (fitsStatusBindings(fullBindings, maxColumns)) return fullBindings;
 
   const compactBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-    `${tasksBinding}tasks`,
+    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
     '[/status]details',
     `[Ctrl-C]${ctrlCAction}`,
@@ -378,13 +383,13 @@ export function statusBarBindingsText(
 
   const minimalBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-    `${tasksBinding}tasks`,
+    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
     `[Ctrl-C]${ctrlCAction}`,
   ]);
   if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
 
-  if (hasMultipleStreams) {
+  if (hasMultipleStreams && taskControlsAvailable) {
     const taskFocusedBindings = joinStatusBindings([
       '[Tab]streams',
       `${tasksBinding}tasks`,
@@ -395,12 +400,14 @@ export function statusBarBindingsText(
     }
   }
 
-  const bareTaskBindings = joinStatusBindings([
-    `${tasksBinding}tasks`,
-    `[Ctrl-C]${ctrlCAction}`,
-  ]);
-  if (fitsStatusBindings(bareTaskBindings, maxColumns)) {
-    return bareTaskBindings;
+  if (taskControlsAvailable) {
+    const bareTaskBindings = joinStatusBindings([
+      `${tasksBinding}tasks`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(bareTaskBindings, maxColumns)) {
+      return bareTaskBindings;
+    }
   }
 
   if (subagentControlsAvailable) {
@@ -644,6 +651,7 @@ export function buildStatusBarDisplay(
         : input.shortcutsActive === false
           ? foregroundBindingsText(input.ctrlCAction ?? 'exit')
           : statusBarBindingsText(
+              input.taskControlsAvailable ?? true,
               input.subagentControlsAvailable,
               input.hasMultipleStreams,
               input.shortcutModifierLabel,
@@ -684,6 +692,12 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     parentStream,
     streams,
   });
+  const taskControlTarget = resolveChildControlStreamTarget({
+    activeStreamId,
+    mode: 'tasks',
+    parentStream,
+    streams,
+  });
 
   const runStartedAt =
     statusSlice?.status === STREAM_STATUS.RUNNING
@@ -704,6 +718,10 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     activeSubagents: statusSlice?.activeSubagents.length ?? 0,
     activeProcesses: statusSlice?.activeProcesses.length ?? 0,
     approvalDepth: approvals,
+    taskControlsAvailable: hasChildControlItems(
+      taskControlTarget.slice,
+      'tasks',
+    ),
     subagentControlsAvailable: canShowSubagentControls(
       sessionMeta,
       subagentControlTarget.slice,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -116,6 +116,65 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
   });
 
+  it('hides task shortcuts when no task rows exist', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 12_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      taskControlsAvailable: false,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'relay',
+      shortcutModifierLabel: 'Option',
+      ctrlCAction: 'stop',
+    });
+
+    expect(display.bindings).toContain('[/status]details');
+    expect(display.bindings).toContain('[Ctrl-C]stop');
+    expect(display.bindings).not.toContain('[Option-p]tasks');
+  });
+
+  it('keeps subagent shortcuts grouped when task shortcuts are hidden', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      elapsedMs: 12_000,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 1,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      taskControlsAvailable: false,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'relay',
+      shortcutModifierLabel: 'Option',
+      ctrlCAction: 'stop',
+    });
+
+    expect(display.bindings).not.toContain('[Option-p]tasks');
+    expect(display.bindings).toContain('[Option-s]subagents');
+    expect(display.bindings.indexOf('[Option-s]subagents')).toBeLessThan(
+      display.bindings.indexOf('[/status]details'),
+    );
+    expect(display.bindings.indexOf('[Option-s]subagents')).toBeLessThan(
+      display.bindings.indexOf('[Ctrl-C]stop'),
+    );
+  });
+
   it('advertises Shift-Enter for newline when the Kitty protocol is active', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,


### PR DESCRIPTION
## Summary

- hide the task-picker shortcut when the current/fallback stream has no task rows
- ignore Option/Alt-p in the same empty state so plain chats do not open a useless foreground panel
- update the TUI harness to assert the empty task shortcut stays hidden while real task pickers still work

Closes #4996

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-cli-frames-next`
- `corepack pnpm --filter @texra-ai/cli run --if-present typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating of shortcuts and picker open logic in the CLI TUI; no auth, data, or API changes.
> 
> **Overview**
> The CLI TUI now treats the **tasks** shortcut like subagents: it only appears in the status bar and responds to **Esc/Alt-p** when the resolved stream actually has task/sub-workflow rows (`hasChildControlItems` on the task control target). Plain chats no longer advertise `[…-p]tasks` or open an empty “Tasks and sub-workflows” foreground panel.
> 
> **Status bar** binding layout was updated so omitted task hints still place subagent shortcuts sensibly in full and narrow widths. **Tests** cover the display model, and the TUI harness scenario now asserts the empty state stays on the normal chat chrome without task labels or picker UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ef32c23576a861209462567920a2117e6cb6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->