### PR TITLE
fix(cli): validate explicit skill source paths

### DIFF
--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -25,6 +25,14 @@ async function listSkills(
   },
 ): Promise<number> {
   const result = await readCliSkills(context, options);
+  const exitCode = result.errors.some(
+    (issue) =>
+      issue.code === 'missing_source' ||
+      issue.code === 'invalid_source' ||
+      issue.code === 'source_read_error',
+  )
+    ? CliExitCode.Usage
+    : CliExitCode.Success;
 
   if (context.outputFormat === 'json') {
     // Match the bare-array JSON shape every other `<resource> list` command
@@ -38,7 +46,7 @@ async function listSkills(
     writeTextStdout(
       JSON.stringify(result.skills.map(skillListRecord), null, 2),
     );
-    return CliExitCode.Success;
+    return exitCode;
   }
 
   if (context.outputFormat === 'ndjson') {
@@ -53,14 +61,16 @@ async function listSkills(
     for (const issue of result.errors) {
       writeNdjsonStdout({ kind: 'skill-issue', ts, issue });
     }
-    return CliExitCode.Success;
+    return exitCode;
   }
 
   for (const issue of result.errors) {
     writeTextStderr(formatCliSkillIssue(issue));
   }
-  writeTextStdout(formatCliSkillList(result.skills));
-  return CliExitCode.Success;
+  if (exitCode === CliExitCode.Success || result.skills.length > 0) {
+    writeTextStdout(formatCliSkillList(result.skills));
+  }
+  return exitCode;
 }
 
 const skillsListCommand = defineCliCommand({

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -6,7 +6,11 @@ import * as path from 'node:path';
 import { ZodError } from 'zod';
 
 // Local imports - common
-import { isFileNotFoundError, toErrorMessage } from '@common/errors';
+import {
+  isFileNotFoundError,
+  isNotADirectoryError,
+  toErrorMessage,
+} from '@common/errors';
 import { isObject } from '@utils/core';
 
 // Local imports - skill parsing
@@ -29,9 +33,12 @@ export type SkillIssueCode =
   | 'duplicate_realpath'
   | 'invalid_frontmatter'
   | 'invalid_name'
+  | 'invalid_source'
+  | 'missing_source'
   | 'missing_description'
   | 'name_mismatch'
-  | 'read_error';
+  | 'read_error'
+  | 'source_read_error';
 
 export interface SkillLoadIssue {
   severity: SkillIssueSeverity;
@@ -57,6 +64,7 @@ export interface SkillSource {
   scope: SkillSourceScope;
   path: string;
   label?: string;
+  required?: boolean;
 }
 
 export interface SourcedSkill {
@@ -362,8 +370,64 @@ export async function discoverSkillSources(
   const seenRealPaths = new Set<string>();
 
   for (const source of sources) {
+    if (source.required === true) {
+      try {
+        const sourceStat = await fs.stat(source.path);
+        if (!sourceStat.isDirectory()) {
+          errors.push(
+            issue(
+              'error',
+              'invalid_source',
+              'Skill source is not a directory',
+              {
+                path: source.path,
+              },
+            ),
+          );
+          continue;
+        }
+      } catch (err) {
+        if (isFileNotFoundError(err)) {
+          errors.push(
+            issue('error', 'missing_source', 'Skill source does not exist', {
+              path: source.path,
+            }),
+          );
+          continue;
+        }
+        if (isNotADirectoryError(err)) {
+          errors.push(
+            issue(
+              'error',
+              'invalid_source',
+              'Skill source is not a directory',
+              {
+                path: source.path,
+              },
+            ),
+          );
+          continue;
+        }
+        errors.push(
+          issue('error', 'source_read_error', toErrorMessage(err), {
+            path: source.path,
+          }),
+        );
+        continue;
+      }
+    }
+
     const result = await discoverSkills(source.path);
-    errors.push(...result.errors);
+    errors.push(
+      ...result.errors.map((error) =>
+        source.required === true &&
+        error.severity === 'error' &&
+        error.code === 'read_error' &&
+        error.path === source.path
+          ? { ...error, code: 'source_read_error' as const }
+          : error,
+      ),
+    );
 
     for (const skill of result.skills) {
       let realSkillPath = skill.path;

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -38,11 +38,17 @@ function resolveSkillSourcePath(base: string, candidate: string): string {
 
 function uniqueSources(sources: readonly SkillSource[]): SkillSource[] {
   const unique: SkillSource[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, number>();
   for (const source of sources) {
     const key = path.resolve(source.path);
-    if (seen.has(key)) continue;
-    seen.add(key);
+    const existingIndex = seen.get(key);
+    if (existingIndex !== undefined) {
+      if (source.required === true) {
+        unique[existingIndex] = { ...unique[existingIndex], required: true };
+      }
+      continue;
+    }
+    seen.set(key, unique.length);
     unique.push({ ...source, path: key });
   }
   return unique;
@@ -89,6 +95,7 @@ export function defaultSkillSources(
       scope: 'custom',
       path: resolveSkillSourcePath(context.cwd, candidate),
       label: 'custom',
+      required: true,
     });
   }
 

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -67,6 +67,9 @@ describe('CLI skills runtime', () => {
         '/tmp/project/vendor/skills',
       ]),
     );
+    expect(
+      sources.find((source) => source.path === '/tmp/project/vendor/skills'),
+    ).toMatchObject({ required: true, scope: 'custom' });
   });
 
   it('lists bundled skills before custom duplicate names', async () => {
@@ -110,6 +113,52 @@ describe('CLI skills runtime', () => {
       expect.objectContaining({
         code: 'duplicate_name',
         name: 'shared-skill',
+      }),
+    );
+  });
+
+  it('reports missing explicit custom skill sources', async () => {
+    const result = await readCliSkills(
+      {
+        cwd: '/tmp/project',
+        resourcesPath: '/tmp/resources',
+      },
+      {
+        additionalPaths: ['missing-skills'],
+      },
+    );
+
+    expect(result.skills).toEqual([]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'missing_source',
+        path: '/tmp/project/missing-skills',
+      }),
+    );
+  });
+
+  it('reports explicit custom skill sources that are not directories', async () => {
+    const root = await createTempRoot();
+    const sourceFile = path.join(root, 'skills-file');
+    await fs.writeFile(sourceFile, 'not a directory');
+
+    const result = await readCliSkills(
+      {
+        cwd: root,
+        resourcesPath: root,
+      },
+      {
+        additionalPaths: [sourceFile],
+      },
+    );
+
+    expect(result.skills).toEqual([]);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_source',
+        path: sourceFile,
       }),
     );
   });

--- a/src/test-kernel/skills/LoadSkills.vitest.mts
+++ b/src/test-kernel/skills/LoadSkills.vitest.mts
@@ -240,4 +240,66 @@ description: A project-specific skill.
       }),
     );
   });
