### PR TITLE
fix(cli): reject unknown command flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **Unknown CLI flags are rejected** — mistyped command options now fail before the command runs, and structured CLI output stays clean for scripts.
 - **File-backed multi-agent CLI prompts** — `texra multi-agent run` now accepts `--instruction-file` for long scripted team prompts, matching `texra agents run`.
 - **Full CLI command paths in help** — nested command help now shows the complete `texra ...` command in usage banners, so commands like `texra multi-agent run --help` and `texra history show --help` are directly copyable.
 

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,4 +1,10 @@
-import { renderUsage, type CommandDef, type CommandMeta } from 'citty';
+import {
+  renderUsage,
+  type ArgDef,
+  type ArgsDef,
+  type CommandDef,
+  type CommandMeta,
+} from 'citty';
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 
@@ -206,6 +212,14 @@ async function commandSubCommands(
     : ((await rawSubs) as Record<string, AnyCommand>);
 }
 
+async function commandArgs(cmd: AnyCommand): Promise<ArgsDef> {
+  const rawArgs = cmd.args;
+  if (!rawArgs) return {};
+  return typeof rawArgs === 'function'
+    ? await (rawArgs as () => Promise<ArgsDef> | ArgsDef)()
+    : ((await rawArgs) as ArgsDef);
+}
+
 /**
  * Walk `rawArgs` positional-by-positional through the subcommand tree to find
  * the deepest matched command. Used to scope `--help` to the subcommand the
@@ -384,6 +398,173 @@ export function formatUnknownCliCommand(command: UnknownCliCommand): string {
       ? ''
       : ` Did you mean \`${command.suggestedCommand}\`?`;
   return `Unknown command: ${command.typedCommand}.${suggestion} Run \`${command.helpCommand} --help\` for usage.`;
+}
+
+export interface UnknownCliFlag {
+  readonly flag: string;
+  readonly helpCommand: string;
+}
+
+interface FlagSpec {
+  readonly takesValue: boolean;
+}
+
+interface CommandFlagSpecs {
+  readonly long: Map<string, FlagSpec>;
+  readonly short: Map<string, FlagSpec>;
+}
+
+function toStringArray(
+  value: string | string[] | undefined,
+): readonly string[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function kebabCaseFlagName(name: string): string {
+  return name
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replaceAll(/_+/g, '-')
+    .toLowerCase();
+}
+
+function addLongFlag(
+  specs: CommandFlagSpecs,
+  flagName: string,
+  spec: FlagSpec,
+): void {
+  const names = new Set([flagName]);
+  if (/[A-Z_]/.test(flagName)) {
+    names.add(kebabCaseFlagName(flagName));
+  }
+  for (const name of names) {
+    specs.long.set(`--${name}`, spec);
+  }
+}
+
+function addFlagSpec(specs: CommandFlagSpecs, name: string, def: ArgDef): void {
+  if (def.type === 'positional') return;
+
+  const spec = { takesValue: def.type !== 'boolean' };
+  addLongFlag(specs, name, spec);
+  const aliases = toStringArray((def as { alias?: string | string[] }).alias);
+  for (const alias of aliases) {
+    if (alias.length === 1) {
+      specs.short.set(`-${alias}`, spec);
+    } else {
+      addLongFlag(specs, alias, spec);
+    }
+  }
+
+  if (def.type === 'boolean' && def.default === true) {
+    addLongFlag(specs, `no-${name}`, { takesValue: false });
+  }
+}
+
+function addInteractiveHeadlessOnlyFlags(specs: CommandFlagSpecs): void {
+  specs.long.set('--print', { takesValue: false });
+  specs.short.set('-p', { takesValue: false });
+  specs.long.set('--no-input', { takesValue: false });
+  addLongFlag(specs, 'output-format', { takesValue: true });
+}
+
+async function commandFlagSpecs(
+  resolved: ResolvedCliCommand,
+): Promise<CommandFlagSpecs> {
+  const specs: CommandFlagSpecs = { long: new Map(), short: new Map() };
+  const args = await commandArgs(resolved.command);
+  for (const [name, def] of Object.entries(args)) {
+    addFlagSpec(specs, name, def);
+  }
+
+  const commandName = resolved.commandPath.at(-1);
+  if (
+    resolved.commandPath.length === 2 &&
+    (commandName === 'chat' || commandName === 'orchestrate')
+  ) {
+    // Keep the existing explicit "interactive command" usage error for these
+    // known headless-only global flags instead of downgrading it to "unknown".
+    addInteractiveHeadlessOnlyFlags(specs);
+  }
+
+  return specs;
+}
+
+function inlineFlagBase(token: string): string {
+  const equalsIndex = token.indexOf('=');
+  return equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+}
+
+function validateLongFlag(
+  specs: CommandFlagSpecs,
+  token: string,
+): { readonly unknownFlag?: string; readonly skipNext: boolean } {
+  const baseFlag = inlineFlagBase(token);
+  const spec = specs.long.get(baseFlag);
+  if (!spec) return { unknownFlag: baseFlag, skipNext: false };
+  return { skipNext: spec.takesValue && baseFlag === token };
+}
+
+function validateShortFlag(
+  specs: CommandFlagSpecs,
+  token: string,
+): { readonly unknownFlag?: string; readonly skipNext: boolean } {
+  for (let i = 1; i < token.length; i += 1) {
+    const flag = `-${token[i]}`;
+    const spec = specs.short.get(flag);
+    if (!spec) return { unknownFlag: flag, skipNext: false };
+    if (spec.takesValue) {
+      return { skipNext: i === token.length - 1 };
+    }
+  }
+  return { skipNext: false };
+}
+
+function helpTargetRawArgs(rawArgs: readonly string[]): readonly string[] {
+  for (let i = 0; i < rawArgs.length; ) {
+    const token = rawArgs[i];
+    if (token === undefined || token === '--') break;
+    if (token.startsWith('-')) {
+      const tokenCount = knownGlobalFlagTokenCount(rawArgs, i);
+      if (tokenCount === undefined) break;
+      i += tokenCount;
+      continue;
+    }
+    return token === 'help' ? rawArgs.slice(i + 1) : rawArgs;
+  }
+  return rawArgs;
+}
+
+export async function detectUnknownCliFlag(
+  rootCommand: AnyCommand,
+  rawArgs: readonly string[],
+): Promise<UnknownCliFlag | undefined> {
+  const targetRawArgs = helpTargetRawArgs(rawArgs);
+  const resolved = await resolveDeepestSubCommand(rootCommand, targetRawArgs);
+  const specs = await commandFlagSpecs(resolved);
+
+  for (let i = 0; i < targetRawArgs.length; i += 1) {
+    const token = targetRawArgs[i];
+    if (token === undefined || token === '--') break;
+    if (!token.startsWith('-') || token === '-') continue;
+
+    const result = token.startsWith('--')
+      ? validateLongFlag(specs, token)
+      : validateShortFlag(specs, token);
+    if (result.unknownFlag) {
+      return {
+        flag: result.unknownFlag,
+        helpCommand: resolved.commandPath.join(' '),
+      };
+    }
+    if (result.skipNext) i += 1;
+  }
+
+  return undefined;
+}
+
+export function formatUnknownCliFlag(flag: UnknownCliFlag): string {
+  return `Unknown option: ${flag.flag}. Run \`${flag.helpCommand} --help\` for usage.`;
 }
 
 /**

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -11,7 +11,9 @@ import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 
 import {
   detectUnknownCliCommand as detectUnknownCliCommandImpl,
+  detectUnknownCliFlag as detectUnknownCliFlagImpl,
   formatUnknownCliCommand,
+  formatUnknownCliFlag,
   isCliError,
   normalizeRootShortcuts,
   reorderGlobalFlags,
@@ -20,6 +22,7 @@ import {
   showUsageStderr,
   withUsageSections,
   type UnknownCliCommand,
+  type UnknownCliFlag,
 } from './_helpers/dispatch';
 import { getExitCode, resetExitCode } from './_helpers/exitCode';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
@@ -112,6 +115,12 @@ export async function detectUnknownCliCommand(
   return detectUnknownCliCommandImpl(rootCommand, rawArgs);
 }
 
+export async function detectUnknownCliFlag(
+  rawArgs: readonly string[],
+): Promise<UnknownCliFlag | undefined> {
+  return detectUnknownCliFlagImpl(rootCommand, rawArgs);
+}
+
 /**
  * Re-implement the surface citty's `runMain` provides — `--help` / `--version`
  * detection plus error handling around `runCommand` — so usage errors (missing
@@ -145,6 +154,12 @@ export async function runCli(
   const unknownCommand = await detectUnknownCliCommand(rawArgs);
   if (unknownCommand) {
     writeTextStderr(formatUnknownCliCommand(unknownCommand));
+    return { exitCode: CliExitCode.Usage };
+  }
+
+  const unknownFlag = await detectUnknownCliFlag(rawArgs);
+  if (unknownFlag) {
+    writeTextStderr(formatUnknownCliFlag(unknownFlag));
     return { exitCode: CliExitCode.Usage };
   }
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -5,11 +5,16 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { detectUnknownCliCommand, runCli } from '@cli/commands/root';
+import {
+  detectUnknownCliCommand,
+  detectUnknownCliFlag,
+  runCli,
+} from '@cli/commands/root';
 import { resolveLoginProvider } from '@cli/commands/auth';
 import { doctorPlatformInitContext } from '@cli/commands/doctor';
 import {
   formatUnknownCliCommand,
+  formatUnknownCliFlag,
   normalizeRootShortcuts,
   reorderGlobalFlags,
 } from '@cli/commands/_helpers/dispatch';
@@ -221,6 +226,84 @@ describe('CLI root argument routing', () => {
     ).toBe(
       'Unknown command: texra chatt. Did you mean `texra chat`? Run `texra --help` for usage.',
     );
+  });
+
+  it('detects unknown command-scoped flags before command execution', async () => {
+    await expect(detectUnknownCliFlag(['doctor', '--bogus'])).resolves.toEqual({
+      flag: '--bogus',
+      helpCommand: 'texra doctor',
+    });
+    await expect(
+      detectUnknownCliFlag([
+        'models',
+        'list',
+        '--unknown',
+        '--no-input',
+        '--output-format',
+        'json',
+      ]),
+    ).resolves.toEqual({
+      flag: '--unknown',
+      helpCommand: 'texra models list',
+    });
+    await expect(detectUnknownCliFlag(['--bogus', 'doctor'])).resolves.toEqual({
+      flag: '--bogus',
+      helpCommand: 'texra doctor',
+    });
+  });
+
+  it('does not classify flag values or known aliases as unknown flags', async () => {
+    await expect(
+      detectUnknownCliFlag(['run', 'polish', '--instruction', '--literal']),
+    ).resolves.toBeUndefined();
+    await expect(
+      detectUnknownCliFlag(['run', 'polish', '-mdeepseekT', '--no-color']),
+    ).resolves.toBeUndefined();
+    await expect(
+      detectUnknownCliFlag([
+        'multi-agent',
+        'run',
+        'mathematician',
+        '--instruction-file=prompt.md',
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects camelCase spellings for kebab-case flags', async () => {
+    await expect(
+      detectUnknownCliFlag(['models', 'list', '--outputFormat', 'json']),
+    ).resolves.toEqual({
+      flag: '--outputFormat',
+      helpCommand: 'texra models list',
+    });
+  });
+
+  it('validates help command paths against the displayed command', async () => {
+    await expect(
+      detectUnknownCliFlag(['help', 'models', 'list', '--unknown']),
+    ).resolves.toEqual({
+      flag: '--unknown',
+      helpCommand: 'texra models list',
+    });
+    await expect(
+      detectUnknownCliFlag([
+        'help',
+        'models',
+        'list',
+        '--no-input',
+        '--output-format',
+        'json',
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('formats unknown flag usage guidance', () => {
+    expect(
+      formatUnknownCliFlag({
+        flag: '--bogus',
+        helpCommand: 'texra doctor',
+      }),
+    ).toBe('Unknown option: --bogus. Run `texra doctor --help` for usage.');
   });
 
   it('does not classify known command arguments as unknown commands', async () => {
@@ -882,6 +965,48 @@ describe('runCli usage output stream routing', () => {
     expect(result.exitCode).toBe(0);
     expect(stdout).toContain('USAGE');
     expect(stderr).toBe('');
+  });
+
+  it('rejects unknown flags before running command bodies', async () => {
+    const result = await runCli(['doctor', '--bogus', '--no-input']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain(
+      'Unknown option: --bogus. Run `texra doctor --help` for usage.',
+    );
+    expect(stdout).toBe('');
+  });
+
+  it('keeps stdout clean when rejecting unknown flags in structured mode', async () => {
+    const result = await runCli([
+      'models',
+      'list',
+      '--unknown',
+      '--no-input',
+      '--output-format',
+      'json',
+    ]);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain(
+      'Unknown option: --unknown. Run `texra models list --help` for usage.',
+    );
+    expect(stdout).toBe('');
+  });
+
+  it('preserves the interactive-command error for headless-only flags', async () => {
+    const result = await runCli(['chat', '--print']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain('texra chat is interactive');
+    expect(stderr).not.toContain('Unknown option');
+    expect(stdout).toBe('');
+  });
+
+  it('rejects camelCase headless-only flags on interactive commands', async () => {
+    const result = await runCli(['chat', '--outputFormat', 'json']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain(
+      'Unknown option: --outputFormat. Run `texra chat --help` for usage.',
+    );
+    expect(stdout).toBe('');
   });
 
   it('documents interactive chat controls in chat --help', async () => {


### PR DESCRIPTION
## Summary

- reject unknown command-scoped CLI flags before command bodies run
- keep stdout clean for structured output modes when flag validation fails
- preserve existing interactive-command errors for known headless-only flags such as `chat --print`

Closes #5087.

## Tests

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing 10 warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- Rebuilt CLI dogfood:
  - `texra doctor --bogus --no-input` exits 2 with empty stdout
  - `texra models list --unknown --no-input --output-format json` exits 2 with empty stdout
  - `texra chat --print` keeps the interactive-command usage error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a pre-parse validation layer on CLI entry with broad test coverage; behavior change is limited to failing fast on typos while preserving existing interactive and help routing.
> 
> **Overview**
> **Unknown command-scoped flags are rejected before any command body runs**, using the deepest matched subcommand’s declared options (long/short names, aliases, `name=value`, and kebab-case spellings). Failures exit with usage code **2**, print guidance on **stderr** with the full `texra …` help path, and leave **stdout** empty so `--output-format json|ndjson` stays machine-parseable.
> 
> `texra help …` validates flags against the target command, not `help` itself. For **`chat`** and **`orchestrate`**, headless-only globals like `--print` stay on the existing “interactive command” error path instead of generic “unknown option”; camelCase variants of those flags are still rejected as unknown.
> 
> Changelog and **`CliRootArgs`** tests cover detection, formatting, structured mode, and the interactive-command exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc5e28c7620e54e047ab57a1ff9d26af2a8b89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->