### PR TITLE
fix(agent): tolerate missing files when building prompt context

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -17,7 +17,7 @@ import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import {
   getListOfFiles,
   getPromptFileName,
-  getXmlFormatFromFiles,
+  getXmlFormatFromReadableFiles,
 } from '@utils/prompt';
 import {
   listExternalRoots,
@@ -238,6 +238,7 @@ async function getFileVars(
   const userVars: UserVars = {};
 
   const contextFiles = getCategoryFiles(agentConfig, 'REFERENCE');
+  const readableFilesByPrefix: Record<string, string[]> = {};
 
   // Log file categories being loaded (skip for tool-use agents).
   // Media files are excluded: they have no user vars (display-only in Init)
@@ -251,28 +252,38 @@ async function getFileVars(
 
   for (const prefix of FILE_VAR_CATEGORIES) {
     const allFiles = getCategoryFiles(agentConfig, prefix);
-    const primaryFile = allFiles[0];
+    const fileContent =
+      allFiles.length > 0
+        ? await getXmlFormatFromReadableFiles(allFiles)
+        : { xml: null, readableFiles: [] };
+    const readableFiles = fileContent.readableFiles;
+    readableFilesByPrefix[prefix] = readableFiles;
+    const primaryFile = readableFiles[0];
 
     // Aliases for custom YAMLs that still reference INPUT_FILE / INPUT_CONTENT.
     if (primaryFile) {
-      await setVarFromFile(primaryFile, prefix, userVars);
+      const loaded = await setVarFromFile(primaryFile, prefix, userVars);
+      if (!loaded) {
+        userVars[`${prefix}_FILE`] = null;
+        userVars[`${prefix}_CONTENT`] = null;
+      }
     } else {
       userVars[`${prefix}_FILE`] = null;
       userVars[`${prefix}_CONTENT`] = null;
     }
 
-    userVars[`ALL_${prefix}S`] =
-      allFiles.length > 0 ? await getXmlFormatFromFiles(allFiles) : null;
-    userVars[`${prefix}_FILES`] = allFiles.map((file) =>
+    userVars[`ALL_${prefix}S`] = fileContent.xml;
+    userVars[`${prefix}_FILES`] = readableFiles.map((file) =>
       getPromptFileName(file),
     );
-    userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles);
+    userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(readableFiles);
   }
 
   // ALL_CONTEXTS is the unified template var; the legacy ALL_REFERENCES
   // alias keeps populating it for back-compat with custom YAMLs.
+  const readableContextFiles = readableFilesByPrefix.REFERENCE ?? [];
   userVars.ALL_CONTEXTS = userVars.ALL_REFERENCES as string | null;
-  userVars.LIST_OF_ALL_CONTEXTS = getListOfFiles(contextFiles);
+  userVars.LIST_OF_ALL_CONTEXTS = getListOfFiles(readableContextFiles);
   userVars.CONTEXT_FILE = userVars.REFERENCE_FILE;
   userVars.CONTEXT_CONTENT = userVars.REFERENCE_CONTENT;
   userVars.ALL_AUXILIARYS = userVars.ALL_CONTEXTS;

--- a/src/test-kernel/agent/UserVarsMissingFiles.vitest.mts
+++ b/src/test-kernel/agent/UserVarsMissingFiles.vitest.mts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+
+import { noopTrace } from '@agent/trace';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  AgentCategory,
+  AgentPromptSchema,
+  AgentWorkflowSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
+import { buildUserVars } from '@agent/utils/userVars';
+
+const providerFlags = {
+  isOpenai: false,
+  isAnthropic: false,
+  isGoogle: false,
+};
+
+describe('buildUserVars with missing configured files', () => {
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+
+    initPlatform(
+      createFakePlatform({
+        workspacePath: '/workspace',
+        files: {
+          '/workspace/present.tex': 'present input',
+          '/workspace/context.tex': 'present context',
+        },
+      }),
+    );
+  });
+
+  it('keeps prompt file metadata in sync with readable prompt XML', async () => {
+    const agentConfig = AgentConfigSchema.parse({
+      agent: 'generic',
+      model: 'test-model',
+      inputFiles: ['missing.tex', 'present.tex'],
+      contextFiles: ['missing-context.tex', 'context.tex'],
+    });
+    const agentSetting = AgentWorkflowSettingSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+    });
+    const agentPrompt = AgentPromptSchema.parse({});
+
+    const vars = await buildUserVars(
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      '/agents/generic',
+      providerFlags,
+      noopTrace,
+      '/workspace',
+    );
+
+    expect(vars.ALL_INPUTS).toBe(
+      '<document name="present.tex">\npresent input\n</document>',
+    );
+    expect(vars.INPUT_FILES).toEqual(['present.tex']);
+    expect(vars.LIST_OF_ALL_INPUTS).toBe('present.tex');
+    expect(vars.INPUT_FILE).toBe('present.tex');
+    expect(vars.INPUT_CONTENT).toBe('present input');
+
+    expect(vars.ALL_CONTEXTS).toBe(
+      '<document name="context.tex">\npresent context\n</document>',
+    );
+    expect(vars.REFERENCE_FILES).toEqual(['context.tex']);
+    expect(vars.LIST_OF_ALL_REFERENCES).toBe('context.tex');
+    expect(vars.LIST_OF_ALL_CONTEXTS).toBe('context.tex');
+    expect(vars.CONTEXT_FILE).toBe('context.tex');
+    expect(vars.CONTEXT_CONTENT).toBe('present context');
+  });
+});

