### PR TITLE
feat(cli): accept stdin for workflow input

### DIFF
--- a/packages/cli/src/commands/_helpers/workflowInputs.ts
+++ b/packages/cli/src/commands/_helpers/workflowInputs.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { glob, hasMagic } from 'glob';
@@ -25,6 +26,70 @@ function normalizeCliInputPath(candidate: string, cwd: string): string {
   return absolutePath;
 }
 
+export interface WorkflowInputExpansionOptions {
+  readonly allowEmpty?: boolean;
+  readonly stdinInputFile?: () => Promise<string>;
+}
+
+export type StdinWorkflowInputMaterializer = (() => Promise<string>) & {
+  cleanup: () => Promise<void>;
+};
+
+export function hasMixedStdinWorkflowInputSpecs(
+  inputSpecs: readonly string[],
+): boolean {
+  const distinctSpecs = new Set(
+    inputSpecs.map((spec) => spec.trim()).filter(Boolean),
+  );
+  return distinctSpecs.has('-') && distinctSpecs.size > 1;
+}
+
+export function createStdinWorkflowInputMaterializer(options: {
+  readonly readStdinText: () => Promise<string>;
+  readonly tempDir?: string;
+}): StdinWorkflowInputMaterializer {
+  let materialized:
+    | Promise<{ readonly directory: string; readonly inputFile: string }>
+    | undefined;
+  const inputFile = (() => {
+    materialized ??= materializeStdinWorkflowInput(options);
+    return materialized.then((result) => result.inputFile);
+  }) as StdinWorkflowInputMaterializer;
+  inputFile.cleanup = async () => {
+    if (!materialized) return;
+    const result = await materialized.catch(() => undefined);
+    if (result) {
+      await fs.rm(result.directory, { recursive: true, force: true });
+    }
+  };
+  return inputFile;
+}
+
+async function materializeStdinWorkflowInput(options: {
+  readonly readStdinText: () => Promise<string>;
+  readonly tempDir?: string;
+}): Promise<{ readonly directory: string; readonly inputFile: string }> {
+  const text = await options.readStdinText();
+  const directory = await fs.mkdtemp(
+    path.join(options.tempDir ?? os.tmpdir(), 'texra-stdin-'),
+  );
+  const inputFile = path.join(directory, 'stdin.tex');
+  await fs.writeFile(inputFile, text, 'utf8');
+  return { directory, inputFile };
+}
+
+function requireStdinWorkflowInputFile(
+  flagLabel: string,
+  options: WorkflowInputExpansionOptions,
+): () => Promise<string> {
+  if (flagLabel !== '--input' || !options.stdinInputFile) {
+    throw new CliUsageError(
+      `${flagLabel}: '-' is only supported for stdin workflow input`,
+    );
+  }
+  return options.stdinInputFile;
+}
+
 /**
  * Expand a single user-supplied path spec into the absolute / cwd-relative
  * paths it resolves to.
@@ -38,9 +103,15 @@ export async function expandWorkflowInputSpec(
   inputSpec: string,
   cwd: string,
   flagLabel: string = '--input',
+  options: WorkflowInputExpansionOptions = {},
 ): Promise<string[]> {
   const trimmed = inputSpec.trim();
   if (!trimmed) return [];
+
+  if (trimmed === '-') {
+    const stdinInputFile = requireStdinWorkflowInputFile(flagLabel, options);
+    return [normalizeCliInputPath(await stdinInputFile(), cwd)];
+  }
 
   if (hasMagic(trimmed)) {
     const isAbsolute = path.isAbsolute(trimmed);
@@ -93,13 +164,29 @@ export async function expandWorkflowInputSpecs(
   inputSpecs: readonly string[],
   cwd: string,
   flagLabel: string = '--input',
-  options: { readonly allowEmpty?: boolean } = {},
+  options: WorkflowInputExpansionOptions = {},
 ): Promise<string[]> {
-  const expanded = (
-    await Promise.all(
-      inputSpecs.map((spec) => expandWorkflowInputSpec(spec, cwd, flagLabel)),
-    )
-  ).flat();
+  const entries: Array<readonly string[] | 'stdin'> = [];
+  let stdinInputFile: (() => Promise<string>) | undefined;
+  for (const spec of inputSpecs) {
+    if (spec.trim() === '-') {
+      stdinInputFile = requireStdinWorkflowInputFile(flagLabel, options);
+      entries.push('stdin');
+      continue;
+    }
+    entries.push(await expandWorkflowInputSpec(spec, cwd, flagLabel));
+  }
+  const expanded: string[] = [];
+  const stdinPath = stdinInputFile
+    ? normalizeCliInputPath(await stdinInputFile(), cwd)
+    : undefined;
+  for (const entry of entries) {
+    if (entry === 'stdin') {
+      if (stdinPath) expanded.push(stdinPath);
+      continue;
+    }
+    expanded.push(...entry);
+  }
   const unique = [...new Set(expanded)];
   if (unique.length === 0 && options.allowEmpty !== true) {
     throw new CliUsageError('At least one workflow input file is required.');
@@ -119,16 +206,11 @@ export async function expandRunInputs(
   inputSpecs: readonly string[],
   contextSpecs: readonly string[],
   cwd: string,
-  options: { readonly allowEmptyInput?: boolean } = {},
+  options: {
+    readonly allowEmptyInput?: boolean;
+    readonly stdinInputFile?: () => Promise<string>;
+  } = {},
 ): Promise<{ inputFiles: string[]; contextFiles: string[] }> {
-  const inputFiles = await expandWorkflowInputSpecs(
-    inputSpecs,
-    cwd,
-    '--input',
-    {
-      allowEmpty: options.allowEmptyInput,
-    },
-  );
   const contextFiles = (
     await Promise.all(
       contextSpecs.map((spec) =>
@@ -136,5 +218,14 @@ export async function expandRunInputs(
       ),
     )
   ).flat();
+  const inputFiles = await expandWorkflowInputSpecs(
+    inputSpecs,
+    cwd,
+    '--input',
+    {
+      allowEmpty: options.allowEmptyInput,
+      stdinInputFile: options.stdinInputFile,
+    },
+  );
   return { inputFiles, contextFiles };
 }

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -13,7 +13,11 @@ import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
-import { CliUsageError, type CliContext } from '../runtime/cliContext';
+import {
+  CliUsageError,
+  readCliStdinText,
+  type CliContext,
+} from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
@@ -37,7 +41,10 @@ import {
   toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
-import { expandWorkflowInputSpecs } from './_helpers/workflowInputs';
+import {
+  createStdinWorkflowInputMaterializer,
+  expandWorkflowInputSpecs,
+} from './_helpers/workflowInputs';
 
 type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
 
@@ -106,15 +113,7 @@ async function runToolUseAgent(
   let contextFiles: string[];
   let instruction: string;
   try {
-    [inputFiles, contextFiles, instruction] = await Promise.all([
-      expandWorkflowInputSpecs(init.inputFiles, runContext.cwd, '--input', {
-        allowEmpty: true,
-      }),
-      expandWorkflowInputSpecs(init.contextFiles, runContext.cwd, '--context', {
-        allowEmpty: true,
-      }),
-      resolveToolUseInstruction(init, runContext.cwd),
-    ]);
+    instruction = await resolveToolUseInstruction(init, runContext.cwd);
   } catch (error: unknown) {
     if (!(error instanceof CliUsageError)) {
       throw error;
@@ -124,7 +123,6 @@ async function runToolUseAgent(
   }
 
   await initCliPlatform(runContext);
-  installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
   const agent = await resolveAgentWithRemoteFallback(init.agent);
 
@@ -141,41 +139,74 @@ async function runToolUseAgent(
     return CliExitCode.Usage;
   }
 
-  const config: AgentConfigPayload = {
-    agent: init.agent,
-    model,
-    inputFiles,
-    contextFiles,
-    instruction,
-    workingDirectory: runContext.cwd,
-    agentCategory: AgentCategory.ToolUse,
-  };
+  const stdinInputFile = createStdinWorkflowInputMaterializer({
+    readStdinText: readCliStdinText,
+  });
+  try {
+    try {
+      contextFiles = await expandWorkflowInputSpecs(
+        init.contextFiles,
+        runContext.cwd,
+        '--context',
+        { allowEmpty: true },
+      );
+      inputFiles = await expandWorkflowInputSpecs(
+        init.inputFiles,
+        runContext.cwd,
+        '--input',
+        {
+          allowEmpty: true,
+          stdinInputFile,
+        },
+      );
+    } catch (error: unknown) {
+      if (!(error instanceof CliUsageError)) {
+        throw error;
+      }
+      writeErrorStderr(error);
+      return CliExitCode.Usage;
+    }
 
-  const executionId = generateExecutionId();
-  const registeredConfig = AgentConfigSchema.parse(config);
-  const { result, terminalStatus } = await executeCliRequest(
-    { config: registeredConfig, executionId },
-    runContext,
-    {
-      enforceCategory: true,
-      registerExecution: true,
-      markErrorOnThrow: true,
-      stopAfterCycle: true,
-    },
-  );
-  if (result.category !== AgentCategory.ToolUse) {
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-    writeTextStderr(`Agent "${init.agent}" resolved to a non tool-use run.`);
-    return CliExitCode.AgentError;
+    installCliApprovalHandlers(runContext);
+
+    const config: AgentConfigPayload = {
+      agent: init.agent,
+      model,
+      inputFiles,
+      contextFiles,
+      instruction,
+      workingDirectory: runContext.cwd,
+      agentCategory: AgentCategory.ToolUse,
+    };
+
+    const executionId = generateExecutionId();
+    const registeredConfig = AgentConfigSchema.parse(config);
+    const { result, terminalStatus } = await executeCliRequest(
+      { config: registeredConfig, executionId },
+      runContext,
+      {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+        stopAfterCycle: true,
+      },
+    );
+    if (result.category !== AgentCategory.ToolUse) {
+      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+      writeTextStderr(`Agent "${init.agent}" resolved to a non tool-use run.`);
+      return CliExitCode.AgentError;
+    }
+
+    const displayResult: CliToolUseRunResult = createCliRunResult(
+      result,
+      terminalStatus,
+    );
+    writeToolUseRunResult(runContext, displayResult);
+
+    return terminalStatusExitCode(terminalStatus, runContext);
+  } finally {
+    await stdinInputFile.cleanup();
   }
-
-  const displayResult: CliToolUseRunResult = createCliRunResult(
-    result,
-    terminalStatus,
-  );
-  writeToolUseRunResult(runContext, displayResult);
-
-  return terminalStatusExitCode(terminalStatus, runContext);
 }
 
 export const agentsRunCommand = defineCliCommand({

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -10,7 +10,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
-import { CliUsageError } from '../runtime/cliContext';
+import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
@@ -47,7 +47,10 @@ import {
   toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
-import { expandRunInputs } from './_helpers/workflowInputs';
+import {
+  createStdinWorkflowInputMaterializer,
+  expandRunInputs,
+} from './_helpers/workflowInputs';
 import type { CliContext } from '../runtime/cliContext';
 
 type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
@@ -178,12 +181,6 @@ export async function runMultiAgentPreset(
   if (init.inputFiles.length === 0 && !hasInlineInstruction) {
     throw new CliUsageError('Provide --input or --instruction.');
   }
-  const { inputFiles, contextFiles } = await expandRunInputs(
-    init.inputFiles,
-    init.contextFiles,
-    context.cwd,
-    { allowEmptyInput: hasInlineInstruction },
-  );
 
   await initCliPlatform({ ...context, quietLogs: true });
   await loadAgents({ includeRemote: false });
@@ -207,51 +204,67 @@ export async function runMultiAgentPreset(
   // model after agent validation so usage errors stay focused on bad agents.
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);
-  await initCliPlatform(runContext);
-  installCliApprovalHandlers(runContext);
-
-  const config: AgentConfigPayload = {
-    agent: plan.rootAgent.name,
-    model,
-    inputFiles,
-    contextFiles,
-    instruction: formatMultiAgentRunInstruction(plan.preset, {
-      inputFiles,
-      instruction: init.instruction,
-      approvalContext: runContext,
-    }),
-    workingDirectory: runContext.cwd,
-    agentCategory: AgentCategory.ToolUse,
-    cliMultiAgentPresetId: plan.preset.id,
-  };
-
-  const executionId = generateExecutionId();
-  const registeredConfig = AgentConfigSchema.parse(config);
-  const { result, terminalStatus } = await executeCliRequest(
-    { config: registeredConfig, executionId },
-    runContext,
-    {
-      enforceCategory: true,
-      registerExecution: true,
-      markErrorOnThrow: true,
-      stopAfterCycle: true,
-      wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
-    },
-  );
-  if (result.category !== AgentCategory.ToolUse) {
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-    writeTextStderr(
-      `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+  const stdinInputFile = createStdinWorkflowInputMaterializer({
+    readStdinText: readCliStdinText,
+  });
+  try {
+    const { inputFiles, contextFiles } = await expandRunInputs(
+      init.inputFiles,
+      init.contextFiles,
+      runContext.cwd,
+      {
+        allowEmptyInput: hasInlineInstruction,
+        stdinInputFile,
+      },
     );
-    return CliExitCode.AgentError;
-  }
-  const displayResult: CliToolUseRunResult = createCliRunResult(
-    result,
-    terminalStatus,
-  );
-  writeMultiAgentRunResult(runContext, plan, displayResult);
+    await initCliPlatform(runContext);
+    installCliApprovalHandlers(runContext);
 
-  return terminalStatusExitCode(terminalStatus, runContext);
+    const config: AgentConfigPayload = {
+      agent: plan.rootAgent.name,
+      model,
+      inputFiles,
+      contextFiles,
+      instruction: formatMultiAgentRunInstruction(plan.preset, {
+        inputFiles,
+        instruction: init.instruction,
+        approvalContext: runContext,
+      }),
+      workingDirectory: runContext.cwd,
+      agentCategory: AgentCategory.ToolUse,
+      cliMultiAgentPresetId: plan.preset.id,
+    };
+
+    const executionId = generateExecutionId();
+    const registeredConfig = AgentConfigSchema.parse(config);
+    const { result, terminalStatus } = await executeCliRequest(
+      { config: registeredConfig, executionId },
+      runContext,
+      {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+        stopAfterCycle: true,
+        wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
+      },
+    );
+    if (result.category !== AgentCategory.ToolUse) {
+      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+      writeTextStderr(
+        `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+      );
+      return CliExitCode.AgentError;
+    }
+    const displayResult: CliToolUseRunResult = createCliRunResult(
+      result,
+      terminalStatus,
+    );
+    writeMultiAgentRunResult(runContext, plan, displayResult);
+
+    return terminalStatusExitCode(terminalStatus, runContext);
+  } finally {
+    await stdinInputFile.cleanup();
+  }
 }
 
 const multiAgentListCommand = defineCliCommand({

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -11,7 +11,7 @@ import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
-import { CliUsageError } from '../runtime/cliContext';
+import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr } from '../runtime/logSinks';
@@ -33,7 +33,11 @@ import {
   terminalStatusExitCode,
   type CliRunResult,
 } from './_helpers/terminalStatus';
-import { expandRunInputs } from './_helpers/workflowInputs';
+import {
+  createStdinWorkflowInputMaterializer,
+  expandRunInputs,
+  hasMixedStdinWorkflowInputSpecs,
+} from './_helpers/workflowInputs';
 import {
   assertOutputDirAvailable,
   assertOutputFileAvailable,
@@ -69,24 +73,12 @@ async function runWorkflowAgent(
   // parent component blows up at copy time (`EISDIR` / `EEXIST`) after the
   // full agent run otherwise.
   await assertOutputFileAvailable(init.output, runContext.cwd);
-  const { inputFiles, contextFiles } = await expandRunInputs(
-    init.inputFiles,
-    init.contextFiles,
-    runContext.cwd,
-  );
-  if (init.output && inputFiles.length > 1) {
-    throw new CliUsageError(
-      'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
-    );
-  }
 
   await initCliPlatform(runContext);
-  installCliApprovalHandlers(runContext);
   await loadAgents({ includeRemote: false });
   const agent = await resolveAgentWithRemoteFallback(init.agent);
-  // Pre-validate the resolved agent so usage errors land before the runtime
-  // host starts: an unknown name or wrong category should be exit 2 (Usage),
-  // not exit 1 (AgentError) raised mid-run.
+  // Pre-validate the resolved agent so usage errors land before stdin is read
+  // or the runtime host starts.
   if (!agent) {
     throw new CliUsageError(
       `Agent not found: ${init.agent}. Use \`texra agents list\` to see available agents.`,
@@ -97,64 +89,94 @@ async function runWorkflowAgent(
       `Agent "${init.agent}" is a ${agent.category} agent; \`texra run\` only handles workflow agents. Start it interactively with \`texra chat --agent ${init.agent}\`, or run a headless team with \`texra multi-agent run\`.`,
     );
   }
-
-  const modelOutputFile =
-    init.output && path.isAbsolute(init.output)
-      ? path.basename(init.output)
-      : init.output;
-  const config: AgentConfigPayload = {
-    agent: init.agent,
-    model,
-    inputFiles,
-    contextFiles,
-    outputFiles: modelOutputFile ? [modelOutputFile] : [],
-    cliOutputFile: init.output,
-    instruction: init.instruction,
-    workingDirectory: runContext.cwd,
-    agentCategory: AgentCategory.Workflow,
-  };
-
-  const executionId = generateExecutionId();
-  const registeredConfig = AgentConfigSchema.parse(config);
-  const { result, terminalStatus } = await executeCliRequest(
-    { config: registeredConfig, executionId },
-    runContext,
-    { enforceCategory: true, registerExecution: true, markErrorOnThrow: true },
-  );
-  let displayResult: CliRunResult;
-  try {
-    ({ displayResult } = await resolveWorkflowOutput(
-      init.output,
-      init.outputDir,
-      result,
-      runContext,
-      {
-        expectedOutputFiles: init.outputDir
-          ? expectedOutputFilesForOutputDir(agent, inputFiles)
-          : undefined,
-        terminalStatus,
-      },
-    ));
-  } catch (error) {
-    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      writeErrorStderr(error);
-      return CliExitCode.Interrupted;
-    }
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-    writeErrorStderr(error);
-    return CliExitCode.AgentError;
+  if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
+    throw new CliUsageError(
+      'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
+    );
   }
 
-  emitCliResult(runContext, {
-    json: displayResult,
-    ndjson: { kind: 'result', result: displayResult },
-    text:
-      displayResult.category === AgentCategory.Workflow
-        ? formatWorkflowTextResult(displayResult)
-        : result.status,
+  const stdinInputFile = createStdinWorkflowInputMaterializer({
+    readStdinText: readCliStdinText,
   });
+  try {
+    const { inputFiles, contextFiles } = await expandRunInputs(
+      init.inputFiles,
+      init.contextFiles,
+      runContext.cwd,
+      { stdinInputFile },
+    );
+    if (init.output && inputFiles.length > 1) {
+      throw new CliUsageError(
+        'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
+      );
+    }
 
-  return terminalStatusExitCode(terminalStatus, runContext);
+    installCliApprovalHandlers(runContext);
+
+    const modelOutputFile =
+      init.output && path.isAbsolute(init.output)
+        ? path.basename(init.output)
+        : init.output;
+    const config: AgentConfigPayload = {
+      agent: init.agent,
+      model,
+      inputFiles,
+      contextFiles,
+      outputFiles: modelOutputFile ? [modelOutputFile] : [],
+      cliOutputFile: init.output,
+      instruction: init.instruction,
+      workingDirectory: runContext.cwd,
+      agentCategory: AgentCategory.Workflow,
+    };
+
+    const executionId = generateExecutionId();
+    const registeredConfig = AgentConfigSchema.parse(config);
+    const { result, terminalStatus } = await executeCliRequest(
+      { config: registeredConfig, executionId },
+      runContext,
+      {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+      },
+    );
+    let displayResult: CliRunResult;
+    try {
+      ({ displayResult } = await resolveWorkflowOutput(
+        init.output,
+        init.outputDir,
+        result,
+        runContext,
+        {
+          expectedOutputFiles: init.outputDir
+            ? expectedOutputFilesForOutputDir(agent, inputFiles)
+            : undefined,
+          terminalStatus,
+        },
+      ));
+    } catch (error) {
+      if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+        writeErrorStderr(error);
+        return CliExitCode.Interrupted;
+      }
+      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+      writeErrorStderr(error);
+      return CliExitCode.AgentError;
+    }
+
+    emitCliResult(runContext, {
+      json: displayResult,
+      ndjson: { kind: 'result', result: displayResult },
+      text:
+        displayResult.category === AgentCategory.Workflow
+          ? formatWorkflowTextResult(displayResult)
+          : result.status,
+    });
+
+    return terminalStatusExitCode(terminalStatus, runContext);
+  } finally {
+    await stdinInputFile.cleanup();
+  }
 }
 
 export const runWorkflowCommand = defineCliCommand({

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -148,6 +148,15 @@ export function readCliEnv(): Record<string, string | undefined> {
   return { ...process.env };
 }
 
+export async function readCliStdinText(): Promise<string> {
+  process.stdin.setEncoding('utf8');
+  const chunks: string[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(String(chunk));
+  }
+  return chunks.join('');
+}
+
 /** Raw CLI argv (post `node texra` slice). Allowlisted file for `process.argv`. */
 export function readCliArgv(): string[] {
   return process.argv.slice(2);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -23,7 +23,12 @@ import {
   rejectHeadlessOnlyFlags,
 } from '@cli/commands/_helpers/globalArgs';
 import { cliTerminalStatus } from '@cli/commands/_helpers/terminalStatus';
-import { expandWorkflowInputSpecs } from '@cli/commands/_helpers/workflowInputs';
+import {
+  createStdinWorkflowInputMaterializer,
+  expandRunInputs,
+  expandWorkflowInputSpecs,
+  hasMixedStdinWorkflowInputSpecs,
+} from '@cli/commands/_helpers/workflowInputs';
 import {
   resolveWorkflowOutput,
   resumeWorkflowOutputFile,
@@ -315,6 +320,132 @@ describe('CLI root argument routing', () => {
       await expect(expandWorkflowInputSpecs([missing], root)).rejects.toThrow(
         /--input: file not found/,
       );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('materializes stdin when --input - is passed', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    try {
+      const tempDir = path.join(root, '.tmp');
+      await fs.mkdir(tempDir);
+      let readCount = 0;
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        tempDir,
+        readStdinText: async () => {
+          readCount += 1;
+          return '\\documentclass{article}\n\\begin{document}Hi\\end{document}\n';
+        },
+      });
+
+      const expanded = await expandWorkflowInputSpecs(
+        ['-', '-'],
+        root,
+        '--input',
+        {
+          stdinInputFile,
+        },
+      );
+
+      expect(expanded).toHaveLength(1);
+      expect(readCount).toBe(1);
+      expect(path.basename(expanded[0])).toBe('stdin.tex');
+      await expect(
+        fs.readFile(path.resolve(root, expanded[0]), 'utf8'),
+      ).resolves.toContain('\\begin{document}Hi');
+      await stdinInputFile.cleanup();
+      await expect(fs.stat(path.resolve(root, expanded[0]))).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves stdin position when mixed with file inputs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    try {
+      await fs.writeFile(path.join(root, 'paper.tex'), 'paper');
+      const tempDir = path.join(root, '.tmp');
+      await fs.mkdir(tempDir);
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        tempDir,
+        readStdinText: async () =>
+          '\\documentclass{article}\\begin{document}Hi\\end{document}',
+      });
+
+      const expanded = await expandWorkflowInputSpecs(
+        ['-', 'paper.tex'],
+        root,
+        '--input',
+        {
+          stdinInputFile,
+        },
+      );
+
+      expect(path.basename(expanded[0])).toBe('stdin.tex');
+      expect(expanded[1]).toBe('paper.tex');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('detects stdin mixed with other raw workflow input specs', () => {
+    expect(hasMixedStdinWorkflowInputSpecs(['-'])).toBe(false);
+    expect(hasMixedStdinWorkflowInputSpecs(['-', '-'])).toBe(false);
+    expect(hasMixedStdinWorkflowInputSpecs(['-', 'paper.tex'])).toBe(true);
+    expect(hasMixedStdinWorkflowInputSpecs(['  -  ', 'paper.tex'])).toBe(true);
+  });
+
+  it('does not read stdin before later --input validation errors', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    try {
+      let readCount = 0;
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        readStdinText: async () => {
+          readCount += 1;
+          return '\\documentclass{article}\\begin{document}Hi\\end{document}';
+        },
+      });
+
+      await expect(
+        expandWorkflowInputSpecs(['-', 'missing.tex'], root, '--input', {
+          stdinInputFile,
+        }),
+      ).rejects.toThrow(/--input: file not found: missing\.tex/);
+      expect(readCount).toBe(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read stdin before --context validation errors', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    try {
+      let readCount = 0;
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        readStdinText: async () => {
+          readCount += 1;
+          return '\\documentclass{article}\\begin{document}Hi\\end{document}';
+        },
+      });
+
+      await expect(
+        expandRunInputs(['-'], ['missing-context.tex'], root, {
+          stdinInputFile,
+        }),
+      ).rejects.toThrow(/--context: file not found: missing-context\.tex/);
+      expect(readCount).toBe(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stdin sentinel for non-input workflow specs', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    try {
+      await expect(
+        expandWorkflowInputSpecs(['-'], root, '--context'),
+      ).rejects.toThrow(/--context: '-' is only supported/);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -2,18 +2,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CliContext } from '@cli/runtime/cliContext';
 
-const mocks = vi.hoisted(() => ({
-  executeCliRequest: vi.fn(),
-  expandRunInputs: vi.fn(),
-  getToolUseAgents: vi.fn(),
-  getWorkflowAgents: vi.fn(),
-  initCliPlatform: vi.fn(),
-  installCliApprovalHandlers: vi.fn(),
-  isAuthenticated: vi.fn(),
-  loadAgents: vi.fn(),
-  writeTextStderr: vi.fn(),
-  writeTextStdout: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const stdinInputFile = Object.assign(vi.fn(), { cleanup: vi.fn() });
+  return {
+    executeCliRequest: vi.fn(),
+    expandRunInputs: vi.fn(),
+    getToolUseAgents: vi.fn(),
+    getWorkflowAgents: vi.fn(),
+    initCliPlatform: vi.fn(),
+    installCliApprovalHandlers: vi.fn(),
+    isAuthenticated: vi.fn(),
+    loadAgents: vi.fn(),
+    stdinInputFile,
+    writeTextStderr: vi.fn(),
+    writeTextStdout: vi.fn(),
+  };
+});
 
 vi.mock('@agent/index', () => ({
   getToolUseAgents: mocks.getToolUseAgents,
@@ -102,6 +106,7 @@ vi.mock('@cli/commands/_helpers/runExecution', () => ({
 }));
 
 vi.mock('@cli/commands/_helpers/workflowInputs', () => ({
+  createStdinWorkflowInputMaterializer: vi.fn(() => mocks.stdinInputFile),
   expandRunInputs: mocks.expandRunInputs,
 }));
 
@@ -175,11 +180,15 @@ describe('CLI multi-agent run command', () => {
       ['problem.tex'],
       [],
       '/tmp/project',
-      { allowEmptyInput: true },
+      {
+        allowEmptyInput: true,
+        stdinInputFile: mocks.stdinInputFile,
+      },
     );
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.instruction).toContain('Primary user input files:');
     expect(request?.config.instruction).toContain('- "problem.tex"');
+    expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('allows instruction-only team runs without input files', async () => {
@@ -200,6 +209,7 @@ describe('CLI multi-agent run command', () => {
     expect(exitCode).toBe(0);
     expect(mocks.expandRunInputs).toHaveBeenCalledWith([], [], '/tmp/project', {
       allowEmptyInput: true,
+      stdinInputFile: mocks.stdinInputFile,
     });
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.inputFiles).toEqual([]);
@@ -207,6 +217,7 @@ describe('CLI multi-agent run command', () => {
     expect(request?.config.instruction).toContain(
       'Prove that every odd square is congruent to 1 modulo 8.',
     );
+    expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('still requires either an input file or an inline instruction', async () => {


### PR DESCRIPTION
## Summary
- support `--input -` by materializing stdin into a temporary workflow input file
- wire stdin input through `texra run`, `texra agents run`, and `texra multi-agent run` while keeping `--context -` rejected
- add regression coverage that stdin is read once and repeated `--input -` deduplicates to the same materialized file

Closes #5028.

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/Pager.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm --filter @texra-ai/cli run build
- printf '\\documentclass{article}\n\\begin{document}Hi\\end{document}\n' | node packages/cli/dist/bin/texra.js run no-such-agent --input - --output-format json --no-input
- git diff --check
- npm run lint (passes with 10 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only input path handling with temp files and usage guards; no auth, billing, or core agent execution logic changes.
> 
> **Overview**
> Adds **`--input -`** so headless runs can take workflow input from **stdin**, materialized once into a temporary **`stdin.tex`** file for the agent runtime.
> 
> The expansion layer reads stdin only after other `--input` / `--context` paths are validated, keeps **stdin position** when mixed with file inputs, **deduplicates** repeated `-`, and rejects `-` on **`--context`**. **`texra run`**, **`texra agents run`**, and **`texra multi-agent run`** share a stdin materializer with **`finally` cleanup**; workflow runs also block **`--output`** when stdin is combined with other raw input specs before expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00d8d9c7af8e7f6bd89c5fdf64a370edbc58243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->