### PR TITLE
fix(cli): keep foreground ctrl-c action visible

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -441,7 +441,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Apply edit to draft.tex?',
       'y approve',
@@ -456,7 +456,7 @@ const SCENARIOS = [
     rows: 12,
     cols: 40,
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     frame: 'tail',
     expect: [
       'Apply edit to draft.tex?',
@@ -470,7 +470,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval-approve',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: ['y'],
     frame: 'tail',
     expect: ['[/status]details', '[/model]models'],
@@ -479,7 +479,7 @@ const SCENARIOS = [
   {
     name: 'bash-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Run bash command?',
       '$ npm run compile:safe',
@@ -497,7 +497,7 @@ const SCENARIOS = [
     rows: 12,
     cols: 40,
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     frame: 'tail',
     expect: [
       'Run bash command?',
@@ -516,7 +516,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Run bash command?',
       "$ python3 << 'EOF'",
@@ -535,7 +535,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     frame: 'tail',
     expect: [
       'Run bash command?',
@@ -555,7 +555,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: [DOWN, DOWN, DOWN],
     frame: 'tail',
     expect: [
@@ -576,7 +576,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: [PAGE_DOWN],
     frame: 'tail',
     expect: [
@@ -597,7 +597,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     frame: 'tail',
     expect: ['Run bash command?', 'more rows', 'scroll command', 'y approve'],
     unexpect: ['[Option-p]tasks'],
@@ -605,7 +605,7 @@ const SCENARIOS = [
   {
     name: 'bash-approval-approve-session',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: ['a'],
     frame: 'tail',
     expect: ['AUTO-BASH', '[/status]details', '[/model]models'],
@@ -614,7 +614,7 @@ const SCENARIOS = [
   {
     name: 'bash-approval-session-status',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: ['a', '/status', '\r'],
     frame: 'tail',
     expect: [
@@ -629,7 +629,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_AGENT_PROPOSAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Spawn review?',
       'Category: tool-use agent',
@@ -646,7 +646,7 @@ const SCENARIOS = [
     name: 'external-inquiry-long',
     rows: 24,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER],
     frame: 'tail',
     expect: [
@@ -664,7 +664,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER],
     frame: 'tail',
     expect: [
@@ -682,7 +682,7 @@ const SCENARIOS = [
     rows: 12,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_USER_QUESTION: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     frame: 'tail',
     expect: [
       'Agent asks:',
@@ -698,7 +698,7 @@ const SCENARIOS = [
   {
     name: 'plan-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_PLAN_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -717,7 +717,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -733,7 +733,7 @@ const SCENARIOS = [
     rows: 10,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_PLAN_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -753,7 +753,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -773,7 +773,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: ['r'],
     frame: 'tail',
     expect: ['PLAN-ODYSSEY', '[/status]details', '[/model]models'],
@@ -786,7 +786,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_ODYSSEY: '1',
     },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: [DC2],
     frame: 'tail',
     expect: ['Approve plan?', 'r approve & run', '1 approval'],
@@ -795,7 +795,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval-reject',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: 'Use foreground panel shortcuts',
+    bootExpect: '[Ctrl-C]',
     keys: ['n'],
     frame: 'tail',
     expect: ['[/status]details', '[/model]models'],
@@ -1268,8 +1268,9 @@ const SCENARIOS = [
       'harness-child-strategy details and',
       'preparing a concise result.',
       '[main]* 1:strategy*',
+      '[Ctrl-C]stop',
     ],
-    unexpect: ['│ ›', 'Task details', 'Output:', '*    y*'],
+    unexpect: ['│ ›', 'Task details', 'Output:', '*    y*', '[Ctrl…'],
   },
   {
     name: 'tiny-task-subworkflow-detail-wrapped-scroll',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -433,8 +433,18 @@ function fitsStatusBindings(text: string, maxColumns: number | undefined) {
   return maxColumns === undefined || stringWidth(text) <= maxColumns;
 }
 
-function foregroundBindingsText(ctrlCAction: CtrlCAction): string {
-  return `Use foreground panel shortcuts  [Ctrl-C]${ctrlCAction}`;
+function foregroundBindingsText(
+  ctrlCAction: CtrlCAction,
+  maxColumns?: number,
+): string {
+  const ctrlCBinding = `[Ctrl-C]${ctrlCAction}`;
+  const full = `Use foreground panel shortcuts  ${ctrlCBinding}`;
+  if (fitsStatusBindings(full, maxColumns)) return full;
+
+  const compact = `Panel shortcuts  ${ctrlCBinding}`;
+  if (fitsStatusBindings(compact, maxColumns)) return compact;
+
+  return ctrlCBinding;
 }
 
 export function ctrlCActionForFocus({
@@ -642,7 +652,12 @@ export function buildStatusBarDisplay(
       input.pendingExitHint && input.pendingExitResumeId
         ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
         : input.shortcutsActive === false
-          ? foregroundBindingsText(input.ctrlCAction ?? 'exit')
+          ? foregroundBindingsText(
+              input.ctrlCAction ?? 'exit',
+              input.width === undefined
+                ? undefined
+                : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
+            )
           : statusBarBindingsText(
               input.subagentControlsAvailable,
               input.hasMultipleStreams,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -584,6 +584,56 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).not.toContain('[/model]models');
   });
 
+  it('keeps the Ctrl-C action visible in narrow foreground panels', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 3,
+      activeProcesses: 1,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      shortcutsActive: false,
+      width: 40,
+    });
+
+    expect(display.bindings).toBe('Panel shortcuts  [Ctrl-C]stop');
+  });
+
+  it('falls back to the bare Ctrl-C action in tiny foreground panels', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 3,
+      activeProcesses: 1,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      ctrlCAction: 'stop',
+      shortcutsActive: false,
+      width: 15,
+    });
+
+    expect(display.bindings).toBe('[Ctrl-C]stop');
+  });
+
   it('shows a live elapsed segment only while running', () => {
     const runningInput = {
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
Closes #4998.

## Summary
- keep the foreground `[Ctrl-C]stop` binding visible in narrow status bars by compacting the surrounding hint text first
- fall back to the bare Ctrl-C binding in tiny foreground panels
- make foreground TUI harness boot sentinels wait for the stable `[Ctrl-C]` binding instead of the full prose
- assert the tiny subworkflow harness snapshot keeps `[Ctrl-C]stop` and does not truncate it to `[Ctrl…`

## Validation
- `npm run test:kernel -- src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-foreground-ctrlc-fix-rerun tiny-task-subworkflow-detail tiny-task-subworkflow-detail-wrapped-scroll tiny-task-process-detail compact-task-picker`
- `npm run test:kernel -- src/test-kernel/cli/StatusBar.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-foreground-ctrlc-review-fix edit-approval narrow-edit-approval edit-approval-approve bash-approval narrow-bash-approval long-bash-approval compact-long-bash-approval compact-long-bash-approval-scroll compact-long-bash-approval-page tiny-compact-long-bash-approval bash-approval-approve-session bash-approval-session-status agent-proposal-long external-inquiry-long external-inquiry-long-80-cols compact-user-question plan-approval plan-approval-odyssey compact-plan-approval compact-plan-approval-odyssey plan-approval-approve-odyssey plan-approval-ctrl-r-ignored edit-approval-reject tiny-task-subworkflow-detail`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, 11 existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`