### PR TITLE
feat(cli): chain the model picker after the agent picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
+- **Pick the model right after the agent in CLI chat** — choosing the root agent with `/agent` before the first message now flows straight into the model picker, so you set the agent and model together in one step instead of remembering to run `/model` separately. Pressing Esc on the model picker keeps the agent you chose.
 - **Dropped the redundant `/btw` chat command** — queuing a follow-up never needed its own command. Just type your message while a run is active and it's queued automatically; the command only duplicated that path with extra error states.
 
 ### Bug Fixes

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -64,6 +64,22 @@ export function registerBuiltinSlashCommands(options?: {
   const onApiModeSelect: ApiModeSelectHandler =
     options?.onApiModeSelect ?? ((value) => patchSessionMeta('apiMode', value));
 
+  // Picking the root agent and the root model is a single up-front choice
+  // before the first message, so advance straight from the agent picker into
+  // the model picker instead of closing — the user chooses both in one flow.
+  function openModelSelectionForm(): void {
+    cliState.activeForm.set({
+      commandName: 'model',
+      render: (close, availableRows) => (
+        <ModelListFormAdapter
+          remainder=""
+          availableRows={availableRows}
+          onDone={() => close()}
+        />
+      ),
+    });
+  }
+
   function AgentListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = cliState.sessionMeta.get().agent;
     const selectable = options?.canSelectAgent?.() ?? true;
@@ -72,9 +88,19 @@ export function registerBuiltinSlashCommands(options?: {
         currentAgent={current}
         availableRows={props.availableRows}
         selectable={selectable}
-        onSelect={(value) =>
-          settleThenDone(onAgentSelect(value), value, props.onDone)
-        }
+        onSelect={(value) => {
+          // Chain into the model picker only while still choosing the root
+          // (before the first message) and model selection is available.
+          // Mirror ModelListFormAdapter's own default (`?? true`) so the two
+          // agree on what "model selection available" means; otherwise close.
+          const advanceToModel =
+            selectable && (options?.canSelectModel?.() ?? true);
+          settleThenDone(
+            onAgentSelect(value),
+            value,
+            advanceToModel ? () => openModelSelectionForm() : props.onDone,
+          );
+        }}
         onClose={() => props.onDone(undefined)}
       />
     );


### PR DESCRIPTION
## What

In CLI chat, choosing the root agent with `/agent` **before the first message** now flows straight into the `/model` picker — you set the agent and model together in one step instead of separately remembering to run `/model`.

## Why

`/agent` and `/model` both already open "Choose the root … for the first message." selection forms, but they were independent: after picking an agent you'd land back at the prompt and have to invoke `/model` yourself. Picking the root agent and the root model is really one up-front decision, so the flow should reflect that.

## How

The agent form's `onSelect` (`AgentListFormAdapter` in `registerBuiltins.tsx`), after applying the agent, advances `cliState.activeForm` to the model form — reusing the real `ModelListFormAdapter` — instead of closing. This only happens while the root is still selectable (`canSelectAgent && canSelectModel`, i.e. before the first message). After the first message, or when model selection isn't available, it closes exactly as before.

Single 16-line change, scoped to the form adapter wiring.

## Behavior

- `/agent` → pick agent → prints `Root agent set to X.` → model picker auto-opens.
- pick model → prints `Root model set to Y.` → back to input.
- **Esc** on the chained model picker → graceful: agent stays set, model unchanged.

## Verification

Driven against `texra-local` under tmux:

| Step | Result |
| --- | --- |
| `/agent` → select agent #2 | `Root agent set to review.` + model picker opens (`Choose the root model for the first message.`) |
| select model #2 | `Root model set to deepseekproT.` → returns to input |
| `/agent` → select → **Esc** | `Root agent set to latexFixer.`; model picker closes; back to input, no model change |

CLI typecheck clean; `SlashRegistry` / `SlashPalette` / `AgentListForm` / `ModelListForm` vitest suites pass (38 tests).

Note: this is an interactive form-flow change. The TUI harness wires `canSelect* → false`, and the form suites cover pure layout helpers, so there's no clean automated seam for the `activeForm` transition without invasive harness changes — hence the manual tmux verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI form-wiring change in slash command registration; no auth, persistence, or run execution logic.
> 
> **Overview**
> CLI chat now treats picking the **root agent** and **root model** as one upfront flow: after you choose an agent with `/agent` before the first message, the **model** picker opens automatically via the existing `ModelListFormAdapter`, instead of dropping you back at the prompt.
> 
> Chaining only runs when both root agent and model selection are allowed (`canSelectAgent` and `canSelectModel`, i.e. before the first message). After a message is sent or model selection is unavailable, `/agent` still closes as before. Esc on the model step leaves the agent you picked unchanged.
> 
> The unreleased changelog entry documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e6733b60776f175847bcd213836452b1533cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->