### PR TITLE
fix(cli): define filename in ESM bundles

### DIFF
--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -74,7 +74,9 @@ await build({
     js:
       '#!/usr/bin/env node\n' +
       'import { createRequire as __texraCreateRequire } from "node:module";\n' +
-      'const require = __texraCreateRequire(import.meta.url);',
+      'import { fileURLToPath as __texraFileURLToPath } from "node:url";\n' +
+      'const require = __texraCreateRequire(import.meta.url);\n' +
+      'const __filename = __texraFileURLToPath(import.meta.url);',
   },
 });
 

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -23,7 +23,12 @@ await build({
   alias: { 'react-devtools-core': reactDevtoolsStub },
   outfile,
   banner: {
-    js: `import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);`,
+    js: [
+      `import { createRequire as __cr } from 'node:module';`,
+      `import { fileURLToPath as __texraFileURLToPath } from 'node:url';`,
+      `const require = __cr(import.meta.url);`,
+      `const __filename = __texraFileURLToPath(import.meta.url);`,
+    ].join('\n'),
   },
   plugins: [reactCompilerPlugin()],
   logLevel: 'info',


### PR DESCRIPTION
Closes #5021

## Summary
- add ESM `__filename` compatibility to the production CLI bundle banner
- add the same compatibility to the TUI harness bundle so bundled CJS dependencies can compute temp file names
- restores the PTY/screenshot validator after the `write-file-atomic` JsonStore dependency started running inside the ESM bundle

## Validation
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-bundle-filename-fix-20260601 subagent-picker task-process-detail bash-approval`
- `npm --workspace @texra-ai/cli run bundle`
- `HOME=$(mktemp -d /tmp/texra-cli-home-XXXXXX) node packages/cli/dist/bin/texra.js doctor`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-cli-bundle-filename-full-20260601` (all 81 scenarios)
- `npm run format`
- `npm run compile:safe`
- `git diff --check`
- `npm run lint` (0 errors, existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-banner-only change with no runtime auth, data, or API surface changes beyond fixing ESM/CJS interop for bundled dependencies.
> 
> **Overview**
> Adds an ESM **`__filename`** shim to the esbuild **banner** for both the production CLI bundle (`build-bundle.mjs`) and the TUI harness bundle (`build-harness.mjs`), alongside the existing `createRequire` polyfill.
> 
> The banner now imports `fileURLToPath` from `node:url` and sets `__filename` from `import.meta.url` so bundled CommonJS dependencies (e.g. `write-file-atomic` / JsonStore) that rely on `__filename` for temp paths work inside the single-file ESM output. This restores PTY/screenshot validation that broke when those deps ran in the bundle without a defined `__filename`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf49a1945d30029777a73b03e4277ddae2b84162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->