### PR TITLE
Replace duplicate pathExists/fileExists with AbsoluteFS.exists

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1,4 +1,4 @@
-import { access, readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -75,6 +75,7 @@ import { OdysseyStore, isOdysseyInFlight } from '@tools/odyssey';
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
+  AbsoluteFS,
   createExternalLocation,
   pathToLocation,
   type FileLocation,
@@ -1280,7 +1281,7 @@ export class DesktopProgressBridge {
       editedLocation.absolutePath,
     );
     const targetExists =
-      isNewFile && (await fileExists(targetLocation.absolutePath));
+      isNewFile && (await AbsoluteFS.exists(targetLocation.absolutePath));
     const action = getAcceptAction(isNewFile, targetExists);
     const extensionNote = isNewFile
       ? `Extensions differ (${path.extname(baseFile).toLowerCase()} vs ${path.extname(editedFile).toLowerCase()}). `
@@ -1392,15 +1393,6 @@ export class DesktopProgressBridge {
 
   private async showErrorMessage(message: string): Promise<void> {
     await this.options.showErrorMessage?.(message);
-  }
-}
-
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await access(filePath);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -8,11 +8,11 @@
  * same session. Sessions are torn down on platform shutdown.
  */
 
-import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { toErrorMessage } from '@common/errors';
 import { warn } from '@logger/logUtils';
+import { AbsoluteFS } from '@utils/files';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
@@ -312,15 +312,6 @@ async function runForAllSessions(
   }
 }
 
-async function pathExists(target: string): Promise<boolean> {
-  try {
-    await access(target);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /** Walk up from `filePath` looking for a Lake project root. */
 export async function defaultResolveWorkspaceRoot(
   filePath: string,
@@ -329,8 +320,8 @@ export async function defaultResolveWorkspaceRoot(
   const root = path.parse(dir).root;
   for (;;) {
     if (
-      (await pathExists(path.join(dir, 'lakefile.lean'))) ||
-      (await pathExists(path.join(dir, 'lakefile.toml')))
+      (await AbsoluteFS.exists(path.join(dir, 'lakefile.lean'))) ||
+      (await AbsoluteFS.exists(path.join(dir, 'lakefile.toml')))
     ) {
       return dir;
     }

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -8,11 +8,11 @@
  * same session. Sessions are torn down on platform shutdown.
  */
 
+import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { toErrorMessage } from '@common/errors';
 import { warn } from '@logger/logUtils';
-import { AbsoluteFS } from '@utils/files';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
@@ -312,6 +312,17 @@ async function runForAllSessions(
   }
 }
 
+// Uses fs/promises directly — must not call platform() because this function
+// is invoked before initPlatform() during early startup / test harness setup.
+async function fsPathExists(target: string): Promise<boolean> {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Walk up from `filePath` looking for a Lake project root. */
 export async function defaultResolveWorkspaceRoot(
   filePath: string,
@@ -320,8 +331,8 @@ export async function defaultResolveWorkspaceRoot(
   const root = path.parse(dir).root;
   for (;;) {
     if (
-      (await AbsoluteFS.exists(path.join(dir, 'lakefile.lean'))) ||
-      (await AbsoluteFS.exists(path.join(dir, 'lakefile.toml')))
+      (await fsPathExists(path.join(dir, 'lakefile.lean'))) ||
+      (await fsPathExists(path.join(dir, 'lakefile.toml')))
     ) {
       return dir;
     }


### PR DESCRIPTION
## Summary

- `desktopAgentExecution.ts`: removes the local `fileExists` helper and its `access` import, replacing the call with `AbsoluteFS.exists()` from `@utils/files`. Safe because the desktop context is always fully initialized before this code path runs.
- `directLspAdapter.ts`: renames `pathExists` → `fsPathExists` and adds a comment documenting why it **must not** use `AbsoluteFS.exists()`. `defaultResolveWorkspaceRoot` can be called before `initPlatform()` (early startup, test harnesses such as `DefaultResolveWorkspaceRoot.vitest.ts`), so routing through `platform().fs.stat()` would throw. The raw `node:fs/promises.access` implementation is intentionally retained.

## Changes

| File | What changed |
|---|---|
| `packages/desktop/src/main/desktopAgentExecution.ts` | `fileExists` removed; replaced with `AbsoluteFS.exists()`; `access` import dropped |
| `src/tools/lean/direct/directLspAdapter.ts` | `pathExists` renamed to `fsPathExists`; comment added explaining the pre-init constraint |

## Test plan

- [x] `npm run typecheck` passes cleanly
- [x] CI: `DefaultResolveWorkspaceRoot.vitest.ts` — all three tests pass (no platform dependency)
- [ ] Lean workspace-root discovery still walks up to `lakefile.lean`/`lakefile.toml` correctly in a real session
- [ ] Desktop "accept file" confirmation correctly detects whether the target already exists

https://claude.ai/code/session_016jjJKnzuv5NijtiQTAhTnj