### PR TITLE
fix(cli): align Node engine guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ work — with every change returned as a diff you approve.
 # VS Code (or Cursor, Windsurf, Antigravity)
 code --install-extension texra-ai.texra
 
-# Terminal — requires Node.js 22+
+# Terminal — requires Node.js ^22.22.2, ^24.15.0, or >=26.0.0
 npm install -g @texra-ai/cli
 ```
 
@@ -112,7 +112,7 @@ In the CLI, export the same variables in your shell and run with
 ## Requirements
 
 - **VS Code 1.105+** (also runs in Cursor, Windsurf, Antigravity), or
-  **Node.js 22+** for the CLI
+  **Node.js ^22.22.2, ^24.15.0, or >=26.0.0** for the CLI
 - **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX)
 - **Perl** (for `latexindent` and `latexdiff`)
 - Optional: ImageMagick + Ghostscript (for PDF/image processing),

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -7,7 +7,7 @@ import {
   probeLatexToolchain,
   type LatexToolchainProbe,
 } from '@latex/latexToolchain';
-import { TEXRA_CLI_SUPPORTED_NODE_RANGE } from '@shared/constants/cliRuntime';
+import { TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY } from '@shared/constants/cliRuntime';
 
 // Local imports - CLI runtime
 import { redactEmailAccountLabelsForDisplay } from './accountDisplay';
@@ -159,7 +159,7 @@ function checkNode(version: string): DoctorCheck {
     'node',
     'Node.js',
     `Node ${version || 'unknown'} is outside the supported range.`,
-    `Install Node ${TEXRA_CLI_SUPPORTED_NODE_RANGE}.`,
+    `Install Node ${TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY} before running TeXRA CLI.`,
   );
 }
 

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -7,6 +7,7 @@ import {
   probeLatexToolchain,
   type LatexToolchainProbe,
 } from '@latex/latexToolchain';
+import { TEXRA_CLI_SUPPORTED_NODE_RANGE } from '@shared/constants/cliRuntime';
 
 // Local imports - CLI runtime
 import { redactEmailAccountLabelsForDisplay } from './accountDisplay';
@@ -61,8 +62,6 @@ interface DoctorDependencies {
 }
 
 type ResolvedDoctorDependencies = Required<DoctorDependencies>;
-
-const SUPPORTED_NODE_RANGE = '^22.22.2 || ^24.15.0 || >=26.0.0';
 
 function parseNodeVersion(version: string): [number, number, number] | null {
   const [majorRaw, minorRaw, patchRaw] = version.split('.');
@@ -160,7 +159,7 @@ function checkNode(version: string): DoctorCheck {
     'node',
     'Node.js',
     `Node ${version || 'unknown'} is outside the supported range.`,
-    `Install Node ${SUPPORTED_NODE_RANGE}.`,
+    `Install Node ${TEXRA_CLI_SUPPORTED_NODE_RANGE}.`,
   );
 }
 

--- a/src/shared/constants/cliRuntime.ts
+++ b/src/shared/constants/cliRuntime.ts
@@ -1,5 +1,14 @@
-export const TEXRA_CLI_SUPPORTED_NODE_RANGE =
-  '^22.22.2 || ^24.15.0 || >=26.0.0';
+const TEXRA_CLI_SUPPORTED_NODE_RANGE = '^22.22.2 || ^24.15.0 || >=26.0.0';
 
-export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY =
-  '^22.22.2, ^24.15.0, or >=26.0.0';
+export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY = formatNodeRangeForDisplay(
+  TEXRA_CLI_SUPPORTED_NODE_RANGE,
+);
+
+function formatNodeRangeForDisplay(range: string): string {
+  const versions = range.split(' || ');
+  const finalVersion = versions.at(-1);
+
+  return versions.length > 1 && finalVersion != null
+    ? `${versions.slice(0, -1).join(', ')}, or ${finalVersion}`
+    : range;
+}

--- a/src/shared/constants/cliRuntime.ts
+++ b/src/shared/constants/cliRuntime.ts
@@ -1,0 +1,5 @@
+export const TEXRA_CLI_SUPPORTED_NODE_RANGE =
+  '^22.22.2 || ^24.15.0 || >=26.0.0';
+
+export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY =
+  '^22.22.2, ^24.15.0, or >=26.0.0';

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -139,6 +139,11 @@ describe('CLI doctor', () => {
       unsupportedOddRelease.checks.find((check) => check.id === 'node')
         ?.message,
     ).toBe('Node 23.0.0 is outside the supported range.');
+    expect(
+      unsupportedOddRelease.checks.find((check) => check.id === 'node')?.hint,
+    ).toBe(
+      'Install Node ^22.22.2, ^24.15.0, or >=26.0.0 before running TeXRA CLI.',
+    );
   });
 
   it('keeps human-readable hints in text output', async () => {

--- a/src/test/tools/externalToolDefs.test.ts
+++ b/src/test/tools/externalToolDefs.test.ts
@@ -30,6 +30,16 @@ describe('external tool definitions', () => {
     assert.strictEqual(texraCli.hideFromCli, true);
     assert.strictEqual(texraCli.toggleable, undefined);
     assert.deepStrictEqual(texraCli.tools, []);
+    assert.ok(
+      texraCli.installGuide?.includes(
+        'requires Node.js ^22.22.2, ^24.15.0, or >=26.0.0',
+      ),
+      'TeXRA CLI install guide should match the published Node engine range',
+    );
+    assert.ok(
+      !texraCli.installGuide?.includes('Node.js >= 22'),
+      'TeXRA CLI install guide should not advertise a stale Node 22+ range',
+    );
   });
 
   it('detects the current TeXRA CLI process through the host checker', async () => {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -15,6 +15,7 @@
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
+import { TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY } from '@shared/constants/cliRuntime';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
@@ -449,7 +450,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Local TeXRA command-line app integration. Detection is shown now; activation is coming soon.',
     installGuide:
       'Run the same agents on your .tex projects without an editor — ideal for scripts, CI, and remote machines.\n\n' +
-      'Install globally from npm (requires Node.js >= 22):\n' +
+      `Install globally from npm (requires Node.js ${TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY}):\n` +
       '  npm install -g @texra-ai/cli\n\n' +
       'The CLI also ships with the TeXRA package — make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
       'Check from a terminal:\n' +


### PR DESCRIPTION
## Summary

- update the README CLI install/requirements text to match the published Node engine range
- share the CLI Node engine range between `texra doctor` and the external tool install guide
- add an external-tool regression assertion so the stale `Node.js >= 22` guide does not return

Closes #5142.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Doctor.vitest.mts --reporter=verbose`
- `corepack pnpm exec tsc --noEmit --project tsconfig.test-kernel.json`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli bundle`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- built `texra doctor --output-format json` smoke check on local Node 22.14.0, expecting unsupported-environment exit and the corrected `Install Node ^22.22.2 || ^24.15.0 || >=26.0.0.` hint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and user-facing messaging only; Node version enforcement logic is unchanged aside from hint wording sourced from a shared constant.
> 
> **Overview**
> This PR replaces vague **Node.js 22+** CLI guidance with the published engine range **^22.22.2, ^24.15.0, or >=26.0.0** in the README install and requirements sections.
> 
> It introduces **`TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY`** in `src/shared/constants/cliRuntime.ts` so **`texra doctor`** failure hints and the VS Code **TeXRA CLI** external-tool install guide stay in sync. Doctor drops its local range constant and uses the shared display string (with a clearer “before running TeXRA CLI” hint). Tests lock in the doctor hint and guard against the old **`Node.js >= 22`** install text coming back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f217a9c3df37cdecd190d05934e7819b1160857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->