### PR TITLE
fix(cli): label TUI question prompts accurately

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -723,8 +723,14 @@ const SCENARIOS = [
       'Enter submit answer',
       'Ctrl-R reject with note',
       'Esc skip',
+      '1 question',
     ],
-    unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
+    unexpect: [
+      '└─Degenerate triples',
+      '[/model]models',
+      'Esc sk…',
+      '1 approval',
+    ],
   },
   {
     name: 'external-inquiry-long-80-cols',
@@ -741,8 +747,14 @@ const SCENARIOS = [
       'Enter submit answer',
       'Ctrl-R reject with note',
       'Esc skip',
+      '1 question',
     ],
-    unexpect: ['└─Degenerate triples', '[/model]models', 'Esc sk…'],
+    unexpect: [
+      '└─Degenerate triples',
+      '[/model]models',
+      'Esc sk…',
+      '1 approval',
+    ],
   },
   {
     name: 'compact-user-question',
@@ -758,8 +770,13 @@ const SCENARIOS = [
       '+2 more',
       'Enter select',
       'Esc skip',
+      '1 question',
     ],
-    unexpect: ['[/model]models', 'Context detail: the candidate proof'],
+    unexpect: [
+      '[/model]models',
+      'Context detail: the candidate proof',
+      '1 approval',
+    ],
     maxLineColumns: 80,
   },
   {

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -16,7 +16,10 @@ import {
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { formatCliStatusLabel } from '../sessionStatus';
-import { approvalQueueDepth } from '../state/approvalQueue';
+import {
+  approvalQueueStatus,
+  type ApprovalQueueStatusKind,
+} from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   cliState,
@@ -58,6 +61,7 @@ export interface StatusBarDisplayInput {
   readonly activeSubagents: number;
   readonly activeProcesses: number;
   readonly approvalDepth: number;
+  readonly approvalKind?: ApprovalQueueStatusKind;
   readonly taskControlsAvailable?: boolean;
   readonly subagentControlsAvailable: boolean;
   /** True when more than the root stream exists, i.e. a subagent or
@@ -238,6 +242,21 @@ function queuedFollowUpsCountSegment(
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.queuedFollowUp,
       }
     : undefined;
+}
+
+function pendingInteractionSegment({
+  depth,
+  kind = 'approval',
+}: {
+  readonly depth: number;
+  readonly kind?: ApprovalQueueStatusKind;
+}): StatusBarSegment | undefined {
+  if (depth <= 0) return undefined;
+  return {
+    text: `${depth} ${kind}${depth === 1 ? '' : 's'}`,
+    color: 'yellow',
+    compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalDepth,
+  };
 }
 
 function statusBarSegmentWidth(segment: StatusBarSegment): number {
@@ -621,15 +640,11 @@ export function buildStatusBarDisplay(
       compactPriority: STATUS_BAR_COMPACT_PRIORITY.activeProcess,
     });
   }
-  if (input.approvalDepth > 0) {
-    left.push({
-      text: `${input.approvalDepth} approval${
-        input.approvalDepth === 1 ? '' : 's'
-      }`,
-      color: 'yellow',
-      compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalDepth,
-    });
-  }
+  const pendingInteraction = pendingInteractionSegment({
+    depth: input.approvalDepth,
+    kind: input.approvalKind,
+  });
+  if (pendingInteraction) left.push(pendingInteraction);
   if (input.bypass.superYolo) {
     left.push({ text: 'YOLO', badge: true, badgeColor: 'red' });
   }
@@ -692,7 +707,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const sessionMeta = useSignal(cliState.sessionMeta);
   const pendingExitHint = useSignal(cliState.pendingExitHint);
   const pendingExitResumeId = useSignal(cliState.pendingExitResumeId);
-  const approvals = useSignal(approvalQueueDepth);
+  const approvals = useSignal(approvalQueueStatus);
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
@@ -732,7 +747,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     conversation: statusSlice?.conversation,
     activeSubagents: statusSlice?.activeSubagents.length ?? 0,
     activeProcesses: statusSlice?.activeProcesses.length ?? 0,
-    approvalDepth: approvals,
+    approvalDepth: approvals.depth,
+    approvalKind: approvals.kind,
     taskControlsAvailable: hasChildControlItems(
       taskControlTarget.slice,
       'tasks',

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -1,11 +1,11 @@
 // Typed approval pipeline per docs/prd/cli-tui-ink/10-architecture.md §9.
 //
-// Each enqueued approval becomes a `p-queue` task. When its turn comes up
-// it publishes itself on the `currentApproval` signal and waits for the
-// modal to call `decide(decision)`. Both `pendingResolvers` (outer Promise
-// returned to the caller) and the currently-running task's `advance` are
-// settled by `clearApprovals` so a session interrupt never leaves the
-// queue blocked or the caller hanging.
+// Each enqueued approval or human-input prompt becomes a `p-queue` task.
+// When its turn comes up it publishes itself on the `currentApproval` signal
+// and waits for the modal to call `decide(decision)`. Both pending outer
+// Promises returned to callers and the currently-running task's `advance` are
+// settled by `clearApprovals` so a session interrupt never leaves the queue
+// blocked or the caller hanging.
 
 import { signal, type Signal } from '@lit-labs/signals';
 import PQueue from 'p-queue';
@@ -23,7 +23,10 @@ import type {
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
+import { assertNever } from '../assertNever';
+
 export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
+export type ApprovalQueueStatusKind = 'approval' | 'question' | 'request';
 
 export type ApprovalPayload =
   | { kind: 'bash'; payload: BashPermission }
@@ -54,21 +57,29 @@ export interface PendingApproval {
   readonly decide: (decision: ApprovalDecision) => void;
 }
 
+export interface ApprovalQueueStatus {
+  readonly depth: number;
+  readonly kind: ApprovalQueueStatusKind;
+}
+
 export interface EnqueueApprovalOptions {
   readonly onPresent?: () => void;
 }
 
 const CURRENT = signal<PendingApproval | undefined>(undefined);
-const DEPTH = signal<number>(0);
+const STATUS = signal<ApprovalQueueStatus>({ depth: 0, kind: 'approval' });
 
 export const currentApproval = CURRENT as Signal.State<
   PendingApproval | undefined
 >;
-export const approvalQueueDepth = DEPTH as Signal.State<number>;
+export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
 
 const queue = new PQueue({ concurrency: 1 });
 
-const pendingResolvers = new Set<(decision: ApprovalDecision) => void>();
+const pendingPayloads = new Map<
+  (decision: ApprovalDecision) => void,
+  ApprovalPayload
+>();
 let currentAdvance: (() => void) | undefined;
 
 const INTERRUPT: ApprovalDecision = {
@@ -76,8 +87,47 @@ const INTERRUPT: ApprovalDecision = {
   userMessage: 'Session interrupted.',
 };
 
-function syncApprovalDepth(): void {
-  DEPTH.set(pendingResolvers.size);
+function statusKindForPayload(
+  payload: ApprovalPayload,
+): Exclude<ApprovalQueueStatusKind, 'request'> {
+  switch (payload.kind) {
+    case 'externalInquiry':
+    case 'userQuestion':
+      return 'question';
+    case 'bash':
+    case 'toolEdit':
+    case 'plan':
+    case 'proposal':
+    case 'retry':
+      return 'approval';
+    default:
+      return assertNever(payload, 'Unknown approval payload kind');
+  }
+}
+
+function approvalQueueStatusKind(
+  payloads: Iterable<ApprovalPayload>,
+): ApprovalQueueStatusKind {
+  let sawApproval = false;
+  let sawQuestion = false;
+  for (const payload of payloads) {
+    const kind = statusKindForPayload(payload);
+    sawApproval ||= kind === 'approval';
+    sawQuestion ||= kind === 'question';
+    if (sawApproval && sawQuestion) return 'request';
+  }
+  return sawQuestion ? 'question' : 'approval';
+}
+
+function syncApprovalStatus(): void {
+  const depth = pendingPayloads.size;
+  STATUS.set({
+    depth,
+    kind:
+      depth === 0
+        ? 'approval'
+        : approvalQueueStatusKind(pendingPayloads.values()),
+  });
 }
 
 export function enqueueApproval(
@@ -88,14 +138,14 @@ export function enqueueApproval(
   const outer = new Promise<ApprovalDecision>((resolve) => {
     resolveOuter = resolve;
   });
-  pendingResolvers.add(resolveOuter);
-  syncApprovalDepth();
+  pendingPayloads.set(resolveOuter, payload);
+  syncApprovalStatus();
 
   void queue
     .add(async () => {
       // Already cleared before scheduling — resolveOuter was settled
       // by clearApprovals; nothing more to do.
-      if (!pendingResolvers.has(resolveOuter)) return;
+      if (!pendingPayloads.has(resolveOuter)) return;
       await new Promise<void>((advance) => {
         currentAdvance = advance;
         try {
@@ -107,8 +157,8 @@ export function enqueueApproval(
         CURRENT.set({
           payload,
           decide: (decision) => {
-            if (!pendingResolvers.delete(resolveOuter)) return;
-            syncApprovalDepth();
+            if (!pendingPayloads.delete(resolveOuter)) return;
+            syncApprovalStatus();
             CURRENT.set(undefined);
             currentAdvance = undefined;
             resolveOuter(decision);
@@ -121,8 +171,8 @@ export function enqueueApproval(
       // p-queue rejects when `queue.clear()` drops the task. Settle the
       // outer promise so the requester (e.g. ToolEditApprovalHandler)
       // doesn't hang forever.
-      if (pendingResolvers.delete(resolveOuter)) {
-        syncApprovalDepth();
+      if (pendingPayloads.delete(resolveOuter)) {
+        syncApprovalStatus();
         resolveOuter(INTERRUPT);
       }
     });
@@ -138,11 +188,10 @@ export function enqueueApproval(
 export function clearApprovals(): void {
   queue.clear();
   CURRENT.set(undefined);
-  for (const resolve of [...pendingResolvers]) {
-    pendingResolvers.delete(resolve);
-    resolve(INTERRUPT);
-  }
-  syncApprovalDepth();
+  const pendingResolves = [...pendingPayloads.keys()];
+  pendingPayloads.clear();
+  syncApprovalStatus();
+  for (const resolve of pendingResolves) resolve(INTERRUPT);
   if (currentAdvance) {
     const advance = currentAdvance;
     currentAdvance = undefined;

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -7,6 +7,7 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
 }));
 
 import {
+  approvalQueueStatus,
   clearApprovals,
   currentApproval,
   enqueueApproval,
@@ -26,6 +27,19 @@ function bashPayload(streamId: string): ApprovalPayload {
       allowBypass: true,
       streamId,
       command: 'echo ok',
+    },
+  };
+}
+
+function externalInquiryPayload(streamId: string): ApprovalPayload {
+  return {
+    kind: 'externalInquiry',
+    payload: {
+      requestId: `external-${streamId}`,
+      question: 'Please verify the finite enumeration independently.',
+      threadId: `thread-${streamId}`,
+      allowBypass: false,
+      streamId,
     },
   };
 }
@@ -66,6 +80,48 @@ describe('CLI approval queue', () => {
     currentApproval.get()?.decide({ accepted: false });
     await expect(secondResult).resolves.toEqual({ accepted: false });
     expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('labels queued human-input prompts separately from approvals', async () => {
+    const question = externalInquiryPayload('question-1');
+    const questionResult = enqueueApproval(question);
+
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 1,
+      kind: 'question',
+    });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(question);
+    });
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(questionResult).resolves.toEqual({ accepted: true });
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 0,
+      kind: 'approval',
+    });
+
+    const approval = bashPayload('approval-1');
+    const mixedQuestion = externalInquiryPayload('question-2');
+    const approvalResult = enqueueApproval(approval);
+    const mixedQuestionResult = enqueueApproval(mixedQuestion);
+
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 2,
+      kind: 'request',
+    });
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(approvalResult).resolves.toEqual({ accepted: false });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(mixedQuestion);
+    });
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 1,
+      kind: 'question',
+    });
+
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(mixedQuestionResult).resolves.toEqual({ accepted: false });
   });
 
   it('notifies only when a TUI approval becomes the foreground modal', async () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -643,6 +643,31 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).not.toContain('[/model]models');
   });
 
+  it('labels foreground user questions as questions instead of approvals', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 1,
+      approvalKind: 'question',
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: 'api',
+      shortcutModifierLabel: 'Alt',
+      shortcutsActive: false,
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toContain('1 question');
+    expect(display.left.map(statusBarSegmentText)).not.toContain('1 approval');
+  });
+
   it('keeps escape and Ctrl-C actions visible in narrow foreground panels', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary
- Track the pending TUI queue as approval/question/request status instead of a bare approval depth.
- Render `1 question` for external inquiry and user-question foreground prompts while keeping true approval prompts as `1 approval`.
- Add focused unit coverage and TUI snapshot expectations for the distinction.

Closes #5108.

## Dogfood Evidence
- Focused TUI capture before the fix showed `Agent asks:` panels with `◆ — api 1 approval` in `/tmp/texra-dogfood-20260602-next/04-external-inquiry-long-80-cols.txt` and `/tmp/texra-dogfood-20260602-next/05-compact-user-question.txt`.
- After the fix, `/tmp/texra-dogfood-20260602-question-status/03-external-inquiry-long-80-cols.txt` and `/tmp/texra-dogfood-20260602-question-status/04-compact-user-question.txt` show `◆ — api 1 question`.
- True approval snapshots still show `◆ — api 1 approval` for bash and plan approvals.

## Validation
- `npm run format`
- `corepack pnpm exec vitest run src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ExternalInquiry.vitest.mts src/test-kernel/cli/UserQuestion.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-dogfood-20260602-question-status external-inquiry-long external-inquiry-long-80-cols compact-user-question plan-approval-ctrl-r-ignored bash-approval`
- `npm run lint` (0 errors, existing 10 import-order warnings)
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-dogfood-20260602-question-status-full` (87 scenarios)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and queue metadata only; approval flow and concurrency are unchanged aside from clearer status-bar copy.
> 
> **Overview**
> The CLI status bar no longer treats every foreground modal as an **approval**. The pending queue now exposes **depth** plus a **kind** (`approval`, `question`, or `request` when both types are queued), derived from payload types (`externalInquiry` / `userQuestion` vs bash, plan, tool edit, etc.).
> 
> **StatusBar** reads that signal and renders labels like **`1 question`** for human-input prompts and **`3 approvals`** for privilege prompts; a mixed backlog uses **`request`**. TUI harness scenarios and unit tests lock in the new copy and assert **`1 approval`** does not appear on question flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de5b6e34c6c3374853bf6dd9a54f3c86c720fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->