### PR TITLE
fix(cli): summarize queued subagent follow-ups

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -103,6 +103,24 @@ const SCENARIOS = [
     unexpect: ['Tip: Ctrl-C exits idle chats', 'First queued follo…'],
   },
   {
+    name: 'queued-subagent-followup-summary',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '2',
+      HARNESS_QUEUED_FOLLOWUPS:
+        '<orchestrator-followup><subagent-result id="child-q" agent="reviewer" category="toolUse" status="completed"><response>All good &lt;ok&gt;</response></subagent-result></orchestrator-followup>',
+    },
+    bootExpect: 'queued 1',
+    keys: ['/status', '\r'],
+    frame: 'tail',
+    expect: [
+      'queued follow-ups: 1',
+      '1. ✓ reviewer completed All good <ok>',
+      'Queued follow-ups (1)',
+    ],
+    unexpect: ['<orchestrator-followup>', '<subagent-result'],
+  },
+  {
     name: 'compact-queued-followups',
     rows: 8,
     cols: 60,

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'ink';
 import stringWidth from 'string-width';
 
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
 export const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
@@ -74,7 +75,10 @@ export function queuedFollowUpPanelDisplay({
       const bodyWidth = Math.max(0, contentWidth - stringWidth(prefix));
       return {
         kind: 'message',
-        text: `${prefix}${truncateToColumns(message, bodyWidth)}`,
+        text: `${prefix}${truncateToColumns(
+          summarizeFollowupMessage(message),
+          bodyWidth,
+        )}`,
       };
     });
 

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,4 +1,5 @@
 import { STREAM_STATUS } from '@shared/schemas';
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import type { BypassState } from './state/cliState';
@@ -40,7 +41,10 @@ function queuedFollowUpStatusLines(messages: readonly string[]): string[] {
     `queued follow-ups: ${messages.length}`,
     ...messages.map(
       (message, index) =>
-        `${index + 1}. ${truncateSummary(message, QUEUED_FOLLOW_UP_STATUS_LENGTH)}`,
+        `${index + 1}. ${truncateSummary(
+          summarizeFollowupMessage(message),
+          QUEUED_FOLLOW_UP_STATUS_LENGTH,
+        )}`,
     ),
   ];
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -13,7 +13,7 @@ import {
 } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 
-import { summarizeSubagentFollowup } from '@shared/subagentFollowup';
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { cliState, patchStream, type ConversationEntry } from './cliState';
 import { isFinalTranscriptStatus } from './transcript';
 
@@ -70,14 +70,6 @@ function toolUseEqual(
   );
 }
 
-export function stripOrchestratorFollowup(text: string): string {
-  const trimmed = text.trim();
-  const match = trimmed.match(
-    /^<orchestrator-followup>\s*([\s\S]*?)\s*<\/orchestrator-followup>$/,
-  );
-  return match?.[1]?.trim() ?? text;
-}
-
 // `normalizeToolUseData` is dominated by a Zod parse + YAML stringify
 // of `entry.data`. `StreamLog.update` spreads its patch into a fresh
 // `data` object every tick, so reference equality is a reliable signal
@@ -127,7 +119,7 @@ function renderLogEntryText(
     case 'error':
       return appendCliApiSwitchHint(text);
     case 'user':
-      return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
+      return summarizeFollowupMessage(text);
     default:
       return text;
   }

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -12,10 +12,20 @@
 // NO host imports (no vscode, no Ink/React) so both @shared (webview) and the
 // CLI can consume it.
 
+import { escapeRegExp } from '@utils/core/stringCore';
+
 const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
 
