### PR TITLE
fix(cli): include cwd in run results

### DIFF
--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -13,6 +13,7 @@ type CliRunResultFor<T extends ExecuteAgentResult> = Omit<T, 'status'> & {
   status: ExecutionStatus;
   endGroupStatus: T['status'];
   terminalStatus: ExecutionStatus;
+  workingDirectory?: string;
   runDirectory?: string;
   copiedOutput?: string;
   copiedOutputs?: string[];
@@ -58,6 +59,7 @@ export function createCliRunResult<T extends ExecuteAgentResult>(
   result: T,
   terminalStatus: ExecutionStatus,
   extras: {
+    readonly workingDirectory?: string;
     readonly runDirectory?: string;
     readonly copiedOutput?: string;
     readonly copiedOutputs?: string[];

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -143,7 +143,9 @@ export async function resolveWorkflowOutput(
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
       return {
         copiedOutput: undefined,
-        displayResult: createCliRunResult(result, terminalStatus),
+        displayResult: createCliRunResult(result, terminalStatus, {
+          workingDirectory: context.cwd,
+        }),
       };
     }
     if (outputDir) {
@@ -193,6 +195,7 @@ export async function resolveWorkflowOutput(
     }
 
     const displayResult = createCliRunResult(result, terminalStatus, {
+      workingDirectory: context.cwd,
       runDirectory,
       copiedOutputs,
     });
@@ -203,6 +206,7 @@ export async function resolveWorkflowOutput(
     return {
       copiedOutput: undefined,
       displayResult: createCliRunResult(result, terminalStatus, {
+        workingDirectory: context.cwd,
         runDirectory,
       }),
     };
@@ -213,6 +217,7 @@ export async function resolveWorkflowOutput(
     return {
       copiedOutput: undefined,
       displayResult: createCliRunResult(result, terminalStatus, {
+        workingDirectory: context.cwd,
         runDirectory,
       }),
     };
@@ -225,6 +230,7 @@ export async function resolveWorkflowOutput(
   }
 
   const displayResult = createCliRunResult(result, terminalStatus, {
+    workingDirectory: context.cwd,
     runDirectory,
     copiedOutput: targetPath,
   });

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -171,6 +171,9 @@ async function runToolUseAgent(
     const displayResult: CliToolUseRunResult = createCliRunResult(
       result,
       terminalStatus,
+      {
+        workingDirectory: runContext.cwd,
+      },
     );
     writeToolUseRunResult(runContext, displayResult);
 

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -338,6 +338,9 @@ export async function runMultiAgentPreset(
     const displayResult: CliToolUseRunResult = createCliRunResult(
       result,
       terminalStatus,
+      {
+        workingDirectory: runContext.cwd,
+      },
     );
     writeMultiAgentRunResult(runContext, plan, displayResult);
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -27,7 +27,10 @@ import {
   collectStringFlagValues,
   rejectHeadlessOnlyFlags,
 } from '@cli/commands/_helpers/globalArgs';
-import { cliTerminalStatus } from '@cli/commands/_helpers/terminalStatus';
+import {
+  cliTerminalStatus,
+  createCliRunResult,
+} from '@cli/commands/_helpers/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
@@ -673,6 +676,26 @@ describe('CLI root argument routing', () => {
         EXECUTION_STATUS.INTERRUPTED,
       ),
     ).toBe(EXECUTION_STATUS.INTERRUPTED);
+  });
+
+  it('includes working directory metadata in CLI run results', () => {
+    const result = createCliRunResult(
+      {
+        status: END_GROUP_STATUS.STOPPED,
+        category: AgentCategory.ToolUse,
+        executionId: 'completed-without-output',
+        streamId: 'stream-without-output',
+        lastResponse: 'done',
+      } as Parameters<typeof createCliRunResult>[0],
+      EXECUTION_STATUS.COMPLETED,
+      { workingDirectory: '/tmp/project' },
+    );
+
+    expect(result).toMatchObject({
+      executionId: 'completed-without-output',
+      workingDirectory: '/tmp/project',
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+    });
   });
 
   it('restores one requested workflow output path for resume', () => {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -117,6 +117,7 @@ describe('CLI workflow output resolution', () => {
       status: EXECUTION_STATUS.COMPLETED,
       endGroupStatus: END_GROUP_STATUS.STOPPED,
       terminalStatus: EXECUTION_STATUS.COMPLETED,
+      workingDirectory: cwd,
       copiedOutputs: [join(cwd, 'out', 'a.tex'), join(cwd, 'out', 'b.tex')],
     });
     await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(
@@ -180,6 +181,7 @@ describe('CLI workflow output resolution', () => {
     );
 
     expect(displayResult).toMatchObject({
+      workingDirectory: cwd,
       copiedOutput: join(cwd, 'out', 'a.tex'),
     });
     await expect(readFile(join(cwd, 'out', 'a.tex'), 'utf8')).resolves.toBe(


### PR DESCRIPTION
## Summary
- add `workingDirectory` metadata to shared CLI run result JSON
- populate it for workflow/resume output resolution, `agents run`, and `multi-agent run`
- add focused tests for the shared formatter and workflow output paths

Closes #5095.

## Dogfood Evidence
- Ran a real Mathematician preset task in `/tmp/texra-dogfood-math-20260602` with `--approval-policy=yolo`; it completed and delegated review successfully.
- The returned `executionId` was only inspectable with the matching `--cwd`, exposing that the JSON result lacked the workspace needed for follow-up automation.

## Validation
- `corepack pnpm exec prettier --write packages/cli/src/commands/_helpers/terminalStatus.ts packages/cli/src/commands/_helpers/workflowOutput.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run compile:safe`
- `npm run lint` (0 errors, 10 existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata on CLI result objects; no changes to auth, execution, or file I/O behavior beyond surfacing cwd in JSON.
> 
> **Overview**
> Headless CLI JSON/NDJSON run results now include **`workingDirectory`**, recording the workspace (`cwd`) used for the run so follow-up commands (e.g. `history show` / resume) do not require guessing or re-passing **`--cwd`**.
> 
> The field is wired through **`createCliRunResult`** and set on workflow output resolution (including interrupted runs with no copies), **`texra agents run`**, and **`texra multi-agent run`**. Tests assert the formatter and workflow output paths expose **`workingDirectory`** alongside existing fields like **`terminalStatus`** and copy paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e051531e2f62a9c4888db12916b41b4a1d21af90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->