### PR TITLE
fix(relay): close profiles self-escalation, enforce native ban, harden free-tier cap

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -15,6 +15,7 @@ import {
   type AgentConfig,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
+import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import {
   AgentCategory,
   isWorkflowSetting,
@@ -152,6 +153,15 @@ function createRoundProgressCallback(
         toolCallCount: 0,
       },
     });
+  };
+}
+
+/** Create the awaited round-finalized callback used by agent flows. */
+function createUsageRecordingCallback(
+  ctx: AgentLaunchContext,
+): RoundFinalizedCallback {
+  return async (run) => {
+    await ctx.usageMonitor.recordUsage(run);
   };
 }
 
@@ -447,10 +457,11 @@ export async function executeAgent(
 
         if (setting.agentCategory === AgentCategory.ToolUse) {
           let toolUseTurns = 0;
+          const onRoundFinalized = createUsageRecordingCallback(ctx);
           const result = await runToolUseFlow({
             ...ctx,
             ...interrupts,
-            onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
+            onRoundFinalized,
             setting,
             isSubagent,
             approvalPromptsUnavailable: options.approvalPromptsUnavailable,
@@ -499,10 +510,11 @@ export async function executeAgent(
           ctx.runtimeHost,
           options.onProgress,
         );
+        const onRoundFinalized = createUsageRecordingCallback(ctx);
         const result = await runReflectionFlow({
           ...ctx,
           ...interrupts,
-          onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
+          onRoundFinalized,
           setting,
           parentStage: ctx.parentStage,
           onRoundCompleted,
@@ -562,7 +574,7 @@ export async function resumeToolUseFromSnapshot(
           {
             ...ctx,
             ...createInterruptCallbacks(),
-            onRoundFinalized: (run) => ctx.usageMonitor.recordUsage(run),
+            onRoundFinalized: createUsageRecordingCallback(ctx),
             setting,
             resumeSnapshot: snapshot,
             // Derive from the recovered parent chain: any execution with a

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -166,8 +166,9 @@ export class UsageMonitor {
         });
       }
 
-      // Log to backend for analytics (non-blocking, fire-and-forget)
-      this.logToBackend(stateGlobal.totalResponseTimeMs, {
+      // Log to backend for analytics/billing. Relay-backed rounds wait for the
+      // flush because the next relay request enforces the cap from DB state.
+      await this.logToBackend(stateGlobal.totalResponseTimeMs, {
         inputTokens: roundInputTokens,
         outputTokens: roundOutputTokens,
         cachedInputTokens: roundCacheReadTokens,
@@ -205,9 +206,9 @@ export class UsageMonitor {
 
   /**
    * Log per-round usage to backend for analytics/billing.
-   * Non-blocking - errors are caught and logged, never thrown.
+   * Errors are caught and logged, never thrown.
    */
-  private logToBackend(
+  private async logToBackend(
     totalResponseTimeMs: number,
     usage: {
       inputTokens: number;
@@ -218,7 +219,7 @@ export class UsageMonitor {
       reasoningTokens?: number;
       cost: number;
     },
-  ): void {
+  ): Promise<void> {
     try {
       const { config } = this.modelInfo;
       const provider = UsageProviderSchema.catch('unknown').parse(
@@ -261,7 +262,7 @@ export class UsageMonitor {
       // pre-call check sees this round's cost before the next call — bounding
       // free-tier overage to roughly one round instead of a whole session.
       if (usedRelay) {
-        void UsageLogService.flush();
+        await UsageLogService.flush();
       }
     } catch (error) {
       this.context.logger.debug(

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -262,7 +262,12 @@ export class UsageMonitor {
       // pre-call check sees this round's cost before the next call — bounding
       // free-tier overage to roughly one round instead of a whole session.
       if (usedRelay) {
-        await UsageLogService.flush();
+        const flushed = await UsageLogService.flush();
+        if (!flushed) {
+          this.context.logger.debug(
+            'Relay usage logging is queued; spend-cap data will retry later.',
+          );
+        }
       }
     } catch (error) {
       this.context.logger.debug(

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -229,6 +229,13 @@ export class UsageMonitor {
         usage.cacheMissInputTokens ??
         Math.max(0, usage.inputTokens - cachedInputTokens);
 
+      const usedRelay =
+        !shouldUseOpenRouter(config) &&
+        getServerSideKeyService().shouldUseServerSideKeysSync(
+          config.provider,
+          config.name,
+        );
+
       UsageLogService.log({
         model: config.fullName,
         provider,
@@ -244,14 +251,18 @@ export class UsageMonitor {
         }),
         cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         reasoningTokens: usage.reasoningTokens ?? 0,
-        usedRelay:
-          !shouldUseOpenRouter(config) &&
-          getServerSideKeyService().shouldUseServerSideKeysSync(
-            config.provider,
-            config.name,
-          ),
+        usedRelay,
         streamId: this.context.streamId,
       });
+
+      // The relay enforces the monthly spend cap from the server-side usage
+      // total, which is only as fresh as the last flush (otherwise batched
+      // every ~30s / 10 entries). For relay rounds, flush now so the relay's
+      // pre-call check sees this round's cost before the next call — bounding
+      // free-tier overage to roughly one round instead of a whole session.
+      if (usedRelay) {
+        void UsageLogService.flush();
+      }
     } catch (error) {
       this.context.logger.debug(
         `Backend usage logging failed: ${toErrorMessage(error)}`,

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -99,6 +99,7 @@ class UsageLogServiceImpl {
   }
 
   private async flushQueuedBatch(): Promise<boolean> {
+    let entries: UsageLogEntry[] = [];
     try {
       const token = await SupabaseClient.getAccessToken();
       if (!token) {
@@ -106,8 +107,9 @@ class UsageLogServiceImpl {
         return false;
       }
 
-      const entries = this.queue;
+      entries = this.queue;
       this.queue = [];
+      if (entries.length === 0) return false;
 
       const batch: UsageLogBatch = {
         entries,
@@ -126,15 +128,20 @@ class UsageLogServiceImpl {
           `Batch ${batch.batchId} sent successfully (${response.accepted} entries)`,
         );
       } else {
-        logger.warn(CHANNEL, `Batch rejected: ${response.error}`);
+        logger.warn(
+          CHANNEL,
+          `Batch rejected; dropped ${entries.length} queued entries: ${response.error}`,
+        );
       }
       return true;
     } catch (error) {
+      const droppedMessage =
+        entries.length > 0 ? `; dropped ${entries.length} queued entries` : '';
       logger.warn(
         CHANNEL,
-        `Failed to send usage batch: ${toErrorMessage(error)}`,
+        `Failed to send usage batch${droppedMessage}: ${toErrorMessage(error)}`,
       );
-      return true;
+      return entries.length > 0;
     }
   }
 

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -34,7 +34,7 @@ const DEFAULT_CONFIG: UsageLogConfig = {
 class UsageLogServiceImpl {
   private queue: UsageLogEntry[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
-  private isFlushing = false;
+  private activeFlush: Promise<boolean> | null = null;
   private config: UsageLogConfig = DEFAULT_CONFIG;
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
@@ -82,14 +82,28 @@ class UsageLogServiceImpl {
   }
 
   async flush(): Promise<void> {
-    if (this.isFlushing || this.queue.length === 0) return;
+    while (this.queue.length > 0 || this.activeFlush) {
+      if (this.activeFlush) {
+        await this.activeFlush;
+        continue;
+      }
 
-    this.isFlushing = true;
+      this.activeFlush = this.flushQueuedBatch();
+      try {
+        const madeProgress = await this.activeFlush;
+        if (!madeProgress) return;
+      } finally {
+        this.activeFlush = null;
+      }
+    }
+  }
+
+  private async flushQueuedBatch(): Promise<boolean> {
     try {
       const token = await SupabaseClient.getAccessToken();
       if (!token) {
         logger.debug(CHANNEL, 'Skipping flush - user not authenticated');
-        return;
+        return false;
       }
 
       const entries = this.queue;
@@ -114,13 +128,13 @@ class UsageLogServiceImpl {
       } else {
         logger.warn(CHANNEL, `Batch rejected: ${response.error}`);
       }
+      return true;
     } catch (error) {
       logger.warn(
         CHANNEL,
         `Failed to send usage batch: ${toErrorMessage(error)}`,
       );
-    } finally {
-      this.isFlushing = false;
+      return true;
     }
   }
 
@@ -175,11 +189,11 @@ class UsageLogServiceImpl {
     this.config.enabled = false;
 
     const deadline = Date.now() + 5000;
-    while (this.isFlushing && Date.now() < deadline) {
+    while (this.activeFlush && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
 
-    if (this.isFlushing) {
+    if (this.activeFlush) {
       logger.warn(CHANNEL, 'Dispose timeout waiting for in-flight flush');
     }
 

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -81,21 +81,24 @@ class UsageLogServiceImpl {
     }
   }
 
-  async flush(): Promise<void> {
+  async flush(): Promise<boolean> {
     while (this.queue.length > 0 || this.activeFlush) {
       if (this.activeFlush) {
-        await this.activeFlush;
+        const madeProgress = await this.activeFlush;
+        if (!madeProgress) return false;
         continue;
       }
 
       this.activeFlush = this.flushQueuedBatch();
       try {
         const madeProgress = await this.activeFlush;
-        if (!madeProgress) return;
+        if (!madeProgress) return false;
       } finally {
         this.activeFlush = null;
       }
     }
+
+    return true;
   }
 
   private async flushQueuedBatch(): Promise<boolean> {
@@ -135,14 +138,30 @@ class UsageLogServiceImpl {
       }
       return true;
     } catch (error) {
-      const droppedMessage =
-        entries.length > 0 ? `; dropped ${entries.length} queued entries` : '';
+      if (entries.length > 0) {
+        this.restoreFailedBatch(entries);
+      }
+      const requeuedMessage =
+        entries.length > 0 ? `; requeued ${entries.length} entries` : '';
       logger.warn(
         CHANNEL,
-        `Failed to send usage batch${droppedMessage}: ${toErrorMessage(error)}`,
+        `Failed to send usage batch${requeuedMessage}: ${toErrorMessage(error)}`,
       );
-      return entries.length > 0;
+      return false;
     }
+  }
+
+  private restoreFailedBatch(entries: UsageLogEntry[]): void {
+    this.queue = [...entries, ...this.queue];
+
+    const overflow = this.queue.length - MAX_QUEUE_SIZE;
+    if (overflow <= 0) return;
+
+    this.queue.splice(0, overflow);
+    logger.warn(
+      CHANNEL,
+      `Queue full while restoring failed batch, dropped ${overflow} oldest entries`,
+    );
   }
 
   private async sendBatch(

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UsageLogService } from '@telemetry/UsageLogService';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SupabaseClient } from '@auth/SupabaseClient';
+
+const usageEntry = (model: string) => ({
+  model,
+  provider: 'openai' as const,
+  agentName: 'agent',
+  agentCategory: AgentCategory.ToolUse,
+  inputTokens: 1,
+  outputTokens: 1,
+  cost: 0.001,
+});
+
+describe('UsageLogService', () => {
+  beforeEach(() => {
+    UsageLogService.initialize({
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+      enabled: true,
+    });
+  });
+
+  afterEach(async () => {
+    await UsageLogService.dispose();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('drains entries queued while another flush is in flight', async () => {
+    vi.spyOn(SupabaseClient, 'getAccessToken').mockResolvedValue('token');
+
+    let releaseFirstFetch: (() => void) | undefined;
+    const firstFetchReleased = new Promise<void>((resolve) => {
+      releaseFirstFetch = resolve;
+    });
+    const batches: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      batches.push(JSON.parse(String(init?.body)));
+      if (fetchMock.mock.calls.length === 1) {
+        await firstFetchReleased;
+      }
+      return new Response(JSON.stringify({ success: true, accepted: 1 }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    UsageLogService.log(usageEntry('first'));
+    const firstFlush = UsageLogService.flush();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    UsageLogService.log(usageEntry('second'));
+    const secondFlush = UsageLogService.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    releaseFirstFetch?.();
+    await Promise.all([firstFlush, secondFlush]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      batches.map((batch) => {
+        const entries = (batch as { entries: Array<{ model: string }> })
+          .entries;
+        return entries.map((entry) => entry.model);
+      }),
+    ).toEqual([['first'], ['second']]);
+  });
+});

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -62,7 +62,10 @@ describe('UsageLogService', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     releaseFirstFetch?.();
-    await Promise.all([firstFlush, secondFlush]);
+    await expect(Promise.all([firstFlush, secondFlush])).resolves.toEqual([
+      true,
+      true,
+    ]);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['first'], ['second']]);
@@ -83,13 +86,39 @@ describe('UsageLogService', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     UsageLogService.log(usageEntry('first'));
-    await UsageLogService.flush();
+    await expect(UsageLogService.flush()).resolves.toBe(false);
 
     expect(fetchMock).not.toHaveBeenCalled();
 
-    await UsageLogService.flush();
+    await expect(UsageLogService.flush()).resolves.toBe(true);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(batches.map(batchModels)).toEqual([['first']]);
+  });
+
+  it('requeues entries when send fails after dequeue', async () => {
+    vi.spyOn(SupabaseClient, 'getAccessToken').mockResolvedValue('token');
+
+    const batches: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      batches.push(JSON.parse(String(init?.body)));
+      if (fetchMock.mock.calls.length === 1) {
+        throw new Error('network unavailable');
+      }
+      return new Response(JSON.stringify({ success: true, accepted: 1 }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    UsageLogService.log(usageEntry('first'));
+    await expect(UsageLogService.flush()).resolves.toBe(false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(UsageLogService.flush()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(batches.map(batchModels)).toEqual([['first'], ['first']]);
   });
 });

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -14,6 +14,11 @@ const usageEntry = (model: string) => ({
   cost: 0.001,
 });
 
+function batchModels(batch: unknown): string[] {
+  const entries = (batch as { entries: Array<{ model: string }> }).entries;
+  return entries.map((entry) => entry.model);
+}
+
 describe('UsageLogService', () => {
   beforeEach(() => {
     UsageLogService.initialize({
@@ -60,12 +65,31 @@ describe('UsageLogService', () => {
     await Promise.all([firstFlush, secondFlush]);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(
-      batches.map((batch) => {
-        const entries = (batch as { entries: Array<{ model: string }> })
-          .entries;
-        return entries.map((entry) => entry.model);
-      }),
-    ).toEqual([['first'], ['second']]);
+    expect(batches.map(batchModels)).toEqual([['first'], ['second']]);
+  });
+
+  it('keeps queued entries when setup fails before dequeue', async () => {
+    vi.spyOn(SupabaseClient, 'getAccessToken')
+      .mockRejectedValueOnce(new Error('auth unavailable'))
+      .mockResolvedValue('token');
+
+    const batches: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      batches.push(JSON.parse(String(init?.body)));
+      return new Response(JSON.stringify({ success: true, accepted: 1 }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    UsageLogService.log(usageEntry('first'));
+    await UsageLogService.flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await UsageLogService.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(batches.map(batchModels)).toEqual([['first']]);
   });
 });

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -322,6 +322,7 @@ async function checkSpendingLimit(
   currentSpend: number;
   limit: number;
   remaining: number;
+  spendCheckFailed?: boolean;
 }> {
   const limit = getSpendingLimit(tier);
   const monthStart = getCurrentMonthStartUTC();
@@ -352,6 +353,7 @@ async function checkSpendingLimit(
       currentSpend: 0,
       limit,
       remaining: failClosed ? 0 : limit,
+      spendCheckFailed: true,
     };
   }
 
@@ -364,6 +366,13 @@ async function checkSpendingLimit(
     limit,
     remaining,
   };
+}
+
+function isFutureTimestamp(
+  timestamp: string | null | undefined,
+  now = new Date(),
+): boolean {
+  return timestamp != null && new Date(timestamp) > now;
 }
 
 // =============================================================================
@@ -448,11 +457,10 @@ app.get('/tier-config', async (c) => {
           .single();
 
         if (profile) {
+          const now = new Date();
           const userStatus = {
             ...calculateAccessStatus(profile.tier, profile.access_expires_at),
-            isBanned:
-              profile.banned_until != null &&
-              new Date(profile.banned_until) > new Date(),
+            isBanned: isFutureTimestamp(profile.banned_until, now),
           };
 
           // Include current spending if service role key is available
@@ -468,6 +476,7 @@ app.get('/tier-config', async (c) => {
               currentSpend: spending.currentSpend,
               limit: spending.limit,
               remaining: spending.remaining,
+              spendCheckFailed: spending.spendCheckFailed ?? false,
               percentUsed:
                 spending.limit > 0
                   ? Math.round((spending.currentSpend / spending.limit) * 100)
@@ -547,7 +556,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   // already blocks sign-in/refresh for banned users, but a still-valid access
   // token would otherwise keep working until it expires — enforce it here so the
   // ban is immediate. Checked before tier/expiry so it can't be circumvented.
-  if (profile.banned_until && new Date(profile.banned_until) > new Date()) {
+  const now = new Date();
+  if (isFutureTimestamp(profile.banned_until, now)) {
     return jsonError(
       'Your account has been suspended. Contact support if you believe this is a mistake.',
       403,
@@ -558,7 +568,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   // Check if access has expired
   if (profile.access_expires_at) {
     const expiresAt = new Date(profile.access_expires_at);
-    if (expiresAt < new Date()) {
+    if (expiresAt < now) {
       return jsonError(
         'Your researcher access has expired. Please contact support to renew.',
         403,
@@ -580,6 +590,19 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     );
 
     if (!spending.allowed) {
+      if (spending.spendCheckFailed) {
+        return jsonError(
+          'Unable to verify your monthly relay usage right now. Please try again shortly, or switch to your own API keys.',
+          503,
+          {
+            spendCheckFailed: true,
+            currentSpend: spending.currentSpend,
+            limit: spending.limit,
+            remaining: spending.remaining,
+          },
+        );
+      }
+
       return jsonError(
         `Monthly spending limit reached ($${spending.limit}). ` +
           `Current usage: $${spending.currentSpend.toFixed(2)}. ` +

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -19,18 +19,21 @@
  * ============================================================================
  *
  * DATABASE REQUIREMENTS:
- * The profiles table must have:
+ * The profiles table must have (all server-managed; clients have SELECT only):
  * - tier: text (values: 'Ultra', 'Max', 'free')
  * - access_expires_at: timestamptz (null = no expiration / lifetime access)
+ * - banned_until: timestamptz, mirror of auth.users.banned_until via trigger
  *
- * To add expiration column:
- *   ALTER TABLE profiles ADD COLUMN access_expires_at timestamptz;
+ * To grant time-limited access (legitimate access window — NOT a ban):
+ *   UPDATE profiles SET access_expires_at = NOW() + INTERVAL '90 days'
+ *     WHERE user_id = '<user-id>';   -- service role only
  *
- * To expire/blacklist a user:
- *   UPDATE profiles SET access_expires_at = NOW() WHERE id = '<user-id>';
- *
- * To grant time-limited access:
- *   UPDATE profiles SET access_expires_at = NOW() + INTERVAL '90 days' WHERE id = '<user-id>';
+ * To BAN a user, use GoTrue's native ban (do NOT overload access_expires_at —
+ * a future date there GRANTS access). Admin API:
+ *   supabase.auth.admin.updateUserById(id, { ban_duration: '876000h' })
+ * or the Dashboard "Ban user" action. That sets auth.users.banned_until and
+ * revokes refresh tokens; the trigger mirrors it to profiles.banned_until,
+ * which the relay enforces below (immediate, even for a still-valid token).
  * ============================================================================
  *
  * TIER HIERARCHY (cumulative access):
@@ -340,8 +343,16 @@ async function checkSpendingLimit(
 
   if (error) {
     console.error('[RELAY] Failed to check spending:', error.message);
-    // Fail open: allow request on error but log it
-    return { allowed: true, currentSpend: 0, limit, remaining: limit };
+    // Fail closed for the free tier (the abuse-prone path): if we can't verify
+    // spend we must not hand out free relay budget. Paid tiers fail open so a
+    // transient DB error never blocks a paying user.
+    const failClosed = tier === FREE_TIER;
+    return {
+      allowed: !failClosed,
+      currentSpend: 0,
+      limit,
+      remaining: failClosed ? 0 : limit,
+    };
   }
 
   const currentSpend = Number(data) || 0;
@@ -432,15 +443,17 @@ app.get('/tier-config', async (c) => {
       if (user) {
         const { data: profile } = await supabaseClient
           .from('profiles')
-          .select('tier, access_expires_at')
+          .select('tier, access_expires_at, banned_until')
           .eq('user_id', user.id)
           .single();
 
         if (profile) {
-          const userStatus = calculateAccessStatus(
-            profile.tier,
-            profile.access_expires_at,
-          );
+          const userStatus = {
+            ...calculateAccessStatus(profile.tier, profile.access_expires_at),
+            isBanned:
+              profile.banned_until != null &&
+              new Date(profile.banned_until) > new Date(),
+          };
 
           // Include current spending if service role key is available
           let spendingStatus = null;
@@ -519,15 +532,27 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     return jsonError('Invalid or expired token', 401);
   }
 
-  // 5. Get user profile and check expiration
+  // 5. Get user profile and check ban / expiration
   const { data: profile, error: profileError } = await userClient
     .from('profiles')
-    .select('tier, access_expires_at')
+    .select('tier, access_expires_at, banned_until')
     .eq('user_id', user.id)
     .single();
 
   if (profileError || !profile) {
     return jsonError('Profile not found', 403);
+  }
+
+  // Ban: profiles.banned_until mirrors GoTrue's auth.users.banned_until. GoTrue
+  // already blocks sign-in/refresh for banned users, but a still-valid access
+  // token would otherwise keep working until it expires — enforce it here so the
+  // ban is immediate. Checked before tier/expiry so it can't be circumvented.
+  if (profile.banned_until && new Date(profile.banned_until) > new Date()) {
+    return jsonError(
+      'Your account has been suspended. Contact support if you believe this is a mistake.',
+      403,
+      { banned: true },
+    );
   }
 
   // Check if access has expired

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -372,7 +372,12 @@ function isFutureTimestamp(
   timestamp: string | null | undefined,
   now = new Date(),
 ): boolean {
-  return timestamp != null && new Date(timestamp) > now;
+  if (timestamp == null) return false;
+  if (timestamp === 'infinity') return true;
+  if (timestamp === '-infinity') return false;
+
+  const parsed = new Date(timestamp);
+  return Number.isFinite(parsed.getTime()) && parsed > now;
 }
 
 // =============================================================================

--- a/supabase/migrations/20260602120000_lock_down_profiles_privileged_columns.sql
+++ b/supabase/migrations/20260602120000_lock_down_profiles_privileged_columns.sql
@@ -19,6 +19,11 @@ DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
 -- Reset client-role privileges, then grant back only what the relay/client need.
 -- service_role and table owner are unaffected (REVOKE targets these two roles).
 REVOKE ALL ON public.profiles FROM anon, authenticated;
+-- Column-level UPDATE grants are independent of table-level grants. Revoke the
+-- privileged columns explicitly so old partial grants cannot survive the reset.
+REVOKE UPDATE (tier, access_expires_at, permissions)
+  ON public.profiles
+  FROM anon, authenticated;
 GRANT SELECT ON public.profiles TO authenticated;
 
 -- The "Users can view own profile" SELECT policy (auth.uid() = user_id) is

--- a/supabase/migrations/20260602120000_lock_down_profiles_privileged_columns.sql
+++ b/supabase/migrations/20260602120000_lock_down_profiles_privileged_columns.sql
@@ -1,0 +1,26 @@
+-- Migration: stop clients from writing their own authorization fields.
+--
+-- public.profiles had RLS enabled with a permissive UPDATE policy
+--   "Users can update own profile"  USING (auth.uid() = user_id)   -- no WITH CHECK
+-- and column UPDATE grants to `authenticated` on tier / access_expires_at /
+-- permissions. Net effect (verified by simulating an authenticated PostgREST
+-- request): any logged-in user could PATCH their own row to set tier='Ultra'
+-- (raising the relay spend cap to $300/mo + unlocking every model), push
+-- access_expires_at to the far future (defeating expiry-based revocation), or
+-- edit permissions. A banned user could simply un-ban themselves this way.
+--
+-- The client only ever READS profiles (see SupabaseClient.getUserAuthContext,
+-- which selects tier/permissions). Every write goes through the backend
+-- (service_role edge functions) or SECURITY DEFINER triggers. So reset the
+-- client roles to SELECT-only and remove the self-update vector entirely.
+
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+
+-- Reset client-role privileges, then grant back only what the relay/client need.
+-- service_role and table owner are unaffected (REVOKE targets these two roles).
+REVOKE ALL ON public.profiles FROM anon, authenticated;
+GRANT SELECT ON public.profiles TO authenticated;
+
+-- The "Users can view own profile" SELECT policy (auth.uid() = user_id) is
+-- intentionally left in place: the relay and client read tier / permissions /
+-- access_expires_at / banned_until for the requesting user from here.

--- a/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
+++ b/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
@@ -23,6 +23,10 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.banned_until IS NOT DISTINCT FROM OLD.banned_until THEN
+    RETURN NEW;
+  END IF;
+
   UPDATE public.profiles
   SET banned_until = NEW.banned_until
   WHERE user_id = NEW.id;
@@ -30,11 +34,13 @@ BEGIN
 END;
 $$;
 
+REVOKE EXECUTE ON FUNCTION public.sync_profile_banned_until()
+  FROM PUBLIC, anon, authenticated;
+
 DROP TRIGGER IF EXISTS trg_sync_profile_banned_until ON auth.users;
 CREATE TRIGGER trg_sync_profile_banned_until
-AFTER UPDATE OF banned_until ON auth.users
+AFTER INSERT OR UPDATE OF banned_until ON auth.users
 FOR EACH ROW
-WHEN (NEW.banned_until IS DISTINCT FROM OLD.banned_until)
 EXECUTE FUNCTION public.sync_profile_banned_until();
 
 -- Backfill from the source of truth (covers the atomicmail.io cluster already

--- a/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
+++ b/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
@@ -12,6 +12,10 @@
 ALTER TABLE public.profiles
   ADD COLUMN IF NOT EXISTS banned_until timestamptz;
 
+REVOKE UPDATE (banned_until)
+  ON public.profiles
+  FROM anon, authenticated;
+
 COMMENT ON COLUMN public.profiles.banned_until IS
   'Mirror of auth.users.banned_until (GoTrue native ban). Relay rejects while in the future. Server-managed via trigger; not client-writable.';
 

--- a/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
+++ b/supabase/migrations/20260602120100_mirror_ban_status_to_profiles.sql
@@ -1,0 +1,46 @@
+-- Migration: mirror GoTrue's native ban into profiles for relay enforcement.
+--
+-- The standard Supabase ban — Admin API `ban_duration` or the Dashboard
+-- "Ban user" action — sets auth.users.banned_until and revokes the user's
+-- refresh tokens. But a still-valid access token keeps working until it expires
+-- (GoTrue exposes no reliable "is banned" check on getUser, see
+-- github.com/supabase/auth/issues/1354). We close that window at the relay by
+-- checking a mirrored banned_until on profiles, which the relay already reads
+-- once per request. The column is server-managed and, after the profiles
+-- lockdown migration, not client-writable — so a banned user cannot clear it.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS banned_until timestamptz;
+
+COMMENT ON COLUMN public.profiles.banned_until IS
+  'Mirror of auth.users.banned_until (GoTrue native ban). Relay rejects while in the future. Server-managed via trigger; not client-writable.';
+
+-- Keep profiles.banned_until in sync with the source of truth on auth.users.
+CREATE OR REPLACE FUNCTION public.sync_profile_banned_until()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  UPDATE public.profiles
+  SET banned_until = NEW.banned_until
+  WHERE user_id = NEW.id;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_profile_banned_until ON auth.users;
+CREATE TRIGGER trg_sync_profile_banned_until
+AFTER UPDATE OF banned_until ON auth.users
+FOR EACH ROW
+WHEN (NEW.banned_until IS DISTINCT FROM OLD.banned_until)
+EXECUTE FUNCTION public.sync_profile_banned_until();
+
+-- Backfill from the source of truth (covers the atomicmail.io cluster already
+-- banned via banned_until = 2099 during the incident response).
+UPDATE public.profiles p
+SET banned_until = u.banned_until
+FROM auth.users u
+WHERE u.id = p.user_id
+  AND p.banned_until IS DISTINCT FROM u.banned_until;


### PR DESCRIPTION
## Summary

Closes the root causes behind "a banned user can still use the relay," found while investigating the `@atomicmail.io` abuse cluster. Two independent holes, plus spend-cap hardening:

1. **Critical privilege escalation in `profiles` (the deeper hole).** RLS was on, but the UPDATE policy had no `WITH CHECK` and `authenticated` held column `UPDATE` grants on `tier` / `access_expires_at` / `permissions`. Any logged-in user could `PATCH /rest/v1/profiles` to self-grant **Ultra tier** ($300/mo relay cap + all models), push `access_expires_at` to 2099, or **un-ban themselves**. Verified with a rolled-back `SET ROLE authenticated` UPDATE.
2. **Bans were inverted / not enforceable.** The incident "ban" set `access_expires_at = NOW() + 2 years`, which *grants* access (the relay denies only when expiry is in the **past**). And even a correct ban was reversible via #1.
3. **Mid-session spend cap.** The relay reads `usage_logs`, flushed only every ~30s / 10 entries, so the first large rounds of a session run before any spend is visible — one session blew past the $10 free cap.

## Changes

**Migrations** (`supabase/migrations/`)
- `…_lock_down_profiles_privileged_columns.sql` — drop the self-update policy, `REVOKE ALL` from `anon`/`authenticated`, `GRANT SELECT` to `authenticated`. Clients are read-only; authz writes are service-role only. (Safe: the only client touch is a read — `SupabaseClient.getUserAuthContext`.)
- `…_mirror_ban_status_to_profiles.sql` — add `profiles.banned_until`, a trigger mirroring `auth.users.banned_until`, and a backfill.

**Relay** (`supabase/functions/relay/index.ts`)
- Reject when `banned_until > now()` (enforces GoTrue's native ban immediately, closing the live-JWT window).
- `checkSpendingLimit` **fails closed for free tier** on RPC error (was fail-open).
- Surface `isBanned` in `/tier-config`; fix the misleading ban doc comment.

**Client** (`src/agent/utils/UsageMonitor.ts`)
- Flush usage immediately after each relay round so the cap sees fresh spend mid-session.

## Banning from now on

GoTrue native: `supabase.auth.admin.updateUserById(id, { ban_duration: '876000h' })` or the Dashboard **Authentication → Users → Ban**. Sets `banned_until`, revokes refresh tokens; the trigger mirrors it and the relay enforces it. No raw SQL, no inversion risk.

## Deploy status

Already applied to prod (`jntubmcgbhwtcktubelv`): both migrations via Supabase MCP, relay redeployed (**v63 ACTIVE**, smoke-tested). Verified: `authenticated` can no longer UPDATE `profiles`; all 8 atomicmail accounts mirrored as banned. The `UsageMonitor` change is client-side and takes effect with the next extension/CLI release.

## Notes
- Migration files are committed for the repo record; the remote migration history has pre-existing `2026-05-17` orphans, so `supabase db push` needs a `db pull`/`repair` reconciliation separately (not blocking).
- Per-round cost is still uncapped for free tier — a request-size cap is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, authorization, and billing enforcement (profiles RLS, ban mirroring, relay spend fail-closed); misconfiguration could block legitimate free users or leave gaps if migrations are not applied.
> 
> **Overview**
> Closes relay abuse paths tied to **`profiles` self-writes**, **non-enforceable bans**, and **stale monthly spend data**.
> 
> **Database:** Clients can no longer update **`profiles`** (drops self-update RLS, revokes writes on `tier` / `access_expires_at` / `permissions`, **SELECT-only** for `authenticated`). Adds **`banned_until`** mirrored from **`auth.users`** via trigger plus backfill so the relay can reject suspended users even with a still-valid JWT.
> 
> **Relay:** Blocks requests when **`banned_until`** is in the future (before tier/expiry). Monthly spend RPC errors **fail closed on free tier** (503 when verification fails; paid tiers still fail open). **`/tier-config`** exposes ban and spend-check failure state.
> 
> **Client:** After each **relay** round, **`UsageMonitor`** **awaits** usage logging and forces **`UsageLogService.flush()`** so the next relay pre-check sees fresh DB spend (instead of ~30s batching). Flush is serialized, requeues on send failure, and is covered by new tests; agent flows use a shared awaited **`onRoundFinalized`** callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9757f676c54ca67ad63d26a3415df0d857748dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->