+export function stripOrchestratorFollowup(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(
+    /^<orchestrator-followup>\s*([\s\S]*?)\s*<\/orchestrator-followup>$/,
+  );
+  return match?.[1]?.trim() ?? text;
+}
+
 function attr(xml: string, name: string): string | undefined {
-  return new RegExp(`\\b${name}="([^"]*)"`).exec(xml)?.[1];
+  return new RegExp(`\\b${escapeRegExp(name)}="([^"]*)"`).exec(xml)?.[1];
 }
 
 function innerTag(xml: string, tag: string): string | undefined {
@@ -91,4 +101,8 @@ export function summarizeSubagentFollowup(text: string): string {
   const retryable = attr(trimmed, 'retryable') === 'true';
   const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
   return message ? `${head}\n${decodeXmlEntities(message)}` : head;
+}
+
+export function summarizeFollowupMessage(text: string): string {
+  return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
 }

--- a/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
+++ b/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
@@ -30,6 +30,20 @@ describe('CLI queued follow-up panel display model', () => {
     expect(display.hiddenCount).toBe(0);
   });
 
+  it('summarizes queued subagent follow-up payloads', () => {
+    const display = queuedFollowUpPanelDisplay({
+      messages: [
+        '<orchestrator-followup><subagent-result id="child-q" agent="reviewer" category="toolUse" status="completed"><response>All good &lt;ok&gt;</response></subagent-result></orchestrator-followup>',
+      ],
+      maxRows: 3,
+      width: 80,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. ✓ reviewer completed All good <ok>',
+    ]);
+  });
+
   it('keeps the panel bounded when more messages are queued', () => {
     expect(queuedFollowUpPanelRowCount(['first', 'second', 'third'])).toBe(3);
 

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -57,6 +57,23 @@ describe('CLI session status formatter', () => {
     );
   });
 
+  it('summarizes queued subagent follow-up payloads', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'running',
+      queuedFollowUpMessages: [
+        '<orchestrator-followup><subagent-result id="child-q" agent="reviewer" category="toolUse" status="completed"><response>All good &lt;ok&gt;</response></subagent-result></orchestrator-followup>',
+      ],
+    });
+
+    expect(status).toContain('1. ✓ reviewer completed All good <ok>');
+    expect(status).not.toContain('<orchestrator-followup>');
+    expect(status).not.toContain('<subagent-result');
+  });
+
   it('reports an empty follow-up queue explicitly', () => {
     expect(
       formatCliSessionStatus({

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { summarizeSubagentFollowup } from '@shared/subagentFollowup';
+import {
+  stripOrchestratorFollowup,
+  summarizeFollowupMessage,
+  summarizeSubagentFollowup,
+} from '@shared/subagentFollowup';
 
 describe('summarizeSubagentFollowup', () => {
   it('passes non-subagent text through unchanged', () => {
@@ -10,6 +14,17 @@ describe('summarizeSubagentFollowup', () => {
         '<orchestrator-followup>x</orchestrator-followup>',
       ),
     ).toBe('<orchestrator-followup>x</orchestrator-followup>');
+  });
+
+  it('strips orchestrator follow-up wrappers', () => {
+    expect(
+      stripOrchestratorFollowup(
+        '<orchestrator-followup>\nPlease inspect the file.\n</orchestrator-followup>',
+      ),
+    ).toBe('Please inspect the file.');
+    expect(stripOrchestratorFollowup('ordinary user text')).toBe(
+      'ordinary user text',
+    );
   });
 
   it('summarizes a started progress block', () => {
@@ -66,6 +81,19 @@ describe('summarizeSubagentFollowup', () => {
     ].join('\n');
     expect(summarizeSubagentFollowup(xml)).toBe(
       '✓ research completed\nKeep </response> literal & inspect <file>',
+    );
+  });
+
+  it('summarizes wrapped result follow-up messages for queued displays', () => {
+    const xml = [
+      '<orchestrator-followup>',
+      '<subagent-result id="abc" agent="reviewer" category="toolUse" status="completed">',
+      '<response>All good &lt;ok&gt;</response>',
+      '</subagent-result>',
+      '</orchestrator-followup>',
+    ].join('');
+    expect(summarizeFollowupMessage(xml)).toBe(
+      '✓ reviewer completed\nAll good <ok>',
     );
   });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -42,7 +42,6 @@ import {
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import {
   finalizeSettledPrefix,
-  stripOrchestratorFollowup,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
 import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
@@ -83,6 +82,7 @@ import {
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
+import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
 
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;


### PR DESCRIPTION
Closes #5036

## Summary
- move orchestrator-followup stripping into the shared subagent follow-up formatter
- use the shared formatter for queued follow-up panel rows and `/status` details
- add unit and TUI validator coverage for queued subagent result payloads

## Dogfood Evidence
Before the fix, a queued subagent result appeared as raw `<orchestrator-followup><subagent-result ...>` XML in `/status` and the queued follow-up panel. After the fix, the same PTY frame renders `✓ reviewer completed All good <ok>` in both places.

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- node scripts/validate-tui.mjs queued-subagent-followup-summary queued-followups subagent-followup-summary
- manual node-pty frame capture for queued subagent payload + `/status`
- npm run format
- npm run compile:safe
- npm run lint (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in shared string formatting and CLI TUI; no auth, persistence, or execution path changes beyond how queued messages are rendered.
> 
> **Overview**
> Queued subagent/orchestrator follow-ups no longer show raw `<orchestrator-followup>` / `<subagent-result>` XML in the CLI.
> 
> **Shared formatting** — `stripOrchestratorFollowup` moves into `@shared/subagentFollowup`, with a new `summarizeFollowupMessage` that unwraps orchestrator envelopes then runs the existing subagent summary (including entity decoding). Attribute parsing uses `escapeRegExp` for safer regex names.
> 
> **CLI surfaces** — The queued follow-ups panel, `/status` queue lines, and transcript user rows all call `summarizeFollowupMessage` instead of printing the raw queue payload (the stream log path drops its duplicate strip helper).
> 
> **Coverage** — Vitest cases for panel, session status, and shared helpers; a `validate-tui` scenario asserts human-readable lines like `✓ reviewer completed All good <ok>` and no XML tags on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b924f0cb26feec99f72ebb28ef787d080a54338f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->