### PR TITLE
docs: add CLI design guidelines from clig.dev to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,7 @@ these invariants, and treat the numbered list as the open backlog.
 **Invariants to preserve (don't regress):**
 
 - **Streams.** stdout carries primary/parseable output; stderr carries logs,
-  progress, and diagnostics. Usage shown *on error* goes to stderr
+  progress, and diagnostics. Usage shown _on error_ goes to stderr
   (`showUsageStderr`) so `--output-format json|ndjson` stays parseable; explicit
   `--help` prints to stdout. Don't move usage-on-error to stdout.
 - **Exit codes.** Use the canonical `CliExitCode` (`runtime/exitCodes.ts`):
@@ -332,7 +332,7 @@ these invariants, and treat the numbered list as the open backlog.
    styled text is written to **stdout** (`runtime/doctor.ts` `writeDoctorReport`).
    So `texra doctor | cat` (stderr still a TTY) emits raw ANSI, and
    `texra doctor 2>/dev/null` strips color from a TTY stdout. Track stdout/stderr
-   color independently and gate primary-output color on the *destination* stream.
+   color independently and gate primary-output color on the _destination_ stream.
    `doctor` is currently the only styled-stdout path (progress + update-checker
    correctly write to stderr).
 2. **[ux] No "did you mean …" for mistyped subcommands.** `formatUnknownCliCommand`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,33 +301,34 @@ The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`. It 
 ### CLI design (clig.dev)
 
 The `texra` CLI (`packages/cli/`) follows the [Command Line Interface
-Guidelines](https://clig.dev). Follow these conventions:
+Guidelines](https://clig.dev). When working on it, design to the guide's
+philosophy and guidelines rather than ad-hoc choices.
 
-- **Don't reinvent the wheel.** Lean on the arg parser (`citty`) and existing
-  libraries rather than hand-rolling flag/help parsing or color-support
-  detection — `picocolors` already gates color. If you add paging or "did you
-  mean" suggestions (neither exists yet), reach for `$PAGER`/`less -FIRX` or a
-  small distance lib instead of writing your own.
-- **Streams.** stdout carries primary/parseable output; stderr carries logs,
-  progress, and diagnostics. Usage shown _on error_ goes to stderr
-  (`showUsageStderr`) so `--output-format json|ndjson` stays parseable; explicit
-  `--help` prints to stdout. Don't move usage-on-error to stdout.
-- **Exit codes.** Use the canonical `CliExitCode` (`runtime/exitCodes.ts`):
-  `0` success, `1` agent error, `2` usage, `3` model/network, `4` approval-denied,
-  `124` cancelled, `130` interrupted, `143` terminated. Usage errors stay `2`
-  (never citty's `1`).
-- **Color gating.** Route every plain-text styled surface through `createCliStyle`
-  (`runtime/style.ts`); never branch on color at call sites. Gating honors
-  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`). Gate each styled
-  surface's color on the stream it writes to, so stdout color doesn't hinge on
-  stderr being a TTY.
-- **Config precedence.** flags > env (`TEXRA_*`) > workspace config file; invalid
-  values warn (non-fatal) rather than throw (`buildCliContext`).
-- **Headless detection.** `--print/-p`, `CI`, or non-TTY stdin ⇒ headless; only
-  prompt (e.g. the update-checker) when all three streams are a TTY.
-- **Destructive guardrails.** Irreversible actions require an explicit opt-in
-  (`history delete --all` needs `--yes`; `init` needs `--force`). Keep new
-  destructive paths behind a confirm flag.
+**Philosophy.** Human-first design; simple parts that work together (composable
+via stdin/stdout, exit codes, and signals); consistency across programs; saying
+(just) enough; ease of discovery; conversation as the norm; robustness; empathy.
+
+**Guidelines.** Apply the relevant section of the guide:
+
+- _The basics_ — use the arg-parsing library; zero exit on success, non-zero on
+  failure; primary/machine-readable output to stdout, logs and errors to stderr.
+- _Help & documentation_ — `-h`/`--help` everywhere, concise by default and
+  full on request; lead with examples; link to web docs; suggest a command when
+  the user mistypes.
+- _Output & errors_ — human-readable by default, machine-readable (JSON) where
+  it doesn't hurt usability; rewrite errors for humans; make bug reports easy;
+  use color with intention and disable it off-TTY / `NO_COLOR` / `TERM=dumb`.
+- _Arguments & flags_ — prefer flags to args; full-length plus short forms;
+  standard names; `-` for stdin/stdout; confirm destructive actions.
+- _Interactivity_ — only prompt on a TTY; honor `--no-input`; never require a
+  prompt.
+- _Subcommands, robustness, future-proofing, signals_ — consistent naming;
+  validate input and stay responsive; keep changes additive; handle Ctrl-C.
+- _Configuration & environment_ — precedence flags > env > project > user >
+  system; honor general-purpose vars (`NO_COLOR`/`FORCE_COLOR`, `PAGER`, …).
+
+Don't reinvent the wheel: lean on `citty` (parsing/help) and `picocolors`
+(color), and reach for existing libraries over bespoke implementations.
 
 ### Separation of Concerns: VS Code Coupling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,21 +310,22 @@ via stdin/stdout, exit codes, and signals); consistency across programs; saying
 
 **Guidelines.** Apply the relevant section of the guide:
 
