### PR TITLE
fix(cli): scope model picks and child status rows

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -8,6 +8,7 @@ import { Spinner } from '@inkjs/ui';
 
 import {
   getCliModelAccessList,
+  runnableCliModelAccessEntries,
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
@@ -69,19 +70,11 @@ export function modelSelectItemsForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): ReadonlyArray<SelectItem<string>> {
-  return models
-    .filter((m) => m.available)
-    .map((m) => ({
-      value: m.model.value,
-      label: m.model.label || m.model.value,
-      description: formatModelStatusForCliMode(m, apiMode),
-    }));
-}
-
-export function hasRunnableModelSelectItems(
-  models: readonly CliModelAccess[],
-): boolean {
-  return models.some((m) => m.available);
+  return runnableCliModelAccessEntries(models).map((m) => ({
+    value: m.model.value,
+    label: m.model.label || m.model.value,
+    description: formatModelStatusForCliMode(m, apiMode),
+  }));
 }
 
 function EmptyModelListState(props: { readonly onClose: () => void }) {
@@ -96,7 +89,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   const { data, loading, error } = useAsyncListForm<readonly CliModelAccess[]>({
     load: () => getCliModelAccessList({ apiMode: props.apiMode }),
     onClose: props.onClose,
-    isEmpty: (models) => !hasRunnableModelSelectItems(models),
+    isEmpty: (models) => !models.some((model) => model.available),
   });
 
   if (loading) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -36,8 +36,8 @@ import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import {
+  effectiveCliApiMode,
   formatCliApiMode,
-  getCliApiMode,
   parseCliApiMode,
   setCliApiMode,
   type CliApiMode,
@@ -932,6 +932,7 @@ export async function runChat(
   }
 
   await initCliPlatform({ ...context, quietLogs: true });
+  const apiMode = effectiveCliApiMode(context);
   const defaults = await resolveChatDefaults({
     cwd: context.cwd,
     agentOverride: init.agentOverride,
@@ -945,21 +946,18 @@ export async function runChat(
   // One API mode for the whole session: an explicit --api-mode/env override
   // wins, otherwise the persisted account default. Model resolution, the
   // no-models hints, and the header/status all read this same value so they can
-  // never disagree — previously resolution used `context.apiMode` (undefined on
-  // a bare launch, so ungated) while the header showed `getCliApiMode()`, which
-  // let a model resolve as if in one mode while the UI reported another.
-  const sessionApiMode = context.apiMode ?? getCliApiMode();
+  // never disagree.
   let modelResolution: Awaited<ReturnType<typeof resolveCliRunnableModel>>;
   try {
     modelResolution = await resolveCliRunnableModel(defaults.model, {
       allowFallback: !explicitModelRequested,
-      apiMode: sessionApiMode,
+      apiMode,
       noAvailableModelsMessage:
-        sessionApiMode === 'included'
+        apiMode === 'included'
           ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
           : undefined,
       noAvailableModelsHint:
-        sessionApiMode === 'included'
+        apiMode === 'included'
           ? undefined
           : 'Run `texra chat --api-mode included` to try included relay access',
     });
@@ -975,6 +973,7 @@ export async function runChat(
   let activeApprovalPolicy = context.approvalPolicy;
   const currentSessionContext = (helperModel: string): CliContext => ({
     ...context,
+    apiMode: cliState.sessionMeta.get().apiMode,
     get approvalPolicy(): CliApprovalPolicy {
       return activeApprovalPolicy;
     },
@@ -1004,7 +1003,7 @@ export async function runChat(
     agent,
     model,
     cwd: context.cwd,
-    apiMode: sessionApiMode,
+    apiMode,
     canDelegate: agentSupportsDelegation(agent),
     teamName: init.teamName,
     version,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -261,19 +261,41 @@ export function removeStream(streamId: StreamTabId): void {
   if (nextParents) cliState.parentStream.set(nextParents);
 }
 
+export function updateChildStreamStatus(
+  childStreamId: StreamTabId,
+  status: StreamStatus,
+): void {
+  const current = cliState.streams.get();
+  let out: Map<StreamTabId, StreamSlice> | undefined;
+  for (const [streamId, slice] of current) {
+    const next = mapChildStreamReferenceLists(slice, (children) =>
+      updateChildStreamReferenceStatus(children, childStreamId, status),
+    );
+    if (next === slice) continue;
+    out ??= new Map(current);
+    out.set(streamId, next);
+  }
+  if (out) cliState.streams.set(out);
+}
+
 function scrubChildStreamReferences(
   slice: StreamSlice,
   streamId: StreamTabId,
 ): StreamSlice {
-  const activeSubagents = removeChildStreamReference(
-    slice.activeSubagents,
-    streamId,
+  return mapChildStreamReferenceLists(slice, (children) =>
+    removeChildStreamReference(children, streamId),
   );
-  const activeProcesses = removeChildStreamReference(
-    slice.activeProcesses,
-    streamId,
-  );
-  const childStreams = removeChildStreamReference(slice.childStreams, streamId);
+}
+
+function mapChildStreamReferenceLists(
+  slice: StreamSlice,
+  mapChildren: (
+    children: readonly ActiveChildInfo[],
+  ) => readonly ActiveChildInfo[],
+): StreamSlice {
+  const activeSubagents = mapChildren(slice.activeSubagents);
+  const activeProcesses = mapChildren(slice.activeProcesses);
+  const childStreams = mapChildren(slice.childStreams);
   if (
     activeSubagents === slice.activeSubagents &&
     activeProcesses === slice.activeProcesses &&
@@ -290,6 +312,25 @@ function removeChildStreamReference(
 ): readonly ActiveChildInfo[] {
   const next = children.filter((child) => child.childStreamId !== streamId);
   return next.length === children.length ? children : next;
+}
+
+function updateChildStreamReferenceStatus(
+  children: readonly ActiveChildInfo[],
+  childStreamId: StreamTabId,
+  status: StreamStatus,
+): readonly ActiveChildInfo[] {
+  let next: ActiveChildInfo[] | undefined;
+  for (const [index, child] of children.entries()) {
+    const updated =
+      child.childStreamId === childStreamId && child.status !== status
+        ? { ...child, status }
+        : child;
+    if (!next && updated !== child) {
+      next = children.slice(0, index);
+    }
+    next?.push(updated);
+  }
+  return next ?? children;
 }
 
 function defaultSessionMeta(): SessionMeta {

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -3,7 +3,7 @@
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
-import { patchStream } from './cliState';
+import { patchStream, updateChildStreamStatus } from './cliState';
 import { syncStreamLog } from './subscribeStreamLog';
 import {
   finalizeAssistantTranscriptEntries,
@@ -28,6 +28,7 @@ export function subscribeStreamStatus(): () => void {
           : undefined;
       return { ...slice, status: change.status, runStartedAt };
     });
+    updateChildStreamStatus(change.streamId, change.status);
     syncStreamLog(change.streamId);
     if (isFinalTranscriptStatus(change.status)) {
       finalizeAssistantTranscriptEntries(change.streamId);

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -8,6 +8,7 @@ import { initCliPlatform } from '@cli/runtime/initPlatform';
 import { writeTextStderr } from '@cli/runtime/logSinks';
 import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 import { shouldRenderRunProgress } from '@cli/runtime/runProgressRenderer';
+import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { toErrorMessage } from '@common/errors/errorMessage';
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
@@ -52,12 +53,13 @@ export async function resolveCliRunModel(
     modelOverride?.trim() || context.envModel?.trim(),
   );
   await initCliPlatform({ ...context, quietLogs: true });
+  const apiMode = effectiveCliApiMode(context);
   try {
     const resolution = await resolveCliRunnableModel(model, {
       allowFallback: !explicitModelRequested,
-      apiMode: context.apiMode,
+      apiMode,
       noAvailableModelsMessage:
-        context.apiMode === 'included'
+        apiMode === 'included'
           ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
           : undefined,
     });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,6 +6,7 @@ import { BUILTIN_DEFAULT_CHAT_AGENT } from '../runtime/chatDefaults';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import { getCliModelAccessList } from '../runtime/modelAccess';
 import {
   buildInitConfig,
@@ -19,7 +20,7 @@ import {
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import type { CliContext } from '../runtime/cliContext';
 
-async function gatherOptions(): Promise<{
+async function gatherOptions(apiMode: CliApiMode): Promise<{
   agents: { name: string; description?: string }[];
   models: {
     value: string;
@@ -33,7 +34,7 @@ async function gatherOptions(): Promise<{
     name: agent.name,
     description: agent.description,
   }));
-  const models = (await getCliModelAccessList()).map((entry) => ({
+  const models = (await getCliModelAccessList({ apiMode })).map((entry) => ({
     value: entry.model.value,
     label: entry.model.label ?? entry.model.value,
     available: entry.available,
@@ -105,7 +106,7 @@ async function runInit(
     return CliExitCode.Usage;
   }
 
-  const { agents, models } = await gatherOptions();
+  const { agents, models } = await gatherOptions(effectiveCliApiMode(context));
 
   const interactive =
     !opts.yes &&

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -5,7 +5,11 @@ import type { ModelOptionData } from '@shared/schemas';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
-import { getCliModelAccessList } from '../runtime/modelAccess';
+import { effectiveCliApiMode } from '../runtime/apiAccessMode';
+import {
+  getCliModelAccessList,
+  runnableCliModelAccessEntries,
+} from '../runtime/modelAccess';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -33,10 +37,12 @@ export function cliModelRecord(
 
 export function listableModelAccessEntries(
   models: ModelAccessList,
-  options: { readonly includeUnavailable?: boolean } = {},
+  options: {
+    readonly includeUnavailable?: boolean;
+  } = {},
 ): ModelAccessList {
   if (options.includeUnavailable === true) return models;
-  return models.filter(({ available }) => available);
+  return runnableCliModelAccessEntries(models);
 }
 
 export function formatNoListableModelsMessage(
@@ -58,13 +64,18 @@ export function formatNoListableModelsMessage(
   );
 }
 
-async function loadModelAccessList(
-  context: CliContext,
-): Promise<ModelAccessList | { error: string }> {
+async function loadModelAccessList(context: CliContext): Promise<
+  | { models: ModelAccessList; apiMode: CliContext['apiMode'] }
+  | {
+      error: string;
+    }
+> {
   try {
     return await suppressCliFetchStackLogs(async () => {
       await initCliPlatform({ ...context, quietLogs: true });
-      return getCliModelAccessList({ apiMode: context.apiMode });
+      const apiMode = effectiveCliApiMode(context);
+      const models = await getCliModelAccessList({ apiMode });
+      return { models, apiMode };
     });
   } catch (error) {
     return { error: formatCliModelListError(error) };
@@ -81,9 +92,9 @@ async function listModels(
     return CliExitCode.ModelOrNetworkError;
   }
 
-  const listedModels = listableModelAccessEntries(result, options);
+  const listedModels = listableModelAccessEntries(result.models, options);
   if (context.outputFormat === 'text' && listedModels.length === 0) {
-    writeTextStderr(formatNoListableModelsMessage(context.apiMode, options));
+    writeTextStderr(formatNoListableModelsMessage(result.apiMode, options));
   }
   emitCliResult(
     context,
@@ -137,7 +148,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
     return CliExitCode.ModelOrNetworkError;
   }
 
-  const entry = findModelById(result, id);
+  const entry = findModelById(result.models, id);
   if (!entry) {
     writeTextStderr(`Model not found: ${id}`);
     return CliExitCode.Usage;

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -5,7 +5,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { listCliHistoryEntries } from '../runtime/history';
-import { initLocalCliPlatform } from '../runtime/initPlatform';
+import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { dumbTerminalMessage } from '../runtime/terminalRequirements';
 import {
@@ -17,7 +17,7 @@ import {
   getCliModelAccessList,
   type CliModelAccess,
 } from '../runtime/modelAccess';
-import { getCliApiMode } from '../runtime/apiAccessMode';
+import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 
 import { contextFromArgs } from './_helpers/context';
@@ -49,7 +49,11 @@ async function runOrchestration(context: CliContext): Promise<number> {
 
   await notifyCliUpdate(context);
 
-  await initLocalCliPlatform(context);
+  await initCliPlatform({
+    ...context,
+    quietLogs: true,
+    bestEffortIncludedModelAccess: true,
+  });
   await loadAgents({ includeRemote: false });
   const history = await listCliHistoryEntries();
   const items = buildCliOrchestrationItems({
@@ -60,7 +64,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
   // Load the model registry up front so the launcher can offer a model pick
   // after an agent/team choice. Best-effort: an unavailable registry just
   // launches with the default model instead of blocking the launcher.
-  const apiMode = context.apiMode ?? getCliApiMode();
+  const apiMode = effectiveCliApiMode(context);
   const models: readonly CliModelAccess[] = await getCliModelAccessList({
     apiMode,
   }).catch(() => []);

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -22,6 +22,12 @@ export function getCliApiMode(): CliApiMode {
     : 'personal';
 }
 
+export function effectiveCliApiMode(source: {
+  readonly apiMode?: CliApiMode;
+}): CliApiMode {
+  return source.apiMode ?? getCliApiMode();
+}
+
 export function formatCliApiMode(mode: CliApiMode): string {
   return mode === 'included' ? 'included relay' : 'personal API keys';
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -55,6 +55,7 @@ type CliPlatformInitOptions = Pick<
   CliContext,
   'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel'
 > & {
+  readonly bestEffortIncludedModelAccess?: boolean;
   readonly installSignalHandlers?: boolean;
   readonly storageRoot?: string;
 };
@@ -116,8 +117,8 @@ export async function setCliHelperModel(
 
 /**
  * Init for commands that act on local state only (no model invocation):
- * inspect paths (history/agents/memory/multi-agent list+show, orchestrate)
- * plus local-destructive paths (history delete). Quiet logs and skip the
+ * inspect paths (history/agents/memory/multi-agent list+show) plus
+ * local-destructive paths (history delete). Quiet logs and skip the
  * included-model-access probe, since no model is run.
  *
  * Not actually read-only — the name describes the boundary (local-only,
@@ -202,9 +203,19 @@ export async function initCliPlatform(
 
   const forcePersonalApiKeys =
     context.skipIncludedModelAccess === true || context.apiMode === 'personal';
-  const authed = forcePersonalApiKeys
-    ? false
-    : await getCliAuthProvider().isAuthenticated();
+  let authed = false;
+  if (!forcePersonalApiKeys) {
+    try {
+      authed = await getCliAuthProvider().isAuthenticated();
+    } catch (error) {
+      if (context.bestEffortIncludedModelAccess !== true) throw error;
+      logAt(
+        'warn',
+        'cli.auth',
+        `Included model access probe failed: ${toErrorMessage(error)}`,
+      );
+    }
+  }
   await getServerSideKeyService().setUseIncludedModelAccess(authed);
   await setCliHelperModel(context.helperModel);
 

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -3,13 +3,14 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - model surfaces
 import { computeModelOptionsData } from '@model/computeModelOptions';
-import type { ModelOptionData } from '@shared/schemas';
+import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 
-import type { CliApiMode } from './apiAccessMode';
 import { getCliAuthProvider } from './supabaseAuth';
+import type { CliApiMode } from './apiAccessMode';
 
 export interface CliModelAccess {
   readonly model: ModelOptionData;
+  /** Runnable in the API mode used to load this access list. */
   readonly available: boolean;
   readonly status: string;
 }
@@ -30,6 +31,45 @@ export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
 }
 
+const PERSONAL_API_AVAILABILITY: ReadonlySet<ModelAvailabilityKind> = new Set([
+  'provider-key',
+  'openrouter-key',
+]);
+
+function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {
+  return model.disabled !== true && model.requiresKey !== true;
+}
+
+function isCliModelOptionAllowedInMode(
+  model: ModelOptionData,
+  apiMode?: CliApiMode,
+): boolean {
+  if (apiMode === 'included') {
+    return model.availability === 'included-access';
+  }
+  if (apiMode === 'personal') {
+    const availability = model.availability;
+    return availability != null && PERSONAL_API_AVAILABILITY.has(availability);
+  }
+  return true;
+}
+
+function isCliModelOptionRunnableInMode(
+  model: ModelOptionData,
+  apiMode?: CliApiMode,
+): boolean {
+  return (
+    isCliModelOptionBasicallyAvailable(model) &&
+    isCliModelOptionAllowedInMode(model, apiMode)
+  );
+}
+
+export function runnableCliModelAccessEntries(
+  models: readonly CliModelAccess[],
+): CliModelAccess[] {
+  return models.filter((entry) => entry.available);
+}
+
 function formatModelAccessStatus(model: ModelOptionData): string {
   if (model.availabilityLabel) return model.availabilityLabel.toLowerCase();
   if (!model.disabled && !model.requiresKey) return 'available';
@@ -40,10 +80,13 @@ function formatModelAccessStatus(model: ModelOptionData): string {
   return 'unavailable';
 }
 
-function toCliModelAccess(model: ModelOptionData): CliModelAccess {
+function toCliModelAccess(
+  model: ModelOptionData,
+  apiMode?: CliApiMode,
+): CliModelAccess {
   return {
     model,
-    available: !model.disabled && !model.requiresKey,
+    available: isCliModelOptionRunnableInMode(model, apiMode),
     status: formatModelAccessStatus(model),
   };
 }
@@ -77,7 +120,9 @@ export async function getCliModelAccessList(
   options: CliModelAccessListOptions = {},
 ): Promise<CliModelAccess[]> {
   const models = await computeModelOptionsData();
-  const access = models.map(toCliModelAccess);
+  const access = models.map((model) =>
+    toCliModelAccess(model, options.apiMode),
+  );
   if (await includedAccessRequiresLogin(options)) {
     return access.map(toIncludedLoginRequiredAccess);
   }
@@ -96,9 +141,9 @@ function findModelAccess(
 }
 
 function availableModelIds(models: readonly CliModelAccess[]): string[] {
-  return models
-    .filter((entry) => entry.available)
-    .map((entry) => entry.model.value);
+  return runnableCliModelAccessEntries(models).map(
+    (entry) => entry.model.value,
+  );
 }
 
 function withModelAccess(
@@ -193,7 +238,7 @@ export async function resolveCliRunnableModel(
         `Model "${hiddenModelId}" is configured but has no option data.`,
       );
     }
-    hiddenModel = toCliModelAccess(hiddenModelOption);
+    hiddenModel = toCliModelAccess(hiddenModelOption, options.apiMode);
     if (await includedAccessRequiresLogin(options)) {
       hiddenModel = toIncludedLoginRequiredAccess(hiddenModel);
     }

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initCliPlatform } from '@cli/runtime/initPlatform';
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const mocks = vi.hoisted(() => ({
+  authProvider: {
+    isAuthenticated: vi.fn(),
+  },
+  bootstrapPlatformAgentDirectories: vi.fn(),
+  initializeCliSupabaseAuth: vi.fn(),
+  initializeServerSideKeyAccess: vi.fn(),
+  serverSideKeyService: {
+    setUseIncludedModelAccess: vi.fn(),
+  },
+  setRuntimeSkillSources: vi.fn(),
+  tryPlatform: vi.fn(),
+}));
+
+vi.mock('@agent/index/platformAgentDirectories', () => ({
+  bootstrapPlatformAgentDirectories: mocks.bootstrapPlatformAgentDirectories,
+}));
+
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => mocks.serverSideKeyService,
+  initializeServerSideKeyAccess: mocks.initializeServerSideKeyAccess,
+}));
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProvider: () => mocks.authProvider,
+  initializeCliSupabaseAuth: mocks.initializeCliSupabaseAuth,
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  setOutputChannelFactory: vi.fn(),
+}));
+
+vi.mock('@platform/platform', () => ({
+  initPlatform: vi.fn(),
+  tryPlatform: mocks.tryPlatform,
+}));
+
+vi.mock('@skills/index', () => ({
+  defaultSkillSources: vi.fn(() => []),
+  setRuntimeSkillSources: mocks.setRuntimeSkillSources,
+}));
+
+vi.mock('@tools/externalToolDefs', () => ({
+  setTexraCliEntrypointChecker: vi.fn(),
+}));
+
+function cliContext(
+  overrides: Partial<CliContext> & {
+    bestEffortIncludedModelAccess?: boolean;
+  } = {},
+): Parameters<typeof initCliPlatform>[0] {
+  return {
+    cwd: '/tmp/project',
+    resourcesPath: '/tmp/resources',
+    quietLogs: true,
+    ...overrides,
+  };
+}
+
+describe('CLI platform init', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tryPlatform.mockReturnValue({
+      globalState: {
+        update: vi.fn(),
+      },
+    });
+    mocks.bootstrapPlatformAgentDirectories.mockResolvedValue(undefined);
+    mocks.serverSideKeyService.setUseIncludedModelAccess.mockResolvedValue(
+      undefined,
+    );
+  });
+
+  it('surfaces included-access auth probe failures by default', async () => {
+    mocks.authProvider.isAuthenticated.mockRejectedValueOnce(
+      new Error('auth offline'),
+    );
+
+    await expect(initCliPlatform(cliContext())).rejects.toThrow('auth offline');
+    expect(
+      mocks.serverSideKeyService.setUseIncludedModelAccess,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('lets launcher init treat auth probe failures as no included access', async () => {
+    mocks.authProvider.isAuthenticated.mockRejectedValueOnce(
+      new Error('auth offline'),
+    );
+
+    await expect(
+      initCliPlatform(cliContext({ bestEffortIncludedModelAccess: true })),
+    ).resolves.toBeUndefined();
+    expect(
+      mocks.serverSideKeyService.setUseIncludedModelAccess,
+    ).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getCliModelAccessList,
+  runnableCliModelAccessEntries,
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
   type CliModelAccess,
@@ -65,7 +66,14 @@ describe('CLI model access resolution', () => {
       resolveCliRunnableModelFromAccessList(
         [
           model('sonnet46T'),
-          model('opus48T', { available: false, status: 'not included' }),
+          model('opus48T', {
+            available: false,
+            status: 'not included',
+            model: modelOption('opus48T', {
+              availability: 'not-included',
+              disabled: true,
+            }),
+          }),
         ],
         'opus48T',
         { allowFallback: false },
@@ -79,7 +87,14 @@ describe('CLI model access resolution', () => {
     expect(
       resolveCliRunnableModelFromAccessList(
         [
-          model('opus48T', { available: false, status: 'not included' }),
+          model('opus48T', {
+            available: false,
+            status: 'not included',
+            model: modelOption('opus48T', {
+              availability: 'not-included',
+              disabled: true,
+            }),
+          }),
           model('deepseekT'),
           model('sonnet46T'),
         ],
@@ -93,10 +108,108 @@ describe('CLI model access resolution', () => {
     });
   });
 
+  it('filters runnable models by access-list availability', () => {
+    const entries = [
+      model('sonnet46T', {
+        model: modelOption('sonnet46T', {
+          availability: 'included-access',
+        }),
+      }),
+      model('deepseekT', {
+        available: false,
+        model: modelOption('deepseekT', {
+          availability: 'provider-key',
+        }),
+      }),
+      model('openrouterOnlyT', {
+        available: false,
+        model: modelOption('openrouterOnlyT', {
+          availability: 'openrouter-key',
+        }),
+      }),
+      model('gemini31p', {
+        available: false,
+        model: modelOption('gemini31p', {
+          availability: 'missing-key',
+          disabled: true,
+          requiresKey: true,
+        }),
+      }),
+    ];
+
+    expect(
+      runnableCliModelAccessEntries(entries).map((entry) => entry.model.value),
+    ).toEqual(['sonnet46T']);
+  });
+
+  it('rejects personal-key models in included relay mode', () => {
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('sonnet46T', {
+            model: modelOption('sonnet46T', {
+              availability: 'included-access',
+            }),
+            status: 'included access',
+          }),
+          model('deepseekT', {
+            available: false,
+            model: modelOption('deepseekT', {
+              availability: 'provider-key',
+            }),
+            status: 'api key set',
+          }),
+        ],
+        'deepseekT',
+        { allowFallback: false, apiMode: 'included' },
+      ),
+    ).toThrow(
+      'Model "deepseekT" is not available in the active API mode (api key set). Available models: sonnet46T.',
+    );
+  });
+
+  it('falls back from included relay models in personal API mode', () => {
+    expect(
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('sonnet46T', {
+            available: false,
+            model: modelOption('sonnet46T', {
+              availability: 'included-access',
+            }),
+            status: 'included access',
+          }),
+          model('deepseekT', {
+            model: modelOption('deepseekT', {
+              availability: 'provider-key',
+            }),
+            status: 'api key set',
+          }),
+        ],
+        'sonnet46T',
+        { allowFallback: true, apiMode: 'personal' },
+      ),
+    ).toEqual({
+      model: 'deepseekT',
+      notice:
+        'Model "sonnet46T" is not available in the active API mode (included access). Available models: deepseekT. Using "deepseekT" instead.',
+    });
+  });
+
   it('reports when no fallback model is runnable', () => {
     expect(() =>
       resolveCliRunnableModelFromAccessList(
-        [model('gemini31p', { available: false, status: 'missing api key' })],
+        [
+          model('gemini31p', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('gemini31p', {
+              availability: 'missing-key',
+              disabled: true,
+              requiresKey: true,
+            }),
+          }),
+        ],
         'gemini31p',
         { allowFallback: true },
       ),
@@ -108,7 +221,17 @@ describe('CLI model access resolution', () => {
   it('can format command-specific recovery hints for interactive chat', () => {
     expect(() =>
       resolveCliRunnableModelFromAccessList(
-        [model('gemini31p', { available: false, status: 'missing api key' })],
+        [
+          model('gemini31p', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('gemini31p', {
+              availability: 'missing-key',
+              disabled: true,
+              requiresKey: true,
+            }),
+          }),
+        ],
         'gemini31p',
         {
           allowFallback: true,
@@ -173,6 +296,87 @@ describe('CLI model access resolution', () => {
         },
       },
     ]);
+  });
+
+  it('marks only included-access models runnable in included relay mode', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('sonnet46T', {
+        availability: 'included-access',
+        availabilityLabel: 'Included access',
+      }),
+      modelOption('deepseekT', {
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+      }),
+      modelOption('openrouterOnlyT', {
+        availability: 'openrouter-key',
+        availabilityLabel: 'OpenRouter key',
+      }),
+    ]);
+
+    await expect(
+      getCliModelAccessList({ apiMode: 'included' }),
+    ).resolves.toMatchObject([
+      { model: { value: 'sonnet46T' }, available: true },
+      { model: { value: 'deepseekT' }, available: false },
+      { model: { value: 'openrouterOnlyT' }, available: false },
+    ]);
+  });
+
+  it('marks only API-key models runnable in personal API mode', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('sonnet46T', {
+        availability: 'included-access',
+        availabilityLabel: 'Included access',
+      }),
+      modelOption('deepseekT', {
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+      }),
+      modelOption('openrouterOnlyT', {
+        availability: 'openrouter-key',
+        availabilityLabel: 'OpenRouter key',
+      }),
+    ]);
+
+    await expect(
+      getCliModelAccessList({ apiMode: 'personal' }),
+    ).resolves.toMatchObject([
+      { model: { value: 'sonnet46T' }, available: false },
+      { model: { value: 'deepseekT' }, available: true },
+      { model: { value: 'openrouterOnlyT' }, available: true },
+    ]);
+  });
+
+  it('uses the loaded access list as the availability source of truth', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('sonnet46T', {
+        availability: 'included-access',
+        availabilityLabel: 'Included access',
+        disabled: false,
+        requiresKey: false,
+      }),
+      modelOption('deepseekT', {
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+        disabled: false,
+        requiresKey: false,
+      }),
+    ]);
+
+    const includedModeEntries = await getCliModelAccessList({
+      apiMode: 'included',
+    });
+
+    expect(includedModeEntries).toMatchObject([
+      { model: { value: 'sonnet46T' }, available: true },
+      { model: { value: 'deepseekT' }, available: false },
+    ]);
+    expect(
+      runnableCliModelAccessEntries(includedModeEntries).map(
+        (entry) => entry.model.value,
+      ),
+    ).toEqual(['sonnet46T']);
   });
 
   it('checks access for explicit models hidden from the visible model list', async () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   formatModelStatusForCliMode,
-  hasRunnableModelSelectItems,
   modelSelectItemsForCliMode,
   modelSelectWindow,
 } from '@cli/chat/tui/forms/ModelListForm';
@@ -24,6 +23,7 @@ import type { ModelOptionData } from '@shared/schemas';
 function access(
   model: Partial<ModelOptionData>,
   status = 'api key set',
+  available = !model.disabled && !model.requiresKey,
 ): CliModelAccess {
   return {
     model: {
@@ -31,7 +31,7 @@ function access(
       label: 'DeepSeek V4 Flash (Thinking)',
       ...model,
     },
-    available: !model.disabled && !model.requiresKey,
+    available,
     status,
   };
 }
@@ -108,12 +108,31 @@ describe('CLI ModelListForm model visibility', () => {
         }),
         access(
           {
+            value: 'deepseekT',
+            label: 'DeepSeek',
+            availability: 'provider-key',
+          },
+          'api key set',
+          false,
+        ),
+        access(
+          {
+            value: 'openrouterOnlyT',
+            label: 'OpenRouter Only',
+            availability: 'openrouter-key',
+          },
+          'openrouter key',
+          false,
+        ),
+        access(
+          {
             value: 'opus48T',
             label: 'Opus',
             availability: 'not-included',
             disabled: true,
           },
           'not included',
+          false,
         ),
         access({
           value: 'gpt54',
@@ -131,25 +150,86 @@ describe('CLI ModelListForm model visibility', () => {
     ]);
   });
 
-  it('treats filtered-empty lists as non-actionable', () => {
-    expect(
-      hasRunnableModelSelectItems([
+  it('shows personal-key models for personal API mode', () => {
+    const items = modelSelectItemsForCliMode(
+      [
         access(
           {
+            value: 'sonnet46T',
+            label: 'Sonnet',
+            availability: 'included-access',
+          },
+          'api key set',
+          false,
+        ),
+        access({
+          value: 'deepseekT',
+          label: 'DeepSeek',
+          availability: 'provider-key',
+        }),
+        access(
+          {
+            value: 'openrouterOnlyT',
+            label: 'OpenRouter Only',
+            availability: 'openrouter-key',
+          },
+          'openrouter key',
+        ),
+        access(
+          {
+            value: 'gemini31p',
+            label: 'Gemini',
             availability: 'missing-key',
             requiresKey: true,
           },
           'missing api key',
+          false,
         ),
-        access(
-          {
-            availability: 'not-included',
-            disabled: true,
-          },
-          'not included',
-        ),
-      ]),
-    ).toBe(false);
+      ],
+      'personal',
+    );
+
+    expect(items.map((item) => item.value)).toEqual([
+      'deepseekT',
+      'openrouterOnlyT',
+    ]);
+    expect(items.map((item) => item.description)).toEqual([
+      'api: api key set',
+      'api: openrouter key',
+    ]);
+  });
+
+  it('treats filtered-empty lists as non-actionable', () => {
+    expect(
+      modelSelectItemsForCliMode(
+        [
+          access(
+            {
+              availability: 'provider-key',
+            },
+            'api key set',
+            false,
+          ),
+          access(
+            {
+              availability: 'missing-key',
+              requiresKey: true,
+            },
+            'missing api key',
+            false,
+          ),
+          access(
+            {
+              availability: 'not-included',
+              disabled: true,
+            },
+            'not included',
+            false,
+          ),
+        ],
+        'included',
+      ).length,
+    ).toBe(0);
   });
 });
 

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -83,7 +83,17 @@ describe('CLI model list filtering', () => {
   it('lists only currently runnable models by default', () => {
     const entries = [
       access('sonnet46T'),
-      access('opus48T', { available: false, status: 'not included' }),
+      access('opus48T', {
+        available: false,
+        status: 'not included',
+        model: model({
+          value: 'opus48T',
+          label: 'opus48T',
+          availability: 'not-included',
+          availabilityLabel: 'Not included',
+          disabled: true,
+        }),
+      }),
       access('deepseekT'),
     ];
 
@@ -92,10 +102,69 @@ describe('CLI model list filtering', () => {
     ).toEqual(['sonnet46T', 'deepseekT']);
   });
 
+  it('lists only models marked runnable by the loaded access list', () => {
+    const includedModeEntries = [
+      access('sonnet46T', {
+        model: model({ value: 'sonnet46T', availability: 'included-access' }),
+      }),
+      access('deepseekT', {
+        available: false,
+        model: model({ value: 'deepseekT', availability: 'provider-key' }),
+      }),
+      access('openrouterOnlyT', {
+        available: false,
+        model: model({
+          value: 'openrouterOnlyT',
+          availability: 'openrouter-key',
+        }),
+      }),
+    ];
+
+    expect(
+      listableModelAccessEntries(includedModeEntries).map(
+        (entry) => entry.model.value,
+      ),
+    ).toEqual(['sonnet46T']);
+  });
+
+  it('does not recompute availability from model metadata', () => {
+    const personalModeEntries = [
+      access('sonnet46T', {
+        available: false,
+        model: model({ value: 'sonnet46T', availability: 'included-access' }),
+      }),
+      access('deepseekT', {
+        model: model({ value: 'deepseekT', availability: 'provider-key' }),
+      }),
+      access('openrouterOnlyT', {
+        model: model({
+          value: 'openrouterOnlyT',
+          availability: 'openrouter-key',
+        }),
+      }),
+    ];
+
+    expect(
+      listableModelAccessEntries(personalModeEntries).map(
+        (entry) => entry.model.value,
+      ),
+    ).toEqual(['deepseekT', 'openrouterOnlyT']);
+  });
+
   it('keeps unavailable models for the explicit diagnostic view', () => {
     const entries = [
       access('sonnet46T'),
-      access('opus48T', { available: false, status: 'not included' }),
+      access('opus48T', {
+        available: false,
+        status: 'not included',
+        model: model({
+          value: 'opus48T',
+          label: 'opus48T',
+          availability: 'not-included',
+          availabilityLabel: 'Not included',
+          disabled: true,
+        }),
+      }),
     ];
 
     expect(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -42,6 +42,7 @@ import {
   finalizeSettledPrefix,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
+import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
   COMPLETED_PROCESS_TAIL_LINES,
@@ -182,6 +183,52 @@ describe('cliState Phase 4 fields', () => {
     expect(hasChildControlItems(parent, 'tasks')).toBe(false);
     expect(hasChildControlItems(parent, 'subagents')).toBe(false);
     expect(nextFocusForward()).toBeUndefined();
+  });
+
+  it('updates retained child rows when a failed subagent leaves the active list', () => {
+    const wrapped = wrapRuntimeHost({
+      emit: () => undefined,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const dispose = subscribeStreamStatus();
+    try {
+      patchStream(root, (s) => ({
+        ...s,
+        activeSubagents: [
+          {
+            executionId: 'agent-1',
+            agentName: 'codex',
+            childStreamId: child1,
+            status: STREAM_STATUS.RUNNING,
+          },
+        ],
+        childStreams: [
+          {
+            executionId: 'agent-1',
+            agentName: 'codex',
+            childStreamId: child1,
+            status: STREAM_STATUS.RUNNING,
+          },
+        ],
+      }));
+      patchStream(root, (s) => ({ ...s, activeSubagents: [] }));
+
+      StreamStatusService.set(child1, STREAM_STATUS.ERROR, {
+        runtimeHost: wrapped,
+      });
+
+      const parent = cliState.streams.get().get(root);
+      expect(parent?.activeSubagents).toEqual([]);
+      expect(visibleSubagentRows(parent!)).toMatchObject([
+        {
+          executionId: 'agent-1',
+          childStreamId: child1,
+          status: STREAM_STATUS.ERROR,
+        },
+      ]);
+    } finally {
+      dispose();
+    }
   });
 
   it('treats a null-parent update as child promotion to top-level', () => {

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -14,12 +14,19 @@ import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 
 const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
+  getCliApiMode: vi.fn(),
   resolveCliRunnableModel: vi.fn(),
   writeTextStderr: vi.fn(),
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({
   initCliPlatform: mocks.initCliPlatform,
+}));
+
+vi.mock('@cli/runtime/apiAccessMode', () => ({
+  effectiveCliApiMode: (source: { readonly apiMode?: string }) =>
+    source.apiMode ?? mocks.getCliApiMode(),
+  getCliApiMode: mocks.getCliApiMode,
 }));
 
 vi.mock('@cli/runtime/modelAccess', () => ({
@@ -52,9 +59,11 @@ const runConfig = (model: string): CliConfigValues => ({ run: { model } });
 describe('resolveCliRunModel precedence', () => {
   beforeEach(() => {
     mocks.initCliPlatform.mockReset();
+    mocks.getCliApiMode.mockReset();
     mocks.resolveCliRunnableModel.mockReset();
     mocks.writeTextStderr.mockReset();
     mocks.initCliPlatform.mockResolvedValue(undefined);
+    mocks.getCliApiMode.mockReturnValue('personal');
     resolveCliRunnableModelMock.mockImplementation(async (model) => ({
       model,
     }));
@@ -145,7 +154,7 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       allowFallback: false,
-      apiMode: undefined,
+      apiMode: 'personal',
       noAvailableModelsMessage: undefined,
     });
   });
@@ -160,7 +169,7 @@ describe('resolveCliRunModel precedence', () => {
 
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       allowFallback: false,
-      apiMode: undefined,
+      apiMode: 'personal',
       noAvailableModelsMessage: undefined,
     });
   });


### PR DESCRIPTION
## Summary

Fixes #5110.

- Scope CLI model access through the effective active API mode so relay users see included relay models and personal/API users see provider/OpenRouter-key models.
- Use full CLI platform init for the startup launcher before loading model availability, because the launcher now needs real access-mode state.
- Refresh retained CLI child rows when child stream status changes, so failed subagents stop displaying as `running`.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model resolution and auth/init paths across chat, run, init, and orchestrate; behavior is covered by expanded vitest coverage but wrong mode gating would block or mis-route model selection.
> 
> **Overview**
> Aligns CLI model listing, resolution, and pickers with the **effective API mode** (`--api-mode` / env override, else persisted default) via `effectiveCliApiMode`, so chat, `texra run`, `init`, `models list`, and the launcher no longer disagree with the header.
> 
> **Model access** now marks `available` per mode when loading the registry: **included relay** only `included-access`; **personal** only provider/OpenRouter-key models. Shared `runnableCliModelAccessEntries` drives `/model`, `texra models list`, and fallbacks; empty-state hints use the resolved mode from the loader.
> 
> **Orchestrate** uses full `initCliPlatform` with `bestEffortIncludedModelAccess` so auth probe failures degrade to personal keys instead of blocking the launcher.
> 
> **TUI:** `updateChildStreamStatus` keeps retained child/subagent rows in sync when `StreamStatusService` updates, so completed/failed children no longer show as `running` after leaving the active list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36196da068613fe632f389696cd3be66d311314d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->