+
+  it('reports missing required sources without treating optional roots as errors', async () => {
+    const optional = path.join(os.tmpdir(), 'texra-skills-optional-missing');
+    const required = path.join(os.tmpdir(), 'texra-skills-required-missing');
+
+    const result = await discoverSkillSources([
+      { scope: 'user', path: optional },
+      { scope: 'custom', path: required, required: true },
+    ]);
+
+    expect(result.skills).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        code: 'missing_source',
+        path: required,
+      }),
+    ]);
+  });
+
+  it('reports required sources that are not directories', async () => {
+    const root = await createTempRoot();
+    const required = path.join(root, 'skills-file');
+    await fs.writeFile(required, 'not a directory');
+
+    const result = await discoverSkillSources([
+      { scope: 'custom', path: required, required: true },
+    ]);
+
+    expect(result.skills).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_source',
+        path: required,
+      }),
+    ]);
+  });
+
+  it('reports required source read errors as source failures', async () => {
+    const root = await createTempRoot();
+    const required = path.join(root, 'blocked-skills');
+    await fs.mkdir(required);
+    await fs.chmod(required, 0o000);
+
+    try {
+      const result = await discoverSkillSources([
+        { scope: 'custom', path: required, required: true },
+      ]);
+
+      expect(result.skills).toEqual([]);
+      expect(result.errors).toEqual([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'source_read_error',
+          path: required,
+        }),
+      ]);
+    } finally {
+      await fs.chmod(required, 0o700);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- mark CLI `skills list --source` roots as required while keeping default/user/project roots optional
- report missing explicit skill source directories as `missing_source` errors and return usage status
- keep JSON stdout parseable for scripts while sending the error to stderr

Closes #5081.

## Dogfood evidence

Before this change:

```sh
node packages/cli/dist/bin/texra.js skills list --source /tmp/does-not-exist
# No skills found.
# exit 0
```

After this change:

```sh
node packages/cli/dist/bin/texra.js skills list --source /tmp/does-not-exist
# error: Skill source does not exist (/tmp/does-not-exist)
# exit 2
```

JSON mode keeps stdout parseable:

```sh
node packages/cli/dist/bin/texra.js skills list --source /tmp/does-not-exist --output-format json
# stderr: error: Skill source does not exist (/tmp/does-not-exist)
# stdout: []
# exit 2
```

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/skills/LoadSkills.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing 10 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to skill discovery and the skills list CLI; default optional roots are unchanged and behavior is covered by new tests.
> 
> **Overview**
> **Explicit `--source` skill roots are now required paths**, while default bundled/user/project/interop directories stay optional when missing.
> 
> `discoverSkillSources` validates `required` sources up front and emits **`missing_source`**, **`invalid_source`**, or **`source_read_error`** instead of silently treating a bad CLI path like an empty optional tree. Custom paths from `skills list --source` are marked `required: true`, and deduplication can promote an existing entry to required when the same path appears twice.
> 
> **`skills list` exits with usage status** when any of those source errors occur, prints the issue on **stderr** (and NDJSON `skill-issue` records), and in **JSON** still writes a parseable **`[]`** on stdout. Plain text skips the “no skills” listing when the command failed solely due to a bad explicit source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba9e83cba37ec3bd7d990cad21f5bfa75173f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->