-- _The basics_ — use the arg-parsing library; zero exit on success, non-zero on
-  failure; primary/machine-readable output to stdout, logs and errors to stderr.
-- _Help & documentation_ — `-h`/`--help` everywhere, concise by default and
+- **The basics.** Use the arg-parsing library; zero exit on success, non-zero
+  on failure; primary/machine-readable output to stdout, logs and errors to
+  stderr.
+- **Help & documentation.** `-h`/`--help` everywhere, concise by default and
   full on request; lead with examples; link to web docs; suggest a command when
   the user mistypes.
-- _Output & errors_ — human-readable by default, machine-readable (JSON) where
+- **Output & errors.** Human-readable by default, machine-readable (JSON) where
   it doesn't hurt usability; rewrite errors for humans; make bug reports easy;
   use color with intention and disable it off-TTY / `NO_COLOR` / `TERM=dumb`.
-- _Arguments & flags_ — prefer flags to args; full-length plus short forms;
+- **Arguments & flags.** Prefer flags to args; full-length plus short forms;
   standard names; `-` for stdin/stdout; confirm destructive actions.
-- _Interactivity_ — only prompt on a TTY; honor `--no-input`; never require a
+- **Interactivity.** Only prompt on a TTY; honor `--no-input`; never require a
   prompt.
-- _Subcommands, robustness, future-proofing, signals_ — consistent naming;
+- **Subcommands, robustness, future-proofing, signals.** Consistent naming;
   validate input and stay responsive; keep changes additive; handle Ctrl-C.