--- a/src/test-kernel/utils/GetXmlFormatFromFiles.vitest.ts
+++ b/src/test-kernel/utils/GetXmlFormatFromFiles.vitest.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(),
+}));
+
+vi.mock('@utils/files', async () => {
+  const actual =
+    await vi.importActual<typeof import('@utils/files')>('@utils/files');
+  return {
+    ...actual,
+    WorkspaceFS: {
+      ...actual.WorkspaceFS,
+      read: mocks.read,
+      // getPromptFileName falls back to the basename when locatePath throws,
+      // which keeps these assertions independent of host workspace state.
+      locatePath: () => {
+        throw new Error('no workspace in test');
+      },
+    },
+  };
+});
+
+// Imported after vi.mock so the mocked WorkspaceFS is in place.
+// eslint-disable-next-line import/order
+import { getXmlFormatFromFiles } from '@utils/prompt';
+
+beforeEach(() => {
+  mocks.read.mockReset();
+});
+
+describe('getXmlFormatFromFiles', () => {
+  it('returns null when given no files', async () => {
+    expect(await getXmlFormatFromFiles([])).toBeNull();
+  });
+
+  it('wraps every readable file in a <document> block', async () => {
+    mocks.read.mockImplementation(async (file: string) => `body of ${file}`);
+
+    const xml = await getXmlFormatFromFiles(['a.tex', 'b.tex']);
+
+    expect(xml).toBe(
+      '<document name="a.tex">\nbody of a.tex\n</document>\n' +
+        '<document name="b.tex">\nbody of b.tex\n</document>',
+    );
+  });
+
+  it('skips a file that cannot be read instead of rejecting the batch', async () => {
+    mocks.read.mockImplementation(async (file: string) => {
+      if (file === 'missing.tex') {
+        throw new Error("ENOENT: no such file or directory, open 'missing.tex'");
+      }
+      return `body of ${file}`;
+    });
+
+    const xml = await getXmlFormatFromFiles(['missing.tex', 'present.tex']);
+
+    expect(xml).toBe('<document name="present.tex">\nbody of present.tex\n</document>');
+  });
+
+  it('returns null when none of the files are readable', async () => {
+    mocks.read.mockRejectedValue(new Error('ENOENT'));
+
+    expect(await getXmlFormatFromFiles(['gone-1.tex', 'gone-2.tex'])).toBeNull();
+  });
+});

--- a/src/test-kernel/utils/GetXmlFormatFromFiles.vitest.ts
+++ b/src/test-kernel/utils/GetXmlFormatFromFiles.vitest.ts
@@ -21,9 +21,10 @@ vi.mock('@utils/files', async () => {
   };
 });
 
