### PR TITLE
fix(cli): derive orchestration harness presets

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -50,13 +50,14 @@ import {
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
+import { cliMultiAgentPresets } from '../src/runtime/multiAgentPresets';
+import { buildCliOrchestrationItems } from '../src/runtime/orchestration';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../src/schemas/cliSettings';
 import { initLocalCliPlatform } from '../src/runtime/initPlatform';
 import { resolveCliResourcesPath } from '../src/runtime/resourcesPath';
-import type { CliOrchestrationItem } from '../src/runtime/orchestration';
 
 const STREAM_ID = 'harness-stream-1';
 const HARNESS_APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
@@ -147,55 +148,18 @@ function parseList(value: string | undefined): string[] {
     .filter((item) => item.length > 0);
 }
 
-const HARNESS_ORCHESTRATION_ITEMS: readonly CliOrchestrationItem[] = [
-  {
-    value: { kind: 'chat' },
-    label: 'New chat',
-    description: 'Start the default tool-use chat',
-  },
-  {
-    value: {
-      kind: 'preset',
-      preset: 'lean-project',
-      presetName: 'Lean Project',
-    },
-    label: 'Team Lean Project',
-    description: 'built-in; workflow:0; tool-use:7',
-  },
-  {
-    value: { kind: 'preset', preset: 'physicist', presetName: 'Physicist' },
-    label: 'Team Physicist',
-    description: 'built-in; workflow:4; tool-use:9',
-  },
-  {
-    value: {
-      kind: 'preset',
-      preset: 'mathematician',
-      presetName: 'Mathematician',
-    },
-    label: 'Team Mathematician',
-    description: 'built-in; workflow:5; tool-use:7',
-  },
-  {
-    value: {
-      kind: 'preset',
-      preset: 'computer-scientist',
-      presetName: 'Computer Scientist',
-    },
-    label: 'Team Computer Scientist',
-    description: 'built-in; workflow:5; tool-use:8',
-  },
-  {
-    value: { kind: 'help' },
-    label: 'Help',
-    description: 'Show CLI commands',
-  },
-];
+const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
+  presets: cliMultiAgentPresets(undefined),
+  history: [],
+  toolUseAgents: [],
+});
 
 if (SHOW_ORCHESTRATION) {
   const instance = render(
     <OrchestrationApp
       items={HARNESS_ORCHESTRATION_ITEMS}
+      models={[]}
+      apiMode="personal"
       onResolve={() => undefined}
     />,
     {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -204,6 +204,7 @@ const SCENARIOS = [
       'New chat',
       'Team Lean Project',
       'Team Physicist',
+      'Team Computer Scientist…',
       'Help',
       '1-9/a-z/Enter open',
       'Esc exit',

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -97,7 +97,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       const result = await withCliMultiAgentPresetVisibility(plan, () =>
         runChat(context, {
           agentOverride: plan.rootAgent?.name,
-          teamName: action.presetName,
+          teamName: plan.preset.name,
           modelOverride: action.model,
         }),
       );

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -1,7 +1,7 @@
 import { render, Box, Text, useApp, useInput, useWindowSize } from 'ink';
 import { useState } from 'react';
 
-import { Select, type SelectItem } from '../chat/tui/ui/Select';
+import { Select } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { modelSelectItemsForCliMode } from '../chat/tui/forms/ModelListForm';
@@ -26,8 +26,9 @@ function isModelPickAction(
 
 export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
-  /** Available models for the second step; empty skips the model pick. */
-  readonly modelItems: ReadonlyArray<SelectItem<string>>;
+  /** Model access list for the second step; if no entries are runnable in the
+   *  active API mode, the launcher skips the model pick. */
+  readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
@@ -54,6 +55,7 @@ export function OrchestrationApp(
   const app = useApp();
   const { rows } = useWindowSize();
   const maxVisibleItems = Math.max(4, rows - 8);
+  const modelItems = modelSelectItemsForCliMode(props.models, props.apiMode);
   // When set, the launcher is on its second step: choosing the model for this
   // chat/team. Esc returns to the item list rather than exiting.
   const [pending, setPending] = useState<ModelPickAction | undefined>(
@@ -66,7 +68,7 @@ export function OrchestrationApp(
   };
 
   const onItemSelect = (action: CliOrchestrationAction): void => {
-    if (isModelPickAction(action) && props.modelItems.length > 0) {
+    if (isModelPickAction(action) && modelItems.length > 0) {
       setPending(action);
     } else {
       finish(action);
@@ -98,9 +100,9 @@ export function OrchestrationApp(
         </Text>
         <Box marginTop={1}>
           <Select
-            items={props.modelItems}
+            items={modelItems}
             maxVisibleItems={maxVisibleItems}
-            showOverflow={props.modelItems.length > maxVisibleItems}
+            showOverflow={modelItems.length > maxVisibleItems}
             onSelect={(model) => finish({ ...pending, model })}
             onCancel={() => setPending(undefined)}
           />
@@ -145,10 +147,6 @@ export async function runOrchestrationTui(
   items: readonly CliOrchestrationItem[],
   options: RunOrchestrationTuiOptions,
 ): Promise<CliOrchestrationAction> {
-  const modelItems = modelSelectItemsForCliMode(
-    options.models,
-    options.apiMode,
-  );
   return new Promise((resolve) => {
     let chosen: CliOrchestrationAction | undefined;
     const record = (action: CliOrchestrationAction): void => {
@@ -159,7 +157,7 @@ export async function runOrchestrationTui(
     const instance = render(
       <OrchestrationApp
         items={items}
-        modelItems={modelItems}
+        models={options.models}
         apiMode={options.apiMode}
         onResolve={record}
       />,

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -10,7 +10,6 @@ export type CliOrchestrationAction =
   | {
       readonly kind: 'preset';
       readonly preset: string;
-      readonly presetName: string;
       /** Lead model the orchestrator agent starts on (and is offered for
        *  delegation). Chosen in the launcher's model step. */
       readonly model?: string;
@@ -95,7 +94,7 @@ function presetItems(
   presets: readonly CliMultiAgentPreset[],
 ): CliOrchestrationItem[] {
   return presets.slice(0, MAX_PRESET_ITEMS).map((preset) => ({
-    value: { kind: 'preset', preset: preset.id, presetName: preset.name },
+    value: { kind: 'preset', preset: preset.id },
     label: `Team ${preset.name}`,
     description: `${preset.source}; workflow:${preset.workflowAgents.length}; tool-use:${preset.toolUseAgents.length}`,
   }));

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -139,21 +139,18 @@ describe('CLI orchestration items', () => {
     );
   });
 
-  it('carries preset display names through team launch actions', () => {
+  it('keeps team launch actions keyed by preset id only', () => {
     const items = buildCliOrchestrationItems({
       presets: [preset({ id: 'physicist', name: 'Physicist' })],
       history: [],
       toolUseAgents: [],
     });
 
-    expect(items.find((item) => item.label === 'Team Physicist')).toEqual(
-      expect.objectContaining({
-        value: {
-          kind: 'preset',
-          preset: 'physicist',
-          presetName: 'Physicist',
-        },
-      }),
-    );
+    expect(
+      items.find((item) => item.label === 'Team Physicist')?.value,
+    ).toEqual({
+      kind: 'preset',
+      preset: 'physicist',
+    });
   });
 });


### PR DESCRIPTION
Closes #5125.

## Summary
- derive the TUI orchestration harness rows from `cliMultiAgentPresets()` and `buildCliOrchestrationItems()` instead of hand-copying built-in preset ids
- assert the rendered Computer Scientist row in the orchestration launcher validation
- remove redundant `presetName` pass-through state from launcher actions; the run plan owns the canonical preset name
- let `OrchestrationApp` receive the model access list and build select rows internally, matching the launcher API to the real inputs

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui orchestrate-launcher compact-orchestrate-launcher`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `corepack pnpm --filter @texra-ai/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor aligns harness, types, and TUI props with existing orchestration builders; team display name still comes from the resolved run plan, not launcher state.
> 
> **Overview**
> The orchestration launcher and its TUI harness now build menu rows from **`cliMultiAgentPresets()`** and **`buildCliOrchestrationItems()`** instead of a duplicated hard-coded preset list, so built-in teams (including **Computer Scientist**) stay in sync with production. The **validate-tui** orchestrate scenario asserts that row is visible.
> 
> **Preset** launch actions no longer carry **`presetName`**; only the preset id flows through the launcher, and **`orchestrate`** sets the chat **`teamName`** from **`plan.preset.name`** after the run plan is resolved.
> 
> **`OrchestrationApp`** takes the raw **`models`** list and **`apiMode`** and builds model select items inside the component (same filtering as before), instead of accepting precomputed **`modelItems`** from **`runOrchestrationTui`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fefc8946f772b6d55a328e60c29a1eb6a717c4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->