### PR TITLE
fix(cli): list TUI validator scenarios

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1612,6 +1612,7 @@ function formatUsage() {
     '',
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
+    '  --list              Print available scenario names and exit',
     '  -h, --help          Show this help',
     '',
     'Available scenarios:',
@@ -1621,6 +1622,10 @@ function formatUsage() {
 
 function printUsage(stream = console.log) {
   stream(formatUsage());
+}
+
+function printScenarioList() {
+  console.log(SCENARIOS.map((scenario) => scenario.name).join('\n'));
 }
 
 function parseArgs(argv) {
@@ -1639,6 +1644,10 @@ function parseArgs(argv) {
     }
     if (!endOfOptions && (arg === '--help' || arg === '-h')) {
       printUsage();
+      process.exit(0);
+    }
+    if (!endOfOptions && arg === '--list') {
+      printScenarioList();
       process.exit(0);
     }
     if (!endOfOptions && arg === '--snapshot-dir') {

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -22,6 +22,7 @@ describe('TUI validator args', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('[validate-tui] usage:');
     expect(result.stdout).toContain('--snapshot-dir DIR');
+    expect(result.stdout).toContain('--list');
     expect(result.stdout).toContain('Available scenarios:');
     expect(result.stdout).toContain('nested-subagent-picker');
     expect(result.stderr).not.toContain('building tui-harness bundle');
@@ -33,6 +34,24 @@ describe('TUI validator args', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('[validate-tui] usage:');
     expect(result.stdout).toContain('Available scenarios:');
+    expect(result.stderr).toBe('');
+  });
+
+  it('prints scenario names without building the harness', () => {
+    const result = runValidator(['--list']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.split('\n')).toContain('transcript');
+    expect(result.stdout.split('\n')).toContain('nested-subagent-picker');
+    expect(result.stdout).not.toContain('Available scenarios:');
+    expect(result.stderr).not.toContain('building tui-harness bundle');
+  });
+
+  it('treats a leading package-manager separator as transparent for list', () => {
+    const result = runValidator(['--', '--list']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.split('\n')).toContain('transcript');
     expect(result.stderr).toBe('');
   });
 });


### PR DESCRIPTION
Closes #5056

## Summary
- add a documented `--list` option to `packages/cli/scripts/validate-tui.mjs`
- print one scenario name per line and exit before building the TUI harness
- cover direct and package-manager-separated invocations in CLI argument tests

## Dogfood / validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --list`
- `node packages/cli/scripts/validate-tui.mjs -- --list`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --list`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI test-tooling only: new early-exit flag and tests, no runtime product or security paths.
> 
> **Overview**
> Adds a **`--list`** flag to `validate-tui.mjs` so you can discover scenario names without running the full validator. Help documents the option; listing prints **one scenario name per line** and exits **before** the TUI harness bundle build (same early-exit pattern as `--help`).
> 
> Argument parsing also accepts **`-- --list`** when pnpm forwards a leading separator. Vitest coverage asserts list output, no harness build on stderr, and transparent `--` for both help and list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8417b00eee4b86da9357130603bae66e4b571845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->