### PR TITLE
fix(cli): clarify status slash command copy

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -461,7 +461,7 @@ const SCENARIOS = [
     expect: [
       '… 6 earlier',
       '/status',
-      'Open the session status tabs',
+      'Show session details',
       '/exit',
       'Exit the CLI session',
     ],

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -238,7 +238,7 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'status',
-    description: 'Open the session status tabs',
+    description: 'Show session details',
   });
   registerSlashCommand({
     name: 'resume',


### PR DESCRIPTION
## Summary

- update the CLI slash-palette description for `/status` from status tabs to session details
- update the TUI validator expectation for the slash-palette overflow case

Closes #5038.

## Validation

- `node scripts/validate-tui.mjs slash-palette-overflow slash-palette`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- real `texra chat /help` PTY capture showed `/status - Show session details`
- `npm run format`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to slash-command descriptions and a matching test expectation; no behavior or security impact.
> 
> **Overview**
> Updates the **`/status`** slash-command help text in the CLI from *Open the session status tabs* to **Show session details**, so the slash palette and `/help` match how the command is presented to users.
> 
> The TUI harness scenario **`slash-palette-overflow`** is updated to expect the new description when scrolling the command list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b041889ceb33c3982149040872c5f09649151f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->