### PR TITLE
refactor(agents): migrate creator tool-use agent to unified documents protocol

### DIFF
--- a/packages/extension/resources/tool_use_agents/creator.yaml
+++ b/packages/extension/resources/tool_use_agents/creator.yaml
@@ -46,7 +46,11 @@ prompts:
     - Process LaTeX documents in fixed rounds (1 or 2).
     - Receive pre-loaded file content via template variables
       ({% raw %}`{{ INPUT_CONTENT }}`, `{{ ALL_INPUTS }}`{% endraw %}, etc.).
-    - Produce output wrapped in XML tags (e.g. `<latex_document>`).
+    - Produce output with the unified documents protocol — one
+      `<document name="...">` block per output file inside a single
+      `<documents>...</documents>` wrapper. Editing agents reuse the input
+      filenames; agents that generate new artifacts declare
+      `defaultOutputFiles` and emit those names (exposed as `OUTPUT_FILES`).
     - Use chain-of-thought with `<scratchpad>` planning before the final
       output.
     - Best for: editing, polishing, correcting, merging, or creating LaTeX


### PR DESCRIPTION
Closes #4862

## What changed

`packages/extension/resources/tool_use_agents/creator.yaml` (line 49) previously taught models that workflow agents "Produce output wrapped in XML tags (e.g. `<latex_document>`)". With the legacy single-document extraction path retired in #4849, that stale example steered any agent authored by `creator` toward output the extractor can now only recover via the regex fallback (and only for single-input agents).

The instruction is now rewritten to describe the unified documents protocol:

- one `<document name="...">` block per output file inside a single `<documents>...</documents>` wrapper;
- editing agents reuse the input filenames;
- agents that generate new artifacts declare `defaultOutputFiles` and emit those names (exposed as `OUTPUT_FILES`).

The change is confined to documentation prose inside `creator`'s system prompt (the text that teaches users how to author *other* agents). No YAML structure, tools, or behavior of `creator` itself changes.

## Reference mirrored

The issue cited a `humanize` agent as the reference, but no agent by that name exists in `packages/extension/resources/agents/` or `tool_use_agents/` (only a stray UI-comment occurrence). The genuinely-migrated references are the agent-creation docs and the workflow agents. The new wording mirrors `packages/extension/resources/docs/agent-creation/workflow_schema.md` (lines 33, 82–94) and `packages/extension/resources/agents/polish.yaml`.

## Validation

- YAML parses cleanly with the `yaml` package.
- Validated against the top-level `AgentDefinitionSchema` shape (`name`, `settings.agentCategory: toolUse`, `tools` array of 10, `prompts.userRequest` contains `{{ INSTRUCTION }}`).
- Confirmed no remaining `latex_document` references anywhere in `resources/`; unified-protocol terms (`<documents>`, `document name`, `OUTPUT_FILES`, `defaultOutputFiles`) present.
- Pre-commit `npm run format` passed.

No bulk agent-YAML loader test exists under `src/test-kernel` to run; validation was done via direct schema parse.

## Open questions

None of substance. Minor note for the maintainer: the issue referenced a `humanize` reference agent that does not exist in the repo — I mirrored the docs + `polish.yaml` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt text only in the agent-designer tool; no runtime, schema, or extraction logic changes.
> 
> **Overview**
> Updates the **creator** tool-use agent’s system prompt so it no longer tells authors to wrap workflow output in legacy tags like `<latex_document>`.
> 
> Workflow agents are now documented to use the **unified documents protocol**: a single `<documents>...</documents>` wrapper with one `<document name="...">` per file, reusing input filenames for editing agents and using `defaultOutputFiles` / `OUTPUT_FILES` when generating new artifacts.
> 
> This is **documentation-only** inside `creator.yaml`; no tools, YAML shape, or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d693c68622065c980c0700c2af576043f8b883af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->