### PR TITLE
fix(cli): erase reflowed rows on terminal resize (shrink residue)

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -246,12 +246,14 @@ const SCENARIOS = [
     expect: [
       '/api',
       'Switch between included relay',
-      '/yolo',
-      'Approve privileged actions',
+      '/login',
+      'Sign in to TeXRA included access',
+      '/logout',
+      'Sign out of TeXRA',
     ],
     unexpect: [
       '/ap  Switch',
-      '/yol  Approve',
+      '/log  Sign',
       'personal API keys',
       'automatically',
     ],
@@ -461,7 +463,7 @@ const SCENARIOS = [
     keys: ['/', DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN, DOWN],
     frame: 'tail',
     expect: [
-      '… 6 earlier',
+      '… 8 earlier',
       '/status',
       'Show session details',
       '/exit',

--- a/patches/ink@7.0.5.patch
+++ b/patches/ink@7.0.5.patch
@@ -1,18 +1,94 @@
 diff --git a/build/ink.js b/build/ink.js
-index b8fd45cc990adbc080eff28fc37463cd91337dff..5640b6159be1e6ababac8a77fbc9dcd45d209ce7 100644
+index b8fd45cc9..3c8a9a99c 100644
 --- a/build/ink.js
 +++ b/build/ink.js
-@@ -261,8 +261,11 @@ export default class Ink {
+@@ -261,9 +261,14 @@ export default class Ink {
      }
      resized = () => {
          const currentWidth = getWindowSize(this.options.stdout).columns;
 -        if (currentWidth < this.lastTerminalWidth) {
 -            // We clear the screen when decreasing terminal width to prevent duplicate overlapping re-renders.
+-            this.log.clear();
 +        if (currentWidth !== this.lastTerminalWidth) {
-+            // Clear on ANY width change, not just a decrease. On widening, the
-+            // previously soft-wrapped output occupies more physical rows than the
-+            // new render, so without clearing first Ink redraws on top and leaves
-+            // the old tail behind as scrollback residue (TeXRA patch).
-             this.log.clear();
++            // Clear on ANY width change, not just a decrease. The emulator reflows
++            // the previous frame at the new width, so the logical line count no
++            // longer matches the physical rows on screen: on shrink a wide line
++            // wraps into extra rows that a logical-count eraseLines() leaves behind
++            // as residue. clearWidthAware() erases the actual physical row count at
++            // the new width, covering both widen and shrink (TeXRA patch).
++            this.log.clearWidthAware(currentWidth);
              this.lastOutput = '';
              this.lastOutputToRender = '';
+         }
+diff --git a/build/log-update.js b/build/log-update.js
+index cdb5fc41f..5b0eaee8b 100644
+--- a/build/log-update.js
++++ b/build/log-update.js
+@@ -1,6 +1,31 @@
+ import ansiEscapes from 'ansi-escapes';
+ import cliCursor from 'cli-cursor';
+ import { cursorPositionChanged, buildCursorSuffix, buildCursorOnlySequence, buildReturnToBottomPrefix, hideCursorEscape, } from './cursor-helpers.js';
++import stringWidth from 'string-width';
++
++// Count the PHYSICAL rows a rendered frame occupies when soft-wrapped at the
++// given terminal width. Each logical line contributes ceil(displayWidth/columns)
++// rows (at least 1). Used to clear correctly after a terminal RESIZE, where the
++// emulator reflows previously-wrapped lines and the logical line count no longer
++// matches what is on screen (TeXRA patch).
++const physicalLineCount = (str, columns) => {
++    if (!str) return 0;
++    const cols = columns > 0 ? columns : 1;
++    const lines = str.split('\n');
++    // Match log-update's `previousLineCount = lines.length` convention exactly so
++    // that, with no wrapping, this equals what the plain clear() erases. The
++    // trailing empty element from a final '\n' counts as one row; each visible
++    // line additionally contributes its soft-wrap overflow at `columns`.
++    const hasTrailingNewline = str.endsWith('\n');
++    const visible = hasTrailingNewline ? lines.length - 1 : lines.length;
++    let rows = hasTrailingNewline ? 1 : 0;
++    for (let i = 0; i < visible; i++) {
++        const w = stringWidth(lines[i]);
++        rows += w <= cols ? 1 : Math.ceil(w / cols);
++    }
++    return rows;
++};
++
+ // Count visible lines in a string, ignoring the trailing empty element
+ // that `split('\n')` produces when the string ends with '\n'.
+ const visibleLineCount = (lines, str) => str.endsWith('\n') ? lines.length - 1 : lines.length;
+@@ -63,6 +88,18 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
+     };
++    // Width-aware clear for terminal resizes: erase the physical rows the frame
++    // occupies after the emulator reflows it at `columns`, not just the logical
++    // line count (which under-erases on shrink and leaves residue). (TeXRA patch)
++    render.clearWidthAware = (columns) => {
++        const physical = physicalLineCount(previousOutput, columns);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
++        stream.write(prefix + ansiEscapes.eraseLines(physical));
++        previousOutput = '';
++        previousLineCount = 0;
++        previousCursorPosition = undefined;
++        cursorWasShown = false;
++    };
+     render.done = () => {
+         previousOutput = '';
+         previousLineCount = 0;
+@@ -204,6 +241,16 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
+     };
++    // Width-aware clear for terminal resizes (see createStandard). (TeXRA patch)
++    render.clearWidthAware = (columns) => {
++        const physical = physicalLineCount(previousOutput, columns);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
++        stream.write(prefix + ansiEscapes.eraseLines(physical));
++        previousOutput = '';
++        previousLines = [];
++        previousCursorPosition = undefined;
++        cursorWasShown = false;
++    };
+     render.done = () => {
+         previousOutput = '';
+         previousLines = [];

--- a/patches/ink@7.0.5.patch
+++ b/patches/ink@7.0.5.patch
@@ -21,10 +21,10 @@ index b8fd45cc990adbc080eff28fc37463cd91337dff..3c8a9a99cc9fd2f5f524905ff61df013
              this.lastOutputToRender = '';
          }
 diff --git a/build/log-update.js b/build/log-update.js
-index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..1ab7877f6bcfa7d33aead4af4b37adc8a67c89c7 100644
+index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..cf17dec7258bf9c267bd382786ca3481b9f9bf5a 100644
 --- a/build/log-update.js
 +++ b/build/log-update.js
-@@ -1,6 +1,31 @@
+@@ -1,6 +1,48 @@
  import ansiEscapes from 'ansi-escapes';
  import cliCursor from 'cli-cursor';
  import { cursorPositionChanged, buildCursorSuffix, buildCursorOnlySequence, buildReturnToBottomPrefix, hideCursorEscape, } from './cursor-helpers.js';
@@ -52,11 +52,28 @@ index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..1ab7877f6bcfa7d33aead4af4b37adc8
 +    }
 +    return rows;
 +};
++const physicalCursorPosition = (str, columns, cursorPosition) => {
++    if (!cursorPosition) return undefined;
++    const cols = columns > 0 ? columns : 1;
++    const lines = str.split('\n');
++    const logicalY = Math.max(0, Math.min(cursorPosition.y, lines.length - 1));
++    let physicalY = 0;
++    for (let i = 0; i < logicalY; i++) {
++        const w = stringWidth(lines[i]);
++        physicalY += w <= cols ? 1 : Math.ceil(w / cols);
++    }
++    physicalY += Math.floor(Math.max(0, cursorPosition.x) / cols);
++    const lastPhysicalY = Math.max(0, physicalLineCount(str, cols) - 1);
++    return {
++        ...cursorPosition,
++        y: Math.min(physicalY, lastPhysicalY),
++    };
++};
 +
  // Count visible lines in a string, ignoring the trailing empty element
  // that `split('\n')` produces when the string ends with '\n'.
  const visibleLineCount = (lines, str) => str.endsWith('\n') ? lines.length - 1 : lines.length;
-@@ -63,6 +88,18 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -63,6 +105,19 @@ const createStandard = (stream, { showCursor = false } = {}) => {
          previousCursorPosition = undefined;
          cursorWasShown = false;
      };
@@ -65,7 +82,8 @@ index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..1ab7877f6bcfa7d33aead4af4b37adc8
 +    // line count (which under-erases on shrink and leaves residue). (TeXRA patch)
 +    render.clearWidthAware = (columns) => {
 +        const physical = physicalLineCount(previousOutput, columns);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, previousCursorPosition);
++        const physicalCursor = physicalCursorPosition(previousOutput, columns, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, physicalCursor);
 +        stream.write(prefix + ansiEscapes.eraseLines(physical));
 +        previousOutput = '';
 +        previousLineCount = 0;
@@ -75,14 +93,15 @@ index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..1ab7877f6bcfa7d33aead4af4b37adc8
      render.done = () => {
          previousOutput = '';
          previousLineCount = 0;
-@@ -204,6 +241,16 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -204,6 +259,17 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
          previousCursorPosition = undefined;
          cursorWasShown = false;
      };
 +    // Width-aware clear for terminal resizes (see createStandard). (TeXRA patch)
 +    render.clearWidthAware = (columns) => {
 +        const physical = physicalLineCount(previousOutput, columns);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, previousCursorPosition);
++        const physicalCursor = physicalCursorPosition(previousOutput, columns, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, physicalCursor);
 +        stream.write(prefix + ansiEscapes.eraseLines(physical));
 +        previousOutput = '';
 +        previousLines = [];

--- a/patches/ink@7.0.5.patch
+++ b/patches/ink@7.0.5.patch
@@ -1,5 +1,5 @@
 diff --git a/build/ink.js b/build/ink.js
-index b8fd45cc9..3c8a9a99c 100644
+index b8fd45cc990adbc080eff28fc37463cd91337dff..3c8a9a99cc9fd2f5f524905ff61df0139f82da05 100644
 --- a/build/ink.js
 +++ b/build/ink.js
 @@ -261,9 +261,14 @@ export default class Ink {
@@ -21,7 +21,7 @@ index b8fd45cc9..3c8a9a99c 100644
              this.lastOutputToRender = '';
          }
 diff --git a/build/log-update.js b/build/log-update.js
-index cdb5fc41f..5b0eaee8b 100644
+index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..1ab7877f6bcfa7d33aead4af4b37adc8a67c89c7 100644
 --- a/build/log-update.js
 +++ b/build/log-update.js
 @@ -1,6 +1,31 @@
@@ -65,7 +65,7 @@ index cdb5fc41f..5b0eaee8b 100644
 +    // line count (which under-erases on shrink and leaves residue). (TeXRA patch)
 +    render.clearWidthAware = (columns) => {
 +        const physical = physicalLineCount(previousOutput, columns);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, previousCursorPosition);
 +        stream.write(prefix + ansiEscapes.eraseLines(physical));
 +        previousOutput = '';
 +        previousLineCount = 0;
@@ -82,7 +82,7 @@ index cdb5fc41f..5b0eaee8b 100644
 +    // Width-aware clear for terminal resizes (see createStandard). (TeXRA patch)
 +    render.clearWidthAware = (columns) => {
 +        const physical = physicalLineCount(previousOutput, columns);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, physical, previousCursorPosition);
 +        stream.write(prefix + ansiEscapes.eraseLines(physical));
 +        previousOutput = '';
 +        previousLines = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.0.5: d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09
+  ink@7.0.5: aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05
 
 importers:
 
@@ -374,7 +374,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@inkjs/ui':
         specifier: ^2.0.0
-        version: 2.0.0(ink@7.0.5(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6))
+        version: 2.0.0(ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6))
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
@@ -413,7 +413,7 @@ importers:
         version: 0.28.0
       ink:
         specifier: ^7.0.5
-        version: 7.0.5(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6)
+        version: 7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6)
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
@@ -7711,13 +7711,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6))':
+  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.4.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 7.0.5(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6)
+      ink: 7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -11027,7 +11027,7 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink@7.0.5(patch_hash=d53e681cd99e047a35271b6eca46eba9010e903bc221e72705ae67e2c0b26a09)(@types/react@19.2.15)(react@19.2.6):
+  ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.0.5: aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05
+  ink@7.0.5: fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac
 
 importers:
 
