### PR TITLE
fix(cli): dedupe rejected tool output

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -75,6 +75,7 @@ const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const BTW_IDLE = process.env.HARNESS_BTW_IDLE === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_REJECTED_BASH_TOOL = process.env.HARNESS_REJECTED_BASH_TOOL === '1';
 const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
   process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
@@ -269,6 +270,37 @@ function makeLongToolOutputEntries(): ConversationEntry[] {
       text: '',
       finalized: true,
       toolUse: makeLongToolOutput(),
+    },
+  ];
+}
+
+function makeRejectedBashToolEntries(): ConversationEntry[] {
+  const command = "printf 'approval-reject-live\\n'";
+  const message = `User rejected bash command: ${command}`;
+  return [
+    {
+      id: 'rejected-bash-user',
+      role: 'user',
+      text: 'Run a harmless command, but reject it at the approval prompt.',
+      finalized: true,
+    },
+    {
+      id: 'rejected-bash-tool',
+      role: 'tool',
+      text: '',
+      finalized: true,
+      toolUse: {
+        parsed: {},
+        toolName: 'bash',
+        errorText: message,
+        outputText: message,
+        userInstructionText: '',
+        input: { command },
+        isError: true,
+        isUserFeedback: false,
+        headerSummary: command,
+        status: TOOL_USE_STATUS.COMPLETED,
+      },
     },
   ];
 }
