### PR TITLE
fix(cli): hide dashboard-only tool entries

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -359,7 +359,7 @@ const SCENARIOS = [
       'always on ·',
       'enabled · detected · available',
     ],
-    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -'],
+    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -', 'TeXRA CLI'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 8 },
     ],
@@ -447,12 +447,12 @@ const SCENARIOS = [
     expect: [
       '/tools',
       'Toggle available external integrations',
-      '+1 earlier, +6 more',
+      '+1 earlier, +5 more',
       '↑/↓ navigate',
       '1-9/a-z/Enter toggle',
       'Esc close',
     ],
-    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -'],
+    unexpect: ['[TeXRA]', 'toolUtils', 'enabled -', 'TeXRA CLI'],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/tools', max: 2 },
     ],

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -1,7 +1,6 @@
 // Local imports - tools
 import {
   EXTERNAL_TOOL_DEFS,
-  findExternalToolDef,
   type ExternalToolDef,
 } from '@tools/externalToolDefs';
 import {
@@ -28,8 +27,10 @@ export interface CliToolStatusRecord {
   readonly note?: string;
 }
 
-const dashboardToolDefs = (): ExternalToolDef[] =>
-  EXTERNAL_TOOL_DEFS.filter((def) => !def.hideFromDashboard);
+const cliToolDefs = (): ExternalToolDef[] =>
+  EXTERNAL_TOOL_DEFS.filter(
+    (def) => !def.hideFromDashboard && !def.hideFromCli,
+  );
 
 function detectedFromStatus(status: string): boolean | null {
   if (status === 'available') return true;
@@ -58,7 +59,7 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
   const checks = new Map((await runExternalToolChecks()).map((r) => [r.id, r]));
   const disabledIds = getDisabledToolIds();
 
-  return dashboardToolDefs().map((def) => {
+  return cliToolDefs().map((def) => {
     const check = checks.get(def.id);
     const comingSoon = def.comingSoon === true;
     const toggleable = def.toggleable === true;
@@ -89,18 +90,18 @@ export async function readCliToolStatus(
 }
 
 export function findCliToolDef(id: string): ExternalToolDef | undefined {
-  return findExternalToolDef(id);
+  return cliToolDefs().find((def) => def.id === id);
 }
 
 export function cliToolIds(): string[] {
-  return dashboardToolDefs().map((def) => def.id);
+  return cliToolDefs().map((def) => def.id);
 }
 
 export async function setCliToolEnabled(
   id: string,
   enabled: boolean,
 ): Promise<boolean> {
-  const def = findExternalToolDef(id);
+  const def = findCliToolDef(id);
   if (!def || !def.toggleable) return false;
   await setToolEnabled(id, enabled);
   return true;

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { formatToolDescriptionForTui } from '@cli/chat/tui/forms/ToolsListForm';
 import {
   cliToolIds,
+  findCliToolDef,
   formatCliBoolean,
   formatCliToolList,
   formatCliToolStatus,
@@ -33,6 +34,8 @@ describe('CLI tools runtime', () => {
     expect(cliToolIds()).toEqual(
       expect.arrayContaining(['codex', 'claude-agent', 'external-inquiry']),
     );
+    expect(cliToolIds()).not.toContain('texra-cli');
+    expect(findCliToolDef('texra-cli')).toBeUndefined();
   });
 
   it('formats nullable booleans consistently', () => {

--- a/src/test/tools/externalToolDefs.test.ts
+++ b/src/test/tools/externalToolDefs.test.ts
@@ -27,6 +27,7 @@ describe('external tool definitions', () => {
     assert.ok(texraCli, 'TeXRA CLI tool definition should exist');
     assert.strictEqual(texraCli.category, 'ai-agents');
     assert.strictEqual(texraCli.comingSoon, true);
+    assert.strictEqual(texraCli.hideFromCli, true);
     assert.strictEqual(texraCli.toggleable, undefined);
     assert.deepStrictEqual(texraCli.tools, []);
   });

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -100,6 +100,8 @@ export interface ExternalToolDef {
   readonly configNotes?: string;
   /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
   readonly hideFromDashboard?: boolean;
+  /** When true, the tool is shown in app dashboards but hidden from CLI tools surfaces. */
+  readonly hideFromCli?: boolean;
   /** Short auth/billing note shown as a badge (e.g. "Uses ChatGPT subscription"). */
   readonly authNote?: string;
   /** When true, the dashboard shows an enable/disable toggle for this tool group. */
@@ -457,6 +459,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Coming soon. This entry only checks whether the local CLI is visible.',
     comingSoon: true,
+    hideFromCli: true,
     probe: probeTexraCli,
     check: async (probeResult) => resolveBooleanProbe(probeResult) ?? false,
     statusLabel: async (probeResult) =>


### PR DESCRIPTION
## Summary
- hide tool definitions marked as dashboard-only from CLI tool list/status/toggle surfaces
- keep the TeXRA CLI integration visible to app dashboards while removing it from CLI `/tools`
- update CLI tool tests and TUI validator expectations

Closes #5089.

## Validation
- `corepack pnpm exec prettier --write packages/cli/scripts/validate-tui.mjs packages/cli/src/runtime/tools.ts src/test-kernel/cli/CliTools.vitest.mts src/test/tools/externalToolDefs.test.ts src/tools/externalToolDefs.ts`
- `git diff --check`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-tools-filter tools-form compact-tools-form`
- `npm run compile:safe`
- `npm run lint` (0 errors, 10 existing warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js tools list --no-input`
- `node packages/cli/dist/bin/texra.js tools status texra-cli --no-input` exits 2 with `Tool integration not found: texra-cli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow filtering change on CLI tool presentation and lookup; app dashboards and availability checks are unchanged.
> 
> **Overview**
> Adds a **`hideFromCli`** flag on external tool definitions so integrations can stay in app dashboards but be omitted from CLI list, status, toggle, and **`/tools`** TUI surfaces.
> 
> CLI runtime now builds its tool set from definitions that are neither **`hideFromDashboard`** nor **`hideFromCli`**, and **`findCliToolDef`** / enable toggles only apply to that filtered set (replacing lookups against the full catalog). **TeXRA CLI** is the first consumer: still defined and probeable for the editor, but excluded from **`texra tools`** and the interactive tools form.
> 
> Tests and TUI snapshot expectations were updated so **`texra-cli`** and **TeXRA CLI** no longer appear in CLI tooling UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f3b643dbc1eb17ce3564ef95cb025ef987b96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->