### PR TITLE
fix(cli): show remote agents

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { getAgent, getVisibleAgents, loadAgents } from '@agent/index';
+import { getVisibleAgents, loadAgents } from '@agent/index';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
@@ -11,6 +11,7 @@ import { writeTextStderr } from '../runtime/logSinks';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
+import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
 import { agentsRunCommand } from './agentsRun';
 import type { CliContext } from '../runtime/cliContext';
 
@@ -68,11 +69,14 @@ function formatAgentDetails(entry: AgentEntry): string {
   return lines.join('\n');
 }
 
-async function showAgent(context: CliContext, name: string): Promise<number> {
+export async function showAgent(
+  context: CliContext,
+  name: string,
+): Promise<number> {
   await initLocalCliPlatform(context);
   await loadAgents({ includeRemote: false });
 
-  const entry = getAgent(name);
+  const entry = await resolveAgentWithRemoteFallback(name);
   if (!entry) {
     writeTextStderr(`Agent not found: ${name}`);
     return CliExitCode.Usage;

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const mocks = vi.hoisted(() => ({
+  emitCliResult: vi.fn(),
+  initLocalCliPlatform: vi.fn(),
+  loadAgents: vi.fn(),
+  resolveAgentWithRemoteFallback: vi.fn(),
+  writeTextStderr: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  getVisibleAgents: vi.fn(() => []),
+  loadAgents: mocks.loadAgents,
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initLocalCliPlatform: mocks.initLocalCliPlatform,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeTextStderr: mocks.writeTextStderr,
+}));
+
+vi.mock('@cli/commands/_helpers/output', () => ({
+  emitCliResult: mocks.emitCliResult,
+}));
+
+vi.mock('@cli/commands/_helpers/remoteAgents', () => ({
+  resolveAgentWithRemoteFallback: mocks.resolveAgentWithRemoteFallback,
+}));
+
+function cliContext(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/project',
+    mode: 'headless',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    quietLogs: false,
+    renderRunProgress: true,
+    stderrIsTty: false,
+    stdoutColorEnabled: false,
+    stderrColorEnabled: false,
+    colorEnabled: false,
+    version: '0.0.0',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+describe('CLI agents command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the remote fallback resolver for agent details', async () => {
+    const remoteAgent = {
+      name: 'orchestrator',
+      source: 'remote',
+      path: '',
+      category: AgentCategory.ToolUse,
+      description: 'Coordinates multi-agent work.',
+      tools: ['delegate_agent', 'delegate_workflow'],
+      visibility: ['public'],
+    };
+    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
+    const { showAgent } = await import('@cli/commands/agents');
+
+    const exitCode = await showAgent(cliContext(), 'orchestrator');
+
+    expect(exitCode).toBe(0);
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledTimes(1);
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith(
+      'orchestrator',
+    );
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
+      json: remoteAgent,
+      ndjson: { kind: 'agent', agent: remoteAgent },
+      text: expect.stringContaining('source: remote'),
+    });
+  });
+
+  it('reports missing agents after the remote fallback is exhausted', async () => {
+    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(undefined);
+    const { showAgent } = await import('@cli/commands/agents');
+
+    const exitCode = await showAgent(cliContext(), 'missing-agent');
+
+    expect(exitCode).toBe(2);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Agent not found: missing-agent',
+    );
+    expect(mocks.emitCliResult).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #5058

## Summary
- make `texra agents show <name>` use the existing remote fallback resolver after the fast local agent load
- keep `agents list` local-only so shell completion and quick listings do not gain new remote/network behavior
- add focused command tests for remote agent details and missing-agent reporting

## Dogfood / validation
- `node packages/cli/dist/bin/texra.js --output-format json multi-agent inspect mathematician` showed `rootAgent.name = orchestrator`, `source = remote`
- before the fix: `node packages/cli/dist/bin/texra.js agents show orchestrator --output-format json` returned `Agent not found: orchestrator`
- after the fix and CLI rebuild: `node packages/cli/dist/bin/texra.js agents show orchestrator --output-format json --color=false` returns the remote orchestrator details
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run format`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI lookup change reusing an existing resolver already used by `agents run`; list behavior unchanged; tests added.
> 
> **Overview**
> **`texra agents show`** now resolves agents through **`resolveAgentWithRemoteFallback`**, so names that only exist remotely (e.g. after multi-agent inspect) can be shown instead of always failing with “Agent not found.” It still does a fast **`loadAgents({ includeRemote: false })`** first, then the shared helper may reload with remotes when needed.
> 
> **`agents list`** is unchanged: local-only load, so listings and completion stay offline-first.
> 
> **`showAgent`** is exported for tests; new Vitest coverage checks successful remote detail output and missing-agent exit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9099312639bdde05c5c5dc6f34df6d4a50c2e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->