@@ -374,7 +374,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@inkjs/ui':
         specifier: ^2.0.0
-        version: 2.0.0(ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6))
+        version: 2.0.0(ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6))
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
@@ -413,7 +413,7 @@ importers:
         version: 0.28.0
       ink:
         specifier: ^7.0.5
-        version: 7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6)
+        version: 7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6)
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
@@ -7711,13 +7711,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6))':
+  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.4.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6)
+      ink: 7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -11027,7 +11027,7 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink@7.0.5(patch_hash=aecdc7632e3d87b977484eb106c9241e54a9d7d4eeefb9ad69afb1e1f2d03f05)(@types/react@19.2.15)(react@19.2.6):
+  ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.0.5: fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac
+  ink@7.0.5: 10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3
 
 importers:
 
@@ -374,7 +374,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@inkjs/ui':
         specifier: ^2.0.0
-        version: 2.0.0(ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6))
+        version: 2.0.0(ink@7.0.5(patch_hash=10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3)(@types/react@19.2.15)(react@19.2.6))
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
@@ -413,7 +413,7 @@ importers:
         version: 0.28.0
       ink:
         specifier: ^7.0.5
-        version: 7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6)
+        version: 7.0.5(patch_hash=10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3)(@types/react@19.2.15)(react@19.2.6)
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
@@ -7711,13 +7711,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6))':
+  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3)(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.4.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6)
+      ink: 7.0.5(patch_hash=10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3)(@types/react@19.2.15)(react@19.2.6)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -11027,7 +11027,7 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink@7.0.5(patch_hash=fdfea253feb1158eb7acffcbdac4bb12855ed7c3f06bc84f4e9b1e62abc8daac)(@types/react@19.2.15)(react@19.2.6):
+  ink@7.0.5(patch_hash=10115179a7eb00e3ec7c73ed6777edb3a2cc8b8d28ba06d3d125073e7b7289d3)(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0

--- a/src/test-kernel/cli/InkResizePatch.vitest.mts
+++ b/src/test-kernel/cli/InkResizePatch.vitest.mts
@@ -1,0 +1,86 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+type LogUpdateRenderer = {
+  (value: string): boolean;
+  clear(): void;
+  clearWidthAware(columns: number): void;
+  setCursorPosition(position: { x: number; y: number }): void;
+};
+
+type LogUpdateModule = {
+  default: {
+    create(
+      stream: { isTTY: boolean; columns: number; write(chunk: string): void },
+      options: { showCursor: boolean },
+    ): LogUpdateRenderer;
+  };
+};
+
+function createRecordingStream() {
+  let writes: string[] = [];
+  return {
+    isTTY: true,
+    columns: 80,
+    write(chunk: string) {
+      writes.push(String(chunk));
+    },
+    output() {
+      return writes.join('');
+    },
+    reset() {
+      writes = [];
+    },
+  };
+}
+
+function countEraseLines(output: string): number {
+  return output.split('\u001B[2K').length - 1;
+}
+
+async function loadCliLogUpdate() {
+  const cliRequire = createRequire(
+    new URL('../../../packages/cli/package.json', import.meta.url),
+  );
+  const inkMain = cliRequire.resolve('ink');
+  const logUpdatePath = path.join(path.dirname(inkMain), 'log-update.js');
+  return (await import(pathToFileURL(logUpdatePath).href)) as LogUpdateModule;
+}
+
+describe('CLI Ink resize patch', () => {
+  it('clears physical wrapped rows after terminal resize', async () => {
+    const { default: logUpdate } = await loadCliLogUpdate();
+    const stream = createRecordingStream();
+    const render = logUpdate.create(stream, { showCursor: true });
+    const longLine = 'x'.repeat(95);
+
+    render(longLine);
+    stream.reset();
+    render.clear();
+    const logicalEraseLines = countEraseLines(stream.output());
+
+    render(longLine);
+    stream.reset();
+    render.clearWidthAware(30);
+    const widthAwareEraseLines = countEraseLines(stream.output());
+
+    expect(logicalEraseLines).toBe(1);
+    expect(widthAwareEraseLines).toBe(4);
+  });
+
+  it('returns from an active cursor using physical resize rows', async () => {
+    const { default: logUpdate } = await loadCliLogUpdate();
+    const stream = createRecordingStream();
+    const render = logUpdate.create(stream, { showCursor: true });
+
+    render.setCursorPosition({ x: 1, y: 0 });
+    render('x'.repeat(95));
+    stream.reset();
+    render.clearWidthAware(30);
+
+    expect(stream.output()).toContain('\x1B[3B');
+  });
+});

--- a/src/test-kernel/cli/InkResizePatch.vitest.mts
+++ b/src/test-kernel/cli/InkResizePatch.vitest.mts
@@ -83,4 +83,18 @@ describe('CLI Ink resize patch', () => {
 
     expect(stream.output()).toContain('\x1B[3B');
   });
+
+  it('uses the physical cursor row after wrapped lines precede the cursor', async () => {
+    const { default: logUpdate } = await loadCliLogUpdate();
+    const stream = createRecordingStream();
+    const render = logUpdate.create(stream, { showCursor: true });
+
+    render.setCursorPosition({ x: 1, y: 1 });
+    render(`${'x'.repeat(95)}\nnext`);
+    stream.reset();
+    render.clearWidthAware(30);
+
+    expect(countEraseLines(stream.output())).toBe(5);
+    expect(stream.output()).not.toContain('\x1B[3B');
+  });
 });