@@ -546,9 +578,11 @@ patchStream(STREAM_ID, (slice) => ({
     QUEUED_FOLLOW_UPS.length > 0 || (SHOW_TODOS && !SHOW_IDLE_TODOS)
       ? Date.now() - 42_000
       : slice.runStartedAt,
-  entries: SHOW_LONG_TOOL_OUTPUT
-    ? makeLongToolOutputEntries()
-    : makeEntries(ENTRY_COUNT),
+  entries: SHOW_REJECTED_BASH_TOOL
+    ? makeRejectedBashToolEntries()
+    : SHOW_LONG_TOOL_OUTPUT
+      ? makeLongToolOutputEntries()
+      : makeEntries(ENTRY_COUNT),
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -147,6 +147,20 @@ const SCENARIOS = [
     unexpect: ['tool-output-line-10 hidden-middle'],
   },
   {
+    name: 'bash-rejection-deduped',
+    env: { HARNESS_ENTRIES: '0', HARNESS_REJECTED_BASH_TOOL: '1' },
+    expect: [
+      "● bash (printf 'approval-reject-live\\n')",
+      "⎿ User rejected bash command: printf 'approval-reject-live\\n'",
+    ],
+    maxOccurrences: [
+      {
+        text: "User rejected bash command: printf 'approval-reject-live\\n'",
+        max: 1,
+      },
+    ],
+  },
+  {
     name: 'transcript-viewer-long-tool-output',
     env: { HARNESS_ENTRIES: '0', HARNESS_LONG_TOOL_OUTPUT: '1' },
     keys: [DC4],
@@ -1720,6 +1734,18 @@ function lineColumns(line) {
   return [...line].length;
 }
 
+function countOccurrences(text, needle) {
+  if (!needle) return 0;
+  let count = 0;
+  let index = 0;
+  while (true) {
+    const next = text.indexOf(needle, index);
+    if (next < 0) return count;
+    count += 1;
+    index = next + needle.length;
+  }
+}
+
 function snapshotFileName(index, name, extension = 'txt') {
   const prefix = String(index + 1).padStart(2, '0');
   return `${prefix}-${name.replace(/[^a-z0-9._-]+/gi, '-')}.${extension}`;
@@ -1979,6 +2005,14 @@ async function runScenario(scenario) {
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  for (const check of scenario.maxOccurrences ?? []) {
+    const actual = countOccurrences(frame, check.text);
+    if (actual > check.max) {
+      failures.push(
+        `text appears too many times: ${JSON.stringify(check.text)} (${actual} > ${check.max})`,
+      );
+    }
+  }
   const slashPaletteVisible =
     frame.includes('Tab complete') && frame.includes('↑/↓ navigate');
   if (

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -168,7 +168,46 @@ function formatHeader(
   return `${STATUS_DOT} ${displayName}${preview ? ` (${preview})` : ''}`;
 }
 
-function visibleOutputLines(toolUse: NormalizedToolUse): readonly string[] {
+function errorTextForDisplay(toolUse: NormalizedToolUse): string {
+  return toolUse.isError ? toolUse.errorText || '(error)' : '';
+}
+
+function errorPreviewWouldTruncate(toolUse: NormalizedToolUse): boolean {
+  return (
+    collapseWhitespace(errorTextForDisplay(toolUse)).length > MAX_ERROR_PREVIEW
+  );
+}
+
+function outputDuplicatesError(
+  toolUse: NormalizedToolUse,
+  options: { readonly keepWhenErrorPreviewTruncates?: boolean } = {},
+): boolean {
+  if (!toolUse.isError || !toolUse.outputText) return false;
+  const errorText = errorTextForDisplay(toolUse);
+  if (
+    options.keepWhenErrorPreviewTruncates &&
+    errorPreviewWouldTruncate(toolUse)
+  ) {
+    return false;
+  }
+  return (
+    errorText.length > 0 &&
+    collapseWhitespace(toolUse.outputText) === collapseWhitespace(errorText)
+  );
+}
+
+function visibleOutputLines(
+  toolUse: NormalizedToolUse,
+  options: { readonly keepDuplicateWhenErrorPreviewTruncates?: boolean } = {},
+): readonly string[] {
+  if (
+    outputDuplicatesError(toolUse, {
+      keepWhenErrorPreviewTruncates:
+        options.keepDuplicateWhenErrorPreviewTruncates,
+    })
+  ) {
+    return [];
+  }
   return toolUse.outputText ? toolUse.outputText.split('\n') : [];
 }
 
@@ -194,7 +233,9 @@ function outputDisplayLines(
   toolUse: NormalizedToolUse,
   elide = true,
 ): string[] {
-  const lines = visibleOutputLines(toolUse);
+  const lines = visibleOutputLines(toolUse, {
+    keepDuplicateWhenErrorPreviewTruncates: !elide,
+  });
   const sliced = elide
     ? elideOutputLines(lines)
     : { head: lines, tail: [] as readonly string[], hiddenCount: 0 };
@@ -217,7 +258,7 @@ export function universalToolUseDisplayLines(
   } = {},
 ): readonly string[] {
   const patchLines = toolUsePatchDisplayLines(toolUse);
-  const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
+  const errorText = errorTextForDisplay(toolUse);
   const outputLines =
     options.showOutput === true
       ? outputDisplayLines(toolUse, options.elide ?? true)
@@ -251,7 +292,7 @@ export function bashToolUseDisplayLines(
 ): readonly string[] {
   const exitCode = extractExitCode(toolUse);
   const outputLines = outputDisplayLines(toolUse, options.elide ?? true);
-  const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
+  const errorText = errorTextForDisplay(toolUse);
   return [
     formatHeader(toolUse),
     ...outputLines,
@@ -392,7 +433,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     };
   }, [toolUse, showPatch, showOutput, preferInputPreview]);
 
-  const errorText = toolUse.isError ? toolUse.errorText || '(error)' : '';
+  const errorText = errorTextForDisplay(toolUse);
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
   const showNoOutput =
     showOutput &&

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -94,6 +94,48 @@ describe('CLI tool renderer registry', () => {
     `);
   });
 
+  it('renders bash approval rejections once when output and error match', () => {
+    const message =
+      "User rejected bash command: printf 'approval-reject-live\\n'";
+    const entry = toolUse(
+      'bash',
+      { command: "printf 'approval-reject-live\\n'" },
+      {
+        errorText: message,
+        headerSummary: "printf 'approval-reject-live\\n'",
+        isError: true,
+        outputText: message,
+      },
+    );
+
+    expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
+      [
+        "● bash (printf 'approval-reject-live\\n')",
+        "⎿ User rejected bash command: printf 'approval-reject-live\\n'",
+      ]
+    `);
+  });
+
+  it('keeps long duplicate error output in the full transcript view', () => {
+    const message = `User rejected bash command: ${'diagnostic detail '.repeat(30)}`;
+    const entry = toolUse(
+      'bash',
+      { command: 'run-diagnostic' },
+      {
+        errorText: message,
+        headerSummary: 'run-diagnostic',
+        isError: true,
+        outputText: message,
+      },
+    );
+
+    const lines = toolUseDisplayLines(entry, { elide: false });
+
+    expect(lines[1]).toBe(`⎿ ${message}`);
+    expect(lines[2]).toContain('User rejected bash command: diagnostic detail');
+    expect(lines[2].length).toBeLessThan(lines[1].length);
+  });
+
   it('elides long bash output to a head+tail slice with a line marker', () => {
     const entry = toolUse(
       'bash',


### PR DESCRIPTION
Closes #5013.

## Summary
- suppress CLI tool output lines when they duplicate the rendered error text exactly
- keep distinct bash stdout/stderr failure rows unchanged
- add unit and TUI harness coverage for a rejected bash approval result appearing once

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ToolRenderers.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-approval-reject-fix bash-rejection-deduped long-tool-output-elided transcript-viewer-long-tool-output bash-approval edit-approval-reject`
- `npm run format`
- `npm run compile:safe`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-approval-reject-full`
- `npm run lint` (0 errors, 11 existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in tool row rendering with targeted unit and TUI validation; no auth, persistence, or execution path changes.
> 
> **Overview**
> The CLI TUI **stops showing duplicate tool output** when `outputText` matches the error message after whitespace normalization, so **rejected bash approvals** (and similar cases) appear once instead of as both stdout and an error line.
> 
> **Transcript viewer** behavior is preserved for long duplicates: when the error preview would truncate, the full output line is still shown with a separate truncated error preview.
> 
> **Tests** add Vitest snapshots for bash rejection deduping and long-message transcript mode, plus a TUI harness scenario (`HARNESS_REJECTED_BASH_TOOL`) and `validate-tui` **`maxOccurrences`** assertion so the rejection string appears at most once on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51e31971734d4d202276b367663e407fb2bac11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->