### PR TITLE
fix(cli): preserve root answer before /btw follow-up

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -196,18 +196,7 @@ export function appendStaticTranscriptItems({
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
     const item: StaticTranscriptItem = { id: entry.id, kind: 'entry', entry };
-    if (
-      !canAppendStaticTranscriptItem({
-        currentRows,
-        item,
-        maxRows,
-        width,
-      })
-    ) {
-      break;
-    }
     nextItems.push(item);
-    currentRows += staticTranscriptItemRowCount(item, width);
     seen.add(entry.id);
   }
   // Same reference when nothing was appended so the `setItems` functional

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -949,6 +949,7 @@ export async function runChat(
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
     disposers.push(unbindApprovals);
     const executionId = generateExecutionId();
+    let waitingTurn = 0;
     session.executionId = executionId;
 
     session.runPromise = setCliHelperModel(currentModel)
@@ -961,6 +962,16 @@ export async function runChat(
             moveLocalTranscriptToStream(resolvedStreamId);
             cliState.activeStreamId.set(resolvedStreamId);
             if (session.stopRequested) interruptActive();
+          },
+          onBeforeWaiting: (lastResponse) => {
+            if (!session.streamId) return;
+            syncStreamLog(session.streamId);
+            appendAssistantTranscriptIfMissing(
+              session.streamId,
+              lastResponse,
+              `waiting:${executionId}:${waitingTurn++}`,
+            );
+            finalizeAssistantTranscriptEntries(session.streamId);
           },
         }),
       )

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -52,6 +52,11 @@ export function appendAssistantTranscriptIfMissing(
         entry.id === entryId ||
         (!entry.synthetic &&
           entry.role === 'assistant' &&
+          normalizeTranscriptText(entry.text) === normalized) ||
+        (entry.synthetic &&
+          entry.syntheticKind === 'final' &&
+          entry.syntheticAfterSeq === syntheticAfterSeq &&
+          entry.role === 'assistant' &&
           normalizeTranscriptText(entry.text) === normalized),
     );
     if (alreadyRendered) return slice;

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -292,7 +292,7 @@ describe('CLI conversation transcript splitting', () => {
     expect(again).toHaveLength(1);
   });
 
-  it('caps static transcript rows for short terminal layouts', () => {
+  it('uses a compact header but preserves static transcript entries for short terminal layouts', () => {
     const user = entry('u1', 'user', 'What is a tensor network?', true);
     const assistant = entry('a1', 'assistant', 'A decomposition.', true);
 
@@ -305,13 +305,13 @@ describe('CLI conversation transcript splitting', () => {
       width: 80,
     });
 
-    expect(compact).toHaveLength(2);
+    expect(compact).toHaveLength(3);
     expect(compact[0]).toMatchObject({
       id: 'session-header',
       kind: 'header',
       compact: true,
     });
-    expect(compact[1]?.id).toBe('u1');
+    expect(compact.slice(1).map((item) => item.id)).toEqual(['u1', 'a1']);
 
     expect(
       appendStaticTranscriptItems({
@@ -321,11 +321,11 @@ describe('CLI conversation transcript splitting', () => {
         meta: SESSION_META,
         maxRows: 0,
         width: 80,
-      }),
-    ).toEqual([]);
+      }).map((item) => item.id),
+    ).toEqual(['u1', 'a1']);
   });
 
-  it('preserves static transcript order when one entry does not fit', () => {
+  it('preserves static transcript order when an entry exceeds the compact row budget', () => {
     const first = entry('u1', 'user', 'first', true);
     const large = entry('a1', 'assistant', 'line 1\nline 2\nline 3', true);
     const later = entry('u2', 'user', 'later', true);
@@ -339,17 +339,7 @@ describe('CLI conversation transcript splitting', () => {
       width: 80,
     });
 
-    expect(compact.map((item) => item.id)).toEqual(['session-header', 'u1']);
-
-    const expanded = appendStaticTranscriptItems({
-      activeStreamId: STREAM_ID,
-      currentItems: compact,
-      streams: streamsFromEntries(STREAM_ID, [first, large, later]),
-      meta: SESSION_META,
-      width: 80,
-    });
-
-    expect(expanded.map((item) => item.id)).toEqual([
+    expect(compact.map((item) => item.id)).toEqual([
       'session-header',
       'u1',
       'a1',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1237,6 +1237,20 @@ describe('CLI transcript state', () => {
     });
   });
 
+  it('does not duplicate waiting and final fallback entries for the same response', () => {
+    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'waiting:1');
+    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final:1');
+
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.id)).toEqual(['waiting:1:root']);
+    expect(entries[0]).toMatchObject({
+      role: 'assistant',
+      text: 'The answer is 2.',
+      finalized: true,
+      synthetic: true,
+    });
+  });
+
   it('keeps repeated final responses from distinct turns visible', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();


### PR DESCRIPTION
## Summary

- finalize/sync the completed root assistant turn at the tool-use `WAITING` boundary
- keep finalized static transcript entries in compact scrollback instead of dropping them under the compact row budget
- preserve immediate runtime follow-up queueing so `/btw` is visible to idle-continuation logic
- dedupe `waiting:`/`final:` synthetic fallbacks when the stream log never materializes the same assistant reply

Closes #5001.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- live compact PTY `/btw` marker check: main answer present, side answer present, main before side (`/var/folders/d1/qpfb8kqs3dj482nzfg_0yvkc0000gn/T/texra-live-btw-reviewfix2-pty-OClMND/clean.txt`)
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-btw-dedupe-fix` (`all 82 scenarios passed`)
- `npm run format`
- `npm run lint` (0 errors; existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI TUI transcript timing, static scrollback budgeting, and dedupe logic; no auth, persistence, or agent execution contract changes beyond a new WAITING hook callback.
> 
> **Overview**
> Fixes the CLI chat TUI so the **root assistant answer stays visible** when the user sends a **`/btw` follow-up** while the run is in **WAITING** (e.g. after tools finish).
> 
> At the **tool-use WAITING boundary**, the chat runner now **syncs the stream log**, **adds a missing assistant line** from `lastResponse`, and **finalizes** transcript entries so the completed turn is promoted before idle follow-up handling runs.
> 
> **Static scrollback** no longer drops finalized conversation lines when the terminal uses a **compact row budget**—only the session header stays compact; entries are still appended in order.
> 
> **Deduping** for synthetic assistant fallbacks was tightened so a **waiting** snapshot and a later **final** fallback for the same text do not create two rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a1217999dd307462a17d181984ca6b68af5278e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->