### PR TITLE
fix(cli): constrain approval policy guidance

### DIFF
--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -5,6 +5,8 @@ export type ApprovalInstructionContext = {
 
 const PRIVILEGED_ACTION_GUIDANCE =
   'Do not call approval-gated tools such as bash/shell commands, file edits, setup/config updates, user questions, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
+const CLI_APPROVAL_POLICY_GUIDANCE =
+  'Valid CLI approval policies are "ask", "never", and "yolo" only. If suggesting a rerun, use --approval-policy yolo for headless auto-approval or an interactive run with --approval-policy ask; do not invent other approval mode names.';
 
 export function approvalPromptsUnavailable(
   context: ApprovalInstructionContext,
@@ -22,6 +24,7 @@ export function formatUnavailableApprovalInstruction(
     return [
       'Approval policy for this run is "never": privileged actions that require approval will be rejected automatically.',
       PRIVILEGED_ACTION_GUIDANCE,
+      CLI_APPROVAL_POLICY_GUIDANCE,
     ].join(' ');
   }
 
@@ -29,6 +32,7 @@ export function formatUnavailableApprovalInstruction(
     return [
       'This is a headless run with approval policy "ask": approval prompts cannot be answered, so privileged actions that require approval will be rejected automatically.',
       PRIVILEGED_ACTION_GUIDANCE,
+      CLI_APPROVAL_POLICY_GUIDANCE,
     ].join(' ');
   }
 

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -58,6 +58,11 @@ describe('formatUnavailableApprovalInstruction', () => {
 
       expect(instruction).toContain('Approval policy for this run is "never"');
       expect(instruction).toContain('will be rejected automatically');
+      expect(instruction).toContain(
+        'Valid CLI approval policies are "ask", "never", and "yolo" only.',
+      );
+      expect(instruction).toContain('--approval-policy yolo');
+      expect(instruction).toContain('--approval-policy ask');
     }
   });
 
@@ -69,6 +74,11 @@ describe('formatUnavailableApprovalInstruction', () => {
 
     expect(instruction).toContain('headless run with approval policy "ask"');
     expect(instruction).toContain('approval prompts cannot be answered');
+    expect(instruction).toContain(
+      'Valid CLI approval policies are "ask", "never", and "yolo" only.',
+    );
+    expect(instruction).toContain('--approval-policy yolo');
+    expect(instruction).toContain('--approval-policy ask');
   });
 
   it('does not warn for interactive ask because prompts are available', () => {
@@ -122,6 +132,7 @@ describe('formatMultiAgentRunInstruction', () => {
     expect(instruction).toContain('Approval policy for this run is "never"');
     expect(instruction).toContain('will be rejected automatically');
     expect(instruction).toContain('Do not call approval-gated tools');
+    expect(instruction).toContain('do not invent other approval mode names');
     expect(instruction).toContain('Additional user instruction:');
   });
 


### PR DESCRIPTION
## Summary

Closes #5122.

- tell headless/approval-denied multi-agent runs the only valid CLI approval policies are `ask`, `never`, and `yolo`
- instruct the root agent to suggest `--approval-policy yolo` for headless auto-approval or an interactive `--approval-policy ask` run, instead of inventing approval mode names
- cover the added guidance in the multi-agent instruction tests

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli build`
- reran the repro math command with `multi-agent run mathematician --approval-policy never --print --output-format json`; the final response no longer suggested invalid `always`/`modify` modes
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only text for multi-agent/headless runs; no runtime approval or auth behavior changes.
> 
> **Overview**
> When approval prompts cannot be used (`never`, or headless `ask`), the CLI now appends explicit guidance that only **`ask`**, **`never`**, and **`yolo`** are valid `--approval-policy` values, and tells the agent to suggest **`--approval-policy yolo`** for headless auto-approval or an interactive **`ask`** rerun instead of inventing other mode names.
> 
> Tests in **`MultiAgentInstruction.vitest.ts`** assert the new strings appear in **`formatUnavailableApprovalInstruction`** and in orchestrator instructions when policy is **`never`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6829aa0b9b91d10a2525e729aa032cabe9eea0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->