### PR TITLE
fix(cli): unify session API mode + theme-adaptive user-message highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - **In-session updates take effect immediately** — accepting the "a new version is available" prompt now restarts `texra` on the freshly installed version, so the session you land in (and its header/`/status`) runs the update instead of silently continuing on the old build until you quit and relaunch by hand.
+- **Chat API mode is reported consistently** — the model is now resolved against the same API mode shown in the header and `/status` (an explicit `--api-mode`/env override, otherwise your account default), so a session can no longer pick a model as if in one mode while the UI reports another.
 - **Unknown CLI flags are rejected** — mistyped command options now fail before the command runs, and structured CLI output stays clean for scripts.
 - **File-backed multi-agent CLI prompts** — `texra multi-agent run` now accepts `--instruction-file` for long scripted team prompts, matching `texra agents run`.
 - **Full CLI command paths in help** — nested command help now shows the complete `texra ...` command in usage banners, so commands like `texra multi-agent run --help` and `texra history show --help` are directly copyable.
+
+### Improvements
+
+- **User turns stand out in chat** — your messages now render on a full-width highlight band (reverse video, so it adapts to your terminal's light/dark theme) in the terminal transcript, making them easy to pick out from the assistant's output when scrolling back.
 
 ## [0.38.4] - 2026-06-01
 

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -5,12 +5,50 @@
 
 import { Box, Text } from 'ink';
 
+import { fillRows } from '../render/DiffView';
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
+
+function UserEntryRow({
+  entry,
+  colorEnabled,
+  width,
+}: {
+  readonly entry: ConversationEntry;
+  readonly colorEnabled?: boolean;
+  readonly width?: number;
+}): React.JSX.Element {
+  // Mark a user turn with a full-width reverse-video band so it stands out in
+  // scrollback against the assistant's `●` rows. Reverse video (not a fixed
+  // color) makes the highlight adapt to the terminal theme automatically — a
+  // dark bar with light text on a light terminal, a light bar with dark text on
+  // a dark one — using the terminal's own foreground/background. The `› `
+  // chevron is 2 cols, matching the static row count in transcriptLines.ts so
+  // render and counting stay in lockstep.
+  const cols = Math.max(1, Math.floor(width ?? 80));
+  const body = wrapAnsiToWidth(entry.text, Math.max(1, cols - 2))
+    .split('\n')
+    .map((line, index) => `${index === 0 ? '› ' : '  '}${line}`)
+    .join('\n');
+  // No-color terminals can't show the band; render the chevron text plain
+  // (skip the width padding so we don't litter scrollback with trailing space).
+  if (colorEnabled === false) {
+    return (
+      <Box>
+        <Text>{body}</Text>
+      </Box>
+    );
+  }
+  return (
+    <Box>
+      <Text inverse>{fillRows(body, cols)}</Text>
+    </Box>
+  );
+}
 
 function ProcessEntryRow({
   process,
@@ -59,10 +97,7 @@ export function TranscriptEntry({
   switch (entry.role) {
     case 'user':
       return (
-        <Box paddingX={1}>
-          <Text dimColor>› </Text>
-          <Text>{entry.text}</Text>
-        </Box>
+        <UserEntryRow entry={entry} colorEnabled={colorEnabled} width={width} />
       );
     case 'error':
       return (

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -839,7 +839,9 @@ async function handleTuiSlashCommand(
           agent: meta.agent || context.initialAgent,
           model: meta.model || context.initialModel,
           teamName: meta.teamName,
-          api: formatCliApiMode(getCliApiMode()),
+          // Read the session's own mode (which honors a --api-mode/env override)
+          // so /status agrees with the header instead of re-reading the global.
+          api: formatCliApiMode(meta.apiMode),
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
@@ -940,17 +942,24 @@ export async function runChat(
   const explicitModelRequested = Boolean(
     init.modelOverride?.trim() || context.envModel?.trim(),
   );
+  // One API mode for the whole session: an explicit --api-mode/env override
+  // wins, otherwise the persisted account default. Model resolution, the
+  // no-models hints, and the header/status all read this same value so they can
+  // never disagree — previously resolution used `context.apiMode` (undefined on
+  // a bare launch, so ungated) while the header showed `getCliApiMode()`, which
+  // let a model resolve as if in one mode while the UI reported another.
+  const sessionApiMode = context.apiMode ?? getCliApiMode();
   let modelResolution: Awaited<ReturnType<typeof resolveCliRunnableModel>>;
   try {
     modelResolution = await resolveCliRunnableModel(defaults.model, {
       allowFallback: !explicitModelRequested,
-      apiMode: context.apiMode,
+      apiMode: sessionApiMode,
       noAvailableModelsMessage:
-        context.apiMode === 'included'
+        sessionApiMode === 'included'
           ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
           : undefined,
       noAvailableModelsHint:
-        context.apiMode === 'included'
+        sessionApiMode === 'included'
           ? undefined
           : 'Run `texra chat --api-mode included` to try included relay access',
     });
@@ -995,7 +1004,7 @@ export async function runChat(
     agent,
     model,
     cwd: context.cwd,
-    apiMode: getCliApiMode(),
+    apiMode: sessionApiMode,
     canDelegate: agentSupportsDelegation(agent),
     teamName: init.teamName,
     version,


### PR DESCRIPTION
Two small CLI follow-ups from a hands-on v0.38.5 session, in two focused commits.

## 1. `fix(cli): resolve chat model against the displayed API mode`

**Symptom:** the header/status showed `relay`, but a model picked through the chained model picker felt like it came "via api" — the mode reported didn't match how the model was chosen.

**Root cause:** `runChat` resolved the session model with `context.apiMode` (`undefined` on a bare launch — so the resolver ran *ungated*, skipping the included-login gate), while the header/`/status` display and execution used `getCliApiMode()` (the persisted account default). The orchestrate launcher builds its model list with `context.apiMode ?? getCliApiMode()`, so `runChat` resolving with *only* `context.apiMode` was inconsistent with both the launcher and the display.

**Fix:** compute one `sessionApiMode = context.apiMode ?? getCliApiMode()` and use it for resolution, the no-models hints, the header, and `/status`, so all surfaces always agree.

## 2. `feat(cli): highlight user messages with a theme-adaptive band`

User turns rendered as a dim `› text` line, easy to lose against the assistant's `●` rows. They now render on a **full-width reverse-video band** with the `› ` chevron:

```
› what is this repo about ▒▒▒▒▒▒  ← reverse-video bar (theme-adaptive)

● The repo is TeXRA, an AI-powered LaTeX research assistant ...

› and how does the agent system work ▒▒▒
```

- **Reverse video, not a fixed color** — the highlight uses the terminal's own fg/bg, so it adapts to the theme automatically (light bar + dark text on a dark terminal; dark bar + light text on a light terminal) and drops out cleanly under `NO_COLOR`.
- Full-width via `fillRows`; the no-color path renders the plain chevron line (no trailing-space litter).
- The `› ` chevron is 2 cols, matching the static row count in `transcriptLines.ts`, so render and counting stay in lockstep.

## Verification

- `@texra-ai/cli` typecheck clean; eslint clean.
- Affected suites green: `ConversationPane`, `cliModelResolution`, `ModelAccess`, `StatusBar`, `TuiStateAndFocus`, `CliContext`.
- Drove a fresh bundle under tmux: user lines carry SGR-7 reverse video (`ESC[7m› what is this repo about…`) full-width; `/status` + the status bar report `api` under `--api-mode personal` (mode now consistent across resolution and display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI presentation and session-mode wiring; no auth, billing, or persistence contract changes beyond aligning existing resolution with displayed mode.
> 
> **Overview**
> **CLI chat** now uses one **`sessionApiMode`** (`--api-mode`/env override, else account default) for **model resolution**, **no-model hints**, **session metadata**, **`/status`**, and the header—fixing cases where the UI showed one API mode while models were chosen under another (e.g. bare launch vs persisted default).
> 
> **User messages** in the transcript render on a **full-width reverse-video band** with a `›` chevron (theme-adaptive; plain text when color is off), reusing **`fillRows`** so scrollback rows stay aligned with static line counting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215327f98b0538796791dc30920a2959f1fe7396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->