### PR TITLE
fix(cli): reject invalid api mode flag

### DIFF
--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -4,6 +4,18 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 export type CliApiMode = 'included' | 'personal';
 
+export const CLI_API_MODE_INPUTS = [
+  'included',
+  'relay',
+  'texra',
+  'personal',
+  'direct',
+  'api',
+  'byok',
+  'key',
+  'keys',
+] as const;
+
 export function getCliApiMode(): CliApiMode {
   return getServerSideKeyService().getUseIncludedModelAccess()
     ? 'included'

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -9,7 +9,11 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../schemas/cliSettings';
-import { parseCliApiMode, type CliApiMode } from './apiAccessMode';
+import {
+  CLI_API_MODE_INPUTS,
+  parseCliApiMode,
+  type CliApiMode,
+} from './apiAccessMode';
 import {
   CLI_OUTPUT_FORMATS,
   isKnownCliModel,
@@ -314,13 +318,22 @@ function pickEnvModel(
 }
 
 function pickCliApiMode(
-  candidates: readonly { readonly label: string; readonly value?: string }[],
+  candidates: readonly {
+    readonly label: string;
+    readonly value?: string;
+    readonly strict?: boolean;
+  }[],
   warnings: string[],
 ): CliApiMode | undefined {
   for (const candidate of candidates) {
     if (!candidate.value) continue;
     const apiMode = parseCliApiMode(candidate.value);
     if (apiMode) return apiMode;
+    if (candidate.strict) {
+      throw new CliUsageError(
+        `Invalid value for argument: ${candidate.label} (${candidate.value}). Expected one of: ${CLI_API_MODE_INPUTS.join(', ')}.`,
+      );
+    }
     warnings.push(`Ignoring invalid ${candidate.label} "${candidate.value}".`);
   }
   return undefined;
@@ -366,7 +379,7 @@ export async function buildCliContext(
   const envModel = pickEnvModel(env, configWarnings);
   const apiMode = pickCliApiMode(
     [
-      { label: '--api-mode', value: init.globalArgs.apiMode },
+      { label: '--api-mode', value: init.globalArgs.apiMode, strict: true },
       { label: 'TEXRA_API_MODE', value: envValue(env, 'TEXRA_API_MODE') },
     ],
     configWarnings,

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -234,6 +234,19 @@ describe('CLI context config defaults', () => {
     expect(context.apiMode).toBe('included');
   });
 
+  it('rejects invalid explicit --api-mode values', async () => {
+    await expect(
+      buildCliContext({
+        ambient,
+        env: { TEXRA_API_MODE: 'included' },
+        globalArgs: {
+          apiMode: 'unknown-mode',
+          cwd: tmpdir(),
+        },
+      }),
+    ).rejects.toThrow('Invalid value for argument: --api-mode');
+  });
+
   it('reports invalid TEXRA_API_MODE values without failing', async () => {
     const context = await buildCliContext({
       ambient,


### PR DESCRIPTION
## Summary
- reject invalid explicit `--api-mode` values as usage errors instead of warning and continuing
- keep invalid ambient `TEXRA_API_MODE` values as non-fatal warnings
- add a regression test for strict explicit flag handling

Closes #5093.

## Validation
- `corepack pnpm exec prettier --write packages/cli/src/runtime/apiAccessMode.ts packages/cli/src/runtime/cliContext.ts src/test-kernel/cli/CliContext.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliContext.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js models list --api-mode=invalid --no-input` exits 2
- `node packages/cli/dist/bin/texra.js models list --api-mode=byok --no-input`
- `node packages/cli/dist/bin/texra.js models list --api-mode=relay --no-input`
- `TEXRA_API_MODE=invalid node packages/cli/dist/bin/texra.js models list --no-input`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (0 errors, 10 existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI argument validation only; no auth, model access, or runtime behavior changes beyond clearer failures for bad flags.
> 
> **Overview**
> Invalid **`--api-mode`** values now fail fast with a **`CliUsageError`** (exit 2) instead of being logged as a warning while the command keeps running. **`pickCliApiMode`** supports a **`strict`** flag; only the explicit flag uses it. Invalid **`TEXRA_API_MODE`** still produces a non-fatal config warning and leaves **`apiMode`** unset.
> 
> A shared **`CLI_API_MODE_INPUTS`** list documents accepted aliases (e.g. `relay`, `byok`) in the usage error. A regression test covers strict flag handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1ab912b0ff7a32b83d4ea79f0b0ed07785defc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->