### PR TITLE
chore(ci): bump Claude review model to Opus 4.8

### DIFF
--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -256,7 +256,7 @@ runs:
 
           model_opus="$INPUT_CLAUDE_OPUS_MODEL"
           if [ -z "$model_opus" ]; then
-            model_opus="${CLAUDE_OPUS_MODEL:-claude-opus-4-7}"
+            model_opus="${CLAUDE_OPUS_MODEL:-claude-opus-4-8}"
           fi
 
           model_sonnet="$INPUT_CLAUDE_SONNET_MODEL"

--- a/.github/actions/texra-code-review/scripts/resolve-model.cjs
+++ b/.github/actions/texra-code-review/scripts/resolve-model.cjs
@@ -11,7 +11,7 @@ const REVIEW_PROVIDER_CONFIGS = [
     provider: 'anthropic',
     keyEnv: 'ANTHROPIC_API_KEY',
     modelEnv: 'TEXRA_REVIEW_ANTHROPIC_MODEL',
-    defaultModel: 'opus47T',
+    defaultModel: 'opus48T',
   },
   {
     provider: 'openai',


### PR DESCRIPTION
Closes #4830

The Claude review CI automation was still pinned to the deprecated Opus 4.7. This bumps the review model defaults to the current Opus 4.8 (`claude-opus-4-8`).

## What changed

- **`.github/actions/claude-code-with-provider/action.yml`** — the Opus-tier fallback default used by the Claude Code Review bot (`claude-code-review.yml` calls it with `model-tier: opus`): `claude-opus-4-7` → `claude-opus-4-8`. This is the model the review uses unless the `CLAUDE_OPUS_MODEL` repo variable overrides it.
- **`.github/actions/texra-code-review/scripts/resolve-model.cjs`** — the Anthropic provider default for the TeXRA-native reviewer: `opus47T` → `opus48T`, matching the model-registry deprecation note (`opus47/opus47T` retired in favor of `opus48/opus48T`).

## Out of scope (intentionally untouched)

- `claude-dispatch.yml` (`claude-opus-4-7`) — the interactive `@claude` dispatch bot, not a reviewer.
- DeepSeek / other provider review defaults.

## Verification

- Both YAML files parse cleanly; `resolve-model.cjs` passes `node --check`.
- Ran `resolveReviewModel({ providerKeys: { anthropic: 'key' } })` → resolves to `opus48T`.
- Existing `validate-run.mjs` review-model assertions (deepseek/openai/openrouter/override) are unaffected.
- No stale `claude-opus-4-7` / `opus47` ids remain in the review config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two default string changes in CI actions only; behavior is unchanged except which model id is used when not overridden.
> 
> **Overview**
> Updates **CI review** defaults from deprecated Opus 4.7 to Opus 4.8 so automated PR reviews use the current model unless overridden by env/repo variables.
> 
> In **`claude-code-with-provider`**, the Anthropic Opus-tier fallback when `claude-opus-model` / `CLAUDE_OPUS_MODEL` are unset changes from `claude-opus-4-7` to **`claude-opus-4-8`** (used by the Claude Code Review workflow at Opus tier). In **`texra-code-review`’s `resolve-model.cjs`**, the Anthropic provider default shifts from **`opus47T`** to **`opus48T`**, aligned with the model registry. Interactive `@claude` dispatch and other providers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb069ff61e7776c21ab56641f3238db88cdcc3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->