### PR TITLE
fix(cli): warn when multi-agent delegation is blocked

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -10,7 +10,6 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { agentKey } from '@shared/schemas/agent';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
@@ -18,6 +17,7 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import {
+  agentHasDelegationTools,
   cliMultiAgentPlanHasGaps,
   cliMultiAgentPresetNdjsonRecords,
   findCliMultiAgentPreset,
@@ -50,6 +50,7 @@ import {
   toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
+import { approvalPromptsUnavailable } from './_helpers/approvalPolicyInstruction';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
@@ -129,9 +130,7 @@ export function writeMissingPresetAgents(
   availableTeamAgents.delete(
     agentKey(plan.rootAgent.source, plan.rootAgent.name),
   );
-  const rootCanDelegate =
-    plan.rootAgent.tools?.some((tool) => DELEGATION_TOOLS.has(tool)) ?? false;
-  if (!rootCanDelegate) {
+  if (!agentHasDelegationTools(plan.rootAgent)) {
     writeTextStderr(
       `WARN team delegation unavailable for preset ${plan.preset.id}; running only root agent ${plan.rootAgent.name}. Enable a delegating team root or pass --agent to choose one.`,
     );
@@ -150,6 +149,27 @@ export function writeMissingPresetAgents(
       : `${availableTeamAgents.size} available team agents`;
   writeTextStderr(
     `WARN preset ${plan.preset.id} is degraded; running root agent ${plan.rootAgent.name} with ${availableText}.`,
+  );
+}
+
+function writeApprovalUnavailableDelegationWarning(
+  context: CliContext,
+  plan: CliMultiAgentPresetRunPlan,
+): void {
+  if (
+    !plan.rootAgent ||
+    !agentHasDelegationTools(plan.rootAgent) ||
+    !approvalPromptsUnavailable(context)
+  ) {
+    return;
+  }
+
+  const reason =
+    context.approvalPolicy === 'never'
+      ? 'approval policy "never" denies approval-gated delegation tools'
+      : 'headless approval policy "ask" cannot show delegation prompts';
+  writeTextStderr(
+    `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
   );
 }
 
@@ -273,6 +293,7 @@ export async function runMultiAgentPreset(
     );
     await initCliPlatform(runContext);
     installCliApprovalHandlers(runContext);
+    writeApprovalUnavailableDelegationWarning(runContext, plan);
 
     const config: AgentConfigPayload = {
       agent: plan.rootAgent.name,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -293,7 +293,7 @@ function includeAgent(
     : [...agents, rootAgent];
 }
 
-function agentHasDelegationTools(agent: AgentEntry): boolean {
+export function agentHasDelegationTools(agent: AgentEntry): boolean {
   return agent.tools?.some((tool) => DELEGATION_TOOLS.has(tool)) ?? false;
 }
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -52,26 +52,40 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
   }),
 }));
 
-vi.mock('@cli/runtime/multiAgentPresets', () => ({
-  cliMultiAgentPlanHasGaps: vi.fn(() => false),
-  cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
-  findCliMultiAgentPreset: vi.fn(() => ({
-    id: 'mathematician',
-    name: 'Mathematician',
-    description: 'For math papers.',
-    workflowAgents: [],
-    toolUseAgents: ['orchestrator'],
-    source: 'built-in',
-  })),
-  formatCliMultiAgentPresetDetails: vi.fn(() => ''),
-  formatCliMultiAgentPresetInspection: vi.fn(() => ''),
-  formatCliMultiAgentPresetList: vi.fn(() => ''),
-  planCliMultiAgentPresetRun: mocks.planCliMultiAgentPresetRun,
-  readCliMultiAgentPresets: vi.fn(() => []),
-  withCliMultiAgentPresetVisibility: vi.fn(
-    (_plan: unknown, run: () => Promise<unknown>) => run(),
-  ),
-}));
+vi.mock('@cli/runtime/multiAgentPresets', () => {
+  const delegationTools = new Set([
+    'delegate_workflow',
+    'delegate_agent',
+    'resume_agent',
+    'propose_workflow',
+    'propose_agent',
+  ]);
+
+  return {
+    agentHasDelegationTools: vi.fn(
+      (agent: { tools?: readonly string[] }) =>
+        agent.tools?.some((tool) => delegationTools.has(tool)) ?? false,
+    ),
+    cliMultiAgentPlanHasGaps: vi.fn(() => false),
+    cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
+    findCliMultiAgentPreset: vi.fn(() => ({
+      id: 'mathematician',
+      name: 'Mathematician',
+      description: 'For math papers.',
+      workflowAgents: [],
+      toolUseAgents: ['orchestrator'],
+      source: 'built-in',
+    })),
+    formatCliMultiAgentPresetDetails: vi.fn(() => ''),
+    formatCliMultiAgentPresetInspection: vi.fn(() => ''),
+    formatCliMultiAgentPresetList: vi.fn(() => ''),
+    planCliMultiAgentPresetRun: mocks.planCliMultiAgentPresetRun,
+    readCliMultiAgentPresets: vi.fn(() => []),
+    withCliMultiAgentPresetVisibility: vi.fn(
+      (_plan: unknown, run: () => Promise<unknown>) => run(),
+    ),
+  };
+});
 
 vi.mock('@cli/commands/_helpers/modelArg', () => ({
   buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
@@ -114,6 +128,11 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
 }
 
 describe('CLI multi-agent run command', () => {
+  const approvalUnavailableWarning =
+    'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
+  const headlessAskWarning =
+    'WARN preset mathematician may run without subagent delegation because headless approval policy "ask" cannot show delegation prompts. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.expandRunInputs.mockResolvedValue({
@@ -192,6 +211,61 @@ describe('CLI multi-agent run command', () => {
     expect(request?.config.instruction).toContain('Primary user input files:');
     expect(request?.config.instruction).toContain('- "problem.tex"');
     expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when approval policy never blocks team delegation', async () => {
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: ['problem.tex'],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Solve the problem with the team.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      approvalUnavailableWarning,
+    );
+  });
+
+  it('warns when headless ask cannot show delegation prompts', async () => {
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(
+      cliContext({ approvalPolicy: 'ask' }),
+      {
+        preset: 'mathematician',
+        inputFiles: ['problem.tex'],
+        contextFiles: [],
+        model: 'deepseekT',
+        instruction: 'Solve the problem with the team.',
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(headlessAskWarning);
+  });
+
+  it('does not warn when yolo can auto-approve delegation', async () => {
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(
+      cliContext({ approvalPolicy: 'yolo' }),
+      {
+        preset: 'mathematician',
+        inputFiles: ['problem.tex'],
+        contextFiles: [],
+        model: 'deepseekT',
+        instruction: 'Solve the problem with the team.',
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
+      expect.stringContaining('may run without subagent delegation'),
+    );
   });
 
   it('allows instruction-only team runs without input files', async () => {


### PR DESCRIPTION
## Summary

- warn before `multi-agent run` executes when the selected root can delegate but the CLI approval context cannot approve delegation tools
- reuse the existing delegation-tool detection for both missing-agent and approval-unavailable warnings
- cover `never`, headless `ask`, and `yolo` cases in the multi-agent command tests

Closes #5079.

## Dogfood evidence

Ran `texra multi-agent run mathematician` on a real odd-square modulo-8 prompt. With `--approval-policy never`, the root orchestrator completed alone and disclosed in its response that subagent delegation was blocked. The CLI now emits a deterministic stderr warning before the model call instead of relying on the model response.

Built-binary smoke after the fix emitted:

```text
WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.
```

## Validation

- `npm run format`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing 10 import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr warnings and a small helper export only; no changes to runtime approval or delegation execution logic beyond clearer CLI messaging.
> 
> **Overview**
> **`multi-agent run`** now prints a **stderr warning before execution** when the preset root can delegate but the CLI **cannot approve delegation tools**—for **`--approval-policy never`** and for **headless `ask`** (no prompts). **`yolo`** is left silent because auto-approve is expected.
> 
> Delegation detection is **centralized** by exporting **`agentHasDelegationTools`** from `multiAgentPresets` and reusing it for both missing-agent degradation messages and the new approval warning. Vitest covers the three approval-policy cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a96d45d993973256883279d0a12a39e92f35163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->