### PR TITLE
fix(cli): make the user-message highlight width-adaptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-- **User turns stand out in chat** — your messages now render on a full-width highlight band (reverse video, so it adapts to your terminal's light/dark theme) in the terminal transcript, making them easy to pick out from the assistant's output when scrolling back.
+- **User turns stand out in chat** — your messages now render with a reverse-video highlight (so it adapts to your terminal's light/dark theme and reflows on resize) in the terminal transcript, making them easy to pick out from the assistant's output when scrolling back.
 
 ## [0.38.4] - 2026-06-01
 

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -5,7 +5,6 @@
 
 import { Box, Text } from 'ink';
 
-import { fillRows } from '../render/DiffView';
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
@@ -22,20 +21,20 @@ function UserEntryRow({
   readonly colorEnabled?: boolean;
   readonly width?: number;
 }): React.JSX.Element {
-  // Mark a user turn with a full-width reverse-video band so it stands out in
+  // Mark a user turn with a reverse-video highlight so it stands out in
   // scrollback against the assistant's `●` rows. Reverse video (not a fixed
-  // color) makes the highlight adapt to the terminal theme automatically — a
-  // dark bar with light text on a light terminal, a light bar with dark text on
-  // a dark one — using the terminal's own foreground/background. The `› `
-  // chevron is 2 cols, matching the static row count in transcriptLines.ts so
-  // render and counting stay in lockstep.
+  // color) adapts to the terminal theme automatically — a light bar with dark
+  // text on a dark terminal, the inverse on a light one — using the terminal's
+  // own foreground/background. The highlight hugs the text (no width padding)
+  // so it stays correct across a resize: a fixed-width fill gets baked into the
+  // printed scrollback line and can't reflow, leaving a dead bar at the old
+  // width when the terminal widens. The `› ` chevron is 2 cols, matching the
+  // static row count in transcriptLines.ts.
   const cols = Math.max(1, Math.floor(width ?? 80));
   const body = wrapAnsiToWidth(entry.text, Math.max(1, cols - 2))
     .split('\n')
     .map((line, index) => `${index === 0 ? '› ' : '  '}${line}`)
     .join('\n');
-  // No-color terminals can't show the band; render the chevron text plain
-  // (skip the width padding so we don't litter scrollback with trailing space).
   if (colorEnabled === false) {
     return (
       <Box>
@@ -45,7 +44,7 @@ function UserEntryRow({
   }
   return (
     <Box>
-      <Text inverse>{fillRows(body, cols)}</Text>
+      <Text inverse>{body}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
Follow-up to #5107.

## Problem

The user-message highlight padded each line to the terminal width (`fillRows`) to form a **full-width** reverse-video band. That padding count is baked into the line Ink prints to `<Static>` scrollback. The resize repaint (clear + reprint the cached static output) re-emits that string and lets the terminal reflow it — but a terminal reflows *text*, not a fixed run of padded cells. So when the terminal **widens**, the band stays its original width and leaves a dead bar with a dark gap to the right:

```
› what is this repo about ░░░░░░░░░░          ← band stuck at old width
                          ^^^^^^^^^^ dark gap after a widen
```

Full-width padding is fundamentally incompatible with width-adaptivity in a reprint-the-cached-string model.

## Fix

Drop the width padding so the reverse-video highlight **hugs the text**:

```
› what is this repo about           ← reverse video covers just the text
```

- **Width-adaptive** — no fixed padding to go stale, so it reflows with the rest of the transcript on resize (no dark gap at any width).
- **Theme-adaptive** — still reverse video (`ESC[7m`), so it uses the terminal's own fg/bg (light bar + dark text on a dark terminal, the inverse on a light one) and drops out under `NO_COLOR`.
- Keeps the `› ` chevron and the 2-col wrap that matches the static row count in `transcriptLines.ts`.

## Verification

- `@texra-ai/cli` typecheck clean; eslint clean.
- Fresh bundle under tmux: user line is `ESC[7m› what is this repo about ESC[0m` — reverse video hugging the text, **no trailing fill** (vs. the prior full-width padded run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI-only change to user transcript styling; no auth, data, or API behavior.
> 
> **Overview**
> CLI chat user messages no longer use **full-width** reverse-video padding (`fillRows`). The highlight now **hugs the wrapped text** only, so terminal resize does not leave a stale band width in `<Static>` scrollback.
> 
> `TranscriptEntry.tsx` drops the `DiffView` `fillRows` import and renders `inverse` on the chevron-prefixed body without padding; comments document the resize/reflow rationale. **CHANGELOG** wording is updated to match (theme-adaptive highlight that reflows on resize).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af4cdb2dc416503f39b55da71314f74e459a060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->