### PR TITLE
Enforce VS Code-free imports in state barrel export

### DIFF
--- a/src/common/state/index.ts
+++ b/src/common/state/index.ts
@@ -3,6 +3,14 @@ export {
   GlobalStateKey,
   INSTRUCTION_PREFIX,
 } from './stateKeys';
+
+// ⚠️  VS Code-free zones must NOT import workspaceSM/globalSM/initializeStateManagers
+// from this barrel — doing so pulls in 'vscode' at module load time.
+// VS Code-free consumers should:
+//   - import keys from '@common/state/stateKeys' (this file only exports enums)
+//   - access state via platform() from '@platform/platform' or the facades in
+//     '@agent/core/stateStore' (getWorkspaceState / getGlobalState)
+// Only extension-host wiring (packages/extension/src/) may use these exports.
 export { workspaceSM, globalSM, initializeStateManagers } from './stateManager';
 export {
   setPendingState,

--- a/src/common/state/index.ts
+++ b/src/common/state/index.ts
@@ -7,7 +7,7 @@ export {
 // ⚠️  VS Code-free zones must NOT import workspaceSM/globalSM/initializeStateManagers
 // from this barrel — doing so pulls in 'vscode' at module load time.
 // VS Code-free consumers should:
-//   - import keys from '@common/state/stateKeys' (this file only exports enums)
+//   - import key constants from '@common/state/stateKeys' (no vscode dependency)
 //   - access state via platform() from '@platform/platform' or the facades in
 //     '@agent/core/stateStore' (getWorkspaceState / getGlobalState)
 // Only extension-host wiring (packages/extension/src/) may use these exports.

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
 
 import { toErrorMessage } from '@common/errors';
-import { workspaceSM, WorkspaceStateKey } from '@common/state';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import { getWorkspaceState } from '@agent/core/stateStore';
 import { isDirectory, isFile, isSymlink } from '@common/files/fsEntryType';
 import { runLatexFormatter } from '@latex/texFormatter';
 import * as logger from '@logger/logUtils';
@@ -53,7 +54,7 @@ export async function indentLatexFilesInDirectory(
     `Starting LaTeX indentation process for directory: ${directory}`,
   );
 
-  const formatter = workspaceSM.get<string>(
+  const formatter = getWorkspaceState().get<string>(
     WorkspaceStateKey.LATEX_FORMATTER,
     LATEX_CONFIG_DEFAULTS.latexFormatter,
   );


### PR DESCRIPTION
## Summary

Refactored `src/common/state/index.ts` to prevent VS Code-free consumers (CLI, platform layer, agent core) from accidentally importing state managers that pull in the `vscode` module at load time. Added a warning comment documenting the correct import patterns for different consumer types, and updated `src/housekeeping/indent.ts` to follow the new guidance by importing from `stateKeys` directly and accessing state via the `getWorkspaceState()` facade.

## Issue acceptance gates

N/A — This is a preventive refactoring to enforce architectural boundaries.

## Single source of truth

The state barrel export (`src/common/state/index.ts`) now documents the single correct import pattern for each consumer type:
- VS Code-free zones: import keys from `@common/state/stateKeys`, access state via `getWorkspaceState()` / `getGlobalState()` from `@agent/core/stateStore`
- Extension-host wiring only: may import `workspaceSM`, `globalSM`, `initializeStateManagers`

## Duplication and abstraction budget

No new abstractions added. The `getWorkspaceState()` facade already existed in `@agent/core/stateStore`; this change simply enforces its use in non-extension code and documents the boundary.

## Host impact

**Extension:** No change — extension host continues to use `workspaceSM` directly.

**Desktop:** No change — uses platform abstraction layer.

**CLI:** Benefits from clearer import guidance; `housekeeping/indent.ts` now follows the correct pattern.

## Scheduled refactoring

None — this is a documentation and enforcement change.

## Validation

- Code compiles with the updated imports
- `housekeeping/indent.ts` now uses the facade pattern instead of direct state manager access
- Warning comment prevents future violations of the VS Code-free boundary

https://claude.ai/code/session_01Wpgmf2gMsQKWy5SJLEXkQD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation plus a single housekeeping call-site change; no auth, data, or extension-host behavior changes.
> 
> **Overview**
> Documents **VS Code-free import rules** on the `@common/state` barrel so CLI/platform/agent code does not pull `workspaceSM` / `globalSM` (and thus `vscode`) at module load. Non-extension code should use `@common/state/stateKeys` for keys and `@agent/core/stateStore` facades for reads/writes; only extension-host wiring may import the managers from the barrel.
> 
> **`housekeeping/indent.ts`** is updated to match: `WorkspaceStateKey` from `stateKeys`, formatter preference via `getWorkspaceState().get(...)` instead of `workspaceSM`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a6df375b75548ea6debb1390c4df95291afb91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->