### PR TITLE
test(cli): cover relay startup model picker

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -175,7 +175,7 @@ const HARNESS_ORCHESTRATION_MODEL_FIXTURES: readonly HarnessModelFixture[] = [
   { value: 'gpt54', label: 'GPT-5.4', availability: 'included-access' },
   {
     value: 'deepseekT',
-    label: 'DeepSeek V4 Flash (Thinking)',
+    label: 'DeepSeek V4 Flash',
     availability: 'provider-key',
   },
 ];

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -50,6 +50,8 @@ import {
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
+import { parseCliApiMode, type CliApiMode } from '../src/runtime/apiAccessMode';
+import type { CliModelAccess } from '../src/runtime/modelAccess';
 import { cliMultiAgentPresets } from '../src/runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../src/runtime/orchestration';
 import {
@@ -79,6 +81,10 @@ const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
   process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
+const HARNESS_API_MODE_FROM_ENV = parseCliApiMode(
+  process.env.HARNESS_API_MODE ?? '',
+);
+const HARNESS_API_MODE: CliApiMode = HARNESS_API_MODE_FROM_ENV ?? 'personal';
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const EXTERNAL_INQUIRY_QUESTION =
@@ -154,12 +160,79 @@ const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
   toolUseAgents: [],
 });
 
+type HarnessModelFixture = Readonly<{
+  value: string;
+  label: string;
+  availability: NonNullable<CliModelAccess['model']['availability']>;
+}>;
+
+const HARNESS_ORCHESTRATION_MODEL_FIXTURES: readonly HarnessModelFixture[] = [
+  {
+    value: 'sonnet46T',
+    label: 'Sonnet 4.6 (Thinking)',
+    availability: 'included-access',
+  },
+  { value: 'gpt54', label: 'GPT-5.4', availability: 'included-access' },
+  {
+    value: 'deepseekT',
+    label: 'DeepSeek V4 Flash (Thinking)',
+    availability: 'provider-key',
+  },
+];
+
+function isHarnessModelAvailable(
+  availability: HarnessModelFixture['availability'],
+  apiMode: CliApiMode,
+): boolean {
+  return apiMode === 'included'
+    ? availability === 'included-access'
+    : availability === 'provider-key' || availability === 'openrouter-key';
+}
+
+function harnessModelStatus(
+  availability: HarnessModelFixture['availability'],
+): string {
+  switch (availability) {
+    case 'included-access':
+      return 'included access';
+    case 'provider-key':
+      return 'api key set';
+    case 'openrouter-key':
+      return 'openrouter key set';
+    default:
+      return availability.replaceAll('-', ' ');
+  }
+}
+
+function harnessModel(
+  fixture: HarnessModelFixture,
+  apiMode: CliApiMode,
+): CliModelAccess {
+  return {
+    model: fixture,
+    available: isHarnessModelAvailable(fixture.availability, apiMode),
+    status: harnessModelStatus(fixture.availability),
+  };
+}
+
+function harnessOrchestrationModels(
+  apiMode: CliApiMode,
+): readonly CliModelAccess[] {
+  return HARNESS_ORCHESTRATION_MODEL_FIXTURES.map((fixture) =>
+    harnessModel(fixture, apiMode),
+  );
+}
+
 if (SHOW_ORCHESTRATION) {
   const instance = render(
     <OrchestrationApp
       items={HARNESS_ORCHESTRATION_ITEMS}
-      models={[]}
-      apiMode="personal"
+      models={
+        HARNESS_API_MODE_FROM_ENV
+          ? harnessOrchestrationModels(HARNESS_API_MODE)
+          : []
+      }
+      apiMode={HARNESS_API_MODE}
       onResolve={() => undefined}
     />,
     {
@@ -173,7 +246,7 @@ if (SHOW_ORCHESTRATION) {
 }
 
 await initLocalCliPlatform({
-  apiMode: 'personal',
+  apiMode: HARNESS_API_MODE,
   cwd: HARNESS_CWD,
   installSignalHandlers: false,
   resourcesPath: resolveCliResourcesPath(),
@@ -522,7 +595,7 @@ cliState.sessionMeta.set({
   agent: 'chat',
   model: 'harness-model',
   cwd: HARNESS_CWD,
-  apiMode: 'personal',
+  apiMode: HARNESS_API_MODE,
   canDelegate: CAN_DELEGATE,
   teamName: TEAM_NAME,
   version: '0.0.0-harness',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -248,10 +248,29 @@ const SCENARIOS = [
       'GPT-5.4 — relay: included',
       'Esc back',
     ],
+    unexpect: ['DeepSeek V4 Flash', 'api: api key set', 'personal API keys'],
+  },
+  {
+    name: 'orchestrate-personal-model-pick',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_API_MODE: 'personal',
+    },
+    bootExpect: 'Choose how to start this CLI session.',
+    keys: ['\r'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Model · personal API keys',
+      'Model for the first message.',
+      'DeepSeek V4 Flash — api: api key set',
+      'Esc back',
+    ],
     unexpect: [
-      'DeepSeek V4 Flash (Thinking)',
-      'api: api key set',
-      'personal API keys',
+      'Sonnet 4.6 (Thinking)',
+      'GPT-5.4',
+      'relay: included',
+      'included relay',
     ],
   },
   {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -232,6 +232,29 @@ const SCENARIOS = [
     unexpect: ['[/model]models', 'Tip:'],
   },
   {
+    name: 'orchestrate-relay-model-pick',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_API_MODE: 'included',
+    },
+    bootExpect: 'Choose how to start this CLI session.',
+    keys: ['\r'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Model · included relay',
+      'Model for the first message.',
+      'Sonnet 4.6 (Thinking) — relay: included',
+      'GPT-5.4 — relay: included',
+      'Esc back',
+    ],
+    unexpect: [
+      'DeepSeek V4 Flash (Thinking)',
+      'api: api key set',
+      'personal API keys',
+    ],
+  },
+  {
     name: 'slash-palette',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],


### PR DESCRIPTION
## Summary
- add TUI validator scenarios for the startup orchestration model-pick step in both included-relay and personal-key modes
- let the TUI harness accept `HARNESS_API_MODE` and derive deterministic fixture model availability from one table
- assert relay users only see included relay models, while personal-key users only see provider-key models, after opening the startup model picker

Closes #5143

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- orchestrate-relay-model-pick orchestrate-personal-model-pick`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness and validator changes; no production CLI runtime behavior.
> 
> **Overview**
> Adds **deterministic TUI coverage** for the startup orchestration **first-message model picker**, split by API access mode.
> 
> The **TUI harness** now reads **`HARNESS_API_MODE`** (via `parseCliApiMode`) and threads that mode through platform init, session meta, and **`OrchestrationApp`**. When orchestration mode is on and the env var is set, it supplies **fixture `CliModelAccess` rows** (included vs provider-key models) whose **availability** follows the same rules as production—so relay vs personal lists are stable without live keys.
> 
> **`validate-tui.mjs`** gains two scenarios: **`orchestrate-relay-model-pick`** (`included`) asserts only relay/included models appear after choosing **New chat**; **`orchestrate-personal-model-pick`** (`personal`) asserts provider-key models show and relay-only labels do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf50de3275f626f8501574fa699d8ead9754d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->