### PR TITLE
fix(cli): clarify multi-agent fallback

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -9,6 +9,8 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
+import { agentKey } from '@shared/schemas/agent';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
@@ -117,6 +119,37 @@ export function writeMissingPresetAgents(
   if (missing.length === 0) return;
   writeTextStderr(
     `WARN preset ${plan.preset.id} references unavailable agents: ${missing.join(', ')}`,
+  );
+  if (!plan.rootAgent) return;
+
+  const availableTeamAgents = new Set([
+    ...plan.workflowAgentKeys,
+    ...plan.toolUseAgentKeys,
+  ]);
+  availableTeamAgents.delete(
+    agentKey(plan.rootAgent.source, plan.rootAgent.name),
+  );
+  const rootCanDelegate =
+    plan.rootAgent.tools?.some((tool) => DELEGATION_TOOLS.has(tool)) ?? false;
+  if (!rootCanDelegate) {
+    writeTextStderr(
+      `WARN team delegation unavailable for preset ${plan.preset.id}; running only root agent ${plan.rootAgent.name}. Enable a delegating team root or pass --agent to choose one.`,
+    );
+    return;
+  }
+  if (availableTeamAgents.size === 0) {
+    writeTextStderr(
+      `WARN preset ${plan.preset.id} is missing team agents; running delegating root agent ${plan.rootAgent.name}.`,
+    );
+    return;
+  }
+
+  const availableText =
+    availableTeamAgents.size === 1
+      ? '1 available team agent'
+      : `${availableTeamAgents.size} available team agents`;
+  writeTextStderr(
+    `WARN preset ${plan.preset.id} is degraded; running root agent ${plan.rootAgent.name} with ${availableText}.`,
   );
 }
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     installCliApprovalHandlers: vi.fn(),
     isAuthenticated: vi.fn(),
     loadAgents: vi.fn(),
+    planCliMultiAgentPresetRun: vi.fn(),
     stdinInputFile,
     writeTextStderr: vi.fn(),
     writeTextStdout: vi.fn(),
@@ -65,24 +66,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => ({
   formatCliMultiAgentPresetDetails: vi.fn(() => ''),
   formatCliMultiAgentPresetInspection: vi.fn(() => ''),
   formatCliMultiAgentPresetList: vi.fn(() => ''),
-  planCliMultiAgentPresetRun: vi.fn(() => ({
-    preset: {
-      id: 'mathematician',
-      name: 'Mathematician',
-      source: 'built-in',
-    },
-    rootAgent: {
-      name: 'orchestrator',
-      category: 'toolUse',
-      source: 'builtInToolUse',
-      path: '/agents/orchestrator.yaml',
-      tools: ['delegate_agent'],
-    },
-    missingWorkflowAgents: [],
-    missingToolUseAgents: [],
-    workflowAgentKeys: [],
-    toolUseAgentKeys: ['builtInToolUse:orchestrator'],
-  })),
+  planCliMultiAgentPresetRun: mocks.planCliMultiAgentPresetRun,
   readCliMultiAgentPresets: vi.fn(() => []),
   withCliMultiAgentPresetVisibility: vi.fn(
     (_plan: unknown, run: () => Promise<unknown>) => run(),
@@ -146,6 +130,24 @@ describe('CLI multi-agent run command', () => {
         tools: ['delegate_agent'],
       },
     ]);
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'orchestrator',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/orchestrator.yaml',
+        tools: ['delegate_agent'],
+      },
+      missingWorkflowAgents: [],
+      missingToolUseAgents: [],
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['builtInToolUse:orchestrator'],
+    });
     mocks.isAuthenticated.mockResolvedValue(false);
     mocks.executeCliRequest.mockResolvedValue({
       result: {
@@ -234,5 +236,116 @@ describe('CLI multi-agent run command', () => {
       }),
     ).rejects.toThrow(/Provide --input or --instruction/);
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+  });
+
+  it('makes signed-out preset fallback to one root agent explicit', async () => {
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'lean',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/lean.yaml',
+        tools: [],
+      },
+      missingWorkflowAgents: ['generic', 'devise', 'apply'],
+      missingToolUseAgents: ['simplifier', 'progressCheck', 'orchestrator'],
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['builtInToolUse:lean'],
+    });
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Solve a short math problem.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN preset mathematician references unavailable agents: workflow:generic, workflow:devise, workflow:apply, tool-use:simplifier, tool-use:progressCheck, tool-use:orchestrator',
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN team delegation unavailable for preset mathematician; running only root agent lean. Enable a delegating team root or pass --agent to choose one.',
+    );
+  });
+
+  it('keeps degraded-team wording when the root can delegate', async () => {
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'orchestrator',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/orchestrator.yaml',
+        tools: ['delegate_agent'],
+      },
+      missingWorkflowAgents: ['generic'],
+      missingToolUseAgents: ['simplifier'],
+      workflowAgentKeys: ['builtIn:devise'],
+      toolUseAgentKeys: ['builtInToolUse:orchestrator'],
+    });
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Solve a short math problem.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN preset mathematician is degraded; running root agent orchestrator with 1 available team agent.',
+    );
+  });
+
+  it('does not show non-delegating fallback text for a delegating root', async () => {
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'orchestrator',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/orchestrator.yaml',
+        tools: ['delegate_agent'],
+      },
+      missingWorkflowAgents: ['generic'],
+      missingToolUseAgents: ['simplifier'],
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['builtInToolUse:orchestrator'],
+    });
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Solve a short math problem.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN preset mathematician is missing team agents; running delegating root agent orchestrator.',
+    );
+    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
+      expect.stringContaining('Enable a delegating team root'),
+    );
   });
 });


### PR DESCRIPTION
Closes #5062

## Summary
- keep the existing missing-agent warning for team presets
- add an explicit degradation notice when a preset runs only the fallback root agent
- cover the signed-out `mathematician` fallback case from CLI dogfooding

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run format`
- `npm run lint` (passes with 10 pre-existing import-order warnings outside this patch)
- `npm run compile:fast`
- `git diff --check`
- after rebase onto `origin/main`, reran `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning text only; no change to execution or auth logic.
> 
> **Overview**
> Extends **`writeMissingPresetAgents`** so that after the existing “unavailable agents” warning, the CLI explains how a degraded preset will actually run.
> 
> When agents are missing but a root is still chosen, it now distinguishes: a **non-delegating** root (warns that only that agent runs and suggests `--agent` or a delegating root), a **delegating root with no other team agents**, and a **partial team** (counts remaining workflow/tool-use agents and reports a “degraded” run). Tests mock `planCliMultiAgentPresetRun` and cover signed-out fallback, partial teams, and delegating roots without the non-delegation hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4e9ac4d88161bbdaf692ca04b96fbab55ab0ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->