### PR TITLE
Replace custom error/duration serialization with battle-tested libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "pdf2pic": "^3.2.0",
     "perfect-debounce": "^2.1.0",
     "postal-mime": "^2.7.4",
+    "pretty-ms": "^9.3.0",
+    "serialize-error": "^13.0.1",
     "shell-quote": "^1.8.4",
     "signal-polyfill": "^0.2.2",
     "sortablejs": "^1.15.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,12 @@ importers:
       postal-mime:
         specifier: ^2.7.4
         version: 2.7.4
+      pretty-ms:
+        specifier: ^9.3.0
+        version: 9.3.0
+      serialize-error:
+        specifier: ^13.0.1
+        version: 13.0.1
       shell-quote:
         specifier: ^1.8.4
         version: 1.8.4
@@ -5100,6 +5106,10 @@ packages:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
     engines: {node: '>=20'}
 
+  non-error@0.1.0:
+    resolution: {integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==}
+    engines: {node: '>=20'}
+
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -5807,6 +5817,10 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@13.0.1:
+    resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
+    engines: {node: '>=20'}
 
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
@@ -11811,6 +11825,8 @@ snapshots:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.5
 
+  non-error@0.1.0: {}
+
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
@@ -12583,6 +12599,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@13.0.1:
+    dependencies:
+      non-error: 0.1.0
+      type-fest: 5.6.0
 
   serialize-error@7.0.1:
     dependencies:

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -306,8 +306,8 @@ describe('CLI child execution controls', () => {
     ).toMatchObject([
       {
         executionId: 'agent-1',
-        description: 'running · 1min, 1sec',
-        elapsed: '1min, 1sec',
+        description: 'running · 1m 1s',
+        elapsed: '1m 1s',
       },
     ]);
     expect(childElapsed(state.activeProcesses[0], 62_000)).toBe('1s');

--- a/src/utils/core/stringCore.ts
+++ b/src/utils/core/stringCore.ts
@@ -18,12 +18,13 @@ import prettyMilliseconds from 'pretty-ms';
 import { serializeError, type ErrorObject } from 'serialize-error';
 
 /**
- * Serialize an Error into a plain object for logging or transport.
+ * Serialize a thrown value into a plain object for logging or transport.
  *
- * Backed by the `serialize-error` package, which (unlike a naive
- * `{ name, message, stack }` copy) preserves `cause` chains, custom
- * properties (e.g. `statusCode`, `requestId`), and handles circular
- * references and non-Error throws.
+ * Typically called with an `Error`, but any thrown value is accepted —
+ * `serialize-error` passes non-`Error` values through and wraps them as
+ * needed. Unlike a naive `{ name, message, stack }` copy it also preserves
+ * `cause` chains, custom enumerable properties (e.g. `statusCode`,
+ * `requestId`), and handles circular references.
  */
 export { serializeError };
 
@@ -70,10 +71,11 @@ export function extractErrorMessage(err: unknown): string | undefined {
  * (e.g. `3m 42s`, `1h 5m`, `2d 4h`).
  *
  * Backed by `pretty-ms`, so durations spanning hours or days render
- * correctly instead of overflowing into `120min` style output. Sub-second
- * durations floor to `1s` and the input is truncated to whole-second
- * granularity so per-second elapsed displays (e.g. ToolTimer) never tick
- * ahead of the real elapsed time.
+ * correctly instead of overflowing into `120min` style output. Durations
+ * of one second or more are floored to whole-second granularity, so
+ * per-second elapsed displays (e.g. ToolTimer) never report more than the
+ * real elapsed time. Sub-second durations render as a `1s` minimum floor
+ * (rather than `0s`) to match the prior behavior.
  */
 export function formatDuration(durationMs: number): string {
   if (durationMs < 0) return '0s';

--- a/src/utils/core/stringCore.ts
+++ b/src/utils/core/stringCore.ts
@@ -14,6 +14,22 @@
  * For guaranteed string conversion, use `toErrorMessage()` from `@common/errors`.
  */
 
+import prettyMilliseconds from 'pretty-ms';
+import { serializeError, type ErrorObject } from 'serialize-error';
+
+/**
+ * Serialize an Error into a plain object for logging or transport.
+ *
+ * Backed by the `serialize-error` package, which (unlike a naive
+ * `{ name, message, stack }` copy) preserves `cause` chains, custom
+ * properties (e.g. `statusCode`, `requestId`), and handles circular
+ * references and non-Error throws.
+ */
+export { serializeError };
+
+/** Plain-object shape produced by {@link serializeError}. */
+export type SerializedError = ErrorObject;
+
 /** Check if value is a non-empty string after trimming. */
 export function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
@@ -49,34 +65,19 @@ export function extractErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
-/** Format duration in milliseconds to human-readable string (e.g. "3min, 42sec"). */
+/**
+ * Format a duration in milliseconds to a compact human-readable string
+ * (e.g. `3m 42s`, `1h 5m`, `2d 4h`).
+ *
+ * Backed by `pretty-ms`, so durations spanning hours or days render
+ * correctly instead of overflowing into `120min` style output. Sub-second
+ * durations floor to `1s` and the input is truncated to whole-second
+ * granularity so per-second elapsed displays (e.g. ToolTimer) never tick
+ * ahead of the real elapsed time.
+ */
 export function formatDuration(durationMs: number): string {
   if (durationMs < 0) return '0s';
   if (durationMs < 1000) return '1s';
-
-  const seconds = Math.floor(durationMs / 1000) % 60;
-  const minutes = Math.floor(durationMs / (1000 * 60));
-
-  if (minutes === 0) return `${seconds}sec`;
-  if (seconds === 0) return `${minutes}min`;
-  return `${minutes}min, ${seconds}sec`;
-}
-
-/** Serialized error object shape. */
-export interface SerializedError {
-  name: string;
-  message: string;
-  stack?: string;
-}
-
-/**
- * Serialize an Error object to a plain object for logging or transport.
- * Returns a structured object with name, message, and optional stack.
- */
-export function serializeError(err: Error): SerializedError {
-  return {
-    name: err.name,
-    message: err.message,
-    stack: err.stack,
-  };
+  const wholeSeconds = Math.floor(durationMs / 1000) * 1000;
+  return prettyMilliseconds(wholeSeconds, { secondsDecimalDigits: 0 });
 }


### PR DESCRIPTION
## Summary

Replace hand-rolled implementations of error serialization and duration formatting with well-maintained open-source libraries:

- **Error serialization**: Swap custom `serializeError()` for `serialize-error` package, which properly handles error cause chains, custom properties, circular references, and non-Error throws
- **Duration formatting**: Replace manual minute/second calculation in `formatDuration()` with `pretty-ms`, which correctly handles multi-hour and multi-day durations and avoids overflow issues

Update test expectations to match the new output format (`1m 1s` instead of `1min, 1sec`).

## Issue acceptance gates

N/A — this is a quality improvement with no associated issue.

## Single source of truth

Error serialization and duration formatting logic now defer to their respective library implementations, eliminating custom code that could diverge from best practices.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated custom `SerializedError` interface in favor of `serialize-error`'s `ErrorObject` type
- Removed manual duration calculation logic (minutes/seconds modulo arithmetic) in favor of `pretty-ms`

**Abstraction benefit:**
- `serialize-error` handles edge cases (cause chains, non-Error throws, circular refs) that the custom implementation missed
- `pretty-ms` correctly scales to hours/days without overflow, improving readability for long-running operations

## Host impact

**Extension:** Duration display in child process status updates now uses compact format (`1m 1s` vs `1min, 1sec`)

**Desktop:** Same duration formatting improvement

**CLI:** Same duration formatting improvement

## Scheduled refactoring

None.

## Validation

- Existing test in `ChildControls.vitest.mts` updated to verify new duration format
- No new tests needed; `formatDuration()` behavior is covered by existing test expectations
- CI will verify no type errors and that all tests pass

https://claude.ai/code/session_0139qF7qXD3T4CRX7qPVwYCT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized utility swap with intentional string-format change for elapsed times; broader error serialization is generally more correct for logging.
> 
> **Overview**
> Adds **`pretty-ms`** and **`serialize-error`** and routes shared helpers in `stringCore.ts` through them instead of hand-rolled logic.
> 
> **`serializeError`** is now re-exported from `serialize-error` (with `SerializedError` typed as `ErrorObject`), so logging/transport paths get **cause chains**, extra properties, and safer handling of non-`Error` throws and circular refs—not just `name` / `message` / `stack`.
> 
> **`formatDuration`** uses `pretty-ms` with whole-second flooring and the same sub-second **`1s`** floor; elapsed text in the UI shifts to a compact style (e.g. **`1m 1s`** instead of **`1min, 1sec`**), with **`ChildControls.vitest.mts`** expectations updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bbb1b3539fb3b6a83824fee2afb97b47d0bf7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->