### PR TITLE
fix(cli): cleanly exit idle chat on ctrl-c

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -69,6 +69,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import { App } from './App';
+import { assertNever } from './assertNever';
 import { AgentListForm } from './forms/AgentListForm';
 import { ApiModeForm } from './forms/ApiModeForm';
 import {
@@ -187,6 +188,23 @@ export function chatTuiCanStartRootRun(
   session: PendingTuiRunSessionState,
 ): boolean {
   return !session.runPromise || session.runCompleted;
+}
+
+export type ChatTuiSigintAction =
+  | 'clean-exit'
+  | 'force-exit'
+  | 'interrupt-and-exit'
+  | 'interrupt-and-arm-exit';
+
+export function chatTuiSigintAction(input: {
+  readonly exitArmed: boolean;
+  readonly canStopActiveRun: boolean;
+  readonly canInterruptActiveRun: boolean;
+}): ChatTuiSigintAction {
+  if (input.exitArmed) return 'force-exit';
+  if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
+  if (input.canInterruptActiveRun) return 'interrupt-and-exit';
+  return 'clean-exit';
 }
 
 function chatTuiActiveChildStreamId(): StreamTabId | undefined {
@@ -1167,21 +1185,35 @@ export async function runChat(
     pendingExitTimer = setTimeout(clearPendingExit, 800);
   };
   const handleSigint = (): void => {
-    if (exitArmed) {
-      exitNow(130);
-      return;
-    }
-    if (!canStopActiveRun()) {
-      if (canInterruptActiveRun()) {
+    const sigintAction = chatTuiSigintAction({
+      exitArmed,
+      canStopActiveRun: canStopActiveRun(),
+      canInterruptActiveRun: canInterruptActiveRun(),
+    });
+    switch (sigintAction) {
+      case 'clean-exit':
         session.stopRequested = true;
         interruptActive();
-      }
-      exitNow(130);
-      return;
+        requestInputExit();
+        return;
+      case 'force-exit':
+        exitNow(130);
+        return;
+      case 'interrupt-and-exit':
+        if (canInterruptActiveRun()) {
+          session.stopRequested = true;
+          interruptActive();
+        }
+        exitNow(130);
+        return;
+      case 'interrupt-and-arm-exit':
+        session.stopRequested = true;
+        interruptActive();
+        armExit();
+        return;
+      default:
+        assertNever(sigintAction, 'Unhandled chat TUI SIGINT action');
     }
-    session.stopRequested = true;
-    interruptActive();
-    armExit();
   };
   const handleSigterm = (): void => {
     session.stopRequested = true;

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -62,6 +62,7 @@ import {
   chatTuiCanStopActiveRun,
   chatTuiCanStopVisibleRun,
   chatTuiCanStartRootRun,
+  chatTuiSigintAction,
   chatTuiActiveChildFollowUpTarget,
   chatTuiRejectedChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
@@ -892,6 +893,40 @@ describe('CLI TUI row allocation', () => {
         STREAM_STATUS.WAITING,
       ),
     ).toBe(false);
+  });
+
+  it('resolves the TUI Ctrl-C action from armed, stoppable, and interruptible state', () => {
+    expect(
+      chatTuiSigintAction({
+        exitArmed: false,
+        canStopActiveRun: false,
+        canInterruptActiveRun: false,
+      }),
+    ).toBe('clean-exit');
+
+    expect(
+      chatTuiSigintAction({
+        exitArmed: false,
+        canStopActiveRun: false,
+        canInterruptActiveRun: true,
+      }),
+    ).toBe('interrupt-and-exit');
+
+    expect(
+      chatTuiSigintAction({
+        exitArmed: false,
+        canStopActiveRun: true,
+        canInterruptActiveRun: true,
+      }),
+    ).toBe('interrupt-and-arm-exit');
+
+    expect(
+      chatTuiSigintAction({
+        exitArmed: true,
+        canStopActiveRun: true,
+        canInterruptActiveRun: true,
+      }),
+    ).toBe('force-exit');
   });
 
   it('selects the focused child stream as a follow-up target', () => {


### PR DESCRIPTION
## Summary

Closes #5065.

- Split the chat TUI Ctrl-C decision into a small testable helper.
- Treat idle Ctrl-C as the same clean input-exit path used by `/exit`.
- Preserve interrupt status for active/armed Ctrl-C paths.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- Real PTY smoke: launched `texra chat`, waited for `[Ctrl-C]exit`, sent Ctrl-C, observed `{"exitCode":0,"signal":0}`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- ctrl-c-interrupt-active`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI signal-handling refactor with explicit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Refactors chat TUI **Ctrl-C** handling by introducing **`chatTuiSigintAction`**, a small pure helper that maps *exit armed*, *stoppable run*, and *interruptible run* into one of four actions. **`handleSigint`** now switches on that result instead of nested conditionals, with **`assertNever`** for exhaustiveness.
> 
> The behavioral fix is the **idle** path: when nothing is stoppable or interruptible, Ctrl-C follows **`clean-exit`**—stop request, **`interruptActive`**, then **`requestInputExit`** (Ink unmount, same as **`/exit`**)—instead of **`exitNow(130)`**, so the session can end with a normal exit code. **Active** runs still use **interrupt + arm** (second Ctrl-C forces exit **130**); **interruptible-only** runs still interrupt and exit **130**.
> 
> Unit tests in **`TuiStateAndFocus.vitest.mts`** cover all four resolved actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbe1165d072bb43d0a5ba00ef93bfed2effb0cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->