### PR TITLE
fix(cli): clarify agent lookup hints

### DIFF
--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -1,0 +1,16 @@
+const AGENT_LOOKUP_HINT =
+  'Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.';
+
+export const AGENT_NAME_DESCRIPTION =
+  'Agent name from `texra agents list` or a known launchable agent name';
+
+export const TOOL_USE_AGENT_NAME_DESCRIPTION =
+  'Tool-use agent name from `texra agents list` or a known launchable agent name';
+
+export function missingAgentMessage(name: string): string {
+  return `Agent not found: ${name}. ${AGENT_LOOKUP_HINT}`;
+}
+
+export function missingToolUseAgentMessage(name: string): string {
+  return `Tool-use agent not found: ${name}. ${AGENT_LOOKUP_HINT}`;
+}

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -8,6 +8,10 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 
+import {
+  AGENT_NAME_DESCRIPTION,
+  missingAgentMessage,
+} from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
@@ -78,7 +82,7 @@ export async function showAgent(
 
   const entry = getAgent(name) ?? (await resolveAgentWithRemoteFallback(name));
   if (!entry) {
-    writeTextStderr(`Agent not found: ${name}`);
+    writeTextStderr(missingAgentMessage(name));
     return CliExitCode.Usage;
   }
 
@@ -105,8 +109,7 @@ const agentsShowCommand = defineCliCommand({
     name: {
       type: 'positional',
       required: true,
-      description:
-        'Agent name from `texra agents list` (use `source:name` to disambiguate when the same name exists in multiple sources)',
+      description: `${AGENT_NAME_DESCRIPTION} (use \`source:name\` to disambiguate when the same name exists in multiple sources)`,
     },
   },
   run: (context, ctx) => showAgent(context, ctx.args.name),

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -18,6 +18,10 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 
+import {
+  TOOL_USE_AGENT_NAME_DESCRIPTION,
+  missingToolUseAgentMessage,
+} from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   GLOBAL_ARGS,
@@ -101,9 +105,7 @@ async function runToolUseAgent(
   const agent = await resolveAgentWithRemoteFallback(init.agent);
 
   if (!agent) {
-    writeTextStderr(
-      `Agent not found: ${init.agent}. Use \`texra agents list\` to see available agents.`,
-    );
+    writeTextStderr(missingToolUseAgentMessage(init.agent));
     return CliExitCode.Usage;
   }
   if (agent.category !== AgentCategory.ToolUse) {
@@ -190,7 +192,7 @@ export const agentsRunCommand = defineCliCommand({
     name: {
       type: 'positional',
       required: true,
-      description: 'Tool-use agent name from `texra agents list`',
+      description: TOOL_USE_AGENT_NAME_DESCRIPTION,
     },
     input: {
       type: 'string',

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -31,6 +31,7 @@ import {
 } from '../runtime/multiAgentPresets';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
+import { missingToolUseAgentMessage } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   buildHeadlessRunContext,
@@ -266,7 +267,7 @@ export async function runMultiAgentPreset(
   const plan = await fillMultiAgentRunPlanGaps(init);
   if (plan.missingAgentOverride) {
     throw new CliUsageError(
-      `Tool-use agent not found: ${plan.missingAgentOverride}. Use \`texra agents list\` to see available agents.`,
+      missingToolUseAgentMessage(plan.missingAgentOverride),
     );
   }
   if (!plan.rootAgent) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -16,6 +16,7 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr } from '../runtime/logSinks';
 
+import { missingAgentMessage } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   buildHeadlessRunContext,
@@ -80,9 +81,7 @@ async function runWorkflowAgent(
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
   if (!agent) {
-    throw new CliUsageError(
-      `Agent not found: ${init.agent}. Use \`texra agents list\` to see available agents.`,
-    );
+    throw new CliUsageError(missingAgentMessage(init.agent));
   }
   if (agent.category !== AgentCategory.Workflow) {
     throw new CliUsageError(

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -121,7 +121,7 @@ describe('CLI agents command', () => {
 
     expect(exitCode).toBe(2);
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Agent not found: missing-agent',
+      'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
     );
     expect(mocks.emitCliResult).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Centralize CLI agent lookup wording for help text and missing-agent errors.
- Clarify that `agents list` is the visible starter catalog while known launchable names from team presets can also resolve.
- Keep internal/hidden agent visibility unchanged.

Closes #5105.

## Dogfood Evidence
- `texra agents list --no-color` only showed visible starters (`lean`, `latexFixer`).
- `texra agents show review --no-color` and `texra agents show orchestrator --no-color` both resolved launchable agents not all shown by `agents list`.
- `texra multi-agent inspect mathematician --no-color` listed available team agents like `review`, `research`, `simplifier`, and `orchestrator`, making the old "from agents list" wording misleading.

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-dogfood-20260602-full` (87 scenarios)
- `npm run format`
- `corepack pnpm exec vitest run src/test-kernel/cli/AgentsCommand.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing 10 import-order warnings)
- `corepack pnpm --filter @texra-ai/cli bundle`
- `node packages/cli/dist/bin/texra.js agents show --help`
- `node packages/cli/dist/bin/texra.js agents run --help`
- `node packages/cli/dist/bin/texra.js agents show missing-agent --no-color`
- `node packages/cli/dist/bin/texra.js multi-agent run mathematician --agent missing-agent --instruction 'Check a simple finite combinatorics claim.' --no-color --no-input`
- `node packages/cli/dist/bin/texra.js agents show review --no-color`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing help and error strings only; agent resolution and visibility behavior are unchanged.
> 
> **Overview**
> Centralizes CLI wording for **how to pick an agent name** in a new `_helpers/agentLookupText` module.
> 
> **Help text** for `agents show` and `agents run` now says names can come from **`texra agents list`** (visible starters) **or** any **known launchable** name (e.g. team-preset agents not all listed). **`agents show`** keeps the `source:name` disambiguation note on top of the shared description.
> 
> **Missing-agent errors** for `agents show`, `texra run`, `agents run`, and `multi-agent run --agent` use the same hint instead of implying every valid name appears in `agents list`. A test expectation for `showAgent` is updated to match.
> 
> No change to agent loading, visibility, or resolution logic—copy and consistency only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74657dc1e4a84245181cbbe3d29c84dfe0368f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->