### PR TITLE
feat(cli): independent subagent history — scoped viewer, persistence, resume=continue

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -28,9 +28,9 @@ import {
   StreamTabsStrip,
   streamTabsDisplayItems,
 } from './panes/StreamTabsStrip';
-import { SubagentList } from './panes/SubagentList';
+import { SubagentList, subagentPanelRowCount } from './panes/SubagentList';
 import { TipRow } from './panes/TipRow';
-import { TodosPlanPanel } from './panes/TodosPlanPanel';
+import { TodosPlanPanel, todosPlanPanelRowCount } from './panes/TodosPlanPanel';
 import { currentApproval, type PendingApproval } from './state/approvalQueue';
 import {
   isKittyKeypadEnter,
@@ -176,39 +176,41 @@ export function allocateMiddleRows({
 }
 
 export function allocateSidePanelRows({
-  hasSubagentPanel,
-  hasTodosPlanPanel,
+  subagentContentRows,
+  todosPlanContentRows,
   rows,
 }: {
-  readonly hasSubagentPanel: boolean;
-  readonly hasTodosPlanPanel: boolean;
+  readonly subagentContentRows: number;
+  readonly todosPlanContentRows: number;
   readonly rows: number;
 }): {
   readonly subagentRows: number;
   readonly todosPlanRows: number;
 } {
-  const availableRows = Math.max(0, rows);
-  if (!hasSubagentPanel && !hasTodosPlanPanel) {
+  const available = Math.max(0, rows);
+  const subagentNeed = Math.max(0, subagentContentRows);
+  const todosNeed = Math.max(0, todosPlanContentRows);
+  if (available === 0 || subagentNeed + todosNeed === 0) {
     return { subagentRows: 0, todosPlanRows: 0 };
   }
-  if (!hasTodosPlanPanel) {
-    return { subagentRows: availableRows, todosPlanRows: 0 };
+  // Everything fits: each panel gets exactly what its content needs.
+  if (subagentNeed + todosNeed <= available) {
+    return { subagentRows: subagentNeed, todosPlanRows: todosNeed };
   }
-  if (!hasSubagentPanel) {
-    return { subagentRows: 0, todosPlanRows: availableRows };
-  }
-  if (availableRows === 0) {
-    return { subagentRows: 0, todosPlanRows: 0 };
-  }
-  if (availableRows === 1) {
-    return { subagentRows: 0, todosPlanRows: 1 };
-  }
-
-  const subagentRows = Math.max(1, Math.floor(availableRows / 2));
-  return {
-    subagentRows,
-    todosPlanRows: availableRows - subagentRows,
-  };
+  // Over budget: a panel with no content gets nothing, a lone panel takes all.
+  if (subagentNeed === 0) return { subagentRows: 0, todosPlanRows: available };
+  if (todosNeed === 0) return { subagentRows: available, todosPlanRows: 0 };
+  // Both present and over budget: keep at least one row each, split the rest
+  // proportionally to need. At a single row the todo/plan panel wins.
+  if (available === 1) return { subagentRows: 0, todosPlanRows: 1 };
+  const subagentRows = Math.min(
+    available - 1,
+    Math.max(
+      1,
+      Math.round((subagentNeed / (subagentNeed + todosNeed)) * available),
+    ),
+  );
+  return { subagentRows, todosPlanRows: available - subagentRows };
 }
 
 export function staticTranscriptRowBudget({
@@ -332,22 +334,6 @@ export function childControlForegroundMaxRows({
     : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
 }
 
-export function foregroundSurfaceJustifyContent(
-  kind: ForegroundSurfaceKind | undefined,
-): 'flex-start' | 'flex-end' {
-  return kind === 'form' || kind === 'approval' ? 'flex-start' : 'flex-end';
-}
-
-export function foregroundSurfaceContainerHeight({
-  kind,
-  rows,
-}: {
-  readonly kind: ForegroundSurfaceKind | undefined;
-  readonly rows: number;
-}): number | undefined {
-  return kind === 'childControls' && rows >= 3 ? undefined : rows;
-}
-
 export function approvalForegroundMaxRows(
   pending: PendingApproval | undefined,
 ): number | undefined {
@@ -389,7 +375,8 @@ export function App(props: AppProps): React.JSX.Element {
   const activeForm = useSignal(cliState.activeForm);
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
   const reverseSearchOpen = useSignal(cliState.reverseSearchOpen);
-  const transcriptViewerOpen = useSignal(cliState.transcriptViewerOpen);
+  const transcriptViewerStreamId = useSignal(cliState.transcriptViewerStreamId);
+  const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
   const [childControlMode, setChildControlMode] = useState<
@@ -526,30 +513,49 @@ export function App(props: AppProps): React.JSX.Element {
     staticTranscriptRows: staticTranscriptRows ?? 0,
     tipVisible: tipRowVisible,
   });
-  // The subagent/todos panels live at the bottom of the same vertical
-  // column. Carve a bounded slice off the transcript area so the
-  // conversation keeps most of the height and the input stays pinned.
-  const bottomPanelBudget =
-    hasSubagentPanel || hasTodosPlanPanel
-      ? Math.min(BOTTOM_PANEL_MAX_ROWS, Math.floor(transcriptRows / 2))
+  // The subagent/todos panels live at the bottom of the same vertical column.
+  // Reserve only as many rows as the panels actually need — capped so they
+  // never take more than half the transcript or push the input off-screen —
+  // and let the conversation reclaim whatever the panels don't use. A fixed
+  // reservation would leave a dead gap above the input whenever the lists are
+  // shorter than the cap.
+  const subagentContentRows =
+    hasSubagentPanel && activeSlice ? subagentPanelRowCount(activeSlice) : 0;
+  const todosPlanContentRows =
+    hasTodosPlanPanel && activeSlice
+      ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
+  const bottomPanelBudget = Math.min(
+    BOTTOM_PANEL_MAX_ROWS,
+    subagentContentRows + todosPlanContentRows,
+    Math.floor(transcriptRows / 2),
+  );
   const conversationRows = transcriptRows - bottomPanelBudget;
   const { subagentRows, todosPlanRows } = allocateSidePanelRows({
-    hasSubagentPanel,
-    hasTodosPlanPanel,
+    subagentContentRows,
+    todosPlanContentRows,
     rows: bottomPanelBudget,
   });
   function renderForegroundSurface(): React.ReactNode {
     switch (foregroundKind) {
-      case 'transcript':
+      case 'transcript': {
+        // foregroundKind is 'transcript' only while transcriptViewerOpen, so
+        // transcriptViewerStreamId is set here — guard once to narrow it.
+        if (!transcriptViewerStreamId) return null;
         return (
           <TranscriptViewer
             availableRows={foregroundRows}
-            onClose={() => cliState.transcriptViewerOpen.set(false)}
-            slice={activeSlice}
+            onClose={() => cliState.transcriptViewerStreamId.set(undefined)}
+            slice={streams.get(transcriptViewerStreamId)}
+            title={streamScopeDisplayLabel({
+              parentStream,
+              streamId: transcriptViewerStreamId,
+              streams,
+            })}
             width={transcriptWidth}
           />
         );
+      }
       case 'childControls': {
         if (!childControlMode) return null;
         const target = childControlTarget;
@@ -583,6 +589,9 @@ export function App(props: AppProps): React.JSX.Element {
             mode={childControlMode}
             onClose={() => setChildControlMode(undefined)}
             onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
+            onViewStream={(streamId) =>
+              cliState.transcriptViewerStreamId.set(streamId)
+            }
             onKillExecution={props.onKillExecution}
             slice={target.slice}
             streamScopeDetail={streamScopeDetail}
@@ -604,10 +613,6 @@ export function App(props: AppProps): React.JSX.Element {
     }
   }
   const foregroundSurface = renderForegroundSurface();
-  const foregroundContainerHeight = foregroundSurfaceContainerHeight({
-    kind: foregroundKind,
-    rows: foregroundRows,
-  });
 
   const focusShortcutsActive = appFocusShortcutsActive({
     inputDisabled,
@@ -643,7 +648,7 @@ export function App(props: AppProps): React.JSX.Element {
     if (!focusShortcutsActive) return;
 
     if (key.ctrl && input.toLowerCase() === 't') {
-      if (activeSlice) cliState.transcriptViewerOpen.set(true);
+      if (activeStreamId) cliState.transcriptViewerStreamId.set(activeStreamId);
       return;
     }
 
@@ -708,11 +713,16 @@ export function App(props: AppProps): React.JSX.Element {
             />
           ) : null}
           {foregroundSurface ? (
+            // Cap the modal area at its row budget but size to the surface's
+            // actual content: every foreground surface (forms, approvals,
+            // transcript viewer, child controls) already windows itself to the
+            // `foregroundRows` budget it is handed, so a fixed height only ever
+            // leaves dead rows below a short form/approval. maxHeight keeps the
+            // budget as a safety clip without reserving it.
             <Box
               flexDirection="column"
-              height={foregroundContainerHeight}
+              maxHeight={foregroundRows}
               alignItems="flex-start"
-              justifyContent={foregroundSurfaceJustifyContent(foregroundKind)}
               overflowY="hidden"
             >
               {foregroundSurface}

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -15,6 +15,7 @@ import {
   clampPickerIndex,
   liveChildExecutionElapsedKey,
   nextPickerIndex,
+  subagentPickerSelection,
   type ChildControlItem,
   type ChildControlMode,
 } from '../state/childControls';
@@ -32,6 +33,9 @@ export interface ChildControlPickerProps {
   readonly mode: ChildControlMode;
   readonly onClose: () => void;
   readonly onFocusStream: (streamId: StreamTabId) => void;
+  /** Open the chosen subagent's scoped transcript viewer (its independent
+   *  history). Falls back to focus when omitted. */
+  readonly onViewStream?: (streamId: StreamTabId) => void;
   readonly onKillExecution: (executionId: string) => void;
   readonly slice: StreamSlice | undefined;
   readonly streamScopeDetail?: string;
@@ -85,7 +89,8 @@ export function pickerKeyHints(
   }
   const hints: KeyHint[] = [{ key: '↑/↓', action: 'navigate' }];
   if (itemCount > 1) hints.push({ key: '1-9', action: 'jump' });
-  hints.push({ key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' });
+  hints.push({ key: 'Enter', action: 'view' });
+  if (mode === 'subagents') hints.push({ key: 'f', action: 'focus' });
   if (canKill) hints.push({ key: 'k', action: 'kill' });
   hints.push({ key: 'Esc', action: 'close' });
   return hints;
@@ -109,7 +114,10 @@ export function pickerKeyHintsForColumns(
   if (itemCount > 1 && availableColumns >= MIN_COLUMNS_FOR_JUMP_HINT) {
     hints.push({ key: '1-9', action: 'jump' });
   }
-  hints.push({ key: 'Enter', action: mode === 'subagents' ? 'focus' : 'view' });
+  hints.push({ key: 'Enter', action: 'view' });
+  if (mode === 'subagents' && availableColumns >= MIN_COLUMNS_FOR_KILL_HINT) {
+    hints.push({ key: 'f', action: 'focus' });
+  }
   if (canKill && availableColumns >= MIN_COLUMNS_FOR_KILL_HINT) {
     hints.push({ key: 'k', action: 'kill' });
   }
@@ -921,6 +929,7 @@ export function ChildControlPicker({
   mode,
   onClose,
   onFocusStream,
+  onViewStream,
   onKillExecution,
   slice,
   streamScopeDetail,
@@ -975,6 +984,18 @@ export function ChildControlPicker({
 
   useInput(
     (input, key) => {
+      // 'f' focuses the highlighted subagent (make it the active stream)
+      // without opening its transcript — distinct from Enter, which opens
+      // the scoped viewer. Mirrors TaskDetailView's 'f: focus stream'.
+      if (
+        mode === 'subagents' &&
+        input.toLowerCase() === 'f' &&
+        selectedItem?.childStreamId
+      ) {
+        onFocusStream(selectedItem.childStreamId);
+        onClose();
+        return;
+      }
       const action = childPickerKeyAction({
         input,
         ctrl: key.ctrl,
@@ -1002,13 +1023,14 @@ export function ChildControlPicker({
           if (action.index < items.length) setHighlight(action.index);
           return;
         case 'select': {
-          if (!selectedItem) return;
-          if (mode === 'subagents' && selectedItem.childStreamId) {
-            onFocusStream(selectedItem.childStreamId);
+          const selection = subagentPickerSelection(mode, selectedItem);
+          if (!selection) return;
+          if (selection.kind === 'view') {
+            (onViewStream ?? onFocusStream)(selection.streamId);
             onClose();
             return;
           }
-          setTailExecutionId(selectedItem.executionId);
+          setTailExecutionId(selection.executionId);
           return;
         }
         case 'kill': {

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -18,6 +18,9 @@ export interface TranscriptViewerProps {
   readonly width: number;
   readonly availableRows: number;
   readonly onClose: () => void;
+  /** Optional header label naming the stream being viewed (e.g. the subagent
+   *  label) so a scoped viewer makes clear whose transcript this is. */
+  readonly title?: string;
 }
 
 interface ScrollState {
@@ -30,6 +33,7 @@ export function TranscriptViewer({
   width,
   availableRows,
   onClose,
+  title,
 }: TranscriptViewerProps): React.JSX.Element {
   const lines = useMemo(
     () => transcriptToLines(slice, Math.max(1, width)),
@@ -39,8 +43,10 @@ export function TranscriptViewer({
     // O(N) re-flatten on status-only ticks during streaming.
     [slice?.entries, width],
   );
-  // Reserve one row for the footer hint strip.
-  const viewRows = Math.max(1, availableRows - 1);
+  // Reserve one row for the footer hint strip, plus one for the title header
+  // when present, so the scrollable region never overflows availableRows.
+  const titleRows = title ? 1 : 0;
+  const viewRows = Math.max(1, availableRows - 1 - titleRows);
   const maxOffset = Math.max(0, lines.length - viewRows);
   // Open pinned to the bottom — the latest output is what the user just asked
   // to inspect.
@@ -88,6 +94,11 @@ export function TranscriptViewer({
 
   return (
     <Box flexDirection="column" width={width}>
+      {title ? (
+        <Text bold color="cyan" wrap="truncate-end">
+          {title}
+        </Text>
+      ) : null}
       <Box flexDirection="column" overflowY="hidden">
         {lines.length === 0 ? (
           <Text dimColor>(no transcript yet)</Text>

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -135,6 +135,19 @@ export function compactRows(params: {
   };
 }
 
+/**
+ * Natural (uncapped) compact-row count for a slice's children: one row per
+ * visible subagent and active process. Drives the bottom-panel reservation in
+ * App so the panel takes only the height it needs.
+ */
+export function subagentPanelRowCount(slice: {
+  readonly activeSubagents: readonly ActiveChildInfo[];
+  readonly childStreams: readonly ActiveChildInfo[];
+  readonly activeProcesses: readonly ActiveChildInfo[];
+}): number {
+  return visibleSubagentRows(slice).length + slice.activeProcesses.length;
+}
+
 export interface SubagentListProps {
   readonly maxRows?: number;
 }

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -164,6 +164,18 @@ export function compactTodosPlanRows({
   };
 }
 
+/**
+ * Natural (uncapped) compact-row count for a slice's todos + plan: one row per
+ * todo, plus the plan summary and one row per plan step. Drives the bottom-panel
+ * reservation in App so the panel takes only the height it needs.
+ */
+export function todosPlanPanelRowCount(
+  todos: readonly TodoItem[],
+  plan: Plan | null,
+): number {
+  return todos.length + (plan ? 1 + plan.steps.length : 0);
+}
+
 function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
   switch (row.kind) {
     case 'todo':

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -8,7 +8,7 @@
 import { render } from 'ink';
 import PQueue from 'p-queue';
 
-import { getDefaultStreamLogStore } from '@transcript';
+import { flushPendingRunTraces, getDefaultStreamLogStore } from '@transcript';
 import { getAgent, loadAgents } from '@agent/index';
 import { type AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -16,7 +16,10 @@ import {
   interruptActiveChildren,
   killExecution,
 } from '@agent/runtime/executionRegistry';
-import { executeAgent } from '@agent/runtime/executeAgent';
+import {
+  executeAgent,
+  resumeToolUseFromSnapshot,
+} from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   notifyFollowUpSent,
@@ -45,7 +48,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { writeTextStderr } from '@cli/runtime/logSinks';
+import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
 import {
   signInCliSupabase,
   signOutCliSupabase,
@@ -56,6 +59,10 @@ import {
   type CliApprovalPolicy,
 } from '@cli/schemas/cliSettings';
 import { parseCliHistoryId, readCliHistoryConfig } from '@cli/runtime/history';
+import {
+  explainNonResumable,
+  resolveCliResumeSnapshot,
+} from '@cli/runtime/sessionResume';
 import {
   formatCliMemoryList,
   formatCliMemoryPreview,
@@ -93,6 +100,7 @@ import { notify } from './notifications/terminalNotifier';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
+import { collectResumeTargets, formatResumeHint } from './state/resumeHint';
 import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog, syncStreamLog } from './state/subscribeStreamLog';
@@ -123,6 +131,13 @@ export interface RunChatInit {
   readonly modelOverride?: string;
   /** Visible team identity when chat was launched from a multi-agent preset. */
   readonly teamName?: string;
+  /**
+   * Continue (resume) a stored tool-use session by its execution id instead of
+   * starting fresh: the interactive `texra --resume <id>` path. Set by the
+   * resume command for TTY sessions; the prior transcript is rehydrated and the
+   * suspended tool-use flow is continued on mount (see `resumeAgentRun`).
+   */
+  readonly resumeExecutionId?: ExecutionId;
 }
 
 const QUEUED_FOLLOW_UP_NOTICE_LENGTH = 96;
@@ -200,7 +215,6 @@ export function chatTuiCanStartRootRun(
 export type ChatTuiSigintAction =
   | 'clean-exit'
   | 'force-exit'
-  | 'interrupt-and-exit'
   | 'interrupt-and-arm-exit';
 
 export function chatTuiSigintAction(input: {
@@ -210,8 +224,32 @@ export function chatTuiSigintAction(input: {
 }): ChatTuiSigintAction {
   if (input.exitArmed) return 'force-exit';
   if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
-  if (input.canInterruptActiveRun) return 'interrupt-and-exit';
+  // Resumable-idle (interruptible but not actively running): exit WITHOUT
+  // interrupting so the suspended tool-use flow record survives for resume —
+  // interrupting would clear it in runToolUseFlow's finally. force-exit calls
+  // process.exit, leaving the suspended flow on disk for `texra --resume`.
+  if (input.canInterruptActiveRun) return 'force-exit';
   return 'clean-exit';
+}
+
+/**
+ * On exit, a tool-use session suspended at the WAIT node (idle/WAITING) must
+ * NOT be interrupted: interrupting clears its per-execution flow record in
+ * `runToolUseFlow`'s finally, destroying the only resumable state. The record
+ * survives only when the process dies while the flow is still suspended.
+ *
+ * The discriminator: `canInterruptActiveRun` is true for any pending run, but
+ * `canStopActiveRun` is true only while a turn is *actively* running. So
+ * "interruptible but not stoppable" is exactly the resumable-idle case. Kept
+ * pure (takes the two precomputed booleans) so the exit policy is unit-testable
+ * without the live status plumbing. Used by the graceful-exit `finally`; the
+ * SIGINT path encodes the same idle→preserve rule via `chatTuiSigintAction`.
+ */
+export function chatTuiIsResumableIdleOnExit(input: {
+  readonly canInterruptActiveRun: boolean;
+  readonly canStopActiveRun: boolean;
+}): boolean {
+  return input.canInterruptActiveRun && !input.canStopActiveRun;
 }
 
 function chatTuiActiveChildStreamId(): StreamTabId | undefined {
@@ -255,19 +293,19 @@ export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
     : undefined;
 }
 
+export function chatTuiShouldAnnounceQueuedFollowUp(
+  targetStreamId: StreamTabId | undefined,
+): boolean {
+  if (!targetStreamId) return true;
+  return !chatTuiStreamStatuses(targetStreamId).includes(STREAM_STATUS.WAITING);
+}
+
 export function chatTuiRejectedChildFollowUpTarget(): StreamTabId | undefined {
   const activeStreamId = chatTuiActiveChildStreamId();
   if (!activeStreamId) return undefined;
   return chatTuiCanAcceptFollowUp(chatTuiStreamStatuses(activeStreamId))
     ? undefined
     : activeStreamId;
-}
-
-export function chatTuiShouldAnnounceQueuedFollowUp(
-  targetStreamId: StreamTabId | undefined,
-): boolean {
-  if (!targetStreamId) return true;
-  return !chatTuiStreamStatuses(targetStreamId).includes(STREAM_STATUS.WAITING);
 }
 
 interface SlashCommandContext {
@@ -978,6 +1016,19 @@ export async function runChat(
     stdout: process.stdout,
   });
 
+  // Enable StreamLog persistence for the interactive session so transcripts
+  // survive exit and can be reopened on resume. Uses the shared (extension-
+  // compatible) StreamLogStore, so a workspace opened in either surface reads
+  // the same `streamLogs/<id>.json`. load() is summaries-only (lazy) and must
+  // run before any append — it clears in-memory logs on entry — hence before
+  // subscribeStreamLog wires the append→sync bridge below. Best-effort: a load
+  // failure leaves persistence off (save() no-ops) rather than breaking chat.
+  try {
+    await getDefaultStreamLogStore().load();
+  } catch {
+    // Persistence stays disabled; the session still runs in-memory as before.
+  }
+
   const disposers: Array<() => void> = [];
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
@@ -1137,6 +1188,81 @@ export async function runChat(
       });
   };
 
+  // Interactive `texra --resume <id>`: continue a suspended tool-use session.
+  // Mirrors startAgentRun's runtimeHost/approvals/runPromise lifecycle, but
+  // (a) resolves a persisted snapshot instead of building a fresh config, and
+  // (b) the streamId is already known (re-derived from the prior run), so we
+  // set session.streamId up front and rehydrate that stream's transcript so
+  // the user sees the prior conversation before the continued turn streams in.
+  const resumeAgentRun = async (id: ExecutionId): Promise<void> => {
+    const resolution = await resolveCliResumeSnapshot(id);
+    if (resolution.kind !== 'toolUse') {
+      // Workflows / missing / already-completed sessions can't continue here —
+      // surface why and leave the session idle so the user can still chat.
+      appendLocalErrorTranscript(explainNonResumable(resolution, id));
+      return;
+    }
+
+    followUpQueue.clear();
+    session.runCompleted = false;
+    session.stopRequested = false;
+    session.runExitCode = CliExitCode.Success;
+    session.streamId = resolution.streamId;
+    session.executionId = resolution.snapshot.executionId;
+
+    const currentModel = resolution.config.model;
+    const sessionContext = currentSessionContext(currentModel);
+    cliState.sessionMeta.set({
+      ...cliState.sessionMeta.get(),
+      agent: resolution.config.agent,
+      model: resolution.config.model,
+      canDelegate: agentSupportsDelegation(resolution.config.agent),
+    });
+
+    // Rehydrate the prior transcript so the user sees the conversation they're
+    // continuing. ensureLoaded pulls the persisted entries off disk into the
+    // store; syncStreamLog promotes them into `<Static>` scrollback. An older
+    // run with no persisted entries simply shows whatever exists (possibly
+    // nothing) — the continued turn streams in regardless.
+    await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
+    syncStreamLog(resolution.streamId);
+    cliState.activeStreamId.set(resolution.streamId);
+
+    const runtimeHost = createCliRuntimeHost(sessionContext);
+    const wrapped = wrapRuntimeHost(runtimeHost);
+    const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
+    disposers.push(unbindApprovals);
+
+    session.runPromise = setCliHelperModel(currentModel)
+      .then(() => resumeToolUseFromSnapshot(resolution.snapshot, wrapped))
+      .then(() => {
+        // resumeToolUseFromSnapshot resolves void (no result object), so the
+        // streamId we already know is the only handle: flush the tail and
+        // promote any deferred assistant/tool rows into `<Static>`.
+        if (session.streamId) {
+          syncStreamLog(session.streamId);
+          finalizeAssistantTranscriptEntries(session.streamId);
+        }
+        session.runExitCode = CliExitCode.Success;
+        notify({ kind: 'agentFinished' });
+      })
+      .catch((error: unknown) => {
+        if (!session.stopRequested) {
+          appendLocalErrorTranscript(toErrorMessage(error));
+        }
+        session.runExitCode = session.stopRequested
+          ? CliExitCode.Success
+          : CliExitCode.AgentError;
+      })
+      .finally(() => {
+        session.runCompleted = true;
+        void runtimeHost.close();
+      });
+    // Don't await session.runPromise here: a resumed session that suspends at
+    // the WAIT node leaves runPromise unresolved (mirrors startAgentRun's
+    // fire-and-forget). The exit `finally` handles the dangling-promise case.
+  };
+
   // Pre-register the slash commands the input palette uses.
   registerBuiltinSlashCommands({
     canSelectAgent: () => chatTuiCanStartRootRun(session),
@@ -1276,6 +1402,11 @@ export async function runChat(
 
   let pendingExitTimer: ReturnType<typeof setTimeout> | undefined;
   let exitArmed = false;
+  // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
+  // waitUntilExit and re-enters the post-waitUntilExit finally, so the finally
+  // guards on this to avoid draining persistence / printing the resume hint a
+  // second time.
+  let exiting = false;
   const clearPendingExit = (): void => {
     if (pendingExitTimer) clearTimeout(pendingExitTimer);
     pendingExitTimer = undefined;
@@ -1288,12 +1419,45 @@ export async function runChat(
     process.off('SIGTERM', handleSigterm);
     process.off('SIGHUP', handleSighup);
   };
+  // Persist the reopen hint to native scrollback: the main session plus each
+  // resumable tool-use subagent, so any route can be continued by its own id.
+  // Read cliState before resetCliState() clears it.
+  const printResumeHintOnExit = (): void => {
+    if (!session.executionId) return;
+    const hint = formatResumeHint(
+      collectResumeTargets({
+        rootExecutionId: session.executionId,
+        streams: cliState.streams.get(),
+      }),
+    );
+    if (hint) writeTextStdout(`\n${hint}`);
+  };
+  // Materialize buffered trace chunks, then drain the debounced StreamLog disk
+  // writes so the tail of the session isn't lost (SAVE_DEBOUNCE_MS window).
+  // flush() is bounded (MAX_WRITE_RETRIES) and a no-op when persistence never
+  // loaded, so this can neither hang nor affect headless paths.
+  const drainPersistence = (): Promise<void> => {
+    flushPendingRunTraces();
+    return getDefaultStreamLogStore().flush();
+  };
   const exitNow = (exitCode: number): void => {
+    exiting = true;
     removeProcessHandlers();
     clearPendingExit();
     ink.unmount();
+    // Print the resume hint while the cursor is still parked at the bottom of
+    // the unmounted frame — BEFORE cleanupTerminalModes, whose `?1049l` jumps
+    // the cursor mid-screen on this (never-alt-screen) TUI and makes the hint
+    // overprint the transcript. Mirrors the requestInputExit path's order.
+    printResumeHintOnExit();
     cleanupTerminalModes({ clearItermProgress });
-    process.exit(exitCode);
+    // Synchronous signal exits (SIGINT double-tap / SIGTERM / SIGHUP) own the
+    // whole teardown here (the finally skips when `exiting`), so drain
+    // persistence before exiting. `.catch` keeps a flush failure from becoming
+    // an unhandled rejection under --unhandled-rejections=strict.
+    void drainPersistence()
+      .catch(() => {})
+      .finally(() => process.exit(exitCode));
   };
   const armExit = (): void => {
     exitArmed = true;
@@ -1315,13 +1479,11 @@ export async function runChat(
         requestInputExit();
         return;
       case 'force-exit':
-        exitNow(130);
-        return;
-      case 'interrupt-and-exit':
-        if (canInterruptActiveRun()) {
-          session.stopRequested = true;
-          interruptActive();
-        }
+        // exitArmed OR resumable-idle: exit WITHOUT interrupting. For an
+        // idle/WAITING session this preserves the suspended tool-use flow
+        // record (executions/<id>/flow-*.json) so `texra --resume` can
+        // continue it — interrupting would clear it in runToolUseFlow's
+        // finally. exitNow() calls process.exit, leaving the flow on disk.
         exitNow(130);
         return;
       case 'interrupt-and-arm-exit':
@@ -1333,16 +1495,17 @@ export async function runChat(
         assertNever(sigintAction, 'Unhandled chat TUI SIGINT action');
     }
   };
-  const handleSigterm = (): void => {
-    session.stopRequested = true;
-    interruptActive();
-    exitNow(143);
+  // Only interrupt an actively-running turn; an idle/WAITING session is left
+  // suspended so its flow record survives for resume (see handleSigint).
+  const handleTermSignal = (exitCode: number): void => {
+    if (canStopActiveRun()) {
+      session.stopRequested = true;
+      interruptActive();
+    }
+    exitNow(exitCode);
   };
-  const handleSighup = (): void => {
-    session.stopRequested = true;
-    interruptActive();
-    exitNow(129);
-  };
+  const handleSigterm = (): void => handleTermSignal(143);
+  const handleSighup = (): void => handleTermSignal(129);
   function requestInputExit(): void {
     removeProcessHandlers();
     clearPendingExit();
@@ -1351,6 +1514,20 @@ export async function runChat(
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);
   process.on('SIGHUP', handleSighup);
+
+  // Interactive resume: kick off the continued tool-use run now that Ink is
+  // mounted (so the rehydrated transcript + streamed continuation render) and
+  // the signal handlers are armed. Fire-and-forget — resumeAgentRun installs
+  // session.runPromise, and the normal first-input path stays available so the
+  // user can keep chatting (follow-ups target session.streamId as usual).
+  if (init.resumeExecutionId) {
+    // Guard the void: resumeAgentRun awaits snapshot resolution / ensureLoaded
+    // before installing its own .then/.catch, so an early throw there would
+    // otherwise surface as an unhandled rejection.
+    void resumeAgentRun(init.resumeExecutionId).catch((error: unknown) => {
+      appendLocalErrorTranscript(toErrorMessage(error));
+    });
+  }
 
   // Auto-prompt when the active stream goes WAITING so the UI clearly
   // signals "your turn." Combined with the StatusBar pill, this replaces
@@ -1370,17 +1547,45 @@ export async function runChat(
   try {
     await ink.waitUntilExit();
   } finally {
-    removeProcessHandlers();
-    clearPendingExit();
-    for (const dispose of disposers) dispose();
-    await followUpQueue.onIdle();
-    if (session.runPromise && !session.runCompleted) {
-      session.stopRequested = true;
-      interruptActive();
+    // A signal exit (SIGINT/SIGTERM/SIGHUP) runs exitNow(), which does the full
+    // teardown and process.exit()s itself; its ink.unmount() resolves
+    // waitUntilExit and re-enters this finally. Skip the entire graceful
+    // teardown in that case — re-running it would duplicate the drain / hint /
+    // cleanup, and the resumableIdle process.exit() below would race exitNow's
+    // async exit, dropping the flush and the signal exit code.
+    if (!exiting) {
+      removeProcessHandlers();
+      clearPendingExit();
+      for (const dispose of disposers) dispose();
+      await followUpQueue.onIdle();
+      // A suspended (idle/WAITING) root session is resumable: its flow record
+      // survives only if we DON'T interrupt the flow (interrupt clears it). See
+      // chatTuiIsResumableIdleOnExit for why "interruptible but not stoppable"
+      // is exactly the idle-but-suspended case we must leave untouched.
+      const resumableIdle = chatTuiIsResumableIdleOnExit({
+        canInterruptActiveRun: canInterruptActiveRun(),
+        canStopActiveRun: canStopActiveRun(),
+      });
+      if (session.runPromise && !session.runCompleted && !resumableIdle) {
+        session.stopRequested = true;
+        interruptActive();
+        // Only await a run we actually interrupted/finished. A resumableIdle run
+        // is parked at the WAIT node and its runPromise NEVER resolves, so
+        // awaiting it would hang the process here.
+        await session.runPromise;
+      }
+      await drainPersistence();
+      printResumeHintOnExit();
+      resetCliState();
+      cleanupTerminalModes({ clearItermProgress });
+      if (resumableIdle) {
+        // The dangling runPromise keeps the event loop alive, so a normal return
+        // would never let the process exit. Force-exit here, AFTER persistence
+        // is flushed and the resume hint is printed, preserving the suspended
+        // flow record on disk for `texra --resume`.
+        process.exit(session.runExitCode);
+      }
     }
-    await session.runPromise;
-    resetCliState();
-    cleanupTerminalModes({ clearItermProgress });
   }
   return { exitCode: session.runExitCode };
 }

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -370,6 +370,26 @@ export function nextPickerIndex(
   return (index + 1) % length;
 }
 
+export type SubagentPickerSelection =
+  | { readonly kind: 'view'; readonly streamId: StreamTabId }
+  | { readonly kind: 'detail'; readonly executionId: string };
+
+/** What pressing Enter on a child-control row should do. In subagents mode a
+ *  row backed by a child stream opens that subagent's scoped transcript
+ *  viewer (its independent history); everything else (tasks/processes, or a
+ *  stream-less row) drops into the inline tail detail view. Pure so the
+ *  picker's key handling stays unit-testable. */
+export function subagentPickerSelection(
+  mode: ChildControlMode,
+  item: Pick<ChildControlItem, 'childStreamId' | 'executionId'> | undefined,
+): SubagentPickerSelection | undefined {
+  if (!item) return undefined;
+  if (mode === 'subagents' && item.childStreamId) {
+    return { kind: 'view', streamId: item.childStreamId };
+  }
+  return { kind: 'detail', executionId: item.executionId };
+}
+
 export function childPickerKeyAction(key: PickerKeyInput): PickerKeyAction {
   if (key.escape) return { kind: 'close' };
   if (key.upArrow) return { kind: 'up' };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -10,6 +10,7 @@ import { signal, Signal } from '@lit-labs/signals';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type {
   ActiveChildInfo,
+  AgentCategory,
   ConversationProgress,
   NormalizedToolUse,
   Plan,
@@ -71,6 +72,10 @@ export interface BypassState {
 
 export interface StreamSlice {
   readonly streamId: StreamTabId;
+  /** Agent category for this stream (`toolUse` / `workflow` / …), captured
+   *  from `setActiveStream`. Lets the exit hint list only resumable tool-use
+   *  subagents (workflows don't resume). Undefined until the stream activates. */
+  readonly category: AgentCategory | undefined;
   readonly status: StreamStatus | undefined;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
    *  status. Drives the StatusBar's live elapsed-time segment so a long
@@ -137,10 +142,14 @@ const ACTIVE_FORM = signal<ActiveSlashForm | undefined>(undefined);
 const SLASH_PALETTE_OPEN = signal<boolean>(false);
 const REVERSE_SEARCH_OPEN = signal<boolean>(false);
 
-/** True while the ctrl+t full-output transcript viewer owns the screen. The
- *  viewer shows the active stream's tool output untruncated and scrollable;
- *  the finalized scrollback and live region only ever show a head+tail slice. */
-const TRANSCRIPT_VIEWER_OPEN = signal<boolean>(false);
+/** The stream whose full-output transcript the viewer is showing, or
+ *  `undefined` when the viewer is closed. ctrl+t opens it on the active
+ *  stream; the Subagents picker opens it on a chosen child so each subagent's
+ *  transcript is independently browsable without disturbing the main
+ *  scrollback. The viewer shows that one stream's tool output untruncated and
+ *  scrollable; the finalized scrollback and live region only ever show a
+ *  head+tail slice. */
+const TRANSCRIPT_VIEWER_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
 const PENDING_EXIT_HINT = signal<boolean>(false);
 const PENDING_EXIT_RESUME_ID = signal<string | undefined>(undefined);
@@ -157,7 +166,9 @@ export const cliState = {
   activeForm: ACTIVE_FORM as Signal.State<ActiveSlashForm | undefined>,
   slashPaletteOpen: SLASH_PALETTE_OPEN as Signal.State<boolean>,
   reverseSearchOpen: REVERSE_SEARCH_OPEN as Signal.State<boolean>,
-  transcriptViewerOpen: TRANSCRIPT_VIEWER_OPEN as Signal.State<boolean>,
+  transcriptViewerStreamId: TRANSCRIPT_VIEWER_STREAM_ID as Signal.State<
+    StreamTabId | undefined
+  >,
   pendingExitHint: PENDING_EXIT_HINT as Signal.State<boolean>,
   pendingExitResumeId: PENDING_EXIT_RESUME_ID as Signal.State<
     string | undefined
@@ -173,6 +184,7 @@ export const NO_BYPASS: BypassState = {
 function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
+    category: undefined,
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
@@ -293,7 +305,7 @@ export function resetCliState(sessionMeta = defaultSessionMeta()): void {
   cliState.activeForm.set(undefined);
   cliState.slashPaletteOpen.set(false);
   cliState.reverseSearchOpen.set(false);
-  cliState.transcriptViewerOpen.set(false);
+  cliState.transcriptViewerStreamId.set(undefined);
   cliState.pendingExitHint.set(false);
   cliState.pendingExitResumeId.set(undefined);
   for (const resetHook of RESET_HOOKS) resetHook();

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -1,0 +1,66 @@
+// Builds the "Resume this session with: …" hint printed to scrollback on exit.
+//
+// Lists the main session plus each resumable tool-use subagent so any route
+// can be continued by its own id. Workflows are excluded — they don't resume
+// (only tool-use agents do). Reads only the in-memory stream tree, which still
+// holds finished subagents for the session, so no exit-time disk I/O is needed.
+
+import { AGENT_CATEGORY, type StreamTabId } from '@shared/schemas';
+
+import type { StreamSlice } from './cliState';
+
+export interface ResumeTarget {
+  readonly executionId: string;
+  /** Human label for the route (agent name for subagents, "main" for root). */
+  readonly label: string;
+  readonly isRoot: boolean;
+}
+
+export interface ResumeTargetsInput {
+  readonly rootExecutionId: string | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}
+
+/** The main session followed by each tool-use subagent (any depth), deduped by
+ *  executionId. Subagents whose stream isn't a tool-use agent — workflow
+ *  children, tool processes — are skipped because they can't be resumed. */
+export function collectResumeTargets({
+  rootExecutionId,
+  streams,
+}: ResumeTargetsInput): readonly ResumeTarget[] {
+  const targets: ResumeTarget[] = [];
+  const seen = new Set<string>();
+
+  if (rootExecutionId) {
+    targets.push({ executionId: rootExecutionId, label: 'main', isRoot: true });
+    seen.add(rootExecutionId);
+  }
+
+  for (const slice of streams.values()) {
+    for (const child of slice.childStreams) {
+      if (!child.childStreamId || seen.has(child.executionId)) continue;
+      const childSlice = streams.get(child.childStreamId);
+      if (childSlice?.category !== AGENT_CATEGORY.TOOL_USE) continue;
+      seen.add(child.executionId);
+      targets.push({
+        executionId: child.executionId,
+        label: child.agentName || child.toolName || child.executionId,
+        isRoot: false,
+      });
+    }
+  }
+
+  return targets;
+}
+
+/** Multi-line reopen hint, or undefined when there's nothing to resume. */
+export function formatResumeHint(
+  targets: readonly ResumeTarget[],
+): string | undefined {
+  if (targets.length === 0) return undefined;
+  const lines = ['Resume this session with:'];
+  for (const target of targets) {
+    lines.push(`  texra --resume ${target.executionId}  (${target.label})`);
+  }
+  return lines.join('\n');
+}

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -83,7 +83,15 @@ function applyToState<K extends ProgressEvent>(
       }
       // Register background child streams without stealing focus from the
       // parent page. This mirrors the extension progress view contract.
-      patchStream(next, (s) => ({ ...s }));
+      // Capture the agent category so the exit hint can list only resumable
+      // tool-use subagents (workflows don't resume).
+      // Always return a fresh slice so a brand-new (e.g. suppressed child)
+      // stream is registered in the map even when no category is supplied —
+      // returning `s` unchanged would leave a never-created stream unregistered.
+      patchStream(next, (s) => ({
+        ...s,
+        category: p.agentCategory ?? s.category,
+      }));
       if (p.suppressViewSwitch !== true) {
         cliState.activeStreamId.set(next);
       }

--- a/packages/cli/src/commands/_helpers/terminalStatus.ts
+++ b/packages/cli/src/commands/_helpers/terminalStatus.ts
@@ -25,7 +25,7 @@ export type CliRunResult = ExecuteAgentResult extends infer T
     : never
   : never;
 
-function isExecutionStatus(
+export function isExecutionStatus(
   value: string | undefined,
 ): value is ExecutionStatus {
   return (

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -13,6 +13,11 @@ import {
   withCliMultiAgentPresetVisibility,
 } from '../runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
+import {
+  getCliModelAccessList,
+  type CliModelAccess,
+} from '../runtime/modelAccess';
+import { getCliApiMode } from '../runtime/apiAccessMode';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 
 import { contextFromArgs } from './_helpers/context';
@@ -52,15 +57,23 @@ async function runOrchestration(context: CliContext): Promise<number> {
     history,
     toolUseAgents: getVisibleAgents(AgentCategory.ToolUse),
   });
+  // Load the model registry up front so the launcher can offer a model pick
+  // after an agent/team choice. Best-effort: an unavailable registry just
+  // launches with the default model instead of blocking the launcher.
+  const apiMode = context.apiMode ?? getCliApiMode();
+  const models: readonly CliModelAccess[] = await getCliModelAccessList({
+    apiMode,
+  }).catch(() => []);
   const { runOrchestrationTui } =
     await import('../orchestration/runOrchestrationTui');
-  const action = await runOrchestrationTui(items);
+  const action = await runOrchestrationTui(items, { models, apiMode });
 
   switch (action.kind) {
     case 'chat': {
       const { runChat } = await import('../chat/tui/runChatTui');
       const result = await runChat(context, {
         agentOverride: action.agent,
+        modelOverride: action.model,
       });
       return result.exitCode;
     }
@@ -81,6 +94,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
         runChat(context, {
           agentOverride: plan.rootAgent?.name,
           teamName: action.presetName,
+          modelOverride: action.model,
         }),
       );
       return result.exitCode;

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,90 +1,71 @@
-import { loadAgents } from '@agent/index';
-import { writeTerminalStatus } from '@agent/storage';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+import type { ExecutionId } from '@shared/schemas';
 
-import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliExitCode } from '../runtime/exitCodes';
-import { readCliHistoryConfig, parseCliHistoryId } from '../runtime/history';
+import { parseCliHistoryId } from '../runtime/history';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
-import { shouldRenderRunProgress } from '../runtime/runProgressRenderer';
+import { writeTextStderr } from '../runtime/logSinks';
+import {
+  explainNonResumable,
+  resolveCliResumeSnapshot,
+} from '../runtime/sessionResume';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
-import { emitCliResult } from './_helpers/output';
-import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
-import { executeCliRequest } from './_helpers/runExecution';
-import {
-  terminalStatusExitCode,
-  type CliRunResult,
-} from './_helpers/terminalStatus';
-import {
-  formatWorkflowTextResult,
-  resolveWorkflowOutput,
-  resumeWorkflowOutputFile,
-} from './_helpers/workflowOutput';
+
 import type { CliContext } from '../runtime/cliContext';
 
+/**
+ * `texra --resume <id>` continues (resumes) a stored tool-use session by
+ * reopening the interactive chat TUI, which rehydrates the prior transcript and
+ * continues the suspended flow.
+ *
+ * Resume is interactive by nature: a resumed tool-use session returns to
+ * WAITING for the user's next message, so there is no meaningful non-interactive
+ * continuation without an input channel — a headless run would simply block at
+ * the WAIT node. Headless callers are therefore pointed at `texra run`.
+ */
 export async function runResumeExecution(
   context: CliContext,
   id: ExecutionId,
 ): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
-  const config = await readCliHistoryConfig(id);
-  if (!config) {
-    writeTextStderr(`Execution not found: ${id}`);
+
+  // Resolve the stored session up front so we (a) fail fast with a clear
+  // message for non-resumable ids (workflow / missing / no live snapshot) and
+  // (b) reopen the TUI on the SAVED model/agent rather than the current chat
+  // defaults — those could be unavailable while the saved model is still
+  // runnable, which would otherwise fail resume for the wrong reason.
+  const resolution = await resolveCliResumeSnapshot(id);
+  if (resolution.kind !== 'toolUse') {
+    writeTextStderr(explainNonResumable(resolution, id));
     return CliExitCode.Usage;
   }
 
-  const runContext: CliContext = {
-    ...context,
-    helperModel: config.model,
-    quietLogs: true,
-    renderRunProgress: shouldRenderRunProgress(context),
-  };
-  await initCliPlatform(runContext);
-  installCliApprovalHandlers(runContext);
-  await loadAgents({ includeRemote: false });
-  await resolveAgentWithRemoteFallback(config.agent);
-
-  const { result, terminalStatus } = await executeCliRequest(
-    { config, executionId: id },
-    runContext,
-  );
-  let displayResult: CliRunResult;
-  try {
-    ({ displayResult } = await resolveWorkflowOutput(
-      resumeWorkflowOutputFile(config),
-      undefined,
-      result,
-      runContext,
-      { terminalStatus },
-    ));
-  } catch (error) {
-    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      writeErrorStderr(error);
-      return CliExitCode.Interrupted;
-    }
-    await writeTerminalStatus(id, EXECUTION_STATUS.ERROR);
-    writeErrorStderr(error);
-    return CliExitCode.AgentError;
+  const headless = context.mode === 'headless' || !process.stdout.isTTY;
+  if (headless) {
+    // A resumed tool-use session goes back to WAITING for the next message;
+    // headless has no input channel to provide one, so continuing here would
+    // block forever. Mirror runChat's non-TTY guidance instead of hanging.
+    writeTextStderr(
+      `Resuming continues an interactive chat session — run \`texra --resume ${id}\` in a terminal. For scripting, use \`texra run\`.`,
+    );
+    return CliExitCode.Usage;
   }
 
-  emitCliResult(runContext, {
-    json: displayResult,
-    ndjson: { kind: 'result', result: displayResult },
-    text:
-      displayResult.category === AgentCategory.Workflow
-        ? formatWorkflowTextResult(displayResult)
-        : displayResult.status,
+  const { runChat } = await import('../chat/tui/runChatTui');
+  const result = await runChat(context, {
+    resumeExecutionId: id,
+    agentOverride: resolution.config.agent,
+    modelOverride: resolution.config.model,
   });
-
-  return terminalStatusExitCode(terminalStatus, runContext);
+  return result.exitCode;
 }
 
 export const resumeCommand = defineCliCommand({
-  meta: { name: 'resume', description: 'Re-run a stored execution config' },
+  meta: {
+    name: 'resume',
+    description: 'Continue (resume) a stored tool-use session',
+  },
   args: {
     ...GLOBAL_ARGS,
     id: {

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -1,15 +1,34 @@
 import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
+import { useState } from 'react';
 
-import { Select } from '../chat/tui/ui/Select';
+import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
+import { modelSelectItemsForCliMode } from '../chat/tui/forms/ModelListForm';
+import { formatCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
+import type { CliModelAccess } from '../runtime/modelAccess';
 import type {
   CliOrchestrationAction,
   CliOrchestrationItem,
 } from '../runtime/orchestration';
 
+/** Launcher items that chain into a model pick before launching the chat. */
+type ModelPickAction = Extract<
+  CliOrchestrationAction,
+  { kind: 'chat' | 'preset' }
+>;
+
+function isModelPickAction(
+  action: CliOrchestrationAction,
+): action is ModelPickAction {
+  return action.kind === 'chat' || action.kind === 'preset';
+}
+
 export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
+  /** Available models for the second step; empty skips the model pick. */
+  readonly modelItems: ReadonlyArray<SelectItem<string>>;
+  readonly apiMode: CliApiMode;
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
 
@@ -21,23 +40,77 @@ export function orchestrationKeyHints(): readonly KeyHint[] {
   ];
 }
 
+function modelPickKeyHints(): readonly KeyHint[] {
+  return [
+    { key: '↑/↓', action: 'navigate' },
+    { key: '1-9/a-z/Enter', action: 'select' },
+    { key: 'Esc', action: 'back' },
+  ];
+}
+
 export function OrchestrationApp(
   props: OrchestrationAppProps,
 ): React.JSX.Element {
   const app = useApp();
   const { rows } = useWindowSize();
   const maxVisibleItems = Math.max(4, rows - 8);
+  // When set, the launcher is on its second step: choosing the model for this
+  // chat/team. Esc returns to the item list rather than exiting.
+  const [pending, setPending] = useState<ModelPickAction | undefined>(
+    undefined,
+  );
 
   const finish = (action: CliOrchestrationAction): void => {
     props.onResolve(action);
     app.exit();
   };
 
+  const onItemSelect = (action: CliOrchestrationAction): void => {
+    if (isModelPickAction(action) && props.modelItems.length > 0) {
+      setPending(action);
+    } else {
+      finish(action);
+    }
+  };
+
   useInput((_input, key) => {
-    if (key.escape) {
+    if (!key.escape) return;
+    if (pending) {
+      setPending(undefined);
+    } else {
       finish({ kind: 'exit' });
     }
   });
+
+  if (pending) {
+    const isTeam = pending.kind === 'preset';
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold color="cyan">
+          {isTeam ? 'Lead model' : 'Model'}
+          {' · '}
+          <Text dimColor>{formatCliApiMode(props.apiMode)}</Text>
+        </Text>
+        <Text dimColor>
+          {isTeam
+            ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
+            : 'Model for the first message.'}
+        </Text>
+        <Box marginTop={1}>
+          <Select
+            items={props.modelItems}
+            maxVisibleItems={maxVisibleItems}
+            showOverflow={props.modelItems.length > maxVisibleItems}
+            onSelect={(model) => finish({ ...pending, model })}
+            onCancel={() => setPending(undefined)}
+          />
+        </Box>
+        <Box marginTop={1}>
+          <KeyHints hints={modelPickKeyHints()} confirmCancel={false} />
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -50,7 +123,7 @@ export function OrchestrationApp(
           items={props.items}
           maxVisibleItems={maxVisibleItems}
           showOverflow={props.items.length > maxVisibleItems}
-          onSelect={finish}
+          onSelect={onItemSelect}
           onCancel={() => finish({ kind: 'exit' })}
         />
       </Box>
@@ -61,9 +134,21 @@ export function OrchestrationApp(
   );
 }
 
+export interface RunOrchestrationTuiOptions {
+  /** Available models for the second step; the launcher filters to runnable
+   *  ones. Empty or all-unavailable skips the model pick. */
+  readonly models: readonly CliModelAccess[];
+  readonly apiMode: CliApiMode;
+}
+
 export async function runOrchestrationTui(
   items: readonly CliOrchestrationItem[],
+  options: RunOrchestrationTuiOptions,
 ): Promise<CliOrchestrationAction> {
+  const modelItems = modelSelectItemsForCliMode(
+    options.models,
+    options.apiMode,
+  );
   return new Promise((resolve) => {
     let chosen: CliOrchestrationAction | undefined;
     const record = (action: CliOrchestrationAction): void => {
@@ -72,7 +157,12 @@ export async function runOrchestrationTui(
     };
 
     const instance = render(
-      <OrchestrationApp items={items} onResolve={record} />,
+      <OrchestrationApp
+        items={items}
+        modelItems={modelItems}
+        apiMode={options.apiMode}
+        onResolve={record}
+      />,
       {
         stdout: process.stdout,
         stderr: process.stderr,

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,11 +6,14 @@ import type { CliHistoryEntry } from './history';
 import type { CliMultiAgentPreset } from './multiAgentPresets';
 
 export type CliOrchestrationAction =
-  | { readonly kind: 'chat'; readonly agent?: string }
+  | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
   | {
       readonly kind: 'preset';
       readonly preset: string;
       readonly presetName: string;
+      /** Lead model the orchestrator agent starts on (and is offered for
+       *  delegation). Chosen in the launcher's model step. */
+      readonly model?: string;
     }
   | { readonly kind: 'resume'; readonly id: ExecutionId }
   | { readonly kind: 'help' }

--- a/packages/cli/src/runtime/sessionResume.ts
+++ b/packages/cli/src/runtime/sessionResume.ts
@@ -1,0 +1,66 @@
+// Resolve what `texra --resume <id>` should continue.
+//
+// Resume = continue (load the prior conversation), not re-run. The resumable
+// state lives in the per-execution flow record (executions/<id>/flow-*.json),
+// written per-step during a tool-use run; `retrieveSessionResumeData` rebuilds
+// a full snapshot (messages + state slices) from it. Only tool-use agents
+// resume this way — workflows are not continuable here.
+
+import { isToolUseTaskState } from '@agent/core/execution/TaskState';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+import { readCliHistoryConfig } from './history';
+
+export type CliResumeResolution =
+  | {
+      readonly kind: 'toolUse';
+      readonly snapshot: ToolUseSessionSnapshot;
+      readonly streamId: StreamTabId;
+      readonly config: AgentConfig;
+    }
+  /** A workflow execution — not continuable via the tool-use snapshot path. */
+  | { readonly kind: 'workflow' }
+  /** No execution with this id. */
+  | { readonly kind: 'not-found' }
+  /** Tool-use, but no live flow record to continue from (completed or cleared). */
+  | { readonly kind: 'no-snapshot' };
+
+export async function resolveCliResumeSnapshot(
+  id: ExecutionId,
+): Promise<CliResumeResolution> {
+  const config = await readCliHistoryConfig(id);
+  if (!config) return { kind: 'not-found' };
+
+  const taskState = agentConfigToTaskState(config);
+  if (!isToolUseTaskState(taskState)) return { kind: 'workflow' };
+
+  // The original run derived its streamId deterministically from agent+model+id,
+  // so re-deriving it here reuses the same stream/transcript on resume.
+  const streamId = getStreamTabId(config.agent, config.model, {
+    executionId: id,
+  });
+  const resume = await retrieveSessionResumeData(streamId, id, taskState);
+  if (resume?.type !== 'toolUse') return { kind: 'no-snapshot' };
+
+  return { kind: 'toolUse', snapshot: resume.snapshot, streamId, config };
+}
+
+/** A user-facing line explaining why a non-tool-use resolution can't continue. */
+export function explainNonResumable(
+  resolution: Exclude<CliResumeResolution, { kind: 'toolUse' }>,
+  id: ExecutionId,
+): string {
+  switch (resolution.kind) {
+    case 'not-found':
+      return `Execution not found: ${id}`;
+    case 'workflow':
+      return `Execution ${id} is a workflow; only tool-use sessions can be resumed.`;
+    case 'no-snapshot':
+      return `Execution ${id} has no resumable session state (it completed or was cleared).`;
+  }
+}

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -79,6 +79,7 @@ function slice(
   StreamSlice {
   return {
     streamId: 'root',
+    category: undefined,
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
@@ -877,6 +878,10 @@ describe('CLI child execution controls', () => {
     });
     expect(pickerKeyHints('subagents', 1)).toContainEqual({
       key: 'Enter',
+      action: 'view',
+    });
+    expect(pickerKeyHints('subagents', 1)).toContainEqual({
+      key: 'f',
       action: 'focus',
     });
     expect(pickerKeyHints('subagents', 1, false)).not.toContainEqual({
@@ -889,7 +894,8 @@ describe('CLI child execution controls', () => {
     expect(pickerKeyHintsForColumns('subagents', 3, true, 60)).toEqual([
       { key: '↑/↓', action: 'nav' },
       { key: '1-9', action: 'jump' },
-      { key: 'Enter', action: 'focus' },
+      { key: 'Enter', action: 'view' },
+      { key: 'f', action: 'focus' },
       { key: 'k', action: 'kill' },
       { key: 'Esc', action: 'close' },
     ]);

--- a/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
+++ b/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
@@ -1,0 +1,100 @@
+// Guards the Stage-2 CLI persistence wiring (runChatTui load()/flush()): the
+// debounced disk write only lands when flush() drains it, so the exit-path
+// flush is load-bearing; and a store that never load()ed (one-shot/headless
+// commands) must persist nothing so those paths stay byte-identical.
+
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StreamLogStore, type StreamLogAppendInput } from '@transcript';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+} from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+
+const STREAM_LOGS_DIR = 'streamLogs';
+
+function storageFile(dir: string, key: string): string {
+  return path.join(dir, `${encodeURIComponent(key)}.json`);
+}
+
+function notFound(): NodeJS.ErrnoException {
+  const error = new Error('not found') as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+/** Spy StorageFS onto an in-memory, initially-empty workspace. */
+function emptyStorage(): { writes: Map<string, unknown> } {
+  const writes = new Map<string, unknown>();
+  vi.spyOn(StorageFS, 'readDir').mockResolvedValue([]);
+  vi.spyOn(StorageFS, 'readJson').mockRejectedValue(notFound());
+  vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+  vi.spyOn(StorageFS, 'stat').mockRejectedValue(notFound());
+  vi.spyOn(StorageFS, 'write').mockImplementation(async (target, content) => {
+    const text =
+      typeof content === 'string'
+        ? content
+        : Buffer.from(content).toString('utf8');
+    writes.set(target, JSON.parse(text));
+  });
+  vi.spyOn(StorageFS, 'delete').mockResolvedValue(undefined);
+  return { writes };
+}
+
+function entry(id: string, text: string): StreamLogAppendInput {
+  return {
+    id,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 500,
+    messageType: MESSAGE_TYPES.DEFAULT,
+    text,
+  };
+}
+
+describe('CLI StreamLog persistence (flush on exit is load-bearing)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists appended entries only once flush() drains the debounce window', async () => {
+    const storage = emptyStorage();
+    const store = new StreamLogStore();
+    await store.load();
+
+    const streamId = 'reviewer@opus#e1';
+    store.append(streamId, entry('a', 'first'));
+    store.append(streamId, entry('b', 'second'));
+
+    // The SAVE_DEBOUNCE_MS (300ms) timer has not fired in this synchronous
+    // window, so nothing is on disk yet — this is exactly the tail the exit
+    // path would lose without an explicit flush.
+    expect(storage.writes.has(storageFile(STREAM_LOGS_DIR, streamId))).toBe(
+      false,
+    );
+
+    await store.flush();
+
+    expect(storage.writes.get(storageFile(STREAM_LOGS_DIR, streamId))).toEqual([
+      expect.objectContaining({ id: 'a', text: 'first' }),
+      expect.objectContaining({ id: 'b', text: 'second' }),
+    ]);
+  });
+
+  it('writes nothing when load() was never called (one-shot/headless paths)', async () => {
+    const storage = emptyStorage();
+    const store = new StreamLogStore();
+
+    // No load() — mirrors `texra run`/`resume`/`agentsRun`, which never enable
+    // persistence. append()/flush() must be inert so headless output and the
+    // on-disk store stay untouched.
+    store.append('main@opus#e2', entry('x', 'headless'));
+    await store.flush();
+
+    expect(storage.writes.size).toBe(0);
+  });
+});

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -437,6 +437,7 @@ function sliceWithEntries(
 ): StreamSlice {
   return {
     streamId,
+    category: undefined,
     status: undefined,
     runStartedAt: undefined,
     description: undefined,

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectResumeTargets,
+  formatResumeHint,
+} from '@cli/chat/tui/state/resumeHint';
+import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
+import {
+  AGENT_CATEGORY,
+  type ActiveChildInfo,
+  type StreamTabId,
+} from '@shared/schemas';
+
+function makeSlice(
+  over: Partial<StreamSlice> & { streamId: string },
+): StreamSlice {
+  return {
+    category: undefined,
+    status: undefined,
+    runStartedAt: undefined,
+    description: undefined,
+    usage: undefined,
+    conversation: undefined,
+    entries: [],
+    queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
+    activeSubagents: [],
+    activeProcesses: [],
+    childStreams: [],
+    todos: [],
+    plan: null,
+    processOutput: new Map(),
+    bypass: NO_BYPASS,
+    ...over,
+    streamId: over.streamId as StreamTabId,
+  };
+}
+
+function child(
+  over: Partial<ActiveChildInfo> & { executionId: string },
+): ActiveChildInfo {
+  return { agentName: 'agent', ...over };
+}
+
+function streamsOf(
+  ...slices: StreamSlice[]
+): ReadonlyMap<StreamTabId, StreamSlice> {
+  return new Map(slices.map((s) => [s.streamId, s]));
+}
+
+describe('collectResumeTargets', () => {
+  it('returns just the main session when there are no subagents', () => {
+    const streams = streamsOf(makeSlice({ streamId: 'main@m#root' }));
+    expect(collectResumeTargets({ rootExecutionId: 'root', streams })).toEqual([
+      { executionId: 'root', label: 'main', isRoot: true },
+    ]);
+  });
+
+  it('lists tool-use subagents and excludes workflow children', () => {
+    const root = makeSlice({
+      streamId: 'main@m#root',
+      childStreams: [
+        child({
+          executionId: 'rev',
+          agentName: 'reviewer',
+          childStreamId: 'reviewer@m#rev' as StreamTabId,
+        }),
+        child({
+          executionId: 'flow',
+          agentName: 'builder',
+          childStreamId: 'builder@m#flow' as StreamTabId,
+        }),
+      ],
+    });
+    const reviewer = makeSlice({
+      streamId: 'reviewer@m#rev',
+      category: AGENT_CATEGORY.TOOL_USE,
+    });
+    const builder = makeSlice({
+      streamId: 'builder@m#flow',
+      category: AGENT_CATEGORY.WORKFLOW,
+    });
+
+    expect(
+      collectResumeTargets({
+        rootExecutionId: 'root',
+        streams: streamsOf(root, reviewer, builder),
+      }),
+    ).toEqual([
+      { executionId: 'root', label: 'main', isRoot: true },
+      { executionId: 'rev', label: 'reviewer', isRoot: false },
+    ]);
+  });
+
+  it('skips children whose stream never reported a category (processes/unknown)', () => {
+    const root = makeSlice({
+      streamId: 'main@m#root',
+      childStreams: [
+        child({
+          executionId: 'sh',
+          agentName: 'bash',
+          childStreamId: 'bash@tool#sh' as StreamTabId,
+        }),
+      ],
+    });
+    const shell = makeSlice({ streamId: 'bash@tool#sh' }); // category undefined
+    expect(
+      collectResumeTargets({
+        rootExecutionId: 'root',
+        streams: streamsOf(root, shell),
+      }),
+    ).toEqual([{ executionId: 'root', label: 'main', isRoot: true }]);
+  });
+
+  it('returns nothing when there is no root execution yet', () => {
+    expect(
+      collectResumeTargets({ rootExecutionId: undefined, streams: new Map() }),
+    ).toEqual([]);
+  });
+});
+
+describe('formatResumeHint', () => {
+  it('renders one resume line per target', () => {
+    expect(
+      formatResumeHint([
+        { executionId: 'root', label: 'main', isRoot: true },
+        { executionId: 'rev', label: 'reviewer', isRoot: false },
+      ]),
+    ).toBe(
+      [
+        'Resume this session with:',
+        '  texra --resume root  (main)',
+        '  texra --resume rev  (reviewer)',
+      ].join('\n'),
+    );
+  });
+
+  it('is undefined when there is nothing to resume', () => {
+    expect(formatResumeHint([])).toBeUndefined();
+  });
+});

--- a/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
@@ -1,0 +1,38 @@
+// Focused test for the preserve-on-exit predicate that decides whether a
+// suspended tool-use session is left untouched (so its flow record survives
+// for `texra --resume`) or interrupted on shutdown. See the rationale on
+// chatTuiIsResumableIdleOnExit: interrupting clears the resumable state, so an
+// idle/WAITING session ("interruptible but not stoppable") must be preserved.
+
+import { describe, expect, it } from 'vitest';
+
+import { chatTuiIsResumableIdleOnExit } from '@cli/chat/tui/runChatTui';
+
+describe('chatTuiIsResumableIdleOnExit', () => {
+  it('preserves an idle/WAITING session (interruptible, not stoppable)', () => {
+    expect(
+      chatTuiIsResumableIdleOnExit({
+        canInterruptActiveRun: true,
+        canStopActiveRun: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not preserve an actively-running turn (interrupt it on exit)', () => {
+    expect(
+      chatTuiIsResumableIdleOnExit({
+        canInterruptActiveRun: true,
+        canStopActiveRun: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not preserve when there is no pending run at all', () => {
+    expect(
+      chatTuiIsResumableIdleOnExit({
+        canInterruptActiveRun: false,
+        canStopActiveRun: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/test-kernel/cli/SessionResumeResolution.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeResolution.vitest.mts
@@ -1,0 +1,140 @@
+// Unit tests for `resolveCliResumeSnapshot` branch logic and the user-facing
+// `explainNonResumable` strings. The retrieval surface is mocked at its module
+// boundaries (history config + snapshot retrieval + stream-id derivation) so
+// the test exercises pure branching, not storage I/O. `agentConfigToTaskState`
+// / `isToolUseTaskState` run for real against minimal configs.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ExecutionId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  readCliHistoryConfig: vi.fn(),
+  retrieveSessionResumeData: vi.fn(),
+  getStreamTabId: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/history', () => ({
+  readCliHistoryConfig: mocks.readCliHistoryConfig,
+}));
+
+vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
+  retrieveSessionResumeData: mocks.retrieveSessionResumeData,
+}));
+
+vi.mock('@agent/runtime/streamTab', () => ({
+  getStreamTabId: mocks.getStreamTabId,
+}));
+
+const EXECUTION_ID = 'exec-1' as ExecutionId;
+const STREAM_ID = 'stream-1';
+
+function toolUseConfig(): AgentConfig {
+  // Minimal config: the resolver only reads `agentCategory`, `agent`, `model`.
+  return {
+    agent: 'planner',
+    model: 'gpt-5',
+    agentCategory: AgentCategory.ToolUse,
+  } as unknown as AgentConfig;
+}
+
+function workflowConfig(): AgentConfig {
+  return {
+    agent: 'correct',
+    model: 'gemini31p',
+    agentCategory: AgentCategory.Workflow,
+    inputFiles: [],
+    outputFiles: [],
+  } as unknown as AgentConfig;
+}
+
+async function resolve(id: ExecutionId = EXECUTION_ID) {
+  const { resolveCliResumeSnapshot } =
+    await import('@cli/runtime/sessionResume');
+  return resolveCliResumeSnapshot(id);
+}
+
+describe('resolveCliResumeSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStreamTabId.mockReturnValue(STREAM_ID);
+  });
+
+  it('returns not-found when no config exists for the id', async () => {
+    mocks.readCliHistoryConfig.mockResolvedValue(null);
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: 'not-found' });
+    expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
+  });
+
+  it('returns workflow for a workflow config (not continuable here)', async () => {
+    mocks.readCliHistoryConfig.mockResolvedValue(workflowConfig());
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: 'workflow' });
+    expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
+  });
+
+  it('returns toolUse with snapshot + streamId when a flow record exists', async () => {
+    const snapshot = { executionId: EXECUTION_ID, streamId: STREAM_ID };
+    const config = toolUseConfig();
+    mocks.readCliHistoryConfig.mockResolvedValue(config);
+    mocks.retrieveSessionResumeData.mockResolvedValue({
+      type: 'toolUse',
+      snapshot,
+    });
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      kind: 'toolUse',
+      snapshot,
+      streamId: STREAM_ID,
+      config,
+    });
+    // The stream id is re-derived from agent + model + execution id so resume
+    // reuses the original stream/transcript.
+    expect(mocks.getStreamTabId).toHaveBeenCalledWith('planner', 'gpt-5', {
+      executionId: EXECUTION_ID,
+    });
+  });
+
+  it('returns no-snapshot for tool-use without a live flow record', async () => {
+    mocks.readCliHistoryConfig.mockResolvedValue(toolUseConfig());
+    mocks.retrieveSessionResumeData.mockResolvedValue(undefined);
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: 'no-snapshot' });
+  });
+
+  it('returns no-snapshot when retrieval yields a non-toolUse payload', async () => {
+    mocks.readCliHistoryConfig.mockResolvedValue(toolUseConfig());
+    mocks.retrieveSessionResumeData.mockResolvedValue({ type: 'workflow' });
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: 'no-snapshot' });
+  });
+});
+
+describe('explainNonResumable', () => {
+  it('explains each non-tool-use resolution kind', async () => {
+    const { explainNonResumable } = await import('@cli/runtime/sessionResume');
+
+    expect(explainNonResumable({ kind: 'not-found' }, EXECUTION_ID)).toBe(
+      `Execution not found: ${EXECUTION_ID}`,
+    );
+    expect(explainNonResumable({ kind: 'workflow' }, EXECUTION_ID)).toBe(
+      `Execution ${EXECUTION_ID} is a workflow; only tool-use sessions can be resumed.`,
+    );
+    expect(explainNonResumable({ kind: 'no-snapshot' }, EXECUTION_ID)).toBe(
+      `Execution ${EXECUTION_ID} has no resumable session state (it completed or was cleared).`,
+    );
+  });
+});

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -39,6 +39,7 @@ function slice(
 ): StreamSlice {
   return {
     streamId: streamId(streamIdValue),
+    category: undefined,
     status: undefined,
     runStartedAt: undefined,
     description: undefined,

--- a/src/test-kernel/cli/SubagentScopedViewer.vitest.mts
+++ b/src/test-kernel/cli/SubagentScopedViewer.vitest.mts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  subagentPickerSelection,
+  type ChildControlItem,
+} from '@cli/chat/tui/state/childControls';
+
+function row(
+  over: Partial<Pick<ChildControlItem, 'childStreamId' | 'executionId'>> = {},
+): Pick<ChildControlItem, 'childStreamId' | 'executionId'> {
+  return {
+    executionId: 'exec-1',
+    childStreamId: 'reviewer@opus#exec-1',
+    ...over,
+  };
+}
+
+describe('subagentPickerSelection (Enter behavior in the child-control picker)', () => {
+  it('opens the scoped transcript viewer for a subagent row backed by a stream', () => {
+    expect(subagentPickerSelection('subagents', row())).toEqual({
+      kind: 'view',
+      streamId: 'reviewer@opus#exec-1',
+    });
+  });
+
+  it('falls back to the inline detail view when a subagent row has no stream', () => {
+    expect(
+      subagentPickerSelection('subagents', row({ childStreamId: undefined })),
+    ).toEqual({ kind: 'detail', executionId: 'exec-1' });
+  });
+
+  it('keeps tasks mode on the inline detail view even with a stream', () => {
+    expect(subagentPickerSelection('tasks', row())).toEqual({
+      kind: 'detail',
+      executionId: 'exec-1',
+    });
+  });
+
+  it('returns undefined when there is no highlighted row', () => {
+    expect(subagentPickerSelection('subagents', undefined)).toBeUndefined();
+    expect(subagentPickerSelection('tasks', undefined)).toBeUndefined();
+  });
+});

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -24,9 +24,7 @@ import {
   appFocusShortcutsActive,
   approvalForegroundMaxRows,
   childControlForegroundMaxRows,
-  foregroundSurfaceContainerHeight,
   foregroundSurfaceKind,
-  foregroundSurfaceJustifyContent,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
   staticTranscriptRowBudget,
@@ -362,34 +360,6 @@ describe('CLI TUI row allocation', () => {
     ).toBe(18);
   });
 
-  it('top-aligns forms and approvals without moving transcript viewer', () => {
-    expect(foregroundSurfaceJustifyContent('form')).toBe('flex-start');
-    expect(foregroundSurfaceJustifyContent('approval')).toBe('flex-start');
-    expect(foregroundSurfaceJustifyContent('childControls')).toBe('flex-end');
-    expect(foregroundSurfaceJustifyContent('transcript')).toBe('flex-end');
-  });
-
-  it('lets child-control foregrounds shrink to their rendered height', () => {
-    expect(
-      foregroundSurfaceContainerHeight({
-        kind: 'childControls',
-        rows: 12,
-      }),
-    ).toBeUndefined();
-    expect(
-      foregroundSurfaceContainerHeight({
-        kind: 'childControls',
-        rows: 2,
-      }),
-    ).toBe(2);
-    expect(
-      foregroundSurfaceContainerHeight({
-        kind: 'approval',
-        rows: 12,
-      }),
-    ).toBe(12);
-  });
-
   it('uses the whole middle region for the transcript without foreground UI', () => {
     const layout = allocateMiddleRows({
       foregroundOpen: false,
@@ -509,27 +479,49 @@ describe('CLI TUI row allocation', () => {
     expect(layout.foregroundRows).toBe(0);
   });
 
-  it('bounds side panels to the available middle row budget', () => {
+  it('sizes side panels to their content within the budget', () => {
+    // Everything fits: each panel takes exactly its content (no dead rows).
     expect(
       allocateSidePanelRows({
-        hasSubagentPanel: true,
-        hasTodosPlanPanel: true,
+        subagentContentRows: 3,
+        todosPlanContentRows: 4,
         rows: 13,
       }),
-    ).toEqual({ subagentRows: 6, todosPlanRows: 7 });
+    ).toEqual({ subagentRows: 3, todosPlanRows: 4 });
 
+    // A lone panel takes only what it needs; the rest is the conversation's.
     expect(
       allocateSidePanelRows({
-        hasSubagentPanel: false,
-        hasTodosPlanPanel: true,
+        subagentContentRows: 0,
+        todosPlanContentRows: 4,
+        rows: 13,
+      }),
+    ).toEqual({ subagentRows: 0, todosPlanRows: 4 });
+
+    // Over budget, a lone panel is capped at the available rows.
+    expect(
+      allocateSidePanelRows({
+        subagentContentRows: 0,
+        todosPlanContentRows: 20,
         rows: 13,
       }),
     ).toEqual({ subagentRows: 0, todosPlanRows: 13 });
 
+    // Over budget with both present: keep at least one row each, split the
+    // remainder proportionally to need.
     expect(
       allocateSidePanelRows({
-        hasSubagentPanel: true,
-        hasTodosPlanPanel: true,
+        subagentContentRows: 10,
+        todosPlanContentRows: 10,
+        rows: 13,
+      }),
+    ).toEqual({ subagentRows: 7, todosPlanRows: 6 });
+
+    // A single row with both present goes to the todos/plan panel.
+    expect(
+      allocateSidePanelRows({
+        subagentContentRows: 5,
+        todosPlanContentRows: 5,
         rows: 1,
       }),
     ).toEqual({ subagentRows: 0, todosPlanRows: 1 });
@@ -906,12 +898,14 @@ describe('CLI TUI row allocation', () => {
     ).toBe('clean-exit');
 
     expect(
+      // Idle/WAITING (interruptible, not stoppable): exit WITHOUT interrupting
+      // so the suspended tool-use flow record survives for `texra --resume`.
       chatTuiSigintAction({
         exitArmed: false,
         canStopActiveRun: false,
         canInterruptActiveRun: true,
       }),
-    ).toBe('interrupt-and-exit');
+    ).toBe('force-exit');
 
     expect(
       chatTuiSigintAction({
@@ -1045,20 +1039,6 @@ describe('CLI TUI row allocation', () => {
     cliState.activeStreamId.set(child1);
     expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
     expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
-  });
-
-  it('announces queued follow-ups only when the target is not waiting', () => {
-    expect(chatTuiShouldAnnounceQueuedFollowUp(undefined)).toBe(true);
-
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    expect(chatTuiShouldAnnounceQueuedFollowUp(root)).toBe(false);
-
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    expect(chatTuiShouldAnnounceQueuedFollowUp(root)).toBe(true);
-
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    setParentStream(child1, root);
-    expect(chatTuiShouldAnnounceQueuedFollowUp(child1)).toBe(false);
   });
 
   it('clears stale resume ids when clearing chat session run state', () => {

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -156,7 +156,7 @@ exports[`CLI shell completion > generates fish completion 1`] = `
 complete -c texra -n '__fish_use_subcommand' -a 'orchestrate' -d 'Interactive launcher (runs by default on bare \`texra\` in a TTY): pick a chat, resume, or team preset'
 complete -c texra -n '__fish_use_subcommand' -a 'chat' -d 'Interactive tool-use chat session'
 complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
-complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Re-run a stored execution config'
+complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Continue (resume) a stored tool-use session'
 complete -c texra -n '__fish_use_subcommand' -a 'init' -d 'Bootstrap a .texra/config.json with sensible defaults'
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'
 complete -c texra -n '__fish_use_subcommand' -a 'memory' -d 'Inspect stored memories'


### PR DESCRIPTION
## Summary

Brings the CLI's subagent UX and resume behavior in line with the VS Code extension. **Rebased onto the latest `main`.**

**Subagent history + resume (this session's feature):**
- **Scoped transcript viewer** — the Subagents picker `Enter` opens that child's own full, scrollable transcript; `f` focuses; Ctrl-T is scoped to a streamId.
- **Extension-compatible persistence** — `runChatTui` `load()`s/`flush()`es the shared `StreamLogStore`, so transcripts survive exit and the same `streamLogs/<id>.json` is readable by **both** the CLI and the extension. Flush is wired into the graceful **and** signal exit paths.
- **Resume = continue (not re-run)** — `texra --resume <id>` reopens the interactive chat TUI and continues a tool-use session from its persisted snapshot (`retrieveSessionResumeData` → `resumeToolUseFromSnapshot`), on the **saved** model/agent. Resumable by any tool-use execution id incl. subagents; workflows rejected with a clear message. **Idle/WAITING sessions exit without interrupting** so their flow record survives. Headless callers get a clear "resume is interactive — use `texra run`" message (a resumed session returns to WAITING, so there's no headless input channel).
- **Exit hint** — on Ctrl-C, prints `Resume this session with: texra --resume <id>` for the main session plus each resumable tool-use subagent.

**Review fixes (Codex / Cursor / Copilot):**
- **Cursor** — signal exits no longer drain persistence / print the resume hint twice (an `exiting` guard skips the `exitNow`-re-entered `finally`).
- **Codex** — headless resume no longer hangs at WAIT (errors cleanly); interactive resume uses the saved model/agent, not the current chat defaults.
- **Copilot** — removed a redundant `initCliPlatform` in the resume path and an unused import; fixed a misleading test comment.
- _(Open)_ Copilot's orchestration-TUI Esc note is in the parallel WIP below; the `<Select>` has no `onCancel` wired, so it looks like a false positive — left for that WIP.

## Rebase notes
Rebased over 35 `main` commits. Kept main's tested **`#5073`** ink resize fix (verified working) over the local WIP; restored main's `chatTuiShouldAnnounceQueuedFollowUp` queued-follow-up feature; reconciled main's **`#5066`** idle-Ctrl-C refactor with this PR's preserve-on-exit (idle now exits without interrupting). New CLI test files use `.vitest.mts` (kept out of the root `tsc`, which can't resolve ink's ESM exports).

## ⚠️ Scope note
This branch also carries parallel CLI WIP that was already in the working tree and is intertwined in `App.tsx`/`runChatTui.tsx` (so it couldn't be cleanly split): orchestration-TUI model picker (`runOrchestrationTui.tsx`, `orchestrate.ts`, `orchestration.ts`) and subagent/todos panel sizing (`SubagentList`/`TodosPlanPanel`/`allocateSidePanelRows`). Happy to split these into a separate PR.

## Test plan
- root `tsc --noEmit`, `tsc -p tsconfig.test-kernel.json`, both package typechecks — clean
- full test-kernel suite green, **except** the `AgentsCommand` suite which is a pre-existing timeout-prone flake (passes in isolation; unrelated to this PR)
- eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes session lifecycle (SIGINT/SIGTERM exit, interrupt vs preserve), persistence flush on all exit paths, and resume/snapshot resolution—mistakes could drop resumable state or corrupt transcripts; scope also touches core chat layout and orchestration entry.
> 
> **Overview**
> Aligns the CLI chat TUI with extension-style **subagent history**, **shared transcript persistence**, and **resume as continue** (not re-run).
> 
> **Scoped transcripts:** `transcriptViewerStreamId` replaces a boolean open flag so Ctrl-T and the subagents picker can show any stream’s full scrollable history (with a title). **Enter** on a subagent row opens that child’s viewer; **`f`** focuses the stream without opening it.
> 
> **Persistence & exit:** Interactive chat `load()`s / `flush()`es the shared `StreamLogStore` (extension-compatible `streamLogs/<id>.json`), including on signal exit, with guards so teardown doesn’t double-drain or double-print hints.
> 
> **Resume:** `texra --resume <id>` resolves a tool-use flow snapshot and reopens the TUI via `resumeToolUseFromSnapshot`, using the **saved** agent/model and rehydrated transcript; workflows / missing snapshots get clear errors; headless callers are rejected. Idle **WAITING** sessions exit **without interrupting** so flow records survive for resume; exit prints `texra --resume` lines for the root and resumable tool-use subagents.
> 
> **Layout polish (bundled):** Bottom subagent/todos panels reserve height from actual content (`subagentPanelRowCount` / `todosPlanPanelRowCount`); foreground modals use `maxHeight` instead of fixed height. Orchestration launcher can add an optional **model** pick step before chat/team start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b1a9f7c2b1d3d373a32bdaa72bb2959defb4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->