### PR TITLE
fix(cli): hide empty subagent shortcut

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -625,6 +625,20 @@ const SCENARIOS = [
     unexpect: ['Run bash command?', '1 approval'],
   },
   {
+    name: 'team-status-empty-subagents-hidden',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_CAN_DELEGATE: '1',
+      HARNESS_TEAM_NAME: 'Physicist',
+    },
+    bootExpect: '[Ctrl-C]',
+    keys: ['a', '/status', '\r'],
+    frame: 'tail',
+    expect: ['team: Physicist', 'auto-approvals: bash commands', 'AUTO-BASH'],
+    unexpect: ['Run bash command?', '1 approval', ']subagents'],
+  },
+  {
     name: 'agent-proposal-long',
     rows: 24,
     cols: 80,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -44,7 +44,7 @@ import {
   resolveChildControlStreamTarget,
   type ChildControlMode,
 } from './state/childControls';
-import { canShowSubagentControls, cliState } from './state/cliState';
+import { cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { streamScopeDisplayLabel } from './state/streamLabels';
 import { useSignal } from './state/useSignal';
@@ -383,7 +383,6 @@ export function App(props: AppProps): React.JSX.Element {
   const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const parentStream = useSignal(cliState.parentStream);
-  const sessionMeta = useSignal(cliState.sessionMeta);
   const activeForm = useSignal(cliState.activeForm);
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
   const reverseSearchOpen = useSignal(cliState.reverseSearchOpen);
@@ -474,9 +473,9 @@ export function App(props: AppProps): React.JSX.Element {
     taskControlTarget.slice,
     'tasks',
   );
-  const subagentControlsAvailable = canShowSubagentControls(
-    sessionMeta,
+  const subagentControlsAvailable = hasChildControlItems(
     subagentControlTarget.slice,
+    'subagents',
   );
   const hasSubagentPanel =
     !foregroundOpen && hasChildExecutionRows(activeSlice);

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -19,7 +19,6 @@ import { formatCliStatusLabel } from '../sessionStatus';
 import { approvalQueueDepth } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
-  canShowSubagentControls,
   cliState,
   NO_BYPASS,
   type BypassState,
@@ -737,9 +736,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
       taskControlTarget.slice,
       'tasks',
     ),
-    subagentControlsAvailable: canShowSubagentControls(
-      sessionMeta,
+    subagentControlsAvailable: hasChildControlItems(
       subagentControlTarget.slice,
+      'subagents',
     ),
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -302,10 +302,3 @@ export function resetCliState(sessionMeta = defaultSessionMeta()): void {
 export function registerCliStateResetHook(resetHook: () => void): void {
   RESET_HOOKS.add(resetHook);
 }
-
-export function canShowSubagentControls(
-  meta: Pick<SessionMeta, 'canDelegate'>,
-  slice: Pick<StreamSlice, 'childStreams'> | undefined,
-): boolean {
-  return meta.canDelegate || (slice?.childStreams.length ?? 0) > 0;
-}


### PR DESCRIPTION
Closes #5008

## Summary
- hide the subagents shortcut unless visible subagent rows exist in the active stream or fallback target
- use the same child-control predicate for opening the picker and rendering the status bar
- add a TUI harness regression for a team session that can delegate but has no child streams yet

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-team-status-fix-20260601 team-status-empty-subagents-hidden subagents subagent-picker empty-task-shortcut-hidden`
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-team-status-full-harness-20260601`
- `npm run lint` (passes with 11 existing import-order warnings)

Evidence frame after fix: `/tmp/texra-cli-team-status-fix-20260601/01-team-status-empty-subagents-hidden.txt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating of shortcuts and status hints; behavior matches existing task-control visibility with a harness regression test.
> 
> **Overview**
> The CLI TUI no longer shows the **subagents** shortcut (status bar binding and Esc/Alt-s opener) just because the session **can delegate** or has child-stream metadata with nothing to act on. **App** and **StatusBar** now use the same **`hasChildControlItems(..., 'subagents')`** check as the subagent picker, so the hint only appears when there are visible subagent rows on the resolved stream target.
> 
> **`canShowSubagentControls`** is removed from **`cliState`**. A **`validate-tui`** scenario covers a delegating team session with no child streams yet and asserts **`]subagents`** stays off the status screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e03fb6f84ede6d532a29a8f093927a875bbd65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->