### PR TITLE
fix(cli): honor no-color in markdown

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -373,6 +373,7 @@ export interface AppProps {
   readonly onKillExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;
+  readonly colorEnabled?: boolean;
   readonly onInterruptActive: () => void;
   readonly onCtrlC?: () => void;
   readonly inputDisabled?: boolean;
@@ -696,6 +697,7 @@ export function App(props: AppProps): React.JSX.Element {
   return (
     <>
       <StaticConversationTranscript
+        colorEnabled={props.colorEnabled}
         maxRows={staticTranscriptRows}
         width={transcriptWidth}
       />

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -205,9 +205,11 @@ export function appendStaticTranscriptItems({
 }
 
 export function StaticConversationTranscript({
+  colorEnabled,
   maxRows,
   width,
 }: {
+  readonly colorEnabled?: boolean;
   readonly maxRows?: number;
   readonly width?: number;
 }): React.JSX.Element {
@@ -245,7 +247,11 @@ export function StaticConversationTranscript({
               width={width}
             />
           ) : (
-            <TranscriptEntry entry={item.entry} width={width} />
+            <TranscriptEntry
+              entry={item.entry}
+              width={width}
+              colorEnabled={colorEnabled}
+            />
           )}
         </Box>
       )}

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -50,9 +50,11 @@ function ProcessEntryRow({
 export function TranscriptEntry({
   entry,
   width,
+  colorEnabled,
 }: {
   readonly entry: ConversationEntry;
   readonly width?: number;
+  readonly colorEnabled?: boolean;
 }): React.JSX.Element {
   switch (entry.role) {
     case 'user':
@@ -78,7 +80,11 @@ export function TranscriptEntry({
   }
   return (
     <Box marginBottom={1}>
-      <Markdown content={entry.text} width={width} />
+      <Markdown
+        content={entry.text}
+        width={width}
+        colorEnabled={colorEnabled}
+      />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/render/Markdown.tsx
+++ b/packages/cli/src/chat/tui/render/Markdown.tsx
@@ -10,12 +10,16 @@ import { renderAnsiMarkdown } from './ansiMarkdown';
 export interface MarkdownProps {
   readonly content: string;
   readonly width?: number;
+  readonly colorEnabled?: boolean;
 }
 
 export function Markdown(props: MarkdownProps): React.JSX.Element {
   // `renderAnsiMarkdown` trims trailing newlines so Ink doesn't add a blank
   // line at the bottom of each conversation entry; the parent
   // `<Box marginBottom={1}>` already provides separation between entries.
-  const rendered = renderAnsiMarkdown(props.content, { width: props.width });
+  const rendered = renderAnsiMarkdown(props.content, {
+    width: props.width,
+    colorEnabled: props.colorEnabled,
+  });
   return <Text>{rendered}</Text>;
 }

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -32,9 +32,49 @@ import type { RenderRule } from 'markdown-it/lib/renderer.mjs';
  *  raw control chars). */
 const ESC = String.fromCharCode(27);
 const sgr = (code: number): string => `${ESC}[${code}m`;
+const plain = (text: string): string => text;
 
-function highlightForTui(code: string, lang: string): string {
+interface AnsiMarkdownStyle {
+  readonly enabled: boolean;
+  bold(text: string): string;
+  cyan(text: string): string;
+  dim(text: string): string;
+  gray(text: string): string;
+  underline(text: string): string;
+  sgr(code: number): string;
+}
+
+const ColorAnsiStyle: AnsiMarkdownStyle = {
+  enabled: true,
+  bold: pico.bold,
+  cyan: pico.cyan,
+  dim: pico.dim,
+  gray: pico.gray,
+  underline: pico.underline,
+  sgr,
+};
+
+const PlainAnsiStyle: AnsiMarkdownStyle = {
+  enabled: false,
+  bold: plain,
+  cyan: plain,
+  dim: plain,
+  gray: plain,
+  underline: plain,
+  sgr: () => '',
+};
+
+function ansiMarkdownStyle(colorEnabled: boolean): AnsiMarkdownStyle {
+  return colorEnabled ? ColorAnsiStyle : PlainAnsiStyle;
+}
+
+function highlightForTui(
+  code: string,
+  lang: string,
+  style: AnsiMarkdownStyle,
+): string {
   const trimmed = code.replace(/\n+$/, '');
+  if (!style.enabled) return trimmed;
   if (lang && supportsLanguage(lang)) {
     try {
       return highlight(trimmed, { language: lang, ignoreIllegals: true });
@@ -42,7 +82,7 @@ function highlightForTui(code: string, lang: string): string {
       // fall through to plain rendering
     }
   }
-  return pico.gray(trimmed);
+  return style.gray(trimmed);
 }
 
 type ColumnAlign = 'left' | 'center' | 'right';
@@ -112,10 +152,11 @@ function renderAnsiTable(
   rows: readonly (readonly string[])[],
   aligns: readonly ColumnAlign[],
   width: number | undefined,
+  style: AnsiMarkdownStyle,
 ): string {
   const numCols = Math.max(head.length, ...rows.map((row) => row.length), 1);
   const table = new Table({
-    head: head.map((cell) => pico.bold(cell)),
+    head: head.map(style.bold),
     colWidths: tableColWidths(head, rows, numCols, width),
     colAligns: Array.from({ length: numCols }, (_, i) => aligns[i] ?? 'left'),
     wordWrap: true,
@@ -136,13 +177,14 @@ function restoreProtectedLatexInCell(cell: string, env: unknown): string {
 function configureAnsi(
   md: MarkdownItInstance,
   width: number | undefined,
+  style: AnsiMarkdownStyle,
 ): void {
   const r = md.renderer.rules;
   let quoteDepth = 0;
   let headingDepth = 0;
 
   const quotePrefix = (): string =>
-    quoteDepth > 0 ? pico.dim('│ '.repeat(quoteDepth)) : '';
+    quoteDepth > 0 ? style.dim('│ '.repeat(quoteDepth)) : '';
 
   const startsAtQuoteOpen = (tokens: Parameters<RenderRule>[0], idx: number) =>
     tokens[idx - 1]?.type === 'blockquote_open';
@@ -196,19 +238,19 @@ function configureAnsi(
     return quoteDepth > 0 ? `\n${quotePrefix()}\n` : '\n\n';
   };
 
-  r.strong_open = () => sgr(1);
-  r.strong_close = () => sgr(22);
-  r.em_open = () => sgr(3);
-  r.em_close = () => sgr(23);
-  r.s_open = () => sgr(9);
-  r.s_close = () => sgr(29);
+  r.strong_open = () => style.sgr(1);
+  r.strong_close = () => style.sgr(22);
+  r.em_open = () => style.sgr(3);
+  r.em_close = () => style.sgr(23);
+  r.s_open = () => style.sgr(9);
+  r.s_close = () => style.sgr(29);
 
   const styleHeadingText = (text: string): string =>
-    headingDepth > 0 ? pico.bold(pico.cyan(text)) : text;
+    headingDepth > 0 ? style.bold(style.cyan(text)) : text;
 
   r.code_inline = (tokens, idx) => {
     const code = `\`${tokens[idx]?.content ?? ''}\``;
-    return headingDepth > 0 ? styleHeadingText(code) : pico.cyan(code);
+    return headingDepth > 0 ? styleHeadingText(code) : style.cyan(code);
   };
   r.fence = (tokens, idx) => {
     const token = tokens[idx];
@@ -220,14 +262,14 @@ function configureAnsi(
     return `${withQuoteGutter(
       tokens,
       idx,
-      body || pico.gray(token.content.replace(/\n+$/, '')),
+      body || style.gray(token.content.replace(/\n+$/, '')),
     )}\n\n`;
   };
   r.code_block = (tokens, idx) =>
     `${withQuoteGutter(
       tokens,
       idx,
-      pico.gray(tokens[idx]?.content.replace(/\n+$/, '') ?? ''),
+      style.gray(tokens[idx]?.content.replace(/\n+$/, '') ?? ''),
     )}\n\n`;
 
   r.bullet_list_open = () => '';
@@ -243,14 +285,14 @@ function configureAnsi(
     const marker = token?.info ? `${token.info}${token.markup || '.'}` : '•';
     const prev = tokens[idx - 1]?.type;
     const fresh = prev === 'bullet_list_open' || prev === 'ordered_list_open';
-    return `${fresh ? '' : quotePrefix()}  ${pico.dim(marker)} `;
+    return `${fresh ? '' : quotePrefix()}  ${style.dim(marker)} `;
   };
   r.list_item_close = () => '';
 
   r.blockquote_open = (tokens, idx) => {
     quoteDepth += 1;
     return tokens[idx - 1]?.type === 'blockquote_open'
-      ? pico.dim('│ ')
+      ? style.dim('│ ')
       : quotePrefix();
   };
   r.blockquote_close = () => {
@@ -259,21 +301,22 @@ function configureAnsi(
   };
 
   r.hr = (tokens, idx) =>
-    `${quoteBlockStart(tokens, idx)}${pico.dim('─'.repeat(40))}\n`;
+    `${quoteBlockStart(tokens, idx)}${style.dim('─'.repeat(40))}\n`;
 
   // Emit raw SGR codes so the styling stays open across the link body. The
   // bracket characters are part of the styled run; if we used `pico.blue('[')`
   // here the close-code would land immediately and the link text would render
   // unstyled (Cursor finding).
-  r.link_open = () => `${sgr(4)}${sgr(34)}[`;
-  r.link_close = () => `]${sgr(39)}${sgr(24)}`;
+  r.link_open = () => `${style.sgr(4)}${style.sgr(34)}[`;
+  r.link_close = () => `]${style.sgr(39)}${style.sgr(24)}`;
 
   r.softbreak = () => `\n${quotePrefix()}`;
   r.hardbreak = () => `\n${quotePrefix()}`;
 
   // markdown-it default `text` rule escapes HTML; we want raw text.
   r.text = (tokens, idx) => styleHeadingText(tokens[idx]?.content ?? '');
-  r.image = (tokens, idx) => pico.dim(`[image: ${tokens[idx]?.content ?? ''}]`);
+  r.image = (tokens, idx) =>
+    style.dim(`[image: ${tokens[idx]?.content ?? ''}]`);
 
   // The table-family tokens (table_open … table_close) have no ANSI rules, so
   // we collapse each table's token range into a single pre-rendered
@@ -341,7 +384,7 @@ function configureAnsi(
         }
       }
       const tableToken = new Token('ansi_table', '', 0);
-      tableToken.content = renderAnsiTable(head, rows, aligns, width);
+      tableToken.content = renderAnsiTable(head, rows, aligns, width, style);
       collapsed.push(tableToken);
       i = j; // land on table_close; the loop's i++ skips it
     }
@@ -354,8 +397,13 @@ function configureAnsi(
   };
 }
 
-function formatAnsiLatexReference(refType: string, label: string): string {
-  return pico.dim(pico.underline(`\\${refType}{${label}}`));
+function formatAnsiLatexReference(
+  refType: string,
+  label: string,
+  style: AnsiMarkdownStyle,
+): string {
+  const text = `\\${refType}{${label}}`;
+  return style.dim(style.underline(text));
 }
 
 let cachedProcessor: MarkdownProcessor | null = null;
@@ -364,9 +412,11 @@ let cachedProcessor: MarkdownProcessor | null = null;
 // and rebuilt when the width changes — a rare event (resize), unlike the
 // per-delta streaming calls the cache exists to serve.
 let cachedWidth: number | undefined;
+let cachedColorEnabled: boolean | undefined;
 
 export interface RenderAnsiMarkdownOptions {
   readonly width?: number;
+  readonly colorEnabled?: boolean;
 }
 
 /**
@@ -378,20 +428,28 @@ export function renderAnsiMarkdown(
   content: string,
   options: RenderAnsiMarkdownOptions = {},
 ): string {
-  if (!cachedProcessor || cachedWidth !== options.width) {
+  const colorEnabled = options.colorEnabled ?? true;
+  const style = ansiMarkdownStyle(colorEnabled);
+  if (
+    !cachedProcessor ||
+    cachedWidth !== options.width ||
+    cachedColorEnabled !== colorEnabled
+  ) {
     const renderer = createMarkdownRenderer({
-      highlight: highlightForTui,
-      configure: (md) => configureAnsi(md, options.width),
+      highlight: (code, lang) => highlightForTui(code, lang, style),
+      configure: (md) => configureAnsi(md, options.width, style),
     });
     cachedProcessor = createMarkdownProcessor({
       renderer,
-      formatLatexReference: formatAnsiLatexReference,
+      formatLatexReference: (refType, label) =>
+        formatAnsiLatexReference(refType, label, style),
       // The CLI shows LaTeX source verbatim (math rendering is disabled), so
       // shield `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans from markdown-it, which
       // would otherwise strip `\(`→`(`, `\;`→`;` and eat `_{…}` subscripts.
       protectLatexMath: true,
     });
     cachedWidth = options.width;
+    cachedColorEnabled = colorEnabled;
   }
   return wrapAnsiToWidth(
     cachedProcessor(content),
@@ -404,6 +462,7 @@ export function renderAnsiMarkdown(
 export function _resetAnsiMarkdownForTests(): void {
   cachedProcessor = null;
   cachedWidth = undefined;
+  cachedColorEnabled = undefined;
 }
 
 /** Test seam: returns cache hit/miss counters for the active processor. */

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1244,6 +1244,7 @@ export async function runChat(
       onSubmit={handleSubmit}
       canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
+      colorEnabled={context.stdoutColorEnabled ?? context.colorEnabled}
       onInterruptActive={interruptActive}
       onCtrlC={() => handleSigint()}
       onKillExecution={(executionId) => {

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -15,6 +15,11 @@ import {
 } from '@cli/chat/tui/render/ansiMarkdown';
 import { wrapAnsiToWidth } from '@cli/chat/tui/render/ansiWrap';
 
+const ANSI_SGR_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-9;]*m`,
+  'u',
+);
+
 function displayWidthForTest(line: string): number {
   let width = 0;
   for (const char of line) {
@@ -121,6 +126,18 @@ describe('renderAnsiMarkdown', () => {
     expect(plain).toContain('Core objects');
     expect(plain).not.toContain('## What');
     expect(plain).not.toContain('### Core');
+  });
+
+  it('renders markdown without ANSI styles when color is disabled', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      '**Bold** and _emphasis_ with `code`.\n\n```ts\nconst x = 1;\n```',
+      { colorEnabled: false },
+    );
+
+    expect(out).toContain('Bold and emphasis with `code`.');
+    expect(out).toContain('const x = 1;');
+    expect(out).not.toMatch(ANSI_SGR_PATTERN);
   });
 
   it('separates consecutive paragraphs visually', () => {


### PR DESCRIPTION
## Summary
- Thread stdout color capability into finalized chat transcript Markdown rendering.
- Centralize colored/plain ANSI behavior in the Markdown renderer via one style strategy.
- Add a regression test proving `colorEnabled: false` output has no SGR styling.

Closes #5098.

## Dogfood Evidence
- Reproduced in chat TUI with `--no-color`; finalized assistant Markdown still emitted SGR codes for bold styling.
- This patch keeps the existing colored path unchanged while disabling Markdown-introduced terminal styling when stdout color is disabled.

## Code Simplifier
- Ran a focused code-simplifier pass on this PR.
- Removed unnecessary live pending transcript color plumbing because that path renders raw streaming text, not finalized Markdown.
- Consolidated style branching in `ansiMarkdown.ts` so no-color behavior is DRY.

## Validation
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing 10 import-order warnings)
- `corepack pnpm exec vitest run src/test-kernel/cli/AnsiMarkdown.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-markdown-color transcript plain-submit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI path with a regression test; default behavior remains color-on when unspecified.
> 
> **Overview**
> The chat TUI now passes the CLI’s stdout color capability (`--no-color`, `NO_COLOR`, etc.) into **static** assistant transcript Markdown so finalized messages no longer inject SGR when color is off.
> 
> `renderAnsiMarkdown` picks a **color** or **plain** style object and routes headings, emphasis, links, code fences (including `cli-highlight`), tables, blockquotes, and LaTeX refs through it; with color disabled, output stays readable text with no escape sequences. The markdown processor cache also rebuilds when `colorEnabled` changes. A Vitest case asserts `colorEnabled: false` produces no SGR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd1d4c4aa772e22ab1550afcae9d760baa1b056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->