### PR TITLE
feat(cli): full-width width-adaptive user-message band (Claude-Code style)

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -237,7 +237,11 @@ export function StaticConversationTranscript({
   }, [activeStreamId, maxRows, streams, sessionMeta, width]);
 
   return (
-    <Static items={[...items]}>
+    // Remount <Static> on a width change so Ink regenerates `fullStaticOutput`
+    // at the new width (via its handleStaticChange identity-reset). Without this
+    // the resize full-repaint reprints the cached, baked-width static output, so
+    // fixed-width content (e.g. the full-width user-message band) can't reflow.
+    <Static key={Math.max(1, Math.floor(width ?? 80))} items={[...items]}>
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
           {item.kind === 'header' ? (

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -5,9 +5,9 @@
 
 import { Box, Text } from 'ink';
 
-import { fillRows } from '../render/DiffView';
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
+import { fillRows } from '../render/terminalText';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -5,6 +5,7 @@
 
 import { Box, Text } from 'ink';
 
+import { fillRows } from '../render/DiffView';
 import { Markdown } from '../render/Markdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
@@ -21,25 +22,21 @@ function UserEntryRow({
   readonly colorEnabled?: boolean;
   readonly width?: number;
 }): React.JSX.Element {
-  // Mark a user turn with a reverse-video highlight so it stands out in
-  // scrollback against the assistant's `●` rows. Reverse video (not a fixed
-  // color) adapts to the terminal theme automatically — a light bar with dark
-  // text on a dark terminal, the inverse on a light one — using the terminal's
-  // own foreground/background. The highlight hugs the text (no width padding)
-  // so it stays correct across a resize: a fixed-width fill gets baked into the
-  // printed scrollback line and can't reflow, leaving a dead bar at the old
-  // width when the terminal widens. The `› ` chevron is 2 cols, matching the
-  // static row count in transcriptLines.ts.
+  // Mark a user turn with a full-width reverse-video band (theme-adaptive via
+  // reverse video). The fixed-width fill is baked at render width, so it only
+  // stays full-width across a resize because `<Static>` is remounted on a width
+  // change (key={columns} in StaticConversationTranscript) — that regenerates
+  // `fullStaticOutput` at the new width, which the resize full-repaint then
+  // reprints. The `› ` chevron is 2 cols, matching the static row count in
+  // transcriptLines.ts.
   const cols = Math.max(1, Math.floor(width ?? 80));
   const body = wrapAnsiToWidth(entry.text, Math.max(1, cols - 2))
     .split('\n')
     .map((line, index) => `${index === 0 ? '› ' : '  '}${line}`)
     .join('\n');
-  // No-color terminals can't show the reverse-video band; the `› ` marker still
-  // distinguishes the turn, so only the `inverse` attribute differs.
   return (
     <Box>
-      <Text inverse={colorEnabled !== false}>{body}</Text>
+      <Text inverse={colorEnabled !== false}>{fillRows(body, cols)}</Text>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -6,11 +6,10 @@
 
 import { Box, Text } from 'ink';
 import { structuredPatch, type StructuredPatchHunk } from 'diff';
-import stringWidth from 'string-width';
 
 import { wrapAnsiToWidth } from './ansiWrap';
 import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
-import { clipToWidth } from './terminalText';
+import { clipToWidth, fillRows, textDisplayWidth } from './terminalText';
 
 export type Hunk = StructuredPatchHunk;
 
@@ -204,8 +203,9 @@ function overflowMarkerText(
 
   const markerWidth = Math.max(MIN_DIFF_WIDTH, width);
   return (
-    candidates.find((candidate) => stringWidth(candidate) <= markerWidth) ??
-    clipToWidth(candidates.at(-1) ?? '', markerWidth)
+    candidates.find(
+      (candidate) => textDisplayWidth(candidate) <= markerWidth,
+    ) ?? clipToWidth(candidates.at(-1) ?? '', markerWidth)
   );
 }
 
@@ -329,19 +329,6 @@ export const DIFF_BAND_BG: Partial<Record<DiffDisplayLine['kind'], string>> = {
   added: '#1f3a28',
   removed: '#4a2526',
 };
-
-/**
- * Pad every visual row out to `width` columns. Ink only paints a background
- * behind the glyphs it draws, so without this the band would stop at the end
- * of the text; padding extends it across the full row. `string-width` measures
- * display columns so wide glyphs (σ, ℂ, ∑ …) and emoji pad correctly.
- */
-export function fillRows(text: string, width: number): string {
-  return text
-    .split('\n')
-    .map((row) => row + ' '.repeat(Math.max(0, width - stringWidth(row))))
-    .join('\n');
-}
 
 function DiffLine({
   line,

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -12,3 +12,17 @@ export function clipToWidth(text: string, width: number): string {
   }
   return clipped;
 }
+
+/**
+ * Pad every visual row out to `width` display columns.
+ *
+ * Ink only paints backgrounds and inverse-video spans behind glyphs it draws,
+ * so padding extends bands across the full row. `textDisplayWidth` keeps wide
+ * glyphs and emoji aligned.
+ */
+export function fillRows(text: string, width: number): string {
+  return text
+    .split('\n')
+    .map((row) => row + ' '.repeat(Math.max(0, width - textDisplayWidth(row))))
+    .join('\n');
+}

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -5,11 +5,11 @@ import {
   buildHunks,
   DIFF_BAND_BG,
   diffVisualRowCount,
-  fillRows,
   maxDiffScrollOffset,
   scrollBoundedDiffDisplayLines,
   wrappedDiffDisplayLines,
 } from '@cli/chat/tui/render/DiffView';
+import { fillRows } from '@cli/chat/tui/render/terminalText';
 
 describe('CLI diff display', () => {
   it('keeps the overflow marker inside the total display budget', () => {

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -20,6 +20,8 @@ import { createRequire } from 'node:module';
 
 import { describe, expect, it } from 'vitest';
 
+import { fillRows } from '@cli/chat/tui/render/terminalText';
+
 const cliRequire = createRequire(
   new URL('../../../packages/cli/package.json', import.meta.url),
 );
@@ -50,13 +52,6 @@ class FakeStdin extends EventEmitter {
   read(): null {
     return null;
   }
-}
-
-function fillRow(text: string, width: number): string {
-  return text
-    .split('\n')
-    .map((row) => row + ' '.repeat(Math.max(0, width - row.length)))
-    .join('\n');
 }
 
 /** Widest visible reverse-video (`ESC[7m…ESC[27m`) run that contains the band. */
@@ -106,7 +101,7 @@ describe('Static band resize', () => {
         createElement(
           ink.Box,
           { key: 'band' },
-          createElement(ink.Text, { inverse: true }, fillRow('> hi', cols)),
+          createElement(ink.Text, { inverse: true }, fillRows('> hi', cols)),
         ),
       );
     }

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -1,0 +1,138 @@
+// Regression test for the width-adaptive `<Static>` user-message band
+// (TranscriptEntry full-width reverse-video band + StaticConversationTranscript
+// `<Static key={width}>`). Renders a minimal Ink app reproducing the pattern to
+// an in-memory fake stdout, simulates a terminal resize by bumping `columns` and
+// emitting `resize`, and asserts the highlighted band reflows to the NEW width
+// instead of staying baked at the original width.
+//
+// This exercises the patched Ink resize full-repaint + the `<Static>` remount
+// (`handleStaticChange` regenerates `fullStaticOutput` at the new width) the
+// feature depends on — without a pty (node-pty's posix_spawn is unavailable in
+// sandboxed CI; the existing InkResizePatch test uses a recording stream too).
+
+// Set before Ink/chalk load so reverse-video SGR (`ESC[7m`) is actually emitted
+// to the non-TTY fake stdout; otherwise chalk no-ops `inverse` and the band has
+// no styled fill to measure.
+process.env.FORCE_COLOR ??= '3';
+
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
+
+class FakeStdout extends EventEmitter {
+  isTTY = true;
+  rows = 12;
+  buf = '';
+  constructor(public columns: number) {
+    super();
+  }
+  write(chunk: string): boolean {
+    this.buf += chunk;
+    return true;
+  }
+  getColorDepth(): number {
+    return 24;
+  }
+}
+
+class FakeStdin extends EventEmitter {
+  isTTY = false;
+  ref(): void {}
+  unref(): void {}
+  pause(): void {}
+  resume(): void {}
+  setEncoding(): void {}
+  read(): null {
+    return null;
+  }
+}
+
+function fillRow(text: string, width: number): string {
+  return text
+    .split('\n')
+    .map((row) => row + ' '.repeat(Math.max(0, width - row.length)))
+    .join('\n');
+}
+
+/** Widest visible reverse-video (`ESC[7m…ESC[27m`) run that contains the band. */
+function bandWidth(output: string): number {
+  let widest = 0;
+  // eslint-disable-next-line no-control-regex -- matching raw SGR escapes
+  const run = /\x1b\[7m([\s\S]*?)\x1b\[(?:27|0)m/g;
+  // eslint-disable-next-line no-control-regex -- stripping raw SGR escapes
+  const sgr = /\x1b\[[0-9;]*[A-Za-z]/g;
+  let match: RegExpExecArray | null;
+  while ((match = run.exec(output))) {
+    const visible = match[1].replaceAll(sgr, '');
+    if (visible.includes('hi')) widest = Math.max(widest, visible.length);
+  }
+  return widest;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return predicate();
+}
+
+describe('Static band resize', () => {
+  it('reflows the full-width user band to the new width on resize', async () => {
+    // Dynamic import so FORCE_COLOR is set first and the patched workspace Ink
+    // (not a hoisted copy) is loaded.
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { useState, useEffect, createElement } = React;
+
+    function App(): unknown {
+      const { stdout } = ink.useStdout();
+      const [cols, setCols] = useState(stdout.columns || 80);
+      useEffect(() => {
+        const onResize = (): void => setCols(stdout.columns || 80);
+        stdout.on('resize', onResize);
+        return () => stdout.off('resize', onResize);
+      }, [stdout]);
+      return createElement(ink.Static, { key: cols, items: [0] }, () =>
+        createElement(
+          ink.Box,
+          { key: 'band' },
+          createElement(ink.Text, { inverse: true }, fillRow('> hi', cols)),
+        ),
+      );
+    }
+
+    const out = new FakeStdout(40);
+    const inst = ink.render(createElement(App), {
+      stdout: out,
+      stdin: new FakeStdin(),
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      expect(await waitFor(() => bandWidth(out.buf) >= 40, 5000)).toBe(true);
+      expect(bandWidth(out.buf)).toBe(40);
+
+      // Widen: bump columns and fire the resize the patched Ink handler listens
+      // for. Clear the buffer so we measure only the post-resize repaint.
+      out.buf = '';
+      out.columns = 80;
+      out.emit('resize');
+
+      expect(await waitFor(() => bandWidth(out.buf) >= 80, 5000)).toBe(true);
+      expect(bandWidth(out.buf)).toBe(80);
+    } finally {
+      inst.unmount();
+    }
+  });
+});


### PR DESCRIPTION
Stacks on `fix/cli-ink-resize-full-repaint` (it depends on the full-repaint).

## What

The Claude-Code-style **full-width** user-message highlight that **adapts to width and theme**, which the `<Static>`-to-scrollback model otherwise can't do.

- **Full-width band** via `fillRows(cols)` + **reverse video** (theme-adaptive — terminal's own fg/bg, `NO_COLOR`-safe).
- **Width-adaptive on resize** via the key insight from Ink's internals: `<Static key={columns}>` remounts on a width change → Ink's `handleStaticChange` resets `fullStaticOutput` → all finalized entries re-render at the new width → the resize full-repaint reprints the regenerated output. So the band (and *all* wide finalized content) reflows instead of soft-wrapping a stale baked-width line.

## Why it's stacked here, not on main

A full-width band can only adapt with the **full-repaint** (reprint of `fullStaticOutput`), which lives on this branch. On main's old count-based-clear path the cached static output is never reprinted, so a full-width band would show the dark gap. The hugging highlight already on main (#5112) is the patch-free fallback for that path.

## Verification

**Automated regression test** — `src/test-kernel/cli/StaticBandResize.vitest.mts`. Renders a minimal Ink app reproducing the pattern (`<Static key={width}>` + a full-width reverse-video line) to an **in-memory fake stdout**, simulates a widen (bump `columns` + emit `resize`), and asserts the highlighted band **reflows 40→80 cols**. It exercises the real patched Ink resize full-repaint + `handleStaticChange` remount. Fake stdout (not a pty) because node-pty's `posix_spawn` is unavailable in sandboxed CI — same reason `InkResizePatch` uses a recording stream.

**Manual (tmux):** on a 70→120 widen, the header separator `'─'.repeat(columns)` grows 70→120, the band's SGR-7 survives, and header appears exactly once with zero residue — resize invariants hold.

## Tradeoff

A width change re-renders the whole transcript (resize-only, debounced). The full-repaint already reprints everything, so the added cost is the React re-render — acceptable for a resize event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Resize clears and reprints all static scrollback (debounced but disruptive), and onboarding touches credential persistence and auth caches in-process.
> 
> **Overview**
> This PR makes **finalized user turns** in the chat TUI a **full-width reverse-video band** (via shared `fillRows` in `terminalText.ts`) and keeps that band **correct after terminal resize** by remounting Ink `<Static>` with `key={columns}` so `fullStaticOutput` is regenerated at the new width.
> 
> The vendored **ink patch** switches resize handling from line-count erasing / `clearWidthAware` to a **debounced full repaint** (`clearTerminal` + reprint `fullStaticOutput`, `log.reset()`), documented in `CLAUDE.md`. Diff overflow markers follow the same display-width helpers.
> 
> Also in the diff (beyond the stacked resize work): **first-run onboarding** (`maybeRunCliOnboarding` on `chat` / `orchestrate`, `texra setup`, masked `ApiKeyEntryForm`), **`hasAnyCliCredential`**, API-key shadow warning in status, root **`version`** routing, and broad CLI tests—including `StaticBandResize.vitest.mts` for the band reflow behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44f71629de2f6397b0bb91df5a796cc1e9049e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->