### PR TITLE
fix(cli): gate doctor color by output stream

### DIFF
--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -39,6 +39,8 @@ export interface CliContext {
   readonly stdoutIsTty?: boolean;
   readonly termIsDumb?: boolean;
   readonly stderrIsTty?: boolean;
+  readonly stdoutColorEnabled?: boolean;
+  readonly stderrColorEnabled?: boolean;
   readonly colorEnabled: boolean;
   readonly version: string;
   readonly resourcesPath: string;
@@ -63,6 +65,8 @@ export interface CliAmbientState {
   readonly stdoutIsTty: boolean;
   readonly stderrIsTty: boolean;
   readonly termIsDumb?: boolean;
+  readonly stdoutColorEnabled: boolean;
+  readonly stderrColorEnabled: boolean;
   readonly colorEnabled: boolean;
 }
 
@@ -75,13 +79,18 @@ export function readCliAmbientState(): CliAmbientState {
   const stdoutIsTty = process.stdout.isTTY === true;
   const noColor = process.env.NO_COLOR != null;
   const dumbTerm = process.env.TERM === 'dumb';
+  const colorAllowed = !noColor && !dumbTerm;
+  const stdoutColorEnabled = stdoutIsTty && colorAllowed;
+  const stderrColorEnabled = stderrIsTty && colorAllowed;
   cachedAmbient = {
     isCi: Boolean(process.env.CI),
     stdinIsTty,
     stdoutIsTty,
     stderrIsTty,
     termIsDumb: dumbTerm,
-    colorEnabled: stderrIsTty && !noColor && !dumbTerm,
+    stdoutColorEnabled,
+    stderrColorEnabled,
+    colorEnabled: stderrColorEnabled,
   };
   return cachedAmbient;
 }
@@ -287,6 +296,8 @@ export async function buildCliContext(
     stdoutIsTty: ambient.stdoutIsTty,
     termIsDumb: ambient.termIsDumb === true,
     stderrIsTty: ambient.stderrIsTty,
+    stdoutColorEnabled: ambient.stdoutColorEnabled,
+    stderrColorEnabled: ambient.stderrColorEnabled,
     colorEnabled: ambient.colorEnabled,
     version: await readCliVersion(),
     resourcesPath: resolveCliResourcesPath(),

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -371,7 +371,14 @@ export function writeDoctorReport(
     }
     return;
   }
-  const text = formatDoctorText(report, createCliStyle(context.colorEnabled));
+  const stdoutColorEnabled =
+    context.stdoutColorEnabled ??
+    (context.colorEnabled && context.stdoutIsTty === true);
+  const stderrColorEnabled =
+    context.stderrColorEnabled ??
+    (context.colorEnabled && context.stderrIsTty === true);
+  const colorEnabled = report.ok ? stdoutColorEnabled : stderrColorEnabled;
+  const text = formatDoctorText(report, createCliStyle(colorEnabled));
   if (report.ok) {
     writeTextStdout(text);
   } else {

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -17,6 +17,8 @@ const ambient = {
   stdinIsTty: false,
   stdoutIsTty: false,
   stderrIsTty: false,
+  stdoutColorEnabled: false,
+  stderrColorEnabled: false,
   colorEnabled: false,
 };
 

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 
 import {
   buildDoctorReport,
   doctorExitCode,
   doctorNdjsonRecords,
   formatDoctorText,
+  type DoctorReport,
+  writeDoctorReport,
 } from '@cli/runtime/doctor';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -42,6 +45,43 @@ const latexProbe = {
   hasBibliographyTool: false,
   hasLatexmk: false,
 } as const;
+
+const healthyNodeReport: DoctorReport = {
+  ok: true,
+  checks: [
+    {
+      id: 'node',
+      name: 'Node.js',
+      status: 'pass',
+      message: 'Node 24.0.0',
+    },
+  ],
+};
+
+function captureDoctorStdout(
+  writeContext: CliContext,
+  report: DoctorReport,
+): string {
+  let stdout = '';
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+      stdout += String(chunk);
+      const cb = rest.find((arg) => typeof arg === 'function') as
+        | ((error?: Error | null) => void)
+        | undefined;
+      cb?.(null);
+      return true;
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+  try {
+    writeDoctorReport(writeContext, report);
+  } finally {
+    stdoutSpy.mockRestore();
+  }
+
+  return stdout;
+}
 
 describe('CLI doctor', () => {
   it('reports failed checks and exits nonzero', async () => {
@@ -233,5 +273,39 @@ describe('CLI doctor', () => {
       ok: true,
     });
     expect(doctorExitCode(report)).toBe(CliExitCode.Success);
+  });
+
+  it('does not color successful text output when stdout is piped', () => {
+    const stdout = captureDoctorStdout(
+      {
+        ...context,
+        colorEnabled: true,
+        stdoutIsTty: false,
+        stderrIsTty: true,
+        stdoutColorEnabled: false,
+        stderrColorEnabled: true,
+      },
+      healthyNodeReport,
+    );
+
+    expect(stdout).toContain('PASS Node.js: Node 24.0.0');
+    expect(stdout).toBe(stripAnsi(stdout));
+  });
+
+  it('keeps successful text output colored when only stderr is redirected', () => {
+    const stdout = captureDoctorStdout(
+      {
+        ...context,
+        colorEnabled: false,
+        stdoutIsTty: true,
+        stderrIsTty: false,
+        stdoutColorEnabled: true,
+        stderrColorEnabled: false,
+      },
+      healthyNodeReport,
+    );
+
+    expect(stripAnsi(stdout)).toContain('PASS Node.js: Node 24.0.0');
+    expect(stdout).not.toBe(stripAnsi(stdout));
   });
 });


### PR DESCRIPTION
## Summary
- track stdout/stderr color gates separately in CLI ambient context
- make `texra doctor` choose the color gate for the stream it writes to
- add regression coverage for piped stdout and redirected stderr cases

Closes #5026.

## Verification
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/Doctor.vitest.mts src/test-kernel/cli/CliContext.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run format`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli bundle`
- packaged CLI: `doctor --output-format ndjson` writes structured stdout and no stderr
- packaged CLI with PTY: `doctor | detector` reports `noansi`
- packaged CLI with inner PTY and `2>/dev/null`: detector reports `ansi`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI presentation and ambient TTY/color detection; no auth, data, or agent execution paths change.
> 
> **Overview**
> The CLI now tracks **stdout** and **stderr** color eligibility separately (TTY plus `NO_COLOR` / `TERM=dumb`), and exposes those flags on `CliContext` alongside the existing stderr-derived `colorEnabled`.
> 
> **`texra doctor`** text output picks styling from the stream it actually writes to: successful reports use the stdout gate; failures use the stderr gate, with fallbacks when the new flags are unset. That stops ANSI from leaking into piped stdout while still allowing color on an interactive terminal when only stderr is redirected.
> 
> Vitest coverage was added for piped-success (plain stdout) and redirected-stderr (colored stdout) cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9c744ee295af4ffbb2f12bff993603231a139d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->