### PR TITLE
docs: update agent-trace doc — logScratchpad → domain call

### DIFF
--- a/docs/architecture/agent-trace.md
+++ b/docs/architecture/agent-trace.md
@@ -18,9 +18,9 @@ from TeXRA-specific helpers; both share one runtime implementation.
                           │  src/logger/TexraTrace        (TYPE)   │
                           │  ────────────────────────────────────  │
                           │  • logError / logProgress              │
-                          │  • logScratchpad / latexDiff           │
-                          │  • missingOutputs / userMessage        │
-                          │  • filesLoaded / logFileCategory       │
+                          │  • latexDiff / missingOutputs          │
+                          │  • userMessage / filesLoaded           │
+                          │  • logFileCategory                     │
                           │  • emitToolUse / updateToolUse         │
                           │  • startGroup / endGroup / statistics  │
                           │  • debugInternal / logInternal / …     │
@@ -81,6 +81,12 @@ from TeXRA-specific helpers; both share one runtime implementation.
             │                     │                       │  drives progress view   │
             └─────────────────────┘                       └─────────────────────────┘
 ```
+
+Not every product event needs a named helper. Low-traffic, TeXRA-specific
+arms ride the `domain` escape hatch directly — for example, scratchpad
+content is emitted with `trace.domain({ key: 'scratchpad', text })`
+(see `src/agent/modelHandlers/utils/fileContentUtils.ts`) instead of a
+dedicated `logScratchpad` method.
 
 ## Where things live
 


### PR DESCRIPTION
Closes #4779

PR #4769 deleted the `logScratchpad()` pass-through helper and replaced its sole call site with a direct `trace.domain({ key: 'scratchpad', text })` emission, but `docs/architecture/agent-trace.md` still listed `logScratchpad` as a current-state helper in the architecture diagram.

**Doc changed:** `docs/architecture/agent-trace.md`

**Old → new:** `logScratchpad` (named helper method on the TexraTrace layer) → `trace.domain({ key: 'scratchpad', text })` (the `domain` escape hatch, already documented at the AgentTrace layer in the same diagram).

Changes:
- Removed `logScratchpad` from the helper list in the diagram and re-paired the remaining items so the box stays aligned.
- Added a short prose note explaining that low-traffic, TeXRA-specific arms ride the `domain` escape hatch directly instead of getting a dedicated helper, citing the live call site.

**Verified against source:** `src/agent/modelHandlers/utils/fileContentUtils.ts:60` — `if (scratchpad) logger.domain({ key: 'scratchpad', text: scratchpad });`. Confirmed `logScratchpad` no longer exists anywhere in `src/` (only in this doc's "instead of" note and the historical proposal doc `docs/proposals/agent-trace-sdk-surface.md:170`, which the issue says to leave as-is). The `domain(input: DomainEventInput)` method is defined on `src/agent/trace/AgentTrace.ts:153`.

Note: the doc's two-layer split (a `src/logger/TexraTrace` TYPE extending `AgentTrace`) is itself broadly stale — that type no longer exists and the TeXRA-specific helpers are now plain functions in `src/agent/trace/helpers.ts`. That larger drift is out of scope for this issue (#4779 scopes the fix to the `logScratchpad` line) and would warrant a separate doc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Updates **`docs/architecture/agent-trace.md`** so the TexraTrace diagram matches the current API: **`logScratchpad`** is removed from the helper list and the remaining bullets are reordered for layout.
> 
> Adds a short note that low-traffic TeXRA events (e.g. scratchpad) use **`trace.domain({ key: 'scratchpad', text })`** at **`fileContentUtils.ts`** instead of a dedicated helper—aligned with the prior code change in #4769.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2061343c68bb58b41eb47440c8c2dae3a8040c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->