### PR DESCRIPTION
## Problem

Resizing the terminal during `texra chat` still garbled the bottom of the
screen — stacked `Tip: …` lines each trailed by a broken input-box top
border (`╭───╮`) of decreasing width. The earlier ink@7.0.4/7.0.5 patch
("clear on any width change") only fixed **widening**; **shrinking** still
leaves residue.

![symptom: stacked tips + broken borders after shrink]

## Root cause

Ink clears its live region with `eraseLines(previousLineCount)`, where
`previousLineCount` is the **logical** line count (`str.split('\n').length`).
Ink's live region (input box border, footer) is exactly terminal-width and
never wraps in normal operation, so logical == physical and the plain clear
works — **except on resize**, when the emulator *reflows* the previous frame
at the new width. On shrink a full-width line wraps into 2 physical rows, but
`eraseLines(logical)` erases only 1 → the wrapped remainder is left behind.

## Fix (`patches/ink@7.0.5.patch`)

Width-aware clear in `ink/build/log-update.js`:

- `physicalLineCount(str, columns)` — sums each line's soft-wrap overflow
  (`ceil(stringWidth(line)/cols)`) at the new width, matching log-update's
  `previousLineCount = lines.length` convention exactly (incl. the
  trailing-`\n` slot — getting this wrong under-erases by one row per resize).
