### PR TITLE
fix(tools): inherit parent bash bypass on child subagent streams

### DIFF
--- a/src/test-kernel/agent/toolUse/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamYoloInheritance.vitest.ts
@@ -1,0 +1,47 @@
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports
+import type { StreamTabId } from '@shared/schemas';
+import {
+  cleanupAllApprovals,
+  enableYoloOnChildStream,
+  isApprovalBypassedForStream,
+  isBashApprovalBypassedForStream,
+  setBashApprovalSessionBypass,
+} from '@tools/approval';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('enableYoloOnChildStream bash inheritance', () => {
+  afterEach(() => {
+    cleanupAllApprovals();
+  });
+
+  it('mirrors the parent bash bypass onto the child stream', () => {
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-yolo' as StreamTabId;
+    const child = 'stream:child-yolo' as StreamTabId;
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+    // Sanity: the parent bypass round-trips through the public barrel.
+    expect(isBashApprovalBypassedForStream(parent)).toBe(true);
+
+    enableYoloOnChildStream(child, parent);
+
+    // Tool-edit bypass is always enabled for the child; bash follows the parent.
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+  });
+
+  it('keeps child bash gated when the parent still prompts for bash', () => {
+    // Mirrors the CLI case where AUTO-APPROVE (tool edits) is on but AUTO-BASH
+    // is off: the child inherits exactly the parent's bash state.
+    const parent = 'stream:parent-edit-only' as StreamTabId;
+    const child = 'stream:child-edit-only' as StreamTabId;
+
+    enableYoloOnChildStream(child, parent);
+
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+});

--- a/src/test-kernel/agent/toolUse/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamYoloInheritance.vitest.ts
@@ -6,6 +6,7 @@ import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupAllApprovals,
   enableYoloOnChildStream,
+  inheritBashBypassOnChildStream,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
@@ -13,33 +14,53 @@ import {
 
 import { createRecordingHost } from '../progressTestUtils';
 
-describe('enableYoloOnChildStream bash inheritance', () => {
+describe('child subagent stream approval inheritance', () => {
   afterEach(() => {
     cleanupAllApprovals();
   });
 
   it('mirrors the parent bash bypass onto the child stream', () => {
     const { host } = createRecordingHost();
-    const parent = 'stream:parent-yolo' as StreamTabId;
-    const child = 'stream:child-yolo' as StreamTabId;
+    const parent = 'stream:parent-bash' as StreamTabId;
+    const child = 'stream:child-bash' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
     // Sanity: the parent bypass round-trips through the public barrel.
     expect(isBashApprovalBypassedForStream(parent)).toBe(true);
 
-    enableYoloOnChildStream(child, parent);
+    inheritBashBypassOnChildStream(child, parent);
 
-    // Tool-edit bypass is always enabled for the child; bash follows the parent.
-    expect(isApprovalBypassedForStream(child)).toBe(true);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
   });
 
-  it('keeps child bash gated when the parent still prompts for bash', () => {
-    // Mirrors the CLI case where AUTO-APPROVE (tool edits) is on but AUTO-BASH
-    // is off: the child inherits exactly the parent's bash state.
-    const parent = 'stream:parent-edit-only' as StreamTabId;
-    const child = 'stream:child-edit-only' as StreamTabId;
+  it('leaves the child gated when the parent still prompts for bash', () => {
+    const parent = 'stream:parent-no-bash' as StreamTabId;
+    const child = 'stream:child-no-bash' as StreamTabId;
 
-    enableYoloOnChildStream(child, parent);
+    inheritBashBypassOnChildStream(child, parent);
+
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('mirrors bash independently of tool-edit YOLO (CLI AUTO-BASH, no AUTO-APPROVE)', () => {
+    // The bug this guards against: a parent with bash auto-approved but edits
+    // still gated must still propagate bash to the child, even though the child
+    // does not get tool-edit YOLO.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-bash-only' as StreamTabId;
+    const child = 'stream:child-bash-only' as StreamTabId;
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+
+    inheritBashBypassOnChildStream(child, parent);
+
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+    // No edit-YOLO was applied, so tool-edit stays gated on the child.
+    expect(isApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('enables tool-edit YOLO on the child without touching bash', () => {
+    const child = 'stream:child-edit' as StreamTabId;
+
+    enableYoloOnChildStream(child);
 
     expect(isApprovalBypassedForStream(child)).toBe(true);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -6,6 +6,7 @@ import { DelegateAgentTool } from '@tools/DelegationTools';
 
 const mocks = vi.hoisted(() => ({
   enableYoloOnChildStream: vi.fn(),
+  inheritBashBypassOnChildStream: vi.fn(),
   executeAgent: vi.fn(),
   getExecutionStore: vi.fn(),
   getVisibleAgents: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock('@model/computeModelOptions', () => ({
 
 vi.mock('@tools/approval', () => ({
   enableYoloOnChildStream: mocks.enableYoloOnChildStream,
+  inheritBashBypassOnChildStream: mocks.inheritBashBypassOnChildStream,
   isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
   isProposalBypassedForStream: mocks.isProposalBypassedForStream,
 }));

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -64,6 +64,7 @@ import {
   isProposalBypassedForStream,
   isApprovalBypassedForStream,
   enableYoloOnChildStream,
+  inheritBashBypassOnChildStream,
 } from '@tools/approval';
 import { computeAndWriteWorkflowDiffs } from '@tools/subagentDiffs';
 import {
@@ -392,8 +393,15 @@ async function executeSubagent(
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
         stopAfterCycle: true,
         onStreamResolved: (resolvedStreamId) => {
+          // Bash bypass follows the parent regardless of edit-YOLO, so a
+          // bash-only parent (CLI AUTO-BASH without AUTO-APPROVE) still
+          // propagates to the child.
+          inheritBashBypassOnChildStream(
+            resolvedStreamId,
+            orchestratorStreamId,
+          );
           if (options?.enableYoloOnChild) {
-            enableYoloOnChildStream(resolvedStreamId, orchestratorStreamId);
+            enableYoloOnChildStream(resolvedStreamId);
           }
         },
         onError: (err) => {
@@ -485,8 +493,11 @@ async function executeSubagent(
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
+      // Bash bypass follows the parent regardless of edit-YOLO, so a bash-only
+      // parent (CLI AUTO-BASH without AUTO-APPROVE) still propagates to the child.
+      inheritBashBypassOnChildStream(resolvedStreamId, orchestratorStreamId);
       if (options?.enableYoloOnChild) {
-        enableYoloOnChildStream(resolvedStreamId, orchestratorStreamId);
+        enableYoloOnChildStream(resolvedStreamId);
       }
     },
     onProgress,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -393,7 +393,7 @@ async function executeSubagent(
         stopAfterCycle: true,
         onStreamResolved: (resolvedStreamId) => {
           if (options?.enableYoloOnChild) {
-            enableYoloOnChildStream(resolvedStreamId);
+            enableYoloOnChildStream(resolvedStreamId, orchestratorStreamId);
           }
         },
         onError: (err) => {
@@ -486,7 +486,7 @@ async function executeSubagent(
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       if (options?.enableYoloOnChild) {
-        enableYoloOnChildStream(resolvedStreamId);
+        enableYoloOnChildStream(resolvedStreamId, orchestratorStreamId);
       }
     },
     onProgress,

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -25,6 +25,7 @@ import {
 import {
   toolEditApprovalController,
   enableYoloOnChildStream,
+  inheritBashBypassOnChildStream,
 } from './toolEditApproval';
 
 /**
@@ -55,7 +56,7 @@ export function cleanupAllApprovals(): void {
   cleanupAllCoordinatorRequests();
 }
 
-export { enableYoloOnChildStream };
+export { enableYoloOnChildStream, inheritBashBypassOnChildStream };
 
 // Re-export commonly used functions from individual modules
 export {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -414,25 +414,33 @@ export async function requestApprovedEditContent(request: {
 }
 
 /**
- * Enable YOLO on a freshly resolved child subagent stream.
+ * Mirror the parent stream's bash-approval bypass onto a freshly resolved child
+ * subagent stream, independent of any tool-edit auto-approval.
  *
- * Used by DelegationTools when launching a subagent that should inherit the
- * parent's auto-approval. Silent because it fires before the child stream is
- * activated; the subsequent SYNC_STREAM_CONTENT carries the bypass state.
- *
- * Tool-edit bypass is enabled unconditionally — the caller only invokes this
- * when the parent is auto-approving edits / delegated tasks. The parent's bash
- * bypass is mirrored independently (when `parentStreamId` is given) so bash
- * commands don't keep prompting in the child. Kept separate from the tool-edit
- * flag to respect the CLI's distinct AUTO-BASH / AUTO-APPROVE grants: the child
- * inherits exactly the parent's bash state.
+ * A child delegated by a parent that auto-runs bash should auto-run bash too. If
+ * the parent's bash is still gated this is a no-op — fresh child streams default
+ * to gated — so the child matches the parent either way. Kept separate from the
+ * tool-edit YOLO flag to respect the CLI's distinct AUTO-BASH / AUTO-APPROVE
+ * grants: a parent with AUTO-BASH but edits still gated still propagates bash.
  */
-export function enableYoloOnChildStream(
+export function inheritBashBypassOnChildStream(
   childStreamId: StreamTabId,
   parentStreamId?: StreamTabId,
 ): void {
-  toolEditApprovalController.setBypass(childStreamId, true);
   if (parentStreamId && bashApprovalController.isBypassed(parentStreamId)) {
     bashApprovalController.setBypass(childStreamId, true);
   }
+}
+
+/**
+ * Enable tool-edit auto-approval on a freshly resolved child subagent stream.
+ *
+ * Used by DelegationTools when the parent is auto-approving edits / delegated
+ * tasks. Silent because it fires before the child stream is activated; the
+ * subsequent SYNC_STREAM_CONTENT carries the tool-edit / super-YOLO bypass.
+ * Bash bypass is handled separately by `inheritBashBypassOnChildStream` so it
+ * follows the parent regardless of the tool-edit flag.
+ */
+export function enableYoloOnChildStream(childStreamId: StreamTabId): void {
+  toolEditApprovalController.setBypass(childStreamId, true);
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -18,6 +18,7 @@ import {
 import { WorkspaceFS } from '@utils/files';
 import { countLines } from '@utils/text/stringUtils';
 
+import { bashApprovalController } from './bashApproval';
 import { createStreamApprovalController } from './streamApprovalQueue';
 
 export const ToolEditApprovalRequestSchema = z.object({
@@ -413,12 +414,25 @@ export async function requestApprovedEditContent(request: {
 }
 
 /**
- * Enable tool-edit YOLO on a freshly resolved child subagent stream.
+ * Enable YOLO on a freshly resolved child subagent stream.
  *
  * Used by DelegationTools when launching a subagent that should inherit the
  * parent's auto-approval. Silent because it fires before the child stream is
  * activated; the subsequent SYNC_STREAM_CONTENT carries the bypass state.
+ *
+ * Tool-edit bypass is enabled unconditionally — the caller only invokes this
+ * when the parent is auto-approving edits / delegated tasks. The parent's bash
+ * bypass is mirrored independently (when `parentStreamId` is given) so bash
+ * commands don't keep prompting in the child. Kept separate from the tool-edit
+ * flag to respect the CLI's distinct AUTO-BASH / AUTO-APPROVE grants: the child
+ * inherits exactly the parent's bash state.
  */
-export function enableYoloOnChildStream(childStreamId: StreamTabId): void {
+export function enableYoloOnChildStream(
+  childStreamId: StreamTabId,
+  parentStreamId?: StreamTabId,
+): void {
   toolEditApprovalController.setBypass(childStreamId, true);
+  if (parentStreamId && bashApprovalController.isBypassed(parentStreamId)) {
+    bashApprovalController.setBypass(childStreamId, true);
+  }
 }


### PR DESCRIPTION
## Context

Follow-up to #5014, addressing the substantive (non-blocking) concern raised in that PR's TeXRA review:

> **`enableYoloOnChildStream` does not mirror bash bypass.** After #5014, child streams spawned with YOLO enabled will have tool-edit bypass but not bash bypass. This is now an inconsistency with the extension shield behavior.

## Problem

`enableYoloOnChildStream` (in `toolEditApproval.ts`) only set the **tool-edit** bypass on a freshly resolved child subagent stream. So when a parent delegates under YOLO / delegated-task auto-approval (`DelegationTools.proposeAndExecute`), the child inherits edit auto-approval but **keeps prompting for every bash command** — the same gap #5014 fixed for the main shield, one level down.

## Fix

Mirror the parent's bash bypass onto the child, **independently** of the tool-edit flag:

```ts
export function enableYoloOnChildStream(
  childStreamId: StreamTabId,
  parentStreamId?: StreamTabId,
): void {
  toolEditApprovalController.setBypass(childStreamId, true);
  if (parentStreamId && bashApprovalController.isBypassed(parentStreamId)) {
    bashApprovalController.setBypass(childStreamId, true);
  }
}
```

Both `DelegationTools` call sites now pass the orchestrator (parent) stream id.

### Why parent-state inheritance (not unconditional)

- **Extension:** the YOLO shield keeps a stream's bash and tool-edit bypass symmetric (#5014), so the child inherits both — fixing the bug.
- **CLI:** `AUTO-BASH` and `AUTO-APPROVE` are independent, intentional grants. A parent with edits auto-approved but bash still gated propagates **only** the edit bypass to the child — bash stays gated, preserving the CLI's safety distinction.

Tool-edit remains unconditional (callers only invoke this when the parent is already auto-approving edits / delegated tasks), matching prior behavior.

## Testing

- New `ChildStreamYoloInheritance.vitest.ts` covers both directions:
  - parent bash bypassed → child bash bypassed
  - parent bash gated → child bash gated (tool-edit still on)
- `npx vitest run` on the new file — 2 passed
- `npm run typecheck` — passes
- `prettier --check` on all changed files — clean

(Concern B — Super-YOLO toast wording — left as-is per the review; "auto-approval" is generic and accurate. Concern C — no `ProgressViewMessageHandler` unit tests — is a pre-existing gap; this PR adds coverage for the core propagation it touches.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval bypass propagation for delegated subagents (bash execution gating), which affects safety behavior but is narrowly scoped with targeted tests.
> 
> **Overview**
> Child subagent streams now **inherit the parent’s bash-approval bypass** when delegation resolves a child stream, via a new **`inheritBashBypassOnChildStream`** helper that only mirrors bash state (not tool-edit YOLO).
> 
> **`DelegationTools`** invokes it in both `onStreamResolved` paths (headless and async) **before** optional `enableYoloOnChildStream`, so a parent with **AUTO-BASH** but edits still gated propagates bash to the child without forcing edit auto-approval. **`enableYoloOnChildStream`** remains tool-edit-only.
> 
> New **`ChildStreamYoloInheritance.vitest.ts`** covers parent→child bash mirroring, gated parents, bash-only vs edit-YOLO independence, and edit-YOLO without bash; headless delegation tests mock the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b333c81a4ffbd57e44fee33a269e0f4fb8c24f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->