### PR TITLE
fix(cli): restart on the new version after an in-session self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **In-session updates take effect immediately** — accepting the "a new version is available" prompt now restarts `texra` on the freshly installed version, so the session you land in (and its header/`/status`) runs the update instead of silently continuing on the old build until you quit and relaunch by hand.
 - **Unknown CLI flags are rejected** — mistyped command options now fail before the command runs, and structured CLI output stays clean for scripts.
 - **File-backed multi-agent CLI prompts** — `texra multi-agent run` now accepts `--instruction-file` for long scripted team prompts, matching `texra agents run`.
 - **Full CLI command paths in help** — nested command help now shows the complete `texra ...` command in usage banners, so commands like `texra multi-agent run --help` and `texra history show --help` are directly copyable.

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { constants as osConstants } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { gt as semverGt, valid as semverValid } from 'semver';
@@ -6,17 +7,22 @@ import { gt as semverGt, valid as semverValid } from 'semver';
 import {
   cliEnvValue,
   readCliAmbientState,
+  readCliArgv,
+  readCliEnv,
   readCliEntrypointPath,
   type CliContext,
 } from './cliContext';
+import { CliExitCode } from './exitCodes';
 import { askCliQuestion, writeTextStderr } from './logSinks';
-import { createCliStyle } from './style';
+import { createCliStyle, type CliStyle } from './style';
 
 /** Published package name on npm; the `texra` bin lives here. */
 export const CLI_PACKAGE_NAME = '@texra-ai/cli';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
+const POSIX_SIGNAL_EXIT_OFFSET = 128;
+const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 
 /** Package manager the running binary was installed with. */
 export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun';
@@ -127,6 +133,96 @@ function affirmative(answer: string): boolean {
   return normalized === '' || normalized === 'y' || normalized === 'yes';
 }
 
