### PR TITLE
refactor: address code-review findings (5 critical, 6 high-priority)

### DIFF
--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -23,9 +23,13 @@ import { getConfig, updateConfig, SETTINGS_QUERY } from '@utils/config';
 import { checkCoreDependencies, getToolDocsCommand } from '@utils/system';
 
 import { DiffManager } from './managers/DiffManager';
-import { ExecutionManager } from './managers/ExecutionManager';
+import {
+  ExecutionManager,
+  type CommandMessage,
+} from './managers/ExecutionManager';
 import { FileManager } from './managers/FileManager';
 import { InstructionManager } from './managers/InstructionManager';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -148,14 +152,18 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: () =>
         safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
+      // The execution/file-op commands are validated as loose `{ command }`
+      // objects (payload typed nearer the handlers), so the dispatcher can't
+      // infer the rich shape — cast to the handler's declared input type
+      // rather than discarding all checking with `any`.
       [MAIN_VIEW_COMMANDS.EXECUTE]: (m) =>
-        this.executionManager.handleExecute(m as any),
+        this.executionManager.handleExecute(m as MainViewExecuteMessage),
       [MAIN_VIEW_COMMANDS.MERGE]: (m) =>
-        this.executionManager.handleFileOperation(m as any),
+        this.executionManager.handleFileOperation(m as CommandMessage),
       [MAIN_VIEW_COMMANDS.COMPARE]: (m) =>
-        this.executionManager.handleFileOperation(m as any),
+        this.executionManager.handleFileOperation(m as CommandMessage),
       [MAIN_VIEW_COMMANDS.ACCEPT_EDITED]: (m) =>
