### PR TITLE
fix(cli): prefer listed agents in show

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { getVisibleAgents, loadAgents } from '@agent/index';
+import { getAgent, getVisibleAgents, loadAgents } from '@agent/index';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
@@ -76,7 +76,7 @@ export async function showAgent(
   await initLocalCliPlatform(context);
   await loadAgents({ includeRemote: false });
 
-  const entry = await resolveAgentWithRemoteFallback(name);
+  const entry = getAgent(name) ?? (await resolveAgentWithRemoteFallback(name));
   if (!entry) {
     writeTextStderr(`Agent not found: ${name}`);
     return CliExitCode.Usage;

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -5,6 +5,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 
 const mocks = vi.hoisted(() => ({
   emitCliResult: vi.fn(),
+  getAgent: vi.fn(),
   initLocalCliPlatform: vi.fn(),
   loadAgents: vi.fn(),
   resolveAgentWithRemoteFallback: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@agent/index', () => ({
+  getAgent: mocks.getAgent,
   getVisibleAgents: vi.fn(() => []),
   loadAgents: mocks.loadAgents,
 }));
@@ -55,7 +57,33 @@ describe('CLI agents command', () => {
     vi.clearAllMocks();
   });
 
-  it('uses the remote fallback resolver for agent details', async () => {
+  it('uses the local registry match for agent details before remote fallback', async () => {
+    const localAgent = {
+      name: 'lean',
+      source: 'builtInToolUse',
+      path: '/tmp/resources/tool_use_agents/lean.yaml',
+      category: AgentCategory.ToolUse,
+      description: 'Lean 4 proof assistant.',
+      tools: ['lean_diagnostics'],
+    };
+    mocks.getAgent.mockReturnValue(localAgent);
+    const { showAgent } = await import('@cli/commands/agents');
+
+    const exitCode = await showAgent(cliContext(), 'lean');
+
+    expect(exitCode).toBe(0);
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledTimes(1);
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.getAgent).toHaveBeenCalledWith('lean');
+    expect(mocks.resolveAgentWithRemoteFallback).not.toHaveBeenCalled();
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
+      json: localAgent,
+      ndjson: { kind: 'agent', agent: localAgent },
+      text: expect.stringContaining('source: builtInToolUse'),
+    });
+  });
+
+  it('uses the remote fallback resolver when local lookup misses', async () => {
     const remoteAgent = {
       name: 'orchestrator',
       source: 'remote',
@@ -65,6 +93,7 @@ describe('CLI agents command', () => {
       tools: ['delegate_agent', 'delegate_workflow'],
       visibility: ['public'],
     };
+    mocks.getAgent.mockReturnValue(undefined);
     mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
@@ -84,6 +113,7 @@ describe('CLI agents command', () => {
   });
 
   it('reports missing agents after the remote fallback is exhausted', async () => {
+    mocks.getAgent.mockReturnValue(undefined);
     mocks.resolveAgentWithRemoteFallback.mockResolvedValue(undefined);
     const { showAgent } = await import('@cli/commands/agents');
 


### PR DESCRIPTION
## Summary
- make `texra agents show <name>` resolve the local registry entry loaded by `agents list` before using remote fallback
- preserve explicit `source:name` remote inspection, such as `remote:lean`
- add CLI command tests for local-first and fallback behavior

Closes #5091.

## Validation
- `corepack pnpm exec prettier --write packages/cli/src/commands/agents.ts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js agents show lean --output-format=json --no-input`
- `node packages/cli/dist/bin/texra.js agents show builtInToolUse:lean --output-format=json --no-input`
- `node packages/cli/dist/bin/texra.js agents show remote:lean --output-format=json --no-input`
- `node packages/cli/dist/bin/texra.js agents list --output-format=json --no-input`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (0 errors, 10 existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI lookup-order change with targeted tests; no auth, data, or security surface changes.
> 
> **Overview**
> **`texra agents show`** now resolves agents the same way as **`agents list`**: after loading the local registry, it uses **`getAgent(name)`** first and only calls **`resolveAgentWithRemoteFallback`** when there is no local match.
> 
> That stops **`show lean`** (and similar bare names) from preferring a remote reload when a built-in/local entry exists, while still allowing remote-only agents and explicit **`source:name`** inspection via the existing fallback path.
> 
> CLI tests cover local hit (no remote call), remote fallback on miss, and the not-found path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0351ee45e8b20655a57e8d285002610b3c2a82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->