-- _Configuration & environment_ — precedence flags > env > project > user >
+- **Configuration & environment.** Precedence flags > env > project > user >
   system; honor general-purpose vars (`NO_COLOR`/`FORCE_COLOR`, `PAGER`, …).
 
 Don't reinvent the wheel: lean on `citty` (parsing/help) and `picocolors`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,10 @@ The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`. It 
 The `texra` CLI (`packages/cli/`) follows the [Command Line Interface
 Guidelines](https://clig.dev). Preserve these invariants:
 
+- **Don't reinvent the wheel.** Lean on the arg parser (`citty`) and existing
+  libraries — `picocolors` for color detection, `$PAGER`/`less -FIRX` for
+  paging, a small distance lib for spelling suggestions. Don't hand-roll
+  flag/help parsing, color support detection, or paging.
 - **Streams.** stdout carries primary/parseable output; stderr carries logs,
   progress, and diagnostics. Usage shown _on error_ goes to stderr
   (`showUsageStderr`) so `--output-format json|ndjson` stays parseable; explicit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,62 @@ The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`. It 
 - **Headless parity is sacred.** The TUI runs only on an interactive TTY. `texra run`, `--print/-p`, and `--output-format json|ndjson` must stay byte-identical — never let Ink rendering, ANSI chrome, or spinners leak into the piped / non-TTY path.
 - **Width changes invalidate wrapped lines.** Soft-wrap is width-dependent: recompute live-region layout from `useWindowSize()` columns on every render; never cache wrapped output across a width change. Already-printed `<Static>` lines keep their original wrap — that is an accepted scrollback tradeoff, not a bug to "fix" by repainting history.
 
+### CLI design (clig.dev)
+
+The `texra` CLI (`packages/cli/`) is reviewed against the [Command Line Interface
+Guidelines](https://clig.dev). Most of the guide is already honored — preserve
+these invariants, and treat the numbered list as the open backlog.
+
+**Invariants to preserve (don't regress):**
+
+- **Streams.** stdout carries primary/parseable output; stderr carries logs,
+  progress, and diagnostics. Usage shown *on error* goes to stderr
+  (`showUsageStderr`) so `--output-format json|ndjson` stays parseable; explicit
+  `--help` prints to stdout. Don't move usage-on-error to stdout.
+- **Exit codes.** Use the canonical `CliExitCode` (`runtime/exitCodes.ts`):
+  `0` success, `1` agent error, `2` usage, `3` model/network, `4` approval-denied,
+  `124` cancelled, `130` interrupted. Usage errors stay `2` (never citty's `1`).
+- **Color gating.** Route every plain-text styled surface through `createCliStyle`
+  (`runtime/style.ts`); never branch on color at call sites. Gating honors
+  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`).
+- **Config precedence.** flags > env (`TEXRA_*`) > workspace config file; invalid
+  values warn (non-fatal) rather than throw (`buildCliContext`).
+- **Headless detection.** `--print/-p`, `CI`, or non-TTY stdin ⇒ headless; the
+  update-checker prompt requires all three streams to be a TTY. Don't prompt when
+  stdin isn't interactive.
+- **Destructive guardrails.** Irreversible actions require an explicit opt-in
+  (`history delete --all` needs `--yes`; `init` needs `--force`). Keep new
+  destructive paths behind a confirm flag.
+
+**Open issues (backlog):**
+
+1. **[bug] Color gate keyed to stderr leaks ANSI into piped stdout.**
+   `colorEnabled = stderrIsTty && …` (`runtime/cliContext.ts`), but `doctor`'s
+   styled text is written to **stdout** (`runtime/doctor.ts` `writeDoctorReport`).
+   So `texra doctor | cat` (stderr still a TTY) emits raw ANSI, and
+   `texra doctor 2>/dev/null` strips color from a TTY stdout. Track stdout/stderr
+   color independently and gate primary-output color on the *destination* stream.
+   `doctor` is currently the only styled-stdout path (progress + update-checker
+   correctly write to stderr).
+2. **[ux] No "did you mean …" for mistyped subcommands.** `formatUnknownCliCommand`
+   (`commands/_helpers/dispatch.ts`) only points at `--help`. Add a Levenshtein
+   suggestion over the sibling command names (already walkable via
+   `commandSubCommands`).
+3. **[feature] `texra run` isn't pipe-composable on input.** `--input` requires a
+   file path; `expandWorkflowInputSpec` (`commands/_helpers/workflowInputs.ts`)
+   treats `-` as a literal path. Support `-`-means-stdin (and/or reading
+   `--instruction` from stdin) so `cat draft.tex | texra run …` works.
+4. **[ux] Top-level crash doesn't point at the issue tracker.** `bin/texra.ts`
+   prints `TeXRA CLI failed: <msg>` with no link, though `package.json` declares
+   `bugs.url`. Append a "report at …" line on unexpected errors.
+5. **[docs] Root/`help` usage has no EXAMPLES block or docs link.** Subcommands add
+   `INTERACTIVE CONTROLS` sections via `withUsageSections`; the root has neither
+   examples nor a `Learn more: https://texra.ai` footer.
+6. **[minor] Conventional knobs absent.** No `FORCE_COLOR` override (only the
+   `NO_COLOR` opt-out exists), no canonical `--no-input` alias (functionally
+   covered by headless detection + `--approval-policy never`), and no pager for
+   long lists (`history`, `agents list`). Low priority.
+
 ### Separation of Concerns: VS Code Coupling
 
 For good separation of concerns, testability, and platform independence, core business logic should not depend on the `vscode` module. Keeping domain logic free of host-specific imports makes the code easier to test, reason about, and reuse.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,11 +300,8 @@ The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`. It 
 
 ### CLI design (clig.dev)
 
-The `texra` CLI (`packages/cli/`) is reviewed against the [Command Line Interface
-Guidelines](https://clig.dev). Most of the guide is already honored — preserve
-these invariants, and treat the numbered list as the open backlog.
-
-**Invariants to preserve (don't regress):**
+The `texra` CLI (`packages/cli/`) follows the [Command Line Interface
+Guidelines](https://clig.dev). Preserve these invariants:
 
 - **Streams.** stdout carries primary/parseable output; stderr carries logs,
   progress, and diagnostics. Usage shown _on error_ goes to stderr
@@ -315,44 +312,16 @@ these invariants, and treat the numbered list as the open backlog.
   `124` cancelled, `130` interrupted. Usage errors stay `2` (never citty's `1`).
 - **Color gating.** Route every plain-text styled surface through `createCliStyle`
   (`runtime/style.ts`); never branch on color at call sites. Gating honors
-  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`).
+  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`). Gate primary-output
+  color on the stream it is written to — stdout color must not depend on stderr
+  being a TTY.
 - **Config precedence.** flags > env (`TEXRA_*`) > workspace config file; invalid
   values warn (non-fatal) rather than throw (`buildCliContext`).
-- **Headless detection.** `--print/-p`, `CI`, or non-TTY stdin ⇒ headless; the
-  update-checker prompt requires all three streams to be a TTY. Don't prompt when
-  stdin isn't interactive.
+- **Headless detection.** `--print/-p`, `CI`, or non-TTY stdin ⇒ headless; only
+  prompt (e.g. the update-checker) when all three streams are a TTY.
 - **Destructive guardrails.** Irreversible actions require an explicit opt-in
   (`history delete --all` needs `--yes`; `init` needs `--force`). Keep new
   destructive paths behind a confirm flag.
-
-**Open issues (backlog):**
-
-1. **[bug] Color gate keyed to stderr leaks ANSI into piped stdout.**
-   `colorEnabled = stderrIsTty && …` (`runtime/cliContext.ts`), but `doctor`'s
-   styled text is written to **stdout** (`runtime/doctor.ts` `writeDoctorReport`).
-   So `texra doctor | cat` (stderr still a TTY) emits raw ANSI, and
-   `texra doctor 2>/dev/null` strips color from a TTY stdout. Track stdout/stderr
-   color independently and gate primary-output color on the _destination_ stream.
-   `doctor` is currently the only styled-stdout path (progress + update-checker
-   correctly write to stderr).
-2. **[ux] No "did you mean …" for mistyped subcommands.** `formatUnknownCliCommand`
-   (`commands/_helpers/dispatch.ts`) only points at `--help`. Add a Levenshtein
-   suggestion over the sibling command names (already walkable via
-   `commandSubCommands`).
-3. **[feature] `texra run` isn't pipe-composable on input.** `--input` requires a
-   file path; `expandWorkflowInputSpec` (`commands/_helpers/workflowInputs.ts`)
-   treats `-` as a literal path. Support `-`-means-stdin (and/or reading
-   `--instruction` from stdin) so `cat draft.tex | texra run …` works.
-4. **[ux] Top-level crash doesn't point at the issue tracker.** `bin/texra.ts`
-   prints `TeXRA CLI failed: <msg>` with no link, though `package.json` declares
-   `bugs.url`. Append a "report at …" line on unexpected errors.
-5. **[docs] Root/`help` usage has no EXAMPLES block or docs link.** Subcommands add
-   `INTERACTIVE CONTROLS` sections via `withUsageSections`; the root has neither
-   examples nor a `Learn more: https://texra.ai` footer.
-6. **[minor] Conventional knobs absent.** No `FORCE_COLOR` override (only the
-   `NO_COLOR` opt-out exists), no canonical `--no-input` alias (functionally
-   covered by headless detection + `--approval-policy never`), and no pager for
-   long lists (`history`, `agents list`). Low priority.
 
 ### Separation of Concerns: VS Code Coupling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,24 +301,26 @@ The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`. It 
 ### CLI design (clig.dev)
 
 The `texra` CLI (`packages/cli/`) follows the [Command Line Interface
-Guidelines](https://clig.dev). Preserve these invariants:
+Guidelines](https://clig.dev). Follow these conventions:
 
 - **Don't reinvent the wheel.** Lean on the arg parser (`citty`) and existing
-  libraries — `picocolors` for color detection, `$PAGER`/`less -FIRX` for
-  paging, a small distance lib for spelling suggestions. Don't hand-roll
-  flag/help parsing, color support detection, or paging.
+  libraries rather than hand-rolling flag/help parsing or color-support
+  detection — `picocolors` already gates color. If you add paging or "did you
+  mean" suggestions (neither exists yet), reach for `$PAGER`/`less -FIRX` or a
+  small distance lib instead of writing your own.
 - **Streams.** stdout carries primary/parseable output; stderr carries logs,
   progress, and diagnostics. Usage shown _on error_ goes to stderr
   (`showUsageStderr`) so `--output-format json|ndjson` stays parseable; explicit
   `--help` prints to stdout. Don't move usage-on-error to stdout.
 - **Exit codes.** Use the canonical `CliExitCode` (`runtime/exitCodes.ts`):
   `0` success, `1` agent error, `2` usage, `3` model/network, `4` approval-denied,
-  `124` cancelled, `130` interrupted. Usage errors stay `2` (never citty's `1`).
+  `124` cancelled, `130` interrupted, `143` terminated. Usage errors stay `2`
+  (never citty's `1`).
 - **Color gating.** Route every plain-text styled surface through `createCliStyle`
   (`runtime/style.ts`); never branch on color at call sites. Gating honors
-  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`). Gate primary-output
-  color on the stream it is written to — stdout color must not depend on stderr
-  being a TTY.
+  `NO_COLOR`, `TERM=dumb`, and TTY (`readCliAmbientState`). Gate each styled
+  surface's color on the stream it writes to, so stdout color doesn't hinge on
+  stderr being a TTY.
 - **Config precedence.** flags > env (`TEXRA_*`) > workspace config file; invalid
   values warn (non-fatal) rather than throw (`buildCliContext`).
 - **Headless detection.** `--print/-p`, `CI`, or non-TTY stdin ⇒ headless; only


### PR DESCRIPTION
## Summary

Added a new "CLI design (clig.dev)" section to CLAUDE.md documenting the texra CLI's alignment with the [Command Line Interface Guidelines](https://clig.dev). The section captures the **conventions to follow** for the CLI.

The documentation covers:
- **Conventions to follow:** don't reinvent the wheel (lean on `citty`/`picocolors`), streams (stdout/stderr separation), exit codes, color gating, config precedence, headless detection, and destructive guardrails

The six review findings are **not** documented in CLAUDE.md (which holds durable conventions, not status). They were filed as independent GitHub issues:
1. Color gate keyed to stderr leaks ANSI into piped stdout — #5026
2. No "did you mean …" for mistyped subcommands — #5027
3. `texra run` isn't pipe-composable on input — #5028
4. Top-level crash doesn't point at the issue tracker — #5029
5. Root/`help` usage has no EXAMPLES block or docs link — #5030
6. Conventional knobs absent (FORCE_COLOR, --no-input, pager) — #5031

## Issue acceptance gates

This is a documentation-only change. No acceptance gates apply.

## Single source of truth

CLAUDE.md now serves as the canonical reference for CLI design conventions in the texra CLI. Known gaps are tracked in issues #5026–#5031, not in the doc.

## Duplication and abstraction budget

N/A — this is documentation.

## Host impact

Extension: None

Desktop: None

CLI: Documented (no code changes)

## Validation

Documentation review only. No code changes to test.

https://claude.ai/code/session_01MSFxJBmqTf1skiVLonqaG5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to CLAUDE.md with no runtime or build impact.
> 
> **Overview**
> **CLAUDE.md** gains a **CLI design (clig.dev)** section that tells contributors to align `packages/cli/` with [clig.dev](https://clig.dev): philosophy (human-first, composable I/O, consistency), and a checklist covering streams/exit codes, help, output/errors/color, flags, TTY/`--no-input`, subcommands/signals, and config precedence (`flags > env > project > user > system`). It also names **`citty`** and **`picocolors`** as the preferred parsing/color stack instead of bespoke CLI code.
> 
> This is documentation only; it does not change CLI behavior. Known gaps vs. those guidelines are tracked separately in issues #5026–#5031 per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c8a05bf9863be7265e49931261e189e8ed476d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->