-        this.executionManager.handleFileOperation(m as any),
+        this.executionManager.handleFileOperation(m as CommandMessage),
 
       [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: () =>
         this.fileManager.handleEditedFileSelection(),
@@ -198,7 +206,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleUpdateFiles(m),
 
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: (m) =>
-        this.instructionManager.handlePolishInstructionText(m as any),
+        this.instructionManager.handlePolishInstructionText(m),
       [MAIN_VIEW_COMMANDS.TRANSCRIBE_INSTRUCTION]: () =>
         this.instructionManager.handleTranscribeInstruction(),
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: (m) =>

--- a/packages/extension/src/webview/managers/ExecutionManager.ts
+++ b/packages/extension/src/webview/managers/ExecutionManager.ts
@@ -10,7 +10,7 @@ const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
 /** Message shape for command-based operations. */
-interface CommandMessage {
+export interface CommandMessage {
   command: string;
   inputFile?: string;
   baseFile?: string;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -718,7 +718,7 @@ export abstract class ModelHandler<
    * @returns Object containing response text, usage info, and stop reason
    */
   abstract extractResponse(
-    responseObject: any,
+    responseObject: Resp,
     endTag: string,
   ): ExtractResponseResult;
 

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -755,19 +755,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Log server-side compaction events when present in response content.
-    this.logContextManagementFromResponse(response, effectiveContextWindow);
+    logContextManagementFromResponse(
+      response,
+      effectiveContextWindow,
+      this.logger,
+    );
 
     return { response };
-  }
-
-  // Kept as a private wrapper so the legacy mocha test suite
-  // (src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts) can invoke
-  // it via `(handler as any).logContextManagementFromResponse(...)`.
-  private logContextManagementFromResponse(
-    response: BetaMessage,
-    contextWindow: number,
-  ): void {
-    logContextManagementFromResponse(response, contextWindow, this.logger);
   }
 
   private enforceCacheControlLimit(

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -2,7 +2,7 @@
 import { ReasoningEffort } from 'llm-zoo';
 
 // Local file imports
-import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
 import type { DeepSeekToolCall } from '../types/IModelHandler';
@@ -27,10 +27,10 @@ import type { DeepSeekToolCall } from '../types/IModelHandler';
  *
  * @see https://api-docs.deepseek.com/guides/thinking_with_tools
  */
-export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
+export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekToolCall> {
   // toolCallProvider and usageProvider inherit from base class via config.provider
-
-  protected override useReasoningStreamAggregator = true;
+  // useReasoningStreamAggregator + shouldIncludeReasoningInToolCalls inherit
+  // from ReasoningModelHandlerOpenAI.
 
   /**
    * DeepSeek models don't support vision/attachments in tool results.
@@ -63,13 +63,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
    */
   protected override formatAssistantContent(text: string): string {
     return text;
-  }
-
-  /**
-   * DeepSeek thinking models require reasoning_content in tool-use follow-up messages.
-   */
-  protected override shouldIncludeReasoningInToolCalls(): boolean {
-    return this.capabilities.supportsReasoning;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -1,5 +1,5 @@
 // Local file imports
-import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 /**
  * Handler for GLM (Zhipu AI / Z.AI) models using OpenAI-compatible API.
@@ -17,9 +17,7 @@ import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
  * @see https://docs.z.ai/guides/capabilities/thinking
  * @see https://open.bigmodel.cn/dev/api
  */
-export class ModelHandlerGLM extends ModelHandlerOpenAI {
-  protected override useReasoningStreamAggregator = true;
-
+export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
   /**
    * GLM models require explicit `thinking` parameter to control reasoning.
    * Thinking models (e.g. GLM-4.5) need it enabled; non-thinking variants
@@ -29,14 +27,6 @@ export class ModelHandlerGLM extends ModelHandlerOpenAI {
     return this.capabilities.supportsReasoning
       ? { type: 'enabled' }
       : { type: 'disabled' };
-  }
-
-  /**
-   * GLM thinking models require reasoning_content in tool-use follow-up messages
-   * to maintain reasoning chain coherence across tool calls.
-   */
-  protected override shouldIncludeReasoningInToolCalls(): boolean {
-    return this.capabilities.supportsReasoning;
   }
 
   // GLM stringifies content for non-vision models; vision models (GLM-4.5v,

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -1,7 +1,7 @@
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { ToolDefinition } from '@model';
-import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
@@ -27,9 +27,7 @@ interface KimiTokenEstimateResponse {
  *
  * @see https://platform.moonshot.cn/docs/guide/reasoning-model
  */
-export class ModelHandlerKimi extends ModelHandlerOpenAI {
-  protected override useReasoningStreamAggregator = true;
-
+export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'moonshot';
   }
@@ -58,13 +56,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       return { type: 'disabled' };
     }
     return undefined;
-  }
-
-  /**
-   * Kimi thinking models require reasoning_content in tool-use follow-up messages.
-   */
-  protected override shouldIncludeReasoningInToolCalls(): boolean {
-    return this.capabilities.supportsReasoning;
   }
 
   protected override buildChatBaseParams(

--- a/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
@@ -1,7 +1,7 @@
 // Local file imports
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { ToolDefinition } from '@model';
-import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
 import type {
@@ -35,19 +35,13 @@ function extractTextFromReasoningDetails(details: unknown): string | undefined {
  * @see https://platform.minimax.io/docs/api-reference/text-openai-api
  * @see https://platform.minimax.io/docs/guides/text-m2-function-call
  */
-export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
-  protected override useReasoningStreamAggregator = true;
-
+export class ModelHandlerMiniMax extends ReasoningModelHandlerOpenAI {
   /**
    * MiniMax emits reasoning alongside parallel tool calls, which must be
    * preserved by batching the results into a single follow-up message.
    */
   override get requiresBatchedParallelToolResults(): boolean {
     return true;
-  }
-
-  protected override shouldIncludeReasoningInToolCalls(): boolean {
-    return this.capabilities.supportsReasoning;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -1018,7 +1018,18 @@ export class ModelHandlerOpenAI<
     });
   }
 
-  /** Extracts response text and usage statistics from API response. */
+  /**
+   * Extracts response text and usage statistics from an API response.
+   *
+   * `responseObject` is intentionally `any`: ModelHandlerOpenAI is the shared
+   * base for every OpenAI-compatible provider (DeepSeek, Kimi, GLM, MiniMax,
+   * xAI, DashScope, …), which in practice don't all return a strict
+   * `ChatCompletion`. The reasoning stream aggregator finalizes to a
+   * streaming-style `{ role, content }` object with no `choices`, and some
+   * relays return a bare `{ error }` payload — the branches below read those
+   * off-spec shapes directly. Typing this as `ChatCompletion` would
+   * misrepresent them and just push the looseness into per-branch casts.
+   */
   extractResponse(responseObject: any, endTag: string): ExtractResponseResult {
     if (!responseObject.choices?.length) {
       this.logger.debug(

--- a/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
@@ -1,0 +1,37 @@
+// Local file imports
+import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+
+// Type imports
+import type { DeepSeekToolCall, OpenAIToolCall } from '../types/IModelHandler';
+
+/**
+ * Intermediate base for OpenAI-compatible providers that expose a separate
+ * reasoning channel (`reasoning_content` / `reasoning_details`): DeepSeek,
+ * Kimi, GLM, MiniMax.
+ *
+ * It captures only the overrides that are *identical across every* such
+ * handler, so reparenting changes no behavior:
+ *
+ * - `useReasoningStreamAggregator` — reasoning models stream reasoning and
+ *   content on separate channels, so the aggregator is always on.
+ * - `shouldIncludeReasoningInToolCalls()` — when the model reasons, its
+ *   reasoning must be replayed into tool-use follow-up messages.
+ *
+ * Overrides that vary between these providers stay on the concrete handlers:
+ * `requiresBatchedParallelToolResults` (GLM does not batch), the
+ * content-stringification flags (DeepSeek stringifies unconditionally while
+ * Kimi/GLM/MiniMax preserve vision parts), the `thinking`/`reasoning_split`
+ * parameter shape, and each provider's reasoning-field extraction.
+ *
+ * Providers that merely tolerate reasoning tokens without a separate channel
+ * (xAI, DashScope) intentionally keep extending {@link ModelHandlerOpenAI}.
+ */
+export class ReasoningModelHandlerOpenAI<
+  TCall extends OpenAIToolCall | DeepSeekToolCall = OpenAIToolCall,
+> extends ModelHandlerOpenAI<TCall> {
+  protected override useReasoningStreamAggregator = true;
+
+  protected override shouldIncludeReasoningInToolCalls(): boolean {
+    return this.capabilities.supportsReasoning;
+  }
+}

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -50,8 +50,10 @@ import type {
   ChatUsage,
   ChatMessages,
   ChatAssistantMessage,
+  ChatUserMessage,
   ChatToolCall,
   ChatContentItems,
+  ChatContentText,
   ChatRequest,
   ChatFinishReasonEnum,
   ReasoningDetailUnion,
@@ -67,16 +69,6 @@ import type { ProviderStopReason } from '../types/StopReasonTypes';
 type OpenRouterReasoningEffort = NonNullable<
   NonNullable<ChatRequest['reasoning']>['effort']
 >;
-
-/**
- * Structural views for the in-place message rewrites below. Every member of
- * the `ChatMessages` union carries `content`, but the union itself makes a
- * direct assignment un-typeable — so these narrow to just the field being
- * written rather than discarding all type-safety with `as any`. The assigned
- * value is still checked against the real content type.
- */
-type ContentWritable = { content: string | ChatContentItems[] };
-type TextPartWritable = { text: string };
 
 export function toOpenRouterReasoningEffort(
   effort: string,
@@ -1008,7 +1000,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           text: pseudoPrefillMsg,
         });
       } else if (lastMessage && typeof lastMessage.content === 'string') {
-        (lastMessage as ContentWritable).content = [
+        (lastMessage as ChatUserMessage).content = [
           { type: 'text', text: lastMessage.content },
           { type: 'text', text: pseudoPrefillMsg },
         ];
@@ -1072,7 +1064,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           // Anthropic prefill: replace the last text part
           const lastPart = (msg.content as ChatContentItems[]).at(-1);
           if (lastPart && 'text' in lastPart) {
-            (lastPart as TextPartWritable).text = bestConnector + newResponse;
+            (lastPart as ChatContentText).text = bestConnector + newResponse;
           }
         } else {
           (msg.content as ChatContentItems[]).push({
@@ -1081,7 +1073,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           });
         }
       } else {
-        (lastMessage as ContentWritable).content = [
+        msg.content = [
           {
             type: 'text',
             text: workspaceState.assembly.accumulatedOutput,
@@ -1141,7 +1133,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
             text: bestConnector + newResponse,
           });
         } else {
-          (secondLastMessage as ContentWritable).content = [
+          msg.content = [
             {
               type: 'text',
               text: workspaceState.assembly.accumulatedOutput,
@@ -1172,13 +1164,13 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     if (!lastUserMsg || !('content' in lastUserMsg)) return;
 
     if (typeof lastUserMsg.content === 'string') {
-      (lastUserMsg as ContentWritable).content = text + lastUserMsg.content;
+      (lastUserMsg as ChatUserMessage).content = text + lastUserMsg.content;
     } else if (Array.isArray(lastUserMsg.content)) {
       const firstTextPart = (lastUserMsg.content as ChatContentItems[]).find(
         (p) => p.type === 'text',
       );
       if (firstTextPart && 'text' in firstTextPart) {
-        const part = firstTextPart as TextPartWritable;
+        const part = firstTextPart as ChatContentText;
         part.text = text + part.text;
       } else {
         (lastUserMsg.content as ChatContentItems[]).unshift({
@@ -1200,7 +1192,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (typeof lastUserMsg.content === 'string') {
-        (lastUserMsg as ContentWritable).content = [
+        (lastUserMsg as ChatUserMessage).content = [
           ...formattedMedia,
           { type: 'text', text: lastUserMsg.content },
         ];

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -68,6 +68,16 @@ type OpenRouterReasoningEffort = NonNullable<
   NonNullable<ChatRequest['reasoning']>['effort']
 >;
 
+/**
+ * Structural views for the in-place message rewrites below. Every member of
+ * the `ChatMessages` union carries `content`, but the union itself makes a
+ * direct assignment un-typeable — so these narrow to just the field being
+ * written rather than discarding all type-safety with `as any`. The assigned
+ * value is still checked against the real content type.
+ */
+type ContentWritable = { content: string | ChatContentItems[] };
+type TextPartWritable = { text: string };
+
 export function toOpenRouterReasoningEffort(
   effort: string,
 ): OpenRouterReasoningEffort {
@@ -998,7 +1008,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           text: pseudoPrefillMsg,
         });
       } else if (lastMessage && typeof lastMessage.content === 'string') {
-        (lastMessage as any).content = [
+        (lastMessage as ContentWritable).content = [
           { type: 'text', text: lastMessage.content },
           { type: 'text', text: pseudoPrefillMsg },
         ];
@@ -1062,7 +1072,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           // Anthropic prefill: replace the last text part
           const lastPart = (msg.content as ChatContentItems[]).at(-1);
           if (lastPart && 'text' in lastPart) {
-            (lastPart as any).text = bestConnector + newResponse;
+            (lastPart as TextPartWritable).text = bestConnector + newResponse;
           }
         } else {
           (msg.content as ChatContentItems[]).push({
@@ -1071,7 +1081,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           });
         }
       } else {
-        (lastMessage as any).content = [
+        (lastMessage as ContentWritable).content = [
           {
             type: 'text',
             text: workspaceState.assembly.accumulatedOutput,
@@ -1131,7 +1141,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
             text: bestConnector + newResponse,
           });
         } else {
-          (secondLastMessage as any).content = [
+          (secondLastMessage as ContentWritable).content = [
             {
               type: 'text',
               text: workspaceState.assembly.accumulatedOutput,
@@ -1162,13 +1172,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     if (!lastUserMsg || !('content' in lastUserMsg)) return;
 
     if (typeof lastUserMsg.content === 'string') {
-      (lastUserMsg as any).content = text + lastUserMsg.content;
+      (lastUserMsg as ContentWritable).content = text + lastUserMsg.content;
     } else if (Array.isArray(lastUserMsg.content)) {
       const firstTextPart = (lastUserMsg.content as ChatContentItems[]).find(
         (p) => p.type === 'text',
       );
       if (firstTextPart && 'text' in firstTextPart) {
-        (firstTextPart as any).text = text + (firstTextPart as any).text;
+        const part = firstTextPart as TextPartWritable;
+        part.text = text + part.text;
       } else {
         (lastUserMsg.content as ChatContentItems[]).unshift({
           type: 'text',
@@ -1189,7 +1200,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (typeof lastUserMsg.content === 'string') {
-        (lastUserMsg as any).content = [
+        (lastUserMsg as ContentWritable).content = [
           ...formattedMedia,
           { type: 'text', text: lastUserMsg.content },
         ];

--- a/src/agent/modelHandlers/utils/fileContentUtils.ts
+++ b/src/agent/modelHandlers/utils/fileContentUtils.ts
@@ -8,7 +8,7 @@ import { type AgentTrace } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 
 // Local imports - replacement
-import { cleanFileContent } from '@replacement/engine';
+import { replacementEngine } from '@replacement/engine';
 
 // Local imports - files
 import { flexibleFS, type FileLocation } from '@utils/files';
@@ -53,7 +53,7 @@ export async function prepareExistingOutputContent(
 ): Promise<PreparedFileContent> {
   // Read and clean the file content
   let content = await flexibleFS.read(outputLocation);
-  content = cleanFileContent(content);
+  content = replacementEngine.applyAll(content);
 
   // Extract any existing scratchpad content and log it
   const scratchpad = await extractScratchpad(content, 'scratchpad');

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -108,7 +108,14 @@ export abstract class BasePromiseCoordinator<
         timeoutId,
       });
 
-      runtimeHost.emit(this.config.showEventName, payload as any);
+      // `showEventName` is a runtime-variable key into ProgressEventPayloads,
+      // so TS can't correlate it with `payload`'s type. Cast to the payload
+      // the emitter expects for that key set rather than discarding all
+      // checking with `any`.
+      runtimeHost.emit(
+        this.config.showEventName,
+        payload as ProgressEventPayloads[keyof ProgressEventPayloads],
+      );
     });
   }
 
@@ -152,9 +159,11 @@ export abstract class BasePromiseCoordinator<
   private cleanup(id: string, runtimeHost: AgentRuntimeHost): void {
     this.requests.set(id, { status: 'resolved' });
 
+    // Computed-key payload for a runtime-variable resolve event — same
+    // dynamic-key limitation as the show event in waitForUserAction.
     runtimeHost.emit(this.config.resolveEventName, {
       [this.config.idFieldName]: id,
-    } as any);
+    } as ProgressEventPayloads[keyof ProgressEventPayloads]);
 
     // Defer Map deletion so callers re-entering this method (e.g. resolving
     // and then immediately re-checking pending state) see the resolved entry.

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -258,18 +258,6 @@ export function applyReplacements(
 }
 
 /**
- * Clean content using all replacement rules.
- * @deprecated Use replacementEngine.applyAll() instead for the recommended order.
- * This function applies non-regex, then regex, then critique wrapping.
- * The engine's applyAll() method applies non-regex, regex, then non-regex again.
- */
-export function cleanFileContent(content: string): string {
-  let cleaned = applyReplacements(content, getAllReplacements()).trim();
-  cleaned = applyReplacements(cleaned, getAllReplacementsRegex()).trim();
-  return shouldWrapCritiqueInAlign() ? wrapCritiqueInAlign(cleaned) : cleaned;
-}
-
-/**
  * Provides high-level APIs for applying text replacement rules.
  */
 export const replacementEngine: ReplacementEngine = new ReplacementEngineImpl();

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
+import { logContextManagementFromResponse } from '@agent/modelHandlers/anthropic/anthropicContextManagement';
 
 // Type imports
 
@@ -1287,20 +1288,17 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('logs server-side compaction events from compaction blocks', () => {
-    const handler = createAnthropicHandler();
     const events: Array<{ message: string; data: unknown }> = [];
 
-    handler.setLogger(
-      createLoggerStub({
-        domain: (event: { key: string; text?: string; data?: unknown }) => {
-          if (event.key === 'contextManagement') {
-            events.push({ message: event.text ?? '', data: event.data });
-          }
-        },
-      }) as unknown as AgentTrace,
-    );
+    const logger = createLoggerStub({
+      domain: (event: { key: string; text?: string; data?: unknown }) => {
+        if (event.key === 'contextManagement') {
+          events.push({ message: event.text ?? '', data: event.data });
+        }
+      },
+    }) as unknown as AgentTrace;
 
-    (handler as any).logContextManagementFromResponse(
+    logContextManagementFromResponse(
       {
         content: [
           { type: 'compaction', content: '<summary>state</summary>' },
@@ -1332,6 +1330,7 @@ describe('ModelHandlerAnthropic message guards', () => {
         },
       } as any,
       200000,
+      logger,
     );
 
     assert.equal(

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -55,7 +55,7 @@ import { AbsoluteFS, StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
-import { splitContentLines } from '@utils/text/stringUtils';
+import { formatTimestamp, splitContentLines } from '@utils/text/stringUtils';
 import {
   formatListingLine,
   formatProgressLine,
@@ -588,7 +588,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     return children.map((child, i) => {
       const childMeta = metas[i];
       const info = getExecutionStatusInfo(child.id, childMeta?.terminalStatus);
-      const ts = child.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+      const ts = formatTimestamp(child.timestamp);
       const desc = childMeta?.description ? `  — ${childMeta.description}` : '';
       return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;
     });

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -11,6 +11,7 @@ import {
   type TodoStatus,
 } from '@shared/schemas';
 import { isProcessAgent } from '@shared/streams/agentKind';
+import { formatTimestamp } from '@utils/text/stringUtils';
 
 export function resolveExecutionDisplayCategory(
   agent: string | undefined,
@@ -81,7 +82,7 @@ export function formatProgressLine(
 
 /** Format a listing entry as a single summary line. */
 export function formatListingLine(entry: ExecutionListingEntry): string {
-  const ts = entry.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+  const ts = formatTimestamp(entry.timestamp);
   const info = getExecutionStatusInfo(entry.id, entry.terminalStatus);
   const category = resolveExecutionDisplayCategory(entry.agent, entry.category);
   const categoryTag = category ? `  ${category}` : '';

--- a/src/tools/github/formatIssueEvent.ts
+++ b/src/tools/github/formatIssueEvent.ts
@@ -7,31 +7,24 @@
  */
 
 import {
-  authorOf,
+  formatCommentEvent,
   issueRef,
+  makeTruncator,
   sections,
-  truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
 import type { GhIssue, GhIssueComment } from './prTypes';
 
 const MAX_BODY = 500;
 
-const truncate = (s: string | null | undefined): string =>
-  truncateBody(s, MAX_BODY);
+const truncate = makeTruncator(MAX_BODY);
 
 export function formatIssueComment(
   slug: string,
   issueNumber: number,
   c: GhIssueComment,
 ): string {
-  return wrap(
-    sections(
-      `New comment on ${issueRef(slug, issueNumber)} by ${authorOf(c.user)}:`,
-      truncate(c.body),
-      c.html_url,
-    ),
-  );
+  return formatCommentEvent(issueRef(slug, issueNumber), c, MAX_BODY);
 }
 
 export function formatIssueClosed(

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -11,7 +11,9 @@
 
 import {
   authorOf,
+  formatCommentEvent,
   formatPreviousStateHint,
+  makeTruncator,
   prRef,
   sections,
   truncate as truncateBody,
@@ -32,8 +34,7 @@ const MAX_ANNOTATIONS_PER_RUN = 20;
 const MAX_CI_STARTED_CHECK_NAMES = 20;
 const MAX_ANNOTATION_MESSAGE = 300;
 
-const truncate = (s: string | null | undefined): string =>
-  truncateBody(s, MAX_BODY);
+const truncate = makeTruncator(MAX_BODY);
 
 /** Verb fragments per `GhReview.state`. Unknown states fall back to "reviewed". */
 const REVIEW_VERBS: Readonly<Record<string, string>> = {
@@ -98,13 +99,7 @@ export function formatIssueComment(
   prNumber: number,
   c: GhIssueComment,
 ): string {
-  return wrap(
-    sections(
-      `New comment on ${prRef(slug, prNumber)} by ${authorOf(c.user)}:`,
-      truncate(c.body),
-      c.html_url,
-    ),
-  );
+  return formatCommentEvent(prRef(slug, prNumber), c, MAX_BODY);
 }
 
 export function formatReviewComment(

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -25,9 +25,9 @@ import {
   authorOf,
   formatPreviousStateHint,
   issueRef,
+  makeTruncator,
   prRef,
   sections,
-  truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
 import type {
@@ -38,8 +38,7 @@ import type {
 
 const MAX_BODY = 200;
 
-const truncate = (s: string | null | undefined): string =>
-  truncateBody(s, MAX_BODY);
+const truncate = makeTruncator(MAX_BODY);
 
 /** Repo-level events use a single newline + URL footer. */
 const withFooterUrl = (headline: string, url: string): string =>

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -70,9 +70,8 @@ export function truncate(s: string | null | undefined, max: number): string {
 }
 
 /**
- * Build a single-arg truncator bound to `max`. Replaces the per-formatter
- * `(s) => truncate(s, MAX_BODY)` wrapper so the cap stays the one
- * file-local knob and the closure shape isn't re-declared everywhere.
+ * Build a single-arg truncator bound to `max`, so each formatter keeps one
+ * file-local cap instead of re-declaring the `(s) => truncate(s, MAX)` wrapper.
  */
 export function makeTruncator(
   max: number,

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -8,6 +8,7 @@
  */
 
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
+import type { GhIssueComment } from './prTypes';
 
 const WEBHOOK_TAG = 'github-webhook-activity';
 
@@ -66,6 +67,37 @@ export function truncate(s: string | null | undefined, max: number): string {
   const body = (s ?? '').trim();
   if (body.length <= max) return body;
   return body.slice(0, max) + '…';
+}
+
+/**
+ * Build a single-arg truncator bound to `max`. Replaces the per-formatter
+ * `(s) => truncate(s, MAX_BODY)` wrapper so the cap stays the one
+ * file-local knob and the closure shape isn't re-declared everywhere.
+ */
+export function makeTruncator(
+  max: number,
+): (s: string | null | undefined) => string {
+  return (s) => truncate(s, max);
+}
+
+/**
+ * "New comment on <ref> by <author>:" event, shared by the issue- and
+ * PR-comment formatters — they differ only in whether `ref` is an issue or
+ * pull path. The repo-level formatter uses a denser single-line shape and
+ * intentionally does not route through here.
+ */
+export function formatCommentEvent(
+  ref: string,
+  c: GhIssueComment,
+  maxBody: number,
+): string {
+  return wrapWebhookEvent(
+    sections(
+      `New comment on ${ref} by ${authorOf(c.user)}:`,
+      truncate(c.body, maxBody),
+      c.html_url,
+    ),
+  );
 }
 
 /** Newest `updated_at` (falling back to `created_at`) in a list, or undefined. */

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -29,6 +29,12 @@ function getMaxImageDimension(): number {
 // Define the temporary directory path
 const TEMP_DIR = path.join(os.tmpdir(), 'texra-pdf-conversion');
 
+/** Default DPI/density used when rasterizing a PDF page to PNG. */
+const DEFAULT_PDF_QUALITY = 300;
+
+/** Default maximum [width, height] in px for a rasterized PDF page. */
+const DEFAULT_PDF_MAX_SIZE: [number, number] = [1024, 1024];
+
 // ImageMagick configuration is now in toolUtils.ts
 
 /** Ensure the pdf2pic temporary directory exists. */
@@ -223,8 +229,8 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
 async function singlePagePdf2Png(
   pdfPath: string,
   pageNum: number = 1,
-  quality: number = 300,
-  maxSize: [number, number] = [1024, 1024],
+  quality: number = DEFAULT_PDF_QUALITY,
+  maxSize: [number, number] = DEFAULT_PDF_MAX_SIZE,
 ): Promise<string> {
   try {
     // Check for GraphicsMagick/ImageMagick installation
@@ -281,8 +287,8 @@ async function singlePagePdf2Png(
 /** Convert multiple pages of a PDF to base64 encoded PNG images. */
 async function multiPagePdf2Png(
   pdfPath: string,
-  quality: number = 300,
-  maxSize: [number, number] = [1024, 1024],
+  quality: number = DEFAULT_PDF_QUALITY,
+  maxSize: [number, number] = DEFAULT_PDF_MAX_SIZE,
   maxPages: number = 100,
 ): Promise<string[]> {
   const pageCount = await countPdfPages(pdfPath);
@@ -325,8 +331,8 @@ export async function processPdf2Png(
       return null;
     }
 
-    const finalQuality = quality ?? 300;
-    const finalMaxSize: [number, number] = maxSize ?? [1024, 1024];
+    const finalQuality = quality ?? DEFAULT_PDF_QUALITY;
+    const finalMaxSize: [number, number] = maxSize ?? DEFAULT_PDF_MAX_SIZE;
 
     if (pageCount === 1) {
       return await singlePagePdf2Png(pdfPath, 1, finalQuality, finalMaxSize);

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -97,6 +97,15 @@ export function tailWithEllipsis(text: string, maxLen: number): string {
 }
 
 /**
+ * Format an ISO-8601 timestamp for compact display: replace the `T`
+ * separator with a space and drop the fractional-seconds + `Z` suffix.
+ * (e.g. `'2026-06-02T14:30:45.123Z'` → `'2026-06-02 14:30:45'`).
+ */
+export function formatTimestamp(isoTimestamp: string): string {
+  return isoTimestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+}
+
+/**
  * Extract the subtype from a MIME type string (e.g. `'wav'` from `'audio/wav'`).
  * Returns `fallback` (defaults to the original string) when no `/` is found.
  */


### PR DESCRIPTION
Type-safety and duplication cleanup from a code-review pass. Each change is scoped to the finding it resolves; **full typecheck, lint (0 errors), and prettier all pass.**

## 🔴 Critical
- **C1** — `fileContentUtils` now calls `replacementEngine.applyAll()` (correct non-regex→regex→non-regex order); deleted the deprecated `cleanFileContent()` (single caller).
- **C2** — Aligned the abstract `ModelHandler.extractResponse` param to the `Resp` generic instead of `any`, matching the `IModelHandler` interface it already implements. The concrete OpenAI body keeps `any` deliberately — it handles three response shapes (`ChatCompletion`, streaming-direct, error), so typing it just reintroduces casts.
- **C3** — Replaced all 7 `as any` message-mutation casts in `modelHandlerOpenRouterNative` with precise structural casts (`ContentWritable` / `TextPartWritable`) that still type-check the assigned value.
- **C4** — `BasePromiseCoordinator` event-emission casts: a genuine typed-emitter-with-runtime-variable-key limitation. Swapped bare `as any` for typed casts to the payload type + explanatory comments (no risky generic surgery across subclasses).
- **C5** — Deleted the test-only private `logContextManagementFromResponse` wrapper; the mocha test now calls the exported util directly (removes `handler as any`).

## 🟠 High-priority
- **H1/H2** — Added `formatCommentEvent` + `makeTruncator` to `formatUtils`; deduped `formatIssueComment` and the truncate wrappers across the three GitHub event formatters (the repo formatter's denser single-line shape stays distinct).
- **H3** — Hoisted `DEFAULT_PDF_QUALITY` / `DEFAULT_PDF_MAX_SIZE` in `img.ts`.
- **H4** — Extracted `formatTimestamp()` into `stringUtils`; both tools files use it.
- **H5** — Replaced the 5 dispatch-table `as any` casts in `MainViewMessageHandler` with precise casts. The POLISH cast was spurious (types already matched) and is removed entirely.
- **H6** — New `ReasoningModelHandlerOpenAI` base holds only the two overrides identical across all four reasoning handlers; reparented DeepSeek/Kimi/GLM/MiniMax. Did **not** lift `requiresBatchedParallelToolResults` (GLM omits it) or the content-stringification flags (DeepSeek differs) — that would silently change behavior. XAI/DashScope stay on `ModelHandlerOpenAI`; provider-specific quirks remain per-handler.

22 files (21 modified + new `reasoningModelHandlerOpenAI.ts`). No behavior changes intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly casts, extractions, and routing to existing `replacementEngine.applyAll()`; the file-content path is the only functional swap (deprecated helper removed) and is called out as order-correct in the PR.
> 
> **Overview**
> This PR tightens types and removes duplication surfaced by a code review, without intended behavior changes.
> 
> **Agent / model handlers:** The abstract `ModelHandler.extractResponse` now uses the `Resp` generic. OpenAI-compatible handlers gain `ReasoningModelHandlerOpenAI` for shared reasoning-stream and tool-call reasoning behavior; DeepSeek, Kimi, GLM, and MiniMax extend it. Anthropic calls `logContextManagementFromResponse` directly (test-only private wrapper removed). OpenRouter native message edits drop `as any` in favor of SDK types. `BasePromiseCoordinator` emits use `ProgressEventPayloads` casts instead of `any`.
> 
> **Replacement & output prep:** `prepareExistingOutputContent` uses `replacementEngine.applyAll()`; deprecated `cleanFileContent()` is removed.
> 
> **Extension webview:** Main-view IPC handlers cast to `MainViewExecuteMessage` / `CommandMessage` instead of `any`; polish instruction no longer uses a spurious cast.
> 
> **GitHub formatters & utils:** Shared `formatCommentEvent`, `makeTruncator`, and `formatTimestamp()` replace repeated logic in issue/PR/repo formatters and execution listings.
> 
> **Misc:** PDF raster defaults centralized in `img.ts`; `ModelHandlerOpenAI.extractResponse` documents why it stays `any`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98806a9aaea4c2a65959ed8407f8aa7324857f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->