### PR TITLE
feat(cli): crash report link + root EXAMPLES/docs

### DIFF
--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -2,6 +2,7 @@ import { tryPlatform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { runCli } from '../commands/root';
+import { formatCrashReportLine, readCliBugsUrl } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import {
   installCliPipeErrorHandlers,
@@ -14,6 +15,12 @@ try {
   process.exitCode = result.exitCode;
 } catch (error) {
   writeTextStderr(`TeXRA CLI failed: ${toErrorMessage(error)}`);
+  // Usage errors are handled inside runCli (exit 2) and never reach here; this
+  // catch only fires on UNEXPECTED crashes, so point the user at the tracker.
+  // formatCrashReportLine keeps the report link off the usage path even if a
+  // usage error is ever rethrown.
+  const reportLine = formatCrashReportLine(error, await readCliBugsUrl());
+  if (reportLine) writeTextStderr(reportLine);
   process.exitCode = CliExitCode.AgentError;
 } finally {
   await tryPlatform()?.lifecycle.runShutdown();

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -18,6 +18,7 @@ import {
   resolveDeepestSubCommand,
   showUsage,
   showUsageStderr,
+  withUsageSections,
   type UnknownCliCommand,
 } from './_helpers/dispatch';
 import { getExitCode, resetExitCode } from './_helpers/exitCode';
@@ -46,49 +47,64 @@ export function defaultRootSubcommand(): 'orchestrate' | 'help' {
   return ambient.stdinIsTty && ambient.stdoutIsTty ? 'orchestrate' : 'help';
 }
 
-export const rootCommand = defineCommand({
-  // Citty's `runMain` reads `meta.version` for `--version`/`-v`. We resolve
-  // lazily so the bundled binary picks up the version emitted by the build
-  // (see `readCliVersion` in cliContext.ts).
-  meta: async () => ({
-    name: 'texra',
-    description: 'TeXRA CLI — AI LaTeX research assistant',
-    version: await readCliVersion(),
+export const rootCommand = withUsageSections(
+  defineCommand({
+    // Citty's `runMain` reads `meta.version` for `--version`/`-v`. We resolve
+    // lazily so the bundled binary picks up the version emitted by the build
+    // (see `readCliVersion` in cliContext.ts).
+    meta: async () => ({
+      name: 'texra',
+      description: 'TeXRA CLI — AI LaTeX research assistant',
+      version: await readCliVersion(),
+    }),
+    // Global flags are duplicated here so citty's `findSubCommandIndex` knows
+    // which leading flags take values (otherwise `texra --output-format ndjson
+    // agents list` mis-detects `ndjson` as the subcommand). The actual parsing
+    // happens on each subcommand; root only acts as a routing layer.
+    args: {
+      ...GLOBAL_ARGS,
+    },
+    subCommands: {
+      orchestrate: orchestrationCommand,
+      chat: chatCommand,
+      run: runWorkflowCommand,
+      resume: resumeCommand,
+      init: initCommand,
+      history: historyCommand,
+      memory: memoryCommand,
+      agents: agentsCommand,
+      skills: skillsCommand,
+      tools: toolsCommand,
+      'multi-agent': multiAgentCommand,
+      models: modelsCommand,
+      // `login`/`logout` are convenience shortcuts; the full auth surface
+      // (login, logout, status, usage) lives under `auth`.
+      login: loginCommand,
+      logout: logoutCommand,
+      auth: authCommand,
+      doctor: doctorCommand,
+      completion: completionCommand,
+      version: versionCommand,
+      help: helpCommand,
+    },
+    // No subcommand on bare `texra`: dispatch to the orchestration view when
+    // both TTYs are interactive; fall through to synthetic `help` otherwise.
+    default: defaultRootSubcommand,
   }),
-  // Global flags are duplicated here so citty's `findSubCommandIndex` knows
-  // which leading flags take values (otherwise `texra --output-format ndjson
-  // agents list` mis-detects `ndjson` as the subcommand). The actual parsing
-  // happens on each subcommand; root only acts as a routing layer.
-  args: {
-    ...GLOBAL_ARGS,
-  },
-  subCommands: {
-    orchestrate: orchestrationCommand,
-    chat: chatCommand,
-    run: runWorkflowCommand,
-    resume: resumeCommand,
-    init: initCommand,
-    history: historyCommand,
-    memory: memoryCommand,
-    agents: agentsCommand,
-    skills: skillsCommand,
-    tools: toolsCommand,
-    'multi-agent': multiAgentCommand,
-    models: modelsCommand,
-    // `login`/`logout` are convenience shortcuts; the full auth surface
-    // (login, logout, status, usage) lives under `auth`.
-    login: loginCommand,
-    logout: logoutCommand,
-    auth: authCommand,
-    doctor: doctorCommand,
-    completion: completionCommand,
-    version: versionCommand,
-    help: helpCommand,
-  },
-  // No subcommand on bare `texra`: dispatch to the orchestration view when
-  // both TTYs are interactive; fall through to synthetic `help` otherwise.
-  default: defaultRootSubcommand,
-});
+  [
+    {
+      title: 'EXAMPLES',
+      rows: [
+        ['texra chat', 'start an interactive tool-use session'],
+        ['texra run <agent> --input file.tex', 'run a workflow agent headless'],
+        ['texra agents list', 'list the available agents'],
+        ['texra doctor', 'check your environment and configuration'],
+      ],
+    },
+    // Footer rows are empty, so `formatUsageSection` renders just this title.
+    { title: 'Learn more: https://texra.ai', rows: [] },
+  ],
+);
 
 export async function detectUnknownCliCommand(
   rawArgs: readonly string[],

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -111,29 +111,66 @@ export function isTexraCliEntrypointPath(entrypointPath: string): boolean {
   );
 }
 
-let cachedVersion: Promise<string> | undefined;
-
-export function readCliVersion(): Promise<string> {
-  cachedVersion ??= resolveCliVersion();
-  return cachedVersion;
+interface CliPackageManifest {
+  readonly version?: string;
+  readonly bugs?: { readonly url?: string };
 }
 
-async function resolveCliVersion(): Promise<string> {
+async function readCliPackageManifest(): Promise<
+  CliPackageManifest | undefined
+> {
   const candidates = [
     new URL('../../package.json', import.meta.url),
     new URL('../package.json', import.meta.url),
   ];
   for (const candidate of candidates) {
     try {
-      const pkg = JSON.parse(await readFile(candidate, 'utf8')) as {
-        version?: string;
-      };
-      if (pkg.version) return pkg.version;
+      const pkg = JSON.parse(
+        await readFile(candidate, 'utf8'),
+      ) as CliPackageManifest;
+      // The source layout nests under `../../`; the bundled layout under `../`.
+      // Either way the first manifest with a version is the CLI's own.
+      if (pkg.version) return pkg;
     } catch {
       // Try the next source/build-layout candidate.
     }
   }
-  return 'unknown';
+  return undefined;
+}
+
+let cachedVersion: Promise<string> | undefined;
+
+export function readCliVersion(): Promise<string> {
+  cachedVersion ??= readCliPackageManifest().then(
+    (pkg) => pkg?.version ?? 'unknown',
+  );
+  return cachedVersion;
+}
+
+let cachedBugsUrl: Promise<string | undefined> | undefined;
+
+/**
+ * The issue-tracker URL declared in the CLI's `package.json` (`bugs.url`), used
+ * to point users at the bug tracker on an unexpected crash. Read from the
+ * manifest rather than hard-coded so it tracks the published metadata.
+ */
+export function readCliBugsUrl(): Promise<string | undefined> {
+  cachedBugsUrl ??= readCliPackageManifest().then((pkg) => pkg?.bugs?.url);
+  return cachedBugsUrl;
+}
+
+/**
+ * The follow-up line appended to the top-level crash message pointing users at
+ * the issue tracker. Returns `undefined` for usage errors (so the exit-2 path
+ * stays clean) or when no tracker URL is configured — only an UNEXPECTED crash
+ * with a known `bugs.url` gets the report prompt.
+ */
+export function formatCrashReportLine(
+  error: unknown,
+  bugsUrl: string | undefined,
+): string | undefined {
+  if (error instanceof CliUsageError || !bugsUrl) return undefined;
+  return `This looks like a bug — please report it at ${bugsUrl} (include the command and the message above).`;
 }
 
 export interface CliGlobalArgs {

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -128,8 +128,9 @@ async function readCliPackageManifest(): Promise<
       const pkg = JSON.parse(
         await readFile(candidate, 'utf8'),
       ) as CliPackageManifest;
-      // The source layout nests under `../../`; the bundled layout under `../`.
-      // Either way the first manifest with a version is the CLI's own.
+      // Source and bundled `dist/bin` layouts both reach the CLI manifest via
+      // `../../`; keep the fallback for build layouts that place runtime files
+      // one level below the package root.
       if (pkg.version) return pkg;
     } catch {
       // Try the next source/build-layout candidate.

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -8,6 +8,8 @@ import {
   buildCliContext,
   CliUsageError,
   isTexraCliEntrypointPath,
+  readCliBugsUrl,
+  readCliVersion,
   resolveCliCwd,
 } from '@cli/runtime/cliContext';
 import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
@@ -38,6 +40,15 @@ describe('CLI entrypoint detection', () => {
       isTexraCliEntrypointPath('/repo/packages/cli/src/bin/texra.ts'),
     ).toBe(true);
     expect(isTexraCliEntrypointPath('/usr/local/bin/vitest')).toBe(false);
+  });
+});
+
+describe('CLI package manifest discovery', () => {
+  it('finds version and bug-report metadata from the source runtime layout', async () => {
+    await expect(readCliVersion()).resolves.toMatch(/^\d+\.\d+\.\d+/);
+    await expect(readCliBugsUrl()).resolves.toBe(
+      'https://github.com/texra-ai/texra-issues/issues',
+    );
   });
 });
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -13,6 +13,7 @@ import {
   normalizeRootShortcuts,
   reorderGlobalFlags,
 } from '@cli/commands/_helpers/dispatch';
+import { CliUsageError, formatCrashReportLine } from '@cli/runtime/cliContext';
 import {
   formatCliModelListError,
   isCliFetchStackLog,
@@ -554,6 +555,26 @@ describe('CLI model flag validation contract', () => {
 describe('CLI login arguments', () => {
   it('prefers explicit provider flags over positional providers', () => {
     expect(resolveLoginProvider('google', 'github')).toBe('github');
+  });
+});
+
+describe('CLI crash report line', () => {
+  const bugsUrl = 'https://github.com/texra-ai/texra-issues/issues';
+
+  it('points unexpected crashes at the issue tracker', () => {
+    expect(formatCrashReportLine(new Error('boom'), bugsUrl)).toBe(
+      `This looks like a bug — please report it at ${bugsUrl} (include the command and the message above).`,
+    );
+  });
+
+  it('does not append a report link for usage errors', () => {
+    expect(
+      formatCrashReportLine(new CliUsageError('bad flag'), bugsUrl),
+    ).toBeUndefined();
+  });
+
+  it('omits the report link when no tracker URL is configured', () => {
+    expect(formatCrashReportLine(new Error('boom'), undefined)).toBeUndefined();
   });
 });
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -689,6 +689,26 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('shows EXAMPLES and a docs link in root --help', async () => {
+    const result = await runCli(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('EXAMPLES');
+    expect(stdout).toContain('texra chat');
+    expect(stdout).toContain('texra run <agent> --input file.tex');
+    expect(stdout).toContain('texra agents list');
+    expect(stdout).toContain('texra doctor');
+    expect(stdout).toContain('Learn more: https://texra.ai');
+    expect(stderr).toBe('');
+  });
+
+  it('shows EXAMPLES and a docs link for bare `help`', async () => {
+    const result = await runCli(['help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('EXAMPLES');
+    expect(stdout).toContain('Learn more: https://texra.ai');
+    expect(stderr).toBe('');
+  });
+
   it('shows command-specific usage for help command paths', async () => {
     const result = await runCli(['help', 'chat']);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Closes #5029
Closes #5030

Rebased onto current `main` and **dropped the did-you-mean change** (#5027) — that landed separately via your merged **#5040** (`fix(cli): suggest mistyped subcommands`), which hand-rolls `editDistance` in `dispatch.ts`. This PR no longer touches `dispatch.ts` and no longer adds the `fastest-levenshtein` dependency; it now carries only the two non-overlapping changes:

- **#5029** — unexpected (non-`CliUsageError`) crashes now append `This looks like a bug — please report it at <bugs.url> …`, read from `package.json`. Usage errors (exit 2) are unaffected.
- **#5030** — root `texra --help` / `texra help` now render an `EXAMPLES` block (chat / run / agents list / doctor) + `Learn more: https://texra.ai`, via the same `withUsageSections` path subcommands use.

#5027 is covered by #5040; closing it can be done there.

### Verification
- CLI + test-kernel typecheck clean; `CliRootArgs.vitest.mts` 55/55 (main's #5040 did-you-mean tests coexist with the new crash + EXAMPLES tests).
- TTY/pipe verified by the orchestrator: `--cwd` usage error → no report line; `texra --help` → EXAMPLES + docs link present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr/help text and manifest reads only; usage errors and exit codes are unchanged aside from the new crash footer.
> 
> **Overview**
> Unexpected CLI crashes (outside the normal usage-error path) now print a second stderr line that points users at the issue tracker URL from `package.json` `bugs.url`, via shared manifest loading with version discovery. **`CliUsageError`** and missing tracker URLs still get no report prompt.
> 
> Root **`texra --help`** / **`texra help`** now include an **EXAMPLES** block (chat, run, agents list, doctor) and a **Learn more: https://texra.ai** footer using the same **`withUsageSections`** helper subcommands already use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee49f42199eb34ef1223c0063c9fe581b9bc8a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->