### PR TITLE
fix(extension): keep YOLO shield covering bash commands

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -44,6 +44,7 @@ import {
   handleProgressViewBashApprovalAction,
   toggleToolEditApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
+  setBashApprovalSessionBypass,
   isApprovalBypassedForStream,
   toggleProposalBypass,
 } from '@tools/approval';
@@ -241,9 +242,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           data.stream,
           extensionAgentRuntimeHost,
         );
+        // Keep bash approval symmetric with tool edits: the single YOLO shield
+        // covers both. Bash gained an independent per-stream flag in #4739 and
+        // the extension has no separate bash toggle, so mirror it here. Silent
+        // because the shield's active state renders from the tool-edit flag.
+        setBashApprovalSessionBypass(
+          data.stream,
+          isNowEnabled,
+          extensionAgentRuntimeHost,
+          { silent: true },
+        );
         const msg = isNowEnabled
-          ? 'YOLO mode enabled: Tool actions will be auto-approved for this stream.'
-          : 'YOLO mode disabled: Tool actions will prompt for approval.';
+          ? 'YOLO mode enabled: Tool actions and bash commands will be auto-approved for this stream.'
+          : 'YOLO mode disabled: Tool actions and bash commands will prompt for approval.';
         await vscode.window.showInformationMessage(msg);
       },
       [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: async (data) => {
@@ -268,6 +279,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             extensionAgentRuntimeHost,
           );
         }
+        // Bash bypass stays symmetric with the tool-edit bypass above.
+        setBashApprovalSessionBypass(
+          data.stream,
+          isNowEnabled,
+          extensionAgentRuntimeHost,
+          { silent: true },
+        );
         const msg = isNowEnabled
           ? 'Delegated task auto-approval enabled for this stream.'
           : 'Delegated task auto-approval disabled for this stream.';


### PR DESCRIPTION
## Problem

After #4739 (*fix(cli): scope bash session approval*), the extension's YOLO shield stopped auto-approving **bash** commands — a bash *Command approval* prompt appears even with YOLO enabled.

That commit gave bash approval its own per-stream bypass flag (`isBashApprovalBypassedForStream`, backed by a separate `bashApprovalController`) and wired the new setter **only into the CLI**. Before it, `683cf52da` had deliberately shared one YOLO flag across edits + bash, so `requestBashApproval` read the same `isApprovalBypassedForStream` the shield toggles. After the split, the extension shield kept flipping only the **tool-edit** bypass, leaving bash's flag permanently `false`.

## Fix

In `ProgressViewMessageHandler.ts`, mirror the bash bypass to the tool-edit bypass in **both** the YOLO (`TOGGLE_TOOL_EDIT_APPROVAL_BYPASS`) and Super-YOLO (`TOGGLE_SUPER_YOLO_BYPASS`) handlers, so the single shield covers edits **and** bash again. Emitted with `{ silent: true }` because the shield's active state renders from the tool-edit flag and the extension has no consumer for `updateBashApprovalBypassState`.

## Why the CLI is intentionally left alone

The CLI keeps `AUTO-BASH` and `AUTO-APPROVE` as **separate, independently reachable** session grants (`ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo'`): a bash prompt offers *approve session* (`kind: 'bash'`) without touching edits, and vice-versa. Since bash is the more dangerous of the two, that asymmetric grant is a feature, and `superYolo` already covers "approve everything." The extension has no per-tool approval UI — just the one shield — so there the two must move together.

## Testing

- `npm run typecheck` — passes
- `prettier --check` on the changed file — clean
- Manual: with the rebuilt extension, toggling the YOLO shield now auto-approves subsequent bash commands for the stream (and toggling it off restores the prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to approval bypass wiring in the progress view message handler; no auth or data-path changes.
> 
> **Overview**
> Restores the extension **YOLO shield** so it auto-approves **bash** as well as tool edits. After bash gained a separate per-stream bypass flag, toggling the shield only updated the tool-edit bypass, so bash still prompted for approval.
> 
> When **YOLO** (`TOGGLE_TOOL_EDIT_APPROVAL_BYPASS`) or **Super-YOLO** (`TOGGLE_SUPER_YOLO_BYPASS`) runs, the handler now calls `setBashApprovalSessionBypass` with the same on/off state as the tool-edit bypass (`{ silent: true }` because the UI reflects only the edit flag). YOLO toast copy now mentions bash commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d4b10d3c18ada699938a6b13b13ca2be533c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->