-// Imported after vi.mock so the mocked WorkspaceFS is in place.
-// eslint-disable-next-line import/order
-import { getXmlFormatFromFiles } from '@utils/prompt';
+import {
+  getXmlFormatFromFiles,
+  getXmlFormatFromReadableFiles,
+} from '@utils/prompt';
 
 beforeEach(() => {
   mocks.read.mockReset();
@@ -48,19 +49,46 @@ describe('getXmlFormatFromFiles', () => {
   it('skips a file that cannot be read instead of rejecting the batch', async () => {
     mocks.read.mockImplementation(async (file: string) => {
       if (file === 'missing.tex') {
-        throw new Error("ENOENT: no such file or directory, open 'missing.tex'");
+        throw new Error(
+          "ENOENT: no such file or directory, open 'missing.tex'",
+        );
       }
       return `body of ${file}`;
     });
 
     const xml = await getXmlFormatFromFiles(['missing.tex', 'present.tex']);
 
-    expect(xml).toBe('<document name="present.tex">\nbody of present.tex\n</document>');
+    expect(xml).toBe(
+      '<document name="present.tex">\nbody of present.tex\n</document>',
+    );
+  });
+
+  it('reports the same readable file set used to build XML', async () => {
+    mocks.read.mockImplementation(async (file: string) => {
+      if (file === 'missing.tex') {
+        throw new Error(
+          "ENOENT: no such file or directory, open 'missing.tex'",
+        );
+      }
+      return `body of ${file}`;
+    });
+
+    const result = await getXmlFormatFromReadableFiles([
+      'missing.tex',
+      'present.tex',
+    ]);
+
+    expect(result).toEqual({
+      xml: '<document name="present.tex">\nbody of present.tex\n</document>',
+      readableFiles: ['present.tex'],
+    });
   });
 
   it('returns null when none of the files are readable', async () => {
     mocks.read.mockRejectedValue(new Error('ENOENT'));
 
-    expect(await getXmlFormatFromFiles(['gone-1.tex', 'gone-2.tex'])).toBeNull();
+    expect(
+      await getXmlFormatFromFiles(['gone-1.tex', 'gone-2.tex']),
+    ).toBeNull();
   });
 });

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -35,8 +35,15 @@ export function getPromptFileName(file: string): string {
 
 /**
  * Get XML formatted string from multiple files
+ *
+ * Best-effort: a file that cannot be read (moved, renamed, or deleted since the
+ * config was saved) is skipped with a warning rather than rejecting the whole
+ * batch. This mirrors {@link setVarFromFile}, which already tolerates missing
+ * files, and keeps prompt-var assembly from hard-failing an agent launch/resume
+ * when an input no longer exists on disk.
+ *
  * @param files List of file paths
- * @returns XML formatted string containing all file contents, or null if no files
+ * @returns XML formatted string of the readable files, or null if none are readable
  */
 export async function getXmlFormatFromFiles(
   files: string[],
@@ -47,11 +54,20 @@ export async function getXmlFormatFromFiles(
 
   const xmlContents = await Promise.all(
     files.map(async (file) => {
-      const content = await WorkspaceFS.read(file);
-      return `<document name="${getPromptFileName(file)}">\n${content}\n</document>`;
+      try {
+        const content = await WorkspaceFS.read(file);
+        return `<document name="${getPromptFileName(file)}">\n${content}\n</document>`;
+      } catch (err) {
+        logger.warn(
+          CHANNEL,
+          `Skipping unreadable file in prompt context: ${file} (${String(err)})`,
+        );
+        return null;
+      }
     }),
   );
-  return xmlContents.join('\n');
+  const readable = xmlContents.filter((doc): doc is string => doc !== null);
+  return readable.length > 0 ? readable.join('\n') : null;
 }
 
 /**

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -8,6 +8,11 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'promptUtils';
 logger.initialize(CHANNEL);
 
+export interface XmlFormatFromFilesResult {
+  readonly xml: string | null;
+  readonly readableFiles: string[];
+}
+
 /**
  * File name exposed to prompt XML and workflow output instructions.
  *
@@ -45,18 +50,21 @@ export function getPromptFileName(file: string): string {
  * @param files List of file paths
  * @returns XML formatted string of the readable files, or null if none are readable
  */
-export async function getXmlFormatFromFiles(
+export async function getXmlFormatFromReadableFiles(
   files: string[],
-): Promise<string | null> {
+): Promise<XmlFormatFromFilesResult> {
   if (files.length === 0) {
-    return null;
+    return { xml: null, readableFiles: [] };
   }
 
   const xmlContents = await Promise.all(
     files.map(async (file) => {
       try {
         const content = await WorkspaceFS.read(file);
-        return `<document name="${getPromptFileName(file)}">\n${content}\n</document>`;
+        return {
+          file,
+          xml: `<document name="${getPromptFileName(file)}">\n${content}\n</document>`,
+        };
       } catch (err) {
         logger.warn(
           CHANNEL,
@@ -66,8 +74,19 @@ export async function getXmlFormatFromFiles(
       }
     }),
   );
-  const readable = xmlContents.filter((doc): doc is string => doc !== null);
-  return readable.length > 0 ? readable.join('\n') : null;
+  const readable = xmlContents.filter(
+    (doc): doc is { file: string; xml: string } => doc !== null,
+  );
+  return {
+    xml: readable.length > 0 ? readable.map((doc) => doc.xml).join('\n') : null,
+    readableFiles: readable.map((doc) => doc.file),
+  };
+}
+
+export async function getXmlFormatFromFiles(
+  files: string[],
+): Promise<string | null> {
+  return (await getXmlFormatFromReadableFiles(files)).xml;
 }
 
 /**


### PR DESCRIPTION
## Problem

Resuming (or starting) an agent whose input file had been renamed/moved/deleted since the run was configured failed hard with:

\`\`\`
Failed to start agent remote:orchestrator: Error: ENOENT: no such file or directory, open '.../dyadic_lifts.tex'
\`\`\`

Root cause: prompt-var assembly reads every configured file off disk via two sibling functions that behaved **inconsistently**:

- \`setVarFromFile\` (primary \`INPUT_CONTENT\`) — try/catch, tolerated a missing file (null content).
- \`getXmlFormatFromFiles\` (\`ALL_INPUTS\` / \`ALL_REFERENCES\` / \`ALL_EDITEDS\`) — bare \`WorkspaceFS.read\` inside \`Promise.all\`, **no error handling**. One missing file rejected the whole batch, propagating up through \`getFileVars → buildUserVars\` and aborting the launch.

On a *resume* this is especially wrong: the prior file content is already baked into the persisted conversation, so a since-moved input should never block the launch.

## Fix

Make \`getXmlFormatFromFiles\` best-effort, matching its sibling's contract:

- Guard each read individually; skip an unreadable file with a warning instead of rejecting the batch.
- Return \`null\` when none are readable — the same "no content" value the sole caller (\`userVars.ts:265\`) already handles.

## Verification

- \`npm run typecheck\` → exit 0 (incl. test-kernel project)
- New regression test \`src/test-kernel/utils/GetXmlFormatFromFiles.vitest.ts\` (empty / all-readable / skip-one-missing / all-missing→null) → 4 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted best-effort read behavior and user-var alignment for agent prompts; no auth, security, or persistence changes.
> 
> **Overview**
> **Prompt file assembly no longer aborts when configured paths are missing on disk.** `getXmlFormatFromReadableFiles` reads each path in a try/catch, logs a warning for failures, and returns both the combined `<document>` XML and the list of paths that actually loaded. `getXmlFormatFromFiles` is a thin wrapper that returns only the XML.
> 
> **`getFileVars` in `userVars.ts` now drives all INPUT/REFERENCE/EDITED template vars from that readable set**, so `ALL_*` XML, `*_FILES`, list vars, context aliases, and the primary `*_FILE` / `*_CONTENT` pair stay aligned when some configured files are gone (e.g. after rename on resume). If the primary file cannot be loaded, those single-file vars are explicitly nulled.
> 
> Regression tests cover the XML helper and an end-to-end `buildUserVars` case with mixed missing and present files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abde08419c2766c6ffa085f946a385bfc83cf11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->