### PR TITLE
fix(cli): wrap transcript viewer tool output

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -71,6 +71,8 @@ const SHOW_AGENT_PROPOSAL = process.env.HARNESS_AGENT_PROPOSAL === '1';
 const PLAN_APPROVAL_ODYSSEY = process.env.HARNESS_PLAN_APPROVAL_ODYSSEY === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const WIDE_TRANSCRIPT_SUFFIX =
+  ' hidden-middle wide-column-A wide-column-B wide-column-C wide-column-D wide-column-E wide-column-F';
 const SHOW_REJECTED_BASH_TOOL = process.env.HARNESS_REJECTED_BASH_TOOL === '1';
 const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
@@ -241,7 +243,7 @@ function makeLongToolOutput(): NormalizedToolUse {
     outputText: Array.from(
       { length: 18 },
       (_, index) =>
-        `tool-output-line-${String(index + 1).padStart(2, '0')}${index === 9 ? ' hidden-middle' : ''}`,
+        `tool-output-line-${String(index + 1).padStart(2, '0')}${index === 9 ? WIDE_TRANSCRIPT_SUFFIX : ''}`,
     ).join('\n'),
     userInstructionText: '',
     input: { command: 'python3 enumerate_triples.py' },

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -180,11 +180,13 @@ const SCENARIOS = [
   },
   {
     name: 'transcript-viewer-long-tool-output',
+    cols: 80,
     env: { HARNESS_ENTRIES: '0', HARNESS_LONG_TOOL_OUTPUT: '1' },
     keys: [DC4],
     frame: 'tail',
     expect: [
       'tool-output-line-10 hidden-middle',
+      'wide-column-F',
       'tool-output-line-18',
       'PgUp/PgDn page',
       'Esc close',

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -95,9 +95,7 @@ export function TranscriptViewer({
           // Ink collapses an empty-string Text to zero height; the space keeps
           // blank separator rows between entries visible.
           visible.map((line, index) => (
-            <Text key={offset + index} wrap="truncate-end">
-              {line || ' '}
-            </Text>
+            <Text key={offset + index}>{line || ' '}</Text>
           ))
         )}
       </Box>

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -18,6 +18,31 @@ function wrap(text: string, cols: number, prefix = ''): string[] {
     );
 }
 
+function leadingWhitespacePrefix(line: string): string {
+  return line.match(/^\s+/)?.[0] ?? '';
+}
+
+function wrapDisplayLine(line: string, cols: number): string[] {
+  if (line.startsWith('⎿ ')) {
+    const width = Math.max(1, cols - 2);
+    return wrapAnsiToWidth(line.slice(2), width)
+      .split('\n')
+      .map((part, index) => `${index === 0 ? '⎿ ' : '  '}${part}`);
+  }
+
+  const prefix = leadingWhitespacePrefix(line);
+  if (!prefix) return wrapAnsiToWidth(line, cols).split('\n');
+
+  const width = Math.max(1, cols - prefix.length);
+  return wrapAnsiToWidth(line.slice(prefix.length), width)
+    .split('\n')
+    .map((part) => `${prefix}${part}`);
+}
+
+function wrapLines(lines: readonly string[], cols: number): string[] {
+  return lines.flatMap((line) => wrapDisplayLine(line, cols));
+}
+
 export function transcriptEntryLines(
   entry: ConversationEntry,
   cols: number,
@@ -25,10 +50,12 @@ export function transcriptEntryLines(
   switch (entry.role) {
     case 'tool':
       return entry.toolUse
-        ? toolUseDisplayLines(entry.toolUse, { elide: false })
+        ? wrapLines(toolUseDisplayLines(entry.toolUse, { elide: false }), cols)
         : [];
     case 'process':
-      return entry.process ? completedProcessDisplayLines(entry.process) : [];
+      return entry.process
+        ? wrapLines(completedProcessDisplayLines(entry.process), cols)
+        : [];
     case 'user':
       return wrap(entry.text, cols, '› ');
     case 'error':

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -46,6 +46,7 @@ function entry(
 function toolEntry(
   id: string,
   status: NormalizedToolUse['status'],
+  outputText = status === 'completed' ? 'ok' : '',
 ): ConversationEntry {
   return {
     id,
@@ -56,7 +57,7 @@ function toolEntry(
       parsed: {},
       toolName: 'Bash',
       errorText: '',
-      outputText: status === 'completed' ? 'ok' : '',
+      outputText,
       userInstructionText: '',
       input: { command: 'ls' },
       isError: false,
@@ -413,6 +414,20 @@ describe('CLI conversation transcript splitting', () => {
       '● Bash (ls)',
       '⎿ ok',
     ]);
+  });
+
+  it('wraps wide tool output lines in the transcript viewer', () => {
+    const lines = transcriptToLines(
+      sliceWithEntries(STREAM_ID, [
+        toolEntry('t1', 'completed', `wide-output ${'segment '.repeat(12)}`),
+      ]),
+      32,
+    );
+
+    expect(lines).toContain('● Bash (ls)');
+    expect(lines.some((line) => line.includes('⎿ wide-output'))).toBe(true);
+    expect(lines.some((line) => line.includes('segment segment'))).toBe(true);
+    expect(lines.some((line) => line.length > 40)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Wrap full transcript viewer tool/process lines before rendering so wide output remains readable instead of being truncated
- Preserve the two-space output gutter for wrapped continuation rows
- Extend the TUI harness scenario to verify a wide hidden-middle tool-output line is reachable in Ctrl-T transcript view

Fixes #5051

## Validation
- `corepack pnpm install`
- `npx prettier --write packages/cli/src/chat/tui/state/transcriptLines.ts packages/cli/src/chat/tui/modals/TranscriptViewer.tsx packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- transcript-viewer-long-tool-output`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run lint` (passes with 10 existing import-order warnings)
- `git diff --check`
- Snapshot report generated at `/tmp/texra-tui-transcript-snapshots-DfaqZ8/index.html`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only transcript viewer and line-flattening changes with regression tests; no auth, persistence, or execution path changes.
> 
> **Overview**
> The **Ctrl+T transcript viewer** now **wraps** full tool and process output to the modal width instead of leaving long lines to Ink truncation, including correct continuation gutters for `⎿` tool lines and indented rows.
> 
> **TranscriptViewer** drops per-line `truncate-end` wrapping because lines are pre-wrapped in `transcriptLines`. The TUI harness and `transcript-viewer-long-tool-output` validation scenario exercise a wide middle tool-output line at 80 columns, and a unit test asserts wrapped bash output stays within the column budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8b02a3f47f314e468675a70fe92acd3a04b72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->