### PR TITLE
fix(cli): inspect multi-agent run plans

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -20,6 +20,7 @@ import {
   cliMultiAgentPresetNdjsonRecords,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
+  formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
   planCliMultiAgentPresetRun,
   readCliMultiAgentPresets,
@@ -173,6 +174,25 @@ async function runMultiAgentShow(
   return CliExitCode.Success;
 }
 
+async function runMultiAgentInspect(
+  context: CliContext,
+  presetIdOrName: string,
+): Promise<number> {
+  await initCliPlatform({ ...context, quietLogs: true });
+  await loadAgents({ includeRemote: false });
+
+  const plan = await fillMultiAgentRunPlanGaps({
+    preset: presetIdOrName,
+  });
+
+  emitCliResult(context, {
+    json: plan,
+    ndjson: { kind: 'multi-agent-preset-inspection', plan },
+    text: formatCliMultiAgentPresetInspection(plan),
+  });
+  return CliExitCode.Success;
+}
+
 export async function runMultiAgentPreset(
   context: CliContext,
   init: MultiAgentRunInit,
@@ -293,7 +313,7 @@ const multiAgentShowCommand = defineCliCommand({
 const multiAgentInspectCommand = defineCliCommand({
   meta: { name: 'inspect', description: 'Inspect one multi-agent team preset' },
   args: multiAgentPresetArgs,
-  run: (context, ctx) => runMultiAgentShow(context, ctx.args.preset),
+  run: (context, ctx) => runMultiAgentInspect(context, ctx.args.preset),
 });
 
 const multiAgentRunCommand = defineCliCommand({

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -92,6 +92,35 @@ export function formatCliMultiAgentPresetDetails(
   ].join('\n');
 }
 
+export function formatCliMultiAgentPresetInspection(
+  plan: CliMultiAgentPresetRunPlan,
+): string {
+  const availableWorkflowAgents = availablePresetAgents(
+    plan.preset.workflowAgents,
+    plan.missingWorkflowAgents,
+  );
+  const availableToolUseAgents = availablePresetAgents(
+    plan.preset.toolUseAgents,
+    plan.missingToolUseAgents,
+  );
+
+  return [
+    `${plan.preset.name} (${plan.preset.id})`,
+    `Source: ${plan.preset.source}`,
+    `Description: ${plan.preset.description}`,
+    'Root tool-use agent:',
+    `  ${plan.rootAgent?.name ?? '(none)'}`,
+    'Available workflow agents:',
+    formatAgentNames(availableWorkflowAgents),
+    'Available tool-use agents:',
+    formatAgentNames(availableToolUseAgents),
+    'Missing workflow agents:',
+    formatAgentNames(plan.missingWorkflowAgents),
+    'Missing tool-use agents:',
+    formatAgentNames(plan.missingToolUseAgents),
+  ].join('\n');
+}
+
 export function cliMultiAgentPresetNdjsonRecords(
   presets: readonly CliMultiAgentPreset[],
 ): object[] {
@@ -270,6 +299,14 @@ function agentHasDelegationTools(agent: AgentEntry): boolean {
 
 function toAgentKey(agent: AgentEntry): string {
   return agentKey(agent.source, agent.name);
+}
+
+function availablePresetAgents(
+  presetAgents: readonly string[],
+  missingAgents: readonly string[],
+): string[] {
+  const missing = new Set(missingAgents);
+  return presetAgents.filter((agent) => !missing.has(agent));
 }
 
 function formatAgentNames(names: readonly string[]): string {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -919,6 +919,9 @@ describe('runCli usage output stream routing', () => {
     const result = await runCli(['multi-agent', 'inspect', 'mathematician']);
     expect(result.exitCode).toBe(0);
     expect(stdout).toContain('Mathematician (mathematician)');
+    expect(stdout).toContain('Root tool-use agent:');
+    expect(stdout).toContain('Available workflow agents:');
+    expect(stdout).toContain('Missing tool-use agents:');
     expect(stderr).toBe('');
   });
 

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -7,6 +7,7 @@ import {
   cliMultiAgentPresets,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
+  formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
   planCliMultiAgentPresetRun,
   parseCliCustomAgentPresets,
@@ -81,6 +82,45 @@ describe('CLI multi-agent presets', () => {
     );
     expect(formatCliMultiAgentPresetDetails(preset!)).toContain(
       'Tool-use agents:\n  lean',
+    );
+  });
+
+  it('formats an inspection plan with root and missing members', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [
+        agent('criticize', AgentCategory.Workflow),
+        agent('generic', AgentCategory.Workflow),
+      ],
+      toolUseAgents: [
+        agent('review', AgentCategory.ToolUse),
+        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+    const details = formatCliMultiAgentPresetInspection(plan);
+
+    expect(details).toContain('Root tool-use agent:\n  orchestrator');
+    expect(details).toContain(
+      'Available workflow agents:\n  criticize\n  generic',
+    );
+    expect(details).toContain(
+      'Available tool-use agents:\n  orchestrator\n  review',
+    );
+    expect(details).toContain('Missing workflow agents:\n  devise\n  apply');
+    expect(details).toContain(
+      [
+        'Missing tool-use agents:',
+        '  research',
+        '  numerics',
+        '  search',
+        '  presenter',
+        '  simplifier',
+        '  latexFixer',
+        '  progressCheck',
+      ].join('\n'),
     );
   });
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -63,6 +63,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => ({
     source: 'built-in',
   })),
   formatCliMultiAgentPresetDetails: vi.fn(() => ''),
+  formatCliMultiAgentPresetInspection: vi.fn(() => ''),
   formatCliMultiAgentPresetList: vi.fn(() => ''),
   planCliMultiAgentPresetRun: vi.fn(() => ({
     preset: {


### PR DESCRIPTION
Closes #5054

## Summary

- make `texra multi-agent inspect <preset>` resolve and print the runnable team plan instead of duplicating `show`
- include the selected root tool-use agent plus available and missing workflow/tool-use members
- keep `show` as the lightweight preset metadata view

## Dogfood evidence

- Compared `multi-agent show mathematician` vs `multi-agent inspect mathematician` on the built CLI; `inspect` now reports root/available/missing team members.
- Ran a headless mathematician prompt for a small proof/review task and confirmed the command path reaches a completed result.
- Rendered focused subagent/workflow TUI harness snapshots for task pickers, nested child streams, stopped child handling, and sub-workflow details.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run build`
- `node packages/cli/dist/bin/texra.js multi-agent inspect mathematician --print --no-input --color=false`
- `git diff --check`
- `npm run lint` (passes with the existing 10 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI read-only inspection and formatting only; no changes to run execution or auth beyond reusing existing plan resolution.
> 
> **Overview**
> **`texra multi-agent inspect`** no longer mirrors **`show`**: it loads agents, resolves a runnable team plan (including the same gap-filling path as **`run`** when authenticated), and prints that plan instead of static preset metadata.
> 
> Output adds **`formatCliMultiAgentPresetInspection`**, which reports the chosen **root tool-use agent**, **available** vs **missing** workflow and tool-use members. **`show`** stays the lightweight preset-only view. Tests cover the new formatter and CLI **`inspect`** output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940acdb3630edc6871443d7d06929242438d5a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->