### PR TITLE
fix(cli): point setup help to auth status

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -55,7 +55,7 @@ export const setupCommand = withUsageSections(
       rows: [
         ['texra setup', 'choose sign-in or a provider API key'],
         ['texra login', 'sign in for included relay access'],
-        ['texra auth status', 'show which credential path is active'],
+        ['texra auth status', 'show TeXRA sign-in status'],
       ],
     },
   ],

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -55,7 +55,7 @@ export const setupCommand = withUsageSections(
       rows: [
         ['texra setup', 'choose sign-in or a provider API key'],
         ['texra login', 'sign in for included relay access'],
-        ['texra status', 'show which credential path is active'],
+        ['texra auth status', 'show which credential path is active'],
       ],
     },
   ],

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1077,6 +1077,14 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('points setup users at the existing auth status command', async () => {
+    const result = await runCli(['setup', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('texra auth status');
+    expect(stdout).not.toContain('texra status');
+    expect(stderr).toBe('');
+  });
+
   it('shows EXAMPLES and a docs link in root --help', async () => {
     const result = await runCli(['--help']);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- update `texra setup --help` to point at the existing `texra auth status` command instead of the nonexistent `texra status`
- add a regression test for the setup help example

Closes #5145

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli bundle`
- isolated direct CLI probes:
  - `node packages/cli/dist/bin/texra.js setup --help`
  - `node packages/cli/dist/bin/texra.js auth status --output-format json`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing import-order warnings)
- `git diff --check`

## Scout context
- `corepack pnpm --filter @texra-ai/cli validate:run` passed
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-next-full` passed all 90 scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text and test-only changes; no runtime behavior or auth logic modified.
> 
> **Overview**
> **`texra setup --help`** now lists **`texra auth status`** (with updated description) in the EXAMPLES section instead of the non-existent **`texra status`**, so setup guidance matches the real auth subcommand.
> 
> A **Vitest** case in **`CliRootArgs.vitest.mts`** asserts setup help mentions **`texra auth status`** and no longer references **`texra status`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de40704d2b4a326495572ae72428f14d6dc09aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->