### PR TITLE
fix(cli): suggest mistyped subcommands

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -191,6 +191,7 @@ export async function resolveDeepestSubCommand(
 export interface UnknownCliCommand {
   readonly typedCommand: string;
   readonly helpCommand: string;
+  readonly suggestedCommand?: string;
 }
 
 function isPureSubCommandContainer(
@@ -201,6 +202,51 @@ function isPureSubCommandContainer(
     Object.keys(subCommands).length > 0 &&
     typeof (cmd as { run?: unknown }).run !== 'function'
   );
+}
+
+function editDistance(a: string, b: string): number {
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  let current = new Array<number>(b.length + 1);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + substitutionCost,
+      );
+    }
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length];
+}
+
+function suggestionThreshold(token: string, candidate: string): number {
+  return Math.max(1, Math.floor(Math.max(token.length, candidate.length) / 3));
+}
+
+function suggestSubCommand(
+  token: string,
+  subCommands: Record<string, AnyCommand>,
+): string | undefined {
+  let best: { readonly name: string; readonly distance: number } | undefined;
+
+  for (const name of Object.keys(subCommands)) {
+    const distance = editDistance(token, name);
+    if (distance > suggestionThreshold(token, name)) continue;
+    if (
+      best === undefined ||
+      distance < best.distance ||
+      (distance === best.distance && name < best.name)
+    ) {
+      best = { name, distance };
+    }
+  }
+
+  return best?.name;
 }
 
 export async function detectUnknownCliCommand(
@@ -233,9 +279,14 @@ export async function detectUnknownCliCommand(
     }
 
     if (isPureSubCommandContainer(cmd, subCommands)) {
+      const suggestedName = suggestSubCommand(token, subCommands);
       return {
         typedCommand: [...pathParts, token].join(' '),
         helpCommand: pathParts.join(' '),
+        suggestedCommand:
+          suggestedName == null
+            ? undefined
+            : [...pathParts, suggestedName].join(' '),
       };
     }
 
@@ -246,7 +297,11 @@ export async function detectUnknownCliCommand(
 }
 
 export function formatUnknownCliCommand(command: UnknownCliCommand): string {
-  return `Unknown command: ${command.typedCommand}. Run \`${command.helpCommand} --help\` for usage.`;
+  const suggestion =
+    command.suggestedCommand == null
+      ? ''
+      : ` Did you mean \`${command.suggestedCommand}\`?`;
+  return `Unknown command: ${command.typedCommand}.${suggestion} Run \`${command.helpCommand} --help\` for usage.`;
 }
 
 /**

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -137,6 +137,14 @@ describe('CLI root argument routing', () => {
     });
   });
 
+  it('suggests close command names for mistyped top-level commands', async () => {
+    await expect(detectUnknownCliCommand(['chatt'])).resolves.toEqual({
+      typedCommand: 'texra chatt',
+      helpCommand: 'texra',
+      suggestedCommand: 'texra chat',
+    });
+  });
+
   it('detects unknown command-group children', async () => {
     await expect(detectUnknownCliCommand(['agents', 'bogus'])).resolves.toEqual(
       {
@@ -172,6 +180,16 @@ describe('CLI root argument routing', () => {
     });
   });
 
+  it('suggests close command names inside command groups', async () => {
+    await expect(
+      detectUnknownCliCommand(['multi-agent', 'rn']),
+    ).resolves.toEqual({
+      typedCommand: 'texra multi-agent rn',
+      helpCommand: 'texra multi-agent',
+      suggestedCommand: 'texra multi-agent run',
+    });
+  });
+
   it('formats unknown command usage guidance', () => {
     expect(
       formatUnknownCliCommand({
@@ -180,6 +198,18 @@ describe('CLI root argument routing', () => {
       }),
     ).toBe(
       'Unknown command: texra agents bogus. Run `texra agents --help` for usage.',
+    );
+  });
+
+  it('formats typo suggestions for unknown commands', () => {
+    expect(
+      formatUnknownCliCommand({
+        typedCommand: 'texra chatt',
+        helpCommand: 'texra',
+        suggestedCommand: 'texra chat',
+      }),
+    ).toBe(
+      'Unknown command: texra chatt. Did you mean `texra chat`? Run `texra --help` for usage.',
     );
   });
 


### PR DESCRIPTION
## Summary

- add close-match suggestions for unknown top-level and command-group subcommands
- keep the existing usage guidance and diagnostic stream behavior
- cover top-level and nested typo suggestions in CLI root argument tests

Closes #5027.

## Dogfood Repro

Before:

```text
$ texra chatt
Unknown command: texra chatt. Run `texra --help` for usage.
```

After:

```text
$ texra chatt
Unknown command: texra chatt. Did you mean `texra chat`? Run `texra --help` for usage.
```

Nested typo:

```text
$ texra multi-agent rn
Unknown command: texra multi-agent rn. Did you mean `texra multi-agent run`? Run `texra multi-agent --help` for usage.
```

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- packaged CLI repros for `texra chatt`, `texra chattt`, `texra multi-agent rn`, and `texra agents liss`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run format`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI UX and error-message logic only; no changes to execution, auth, or data handling.
> 
> **Overview**
> Unknown CLI subcommand errors now include **“Did you mean …?”** hints when the mistyped token is close to a valid sibling name, for both top-level commands (e.g. `chatt` → `chat`) and nested command groups (e.g. `multi-agent rn` → `multi-agent run`).
> 
> `detectUnknownCliCommand` picks the nearest subcommand name via edit distance with a length-based threshold and stable tie-breaking; `formatUnknownCliCommand` appends the suggestion while keeping the existing `--help` guidance and stderr routing unchanged. Tests cover detection and message formatting for top-level and nested typos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418f4e55f26a7d00c60117340987e788f840ef86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->