### PR TITLE
docs: document CLI TUI snapshot validation

### DIFF
--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -26,6 +26,18 @@ cd packages/desktop && npx vite build --mode development
 # Playwright Electron smoke — launches the desktop app, swaps routes,
 # captures screenshots, exercises the command palette.
 cd packages/desktop && pnpm exec playwright test
+
+# CLI TUI frame validator — drives the Ink TUI through a PTY and checks the
+# visible terminal frame for chat, slash commands, approvals, subagents, and
+# compact layouts. If the optional native node-pty dependency is unavailable,
+# the validator prints a skip notice instead of failing the install.
+corepack pnpm --filter @texra-ai/cli validate:tui
+
+# CLI TUI snapshot report — use this when a PR or issue needs terminal
+# screenshots for product review. It writes numbered .txt/.svg frames and an
+# index.html report under the requested directory.
+corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-frames \
+  transcript slash-palette bash-approval subagents
 ```
 
 ## PR review automation


### PR DESCRIPTION
## Summary

- add the CLI TUI frame validator to the manual verification matrix
- document the snapshot-report command for terminal product review screenshots
- note that the validator skips cleanly when optional `node-pty` is unavailable

Closes #5083.

## Dogfood evidence

Selected snapshot run:

```sh
node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-frames transcript slash-palette bash-approval subagents
# validate-tui: all 4 scenarios passed
# validate-tui: wrote snapshots to /tmp/texra-tui-frames
# validate-tui: wrote snapshot report to /tmp/texra-tui-frames/index.html
```

Full TUI harness run:

```sh
corepack pnpm --filter @texra-ai/cli validate:tui
# validate-tui: all 87 scenarios passed
```

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-frames-pnpm transcript`
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing 10 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the verification matrix; no runtime or build behavior is modified.
> 
> **Overview**
> Extends the **Quick automated pass** section in `docs/dev/verification.md` with two CLI TUI workflows: the standard `validate:tui` harness and an optional `--snapshot-dir` run for terminal screenshots used in product review.
> 
> The new text documents what the validator covers (PTY-driven Ink frames, scenarios like transcript and approvals), that missing optional `node-pty` results in a skip rather than a hard failure, and example snapshot scenarios plus output artifacts (`.txt`/`.svg` frames and `index.html`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9cb504501c373e9a1706b3f0f607180dc47284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->