### PR TITLE
fix(cli): route pager env through cli context

### DIFF
--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -145,7 +145,7 @@ export function cliEnvValue(key: string): string | undefined {
 }
 
 export function readCliEnv(): Record<string, string | undefined> {
-  return process.env;
+  return { ...process.env };
 }
 
 /** Raw CLI argv (post `node texra` slice). Allowlisted file for `process.argv`. */

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -144,6 +144,10 @@ export function cliEnvValue(key: string): string | undefined {
   return process.env[key];
 }
 
+export function readCliEnv(): Record<string, string | undefined> {
+  return process.env;
+}
+
 /** Raw CLI argv (post `node texra` slice). Allowlisted file for `process.argv`. */
 export function readCliArgv(): string[] {
   return process.argv.slice(2);

--- a/packages/cli/src/runtime/pager.ts
+++ b/packages/cli/src/runtime/pager.ts
@@ -55,7 +55,8 @@ export function pageStdout(
     return;
   }
 
-  const command = resolvePagerCommand(options.env);
+  const env = options.env ? { ...readCliEnv(), ...options.env } : readCliEnv();
+  const command = resolvePagerCommand(env);
   if (!command) {
     writeTextStdout(text);
     return;
@@ -67,7 +68,7 @@ export function pageStdout(
     input: `${text}\n`,
     stdio: ['pipe', 'inherit', 'inherit'],
     shell: true,
-    env: options.env ? { ...readCliEnv(), ...options.env } : readCliEnv(),
+    env: options.env ? env : undefined,
   });
 
   if (result.error || result.status === 126 || result.status === 127) {

--- a/packages/cli/src/runtime/pager.ts
+++ b/packages/cli/src/runtime/pager.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 
+import { readCliEnv } from './cliContext';
 import { writeTextStdout } from './logSinks';
 
 /**
@@ -18,7 +19,7 @@ const DEFAULT_PAGER = 'less -FIRX';
  * `PAGER=` disables paging, matching how `git`/`man` treat it.
  */
 export function resolvePagerCommand(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined> = readCliEnv(),
 ): string | undefined {
   const pager = env.PAGER;
   if (pager === undefined) return DEFAULT_PAGER;
@@ -66,7 +67,7 @@ export function pageStdout(
     input: `${text}\n`,
     stdio: ['pipe', 'inherit', 'inherit'],
     shell: true,
-    env: options.env ? { ...process.env, ...options.env } : undefined,
+    env: options.env ?? readCliEnv(),
   });
 
   if (result.error || result.status === 126 || result.status === 127) {

--- a/packages/cli/src/runtime/pager.ts
+++ b/packages/cli/src/runtime/pager.ts
@@ -67,7 +67,7 @@ export function pageStdout(
     input: `${text}\n`,
     stdio: ['pipe', 'inherit', 'inherit'],
     shell: true,
-    env: options.env ?? readCliEnv(),
+    env: options.env ? { ...readCliEnv(), ...options.env } : readCliEnv(),
   });
 
   if (result.error || result.status === 126 || result.status === 127) {

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -9,6 +9,7 @@ import {
   CliUsageError,
   isTexraCliEntrypointPath,
   readCliBugsUrl,
+  readCliEnv,
   readCliVersion,
   resolveCliCwd,
   resolveStreamColor,
@@ -66,6 +67,19 @@ describe('CLI package manifest discovery', () => {
     await expect(readCliBugsUrl()).resolves.toBe(
       'https://github.com/texra-ai/texra-issues/issues',
     );
+  });
+});
+
+describe('CLI env boundary', () => {
+  it('returns a snapshot for environment reads', () => {
+    process.env.TEXRA_READ_ENV_TEST = 'original';
+    try {
+      const env = readCliEnv();
+      env.TEXRA_READ_ENV_TEST = 'mutated';
+      expect(process.env.TEXRA_READ_ENV_TEST).toBe('original');
+    } finally {
+      delete process.env.TEXRA_READ_ENV_TEST;
+    }
   });
 });
 

--- a/src/test-kernel/cli/Pager.vitest.mts
+++ b/src/test-kernel/cli/Pager.vitest.mts
@@ -70,18 +70,29 @@ describe('pageStdout', () => {
   });
 
   it('pages through $PAGER only on an interactive TTY', () => {
-    pageStdout('row1\nrow2', { stdoutIsTty: true, env: { PAGER: 'less -R' } });
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
-    const [command, opts] = spawnSyncMock.mock.calls[0] as unknown as [
-      string,
-      childProcess.SpawnSyncOptions,
-    ];
-    expect(command).toBe('less -R');
-    expect(opts.input).toBe('row1\nrow2\n');
-    expect(opts.shell).toBe(true);
-    expect(opts.env).toMatchObject({ PAGER: 'less -R' });
-    // Paging writes through the child; nothing is written directly to stdout.
-    expect(stdout).toBe('');
+    process.env.TEXRA_PAGER_TEST_ENV = 'inherited';
+    try {
+      pageStdout('row1\nrow2', {
+        stdoutIsTty: true,
+        env: { PAGER: 'less -R' },
+      });
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      const [command, opts] = spawnSyncMock.mock.calls[0] as unknown as [
+        string,
+        childProcess.SpawnSyncOptions,
+      ];
+      expect(command).toBe('less -R');
+      expect(opts.input).toBe('row1\nrow2\n');
+      expect(opts.shell).toBe(true);
+      expect(opts.env).toMatchObject({
+        PAGER: 'less -R',
+        TEXRA_PAGER_TEST_ENV: 'inherited',
+      });
+      // Paging writes through the child; nothing is written directly to stdout.
+      expect(stdout).toBe('');
+    } finally {
+      delete process.env.TEXRA_PAGER_TEST_ENV;
+    }
   });
 
   it('writes directly (no pager) when $PAGER is disabled even on a TTY', () => {

--- a/src/test-kernel/cli/Pager.vitest.mts
+++ b/src/test-kernel/cli/Pager.vitest.mts
@@ -95,6 +95,25 @@ describe('pageStdout', () => {
     }
   });
 
+  it('inherits the live environment when no explicit env override is passed', () => {
+    const originalPager = process.env.PAGER;
+    process.env.PAGER = 'less -R';
+    try {
+      pageStdout('row', { stdoutIsTty: true });
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      const [command, opts] = spawnSyncMock.mock.calls[0] as unknown as [
+        string,
+        childProcess.SpawnSyncOptions,
+      ];
+      expect(command).toBe('less -R');
+      expect(opts.env).toBeUndefined();
+      expect(stdout).toBe('');
+    } finally {
+      if (originalPager === undefined) delete process.env.PAGER;
+      else process.env.PAGER = originalPager;
+    }
+  });
+
   it('writes directly (no pager) when $PAGER is disabled even on a TTY', () => {
     pageStdout('row', { stdoutIsTty: true, env: { PAGER: '' } });
     expect(spawnSyncMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add a CLI context env accessor for runtime helpers that need process env
- route pager default/spawn env reads through that accessor so the CLI architecture check passes

Closes #5049.

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/Pager.vitest.mts src/test-kernel/cli/CliContext.vitest.mts
- corepack pnpm --filter @texra-ai/cli run check:architecture
- npx prettier --check packages/cli/src/runtime/cliContext.ts packages/cli/src/runtime/pager.ts
- corepack pnpm --filter @texra-ai/cli run build
- npm run lint (passes with 10 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small runtime boundary refactor for TTY paging only; behavior is covered by existing and new pager/cliContext tests.
> 
> **Overview**
> Introduces **`readCliEnv()`** in the CLI runtime boundary (`cliContext`) as a shallow copy of `process.env`, so helpers can read environment without touching `process.env` outside the allowlisted file.
> 
> **Pager** (`resolvePagerCommand` / `pageStdout`) now uses that accessor instead of direct `process.env` reads, satisfying the CLI architecture check. When callers pass an `env` override, paging merges it onto the live snapshot for `$PAGER` resolution and for `spawnSync`; with no override, the child still inherits the process environment (`env` left `undefined`).
> 
> Tests cover snapshot immutability and that TTY paging sees inherited vars plus overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f3499324898d95a73f5a18e439800947ef1e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->