### PR TITLE
fix(cli): show full command paths in nested help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Full CLI command paths in help** — nested command help now shows the complete `texra ...` command in usage banners, so commands like `texra multi-agent run --help` and `texra history show --help` are directly copyable.
+
 ## [0.38.4] - 2026-06-01
 
 ### Features

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -219,11 +219,33 @@ async function commandSubCommands(
 export async function resolveDeepestSubCommand(
   cmd: AnyCommand,
   rawArgs: readonly string[],
-  parent?: AnyCommand,
-  commandPath: readonly string[] = ['texra'],
-  parentPath: readonly string[] = [],
-  rootCommand: AnyCommand = cmd,
 ): Promise<ResolvedCliCommand> {
+  return resolveDeepestSubCommandPath({
+    cmd,
+    rawArgs,
+    commandPath: ['texra'],
+    parentPath: [],
+    rootCommand: cmd,
+  });
+}
+
+interface ResolveDeepestSubCommandPathInput {
+  readonly cmd: AnyCommand;
+  readonly rawArgs: readonly string[];
+  readonly parent?: AnyCommand;
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly rootCommand: AnyCommand;
+}
+
+async function resolveDeepestSubCommandPath({
+  cmd,
+  rawArgs,
+  parent,
+  commandPath,
+  parentPath,
+  rootCommand,
+}: ResolveDeepestSubCommandPathInput): Promise<ResolvedCliCommand> {
   const subCommands = await commandSubCommands(cmd);
   if (!subCommands) {
     return { command: cmd, parent, commandPath, parentPath, rootCommand };
@@ -234,14 +256,14 @@ export async function resolveDeepestSubCommand(
     if (token.startsWith('-')) continue;
     const next = subCommands[token];
     if (next) {
-      return resolveDeepestSubCommand(
-        next,
-        rawArgs.slice(i + 1),
-        cmd,
-        [...commandPath, token],
-        commandPath,
+      return resolveDeepestSubCommandPath({
+        cmd: next,
+        rawArgs: rawArgs.slice(i + 1),
+        parent: cmd,
+        commandPath: [...commandPath, token],
+        parentPath: commandPath,
         rootCommand,
-      );
+      });
     }
     break;
   }

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,4 +1,4 @@
-import { renderUsage, type CommandDef } from 'citty';
+import { renderUsage, type CommandDef, type CommandMeta } from 'citty';
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 
@@ -114,6 +114,14 @@ export function isCliError(error: unknown): error is Error & { code?: string } {
 
 export type AnyCommand = CommandDef<any>;
 
+export interface ResolvedCliCommand {
+  readonly command: AnyCommand;
+  readonly parent?: AnyCommand;
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly rootCommand: AnyCommand;
+}
+
 export interface UsageSection {
   readonly title: string;
   readonly rows: readonly (readonly [label: string, description: string])[];
@@ -144,11 +152,48 @@ function formatUsageSection(section: UsageSection): string {
 async function renderUsageWithSections(
   cmd: AnyCommand,
   parent?: AnyCommand,
+  context?: UsageRenderContext,
 ): Promise<string> {
-  const usage = await renderUsage(cmd, parent);
+  const usage = await renderUsage(
+    cmd,
+    await usageParentWithFullPath(parent, context),
+  );
   const sections = usageSections.get(cmd);
   if (!sections?.length) return usage;
   return `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`;
+}
+
+interface UsageRenderContext {
+  readonly parentPath?: readonly string[];
+  readonly rootCommand?: AnyCommand;
+}
+
+async function resolveCommandMeta(cmd: AnyCommand): Promise<CommandMeta> {
+  const meta = cmd.meta;
+  if (meta == null) return {};
+  return typeof meta === 'function' ? await meta() : await meta;
+}
+
+async function usageParentWithFullPath(
+  parent: AnyCommand | undefined,
+  context: UsageRenderContext | undefined,
+): Promise<AnyCommand | undefined> {
+  if (!parent || !context?.parentPath || context.parentPath.length <= 1) {
+    return parent;
+  }
+
+  const [parentMeta, rootMeta] = await Promise.all([
+    resolveCommandMeta(parent),
+    context.rootCommand ? resolveCommandMeta(context.rootCommand) : undefined,
+  ]);
+  return {
+    ...parent,
+    meta: {
+      ...parentMeta,
+      name: context.parentPath.join(' '),
+      version: parentMeta.version ?? rootMeta?.version,
+    },
+  };
 }
 
 async function commandSubCommands(
@@ -167,25 +212,40 @@ async function commandSubCommands(
  * user typed rather than always showing root-level usage.
  *
  * Stops at the first positional that doesn't match a child subcommand. Returns
- * a tuple of `[matchedCommand, parentCommandOrUndefined]` so `showUsage` can
- * render the same breadcrumb citty's own resolver produces.
+ * the matched command, immediate parent, and the full command path so usage can
+ * render `texra multi-agent run` rather than citty's immediate-parent fallback
+ * of `multi-agent run`.
  */
 export async function resolveDeepestSubCommand(
   cmd: AnyCommand,
   rawArgs: readonly string[],
   parent?: AnyCommand,
-): Promise<[AnyCommand, AnyCommand | undefined]> {
+  commandPath: readonly string[] = ['texra'],
+  parentPath: readonly string[] = [],
+  rootCommand: AnyCommand = cmd,
+): Promise<ResolvedCliCommand> {
   const subCommands = await commandSubCommands(cmd);
-  if (!subCommands) return [cmd, parent];
+  if (!subCommands) {
+    return { command: cmd, parent, commandPath, parentPath, rootCommand };
+  }
   for (let i = 0; i < rawArgs.length; i++) {
     const token = rawArgs[i];
     if (token === undefined) break;
     if (token.startsWith('-')) continue;
     const next = subCommands[token];
-    if (next) return resolveDeepestSubCommand(next, rawArgs.slice(i + 1), cmd);
+    if (next) {
+      return resolveDeepestSubCommand(
+        next,
+        rawArgs.slice(i + 1),
+        cmd,
+        [...commandPath, token],
+        commandPath,
+        rootCommand,
+      );
+    }
     break;
   }
-  return [cmd, parent];
+  return { command: cmd, parent, commandPath, parentPath, rootCommand };
 }
 
 export interface UnknownCliCommand {
@@ -317,13 +377,15 @@ export function formatUnknownCliCommand(command: UnknownCliCommand): string {
 export async function showUsageStderr(
   cmd: AnyCommand,
   parent?: AnyCommand,
+  context?: UsageRenderContext,
 ): Promise<void> {
-  writeRawStderr(`${await renderUsageWithSections(cmd, parent)}\n`);
+  writeRawStderr(`${await renderUsageWithSections(cmd, parent, context)}\n`);
 }
 
 export async function showUsage(
   cmd: AnyCommand,
   parent?: AnyCommand,
+  context?: UsageRenderContext,
 ): Promise<void> {
-  writeRawStdout(`${await renderUsageWithSections(cmd, parent)}\n\n`);
+  writeRawStdout(`${await renderUsageWithSections(cmd, parent, context)}\n\n`);
 }

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -26,10 +26,7 @@ export const helpCommand = defineCommand({
       throw new CliUsageError(formatUnknownCliCommand(unknownCommand));
     }
 
-    const [target, parent] = await resolveDeepestSubCommand(
-      rootCommand,
-      ctx.rawArgs,
-    );
-    await showUsage(target, parent);
+    const resolved = await resolveDeepestSubCommand(rootCommand, ctx.rawArgs);
+    await showUsage(resolved.command, resolved.parent, resolved);
   },
 });

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -130,11 +130,8 @@ export async function runCli(
   // (e.g. `texra agents list --help` → list-level usage), mirroring citty's
   // own `runMain` behavior without inheriting its `exit(1)` for usage errors.
   if (rawArgs.some((arg) => arg === '--help' || arg === '-h')) {
-    const [target, parent] = await resolveDeepestSubCommand(
-      rootCommand,
-      rawArgs,
-    );
-    await showUsage(target, parent);
+    const resolved = await resolveDeepestSubCommand(rootCommand, rawArgs);
+    await showUsage(resolved.command, resolved.parent, resolved);
     return { exitCode: CliExitCode.Success };
   }
   if (
@@ -159,15 +156,12 @@ export async function runCli(
       return { exitCode: CliExitCode.Usage };
     }
     if (isCliError(error)) {
-      const [target, parent] = await resolveDeepestSubCommand(
-        rootCommand,
-        rawArgs,
-      );
+      const resolved = await resolveDeepestSubCommand(rootCommand, rawArgs);
       // Usage shown on an ERROR goes to STDERR so STDOUT stays clean and
       // machine-parseable under `--output-format json|ndjson`. The explicit
       // `--help` path above keeps using STDOUT (`showUsage`) per Unix
       // convention.
-      await showUsageStderr(target, parent);
+      await showUsageStderr(resolved.command, resolved.parent, resolved);
       writeTextStderr(error.message);
       return { exitCode: CliExitCode.Usage };
     }

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -964,8 +964,23 @@ describe('runCli usage output stream routing', () => {
     const result = await runCli(['help', 'multi-agent', 'run']);
     expect(result.exitCode).toBe(0);
     expect(stdout).toContain('Run a multi-agent team preset');
-    expect(stdout).toContain('USAGE multi-agent run');
+    expect(stdout).toContain('USAGE texra multi-agent run');
     expect(stderr).toBe('');
+  });
+
+  it('shows full command paths for nested --help usage', async () => {
+    const result = await runCli(['history', 'show', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('Show one stored execution');
+    expect(stdout).toContain('USAGE texra history show');
+    expect(stderr).toBe('');
+  });
+
+  it('shows full command paths for nested usage errors', async () => {
+    const result = await runCli(['history', 'show']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain('USAGE texra history show');
+    expect(stdout).toBe('');
   });
 
   it('accepts the documented multi-agent inspect command', async () => {


### PR DESCRIPTION
## Summary
- Track the full resolved CLI command path when rendering help/usage.
- Render nested usage banners as copyable commands like `texra multi-agent run` and `texra history show`.
- Add regression tests and an Unreleased changelog entry.

## Tests
- `corepack pnpm vitest run src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:fast`
- Rebuilt binary checks for `texra multi-agent run --help`, `texra history show --help`, and `texra history show`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help and usage-banner text only; no changes to command execution, auth, or data handling.
> 
> **Overview**
> Nested CLI **help** and **usage-error** banners now print the full invocable command (e.g. `USAGE texra multi-agent run`, `USAGE texra history show`) instead of citty’s shorter parent-relative form like `multi-agent run`.
> 
> **`resolveDeepestSubCommand`** now returns a **`ResolvedCliCommand`** object with `commandPath`, `parentPath`, and `rootCommand` while walking the subcommand tree. **`showUsage`** / **`showUsageStderr`** pass that context into usage rendering, which **synthesizes parent command meta** so citty’s `renderUsage` sees the joined path. **`help`**, root **`--help`**, and usage-on-error paths in **`root.ts`** were updated to use the new shape.
> 
> Regression tests cover nested `--help`, `help` subpaths, and usage errors on stderr; **CHANGELOG** documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c59d823131a263bb0bebc3e0c7873461f07eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->