### PR TITLE
fix(cli): add chat auth slash commands

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -228,6 +228,14 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'Show TeXRA login status',
   });
   registerSlashCommand({
+    name: 'login',
+    description: 'Sign in to TeXRA included access',
+  });
+  registerSlashCommand({
+    name: 'logout',
+    description: 'Sign out of TeXRA',
+  });
+  registerSlashCommand({
     name: 'approval',
     description: 'Switch approval policy',
     formComponent: ApprovalPolicyFormAdapter,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -27,7 +27,10 @@ import {
   getToolUseFlowContext,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
+import { isOAuthProvider, type OAuthProvider } from '@auth/sharedConfig';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
+import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import {
   formatCliApiMode,
@@ -43,6 +46,10 @@ import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr } from '@cli/runtime/logSinks';
+import {
+  signInCliSupabase,
+  signOutCliSupabase,
+} from '@cli/runtime/supabaseAuth';
 import { dumbTerminalMessage } from '@cli/runtime/terminalRequirements';
 import {
   CLI_APPROVAL_POLICIES,
@@ -463,6 +470,111 @@ async function showCliAuthStatus(): Promise<void> {
   appendLocalAssistantTranscript((await loadCliApiStatusLines()).join('\n'));
 }
 
+export const CHAT_LOGIN_USAGE =
+  'Usage: /login [github | google] [--no-browser] [--select-account] [--login-hint <account>]';
+
+interface ChatLoginSlashArgs {
+  readonly provider: OAuthProvider;
+  readonly noBrowser: boolean;
+  readonly selectAccount: boolean;
+  readonly loginHint?: string;
+}
+
+export function parseChatLoginSlashArgs(
+  input: string,
+): ChatLoginSlashArgs | undefined {
+  const tokens = input.trim().split(/\s+/).filter(Boolean);
+  let provider: string = DEFAULT_OAUTH_PROVIDER;
+  let providerSet = false;
+  let noBrowser = false;
+  let selectAccount = false;
+  let loginHint: string | undefined;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--no-browser') {
+      noBrowser = true;
+      continue;
+    }
+    if (token === '--select-account') {
+      selectAccount = true;
+      continue;
+    }
+    if (token === '--login-hint') {
+      const next = tokens[index + 1];
+      if (!next || next.startsWith('--')) return undefined;
+      loginHint = next;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--login-hint=')) {
+      const value = token.slice('--login-hint='.length).trim();
+      if (!value || value.startsWith('--')) return undefined;
+      loginHint = value;
+      continue;
+    }
+    if (token.startsWith('--') || providerSet) return undefined;
+    provider = token;
+    providerSet = true;
+  }
+
+  if (!isOAuthProvider(provider)) return undefined;
+  return { provider, noBrowser, selectAccount, loginHint };
+}
+
+async function loginFromChat(input: string): Promise<void> {
+  const args = parseChatLoginSlashArgs(input);
+  if (!args) {
+    appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
+    return;
+  }
+
+  if (args.provider === 'github' && args.selectAccount && !args.loginHint) {
+    appendLocalAssistantTranscript(
+      'GitHub does not support --select-account by itself. Use --login-hint <username> to request a specific GitHub account.',
+    );
+  }
+  appendLocalAssistantTranscript(
+    args.noBrowser
+      ? `Starting TeXRA ${args.provider} sign-in.`
+      : `Opening browser for TeXRA ${args.provider} sign-in...`,
+  );
+
+  try {
+    const session = await signInCliSupabase({
+      provider: args.provider,
+      openBrowser: !args.noBrowser,
+      selectAccount: args.selectAccount,
+      loginHint: args.loginHint,
+      manualBrowserHint: '/login --no-browser',
+      onAuthUrl: (url) => {
+        if (args.noBrowser) {
+          appendLocalAssistantTranscript(`Open this URL to sign in:\n${url}`);
+        }
+      },
+    });
+    appendLocalAssistantTranscript(
+      [
+        `Signed in as ${formatCliAccountLabelForDisplay(session.account.label)}.`,
+        ...(await loadCliApiStatusLines()),
+      ].join('\n'),
+    );
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+  }
+}
+
+async function logoutFromChat(): Promise<void> {
+  try {
+    await signOutCliSupabase();
+    appendLocalAssistantTranscript(
+      ['Signed out.', ...(await loadCliApiStatusLines())].join('\n'),
+    );
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+  }
+}
+
 function parseApprovalPolicy(input: string): CliApprovalPolicy | undefined {
   const normalized = input.trim().toLowerCase();
   if ((CLI_APPROVAL_POLICIES as readonly string[]).includes(normalized)) {
@@ -608,7 +720,7 @@ async function handleTuiSlashCommand(
   // exit commands (the TUI is tearing down); /clear still echoes because
   // resetSessionForClear refuses while a run is active and surfaces an
   // error — without the echo the user wouldn't see what triggered it.
-  if (command !== 'exit' && command !== 'quit') {
+  if (command !== 'exit' && command !== 'quit' && command !== 'login') {
     appendLocalUserTranscript(line.trim());
   }
   switch (command) {
@@ -661,6 +773,12 @@ async function handleTuiSlashCommand(
       } catch (error: unknown) {
         appendLocalAssistantTranscript(toErrorMessage(error));
       }
+      return true;
+    case 'login':
+      await loginFromChat(rest);
+      return true;
+    case 'logout':
+      await logoutFromChat();
       return true;
     case 'approval':
       if (rest) {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -43,6 +43,7 @@ export const chatCommand = withUsageSections(
       rows: [
         ['/help', 'show slash commands inside chat'],
         ['/status', 'show session state'],
+        ['/login, /logout', 'sign in or out of included access'],
         ['Ctrl-T', 'open the transcript viewer'],
         ['Tab', 'cycle visible streams when subagents are active'],
         ['Esc p', 'open tasks and sub-workflows (Alt-p when configured)'],

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -838,6 +838,7 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('INTERACTIVE CONTROLS');
     expect(stdout).toContain('/help');
     expect(stdout).toContain('/status');
+    expect(stdout).toContain('/login, /logout');
     expect(stdout).toContain('Ctrl-T');
     expect(stdout).toContain('Tab');
     expect(stdout).toContain('cycle visible streams');

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -25,6 +25,8 @@ describe('slashRegistry', () => {
         'model',
         'api',
         'auth',
+        'login',
+        'logout',
         'approval',
         'yolo',
         'status',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -66,6 +66,7 @@ import {
   chatTuiActiveChildFollowUpTarget,
   chatTuiRejectedChildFollowUpTarget,
   chatTuiShouldAnnounceQueuedFollowUp,
+  parseChatLoginSlashArgs,
   clearTuiSessionRunState,
 } from '@cli/chat/tui/runChatTui';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -927,6 +928,45 @@ describe('CLI TUI row allocation', () => {
         canInterruptActiveRun: true,
       }),
     ).toBe('force-exit');
+  });
+
+  it('parses in-chat login slash command options', () => {
+    expect(parseChatLoginSlashArgs('')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: undefined,
+    });
+    expect(
+      parseChatLoginSlashArgs('google --no-browser --select-account'),
+    ).toEqual({
+      provider: 'google',
+      noBrowser: true,
+      selectAccount: true,
+      loginHint: undefined,
+    });
+    expect(parseChatLoginSlashArgs('--login-hint user@example.edu')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: 'user@example.edu',
+    });
+    expect(parseChatLoginSlashArgs('github --login-hint=octocat')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: 'octocat',
+    });
+  });
+
+  it('rejects invalid in-chat login slash command options', () => {
+    expect(parseChatLoginSlashArgs('slack')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('github google')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('--login-hint')).toBeUndefined();
+    expect(
+      parseChatLoginSlashArgs('--login-hint --no-browser'),
+    ).toBeUndefined();
+    expect(parseChatLoginSlashArgs('--unexpected')).toBeUndefined();
   });
 
   it('selects the focused child stream as a follow-up target', () => {


### PR DESCRIPTION
## Summary

- add `/login` and `/logout` to the `texra chat` slash command registry
- route `/login` through the existing TeXRA OAuth flow, including `--no-browser`, `--select-account`, and `--login-hint`
- route `/logout` through the existing CLI sign-out flow and refresh auth status in the transcript
- document `/login, /logout` in `texra chat --help`

Closes #5067.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`
- `node packages/cli/dist/bin/texra.js chat --help`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-auth-fix-scout-2 slash-palette`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session authentication via OAuth in the interactive chat path; behavior is delegated to existing `signInCliSupabase`/`signOutCliSupabase` with limited new surface area.
> 
> **Overview**
> Adds **`/login`** and **`/logout`** to interactive `texra chat` so users can manage TeXRA included access without leaving the TUI.
> 
> The slash palette registers both commands next to existing **`/auth`**. **`/login`** reuses the same OAuth path as `texra login` (GitHub/Google, `--no-browser`, `--select-account`, `--login-hint`), with progress, URLs, account label, and refreshed API status written to the chat transcript. **`/logout`** calls the existing CLI sign-out flow and appends status the same way. **`/login`** is excluded from the usual user-message echo (like exit) so OAuth output isn’t duplicated awkwardly.
> 
> **`texra chat --help`** documents `/login, /logout` under interactive controls; tests cover registry registration, argument parsing, and help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e60321a83f872cb464b88e3953269c39560e88e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->