- `clearWidthAware(columns)` — erases that many physical rows. Added to both
  `createStandard` (the active renderer) and `createIncremental`.

`resized` in `ink/build/ink.js` now calls `this.log.clearWidthAware(currentWidth)`
instead of `this.log.clear()`, covering both widen and shrink.
`string-width` is already an `ink` dependency.

`pnpm-lock.yaml` change is purely the rotated `patch_hash`.

## Verification

PTY harness (`@xterm/headless` + `node-pty`) driving the real `<App/>`:

- 140→60 shrink: residual `Tip:` lines **6 → 1**.
- 13 widen/shrink cycles with a tall live region (todos + subagents +
  process panel + footer): exactly **1 intact input box**, no broken borders.

Patch regenerated from pristine `npm pack ink@7.0.5`; `git apply --check`
passes and the applied result is byte-identical to the working `node_modules`.

Validator note:

- The `validate-tui.mjs` slash-palette expectations were refreshed for the
  current base, where `/login` and `/logout` are registered CLI slash commands.
  This PR does not introduce those commands; it keeps the full TUI validator
  aligned so the resize patch can be exercised against the current CLI command
  set. The overflow count changes from `... 6 earlier` to `... 8 earlier` for
  the same reason.

## Follow-up

Worth upstreaming the same `clearWidthAware` change to Ink so we can drop the
patch on a future bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level TUI rendering via a forked Ink dependency; incorrect erase math could cause flicker or missed clears, but scope is isolated to resize handling with new unit tests.
> 
> **Overview**
> Fixes **garbled CLI output when the terminal is narrowed** during `texra chat` by extending the vendored **ink@7.0.5** patch: on any column-width change, Ink now calls **`clearWidthAware`** instead of a logical-line **`clear()`**, so the live region is erased using **soft-wrap physical row counts** (and physical cursor position) after the emulator reflows the previous frame.
> 
> Adds **`InkResizePatch.vitest.mts`** to assert the patched `log-update` behavior against the CLI’s installed Ink build, rotates **`pnpm-lock.yaml`** patch hash, and updates **`validate-tui.mjs`** expectations (slash palette shows **`/login`** / **`/logout`** instead of **`/yolo`**, and overflow ellipsis count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1a2c9414aa479a51015f6ecd017eaf6ad70150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
