### PR TITLE
fix(cli): filter workflow approval tools

### DIFF
--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -94,7 +94,9 @@ export class ModelInvocationNode<
         systemPrompt: prepRes.systemPrompt,
         endTag: this._config.getEndTag?.(services),
         signal,
-        tools: this._config.getTools?.(services) ?? services.setting.tools,
+        tools: this._config.getTools
+          ? this._config.getTools(services)
+          : services.setting.tools,
       });
 
       return {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -20,8 +20,10 @@ import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';
 import { K_SLICE } from '@agent/core/constants';
 import { bestConnectionMethod } from '@latex';
+import type { ToolDefinition } from '@model';
 import replacementEngine from '@replacement/engine';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
+import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getSystemPromptWithRules } from '@utils/prompt';
 import { extractScratchpad } from '@utils/text/xmlUtils';
@@ -190,6 +192,23 @@ type ContinuationNodeResult = SkippableNodeResult<{
   shouldStop: boolean;
   shouldContinue: boolean;
 }>;
+
+export function responseCycleToolsForModel<C>(
+  services: Pick<
+    ResponseCycleServices<C>,
+    'approvalPromptsUnavailable' | 'modelHandler' | 'setting'
+  >,
+): ToolDefinition[] | undefined {
+  if (!services.modelHandler.capabilities.supportsFunctionCalling) {
+    return undefined;
+  }
+  if (services.approvalPromptsUnavailable !== true) {
+    return services.setting.tools;
+  }
+  return services.setting.tools.filter(
+    (tool) => !isApprovalGatedToolName(tool.name),
+  );
+}
 
 /**
  * Transforms the raw model response into output-ready text, updates usage metrics,
@@ -580,10 +599,7 @@ export function createResponseCycleFlow<C>(): Flow<
     backgroundModeAware: true,
     getSystemPrompt: (shared) => shared.systemPrompt,
     getEndTag: (services) => services.setting.endTag,
-    getTools: (services) =>
-      services.modelHandler.capabilities.supportsFunctionCalling
-        ? services.setting.tools
-        : undefined,
+    getTools: responseCycleToolsForModel,
     storeResponse: (shared, response) => {
       shared.responseObject = response;
     },

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -46,6 +46,8 @@ export interface AgentCore<C = unknown> {
    * max-depth setting without carrying a second depth value.
    */
   delegationConfig?: NestedDelegationConfig;
+  /** Whether approval or user prompts cannot be answered by the current host. */
+  approvalPromptsUnavailable?: boolean;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
+import { responseCycleToolsForModel } from '@agent/core/flows/ResponseCycleFlow';
+
+function toolNames(tools: readonly { name: string }[] | undefined): string[] {
+  return tools?.map((tool) => tool.name) ?? [];
+}
+
+function responseServices({
+  approvalPromptsUnavailable,
+  supportsFunctionCalling = true,
+}: {
+  approvalPromptsUnavailable?: boolean;
+  supportsFunctionCalling?: boolean;
+}) {
+  return {
+    approvalPromptsUnavailable,
+    modelHandler: {
+      capabilities: { supportsFunctionCalling },
+    },
+    setting: {
+      tools: [
+        { name: 'bash' },
+        { name: 'grep' },
+        { name: 'write_file' },
+        { name: 'wolfram' },
+      ],
+    },
+  };
+}
+
+describe('response cycle tool visibility', () => {
+  it('filters approval-gated workflow tools when prompts are unavailable', () => {
+    const tools = responseCycleToolsForModel(
+      responseServices({
+        approvalPromptsUnavailable: true,
+      }) as any,
+    );
+
+    expect(toolNames(tools)).toEqual(['grep', 'wolfram']);
+  });
+
+  it('keeps workflow tools when approval prompts are available', () => {
+    const tools = responseCycleToolsForModel(
+      responseServices({
+        approvalPromptsUnavailable: false,
+      }) as any,
+    );
+
+    expect(toolNames(tools)).toEqual(['bash', 'grep', 'write_file', 'wolfram']);
+  });
+
+  it('omits workflow tools when the model handler cannot call functions', () => {
+    const tools = responseCycleToolsForModel(
+      responseServices({
+        supportsFunctionCalling: false,
+      }) as any,
+    );
+
+    expect(tools).toBeUndefined();
+  });
+
+  it('honors an explicit getTools result even when it is undefined', async () => {
+    const createResponse = vi.fn().mockResolvedValue({
+      response: { text: 'ok' },
+      updatedMessages: [],
+    });
+    const node = new ModelInvocationNode({
+      operationName: 'test invocation',
+      streaming: false,
+      getTools: () => undefined,
+      storeResponse: (shared, response) => {
+        (shared as { responseObject?: unknown }).responseObject = response;
+      },
+    });
+    node.setServices({
+      client: {},
+      config: {},
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      modelHandler: {
+        createResponse,
+        isBackgroundModeActive: () => false,
+        setOutputStreaming: vi.fn(),
+      },
+      runtimeHost: { emit: vi.fn() },
+      setAbortController: vi.fn(),
+      setting: {
+        temperature: 0,
+        tools: [{ name: 'bash' }],
+      },
+      streamId: 'stream-1',
+    } as any);
+
+    await node.run({
+      messages: [],
+      shouldStop: false,
+    } as any);
+
+    expect(createResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: undefined }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #5060

## Summary
- thread the CLI approval-unavailable flag into response-cycle services
- filter approval-gated workflow tools before model invocation when prompts cannot be answered
- preserve the existing no-function-calling behavior by allowing response cycles to pass `tools: undefined` explicitly

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run typecheck`
- `npm run format`
- `npm run lint` (passes with 10 pre-existing import-order warnings outside this patch)
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli run build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools the model sees during response cycles in no-approval environments; incorrect filtering could hide needed tools or leave risky ones exposed.
> 
> **Overview**
> Response-cycle model invocations now build the tool list through **`responseCycleToolsForModel`**, which drops **approval-gated** tools when `approvalPromptsUnavailable` is set on flow services (e.g. headless CLI / no-approval runs) while leaving the full tool set when prompts can be answered. Models that do not support function calling still get **`tools: undefined`**.
> 
> **`ModelInvocationNode`** no longer treats a missing `getTools` the same as an explicit resolver: if `getTools` is provided, its return value—including `undefined`—is passed through; otherwise default settings tools are used.
> 
> **`AgentCore`** documents the new optional **`approvalPromptsUnavailable`** flag; tests cover filtering, full tools, no function calling, and explicit `undefined` tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5027f2e1bcb65db72e8732e7688697e05c2b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->