### PR TITLE
refactor(cli): collapse identical user-message render branches

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -35,16 +35,11 @@ function UserEntryRow({
     .split('\n')
     .map((line, index) => `${index === 0 ? '› ' : '  '}${line}`)
     .join('\n');
-  if (colorEnabled === false) {
-    return (
-      <Box>
-        <Text>{body}</Text>
-      </Box>
-    );
-  }
+  // No-color terminals can't show the reverse-video band; the `› ` marker still
+  // distinguishes the turn, so only the `inverse` attribute differs.
   return (
     <Box>
-      <Text inverse>{body}</Text>
+      <Text inverse={colorEnabled !== false}>{body}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
Addresses the one still-valid review note on #5112 (Cursor, low severity): after #5112 removed `fillRows`, the `colorEnabled === false` and default branches of `UserEntryRow` were identical `<Box><Text>{body}</Text></Box>` differing only by the `inverse` prop.

Collapse into a single return — `inverse={colorEnabled !== false}`. Behavior is unchanged: the `› ` marker (already in `body`) distinguishes a user turn on no-color terminals, and reverse video applies otherwise.

The rest of the #5107/#5112 review feedback was already resolved — superseded by #5112's hug (the `▌` marker, `fillRows`-from-DiffView import, and the no-color "drops markers" concern all no longer apply), and #5102's notes were fixed in `80f6f0cee`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor in the TUI transcript with no logic or data-path changes.
> 
> **Overview**
> **`UserEntryRow`** in the CLI transcript TUI no longer splits on `colorEnabled === false` vs default. Both paths rendered the same `<Box><Text>{body}</Text></Box>`; the only difference was whether **`inverse`** was set on **`Text`**.
> 
> A single return now uses **`inverse={colorEnabled !== false}`**, with a short comment that no-color terminals still get the **`› `** chevron for turn distinction. **No behavior change** for color or monochrome terminals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd09aca6e6c6fcaf0004a8a690c5e90e01d67921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->