### PR TITLE
fix(cli): honor negated login flags

### DIFF
--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -37,11 +37,41 @@ export function resolveLoginProvider(
   return DEFAULT_OAUTH_PROVIDER;
 }
 
-interface LoginInit {
+export interface LoginInit {
   readonly provider: string;
   readonly noBrowser: boolean;
   readonly selectAccount: boolean;
   readonly loginHint?: string;
+}
+
+type LoginCommandArgs = Record<string, unknown>;
+
+function readBooleanArg(
+  args: LoginCommandArgs,
+  hyphenKey: string,
+  camelKey: string,
+): boolean {
+  return args[hyphenKey] === true || args[camelKey] === true;
+}
+
+function readStringArg(
+  args: LoginCommandArgs,
+  hyphenKey: string,
+  camelKey: string,
+): string | undefined {
+  return optString(args[hyphenKey]) ?? optString(args[camelKey]);
+}
+
+export function loginInitFromArgs(args: LoginCommandArgs): LoginInit {
+  const positional = optString(args.providerArg);
+  const flag = optString(args.provider);
+  return {
+    provider: resolveLoginProvider(positional, flag),
+    noBrowser:
+      readBooleanArg(args, 'no-browser', 'noBrowser') || args.browser === false,
+    selectAccount: readBooleanArg(args, 'select-account', 'selectAccount'),
+    loginHint: readStringArg(args, 'login-hint', 'loginHint'),
+  };
 }
 
 async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
@@ -125,15 +155,7 @@ export const loginCommand = defineCliCommand({
     },
   },
   run: (context, ctx) => {
-    const positional = optString(ctx.args.providerArg);
-    const flag = optString(ctx.args.provider);
-    const provider = resolveLoginProvider(positional, flag);
-    return runLogin(context, {
-      provider,
-      noBrowser: ctx.args['no-browser'] === true,
-      selectAccount: ctx.args['select-account'] === true,
-      loginHint: optString(ctx.args['login-hint']),
-    });
+    return runLogin(context, loginInitFromArgs(ctx.args));
   },
 });
 

--- a/packages/cli/src/runtime/globalArgs.ts
+++ b/packages/cli/src/runtime/globalArgs.ts
@@ -23,6 +23,9 @@ export interface ParsedGlobalArgs {
   // when the user passes `--no-color`.
   readonly color?: boolean;
   readonly 'no-input'?: boolean;
+  // citty treats every `--no-*` token as a negated positive flag before it
+  // applies aliases, so `--no-input` can arrive as `input: false`.
+  readonly input?: unknown;
 }
 
 export function pickGlobalArgs(args: ParsedGlobalArgs): CliGlobalArgs {
@@ -35,9 +38,11 @@ export function pickGlobalArgs(args: ParsedGlobalArgs): CliGlobalArgs {
     apiMode: isNonEmptyString(args['api-mode'])
       ? args['api-mode'].trim()
       : undefined,
-    // `--no-input` is direct so it does not collide with command-specific
-    // `--input <file>` flags on run-style commands.
+    // `--no-input` is intentionally not registered as `input` so it does not
+    // become a leading global `--input <file>` flag. citty still parses the
+    // negative spelling as `input: false`, which is safe to recognize here
+    // because command-specific `--input <file>` arrives as a string/array.
     noColor: args.color === false,
-    noInput: args['no-input'] === true,
+    noInput: args['no-input'] === true || args.input === false,
   };
 }

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -683,11 +683,18 @@ describe('CLI root argument routing', () => {
 
 describe('CLI global color/input flags', () => {
   it('maps CLI color and no-input flags to canonical knobs', () => {
-    // `--no-input` is direct so it does not collide with the run commands'
-    // command-specific `--input <file>` flag.
     expect(pickGlobalArgs({ color: false, 'no-input': true })).toMatchObject({
       noColor: true,
       noInput: true,
+    });
+  });
+
+  it('maps citty negated input output to --no-input', () => {
+    expect(pickGlobalArgs({ input: false })).toMatchObject({
+      noInput: true,
+    });
+    expect(pickGlobalArgs({ input: 'file.tex' })).toMatchObject({
+      noInput: false,
     });
   });
 

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveLoginProvider } from '@cli/commands/auth';
+import { loginInitFromArgs, resolveLoginProvider } from '@cli/commands/auth';
 
 describe('CLI login arguments (texra login)', () => {
   it('defaults texra login to GitHub sign-in', () => {
@@ -13,5 +13,43 @@ describe('CLI login arguments (texra login)', () => {
 
   it('falls back to the positional argument when --provider is empty', () => {
     expect(resolveLoginProvider('google', undefined)).toBe('google');
+  });
+
+  it('reads login flags from hyphenated argument keys', () => {
+    expect(
+      loginInitFromArgs({
+        providerArg: 'github',
+        'no-browser': true,
+        'select-account': true,
+        'login-hint': 'octocat',
+      }),
+    ).toEqual({
+      provider: 'github',
+      noBrowser: true,
+      selectAccount: true,
+      loginHint: 'octocat',
+    });
+  });
+
+  it('reads login flags from camelCase argument keys', () => {
+    expect(
+      loginInitFromArgs({
+        provider: 'google',
+        noBrowser: true,
+        selectAccount: true,
+        loginHint: 'person@example.com',
+      }),
+    ).toEqual({
+      provider: 'google',
+      noBrowser: true,
+      selectAccount: true,
+      loginHint: 'person@example.com',
+    });
+  });
+
+  it('treats citty negated browser output as --no-browser', () => {
+    expect(loginInitFromArgs({ browser: false })).toMatchObject({
+      noBrowser: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- normalize `texra login` args so citty's `browser: false` output correctly honors `--no-browser`
- recognize citty's `input: false` output for global `--no-input` without treating `--input <file>` as no-input
- add regression coverage for the login and global flag parsing paths

Closes #5069

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint` (0 errors, 10 existing import-order warnings outside this patch)
- `git diff --check`
- live smoke: `texra login --no-browser` and `texra login --no-browser --no-input` both printed `Open this URL to sign in:` and did not emit `Opening browser for TeXRA`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI argument normalization with tests; no auth protocol or credential handling changes beyond correct flag interpretation.
> 
> **Overview**
> Fixes **CLI flag parsing** so **citty**’s negated boolean form (`browser: false`, `input: false`) is honored the same as explicit `--no-browser` and `--no-input`.
> 
> **`texra login`** now builds options via exported **`loginInitFromArgs`**, which accepts hyphenated and camelCase keys and sets **`noBrowser`** when **`browser === false`**, so manual sign-in URLs print instead of opening a browser.
> 
> **Global args** in **`pickGlobalArgs`** set **`noInput`** when **`input === false`** only; string **`input`** values (e.g. run **`--input file.tex`**) stay non–no-input. Comments document why global **`input`** is not registered as a positive flag.
> 
> Regression tests cover login and global mapping paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9beb15f1220e9dca18feefb68aab43b621f9f680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->