+/**
+ * Build the argv to re-exec the just-installed binary in place, preserving the
+ * user's own arguments. We launch through `execPath` (the running Node) rather
+ * than the bin's shebang so it works regardless of how the entrypoint is
+ * marked executable. Returns `undefined` when there is no entrypoint to
+ * re-exec — caller falls back to asking the user to restart by hand.
+ */
+export function buildRelaunchCommand(
+  entrypoint: string,
+  argv: readonly string[],
+  execPath: string = process.execPath,
+): { command: string; args: string[] } | undefined {
+  if (!entrypoint.trim()) return undefined;
+  return { command: execPath, args: [entrypoint, ...argv] };
+}
+
+/** Env for the fresh process, skipping the redundant post-update check once. */
+export function buildRelaunchEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  return { ...env, [UPDATE_CHECK_SKIP_ENV]: '1' };
+}
+
+export function exitCodeForRelaunchClose(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): number {
+  if (code != null) return code;
+  if (!signal) return CliExitCode.Success;
+
+  const signalNumber = osConstants.signals[signal];
+  return typeof signalNumber === 'number'
+    ? POSIX_SIGNAL_EXIT_OFFSET + signalNumber
+    : CliExitCode.Terminated;
+}
+
+/**
+ * Replace this now-stale process with a fresh one running the just-installed
+ * binary, carrying the same argv. Inherits stdio so the child owns the terminal
+ * and mirrors the child's exit code, making the in-session update seamless: the
+ * launcher/session the user lands in actually runs `latest` instead of silently
+ * continuing on the old code (which would keep reporting the previous version
+ * in the header, `/status`, and the launcher).
+ *
+ * Never returns on success — it calls `process.exit`. If the child can't be
+ * spawned, or there is nothing to re-exec, it prints the restart hint and exits
+ * cleanly so we never carry on executing the stale build.
+ */
+async function relaunchAfterUpdate(
+  latest: string,
+  style: CliStyle,
+): Promise<never> {
+  const invocation = buildRelaunchCommand(
+    readCliEntrypointPath(),
+    readCliArgv(),
+  );
+  if (!invocation) {
+    writeTextStderr(
+      style.success(
+        `Updated to ${latest}. Restart texra to use the new version.`,
+      ),
+    );
+    process.exit(CliExitCode.Success);
+  }
+
+  writeTextStderr(style.success(`Updated to ${latest}. Restarting…`));
+  await new Promise<never>(() => {
+    const child = spawn(invocation.command, invocation.args, {
+      stdio: 'inherit',
+      // The relaunched process just verified it is current, so suppress its own
+      // startup check: it would otherwise re-hit the registry (and could even
+      // re-prompt) on every auto-update. This only skips that single
+      // once-per-process check; there are no later in-session checks to lose.
+      env: buildRelaunchEnv(readCliEnv()),
+    });
+    child.on('error', () => {
+      writeTextStderr(
+        style.muted('Could not restart automatically — ') +
+          style.success(`run texra again to use ${latest}.`),
+      );
+      process.exit(CliExitCode.Success);
+    });
+    child.on('close', (code, signal) => {
+      process.exit(exitCodeForRelaunchClose(code, signal));
+    });
+  });
+  // Unreachable: every branch above ends the process via `process.exit`.
+  throw new Error('unreachable: relaunchAfterUpdate did not exit');
+}
+
 let notified = false;
 
 /**
@@ -142,7 +238,7 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   notified = true;
 
   const ambient = readCliAmbientState();
-  if (cliEnvValue('TEXRA_NO_UPDATE_CHECK')) return;
+  if (cliEnvValue(UPDATE_CHECK_SKIP_ENV)) return;
   if (ambient.isCi) return;
   // Require all three standard streams to be a TTY. stdout matters even though
   // the prompt uses stdin/stderr: a half-redirected invocation like
@@ -179,11 +275,15 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
 
   writeTextStderr(style.muted(`Updating via ${method}…`));
   const ok = await runCliUpdate(method);
-  writeTextStderr(
-    ok
-      ? style.success(
-          `Updated to ${latest}. Restart texra to use the new version.`,
-        )
-      : `${style.error('Update failed.')} Run manually: ${style.command(updateCmd)}`,
-  );
+  if (!ok) {
+    writeTextStderr(
+      `${style.error('Update failed.')} Run manually: ${style.command(updateCmd)}`,
+    );
+    return;
+  }
+
+  // The new version is on disk, but THIS process is still the old code. Re-exec
+  // the freshly installed binary so the session that follows actually runs the
+  // update; otherwise it silently does nothing until a manual relaunch.
+  await relaunchAfterUpdate(latest, style);
 }

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildRelaunchCommand,
+  buildRelaunchEnv,
   buildUpdateCommand,
   detectInstallMethod,
+  exitCodeForRelaunchClose,
   fetchLatestCliVersion,
   formatUpdateCommand,
   isNewerVersion,
 } from '@cli/runtime/updateChecker';
+import { CliExitCode } from '@cli/runtime/exitCodes';
 
 describe('isNewerVersion', () => {
   it('compares numerically across all components', () => {
@@ -66,6 +70,69 @@ describe('buildUpdateCommand / formatUpdateCommand', () => {
       command: 'npm',
       args: ['install', '-g', '@texra-ai/cli@latest'],
     });
+  });
+});
+
+describe('buildRelaunchCommand', () => {
+  it('re-execs the entrypoint through the running Node, preserving argv', () => {
+    expect(
+      buildRelaunchCommand(
+        '/usr/local/bin/texra',
+        ['chat', '--agent', 'research'],
+        '/usr/bin/node',
+      ),
+    ).toEqual({
+      command: '/usr/bin/node',
+      args: ['/usr/local/bin/texra', 'chat', '--agent', 'research'],
+    });
+  });
+
+  it('handles a bare launch with no user arguments', () => {
+    expect(buildRelaunchCommand('/usr/local/bin/texra', [], 'node')).toEqual({
+      command: 'node',
+      args: ['/usr/local/bin/texra'],
+    });
+  });
+
+  it('returns undefined when there is no entrypoint to re-exec', () => {
+    expect(buildRelaunchCommand('', ['chat'], 'node')).toBeUndefined();
+    expect(buildRelaunchCommand('   ', ['chat'], 'node')).toBeUndefined();
+  });
+});
+
+describe('buildRelaunchEnv', () => {
+  it('preserves the current environment while skipping the redundant update check', () => {
+    expect(buildRelaunchEnv({ HOME: '/Users/me' })).toEqual({
+      HOME: '/Users/me',
+      TEXRA_NO_UPDATE_CHECK: '1',
+    });
+  });
+
+  it('overwrites an inherited update-check setting for the relaunched process', () => {
+    expect(buildRelaunchEnv({ TEXRA_NO_UPDATE_CHECK: '0' })).toEqual({
+      TEXRA_NO_UPDATE_CHECK: '1',
+    });
+  });
+});
+
+describe('exitCodeForRelaunchClose', () => {
+  it('mirrors the child exit code when one is available', () => {
+    expect(exitCodeForRelaunchClose(0, null)).toBe(CliExitCode.Success);
+    expect(exitCodeForRelaunchClose(7, 'SIGTERM')).toBe(7);
+  });
+
+  it('uses conventional signal exit codes when the child was killed', () => {
+    expect(exitCodeForRelaunchClose(null, 'SIGINT')).toBe(
+      CliExitCode.Interrupted,
+    );
+    expect(exitCodeForRelaunchClose(null, 'SIGTERM')).toBe(
+      CliExitCode.Terminated,
+    );
+    expect(exitCodeForRelaunchClose(null, 'SIGKILL')).toBe(137);
+  });
+
+  it('falls back to success only when no code or signal was reported', () => {
+    expect(exitCodeForRelaunchClose(null, null)).toBe(CliExitCode.Success);
   });
 });
 


### PR DESCRIPTION
## Problem

Accepting the in-session auto-update prompt updates the files on disk but the **running process keeps executing the old code**, so the session you land in still reports the previous version everywhere.

Repro (from a user report):

```
A new version of texra is available: 0.38.2 → 0.38.4
Update now with `npm install -g @texra-ai/cli@latest`? [Y/n] y
Updating via npm…
Updated to 0.38.4. Restart texra to use the new version.
 TeXRA  v0.38.2  relay      ← still 0.38.2 in the session that follows
```

Opening `texra` fresh correctly shows `0.38.4` — proof the install landed, but the in-session continuation never reloaded it.

### Root cause

`notifyCliUpdate` (`packages/cli/src/runtime/updateChecker.ts`) runs `npm install -g …@latest`, prints *"Restart texra…"*, and **returns**. Both callers (`orchestrate.ts`, `chat.ts`) then continue in the same still-running process: they build the launcher and start a chat session on the stale build. The header/`/status`/launcher read the version from this process's own (old) `package.json`, so they keep showing the previous version until the user quits and relaunches by hand.

## Fix

After a successful update, **re-exec the freshly installed binary in place** with the same argv:

- Launch through `process.execPath` + the original entrypoint, `stdio: 'inherit'` so the child owns the terminal.
- Build the child env through `readCliEnv()` and set `TEXRA_NO_UPDATE_CHECK=1` to skip the now-redundant startup check.
- Mirror child exit codes, including conventional POSIX signal exit codes when the relaunched process is killed by a signal.
- **Fallback:** if there's no entrypoint to re-exec or the child can't be spawned, print the restart hint and exit cleanly — we never carry on executing the stale build.

`buildRelaunchCommand`, `buildRelaunchEnv`, and `exitCodeForRelaunchClose` keep the relaunch decisions small and unit-tested; `relaunchAfterUpdate` owns the spawn + `process.exit` side effects.

## Tests

- `corepack pnpm exec vitest run src/test-kernel/cli/UpdateChecker.vitest.mts` → 18 passing.
- `corepack pnpm --filter @texra-ai/cli check:architecture` passes.
- `npm run compile:safe` passes.
- `npm run lint` passes with existing unrelated import-order warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to interactive update flow in updateChecker; fallbacks avoid continuing on stale code; behavior is unit-tested.
> 
> **Overview**
> After a successful in-session global install, the CLI **re-execs** the updated `texra` binary with the same argv instead of continuing in the old process—so chat/orchestrate sessions, headers, and `/status` reflect the new version immediately.
> 
> Relaunch uses `process.execPath` + the saved entrypoint, inherits stdio, forwards the child’s exit code (including POSIX signal codes), and sets **`TEXRA_NO_UPDATE_CHECK=1`** on the child to avoid a redundant registry check or re-prompt. If relaunch isn’t possible or spawn fails, it prints the manual restart message and exits without running stale code.
> 
> Pure helpers (`buildRelaunchCommand`, `buildRelaunchEnv`, `exitCodeForRelaunchClose`) are covered by new unit tests; the unreleased changelog documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f6f0cee172196f3c29a135b9ce2edb3d53e683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->