### PR TITLE
fix(cli): keep compact active todo visible

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -820,7 +820,7 @@ const SCENARIOS = [
     },
     bootExpect: '[Tab]streams',
     expect: [
-      '+4 more child executions',
+      'Waiting for leanSolver',
       '3 sub',
       '1 proc',
       '[Tab]streams',
@@ -840,7 +840,7 @@ const SCENARIOS = [
       HARNESS_CAN_INTERRUPT: '1',
     },
     bootExpect: ']tasks',
-    expect: [']tasks', '[Ctrl-C]stop'],
+    expect: ['Waiting for leanSolver', ']tasks', '[Ctrl-C]stop'],
     unexpect: [']subagents', '[Option-p]tasks'],
   },
   {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -200,6 +200,9 @@ export function allocateSidePanelRows({
   if (availableRows === 0) {
     return { subagentRows: 0, todosPlanRows: 0 };
   }
+  if (availableRows === 1) {
+    return { subagentRows: 0, todosPlanRows: 1 };
+  }
 
   const subagentRows = Math.max(1, Math.floor(availableRows / 2));
   return {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -530,7 +530,7 @@ describe('CLI TUI row allocation', () => {
         hasTodosPlanPanel: true,
         rows: 1,
       }),
-    ).toEqual({ subagentRows: 1, todosPlanRows: 0 });
+    ).toEqual({ subagentRows: 0, todosPlanRows: 1 });
   });
 
   it('shows todo and plan chrome only while a stream is active', () => {


### PR DESCRIPTION
Closes #5016

## Summary
- allocate the single combined bottom-panel row to the todo/plan panel when subagents and todos both exist
- update the row allocation unit expectation for that compact edge case
- require the compact subagent+todo TUI scenarios to render `Waiting for leanSolver`

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/TodosPlanPanel.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts`
- `npm run compile:safe`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-subworkflow-full-20260601`
- `npm run lint` (0 errors, existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout allocation and test expectations only; no auth, data, or runtime behavior changes.
> 
> **Overview**
> When the bottom area only has **one row** and both subagent and todo/plan panels are shown, that row now goes to the **todo/plan** panel instead of the subagent list, so compact terminals can still show the active in-progress todo (e.g. `Waiting for leanSolver`).
> 
> Tests were updated: `allocateSidePanelRows` expects `{ subagentRows: 0, todosPlanRows: 1 }` for the single-row case, and the compact subagent+todos TUI harness scenarios assert that todo line instead of subagent overflow text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3181d3d7945b105d31126f2b3b62c3fbaa003d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->